### PR TITLE
feat: make Claude Code auto-compact window configurable

### DIFF
--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -544,6 +544,18 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         restart_required=True,
     ),
     ConfigFieldSpec(
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+        "Claude Code Auto Compact Window",
+        "runtime",
+        "number",
+        settings_attr="claude_code_auto_compact_window",
+        default="190000",
+        description=(
+            "The context length (in tokens) at which Claude Code CLI automatically "
+            "triggers context compaction."
+        ),
+    ),
+    ConfigFieldSpec(
         "MESSAGING_PLATFORM",
         "Messaging Platform",
         "messaging",

--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -182,7 +182,9 @@ def _claude_child_env(
     env.pop("ANTHROPIC_API_KEY", None)
     env["ANTHROPIC_BASE_URL"] = local_proxy_root_url(settings)
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = "190000"
+    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(
+        settings.claude_code_auto_compact_window
+    )
     if token := settings.anthropic_auth_token.strip():
         env["ANTHROPIC_AUTH_TOKEN"] = token
     return env

--- a/cli/session.py
+++ b/cli/session.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from loguru import logger
 
+from config.settings import get_settings
 from core.trace import trace_event
 
 from .process_registry import kill_pid_tree_best_effort, register_pid, unregister_pid
@@ -119,7 +120,9 @@ class CLISession:
             else:
                 env["ANTHROPIC_BASE_URL"] = self.api_url
             env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = "190000"
+            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(
+                get_settings().claude_code_auto_compact_window
+            )
             env.pop("ANTHROPIC_API_KEY", None)
             if token := self.auth_token.strip():
                 env["ANTHROPIC_AUTH_TOKEN"] = token

--- a/config/settings.py
+++ b/config/settings.py
@@ -324,6 +324,11 @@ class Settings(BaseSettings):
         default=None, validation_alias="MAX_MESSAGE_LOG_ENTRIES_PER_CHAT"
     )
 
+    # ==================== Claude Code CLI Settings ====================
+    claude_code_auto_compact_window: int = Field(
+        default=190000, validation_alias="CLAUDE_CODE_AUTO_COMPACT_WINDOW"
+    )
+
     # ==================== Server ====================
     host: str = "0.0.0.0"
     port: int = 8082
@@ -403,6 +408,13 @@ class Settings(BaseSettings):
     def validate_messaging_rate_limit(cls, v: int) -> int:
         if v <= 0:
             raise ValueError("messaging_rate_limit must be > 0")
+        return v
+
+    @field_validator("claude_code_auto_compact_window")
+    @classmethod
+    def validate_claude_code_auto_compact_window(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("claude_code_auto_compact_window must be > 0")
         return v
 
     @field_validator("messaging_rate_window")

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -106,6 +106,7 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
     assert "GEMINI_API_KEY" in keys
     assert "GROQ_API_KEY" in keys
     assert "CEREBRAS_API_KEY" in keys
+    assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" in keys
     assert "ZAI_BASE_URL" not in keys
     assert "CLAUDE_WORKSPACE" not in keys
     assert "CLAUDE_CLI_BIN" not in keys

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -567,7 +567,9 @@ class TestCLISession:
         from cli.session import CLISession
         from config.settings import Settings
 
-        custom_settings = Settings(CLAUDE_CODE_AUTO_COMPACT_WINDOW=250000)
+        custom_settings = Settings.model_construct(
+            claude_code_auto_compact_window=250000
+        )
         session = CLISession(
             "/tmp", "http://localhost:8082/v1", auth_token="proxy-token"
         )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -562,6 +562,35 @@ class TestCLISession:
             assert "ANTHROPIC_AUTH_TOKEN" not in env
 
     @pytest.mark.asyncio
+    async def test_start_task_custom_auto_compact_window(self):
+        """Test start_task forwards custom CLAUDE_CODE_AUTO_COMPACT_WINDOW to Claude Code."""
+        from cli.session import CLISession
+        from config.settings import Settings
+
+        custom_settings = Settings(CLAUDE_CODE_AUTO_COMPACT_WINDOW=250000)
+        session = CLISession(
+            "/tmp", "http://localhost:8082/v1", auth_token="proxy-token"
+        )
+
+        mock_process = AsyncMock()
+        mock_process.stdout.read.side_effect = [b""]
+        mock_process.stderr.read.return_value = b""
+        mock_process.wait.return_value = 0
+
+        with (
+            patch("cli.session.get_settings", return_value=custom_settings),
+            patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec,
+        ):
+            mock_exec.return_value = mock_process
+            async for _ in session.start_task("test"):
+                pass
+
+            env = mock_exec.call_args.kwargs["env"]
+            assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "250000"
+
+    @pytest.mark.asyncio
     async def test_start_task_allowed_dirs(self):
         """Test start_task includes allowed dirs in command."""
         from cli.session import CLISession

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -14,11 +14,13 @@ def _launcher_settings(
     *,
     port: int = 8082,
     token: str = "freecc",
+    claude_code_auto_compact_window: int = 190000,
 ) -> Settings:
     return Settings.model_construct(
         host="0.0.0.0",
         port=port,
         anthropic_auth_token=token,
+        claude_code_auto_compact_window=claude_code_auto_compact_window,
     )
 
 
@@ -308,6 +310,21 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
     assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_claude_child_env_custom_auto_compact_window() -> None:
+    from cli.entrypoints import _claude_child_env
+
+    env = _claude_child_env(
+        _launcher_settings(
+            port=9090, token=" proxy-token ", claude_code_auto_compact_window=250000
+        ),
+        {
+            "PATH": "keep",
+        },
+    )
+
+    assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "250000"
 
 
 def test_claude_child_env_removes_blank_configured_auth_token() -> None:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -244,6 +244,24 @@ class TestSettings:
         settings = Settings()
         assert settings.http_connect_timeout == 5.0
 
+    def test_claude_code_auto_compact_window_from_env(self, monkeypatch):
+        """CLAUDE_CODE_AUTO_COMPACT_WINDOW env var is loaded into settings."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "300000")
+        settings = Settings()
+        assert settings.claude_code_auto_compact_window == 300000
+
+    def test_claude_code_auto_compact_window_invalid(self, monkeypatch):
+        """CLAUDE_CODE_AUTO_COMPACT_WINDOW must be > 0."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "-1")
+        with pytest.raises(
+            ValidationError, match="claude_code_auto_compact_window must be > 0"
+        ):
+            Settings()
+
     def test_http_connect_timeout_default_matches_shared_constant(
         self, monkeypatch
     ) -> None:


### PR DESCRIPTION
This PR introduces a configurable `CLAUDE_CODE_AUTO_COMPACT_WINDOW` setting. It allows users to modify the auto-compaction threshold via the Admin UI (under the Runtime section) or using environment variables. This is particularly useful for models with large context windows (like DeepSeek V4 Pro) that would otherwise compact prematurely.