### PR TITLE
fcc-claude: manage the proxy lifecycle and stop it on exit

### DIFF
--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import subprocess
@@ -30,6 +31,8 @@ from config.settings import Settings, get_settings
 PROXY_PREFLIGHT_PATH = "/health"
 PROXY_PREFLIGHT_TIMEOUT_SECONDS = 1.5
 SERVER_GRACEFUL_SHUTDOWN_SECONDS = 5
+SERVER_READY_TIMEOUT_SECONDS = 30.0
+SERVER_READY_POLL_INTERVAL_SECONDS = 0.15
 
 
 def _load_env_template() -> str:
@@ -208,18 +211,119 @@ def _preflight_proxy(proxy_root_url: str) -> str | None:
     return None
 
 
-def launch_claude(argv: Sequence[str] | None = None) -> None:
-    """Launch Claude Code with Free Claude Code proxy environment variables."""
+def _auto_server_enabled() -> bool:
+    """Whether fcc-claude may start its own proxy when none is reachable (FCC_AUTO_SERVER)."""
 
-    settings = get_settings()
-    proxy_root_url = local_proxy_root_url(settings)
-    if error := _preflight_proxy(proxy_root_url):
+    raw = os.environ.get("FCC_AUTO_SERVER", "true").strip().lower()
+    return raw not in {"", "0", "false", "no"}
+
+
+def _managed_server_log_path() -> Path:
+    """Return the log file a fcc-claude-owned proxy writes to."""
+
+    return config_dir_path() / "managed-server.log"
+
+
+def _spawn_managed_server(base_env: Mapping[str, str]) -> subprocess.Popen[bytes]:
+    """Start a background proxy this CLI owns; suppress its browser and tee logs to a file."""
+
+    env = dict(base_env)
+    env["FCC_OPEN_BROWSER"] = "0"
+    command = [sys.executable, "-c", "from cli.entrypoints import serve; serve()"]
+    log_path = _managed_server_log_path()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return subprocess.Popen(
+            command,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    # ``with`` closes the parent's handle once the child has inherited the fd.
+    with open(log_path, "ab") as log_file:
+        return subprocess.Popen(command, env=env, stdout=log_file, stderr=log_file)
+
+
+def _wait_for_proxy_ready(
+    proxy_root_url: str,
+    process: subprocess.Popen[bytes],
+    timeout_seconds: float,
+) -> str | None:
+    """Poll /health until the managed proxy answers; return an error message on failure."""
+
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            return f"proxy process exited early with code {process.returncode}"
+        if _preflight_proxy(proxy_root_url) is None:
+            return None
+        time.sleep(SERVER_READY_POLL_INTERVAL_SECONDS)
+    return f"proxy did not become reachable within {timeout_seconds:.0f}s"
+
+
+def _stop_managed_server(process: subprocess.Popen[bytes]) -> None:
+    """Gracefully stop a CLI-owned proxy: SIGTERM, wait, then force-kill the tree."""
+
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=SERVER_GRACEFUL_SHUTDOWN_SECONDS + 2)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    if process.pid:
+        kill_pid_tree_best_effort(process.pid)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=3)
+
+
+def _ensure_proxy_running(proxy_root_url: str) -> subprocess.Popen[bytes] | None:
+    """Make sure a proxy is reachable; return a process only when this CLI started one.
+
+    A proxy that already answers is reused and left untouched (returns ``None``).
+    Otherwise, unless ``FCC_AUTO_SERVER`` disables it, start one, wait for it to
+    become healthy, and return it so the caller can stop it when the session ends.
+    """
+
+    if _preflight_proxy(proxy_root_url) is None:
+        return None
+
+    if not _auto_server_enabled():
         print(
-            f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
+            f"Free Claude Code proxy is not reachable at {proxy_root_url}.",
             file=sys.stderr,
         )
         print("Start it in another terminal with: fcc-server", file=sys.stderr)
+        print(
+            "(or set FCC_AUTO_SERVER=1 to let fcc-claude start the proxy automatically)",
+            file=sys.stderr,
+        )
         raise SystemExit(1)
+
+    print(f"Starting Free Claude Code proxy at {proxy_root_url} ...", file=sys.stderr)
+    process = _spawn_managed_server(os.environ)
+    if process.pid:
+        register_pid(process.pid)
+    if error := _wait_for_proxy_ready(
+        proxy_root_url, process, SERVER_READY_TIMEOUT_SECONDS
+    ):
+        print(f"Could not start proxy at {proxy_root_url}: {error}", file=sys.stderr)
+        print(f"See {_managed_server_log_path()} for details.", file=sys.stderr)
+        _stop_managed_server(process)
+        if process.pid:
+            unregister_pid(process.pid)
+        raise SystemExit(1)
+    print("Proxy ready; it will stop when this session ends.", file=sys.stderr)
+    return process
+
+
+def _run_claude_client(settings: Settings, argv: Sequence[str] | None) -> None:
+    """Spawn the Claude Code CLI against the proxy and propagate its exit code."""
 
     args = list(sys.argv[1:] if argv is None else argv)
     claude_command = shutil.which(settings.claude_cli_bin)
