### PR TITLE
fix(deepseek): resolve "Invalid request sent to provider" on tool turns

### DIFF
--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -449,8 +449,6 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
         if isinstance(budget_tokens, int):
             thinking_payload["budget_tokens"] = budget_tokens
         data["thinking"] = thinking_payload
-    else:
-        data["thinking"] = {"type": "disabled"}
 
     if "messages" in data:
         data["messages"] = _strip_reasoning_content_when_native(

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -290,13 +290,28 @@ def sanitize_deepseek_messages_for_native(
                 )
             ]
         else:
-            filtered = [
-                block
-                for block in content
-                if not (
-                    isinstance(block, dict) and block.get("type") == "redacted_thinking"
+            filtered = []
+            has_thinking = False
+            has_tool_use = False
+            for block in content:
+                if not isinstance(block, dict):
+                    filtered.append(block)
+                    continue
+                if block.get("type") == "redacted_thinking":
+                    continue
+                if block.get("type") == "thinking":
+                    has_thinking = True
+                    if "signature" not in block:
+                        block = dict(block)
+                        block["signature"] = ""
+                if block.get("type") == "tool_use":
+                    has_tool_use = True
+                filtered.append(block)
+            if has_tool_use and not has_thinking and filtered:
+                filtered.insert(
+                    0,
+                    {"type": "thinking", "thinking": "", "signature": ""},
                 )
-            ]
         new_msg = dict(message)
         new_msg["content"] = filtered or ""
         sanitized.append(new_msg)
@@ -434,6 +449,8 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
         if isinstance(budget_tokens, int):
             thinking_payload["budget_tokens"] = budget_tokens
         data["thinking"] = thinking_payload
+    else:
+        data["thinking"] = {"type": "disabled"}
 
     if "messages" in data:
         data["messages"] = _strip_reasoning_content_when_native(


### PR DESCRIPTION
## Summary

Fixes the "Invalid request sent to provider" error that occurs on
follow-up turns after tool use when using the DeepSeek provider.

## Root Cause

DeepSeek requires `content[].thinking` blocks in message history when
the API is in thinking mode. When assistant messages contain `tool_use`
blocks but either lack thinking blocks entirely or have unsigned
thinking blocks, the API returns HTTP 400:

> The `content[].thinking` in the thinking mode must be passed back
> to the API.

## Fix

In `sanitize_deepseek_messages_for_native`:

- Add `signature: ""` to unsigned thinking blocks so they can be
  replayed by DeepSeek
- Insert a minimal thinking placeholder when assistant messages have
  `tool_use` blocks but no thinking content
