### PR TITLE
Add Cloudflare Workers AI provider

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -6,6 +6,7 @@ from loguru import logger
 from config.settings import Settings
 from config.settings import get_settings as _get_settings
 from providers.base import BaseProvider, ProviderConfig
+from providers.cloudflare import CLOUDFLARE_BASE_URL_TEMPLATE, CloudflareProvider
 from providers.common import get_user_facing_error_message
 from providers.deepseek import DEEPSEEK_BASE_URL, DeepSeekProvider
 from providers.exceptions import AuthenticationError
@@ -36,6 +37,7 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
         "open_router": _get_proxy_value(settings, "open_router_proxy"),
         "lmstudio": _get_proxy_value(settings, "lmstudio_proxy"),
         "llamacpp": _get_proxy_value(settings, "llamacpp_proxy"),
+        "cloudflare": _get_proxy_value(settings, "cloudflare_proxy"),
     }
     proxy = _proxy_map.get(provider_type, "")
 
@@ -123,13 +125,41 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
             proxy=proxy,
         )
         return LlamaCppProvider(config)
-    logger.error(
-        "Unknown provider_type: '{}'. Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'",
-        provider_type,
+    if provider_type == "cloudflare":
+        if not settings.cloudflare_api_key or not settings.cloudflare_api_key.strip():
+            raise AuthenticationError(
+                "CLOUDFLARE_API_KEY is not set. Add it to your .env file. "
+                "Get a key at https://dash.cloudflare.com/profile/api-tokens"
+            )
+        if (
+            not settings.cloudflare_account_id
+            or not settings.cloudflare_account_id.strip()
+        ):
+            raise AuthenticationError(
+                "CLOUDFLARE_ACCOUNT_ID is not set. Add it to your .env file. "
+                "Find it at https://dash.cloudflare.com/ (right sidebar on any zone)"
+            )
+        config = ProviderConfig(
+            api_key=settings.cloudflare_api_key,
+            base_url=CLOUDFLARE_BASE_URL_TEMPLATE.format(
+                account_id=settings.cloudflare_account_id
+            ),
+            rate_limit=settings.provider_rate_limit,
+            rate_window=settings.provider_rate_window,
+            max_concurrency=settings.provider_max_concurrency,
+            http_read_timeout=settings.http_read_timeout,
+            http_write_timeout=settings.http_write_timeout,
+            http_connect_timeout=settings.http_connect_timeout,
+            enable_thinking=settings.enable_thinking,
+            proxy=proxy,
+        )
+        return CloudflareProvider(config)
+    supported = (
+        "'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp', 'cloudflare'"
     )
+    logger.error("Unknown provider_type: '{}'. Supported: {}", provider_type, supported)
     raise ValueError(
-        f"Unknown provider_type: '{provider_type}'. "
-        f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'"
+        f"Unknown provider_type: '{provider_type}'. Supported: {supported}"
     )
 
 

--- a/config/env.example
+++ b/config/env.example
@@ -14,9 +14,15 @@ DEEPSEEK_API_KEY=""
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
 
+# Cloudflare Workers AI Config (OpenAI-compatible endpoint)
+# Model format: cloudflare/@cf/<org>/<model>, e.g. cloudflare/@cf/moonshotai/kimi-k2.6
+CLOUDFLARE_API_KEY=""
+CLOUDFLARE_ACCOUNT_ID=""
+
+
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp"
+# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "cloudflare"
 MODEL_OPUS="nvidia_nim/z-ai/glm4.7"
 MODEL_SONNET="open_router/arcee-ai/trinity-large-preview:free"
 MODEL_HAIKU="open_router/stepfun/step-3.5-flash:free"

--- a/config/settings.py
+++ b/config/settings.py
@@ -104,6 +104,12 @@ class Settings(BaseSettings):
     # ==================== NVIDIA NIM Config ====================
     nvidia_nim_api_key: str = ""
 
+    # ==================== Cloudflare Workers AI Config ====================
+    cloudflare_api_key: str = Field(default="", validation_alias="CLOUDFLARE_API_KEY")
+    cloudflare_account_id: str = Field(
+        default="", validation_alias="CLOUDFLARE_ACCOUNT_ID"
+    )
+
     # ==================== LM Studio Config ====================
     lm_studio_base_url: str = Field(
         default="http://localhost:1234/v1",
@@ -132,6 +138,7 @@ class Settings(BaseSettings):
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
     lmstudio_proxy: str = Field(default="", validation_alias="LMSTUDIO_PROXY")
     llamacpp_proxy: str = Field(default="", validation_alias="LLAMACPP_PROXY")
+    cloudflare_proxy: str = Field(default="", validation_alias="CLOUDFLARE_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")
@@ -245,6 +252,7 @@ class Settings(BaseSettings):
             "deepseek",
             "lmstudio",
             "llamacpp",
+            "cloudflare",
         )
         if "/" not in v:
             raise ValueError(
@@ -256,7 +264,7 @@ class Settings(BaseSettings):
         if provider not in valid_providers:
             raise ValueError(
                 f"Invalid provider: '{provider}'. "
-                f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'"
+                f"Supported: {', '.join(repr(p) for p in valid_providers)}"
             )
         return v
 

--- a/providers/cloudflare/__init__.py
+++ b/providers/cloudflare/__init__.py
@@ -1,0 +1,5 @@
+"""Cloudflare Workers AI provider - OpenAI-compatible API."""
+
+from .client import CLOUDFLARE_BASE_URL_TEMPLATE, CloudflareProvider
+
+__all__ = ["CLOUDFLARE_BASE_URL_TEMPLATE", "CloudflareProvider"]

--- a/providers/cloudflare/client.py
+++ b/providers/cloudflare/client.py
@@ -1,0 +1,30 @@
+"""Cloudflare Workers AI provider implementation."""
+
+from typing import Any
+
+from providers.base import ProviderConfig
+from providers.openai_compat import OpenAICompatibleProvider
+
+from .request import build_request_body
+
+CLOUDFLARE_BASE_URL_TEMPLATE = (
+    "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
+)
+
+
+class CloudflareProvider(OpenAICompatibleProvider):
+    """Cloudflare Workers AI provider using its OpenAI-compatible endpoint."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="CLOUDFLARE",
+            base_url=config.base_url,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(self, request: Any) -> dict:
+        return build_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request),
+        )

--- a/providers/cloudflare/request.py
+++ b/providers/cloudflare/request.py
@@ -1,0 +1,38 @@
+"""Request builder for Cloudflare Workers AI provider."""
+
+from typing import Any
+
+from loguru import logger
+
+from providers.common.message_converter import build_base_request_body
+
+CLOUDFLARE_DEFAULT_MAX_TOKENS = 8192
+
+
+def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
+    """Build OpenAI-format request body from Anthropic request for Cloudflare."""
+    logger.debug(
+        "CLOUDFLARE_REQUEST: conversion start model={} msgs={}",
+        getattr(request_data, "model", "?"),
+        len(getattr(request_data, "messages", [])),
+    )
+    body = build_base_request_body(
+        request_data,
+        include_thinking=thinking_enabled,
+        default_max_tokens=CLOUDFLARE_DEFAULT_MAX_TOKENS,
+    )
+
+    extra_body: dict[str, Any] = {}
+    request_extra = getattr(request_data, "extra_body", None)
+    if request_extra:
+        extra_body.update(request_extra)
+    if extra_body:
+        body["extra_body"] = extra_body
+
+    logger.debug(
+        "CLOUDFLARE_REQUEST: conversion done model={} msgs={} tools={}",
+        body.get("model"),
+        len(body.get("messages", [])),
+        len(body.get("tools", [])),
+    )
+    return body


### PR DESCRIPTION
Adds a sixth provider that routes requests to Cloudflare's OpenAI-compatible endpoint, enabling models such as `cloudflare/@cf/moonshotai/kimi-k2.6`.

The provider reuses OpenAICompatibleProvider; the base URL is built per-request from CLOUDFLARE_ACCOUNT_ID and the key is read from CLOUDFLARE_API_KEY.