### PR TITLE
feat: add Modal Research provider with free GLM-5.1 endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ NVIDIA_NIM_API_KEY=""
 OPENROUTER_API_KEY=""
 
 
+# Modal Research Config
+MODAL_API_KEY=""
+
+
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
@@ -16,9 +20,9 @@ LLAMACPP_BASE_URL="http://localhost:8080/v1"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "lmstudio" | "llamacpp"
-MODEL_OPUS="nvidia_nim/z-ai/glm4.7"
-MODEL_SONNET="open_router/arcee-ai/trinity-large-preview:free"
+# Valid providers: "nvidia_nim" | "open_router" | "modal" | "lmstudio" | "llamacpp" 
+MODEL_OPUS="modal/zai-org/GLM-5.1-FP8"
+MODEL_SONNET="nvidia_nim/minimaxai/minimax-m2.7"
 MODEL_HAIKU="open_router/stepfun/step-3.5-flash:free"
 MODEL="nvidia_nim/z-ai/glm4.7"
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A lightweight proxy that routes Claude Code's Anthropic API calls to **NVIDIA NI
 1. Get an API key (or use LM Studio / llama.cpp locally):
    - **NVIDIA NIM**: [build.nvidia.com/settings/api-keys](https://build.nvidia.com/settings/api-keys)
    - **OpenRouter**: [openrouter.ai/keys](https://openrouter.ai/keys)
+   - **Modal**: [modal.com/glm-5-endpoint](https://modal.com/glm-5-endpoint)
    - **LM Studio**: No API key needed. Run locally with [LM Studio](https://lmstudio.ai)
    - **llama.cpp**: No API key needed. Run `llama-server` locally.
 2. Install [Claude Code](https://github.com/anthropics/claude-code)
@@ -101,6 +102,20 @@ MODEL="open_router/stepfun/step-3.5-flash:free"     # fallback
 </details>
 
 <details>
+<summary><b>Modal</b> (GLM 5.1)</summary>
+
+```dotenv
+MODAL_API_KEY="modalresearch-your-key-here"
+
+MODEL_OPUS="modal/zai-org/GLM-5.1-FP8"
+MODEL_SONNET="modal/zai-org/GLM-5.1-FP8"
+MODEL_HAIKU="modal/zai-org/GLM-5.1-FP8"
+MODEL="modal/zai-org/GLM-5.1-FP8"         # fallback
+```
+
+</details>
+
+<details>
 <summary><b>LM Studio</b> (fully local, no API key)</summary>
 
 ```dotenv
@@ -134,11 +149,13 @@ Each `MODEL_*` variable can use a different provider. `MODEL` is the fallback fo
 ```dotenv
 NVIDIA_NIM_API_KEY="nvapi-your-key-here"
 OPENROUTER_API_KEY="sk-or-your-key-here"
+MODAL_API_KEY="modalresearch-your-key-here"
 
-MODEL_OPUS="nvidia_nim/moonshotai/kimi-k2.5"
-MODEL_SONNET="open_router/deepseek/deepseek-r1-0528:free"
+
+MODEL_OPUS="modal/zai-org/GLM-5.1-FP8"
+MODEL_SONNET="nvidia_nim/minimaxai/minimax-m2.7"
 MODEL_HAIKU="lmstudio/unsloth/GLM-4.7-Flash-GGUF"
-MODEL="nvidia_nim/z-ai/glm4.7"                      # fallback
+MODEL="open_router/deepseek/deepseek-r1-0528:free"  # fallback
 ```
 
 </details>
@@ -283,21 +300,23 @@ free-claude-code    # starts the server
 
 ## Providers
 
-| Provider       | Cost         | Rate Limit | Best For                             |
-| -------------- | ------------ | ---------- | ------------------------------------ |
-| **NVIDIA NIM** | Free         | 40 req/min | Daily driver, generous free tier     |
-| **OpenRouter** | Free / Paid  | Varies     | Model variety, fallback options      |
-| **LM Studio**  | Free (local) | Unlimited  | Privacy, offline use, no rate limits |
-| **llama.cpp**  | Free (local) | Unlimited  | Lightweight local inference engine   |
+| Provider       | Cost         | Rate Limit            | Best For                             |
+| -------------- | ------------ | --------------------- | ------------------------------------ |
+| **NVIDIA NIM** | Free         | 40 req/min            | Daily driver, generous free tier     |
+| **OpenRouter** | Free / Paid  | Varies                | Model variety, fallback options      |
+| **Modal**      | Free / Paid  | 1 concurrent request  | Long-running reasoning tasks         |
+| **LM Studio**  | Free (local) | Unlimited             | Privacy, offline use, no rate limits |
+| **llama.cpp**  | Free (local) | Unlimited             | Lightweight local inference engine   |
 
 Models use a prefix format: `provider_prefix/model/name`. An invalid prefix causes an error.
 
-| Provider   | `MODEL` prefix    | API Key Variable     | Default Base URL              |
-| ---------- | ----------------- | -------------------- | ----------------------------- |
-| NVIDIA NIM | `nvidia_nim/...`  | `NVIDIA_NIM_API_KEY` | `integrate.api.nvidia.com/v1` |
-| OpenRouter | `open_router/...` | `OPENROUTER_API_KEY` | `openrouter.ai/api/v1`        |
-| LM Studio  | `lmstudio/...`    | (none)               | `localhost:1234/v1`           |
-| llama.cpp  | `llamacpp/...`    | (none)               | `localhost:8080/v1`           |
+| Provider   | `MODEL` prefix    | API Key Variable     | Default Base URL                                   |
+| ---------- | ----------------- | -------------------- | -------------------------------------------------- |
+| NVIDIA NIM | `nvidia_nim/...`  | `NVIDIA_NIM_API_KEY` | `integrate.api.nvidia.com/v1`                      |
+| OpenRouter | `open_router/...` | `OPENROUTER_API_KEY` | `openrouter.ai/api/v1`                             |
+| modal      | `modal/...`       | `MODAL_API_KEY`      | `api.us-west-2.modal.direct/v1/chat/completions`   |
+| LM Studio  | `lmstudio/...`    | (none)               | `localhost:1234/v1`                                |
+| llama.cpp  | `llamacpp/...`    | (none)               | `localhost:8080/v1`                                |
 
 <details>
 <summary><b>NVIDIA NIM models</b></summary>
@@ -327,7 +346,16 @@ Popular free models:
 Browse: [openrouter.ai/models](https://openrouter.ai/models) · [Free models](https://openrouter.ai/collections/free-models)
 
 </details>
+<details>
+<summary><b>Modal model</b></summary>
 
+Popular free model:
+
+- `modal/zai-org/GLM-5.1-FP8`
+
+Browse: [modal.com/glm-5-endpoint](https://modal.com/glm-5-endpoint) 
+
+</details>
 <details>
 <summary><b>LM Studio models</b></summary>
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -10,6 +10,7 @@ from providers.common import get_user_facing_error_message
 from providers.exceptions import AuthenticationError
 from providers.llamacpp import LlamaCppProvider
 from providers.lmstudio import LMStudioProvider
+from providers.modal import MODAL_BASE_URL, ModalProvider
 from providers.nvidia_nim import NVIDIA_NIM_BASE_URL, NvidiaNimProvider
 from providers.open_router import OPENROUTER_BASE_URL, OpenRouterProvider
 
@@ -24,6 +25,23 @@ def get_settings() -> Settings:
 
 def _create_provider_for_type(provider_type: str, settings: Settings) -> BaseProvider:
     """Construct and return a new provider instance for the given provider type."""
+    if provider_type == "modal":
+        if not settings.modal_api_key or not settings.modal_api_key.strip():
+            raise AuthenticationError(
+                "MODAL_API_KEY is not set. Add it to your .env file. "
+                "Get a token from your Modal dashboard."
+            )
+        config = ProviderConfig(
+            api_key=settings.modal_api_key,
+            base_url=settings.modal_base_url,
+            rate_limit=settings.provider_rate_limit,
+            rate_window=settings.provider_rate_window,
+            max_concurrency=settings.provider_max_concurrency,
+            http_read_timeout=settings.http_read_timeout,
+            http_write_timeout=settings.http_write_timeout,
+            http_connect_timeout=settings.http_connect_timeout,
+        )
+        return ModalProvider(config)
     if provider_type == "nvidia_nim":
         if not settings.nvidia_nim_api_key or not settings.nvidia_nim_api_key.strip():
             raise AuthenticationError(
@@ -83,12 +101,12 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
         )
         return LlamaCppProvider(config)
     logger.error(
-        "Unknown provider_type: '{}'. Supported: 'nvidia_nim', 'open_router', 'lmstudio', 'llamacpp'",
+        "Unknown provider_type: '{}'. Supported: 'modal', 'nvidia_nim', 'open_router', 'lmstudio', 'llamacpp'",
         provider_type,
     )
     raise ValueError(
         f"Unknown provider_type: '{provider_type}'. "
-        f"Supported: 'nvidia_nim', 'open_router', 'lmstudio', 'llamacpp'"
+        f"Supported: 'modal', 'nvidia_nim', 'open_router', 'lmstudio', 'llamacpp'"
     )
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -33,6 +33,13 @@ class Settings(BaseSettings):
         default="discord", validation_alias="MESSAGING_PLATFORM"
     )
 
+    # ==================== Modal Research Config ====================
+    modal_api_key: str = Field(default="", validation_alias="MODAL_API_KEY")
+    modal_base_url: str = Field(
+        default="https://api.us-west-2.modal.direct/v1",
+        validation_alias="MODAL_BASE_URL",
+    )
+
     # ==================== NVIDIA NIM Config ====================
     nvidia_nim_api_key: str = ""
 
@@ -159,7 +166,7 @@ class Settings(BaseSettings):
     def validate_model_format(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        valid_providers = ("nvidia_nim", "open_router", "lmstudio", "llamacpp")
+        valid_providers = ("nvidia_nim", "open_router", "lmstudio", "llamacpp", "modal")
         if "/" not in v:
             raise ValueError(
                 f"Model must be prefixed with provider type. "
@@ -170,7 +177,7 @@ class Settings(BaseSettings):
         if provider not in valid_providers:
             raise ValueError(
                 f"Invalid provider: '{provider}'. "
-                f"Supported: 'nvidia_nim', 'open_router', 'lmstudio', 'llamacpp'"
+                f"Supported: 'nvidia_nim', 'open_router', 'lmstudio', 'llamacpp', 'modal'"
             )
         return v
 

--- a/nvidia_nim_models.json
+++ b/nvidia_nim_models.json
@@ -1,1133 +1,1145 @@
 {
-    "object": "list",
-    "data": [
-        {
-            "id": "01-ai/yi-large",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "01-ai"
-        },
-        {
-            "id": "abacusai/dracarys-llama-3.1-70b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "abacusai"
-        },
-        {
-            "id": "adept/fuyu-8b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "adept"
-        },
-        {
-            "id": "ai21labs/jamba-1.5-large-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ai21labs"
-        },
-        {
-            "id": "ai21labs/jamba-1.5-mini-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ai21labs"
-        },
-        {
-            "id": "aisingapore/sea-lion-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "aisingapore"
-        },
-        {
-            "id": "baai/bge-m3",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "baai"
-        },
-        {
-            "id": "baichuan-inc/baichuan2-13b-chat",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "baichuan-inc"
-        },
-        {
-            "id": "bigcode/starcoder2-15b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "bigcode"
-        },
-        {
-            "id": "bigcode/starcoder2-7b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "bigcode"
-        },
-        {
-            "id": "bytedance/seed-oss-36b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "bytedance"
-        },
-        {
-            "id": "databricks/dbrx-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "databricks"
-        },
-        {
-            "id": "deepseek-ai/deepseek-coder-6.7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "deepseek-ai/deepseek-r1-distill-llama-8b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "deepseek-ai/deepseek-r1-distill-qwen-14b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "deepseek-ai/deepseek-r1-distill-qwen-32b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "deepseek-ai/deepseek-r1-distill-qwen-7b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "deepseek-ai/deepseek-v3.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "deepseek-ai/deepseek-v3.1-terminus",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "deepseek-ai/deepseek-v3.2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "deepseek-ai"
-        },
-        {
-            "id": "google/codegemma-1.1-7b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/codegemma-7b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/deplot",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-2-27b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-2-2b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-2-9b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-2b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-3-12b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-3-1b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-3-27b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-3-4b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-3n-e2b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-3n-e4b-it",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/gemma-7b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/paligemma",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/recurrentgemma-2b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "google/shieldgemma-9b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "google"
-        },
-        {
-            "id": "gotocompany/gemma-2-9b-cpt-sahabatai-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "gotocompany"
-        },
-        {
-            "id": "ibm/granite-3.0-3b-a800m-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ibm"
-        },
-        {
-            "id": "ibm/granite-3.0-8b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ibm"
-        },
-        {
-            "id": "ibm/granite-3.3-8b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ibm"
-        },
-        {
-            "id": "ibm/granite-34b-code-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ibm"
-        },
-        {
-            "id": "ibm/granite-8b-code-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ibm"
-        },
-        {
-            "id": "ibm/granite-guardian-3.0-8b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "ibm"
-        },
-        {
-            "id": "igenius/colosseum_355b_instruct_16k",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "igenius"
-        },
-        {
-            "id": "igenius/italia_10b_instruct_16k",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "igenius"
-        },
-        {
-            "id": "institute-of-science-tokyo/llama-3.1-swallow-70b-instruct-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "institute-of-science-tokyo"
-        },
-        {
-            "id": "institute-of-science-tokyo/llama-3.1-swallow-8b-instruct-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "institute-of-science-tokyo"
-        },
-        {
-            "id": "marin/marin-8b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "marin"
-        },
-        {
-            "id": "mediatek/breeze-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mediatek"
-        },
-        {
-            "id": "meta/codellama-70b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.1-405b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.1-70b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.1-8b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.2-11b-vision-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.2-1b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.2-3b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.2-90b-vision-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-3.3-70b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-4-maverick-17b-128e-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-4-scout-17b-16e-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama-guard-4-12b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama2-70b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama3-70b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "meta/llama3-8b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "meta"
-        },
-        {
-            "id": "microsoft/kosmos-2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3-medium-128k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3-medium-4k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3-mini-128k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3-mini-4k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3-small-128k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3-small-8k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3-vision-128k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3.5-mini-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3.5-moe-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-3.5-vision-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-4-mini-flash-reasoning",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-4-mini-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "microsoft/phi-4-multimodal-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "microsoft"
-        },
-        {
-            "id": "minimaxai/minimax-m2.5",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "minimaxai"
-        },
-        {
-            "id": "mistralai/codestral-22b-instruct-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/devstral-2-123b-instruct-2512",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/magistral-small-2506",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mamba-codestral-7b-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mathstral-7b-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/ministral-14b-instruct-2512",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct-v0.2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct-v0.3",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-large",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-large-2-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-large-3-675b-instruct-2512",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-medium-3-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-nemotron",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-small-24b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-small-3.1-24b-instruct-2503",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mistral-small-4-119b-2603",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mixtral-8x22b-instruct-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mixtral-8x22b-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "mistralai/mixtral-8x7b-instruct-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "mistralai"
-        },
-        {
-            "id": "moonshotai/kimi-k2-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "moonshotai"
-        },
-        {
-            "id": "moonshotai/kimi-k2-instruct-0905",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "moonshotai"
-        },
-        {
-            "id": "moonshotai/kimi-k2-thinking",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "moonshotai"
-        },
-        {
-            "id": "moonshotai/kimi-k2.5",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "moonshotai"
-        },
-        {
-            "id": "nv-mistralai/mistral-nemo-12b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nv-mistralai"
-        },
-        {
-            "id": "nvidia/cosmos-reason2-8b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/embed-qa-4",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/gliner-pii",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemoguard-8b-content-safety",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemoguard-8b-topic-control",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-51b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-70b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-70b-reward",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-nano-4b-v1.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-nano-8b-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.2-nemoretriever-300m-embed-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.2-nv-embedqa-1b-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.2-nv-embedqa-1b-v2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.3-nemotron-super-49b-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-nemotron-embed-1b-v2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama3-chatqa-1.5-70b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/llama3-chatqa-1.5-8b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/mistral-nemo-minitron-8b-8k-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/mistral-nemo-minitron-8b-base",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemoretriever-parse",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-3-nano-30b-a3b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-3-super-120b-a12b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-4-340b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-4-340b-reward",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-4-mini-hindi-4b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-content-safety-reasoning-4b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-mini-4b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-nano-12b-v2-vl",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-nano-3-30b-a3b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nemotron-parse",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/neva-22b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nv-embed-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nv-embedcode-7b-v1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nv-embedqa-e5-v5",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nv-embedqa-mistral-7b-v2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nvclip",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/nvidia-nemotron-nano-9b-v2",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/riva-translate-4b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/riva-translate-4b-instruct-v1.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/streampetr",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/usdcode-llama-3.1-70b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "nvidia/vila",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "nvidia"
-        },
-        {
-            "id": "openai/gpt-oss-120b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "openai"
-        },
-        {
-            "id": "openai/gpt-oss-120b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "openai"
-        },
-        {
-            "id": "openai/gpt-oss-20b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "openai"
-        },
-        {
-            "id": "openai/gpt-oss-20b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "openai"
-        },
-        {
-            "id": "opengpt-x/teuken-7b-instruct-commercial-v0.4",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "opengpt-x"
-        },
-        {
-            "id": "qwen/qwen2-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen2.5-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen2.5-coder-32b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen2.5-coder-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen3-coder-480b-a35b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen3-next-80b-a3b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen3-next-80b-a3b-thinking",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen3.5-122b-a10b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwen3.5-397b-a17b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "qwen/qwq-32b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "qwen"
-        },
-        {
-            "id": "rakuten/rakutenai-7b-chat",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "rakuten"
-        },
-        {
-            "id": "rakuten/rakutenai-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "rakuten"
-        },
-        {
-            "id": "sarvamai/sarvam-m",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "sarvamai"
-        },
-        {
-            "id": "snowflake/arctic-embed-l",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "snowflake"
-        },
-        {
-            "id": "speakleash/bielik-11b-v2.3-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "speakleash"
-        },
-        {
-            "id": "speakleash/bielik-11b-v2.6-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "speakleash"
-        },
-        {
-            "id": "stepfun-ai/step-3.5-flash",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "stepfun-ai"
-        },
-        {
-            "id": "stockmark/stockmark-2-100b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "stockmark"
-        },
-        {
-            "id": "thudm/chatglm3-6b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "thudm"
-        },
-        {
-            "id": "tiiuae/falcon3-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "tiiuae"
-        },
-        {
-            "id": "tokyotech-llm/llama-3-swallow-70b-instruct-v0.1",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "tokyotech-llm"
-        },
-        {
-            "id": "upstage/solar-10.7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "upstage"
-        },
-        {
-            "id": "utter-project/eurollm-9b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "utter-project"
-        },
-        {
-            "id": "writer/palmyra-creative-122b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "writer"
-        },
-        {
-            "id": "writer/palmyra-fin-70b-32k",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "writer"
-        },
-        {
-            "id": "writer/palmyra-med-70b",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "writer"
-        },
-        {
-            "id": "writer/palmyra-med-70b-32k",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "writer"
-        },
-        {
-            "id": "yentinglin/llama-3-taiwan-70b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "yentinglin"
-        },
-        {
-            "id": "z-ai/glm4.7",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "z-ai"
-        },
-        {
-            "id": "z-ai/glm5",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "z-ai"
-        },
-        {
-            "id": "zyphra/zamba2-7b-instruct",
-            "object": "model",
-            "created": 735790403,
-            "owned_by": "zyphra"
-        }
-    ]
+  "object": "list",
+  "data": [
+    {
+      "id": "01-ai/yi-large",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "01-ai"
+    },
+    {
+      "id": "abacusai/dracarys-llama-3.1-70b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "abacusai"
+    },
+    {
+      "id": "adept/fuyu-8b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "adept"
+    },
+    {
+      "id": "ai21labs/jamba-1.5-large-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ai21labs"
+    },
+    {
+      "id": "ai21labs/jamba-1.5-mini-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ai21labs"
+    },
+    {
+      "id": "aisingapore/sea-lion-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "aisingapore"
+    },
+    {
+      "id": "baai/bge-m3",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "baai"
+    },
+    {
+      "id": "baichuan-inc/baichuan2-13b-chat",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "baichuan-inc"
+    },
+    {
+      "id": "bigcode/starcoder2-15b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "bigcode"
+    },
+    {
+      "id": "bigcode/starcoder2-7b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "bigcode"
+    },
+    {
+      "id": "bytedance/seed-oss-36b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "bytedance"
+    },
+    {
+      "id": "databricks/dbrx-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "databricks"
+    },
+    {
+      "id": "deepseek-ai/deepseek-coder-6.7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "deepseek-ai/deepseek-r1-distill-llama-8b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "deepseek-ai/deepseek-r1-distill-qwen-14b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "deepseek-ai/deepseek-r1-distill-qwen-32b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "deepseek-ai/deepseek-r1-distill-qwen-7b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "deepseek-ai/deepseek-v3.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "deepseek-ai/deepseek-v3.1-terminus",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "deepseek-ai/deepseek-v3.2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "deepseek-ai"
+    },
+    {
+      "id": "google/codegemma-1.1-7b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/codegemma-7b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/deplot",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-2-27b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-2-2b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-2-9b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-2b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-3-12b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-3-1b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-3-27b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-3-4b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-3n-e2b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-3n-e4b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-4-31b-it",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/gemma-7b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/paligemma",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/recurrentgemma-2b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "google/shieldgemma-9b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "google"
+    },
+    {
+      "id": "gotocompany/gemma-2-9b-cpt-sahabatai-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "gotocompany"
+    },
+    {
+      "id": "ibm/granite-3.0-3b-a800m-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ibm"
+    },
+    {
+      "id": "ibm/granite-3.0-8b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ibm"
+    },
+    {
+      "id": "ibm/granite-3.3-8b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ibm"
+    },
+    {
+      "id": "ibm/granite-34b-code-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ibm"
+    },
+    {
+      "id": "ibm/granite-8b-code-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ibm"
+    },
+    {
+      "id": "ibm/granite-guardian-3.0-8b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "ibm"
+    },
+    {
+      "id": "igenius/colosseum_355b_instruct_16k",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "igenius"
+    },
+    {
+      "id": "igenius/italia_10b_instruct_16k",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "igenius"
+    },
+    {
+      "id": "institute-of-science-tokyo/llama-3.1-swallow-70b-instruct-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "institute-of-science-tokyo"
+    },
+    {
+      "id": "institute-of-science-tokyo/llama-3.1-swallow-8b-instruct-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "institute-of-science-tokyo"
+    },
+    {
+      "id": "marin/marin-8b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "marin"
+    },
+    {
+      "id": "mediatek/breeze-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mediatek"
+    },
+    {
+      "id": "meta/codellama-70b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.1-405b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.1-70b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.1-8b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.2-11b-vision-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.2-1b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.2-3b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.2-90b-vision-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-3.3-70b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-4-maverick-17b-128e-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-4-scout-17b-16e-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama-guard-4-12b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama2-70b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama3-70b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "meta/llama3-8b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "meta"
+    },
+    {
+      "id": "microsoft/kosmos-2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3-medium-128k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3-medium-4k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3-mini-128k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3-mini-4k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3-small-128k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3-small-8k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3-vision-128k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3.5-mini-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3.5-moe-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-3.5-vision-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-4-mini-flash-reasoning",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-4-mini-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "microsoft/phi-4-multimodal-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "microsoft"
+    },
+    {
+      "id": "minimaxai/minimax-m2.5",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "minimaxai"
+    },
+    {
+      "id": "minimaxai/minimax-m2.7",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "minimaxai"
+    },
+    {
+      "id": "mistralai/codestral-22b-instruct-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/devstral-2-123b-instruct-2512",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/magistral-small-2506",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mamba-codestral-7b-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mathstral-7b-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/ministral-14b-instruct-2512",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct-v0.2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct-v0.3",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-large",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-large-2-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-large-3-675b-instruct-2512",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-medium-3-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-nemotron",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-small-24b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-small-3.1-24b-instruct-2503",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mistral-small-4-119b-2603",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mixtral-8x22b-instruct-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mixtral-8x22b-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "mistralai/mixtral-8x7b-instruct-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "mistralai"
+    },
+    {
+      "id": "moonshotai/kimi-k2-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "moonshotai"
+    },
+    {
+      "id": "moonshotai/kimi-k2-instruct-0905",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "moonshotai"
+    },
+    {
+      "id": "moonshotai/kimi-k2-thinking",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "moonshotai"
+    },
+    {
+      "id": "moonshotai/kimi-k2.5",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "moonshotai"
+    },
+    {
+      "id": "nv-mistralai/mistral-nemo-12b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nv-mistralai"
+    },
+    {
+      "id": "nvidia/cosmos-reason2-8b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/embed-qa-4",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/gliner-pii",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemoguard-8b-content-safety",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemoguard-8b-topic-control",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-51b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-70b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-70b-reward",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-nano-4b-v1.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-nano-8b-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.2-nemoretriever-300m-embed-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.2-nv-embedqa-1b-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.2-nv-embedqa-1b-v2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.3-nemotron-super-49b-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-nemotron-embed-1b-v2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama3-chatqa-1.5-70b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/llama3-chatqa-1.5-8b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/mistral-nemo-minitron-8b-8k-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/mistral-nemo-minitron-8b-base",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemoretriever-parse",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-3-nano-30b-a3b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-3-super-120b-a12b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-3-super-120b-a12b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-4-340b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-4-340b-reward",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-4-mini-hindi-4b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-content-safety-reasoning-4b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-mini-4b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-nano-12b-v2-vl",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-nano-3-30b-a3b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nemotron-parse",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/neva-22b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nv-embed-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nv-embedcode-7b-v1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nv-embedqa-e5-v5",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nv-embedqa-mistral-7b-v2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nvclip",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/nvidia-nemotron-nano-9b-v2",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/riva-translate-4b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/riva-translate-4b-instruct-v1.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/streampetr",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "nvidia/vila",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "nvidia"
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "openai"
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "openai"
+    },
+    {
+      "id": "openai/gpt-oss-20b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "openai"
+    },
+    {
+      "id": "openai/gpt-oss-20b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "openai"
+    },
+    {
+      "id": "opengpt-x/teuken-7b-instruct-commercial-v0.4",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "opengpt-x"
+    },
+    {
+      "id": "qwen/qwen2-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen2.5-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen2.5-coder-32b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen2.5-coder-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen3-coder-480b-a35b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen3-next-80b-a3b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen3-next-80b-a3b-thinking",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen3.5-122b-a10b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwen3.5-397b-a17b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "qwen/qwq-32b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "qwen"
+    },
+    {
+      "id": "rakuten/rakutenai-7b-chat",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "rakuten"
+    },
+    {
+      "id": "rakuten/rakutenai-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "rakuten"
+    },
+    {
+      "id": "sarvamai/sarvam-m",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "sarvamai"
+    },
+    {
+      "id": "snowflake/arctic-embed-l",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "snowflake"
+    },
+    {
+      "id": "speakleash/bielik-11b-v2.3-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "speakleash"
+    },
+    {
+      "id": "speakleash/bielik-11b-v2.6-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "speakleash"
+    },
+    {
+      "id": "stepfun-ai/step-3.5-flash",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "stepfun-ai"
+    },
+    {
+      "id": "stockmark/stockmark-2-100b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "stockmark"
+    },
+    {
+      "id": "thudm/chatglm3-6b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "thudm"
+    },
+    {
+      "id": "tiiuae/falcon3-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "tiiuae"
+    },
+    {
+      "id": "tokyotech-llm/llama-3-swallow-70b-instruct-v0.1",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "tokyotech-llm"
+    },
+    {
+      "id": "upstage/solar-10.7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "upstage"
+    },
+    {
+      "id": "utter-project/eurollm-9b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "utter-project"
+    },
+    {
+      "id": "writer/palmyra-creative-122b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "writer"
+    },
+    {
+      "id": "writer/palmyra-fin-70b-32k",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "writer"
+    },
+    {
+      "id": "writer/palmyra-med-70b",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "writer"
+    },
+    {
+      "id": "writer/palmyra-med-70b-32k",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "writer"
+    },
+    {
+      "id": "yentinglin/llama-3-taiwan-70b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "yentinglin"
+    },
+    {
+      "id": "z-ai/glm4.7",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "z-ai"
+    },
+    {
+      "id": "z-ai/glm5",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "z-ai"
+    },
+    {
+      "id": "zyphra/zamba2-7b-instruct",
+      "object": "model",
+      "created": 735790403,
+      "owned_by": "zyphra"
+    }
+  ]
 }

--- a/providers/modal/__init__.py
+++ b/providers/modal/__init__.py
@@ -1,0 +1,5 @@
+"""Modal Research provider - OpenAI-compatible API for Modal's inference platform."""
+
+from .client import MODAL_BASE_URL, ModalProvider
+
+__all__ = ["MODAL_BASE_URL", "ModalProvider"]

--- a/providers/modal/client.py
+++ b/providers/modal/client.py
@@ -1,0 +1,24 @@
+"""Modal Research provider implementation."""
+
+from providers.base import ProviderConfig
+from providers.openai_compat import OpenAICompatibleProvider
+from .request import build_request_body
+
+# Modal's OpenAI-compatible endpoint
+MODAL_BASE_URL = "https://api.us-west-2.modal.direct/v1"
+
+
+class ModalProvider(OpenAICompatibleProvider):
+    """Modal Research provider using OpenAI-compatible API."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="MODAL",
+            base_url=config.base_url or MODAL_BASE_URL,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(self, request) -> dict:
+        """Internal helper for tests and shared building."""
+        return build_request_body(request)

--- a/providers/modal/request.py
+++ b/providers/modal/request.py
@@ -1,0 +1,35 @@
+"""Request builder for Modal Research provider."""
+
+from typing import Any
+
+from loguru import logger
+
+from providers.common.message_converter import build_base_request_body
+
+MODAL_DEFAULT_MAX_TOKENS = 81920
+
+
+def build_request_body(request_data: Any) -> dict:
+    """Build OpenAI-format request body from Anthropic request for Modal.
+
+    Modal Research uses a standard OpenAI-compatible API, so we just use
+    the base converter without special handling.
+    """
+    logger.debug(
+        "MODAL_REQUEST: conversion start model={} msgs={}",
+        getattr(request_data, "model", "?"),
+        len(getattr(request_data, "messages", [])),
+    )
+
+    body = build_base_request_body(
+        request_data,
+        default_max_tokens=MODAL_DEFAULT_MAX_TOKENS,
+    )
+
+    logger.debug(
+        "MODAL_REQUEST: conversion done model={} msgs={} tools={}",
+        body.get("model"),
+        len(body.get("messages", [])),
+        len(body.get("tools", [])),
+    )
+    return body

--- a/tests/providers/test_modal.py
+++ b/tests/providers/test_modal.py
@@ -1,0 +1,368 @@
+"""Tests for Modal Research provider."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from providers.base import ProviderConfig
+from providers.modal import MODAL_BASE_URL, ModalProvider
+from providers.modal.request import MODAL_DEFAULT_MAX_TOKENS
+
+
+class MockMessage:
+    def __init__(self, role, content):
+        self.role = role
+        self.content = content
+
+
+class MockRequest:
+    def __init__(self, **kwargs):
+        self.model = "test-model"
+        self.messages = [MockMessage("user", "Hello")]
+        self.max_tokens = 100
+        self.temperature = 0.5
+        self.top_p = 0.9
+        self.system = "System prompt"
+        self.stop_sequences = None
+        self.tools = []
+        self.extra_body = {}
+        self.thinking = MagicMock()
+        self.thinking.enabled = False
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+@pytest.fixture
+def modal_config():
+    return ProviderConfig(
+        api_key="test_modal_key",
+        base_url="https://api.us-west-2.modal.direct/v1",
+        rate_limit=10,
+        rate_window=60,
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_rate_limiter():
+    """Mock the global rate limiter to prevent waiting."""
+    with patch("providers.openai_compat.GlobalRateLimiter") as mock:
+        instance = mock.get_instance.return_value
+        instance.wait_if_blocked = AsyncMock(return_value=False)
+
+        async def _passthrough(fn, *args, **kwargs):
+            return await fn(*args, **kwargs)
+
+        instance.execute_with_retry = AsyncMock(side_effect=_passthrough)
+        yield instance
+
+
+@pytest.fixture
+def modal_provider(modal_config):
+    return ModalProvider(modal_config)
+
+
+def test_init(modal_config):
+    """Test provider initialization."""
+    with patch("providers.openai_compat.AsyncOpenAI") as mock_openai:
+        provider = ModalProvider(modal_config)
+        assert provider._api_key == "test_modal_key"
+        assert provider._base_url == "https://api.us-west-2.modal.direct/v1"
+        mock_openai.assert_called_once()
+
+
+def test_init_default_base_url():
+    """Test that provider uses MODAL_BASE_URL when no base_url is configured."""
+    config = ProviderConfig(api_key="test_modal_key")
+    with patch("providers.openai_compat.AsyncOpenAI"):
+        provider = ModalProvider(config)
+        assert provider._base_url == MODAL_BASE_URL
+
+
+def test_init_uses_configurable_timeouts():
+    """Test that provider passes configurable read/write/connect timeouts to client."""
+    config = ProviderConfig(
+        api_key="test_modal_key",
+        base_url="https://api.us-west-2.modal.direct/v1",
+        http_read_timeout=600.0,
+        http_write_timeout=15.0,
+        http_connect_timeout=5.0,
+    )
+    with patch("providers.openai_compat.AsyncOpenAI") as mock_openai:
+        ModalProvider(config)
+        call_kwargs = mock_openai.call_args[1]
+        timeout = call_kwargs["timeout"]
+        assert timeout.read == 600.0
+        assert timeout.write == 15.0
+        assert timeout.connect == 5.0
+
+
+def test_build_request_body(modal_provider):
+    """Test request body construction."""
+    req = MockRequest()
+    body = modal_provider._build_request_body(req)
+
+    assert body["model"] == "test-model"
+    assert body["temperature"] == 0.5
+    assert body["max_tokens"] == 100
+    assert len(body["messages"]) == 2  # System + User
+    assert body["messages"][0]["role"] == "system"
+    assert body["messages"][0]["content"] == "System prompt"
+    assert body["messages"][1]["role"] == "user"
+    assert body["messages"][1]["content"] == "Hello"
+
+
+def test_build_request_body_default_max_tokens(modal_provider):
+    """max_tokens=None uses MODAL_DEFAULT_MAX_TOKENS (81920)."""
+    req = MockRequest(max_tokens=None)
+    body = modal_provider._build_request_body(req)
+    assert body["max_tokens"] == MODAL_DEFAULT_MAX_TOKENS
+    assert body["max_tokens"] == 81920
+
+
+def test_build_request_body_with_tools(modal_provider):
+    """Test request body includes converted tools."""
+
+    class MockTool:
+        def __init__(self, name, description, input_schema):
+            self.name = name
+            self.description = description
+            self.input_schema = input_schema
+
+    tools = [
+        MockTool(
+            name="search",
+            description="Search the web",
+            input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+        )
+    ]
+    req = MockRequest(tools=tools)
+    body = modal_provider._build_request_body(req)
+
+    assert "tools" in body
+    assert len(body["tools"]) == 1
+    assert body["tools"][0]["function"]["name"] == "search"
+
+
+def test_build_request_body_stop_sequences(modal_provider):
+    """Test stop sequences are included when provided."""
+    req = MockRequest(stop_sequences=["STOP", "END"])
+    body = modal_provider._build_request_body(req)
+    assert body["stop"] == ["STOP", "END"]
+
+
+@pytest.mark.asyncio
+async def test_stream_response_text(modal_provider):
+    """Test streaming text response."""
+    req = MockRequest()
+
+    mock_chunk1 = MagicMock()
+    mock_chunk1.choices = [
+        MagicMock(
+            delta=MagicMock(content="Hello", reasoning_content=None),
+            finish_reason=None,
+        )
+    ]
+    mock_chunk1.usage = None
+
+    mock_chunk2 = MagicMock()
+    mock_chunk2.choices = [
+        MagicMock(
+            delta=MagicMock(content=" World", reasoning_content=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk2.usage = MagicMock(completion_tokens=10)
+
+    async def mock_stream():
+        yield mock_chunk1
+        yield mock_chunk2
+
+    with patch.object(
+        modal_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [e async for e in modal_provider.stream_response(req)]
+
+        assert len(events) > 0
+        assert "event: message_start" in events[0]
+
+        text_content = ""
+        for e in events:
+            if "event: content_block_delta" in e and '"text_delta"' in e:
+                for line in e.splitlines():
+                    if line.startswith("data: "):
+                        data = json.loads(line[6:])
+                        if "delta" in data and "text" in data["delta"]:
+                            text_content += data["delta"]["text"]
+
+        assert "Hello World" in text_content
+
+
+@pytest.mark.asyncio
+async def test_stream_response_reasoning_content(modal_provider):
+    """Test streaming with reasoning_content delta."""
+    req = MockRequest()
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content=None, reasoning_content="Thinking..."),
+            finish_reason=None,
+        )
+    ]
+    mock_chunk.usage = None
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        modal_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [e async for e in modal_provider.stream_response(req)]
+
+        found_thinking = False
+        for e in events:
+            if (
+                "event: content_block_delta" in e
+                and '"thinking_delta"' in e
+                and "Thinking..." in e
+            ):
+                found_thinking = True
+        assert found_thinking
+
+
+@pytest.mark.asyncio
+async def test_stream_response_empty_choices_skipped(modal_provider):
+    """Chunks with empty choices are skipped."""
+    req = MockRequest()
+
+    async def mock_stream():
+        yield MagicMock(choices=[], usage=None)
+        yield MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(content="ok", reasoning_content=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=MagicMock(completion_tokens=2),
+        )
+
+    with patch.object(
+        modal_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+        events = [e async for e in modal_provider.stream_response(req)]
+        assert any("content_block_delta" in e and "ok" in e for e in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_response_delta_none_skipped(modal_provider):
+    """Chunks with delta=None are skipped."""
+    req = MockRequest()
+
+    async def mock_stream():
+        yield MagicMock(
+            choices=[MagicMock(delta=None, finish_reason=None)],
+            usage=None,
+        )
+        yield MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(content="x", reasoning_content=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=MagicMock(completion_tokens=1),
+        )
+
+    with patch.object(
+        modal_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+        events = [e async for e in modal_provider.stream_response(req)]
+        assert any("x" in e for e in events)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_stream(modal_provider):
+    """Test streaming tool calls."""
+    req = MockRequest()
+
+    mock_tc = MagicMock()
+    mock_tc.index = 0
+    mock_tc.id = "call_1"
+    mock_tc.function.name = "search"
+    mock_tc.function.arguments = '{"q": "test"}'
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content=None, reasoning_content=None, tool_calls=[mock_tc]),
+            finish_reason=None,
+        )
+    ]
+    mock_chunk.usage = None
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        modal_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [e async for e in modal_provider.stream_response(req)]
+
+        starts = [
+            e for e in events if "event: content_block_start" in e and '"tool_use"' in e
+        ]
+        assert len(starts) == 1
+        assert "search" in starts[0]
+
+
+@pytest.mark.asyncio
+async def test_stream_response_error_path(modal_provider):
+    """Stream raises exception -> error event emitted."""
+    req = MockRequest()
+
+    async def mock_stream():
+        raise RuntimeError("API failed")
+        yield  # unreachable, makes it a generator
+
+    with patch.object(
+        modal_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+        events = [e async for e in modal_provider.stream_response(req)]
+        assert any("API failed" in e for e in events)
+        assert any("message_stop" in e for e in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_response_finish_reason_only(modal_provider):
+    """Chunk with finish_reason but no content still completes."""
+    req = MockRequest()
+
+    async def mock_stream():
+        yield MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(content=None, reasoning_content=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=MagicMock(completion_tokens=0),
+        )
+
+    with patch.object(
+        modal_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+        events = [e async for e in modal_provider.stream_response(req)]
+        assert any("message_delta" in e for e in events)
+        assert any("message_stop" in e for e in events)


### PR DESCRIPTION
## Summary
Adds Modal Research as a new AI provider to Free-Claude-Code, 
giving users access to a free GLM-5.1 endpoint.

## Changes

### New Provider — Modal Research
- Integrated Modal Research as a supported provider
- Configured free GLM-5.1 endpoint

### Tests
- Added a comprehensive test suite covering the Modal Research provider
- Ensures reliability and correct request/response handling

### Docs
- Added Modal provider documentation with setup instructions and usage

## Why
Modal Research offers a completely free GLM-5.1 endpoint, making it a 
valuable addition for users who want a no-cost alternative provider.

## Related Commits
- `43029a7` feat: add Modal Research provider support
- `d5661e2` feat: refresh NVIDIA NIM model catalog
- `bea925b` feat: add comprehensive test suite for Modal Research provider
- `4e57a93` docs: add Modal provider documentation