@@ -262,3 +366,25 @@ def launch_claude(argv: Sequence[str] | None = None) -> None:
             unregister_pid(process.pid)
 
     raise SystemExit(return_code)
+
+
+def launch_claude(argv: Sequence[str] | None = None) -> None:
+    """Launch Claude Code with Free Claude Code proxy environment variables.
+
+    When no proxy is reachable, start one this CLI owns and tear it down when the
+    session ends (interactive or one-shot ``-p`` runs alike), unless
+    ``FCC_AUTO_SERVER`` disables auto-start. A proxy that is already running — for
+    example a separately launched ``fcc-server`` — is reused and left running.
+    """
+
+    settings = get_settings()
+    proxy_root_url = local_proxy_root_url(settings)
+
+    managed_server = _ensure_proxy_running(proxy_root_url)
+    try:
+        _run_claude_client(settings, argv)
+    finally:
+        if managed_server is not None:
+            _stop_managed_server(managed_server)
+            if managed_server.pid:
+                unregister_pid(managed_server.pid)

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -409,22 +409,162 @@ def test_launch_claude_exits_when_command_cannot_be_resolved(
     assert "npm install -g @anthropic-ai/claude-code" in captured.err
 
 
-def test_launch_claude_unreachable_proxy_exits_with_hint(
+def test_launch_claude_unreachable_proxy_exits_with_hint_when_autostart_disabled(
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("FCC_AUTO_SERVER", "0")
     from cli.entrypoints import launch_claude
 
     settings = _launcher_settings(port=9393)
     with (
         patch("cli.entrypoints.get_settings", return_value=settings),
         patch("cli.entrypoints._preflight_proxy", return_value="connection refused"),
-        patch("cli.entrypoints.subprocess.run") as run,
+        patch("cli.entrypoints.subprocess.Popen") as popen,
         pytest.raises(SystemExit) as exc_info,
     ):
         launch_claude([])
 
     assert exc_info.value.code == 1
-    run.assert_not_called()
+    popen.assert_not_called()
     captured = capsys.readouterr()
     assert "http://127.0.0.1:9393" in captured.err
     assert "fcc-server" in captured.err
+
+
+def test_launch_claude_auto_starts_and_stops_managed_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no proxy answers, fcc-claude starts one and stops it on exit."""
+    monkeypatch.delenv("FCC_AUTO_SERVER", raising=False)
+    from cli import entrypoints
+
+    settings = _launcher_settings(port=9494, token="proxy-token")
+
+    server_proc = MagicMock()
+    server_proc.pid = 999
+    server_proc.poll.return_value = None  # still running at teardown
+    server_proc.wait.return_value = 0
+
+    claude_proc = MagicMock()
+    claude_proc.pid = 12345
+    claude_proc.wait.return_value = 0
+
+    registered: list[int] = []
+    unregistered: list[int] = []
+
+    with (
+        patch.object(entrypoints, "get_settings", return_value=settings),
+        patch.object(entrypoints, "_preflight_proxy", return_value="refused"),
+        patch.object(entrypoints, "_spawn_managed_server", return_value=server_proc),
+        patch.object(entrypoints, "_wait_for_proxy_ready", return_value=None),
+        patch.object(entrypoints.shutil, "which", return_value="claude"),
+        patch.object(entrypoints.subprocess, "Popen", return_value=claude_proc),
+        patch.object(entrypoints, "register_pid", side_effect=registered.append),
+        patch.object(entrypoints, "unregister_pid", side_effect=unregistered.append),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        launch = entrypoints.launch_claude
+        launch([])
+
+    assert exc_info.value.code == 0
+    # Managed proxy was started, then gracefully stopped on exit.
+    server_proc.terminate.assert_called_once()
+    assert 999 in registered and 999 in unregistered
+    assert 12345 in registered and 12345 in unregistered
+
+
+def test_launch_claude_reuses_running_proxy_without_stopping_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A proxy that already answers is reused and left running on exit."""
+    monkeypatch.delenv("FCC_AUTO_SERVER", raising=False)
+    from cli import entrypoints
+
+    settings = _launcher_settings(port=9595, token="proxy-token")
+    claude_proc = MagicMock()
+    claude_proc.pid = 22222
+    claude_proc.wait.return_value = 3
+
+    with (
+        patch.object(entrypoints, "get_settings", return_value=settings),
+        patch.object(entrypoints, "_preflight_proxy", return_value=None),
+        patch.object(entrypoints, "_spawn_managed_server") as spawn,
+        patch.object(entrypoints, "_stop_managed_server") as stop,
+        patch.object(entrypoints.shutil, "which", return_value="claude"),
+        patch.object(entrypoints.subprocess, "Popen", return_value=claude_proc),
+        patch.object(entrypoints, "register_pid"),
+        patch.object(entrypoints, "unregister_pid"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        entrypoints.launch_claude([])
+
+    assert exc_info.value.code == 3
+    spawn.assert_not_called()
+    stop.assert_not_called()
+
+
+def test_auto_server_enabled_env_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cli.entrypoints import _auto_server_enabled
+
+    monkeypatch.delenv("FCC_AUTO_SERVER", raising=False)
+    assert _auto_server_enabled() is True
+    for falsy in ("0", "false", "no", "", "  FALSE  "):
+        monkeypatch.setenv("FCC_AUTO_SERVER", falsy)
+        assert _auto_server_enabled() is False
+    monkeypatch.setenv("FCC_AUTO_SERVER", "1")
+    assert _auto_server_enabled() is True
+
+
+def test_spawn_managed_server_builds_serve_command_and_suppresses_browser(
+    tmp_path: Path,
+) -> None:
+    import sys as _sys
+
+    from cli import entrypoints
+
+    log_path = tmp_path / "managed-server.log"
+    with (
+        patch.object(entrypoints, "_managed_server_log_path", return_value=log_path),
+        patch.object(entrypoints.subprocess, "Popen") as popen,
+    ):
+        entrypoints._spawn_managed_server({"PATH": "keep", "FCC_OPEN_BROWSER": "1"})
+
+    popen.assert_called_once()
+    assert popen.call_args.args[0] == [
+        _sys.executable,
+        "-c",
+        "from cli.entrypoints import serve; serve()",
+    ]
+    child_env = popen.call_args.kwargs["env"]
+    assert child_env["FCC_OPEN_BROWSER"] == "0"
+    assert child_env["PATH"] == "keep"
+
+
+def test_wait_for_proxy_ready_detects_early_exit() -> None:
+    from cli import entrypoints
+
+    process = MagicMock()
+    process.poll.return_value = 1
+    process.returncode = 1
+
+    with patch.object(entrypoints, "_preflight_proxy", return_value="refused"):
+        error = entrypoints._wait_for_proxy_ready("http://127.0.0.1:9090", process, 5.0)
+
+    assert error is not None
+    assert "exited early" in error
+
+
+def test_stop_managed_server_force_kills_on_timeout() -> None:
+    from cli import entrypoints
+
+    process = MagicMock()
+    process.pid = 4242
+    process.poll.return_value = None
+    process.wait.side_effect = entrypoints.subprocess.TimeoutExpired(cmd="x", timeout=1)
+
+    with patch.object(entrypoints, "kill_pid_tree_best_effort") as kill_tree:
+        entrypoints._stop_managed_server(process)
+
+    process.terminate.assert_called_once()
+    kill_tree.assert_called_once_with(4242)


### PR DESCRIPTION
## Summary

`fcc-claude` previously required a separately running `fcc-server` and, when one was running, **left it running after the session**. In non-interactive (`-p`) runs this is clearly a bug: the one-shot command finishes but the proxy lingers with nothing to serve (you have to hunt down and kill it manually).

This change makes `fcc-claude` own the proxy lifecycle.

## Behavior

- **Auto-start:** if nothing answers `/health`, `fcc-claude` starts a proxy it owns — browser auto-open suppressed, logs teed to `~/.fcc/managed-server.log` — waits for it to become healthy, then launches Claude Code.
- **Auto-stop:** on exit (normal, `-p` one-shot, error, or Ctrl-C) the proxy we started is gracefully stopped (SIGTERM → wait → force-kill the tree).
- **Reuse, don't hijack:** a proxy that is **already running** (e.g. a separate `fcc-server`) is reused and **left untouched** on exit — so concurrent sessions and long-lived servers are safe. We only ever stop a proxy this CLI started.
- **Opt-out:** `FCC_AUTO_SERVER=0` restores the previous behavior (print a hint and exit instead of auto-starting).

`launch_claude` is split into `_ensure_proxy_running` + `_run_claude_client`; the client-spawn path keeps its exact prior behavior and exit codes.

## Tests

New unit coverage in `tests/cli/test_entrypoints.py`: auto-start + teardown, reuse-without-stopping, `FCC_AUTO_SERVER` parsing, managed `serve` command construction (+ browser suppression), readiness early-exit detection, and force-kill on shutdown timeout. The pre-existing "unreachable proxy" test now exercises the `FCC_AUTO_SERVER=0` opt-out path.

## Validation

- `ruff format`, `ruff check`, `ty check` — clean.
- `uv run pytest` — **1435 passed**.
- **Verified live:** `fcc-claude -p` with no server running auto-starts the proxy, returns an answer, and on exit leaves port `8082` closed with no lingering process (`managed-server.log` shows a clean `Finished server process`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)