### PR TITLE
fix: default model nvidia_nim/z-ai/glm4.7 does not exist on NVIDIA NIM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ debug-*.log
 llama_cache
 .smoke-results
 .vscode
-server.*

--- a/config/settings.py
+++ b/config/settings.py
@@ -180,7 +180,7 @@ class Settings(BaseSettings):
     # ==================== Model ====================
     # All Claude model requests are mapped to this single model (fallback)
     # Format: provider_type/model/name
-    model: str = "nvidia_nim/z-ai/glm4.7"
+    model: str = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 
     # Per-model overrides (optional, falls back to MODEL)
     # Each can use a different provider

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -456,7 +456,9 @@ class OpenAIChatTransport(BaseProvider):
                             ):
                                 yield event
 
-            except asyncio.CancelledError, GeneratorExit:
+            except asyncio.CancelledError:
+                raise
+            except GeneratorExit:
                 raise
             except Exception as e:
                 self._log_stream_transport_error(tag, req_tag, e, request_id=request_id)


### PR DESCRIPTION
The hardcoded default model `nvidia_nim/z-ai/glm4.7` is not a valid NVIDIA NIM model. Users who start without configuring `.env` get `"Invalid request sent to provider"` errors.

The `.env.example` recommends `nvidia_nim/nvidia/nemotron-3-super-120b-a12b` which is a valid NIM model. Updated the default to match.