### PR TITLE
fix: assign cls._instance in GlobalRateLimiter.__new__ + add test

### DIFF
--- a/providers/rate_limit.py
+++ b/providers/rate_limit.py
@@ -34,6 +34,7 @@ class GlobalRateLimiter:
         if cls._instance is not None:
             return cls._instance
         instance = super().__new__(cls)
+        cls._instance = instance
         return instance
 
     def __init__(

--- a/tests/providers/test_provider_rate_limit.py
+++ b/tests/providers/test_provider_rate_limit.py
@@ -137,6 +137,23 @@ class TestProviderRateLimiter:
         assert limiter1 is limiter2
 
     @pytest.mark.asyncio
+    async def test_direct_instantiation_returns_singleton(self):
+        """
+        Direct calls to GlobalRateLimiter(...) must return the singleton.
+
+        Without the __new__ fix, each direct call creates a separate instance.
+        """
+        GlobalRateLimiter.reset_instance()
+        limiter1 = GlobalRateLimiter(rate_limit=10, rate_window=1)
+        limiter2 = GlobalRateLimiter(rate_limit=20, rate_window=2)
+        assert limiter1 is limiter2, (
+            "Direct instantiation returned separate objects instead of the singleton"
+        )
+        # Second call should return the stored instance (idempotent __init__ guard)
+        limiter3 = GlobalRateLimiter(rate_limit=99, rate_window=99)
+        assert limiter3 is limiter1
+
+    @pytest.mark.asyncio
     async def test_reset_instance(self):
         """reset_instance should allow creating a new instance."""
         limiter1 = GlobalRateLimiter.get_instance(rate_limit=10, rate_window=1)


### PR DESCRIPTION
## Fix GlobalRateLimiter singleton broken by missing cls._instance assignment

**Problem:** GlobalRateLimiter.__new__ never assigns the newly created instance back to cls._instance, so direct instantiation (bypassing get_instance()) creates a separate, unregistered object. This causes multiple independent rate limiter instances to run concurrently, defeating the singleton's purpose.

**Fix:** Add `cls._instance = instance` before `return instance` in `__new__`.

**Also:** Added `test_direct_instantiation_returns_singleton` test to explicitly cover direct `GlobalRateLimiter(...)` calls, complementing the existing `test_singleton_pattern` test that only covered `get_instance()`.

Fixes #154