### PR TITLE
fix: Python 2 style except syntax catches only one exception (GeneratorExit not caught)

### DIFF
--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -456,7 +456,9 @@ class OpenAIChatTransport(BaseProvider):
                             ):
                                 yield event
 
-            except asyncio.CancelledError, GeneratorExit:
+            except asyncio.CancelledError:
+                raise
+            except GeneratorExit:
                 raise
             except Exception as e:
                 self._log_stream_transport_error(tag, req_tag, e, request_id=request_id)


### PR DESCRIPTION
In `providers/openai_compat.py`, the line `except asyncio.CancelledError, GeneratorExit:` uses Python 2 comma-separated syntax. In Python 3 this only catches `CancelledError` and binds the exception instance to a variable named `GeneratorExit`. `GeneratorExit` itself is never caught.

**Fix:** Split into separate except clauses:
```python
except asyncio.CancelledError:
    raise
except GeneratorExit:
    raise
```

**Verification:** `ruff format`, `ruff check`, `ty check`, `pytest` (1429 passed)