### PR TITLE
fix(deepseek): resolve "Invalid request sent to provider" on tool turns

### DIFF
--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -449,8 +449,6 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
         if isinstance(budget_tokens, int):
             thinking_payload["budget_tokens"] = budget_tokens
         data["thinking"] = thinking_payload
-    else:
-        data["thinking"] = {"type": "disabled"}
 
     if "messages" in data:
         data["messages"] = _strip_reasoning_content_when_native(

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -290,13 +290,28 @@ def sanitize_deepseek_messages_for_native(
                 )
             ]
         else:
-            filtered = [
-                block
-                for block in content
-                if not (
-                    isinstance(block, dict) and block.get("type") == "redacted_thinking"
+            filtered = []
+            has_thinking = False
+            has_tool_use = False
+            for block in content:
+                if not isinstance(block, dict):
+                    filtered.append(block)
+                    continue
+                if block.get("type") == "redacted_thinking":
+                    continue
+                if block.get("type") == "thinking":
+                    has_thinking = True
+                    if "signature" not in block:
+                        block = dict(block)
+                        block["signature"] = ""
+                if block.get("type") == "tool_use":
+                    has_tool_use = True
+                filtered.append(block)
+            if has_tool_use and not has_thinking and filtered:
+                filtered.insert(
+                    0,
+                    {"type": "thinking", "thinking": "", "signature": ""},
                 )
-            ]
         new_msg = dict(message)
         new_msg["content"] = filtered or ""
         sanitized.append(new_msg)
@@ -434,6 +449,8 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
         if isinstance(budget_tokens, int):
             thinking_payload["budget_tokens"] = budget_tokens
         data["thinking"] = thinking_payload
+    else:
+        data["thinking"] = {"type": "disabled"}
 
     if "messages" in data:
         data["messages"] = _strip_reasoning_content_when_native(

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -167,98 +167,6 @@ def _validate_deepseek_native_request_dict(data: dict[str, Any]) -> None:
         _walk_block_list_for_unsupported(system, where="system")
 
 
-def _has_tool_history_blocks(message: Mapping[str, Any]) -> bool:
-    role = message.get("role")
-    content = message.get("content")
-    if not isinstance(content, list):
-        return False
-
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        btype = block.get("type")
-        if role == "assistant" and btype == "tool_use":
-            return True
-        if role == "user" and btype == "tool_result":
-            return True
-    return False
-
-
-def _has_replayable_thinking_before_tool_use(message: Mapping[str, Any]) -> bool:
-    if message.get("role") != "assistant":
-        return False
-    content = message.get("content")
-    if not isinstance(content, list):
-        return False
-
-    has_thinking = False
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        btype = block.get("type")
-        if btype == "thinking" and isinstance(block.get("thinking"), str):
-            has_thinking = True
-            continue
-        if btype == "tool_use":
-            return has_thinking
-    return False
-
-
-def _has_tool_history(data: dict[str, Any]) -> bool:
-    for message in data.get("messages") or ():
-        if isinstance(message, Mapping) and _has_tool_history_blocks(message):
-            return True
-    return False
-
-
-def _has_replayable_tool_thinking(data: dict[str, Any]) -> bool:
-    for message in data.get("messages") or ():
-        if isinstance(message, Mapping) and _has_replayable_thinking_before_tool_use(
-            message
-        ):
-            return True
-    return False
-
-
-def _remove_deepseek_thinking_hints(data: dict[str, Any]) -> None:
-    """Remove request hints that can keep DeepSeek in thinking mode after fallback."""
-    output_config = data.get("output_config")
-    if isinstance(output_config, dict) and "effort" in output_config:
-        cleaned_output_config = dict(output_config)
-        cleaned_output_config.pop("effort", None)
-        if cleaned_output_config:
-            data["output_config"] = cleaned_output_config
-        else:
-            data.pop("output_config", None)
-
-    context_management = data.get("context_management")
-    if not isinstance(context_management, dict):
-        return
-    edits = context_management.get("edits")
-    if not isinstance(edits, list):
-        return
-    filtered_edits = [
-        edit
-        for edit in edits
-        if not (
-            isinstance(edit, dict)
-            and isinstance(edit.get("type"), str)
-            and edit["type"].startswith("clear_thinking_")
-        )
-    ]
-    if len(filtered_edits) == len(edits):
-        return
-    cleaned_context_management = dict(context_management)
-    if filtered_edits:
-        cleaned_context_management["edits"] = filtered_edits
-        data["context_management"] = cleaned_context_management
-    else:
-        cleaned_context_management.pop("edits", None)
-        if cleaned_context_management:
-            data["context_management"] = cleaned_context_management
-        else:
-            data.pop("context_management", None)
-
 
 def sanitize_deepseek_messages_for_native(
     messages: Any, *, thinking_enabled: bool
@@ -417,20 +325,7 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
             thinking_enabled=thinking_enabled,
         )
 
-    has_tool_history = _has_tool_history(data)
-    has_replayable_tool_thinking = _has_replayable_tool_thinking(data)
-    unsafe_tool_followup = has_tool_history and not has_replayable_tool_thinking
-    effective_thinking_enabled = thinking_enabled and not unsafe_tool_followup
-    if thinking_enabled:
-        if unsafe_tool_followup:
-            logger.debug(
-                "DEEPSEEK_REQUEST: unsafe tool follow-up, disabling thinking "
-                "model={} msgs={} tools={}",
-                data.get("model"),
-                len(data.get("messages", [])),
-                len(data.get("tools", [])),
-            )
-            _remove_deepseek_thinking_hints(data)
+    effective_thinking_enabled = thinking_enabled
 
     thinking_cfg = data.pop("thinking", None)
     if effective_thinking_enabled and isinstance(thinking_cfg, dict):

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -197,7 +197,7 @@ def _has_replayable_thinking_before_tool_use(message: Mapping[str, Any]) -> bool
             continue
         btype = block.get("type")
         if btype == "thinking" and isinstance(block.get("thinking"), str):
-            has_thinking = bool(block["thinking"])
+            has_thinking = True
             continue
         if btype == "tool_use":
             return has_thinking
@@ -411,6 +411,12 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
     _validate_deepseek_native_request_dict(data)
     data.pop("extra_body", None)
 
+    if "messages" in data:
+        data["messages"] = sanitize_deepseek_messages_for_native(
+            data["messages"],
+            thinking_enabled=thinking_enabled,
+        )
+
     has_tool_history = _has_tool_history(data)
     has_replayable_tool_thinking = _has_replayable_tool_thinking(data)
     unsafe_tool_followup = has_tool_history and not has_replayable_tool_thinking
@@ -418,29 +424,13 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
     if thinking_enabled:
         if unsafe_tool_followup:
             logger.debug(
-                "DEEPSEEK_REQUEST: disabling thinking for tool follow-up without "
-                "replayable thinking model={} msgs={} tools={}",
-                data.get("model"),
-                len(data.get("messages", [])),
-                len(data.get("tools", [])),
-            )
-            _remove_deepseek_thinking_hints(data)
-        elif has_tool_history:
-            logger.debug(
-                "DEEPSEEK_REQUEST: keeping thinking for tool follow-up with "
-                "replayable thinking model={} msgs={} tools={}",
-                data.get("model"),
-                len(data.get("messages", [])),
-                len(data.get("tools", [])),
-            )
-        elif data.get("tools") or data.get("tool_choice"):
-            logger.debug(
-                "DEEPSEEK_REQUEST: keeping thinking for initial tool request "
+                "DEEPSEEK_REQUEST: unsafe tool follow-up, disabling thinking "
                 "model={} msgs={} tools={}",
                 data.get("model"),
                 len(data.get("messages", [])),
                 len(data.get("tools", [])),
             )
+            _remove_deepseek_thinking_hints(data)
 
     thinking_cfg = data.pop("thinking", None)
     if effective_thinking_enabled and isinstance(thinking_cfg, dict):
@@ -449,15 +439,12 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
         if isinstance(budget_tokens, int):
             thinking_payload["budget_tokens"] = budget_tokens
         data["thinking"] = thinking_payload
+    else:
+        data["thinking"] = {"type": "disabled"}
 
     if "messages" in data:
         data["messages"] = _strip_reasoning_content_when_native(
-            _normalize_tool_result_content(
-                sanitize_deepseek_messages_for_native(
-                    data["messages"],
-                    thinking_enabled=effective_thinking_enabled,
-                )
-            )
+            _normalize_tool_result_content(data["messages"])
         )
     if "max_tokens" not in data or data.get("max_tokens") is None:
         data["max_tokens"] = ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -172,7 +172,7 @@ def test_build_request_body_respects_global_thinking_disable():
         }
     )
     body = provider._build_request_body(request)
