### PR TITLE
Fix Gemini model validation warning and tool call index crash

### DIFF
--- a/providers/gemini/client.py
+++ b/providers/gemini/client.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from providers.base import ProviderConfig
 from providers.defaults import GEMINI_DEFAULT_BASE
+from providers.model_listing import ProviderModelInfo
 from providers.openai_compat import OpenAIChatTransport
 
 from .request import build_request_body
@@ -20,6 +21,17 @@ class GeminiProvider(OpenAIChatTransport):
             provider_name="GEMINI",
             base_url=config.base_url or GEMINI_DEFAULT_BASE,
             api_key=config.api_key,
+        )
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        """Return model infos, stripping the 'models/' prefix Gemini adds to IDs."""
+        infos = await super().list_model_infos()
+        return frozenset(
+            ProviderModelInfo(
+                model_id=info.model_id.removeprefix("models/"),
+                supports_thinking=info.supports_thinking,
+            )
+            for info in infos
         )
 
     def _build_request_body(

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -234,7 +234,7 @@ class OpenAIChatTransport(BaseProvider):
         tool_argument_alias_buffers: dict[int, str] | None = None,
     ) -> Iterator[str]:
         """Process a single tool call delta and yield SSE events."""
-        tc_index = tc.get("index", 0)
+        tc_index = tc.get("index") if tc.get("index") is not None else 0
         if tc_index < 0:
             tc_index = len(sse.blocks.tool_states)
 


### PR DESCRIPTION
## Summary

Two bugs found while debugging `fcc-claude start` returning `Invalid request sent to provider`.

### Bug 1 - Startup WARNING: `missing model` (`providers/gemini/client.py`)

Gemini's OpenAI-compatible `/models` endpoint returns model IDs with a `models/` prefix (e.g. `models/gemini-2.5-flash`), but the configured model in `.env` is `gemini/gemini-2.5-flash` (resolved to `gemini-2.5-flash` after stripping the provider prefix). The validator compared `gemini-2.5-flash` against `models/gemini-2.5-flash` and found no match, producing the startup warning.

**Fix:** Override `list_model_infos()` in `GeminiProvider` to strip the `models/` prefix from all model IDs returned by the API.

### Bug 2 - `TypeError: '<' not supported between instances of 'NoneType' and 'int'` (`providers/openai_compat.py`)

When Gemini returns a streaming tool call chunk with `"index": null`, `tc.get("index", 0)` returns `None` - Python's `dict.get(key, default)` only uses the default when the key is **absent**, not when the value is `None`. The subsequent `if tc_index < 0` comparison then raises a `TypeError`.

**Fix:** Replace `tc.get("index", 0)` with an explicit `None`-check: `tc.get("index") if tc.get("index") is not None else 0`.

?? Generated with [Claude Code](https://claude.com/claude-code)