### PR TITLE
fix(telegram): fail closed when no user allowlist is configured

### DIFF
--- a/messaging/platforms/telegram.py
+++ b/messaging/platforms/telegram.py
@@ -106,6 +106,21 @@ class TelegramPlatform(MessagingPlatform):
         self._log_raw_messaging_content = log_raw_messaging_content
         self._log_api_error_tracebacks = log_api_error_tracebacks
 
+    def _is_authorized(self, user_id: str) -> bool:
+        """Return whether ``user_id`` may drive the bot.
+
+        Fails closed: when no allowlist is configured the bot rejects everyone,
+        mirroring the Discord adapter (see
+        :meth:`messaging.platforms.discord.DiscordPlatform._on_discord_message`,
+        which drops all traffic when ``allowed_channel_ids`` is empty). Without
+        this guard an empty ``allowed_telegram_user_id`` would let any Telegram
+        user reach a ``claude --dangerously-skip-permissions`` session.
+        """
+        allowed = (self.allowed_user_id or "").strip()
+        if not allowed:
+            return False
+        return user_id == allowed
+
     async def _register_pending_voice(
         self, chat_id: str, voice_msg_id: str, status_msg_id: str
     ) -> None:
@@ -126,6 +141,12 @@ class TelegramPlatform(MessagingPlatform):
         """Initialize and connect to Telegram."""
         if not self.bot_token:
             raise ValueError("TELEGRAM_BOT_TOKEN is required")
+
+        if not (self.allowed_user_id or "").strip():
+            logger.warning(
+                "ALLOWED_TELEGRAM_USER_ID is not set; the Telegram bot will reject "
+                "all messages. Set it to your numeric Telegram user id to enable the bot."
+            )
 
         # Configure request with longer timeouts
         request = HTTPXRequest(
@@ -507,8 +528,8 @@ class TelegramPlatform(MessagingPlatform):
         user_id = str(update.effective_user.id)
         chat_id = str(update.effective_chat.id)
 
-        # Security check
-        if self.allowed_user_id and user_id != str(self.allowed_user_id).strip():
+        # Security check (fail closed: no allowlist -> reject everyone)
+        if not self._is_authorized(user_id):
             logger.warning(f"Unauthorized access attempt from {user_id}")
             return
 
@@ -593,7 +614,7 @@ class TelegramPlatform(MessagingPlatform):
         user_id = str(update.effective_user.id)
         chat_id = str(update.effective_chat.id)
 
-        if self.allowed_user_id and user_id != str(self.allowed_user_id).strip():
+        if not self._is_authorized(user_id):
             logger.warning(f"Unauthorized voice access attempt from {user_id}")
             return
 

--- a/tests/messaging/test_telegram.py
+++ b/tests/messaging/test_telegram.py
@@ -113,3 +113,57 @@ async def test_on_telegram_message_unauthorized(telegram_platform):
     await telegram_platform._on_telegram_message(mock_update, MagicMock())
 
     handler.assert_not_called()
+
+
+@pytest.mark.parametrize("allowed", [None, "", "   "])
+def test_is_authorized_fails_closed_without_allowlist(allowed):
+    """No allowlist must reject everyone (fail closed), mirroring Discord."""
+    with patch("messaging.platforms.telegram.TELEGRAM_AVAILABLE", True):
+        platform = TelegramPlatform(bot_token="test_token", allowed_user_id=allowed)
+    assert platform._is_authorized("12345") is False
+    assert platform._is_authorized("") is False
+
+
+def test_is_authorized_matches_allowlisted_user():
+    with patch("messaging.platforms.telegram.TELEGRAM_AVAILABLE", True):
+        platform = TelegramPlatform(bot_token="test_token", allowed_user_id=" 12345 ")
+    assert platform._is_authorized("12345") is True
+    assert platform._is_authorized("99999") is False
+
+
+@pytest.mark.asyncio
+async def test_on_telegram_message_rejected_when_no_allowlist():
+    """An empty allowlist must not fall through to the handler (the bypass bug)."""
+    with patch("messaging.platforms.telegram.TELEGRAM_AVAILABLE", True):
+        platform = TelegramPlatform(bot_token="test_token", allowed_user_id=None)
+    handler = AsyncMock()
+    platform.on_message(handler)
+
+    mock_update = MagicMock()
+    mock_update.message.text = "hello"
+    mock_update.message.message_id = 1
+    mock_update.effective_user.id = 12345
+    mock_update.effective_chat.id = 6789
+    mock_update.message.reply_to_message = None
+
+    await platform._on_telegram_message(mock_update, MagicMock())
+
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_telegram_voice_rejected_when_no_allowlist():
+    with patch("messaging.platforms.telegram.TELEGRAM_AVAILABLE", True):
+        platform = TelegramPlatform(bot_token="test_token", allowed_user_id=None)
+    handler = AsyncMock()
+    platform.on_message(handler)
+
+    mock_update = MagicMock()
+    mock_update.message.voice = MagicMock()
+    mock_update.message.message_id = 1
+    mock_update.effective_user.id = 12345
+    mock_update.effective_chat.id = 6789
+
+    await platform._on_telegram_voice(mock_update, MagicMock())
+
+    handler.assert_not_called()


### PR DESCRIPTION
## Summary

The Telegram adapter **fails open**: when a bot token is configured but `ALLOWED_TELEGRAM_USER_ID` is left empty, **any Telegram user can drive the bot** — including a `claude --dangerously-skip-permissions` CLI session. This is effectively unauthorized remote code execution / filesystem access in the operator's workspace.

This PR makes Telegram **fail closed**, matching the Discord adapter, and adds regression tests.

## The bug

`messaging/platforms/telegram.py` gated the allowlist on its own truthiness:

```python
# _on_telegram_message and _on_telegram_voice
if self.allowed_user_id and user_id != str(self.allowed_user_id).strip():
    return
```

`allowed_telegram_user_id` defaults to `None` (`config/settings.py`), and `AppRuntime._start_messaging_if_configured` starts the platform whenever a token is present — **with no guard requiring an allowlist**. When the allowlist is empty, `self.allowed_user_id and ...` short-circuits to `False`, the guard is skipped, and every message **and voice note** from any user reaches the handler.

The Discord adapter already does the right thing (fail closed):

```python
# DiscordPlatform._on_discord_message
if not self.allowed_channel_ids or channel_id not in self.allowed_channel_ids:
    return
```

## Impact

- **Severity:** Critical. Unauthorized users gain control of a `--dangerously-skip-permissions` Claude Code session (arbitrary command execution, file read/write) in the host workspace.
- **Trigger:** Set `TELEGRAM_BOT_TOKEN`, leave `ALLOWED_TELEGRAM_USER_ID` empty (the default). Anyone who finds the bot can use it.
- **Pre-existing gap:** no test covered the empty-allowlist case, so the fail-open behavior was unverified.

## Fix

- Add `TelegramPlatform._is_authorized()` that **rejects everyone when the allowlist is empty** (handles `None` / `""` / whitespace) and use it on both the text and voice paths.
- Log a clear startup warning when no allowlist is configured, so an operator understands why the bot ignores all input (fail-closed can otherwise look like "the bot is broken").
- Add regression tests for the empty-allowlist text and voice paths, plus `_is_authorized` unit coverage.

## Verification

- `ruff format` / `ruff check` / `ty check` clean.
- `pytest`: full suite green (1435 passed, +6 new tests).

Found during a security-focused audit of the messaging subsystem.