-    assert "thinking" not in body
+    assert body["thinking"] == {"type": "disabled"}
 
 
 def test_preserve_unsigned_thinking_when_thinking_on(deepseek_provider):
@@ -199,6 +199,7 @@ def test_preserve_unsigned_thinking_when_thinking_on(deepseek_provider):
     assert len(blocks) == 2
     assert blocks[0]["type"] == "thinking"
     assert blocks[0]["thinking"] == "plain"
+    assert blocks[0].get("signature") == ""
 
 
 def test_strip_redacted_thinking_when_thinking_on(deepseek_provider):
@@ -316,6 +317,7 @@ def test_tool_history_with_unsigned_thinking_preserves_thinking(deepseek_provide
     assert body["messages"][0]["content"][0] == {
         "type": "thinking",
         "thinking": "plain",
+        "signature": "",
     }
 
 
@@ -368,15 +370,24 @@ def test_tool_history_without_thinking_disables_thinking_and_hints(deepseek_prov
 
     body = deepseek_provider._build_request_body(request)
 
-    assert "thinking" not in body
+    # Thinking stays enabled now — placeholder fixed the replayability gap,
+    # so context_management hints and output_config effort are preserved.
+    assert body["thinking"] == {"type": "enabled", "budget_tokens": 2000}
     assert body["context_management"] == {
-        "edits": [{"type": "other_edit", "keep": "all"}],
+        "edits": [
+            {"type": "clear_thinking_20251015", "keep": "all"},
+            {"type": "other_edit", "keep": "all"},
+        ],
         "other": True,
     }
-    assert body["output_config"] == {"format": "text"}
+    assert body["output_config"] == {"effort": "high", "format": "text"}
     assert body["tools"][0]["name"] == "Read"
     assert body["tool_choice"] == {"type": "auto"}
-    assert body["messages"][0]["content"][0]["type"] == "tool_use"
+    # Placeholder inserted before tool_use
+    assert [b["type"] for b in body["messages"][0]["content"]] == [
+        "thinking",
+        "tool_use",
+    ]
     assert body["messages"][1]["content"][0]["type"] == "tool_result"
 
 
@@ -414,8 +425,13 @@ def test_tool_history_with_empty_thinking_disables_thinking(deepseek_provider):
 
     body = deepseek_provider._build_request_body(request)
 
-    assert "thinking" not in body
-    assert [block["type"] for block in body["messages"][0]["content"]] == ["tool_use"]
+    # Empty thinking gets signature and counts as replayable, keeping
+    # thinking enabled.
+    assert body["thinking"] == {"type": "enabled"}
+    assert [block["type"] for block in body["messages"][0]["content"]] == [
+        "thinking",
+        "tool_use",
+    ]
 
 
 def test_thinking_off_strips_thinking_history():
@@ -478,7 +494,11 @@ def test_passthrough_tool_use_and_result(deepseek_provider):
         }
     )
     body = deepseek_provider._build_request_body(request)
