### PR TITLE
fix(stream): harden tool-call parsing against malformed provider output

### DIFF
--- a/core/anthropic/sse.py
+++ b/core/anthropic/sse.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from typing import Any
 
 from loguru import logger
 
@@ -158,8 +159,16 @@ class ContentBlockManager:
         return results
 
 
-def _normalize_task_run_in_background(args_json: dict) -> None:
-    """Force Claude Code Task subagents to run in foreground (single shared rule)."""
+def _normalize_task_run_in_background(args_json: Any) -> None:
+    """Force Claude Code Task subagents to run in foreground (single shared rule).
+
+    A well-formed Task tool call streams a JSON object, but a misbehaving model
+    can emit valid JSON that is not an object (e.g. ``[]`` or ``42``). Guard
+    against that so the SSE generator is not aborted by an ``AttributeError``;
+    a non-object payload has no ``run_in_background`` to normalize anyway.
+    """
+    if not isinstance(args_json, dict):
+        return
     if args_json.get("run_in_background") is not False:
         args_json["run_in_background"] = False
 

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -440,12 +440,17 @@ class OpenAIChatTransport(BaseProvider):
                         for event in sse.close_content_blocks():
                             yield event
                         for tc in delta.tool_calls:
+                            # ``function`` is optional on a streamed tool-call delta
+                            # (e.g. an index-only continuation chunk); accessing
+                            # ``tc.function.name`` directly would raise and abort the
+                            # whole response mid tool call.
+                            fn = tc.function
                             tc_info = {
                                 "index": tc.index,
                                 "id": tc.id,
                                 "function": {
-                                    "name": tc.function.name,
-                                    "arguments": tc.function.arguments,
+                                    "name": fn.name if fn else None,
+                                    "arguments": (fn.arguments if fn else None) or "",
                                 },
                             }
                             for event in self._process_tool_call(

--- a/tests/providers/test_sse_builder.py
+++ b/tests/providers/test_sse_builder.py
@@ -1,5 +1,6 @@
 """Tests for core.anthropic.sse."""
 
+import json
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -80,6 +81,28 @@ class TestContentBlockManager:
         text = " | ".join(r.message for r in caplog.records)
         assert "sk-live-super-secret" not in text
         assert "buffer_sha256_prefix=" in text
+
+    @pytest.mark.parametrize("payload", ["[]", "42", "true", '"x"'])
+    def test_buffer_task_args_non_object_json_does_not_raise(self, payload):
+        """Valid-but-non-object Task args must not abort the stream (AttributeError)."""
+        mgr = ContentBlockManager()
+        mgr.tool_states[0] = ToolCallState(
+            block_index=0, tool_id="call_x", name="Task", started=True
+        )
+        # Must not raise; the value is passed through unchanged (no run_in_background).
+        parsed = mgr.buffer_task_args(0, payload)
+        assert parsed == json.loads(payload)
+
+    @pytest.mark.parametrize("payload", ["[]", "42", "true", '"x"'])
+    def test_flush_task_arg_buffers_non_object_json_does_not_raise(self, payload):
+        """flush must tolerate valid-but-non-object buffered Task args."""
+        mgr = ContentBlockManager()
+        mgr.tool_states[0] = ToolCallState(
+            block_index=0, tool_id="call_x", name="Task", started=True
+        )
+        mgr.tool_states[0].task_arg_buffer = payload
+        out = mgr.flush_task_arg_buffers()
+        assert out == [(0, json.dumps(json.loads(payload)))]
 
 
 class TestSSEBuilderMessageLifecycle:

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -886,3 +886,37 @@ async def test_openai_compat_stream_ends_with_contract_when_tool_name_never_arri
     text = "".join(events)
     assert_anthropic_stream_contract(parse_sse_text(text))
     assert "text_delta" in text
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_stream_tolerates_tool_call_with_no_function() -> None:
+    """A streamed tool-call delta may carry ``function=None`` (e.g. an index-only
+    continuation chunk). Accessing ``tc.function.name`` would raise and corrupt the
+    whole response; the proxy must skip such chunks and finish a valid stream."""
+    provider = _make_provider()
+    request = _make_request()
+    tc_no_fn = SimpleNamespace(index=0, id="call_nofn", function=None)
+    stream_mock = AsyncStreamMock(
+        [_make_chunk(tool_calls=[tc_no_fn]), _make_chunk(finish_reason="stop")]
+    )
+    with (
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            return_value=stream_mock,
+        ),
+        patch.object(
+            provider._global_rate_limiter,
+            "wait_if_blocked",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        events = await _collect_stream(provider, request)
+    text = "".join(events)
+    assert_anthropic_stream_contract(parse_sse_text(text))
+    assert "message_stop" in text
+    # The bug surfaced as the mapped transport error being injected into the stream.
+    assert "'NoneType'" not in text
+    assert "AttributeError" not in text


### PR DESCRIPTION
## Summary

Two streaming paths could be aborted by **valid-but-unexpected provider output**, turning a working response into an error injected mid tool call. Both are fixed surgically with red→green regression tests.

## Bug 1 — `tc.function` is optional on a streamed tool-call delta

`providers/openai_compat.py` built the tool-call info via:

```python
"name": tc.function.name,
"arguments": tc.function.arguments,
```

But `ChoiceDeltaToolCall.function` is `Optional[ChoiceDeltaToolCallFunction]` in the OpenAI SDK, and OpenAI-compatible backends legitimately stream index-only / id-only continuation chunks with `function` unset. `tc.function.name` then raises `AttributeError`, which the broad `except Exception` maps into a transport error injected into the stream — **the in-flight tool call is lost** and the user sees a failure.

```python
>>> from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
>>> ChoiceDeltaToolCall(index=0).function is None
True   # -> tc.function.name raises AttributeError
```

**Fix:** read `tc.function` once and fall back to `name=None` / `arguments=""`. `_process_tool_call` already tolerates this (it skips nameless/empty fragments), so a function-less chunk now contributes nothing instead of crashing.

## Bug 2 — `Task` args that are valid JSON but not an object crash the SSE generator

`core/anthropic/sse.py`'s `_normalize_task_run_in_background` assumed the buffered `Task` tool arguments parse to a JSON **object** and called `.get()` on them. A model emitting valid non-object JSON (`[]`, `42`, `true`, `"x"`) makes `json.loads` succeed and `.get()` raise `AttributeError`:

- In `buffer_task_args`, the `try` only wrapped `json.loads`, so the `AttributeError` **escapes the SSE async generator entirely** → the whole stream is truncated with no `message_stop`.
- In `flush_task_arg_buffers`, the `except` tuple was `(JSONDecodeError, TypeError, ValueError)` — it didn't list `AttributeError`, so it escaped there too, bypassing the existing `{}` fallback.

**Fix:** guard the normalizer with `isinstance(args_json, dict)`. A non-object payload has no `run_in_background` to normalize and is passed through unchanged.

## Verification

- New regression tests fail on the prior code with `exc_type=AttributeError` and pass after the fix (verified by stashing the source change and re-running):
  - `test_openai_compat_stream_tolerates_tool_call_with_no_function` (asserts the Anthropic stream contract still holds)
  - `test_buffer_task_args_non_object_json_does_not_raise` / `test_flush_task_arg_buffers_non_object_json_does_not_raise` (`[]`, `42`, `true`, `"x"`)
- `ruff format` / `ruff check` / `ty check` clean.
- `pytest`: full suite green (1438 passed, +9 new test cases).

Found during a correctness-focused audit of the streaming/conversion core.