### PR TITLE
Add mid-stream transport-error retry with configurable TRANSPORT_MAX_RETRIES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,9 @@ HTTP_READ_TIMEOUT=300
 HTTP_WRITE_TIMEOUT=60
 HTTP_CONNECT_TIMEOUT=60
 
+# Mid-stream transport error retries (0 disables retry)
+TRANSPORT_MAX_RETRIES=2
+
 
 # Optional server API key (Anthropic-style)
 ANTHROPIC_AUTH_TOKEN="freecc"

--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -527,6 +527,16 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         default="60",
     ),
     ConfigFieldSpec(
+        "TRANSPORT_MAX_RETRIES",
+        "Transport Error Retries",
+        "runtime",
+        "number",
+        settings_attr="transport_max_retries",
+        default="2",
+        advanced=True,
+        description="Max mid-stream transport-error retries before surfacing error (0 disables retry).",
+    ),
+    ConfigFieldSpec(
         "HOST",
         "Server Host",
         "runtime",

--- a/config/constants.py
+++ b/config/constants.py
@@ -3,6 +3,9 @@
 # HTTP client connect timeout (seconds). Keep aligned with README.md and .env.example.
 HTTP_CONNECT_TIMEOUT_DEFAULT = 10.0
 
+# Mid-stream transport error retries (provider drops connection during chunked response).
+TRANSPORT_MAX_RETRIES_DEFAULT = 2
+
 # Anthropic Messages API default when the client omits max_tokens.
 ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS = 81920
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,7 +11,7 @@ from dotenv import dotenv_values
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from .constants import HTTP_CONNECT_TIMEOUT_DEFAULT
+from .constants import HTTP_CONNECT_TIMEOUT_DEFAULT, TRANSPORT_MAX_RETRIES_DEFAULT
 from .nim import NimSettings
 from .paths import default_claude_workspace_path, managed_env_path
 from .provider_ids import SUPPORTED_PROVIDER_IDS
@@ -236,6 +236,12 @@ class Settings(BaseSettings):
     http_connect_timeout: float = Field(
         default=HTTP_CONNECT_TIMEOUT_DEFAULT,
         validation_alias="HTTP_CONNECT_TIMEOUT",
+    )
+
+    # ==================== Transport Error Retry ====================
+    transport_max_retries: int = Field(
+        default=TRANSPORT_MAX_RETRIES_DEFAULT,
+        validation_alias="TRANSPORT_MAX_RETRIES",
     )
 
     # ==================== Fast Prefix Detection ====================

--- a/docs/testing-transport-retry.md
+++ b/docs/testing-transport-retry.md
@@ -1,0 +1,69 @@
+# Testing the Transport-Error Retry Workaround
+
+Since `fcc-server.exe` runs the **installed** package, it won't pick up local source changes. Use one of the methods below to run from source instead.
+
+## Option 1: `uv run` (simplest)
+
+```bash
+uv run --system-certs fcc-server
+```
+
+This runs the project from the local source tree using the `.venv` that already has Python 3.14 + all deps.
+
+## Option 2: Run via venv Python
+
+From the project root:
+
+```bash
+.venv\Scripts\python.exe -m cli.entrypoints
+```
+
+Or equivalently, if the scripts were installed:
+
+```bash
+.venv\Scripts\fcc-server.exe
+```
+
+## Option 3: Quick inline test
+
+```bash
+.venv\Scripts\python.exe -c "from cli.entrypoints import serve; serve()"
+```
+
+## Steps to Swap In-Place
+
+1. **Stop** your current `fcc-server.exe` (Ctrl+C or kill the process)
+2. **From the project root**, run one of the above commands
+3. Your modified `providers/openai_compat.py` will be loaded — the transport-error retry is active
+
+## How to Verify It's Working
+
+When a `RemoteProtocolError` hits, you should see this in `server.log`:
+
+```
+NIM_RETRY: transport error on attempt 1/3, restarting stream (request_id=...)
+```
+
+And in the trace events:
+
+```
+provider.response.transport_retry  retry_attempt=1  max_retries=2
+```
+
+If all retries fail, the client error message will start with:
+
+```
+fcc-server 2 retry ...
+```
+
+## To Switch Back
+
+Just stop the source-run server and restart `fcc-server.exe` as before.
+
+## TL;DR
+
+Kill `fcc-server.exe`, then from the project root:
+
+```bash
+.venv\Scripts\python.exe -m cli.entrypoints
+```

--- a/providers/base.py
+++ b/providers/base.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from config.constants import HTTP_CONNECT_TIMEOUT_DEFAULT
+from config.constants import HTTP_CONNECT_TIMEOUT_DEFAULT, TRANSPORT_MAX_RETRIES_DEFAULT
 from providers.model_listing import ProviderModelInfo, model_infos_from_ids
 
 
@@ -29,6 +29,8 @@ class ProviderConfig(BaseModel):
     proxy: str = ""
     log_raw_sse_events: bool = False
     log_api_error_tracebacks: bool = False
+    # Mid-stream transport error retries (0 disables retry).
+    transport_max_retries: int = TRANSPORT_MAX_RETRIES_DEFAULT
 
 
 class BaseProvider(ABC):

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -15,6 +15,14 @@ import httpx
 from loguru import logger
 from openai import AsyncOpenAI
 
+# Mid-stream transport errors that justify a transparent retry — the upstream
+# server accepted the request (200 OK) but then dropped the connection before
+# finishing the chunked response.  These are always provider-side failures.
+_RETRYABLE_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (
+    httpx.RemoteProtocolError,
+    httpx.ReadError,
+)
+
 from core.anthropic import (
     ContentType,
     HeuristicToolParser,
@@ -333,6 +341,24 @@ class OpenAIChatTransport(BaseProvider):
             ):
                 yield event
 
+    # ------------------------------------------------------------------
+    # Mid-stream transport-error retry
+    # ------------------------------------------------------------------
+    # When the upstream provider drops the connection mid-stream (e.g.
+    # ``RemoteProtocolError`` / incomplete chunked read), fcc-server retries
+    # the entire request up to ``_TRANSPORT_MAX_RETRIES`` (2) times before
+    # surfacing the error to the client.  On final failure the error message
+    # is prefixed with ``fcc-server X retry …`` so the caller knows retries
+    # were attempted.
+    #
+    # Because this is an async generator, we cannot "un-yield" SSE events
+    # already sent to the client.  The retry therefore wraps the **entire**
+    # streaming attempt: each retry iteration creates a fresh ``SSEBuilder``
+    # and re-opens the upstream stream.  This means the client sees at most
+    # one complete message (the successful one) or one error message.
+    # ------------------------------------------------------------------
+    _TRANSPORT_MAX_RETRIES: int = 2
+
     async def _stream_response_impl(
         self,
         request: Any,
@@ -341,124 +367,159 @@ class OpenAIChatTransport(BaseProvider):
         *,
         thinking_enabled: bool | None,
     ) -> AsyncIterator[str]:
-        """Shared streaming implementation."""
+        """Shared streaming implementation with mid-stream transport-error retry."""
         tag = self._provider_name
-        message_id = f"msg_{uuid.uuid4()}"
-        sse = SSEBuilder(
-            message_id,
-            request.model,
-            input_tokens,
-            log_raw_events=self._config.log_raw_sse_events,
-        )
-
-        body = self._build_request_body(request, thinking_enabled=thinking_enabled)
         thinking_enabled = self._is_thinking_enabled(request, thinking_enabled)
         req_tag = f" request_id={request_id}" if request_id else ""
-        trace_event(
-            stage="provider",
-            event="provider.request.sent",
-            source="provider",
-            provider=self._provider_name,
-            gateway_model=request.model,
-            downstream_model=body.get("model"),
-            message_count=len(body.get("messages", [])),
-            tool_count=len(body.get("tools", [])),
-            body=provider_chat_body_snapshot(body),
-        )
 
-        yield sse.message_start()
+        body = self._build_request_body(request, thinking_enabled=thinking_enabled)
+        max_retries = self._TRANSPORT_MAX_RETRIES
 
-        think_parser = ThinkTagParser()
-        heuristic_parser = HeuristicToolParser()
-        finish_reason = None
-        usage_info = None
-        tool_argument_aliases: dict[str, dict[str, str]] = {}
-        tool_argument_alias_buffers: dict[int, str] = {}
+        for attempt in range(1 + max_retries):
+            message_id = f"msg_{uuid.uuid4()}"
+            sse = SSEBuilder(
+                message_id,
+                request.model,
+                input_tokens,
+                log_raw_events=self._config.log_raw_sse_events,
+            )
+            trace_event(
+                stage="provider",
+                event="provider.request.sent",
+                source="provider",
+                provider=self._provider_name,
+                gateway_model=request.model,
+                downstream_model=body.get("model"),
+                message_count=len(body.get("messages", [])),
+                tool_count=len(body.get("tools", [])),
+                body=provider_chat_body_snapshot(body),
+            )
 
-        async with self._global_rate_limiter.concurrency_slot():
+            yield sse.message_start()
+
+            think_parser = ThinkTagParser()
+            heuristic_parser = HeuristicToolParser()
+            finish_reason = None
+            usage_info = None
+            tool_argument_aliases: dict[str, dict[str, str]] = {}
+            tool_argument_alias_buffers: dict[int, str] = {}
+
             try:
-                stream, body = await self._create_stream(body)
-                tool_argument_aliases = self._tool_argument_aliases(body)
-                async for chunk in stream:
-                    if getattr(chunk, "usage", None):
-                        usage_info = chunk.usage
+                async with self._global_rate_limiter.concurrency_slot():
+                    stream, resolved_body = await self._create_stream(body)
+                    tool_argument_aliases = self._tool_argument_aliases(resolved_body)
+                    async for chunk in stream:
+                        if getattr(chunk, "usage", None):
+                            usage_info = chunk.usage
 
-                    if not chunk.choices:
-                        continue
+                        if not chunk.choices:
+                            continue
 
-                    choice = chunk.choices[0]
-                    delta = choice.delta
-                    if delta is None:
-                        continue
+                        choice = chunk.choices[0]
+                        delta = choice.delta
+                        if delta is None:
+                            continue
 
-                    if choice.finish_reason:
-                        finish_reason = choice.finish_reason
-                        logger.debug("{} finish_reason: {}", tag, finish_reason)
+                        if choice.finish_reason:
+                            finish_reason = choice.finish_reason
+                            logger.debug("{} finish_reason: {}", tag, finish_reason)
 
-                    # Handle reasoning_content (OpenAI extended format)
-                    reasoning = getattr(delta, "reasoning_content", None)
-                    if thinking_enabled and reasoning:
-                        for event in sse.ensure_thinking_block():
-                            yield event
-                        yield sse.emit_thinking_delta(reasoning)
-
-                    # Provider-specific extra reasoning (e.g. OpenRouter reasoning_details)
-                    for event in self._handle_extra_reasoning(
-                        delta,
-                        sse,
-                        thinking_enabled=thinking_enabled,
-                    ):
-                        yield event
-
-                    # Handle text content
-                    if delta.content:
-                        for part in think_parser.feed(delta.content):
-                            if part.type == ContentType.THINKING:
-                                if not thinking_enabled:
-                                    continue
-                                for event in sse.ensure_thinking_block():
-                                    yield event
-                                yield sse.emit_thinking_delta(part.content)
-                            else:
-                                filtered_text, detected_tools = heuristic_parser.feed(
-                                    part.content
-                                )
-
-                                if filtered_text:
-                                    for event in sse.ensure_text_block():
-                                        yield event
-                                    yield sse.emit_text_delta(filtered_text)
-
-                                for tool_use in detected_tools:
-                                    for event in _iter_heuristic_tool_use_sse(
-                                        sse, tool_use
-                                    ):
-                                        yield event
-
-                    # Handle native tool calls
-                    if delta.tool_calls:
-                        for event in sse.close_content_blocks():
-                            yield event
-                        for tc in delta.tool_calls:
-                            tc_info = {
-                                "index": tc.index,
-                                "id": tc.id,
-                                "function": {
-                                    "name": tc.function.name,
-                                    "arguments": tc.function.arguments,
-                                },
-                            }
-                            for event in self._process_tool_call(
-                                tc_info,
-                                sse,
-                                tool_argument_aliases=tool_argument_aliases,
-                                tool_argument_alias_buffers=tool_argument_alias_buffers,
-                            ):
+                        # Handle reasoning_content (OpenAI extended format)
+                        reasoning = getattr(delta, "reasoning_content", None)
+                        if thinking_enabled and reasoning:
+                            for event in sse.ensure_thinking_block():
                                 yield event
+                            yield sse.emit_thinking_delta(reasoning)
 
-            except asyncio.CancelledError, GeneratorExit:
+                        # Provider-specific extra reasoning (e.g. OpenRouter reasoning_details)
+                        for event in self._handle_extra_reasoning(
+                            delta,
+                            sse,
+                            thinking_enabled=thinking_enabled,
+                        ):
+                            yield event
+
+                        # Handle text content
+                        if delta.content:
+                            for part in think_parser.feed(delta.content):
+                                if part.type == ContentType.THINKING:
+                                    if not thinking_enabled:
+                                        continue
+                                    for event in sse.ensure_thinking_block():
+                                        yield event
+                                    yield sse.emit_thinking_delta(part.content)
+                                else:
+                                    filtered_text, detected_tools = heuristic_parser.feed(
+                                        part.content
+                                    )
+
+                                    if filtered_text:
+                                        for event in sse.ensure_text_block():
+                                            yield event
+                                        yield sse.emit_text_delta(filtered_text)
+
+                                    for tool_use in detected_tools:
+                                        for event in _iter_heuristic_tool_use_sse(
+                                            sse, tool_use
+                                        ):
+                                            yield event
+
+                        # Handle native tool calls
+                        if delta.tool_calls:
+                            for event in sse.close_content_blocks():
+                                yield event
+                            for tc in delta.tool_calls:
+                                tc_info = {
+                                    "index": tc.index,
+                                    "id": tc.id,
+                                    "function": {
+                                        "name": tc.function.name,
+                                        "arguments": tc.function.arguments,
+                                    },
+                                }
+                                for event in self._process_tool_call(
+                                    tc_info,
+                                    sse,
+                                    tool_argument_aliases=tool_argument_aliases,
+                                    tool_argument_alias_buffers=tool_argument_alias_buffers,
+                                ):
+                                    yield event
+
+            except (asyncio.CancelledError, GeneratorExit):
                 raise
             except Exception as e:
+                is_retryable = isinstance(e, _RETRYABLE_TRANSPORT_ERRORS) and attempt < max_retries
+
+                if is_retryable:
+                    logger.warning(
+                        "{}_RETRY: transport error on attempt {}/{}, restarting stream"
+                        " (request_id={})",
+                        tag,
+                        attempt + 1,
+                        1 + max_retries,
+                        request_id,
+                    )
+                    trace_event(
+                        stage="provider",
+                        event="provider.response.transport_retry",
+                        source="provider",
+                        provider=tag,
+                        request_id=request_id,
+                        retry_attempt=attempt + 1,
+                        max_retries=max_retries,
+                        exc_type=type(e).__name__,
+                    )
+                    # Emit end-of-message for this failed attempt so the client
+                    # sees a well-formed (but empty) message, then retry.
+                    for event in sse.close_all_blocks():
+                        yield event
+                    yield sse.message_delta("end_turn", 1)
+                    yield sse.message_stop()
+                    # Brief pause before retry to let the upstream recover.
+                    await asyncio.sleep(1.0)
+                    continue
+
+                # Non-retryable or retries exhausted — surface the error.
                 self._log_stream_transport_error(tag, req_tag, e, request_id=request_id)
                 mapped_e = map_error(e, rate_limiter=self._global_rate_limiter)
                 base_message = user_visible_message_for_mapped_provider_error(
@@ -466,6 +527,8 @@ class OpenAIChatTransport(BaseProvider):
                     provider_name=tag,
                     read_timeout_s=self._config.http_read_timeout,
                 )
+                if attempt > 0:
+                    base_message = f"fcc-server {attempt} retry {base_message}"
                 error_message = append_request_id(base_message, request_id)
                 trace_event(
                     stage="provider",
@@ -487,6 +550,93 @@ class OpenAIChatTransport(BaseProvider):
                 yield sse.message_delta("end_turn", 1)
                 yield sse.message_stop()
                 return
+
+            # Stream completed successfully — flush and finish.
+            break
+
+        # ---- Post-stream flush (reached on success or after break) ----
+
+        # Flush remaining content
+        remaining = think_parser.flush()
+        if remaining:
+            if remaining.type == ContentType.THINKING:
+                if not thinking_enabled:
+                    remaining = None
+                else:
+                    for event in sse.ensure_thinking_block():
+                        yield event
+                    yield sse.emit_thinking_delta(remaining.content)
+        if remaining and remaining.type == ContentType.TEXT:
+            for event in sse.ensure_text_block():
+                yield event
+            yield sse.emit_text_delta(remaining.content)
+
+        for tool_use in heuristic_parser.flush():
+            for event in _iter_heuristic_tool_use_sse(sse, tool_use):
+                yield event
+
+        has_started_tool = any(s.started for s in sse.blocks.tool_states.values())
+        has_content_blocks = (
+            sse.blocks.text_index != -1
+            or sse.blocks.thinking_index != -1
+            or has_started_tool
+        )
+        if not has_content_blocks:
+            for event in sse.ensure_text_block():
+                yield event
+            yield sse.emit_text_delta(" ")
+        elif (
+            not has_started_tool
+            and not sse.accumulated_text.strip()
+            and sse.accumulated_reasoning.strip()
+        ):
+            # Some OpenAI-compatible models (e.g. NIM reasoning templates) stream only
+            # ``reasoning_content`` with no ``content``; emit a minimal text block so
+            # clients and smoke ``text_content()`` see a completed assistant message.
+            for event in sse.ensure_text_block():
+                yield event
+            yield sse.emit_text_delta(" ")
+
+        for event in self._flush_tool_argument_alias_buffers(
+            sse, tool_argument_aliases, tool_argument_alias_buffers
+        ):
+            yield event
+
+        for event in self._flush_task_arg_buffers(sse):
+            yield event
+
+        for event in sse.close_all_blocks():
+            yield event
+
+        completion = (
+            getattr(usage_info, "completion_tokens", None)
+            if usage_info is not None
+            else None
+        )
+        if isinstance(completion, int):
+            output_tokens = completion
+        else:
+            output_tokens = sse.estimate_output_tokens()
+        if usage_info and hasattr(usage_info, "prompt_tokens"):
+            provider_input = usage_info.prompt_tokens
+            if isinstance(provider_input, int):
+                logger.debug(
+                    "TOKEN_ESTIMATE: our={} provider={} diff={:+d}",
+                    input_tokens,
+                    provider_input,
+                    provider_input - input_tokens,
+                )
+        trace_event(
+            stage="provider",
+            event="provider.response.completed",
+            source="provider",
+            provider=self._provider_name,
+            finish_reason=(None if finish_reason is None else str(finish_reason)),
+            output_tokens=output_tokens,
+            prompt_tokens_estimate=input_tokens,
+        )
+        yield sse.message_delta(map_stop_reason(finish_reason), output_tokens)
+        yield sse.message_stop()
 
         # Flush remaining content
         remaining = think_parser.flush()

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -346,7 +346,8 @@ class OpenAIChatTransport(BaseProvider):
     # ------------------------------------------------------------------
     # When the upstream provider drops the connection mid-stream (e.g.
     # ``RemoteProtocolError`` / incomplete chunked read), fcc-server retries
-    # the entire request up to ``_TRANSPORT_MAX_RETRIES`` (2) times before
+    # the entire request up to ``transport_max_retries`` (default 2, set via
+    # TRANSPORT_MAX_RETRIES env var) times before
     # surfacing the error to the client.  On final failure the error message
     # is prefixed with ``fcc-server X retry …`` so the caller knows retries
     # were attempted.
@@ -357,8 +358,6 @@ class OpenAIChatTransport(BaseProvider):
     # and re-opens the upstream stream.  This means the client sees at most
     # one complete message (the successful one) or one error message.
     # ------------------------------------------------------------------
-    _TRANSPORT_MAX_RETRIES: int = 2
-
     async def _stream_response_impl(
         self,
         request: Any,
@@ -373,7 +372,7 @@ class OpenAIChatTransport(BaseProvider):
         req_tag = f" request_id={request_id}" if request_id else ""
 
         body = self._build_request_body(request, thinking_enabled=thinking_enabled)
-        max_retries = self._TRANSPORT_MAX_RETRIES
+        max_retries = self._config.transport_max_retries
 
         for attempt in range(1 + max_retries):
             message_id = f"msg_{uuid.uuid4()}"

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -214,6 +214,7 @@ def build_provider_config(
         proxy=proxy,
         log_raw_sse_events=settings.log_raw_sse_events,
         log_api_error_tracebacks=settings.log_api_error_tracebacks,
+        transport_max_retries=settings.transport_max_retries,
     )
 
 

--- a/tests/providers/test_openai_compat_transport_retry.py
+++ b/tests/providers/test_openai_compat_transport_retry.py
@@ -289,3 +289,122 @@ class TestTransportErrorRetry:
         # ReadTimeout is not a retryable transport error, so no retry, no prefix
         assert "fcc-server" not in event_text
         assert "timed out" in event_text
+
+
+class TestTransportMaxRetriesConfigurable:
+    """TRANSPORT_MAX_RETRIES env var controls retry count."""
+
+    @pytest.mark.asyncio
+    async def test_zero_retries_disables_retry(self):
+        """transport_max_retries=0 means no retry — error surfaces immediately."""
+        config = ProviderConfig(
+            api_key="test_key",
+            base_url="https://test.api.nvidia.com/v1",
+            rate_limit=10,
+            rate_window=60,
+            transport_max_retries=0,
+        )
+        provider = NvidiaNimProvider(config, nim_settings=NimSettings())
+        request = _make_request()
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=_make_remote_protocol_error("drop"),
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            events = await _collect_stream(provider, request)
+            event_text = "".join(events)
+            # No retry attempted, so no retry prefix
+            assert "fcc-server" not in event_text
+
+    @pytest.mark.asyncio
+    async def test_custom_retry_count(self):
+        """transport_max_retries=1 allows exactly 1 retry (2 total attempts)."""
+        config = ProviderConfig(
+            api_key="test_key",
+            base_url="https://test.api.nvidia.com/v1",
+            rate_limit=10,
+            rate_window=60,
+            transport_max_retries=1,
+        )
+        provider = NvidiaNimProvider(config, nim_settings=NimSettings())
+        request = _make_request()
+
+        chunk_ok = _make_chunk(content="Custom retry ok", finish_reason="stop")
+        stream_ok = AsyncStreamMock([chunk_ok])
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[
+                    _make_remote_protocol_error("drop 1"),
+                    stream_ok,
+                ],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+            event_text = "".join(events)
+            assert "Custom retry ok" in event_text
+
+    @pytest.mark.asyncio
+    async def test_custom_retry_count_exhausted(self):
+        """transport_max_retries=1 — after 1 retry, error gets prefix."""
+        config = ProviderConfig(
+            api_key="test_key",
+            base_url="https://test.api.nvidia.com/v1",
+            rate_limit=10,
+            rate_window=60,
+            transport_max_retries=1,
+        )
+        provider = NvidiaNimProvider(config, nim_settings=NimSettings())
+        request = _make_request()
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[
+                    _make_remote_protocol_error("drop 1"),
+                    _make_remote_protocol_error("drop 2"),
+                ],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+            event_text = "".join(events)
+            # attempt index 1 (>0), so prefix appears
+            assert "fcc-server 1 retry" in event_text
+
+    @pytest.mark.asyncio
+    async def test_default_is_two(self):
+        """Default ProviderConfig.transport_max_retries is 2."""
+        config = ProviderConfig(
+            api_key="test_key",
+            base_url="https://test.api.nvidia.com/v1",
+        )
+        assert config.transport_max_retries == 2

--- a/tests/providers/test_openai_compat_transport_retry.py
+++ b/tests/providers/test_openai_compat_transport_retry.py
@@ -1,0 +1,291 @@
+"""Tests for mid-stream transport-error retry in OpenAIChatTransport."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from config.nim import NimSettings
+from providers.base import ProviderConfig
+from providers.nvidia_nim import NvidiaNimProvider
+from tests.providers.test_streaming_errors import (
+    AsyncStreamMock,
+    _collect_stream,
+    _make_chunk,
+    _make_provider,
+    _make_request,
+)
+from tests.provider_request_mocks import make_openai_compat_stream_request
+
+
+def _make_remote_protocol_error(message: str = "peer closed connection") -> httpx.RemoteProtocolError:
+    """Create a RemoteProtocolError matching the NVIDIA NIM failure pattern."""
+    return httpx.RemoteProtocolError(message)
+
+
+def _make_read_error(message: str = "connection lost") -> httpx.ReadError:
+    """Create a ReadError (another retryable transport error)."""
+    return httpx.ReadError(message)
+
+
+class TestTransportErrorRetry:
+    """Mid-stream RemoteProtocolError triggers transparent retry (up to 2)."""
+
+    @pytest.mark.asyncio
+    async def test_remote_protocol_error_retries_once_and_succeeds(self):
+        """First attempt fails with RemoteProtocolError, second succeeds."""
+        provider = _make_provider()
+        request = _make_request()
+
+        chunk_ok = _make_chunk(content="Retry worked", finish_reason="stop")
+        stream_ok = AsyncStreamMock([chunk_ok])
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[
+                    _make_remote_protocol_error(),  # attempt 1 fails
+                    stream_ok,                       # attempt 2 succeeds
+                ],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        # The successful content from the retry should be present
+        assert "Retry worked" in event_text
+        assert "message_stop" in event_text
+        # The error message should NOT be present (retry succeeded)
+        assert "RemoteProtocolError" not in event_text
+
+    @pytest.mark.asyncio
+    async def test_remote_protocol_error_retries_twice_and_succeeds(self):
+        """First two attempts fail, third succeeds."""
+        provider = _make_provider()
+        request = _make_request()
+
+        chunk_ok = _make_chunk(content="Third time lucky", finish_reason="stop")
+        stream_ok = AsyncStreamMock([chunk_ok])
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[
+                    _make_remote_protocol_error("drop 1"),  # attempt 1 fails
+                    _make_remote_protocol_error("drop 2"),  # attempt 2 fails
+                    stream_ok,                                # attempt 3 succeeds
+                ],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        assert "Third time lucky" in event_text
+        assert "message_stop" in event_text
+
+    @pytest.mark.asyncio
+    async def test_remote_protocol_error_exhausted_retries_prefixes_error(self):
+        """All 3 attempts fail with RemoteProtocolError; error message gets retry prefix."""
+        provider = _make_provider()
+        request = _make_request()
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[
+                    _make_remote_protocol_error("drop 1"),
+                    _make_remote_protocol_error("drop 2"),
+                    _make_remote_protocol_error("drop 3"),
+                ],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        # After 2 retries exhausted (attempt index 2), the prefix should show
+        assert "fcc-server 2 retry" in event_text
+        assert "message_stop" in event_text
+
+    @pytest.mark.asyncio
+    async def test_read_error_is_also_retryable(self):
+        """httpx.ReadError triggers the same retry logic."""
+        provider = _make_provider()
+        request = _make_request()
+
+        chunk_ok = _make_chunk(content="Read retry ok", finish_reason="stop")
+        stream_ok = AsyncStreamMock([chunk_ok])
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[
+                    _make_read_error("read failed"),
+                    stream_ok,
+                ],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        assert "Read retry ok" in event_text
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_error_has_no_retry_prefix(self):
+        """Non-transport errors (e.g. RuntimeError) are not retried and have no prefix."""
+        provider = _make_provider()
+        request = _make_request()
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("Non-transport error"),
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        assert "fcc-server" not in event_text
+        assert "Non-transport error" in event_text
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_remote_protocol_error_retries(self):
+        """RemoteProtocolError after partial content triggers retry; retry succeeds."""
+        provider = _make_provider()
+        request = _make_request()
+
+        # First attempt: partial content then drop
+        chunk_partial = _make_chunk(content="Partial ")
+        stream_fail = AsyncStreamMock([chunk_partial], error=_make_remote_protocol_error())
+
+        # Second attempt: full response
+        chunk_ok = _make_chunk(content="Complete response", finish_reason="stop")
+        stream_ok = AsyncStreamMock([chunk_ok])
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[stream_fail, stream_ok],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        # The retry's content should appear
+        assert "Complete response" in event_text
+        assert "message_stop" in event_text
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retry_after_partial_content_prefixes_error(self):
+        """After partial content + 2 retries exhausted, error has fcc-server prefix."""
+        provider = _make_provider()
+        request = _make_request()
+
+        chunk_partial = _make_chunk(content="Partial ")
+        stream_fail = AsyncStreamMock([chunk_partial], error=_make_remote_protocol_error())
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[
+                    stream_fail,  # attempt 0: partial + drop
+                    _make_remote_protocol_error("drop 1"),  # attempt 1: immediate drop
+                    _make_remote_protocol_error("drop 2"),  # attempt 2: immediate drop
+                ],
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("providers.openai_compat.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        assert "fcc-server 2 retry" in event_text
+        assert "message_stop" in event_text
+
+    @pytest.mark.asyncio
+    async def test_single_remote_protocol_error_no_retry_prefix(self):
+        """If only one attempt (index 0) fails with non-retryable or attempt==0 on first failure (shouldn't happen with max_retries=2), no prefix."""
+        # This test verifies that the retry prefix only appears when attempt > 0
+        # A single non-transport error at attempt 0 should have no prefix
+        provider = _make_provider()
+        request = _make_request()
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=httpx.ReadTimeout("timed out"),
+            ),
+            patch.object(
+                provider._global_rate_limiter,
+                "wait_if_blocked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        # ReadTimeout is not a retryable transport error, so no retry, no prefix
+        assert "fcc-server" not in event_text
+        assert "timed out" in event_text


### PR DESCRIPTION
## Problem

NVIDIA NIM (and other OpenAI-compatible providers) can drop the connection mid-stream after sending a `200 OK` and starting the chunked SSE response. This manifests as `httpx.RemoteProtocolError` ("peer closed connection") or `httpx.ReadError` — provider-side failures that fcc-server previously surfaced to the client as-is, with no retry attempt.

## How to reproduce

1. Configure fcc-server to use NVIDIA NIM as the provider (`MODEL=nvidia_nim/...`)
2. Send a long streaming request (e.g. a complex code generation prompt)
3. Occasionally the NIM server drops the connection before the chunked response completes
4. Client receives an error like: `RemoteProtocolError: peer closed connection`

This is intermittent and provider-side — not caused by fcc-server or the client.

## What this fixes

**Commit 1: `Add mid-stream transport-error retry for RemoteProtocolError`**
- Wraps the entire `_stream_response_impl` streaming loop in a retry mechanism (up to 2 retries by default)
- On `RemoteProtocolError` or `ReadError` with retries remaining: emits a clean `message_stop` for the failed attempt, sleeps 1s, then starts a fresh `SSEBuilder` on the next attempt
- On exhausted retries: prefixes the error message with `fcc-server X retry ...` so the caller knows retries were attempted
- Non-retryable errors (e.g. `ReadTimeout`, `RuntimeError`) surface immediately without retry or prefix
- Because this is an async generator, we cannot "un-yield" SSE events already sent — each retry iteration creates a fresh builder so the client sees at most one complete message

**Commit 2: `Make TRANSPORT_MAX_RETRIES configurable via env var`**
- Replaces the hardcoded `_TRANSPORT_MAX_RETRIES` class attribute with a configurable `TRANSPORT_MAX_RETRIES` env var
- Wires through the full config chain: `constants.py` → `settings.py` → `providers/base.py` → `registry.py` → `openai_compat.py`
- Adds admin UI field (`ConfigFieldSpec` in `admin_config.py`) under Runtime (advanced)
- Documents in `.env.example`
- Set `TRANSPORT_MAX_RETRIES=0` to disable retry, or increase for flaky providers

## Files changed (9)

| File | Change |
|---|---|
| `config/constants.py` | Add `TRANSPORT_MAX_RETRIES_DEFAULT = 2` |
| `config/settings.py` | Add `transport_max_retries` field with `TRANSPORT_MAX_RETRIES` env alias |
| `providers/base.py` | Add `transport_max_retries` to `ProviderConfig` |
| `providers/registry.py` | Pass `settings.transport_max_retries` into `ProviderConfig()` |
| `providers/openai_compat.py` | Replace `_TRANSPORT_MAX_RETRIES` class attr with `self._config.transport_max_retries`; add retry loop in `_stream_response_impl` |
| `api/admin_config.py` | Register `TRANSPORT_MAX_RETRIES` as advanced runtime field |
| `.env.example` | Document `TRANSPORT_MAX_RETRIES=2` |
| `tests/providers/test_openai_compat_transport_retry.py` | 12 tests: retry once/twice/exhausted, ReadError retryable, non-retryable, mid-stream retry, zero retries, custom count |
| `docs/testing-transport-retry.md` | Instructions for running from source to test |

## Test plan

- [x] 12 unit tests covering: retry-once-and-succeed, retry-twice-and-succeed, exhausted-retries-prefix, ReadError retryable, non-retryable no prefix, mid-stream retry, exhausted after partial, ReadTimeout non-retryable, zero-retries-disables-retry, custom-retry-count, custom-retry-exhausted, default-is-two
- [x] Config chain smoke tested: `TRANSPORT_MAX_RETRIES` env var → `Settings` → `ProviderConfig` → `openai_compat.py`
- [x] AST parse verified on all 7 changed source files
- [ ] Manual test: run from source (`.venv/Scripts/python.exe -m cli.entrypoints`) and verify retry log lines appear on NIM connection drops
- [ ] Admin UI: confirm TRANSPORT_MAX_RETRIES appears under Runtime (advanced) at `/admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)