-    assert body["messages"][0]["content"][0]["type"] == "tool_use"
+    # Placeholder injected for the tool-use-only message; thinking enabled
+    assert [b["type"] for b in body["messages"][0]["content"]] == [
+        "thinking",
+        "tool_use",
+    ]
     assert body["messages"][1]["content"][0]["type"] == "tool_result"
 
 
@@ -1091,3 +1111,139 @@ def test_no_warning_when_no_attachments(deepseek_provider, caplog):
         for r in caplog.records
         if r.levelno == logging.WARNING
     )
+
+
+def test_inserts_placeholder_thinking_for_tool_only_assistant(deepseek_provider):
+    """When thinking is enabled and an assistant msg has tool_use but no thinking
+    blocks, a minimal placeholder is inserted so the API accepts the history."""
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "signed",
+                            "signature": "sig_1",
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "t1",
+                            "name": "Read",
+                            "input": {"file_path": "x"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "t1",
+                            "content": "ok",
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "t2",
+                            "name": "Write",
+                            "input": {"file_path": "y", "content": "done"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "t2",
+                            "content": "written",
+                        }
+                    ],
+                },
+            ],
+            "tools": [
+                {
+                    "name": "Read",
+                    "description": "Read a file",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+                {
+                    "name": "Write",
+                    "description": "Write a file",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+            ],
+            "thinking": {"type": "enabled", "budget_tokens": 2000},
+        }
+    )
+
+    body = deepseek_provider._build_request_body(request)
+
+    # First assistant msg keeps its thinking + tool_use
+    msg0 = body["messages"][0]["content"]
+    assert [b["type"] for b in msg0] == ["thinking", "tool_use"]
+
+    # Second assistant msg gets a placeholder thinking inserted before tool_use
+    msg2 = body["messages"][2]["content"]
+    assert [b["type"] for b in msg2] == ["thinking", "tool_use"]
+    assert msg2[0] == {"type": "thinking", "thinking": "", "signature": ""}
+
+    # Thinking stays enabled
+    assert body["thinking"] == {"type": "enabled", "budget_tokens": 2000}
+
+
+def test_placeholder_only_for_nonempty_thinking_text(deepseek_provider):
+    """Empty-content thinking blocks don't satisfy the API requirement, so
+    a placeholder is still inserted when those are the only thinking blocks."""
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "", "signature": ""},
+                        {
+                            "type": "tool_use",
+                            "id": "t1",
+                            "name": "Read",
+                            "input": {"file_path": "x"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "t1",
+                            "content": "ok",
+                        }
+                    ],
+                },
+            ],
+            "tools": [
+                {
+                    "name": "Read",
+                    "description": "Read a file",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+            "thinking": {"type": "enabled"},
+        }
+    )
+
+    body = deepseek_provider._build_request_body(request)
+
+    # Empty thinking gets signature and counts as replayable; sanitizer
+    # keeps the empty-thinking block so no placeholder is needed.
+    assert body["thinking"] == {"type": "enabled"}
+    msg0 = body["messages"][0]["content"]
+    assert [b["type"] for b in msg0] == ["thinking", "tool_use"]

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -1199,9 +1199,9 @@ def test_inserts_placeholder_thinking_for_tool_only_assistant(deepseek_provider)
     assert body["thinking"] == {"type": "enabled", "budget_tokens": 2000}
 
 
-def test_placeholder_only_for_nonempty_thinking_text(deepseek_provider):
-    """Empty-content thinking blocks don't satisfy the API requirement, so
-    a placeholder is still inserted when those are the only thinking blocks."""
+def test_existing_empty_thinking_prevents_placeholder(deepseek_provider):
+    """Empty thinking with a signature is already replayable — the sanitizer
+    keeps the block and does not insert a duplicate placeholder."""
     request = MessagesRequest.model_validate(
         {
             "model": "m",


### PR DESCRIPTION
## Summary

Fixes HTTP 400 errors on follow-up turns after tool use with the
DeepSeek provider.

## Root Cause

DeepSeek requires `content[].thinking` blocks in message history when
the API is in thinking mode. When assistant messages contain `tool_use`
blocks but either lack thinking blocks entirely or have unsigned
thinking blocks, the API returns:

> The `content[].thinking` in the thinking mode must be passed back
> to the API.

## Fix

Sanitize message history before checking replayability:

- Add `signature: ""` to unsigned thinking blocks so DeepSeek can
  replay them
- Insert a minimal thinking placeholder when assistant messages have
  `tool_use` blocks but no thinking content
- Reorder sanitize step to run before the replayability check
- Fall back to `thinking: {"type": "disabled"}` when thinking is
  globally off

## Cleanup

Since the sanitizer now guarantees every tool-use assistant message has
a replayable thinking block before the replayability check runs, the
`unsafe_tool_followup` fallback path is unreachable. Removed:

- The dead `unsafe_tool_followup` branch in `build_request_body`
- Five unused helper functions: `_has_tool_history_blocks`,
  `_has_replayable_thinking_before_tool_use`, `_has_tool_history`,
  `_has_replayable_tool_thinking`, `_remove_deepseek_thinking_hints`
- Renamed misleading test `test_placeholder_only_for_nonempty_thinking_text`
  to `test_existing_empty_thinking_prevents_placeholder` to match what it
  actually verifies

