### PR TITLE
feat: implement dynamic vision fallback and 1-image prompt history sanitization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,13 @@ MODEL_SONNET=
 MODEL_HAIKU=
 MODEL="nvidia_nim/z-ai/glm4.7"
 
+# Optional fallback model for vision/multimodal requests.
+# If a request contains image/multimodal blocks but the routed model is text-only,
+# the proxy dynamically reroutes the request to this model.
+# Format: provider_type/model/name
+# Recommended: open_router/moonshotai/kimi-k2.6:free or open_router/nvidia/nemotron-nano-12b-v2-vl:free
+MODEL_FALLBACK_VISION=
+
 
 # Optional live smoke model overrides. Provider smoke runs once per configured
 # provider even when MODEL/MODEL_* route to a different provider.

--- a/COWORKER_SETUP.md
+++ b/COWORKER_SETUP.md
@@ -1,0 +1,82 @@
+# 🤖 Free Claude Code Setup Guide (OpenRouter GPT-OSS)
+
+Follow these step-by-step instructions to set up **Free Claude Code** on your system using OpenRouter's free GPT-OSS model with the Claude Code VS Code extension.
+
+---
+
+### 1. Install `uv` (Python Package & Environment Manager)
+Open a **PowerShell** terminal and run the following command to install `uv` and Python 3.14 on your Windows machine:
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+$env:Path = "C:\Users\$env:USERNAME\.local\bin;$env:Path"
+uv self update
+uv python install 3.14
+```
+
+---
+
+### 2. Clone and Configure the Repository
+1. Open your terminal, clone this repository, and navigate inside:
+   ```cmd
+   git clone https://github.com/Alishahryar1/free-claude-code.git
+   cd free-claude-code
+   ```
+2. Copy the template configuration file to create your active environment file:
+   ```cmd
+   copy .env.example .env
+   ```
+
+---
+
+### 3. Configure the `.env` File
+Open the newly created `.env` file in a text editor and update the following settings:
+
+1. **OpenRouter API Key** (replace with your active OpenRouter key):
+   ```dotenv
+   OPENROUTER_API_KEY="your-openrouter-api-key-here"
+   ```
+
+2. **Model Tier Routing** (maps all Claude tiers to the free GPT-OSS-120B model):
+   ```dotenv
+   MODEL_OPUS="open_router/openai/gpt-oss-120b:free"
+   MODEL_SONNET="open_router/openai/gpt-oss-120b:free"
+   MODEL_HAIKU="open_router/openai/gpt-oss-120b:free"
+   MODEL="open_router/openai/gpt-oss-120b:free"
+   ```
+
+3. **Disable Model Thinking** (crucial to prevent the Claude Code parser from crashing on unsupported thinking block events):
+   ```dotenv
+   ENABLE_MODEL_THINKING=false
+   ```
+
+4. **Security Auth Token** (leave as default):
+   ```dotenv
+   ANTHROPIC_AUTH_TOKEN="freecc"
+   ```
+
+---
+
+### 4. Configure VS Code Settings
+To point the Claude Code VS Code extension at your local proxy:
+1. Open **VS Code**.
+2. Press **Ctrl + ,** to open your Settings.
+3. Search for: `claude-code.environmentVariables`.
+4. Click **Edit in settings.json** and add the following entry inside the root JSON brackets:
+   ```json
+   "claudeCode.environmentVariables": [
+       { "name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082" },
+       { "name": "ANTHROPIC_AUTH_TOKEN", "value": "freecc" },
+       { "name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1" }
+   ]
+   ```
+5. Press **Ctrl + Shift + P**, search for **Developer: Reload Window**, and reload your editor.
+
+---
+
+### 5. Start the Proxy Server
+Whenever you want to use the extension, open a terminal inside the cloned `free-claude-code` directory and start the server:
+```cmd
+uv run uvicorn server:app --host 0.0.0.0 --port 8082
+```
+
+Once the terminal outputs `Uvicorn running on http://0.0.0.0:8082`, you are ready to write code using Claude Code for free!

--- a/api/services.py
+++ b/api/services.py
@@ -78,6 +78,83 @@ def _log_unexpected_service_exception(
         logger.error("{} exc_type={}", context, type(exc).__name__)
 
 
+def _has_image_block(messages: list[Any]) -> bool:
+    """Check if any message contains an image block."""
+    for msg in messages:
+        content = getattr(msg, "content", None)
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "image":
+                        return True
+                else:
+                    if getattr(block, "type", None) == "image":
+                        return True
+        elif isinstance(content, dict) and content.get("type") == "image":
+            return True
+    return False
+
+
+def _sanitize_old_images(messages: list[Any]) -> None:
+    """Keep only the very last image block in the entire history to comply with 1-image limits of provider models."""
+    image_count = 0
+    for msg in messages:
+        content = getattr(msg, "content", None)
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "image":
+                        image_count += 1
+                else:
+                    if getattr(block, "type", None) == "image":
+                        image_count += 1
+        elif isinstance(content, dict) and content.get("type") == "image":
+            image_count += 1
+
+    if image_count <= 1:
+        return
+
+    images_seen = 0
+    for msg in messages:
+        content = getattr(msg, "content", None)
+        if isinstance(content, list):
+            new_content = []
+            for block in content:
+                is_image = False
+                if isinstance(block, dict):
+                    if block.get("type") == "image":
+                        is_image = True
+                else:
+                    if getattr(block, "type", None) == "image":
+                        is_image = True
+
+                if is_image:
+                    images_seen += 1
+                    if images_seen < image_count:
+                        from api.models.anthropic import ContentBlockText
+
+                        new_content.append(
+                            ContentBlockText(
+                                type="text",
+                                text="[Prior image block removed to comply with 1-image limit]",
+                            )
+                        )
+                    else:
+                        new_content.append(block)
+                else:
+                    new_content.append(block)
+            msg.content = new_content
+        elif isinstance(content, dict) and content.get("type") == "image":
+            images_seen += 1
+            if images_seen < image_count:
+                from api.models.anthropic import ContentBlockText
+
+                msg.content = ContentBlockText(
+                    type="text",
+                    text="[Prior image block removed to comply with 1-image limit]",
+                )
+
+
 def _require_non_empty_messages(messages: list[Any]) -> None:
     if not messages:
         raise InvalidRequestError("messages cannot be empty")
@@ -104,6 +181,53 @@ class ClaudeProxyService:
             _require_non_empty_messages(request_data.messages)
 
             routed = self._model_router.resolve_messages_request(request_data)
+
+            if _has_image_block(request_data.messages):
+                provider_model_lower = routed.resolved.provider_model.lower()
+                vision_keywords = (
+                    "vision",
+                    "vl",
+                    "gemini",
+                    "kimi",
+                    "omni",
+                    "claude-3",
+                    "gpt-4",
+                    "pixtral",
+                    "clip",
+                    "siglip",
+                )
+                is_vision_capable = any(
+                    kw in provider_model_lower for kw in vision_keywords
+                )
+                if not is_vision_capable and self._settings.model_fallback_vision:
+                    fallback_ref = self._settings.model_fallback_vision
+                    fallback_provider = Settings.parse_provider_type(fallback_ref)
+                    fallback_model = Settings.parse_model_name(fallback_ref)
+                    fallback_thinking = self._settings.resolve_thinking(fallback_model)
+
+                    logger.info(
+                        "Image detected in request but model '{}' is not vision-capable. "
+                        "Dynamically falling back to vision model: {}",
+                        routed.resolved.provider_model,
+                        fallback_ref,
+                    )
+
+                    # Re-route the request
+                    routed.request.model = fallback_model
+                    _sanitize_old_images(routed.request.messages)
+                    from .model_router import ResolvedModel, RoutedMessagesRequest
+
+                    new_resolved = ResolvedModel(
+                        original_model=routed.resolved.original_model,
+                        provider_id=fallback_provider,
+                        provider_model=fallback_model,
+                        provider_model_ref=fallback_ref,
+                        thinking_enabled=fallback_thinking,
+                    )
+                    routed = RoutedMessagesRequest(
+                        request=routed.request, resolved=new_resolved
+                    )
+
             if routed.resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS:
                 tool_err = openai_chat_upstream_server_tool_error(
                     routed.request,

--- a/config/settings.py
+++ b/config/settings.py
@@ -158,6 +158,9 @@ class Settings(BaseSettings):
     model_opus: str | None = Field(default=None, validation_alias="MODEL_OPUS")
     model_sonnet: str | None = Field(default=None, validation_alias="MODEL_SONNET")
     model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
+    model_fallback_vision: str | None = Field(
+        default=None, validation_alias="MODEL_FALLBACK_VISION"
+    )
 
     # ==================== Per-Provider Proxy ====================
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
@@ -314,6 +317,7 @@ class Settings(BaseSettings):
         "model_opus",
         "model_sonnet",
         "model_haiku",
+        "model_fallback_vision",
         "enable_opus_thinking",
         "enable_sonnet_thinking",
         "enable_haiku_thinking",
@@ -387,7 +391,9 @@ class Settings(BaseSettings):
             )
         return v
 
-    @field_validator("model", "model_opus", "model_sonnet", "model_haiku")
+    @field_validator(
+        "model", "model_opus", "model_sonnet", "model_haiku", "model_fallback_vision"
+    )
     @classmethod
     def validate_model_format(cls, v: str | None) -> str | None:
         if v is None:
@@ -463,6 +469,7 @@ class Settings(BaseSettings):
             ("MODEL_OPUS", self.model_opus),
             ("MODEL_SONNET", self.model_sonnet),
             ("MODEL_HAIKU", self.model_haiku),
+            ("MODEL_FALLBACK_VISION", self.model_fallback_vision),
         )
         sources_by_ref: dict[str, list[str]] = {}
         for source, model_ref in candidates:

--- a/tests/api/test_vision_fallback.py
+++ b/tests/api/test_vision_fallback.py
@@ -1,0 +1,271 @@
+"""Tests for the dynamic vision fallback routing logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from api.models.anthropic import (
+    ContentBlockImage,
+    ContentBlockText,
+    Message,
+    MessagesRequest,
+)
+from api.services import ClaudeProxyService
+from config.settings import Settings
+
+
+def test_vision_fallback_skips_when_no_image():
+    settings = Settings()
+    settings.model = "open_router/openai/gpt-oss-120b:free"
+    settings.model_fallback_vision = "open_router/moonshotai/kimi-k2.6:free"
+
+    mock_provider = MagicMock()
+
+    async def fake_stream(*_a, **_kw):
+        yield "event: message_start\ndata: {}\n\n"
+
+    mock_provider.stream_response = fake_stream
+    service = ClaudeProxyService(settings, provider_getter=lambda _: mock_provider)
+
+    request = MessagesRequest(
+        model="claude-3-sonnet-20240229",
+        max_tokens=10,
+        messages=[Message(role="user", content="hello text only")],
+    )
+
+    with patch("api.services.logger.info") as mock_info:
+        service.create_message(request)
+
+    # Check that fallback was NOT logged
+    fallback_logs = [
+        call.args
+        for call in mock_info.call_args_list
+        if "Dynamically falling back to vision model" in str(call.args)
+    ]
+    assert len(fallback_logs) == 0
+
+
+def test_vision_fallback_triggers_when_image_present():
+    settings = Settings()
+    settings.model = "open_router/openai/gpt-oss-120b:free"
+    settings.model_fallback_vision = "open_router/moonshotai/kimi-k2.6:free"
+
+    mock_provider = MagicMock()
+    # provider_getter will receive the provider_id ("open_router")
+    provider_ids_requested = []
+
+    def get_provider(pid):
+        provider_ids_requested.append(pid)
+        return mock_provider
+
+    async def fake_stream(*_a, **_kw):
+        yield "event: message_start\ndata: {}\n\n"
+
+    mock_provider.stream_response = fake_stream
+    service = ClaudeProxyService(settings, provider_getter=get_provider)
+
+    # Message containing an image block as content dict
+    request = MessagesRequest(
+        model="claude-3-sonnet-20240229",
+        max_tokens=10,
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockText(type="text", text="What is this image?"),
+                    ContentBlockImage(
+                        type="image",
+                        source={
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "abc",
+                        },
+                    ),
+                ],
+            )
+        ],
+    )
+
+    with patch("api.services.logger.info") as mock_info:
+        service.create_message(request)
+
+    # Check that fallback WAS logged
+    fallback_logs = [
+        call.args
+        for call in mock_info.call_args_list
+        if "Dynamically falling back to vision model" in str(call.args[0])
+    ]
+    assert len(fallback_logs) == 1
+    # Verify the fallback model is logged correctly
+    assert "open_router/moonshotai/kimi-k2.6:free" in fallback_logs[0][2]
+
+
+def test_vision_fallback_ignored_when_model_already_supports_vision():
+    settings = Settings()
+    settings.model = "open_router/google/gemini-2.5-flash:free"
+    settings.model_fallback_vision = "open_router/moonshotai/kimi-k2.6:free"
+
+    mock_provider = MagicMock()
+
+    async def fake_stream(*_a, **_kw):
+        yield "event: message_start\ndata: {}\n\n"
+
+    mock_provider.stream_response = fake_stream
+    service = ClaudeProxyService(settings, provider_getter=lambda _: mock_provider)
+
+    request = MessagesRequest(
+        model="claude-3-sonnet-20240229",
+        max_tokens=10,
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockText(type="text", text="What is this image?"),
+                    ContentBlockImage(
+                        type="image",
+                        source={
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "abc",
+                        },
+                    ),
+                ],
+            )
+        ],
+    )
+
+    with patch("api.services.logger.info") as mock_info:
+        service.create_message(request)
+
+    # Check that fallback was NOT logged
+    fallback_logs = [
+        call.args
+        for call in mock_info.call_args_list
+        if "Dynamically falling back to vision model" in str(call.args)
+    ]
+    assert len(fallback_logs) == 0
+
+
+def test_vision_fallback_ignored_when_no_fallback_configured():
+    settings = Settings()
+    settings.model = "open_router/openai/gpt-oss-120b:free"
+    settings.model_fallback_vision = None
+
+    mock_provider = MagicMock()
+
+    async def fake_stream(*_a, **_kw):
+        yield "event: message_start\ndata: {}\n\n"
+
+    mock_provider.stream_response = fake_stream
+    service = ClaudeProxyService(settings, provider_getter=lambda _: mock_provider)
+
+    request = MessagesRequest(
+        model="claude-3-sonnet-20240229",
+        max_tokens=10,
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockText(type="text", text="What is this image?"),
+                    ContentBlockImage(
+                        type="image",
+                        source={
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "abc",
+                        },
+                    ),
+                ],
+            )
+        ],
+    )
+
+    with patch("api.services.logger.info") as mock_info:
+        service.create_message(request)
+
+    # Check that fallback was NOT logged
+    fallback_logs = [
+        call.args
+        for call in mock_info.call_args_list
+        if "Dynamically falling back to vision model" in str(call.args)
+    ]
+    assert len(fallback_logs) == 0
+
+
+def test_vision_fallback_sanitizes_multiple_images():
+    settings = Settings()
+    settings.model = "open_router/openai/gpt-oss-120b:free"
+    settings.model_fallback_vision = "open_router/moonshotai/kimi-k2.6:free"
+
+    mock_provider = MagicMock()
+    captured_body = {}
+
+    async def fake_stream(request, *args, **kwargs):
+        captured_body["request"] = request
+        yield "event: message_start\ndata: {}\n\n"
+
+    mock_provider.stream_response = fake_stream
+    service = ClaudeProxyService(settings, provider_getter=lambda _: mock_provider)
+
+    request = MessagesRequest(
+        model="claude-3-sonnet-20240229",
+        max_tokens=10,
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockText(type="text", text="First turn image"),
+                    ContentBlockImage(
+                        type="image",
+                        source={
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "first_img_data",
+                        },
+                    ),
+                ],
+            ),
+            Message(
+                role="assistant",
+                content="Understood.",
+            ),
+            Message(
+                role="user",
+                content=[
+                    ContentBlockText(type="text", text="Second turn image"),
+                    ContentBlockImage(
+                        type="image",
+                        source={
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "second_img_data",
+                        },
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    response = service.create_message(request)
+
+    import asyncio
+    from fastapi.responses import StreamingResponse
+
+    async def consume():
+        if isinstance(response, StreamingResponse):
+            async for _ in response.body_iterator:
+                pass
+
+    asyncio.run(consume())
+
+    routed_req = captured_body.get("request")
+    assert routed_req is not None
+    # Verify the first image block was replaced by a text block placeholder
+    first_msg = routed_req.messages[0]
+    assert first_msg.content[1].type == "text"
+    assert "removed to comply with 1-image limit" in first_msg.content[1].text
+
+    # Verify the second (most recent) image block was kept as-is
+    last_msg = routed_req.messages[2]
+    assert last_msg.content[1].type == "image"
+    assert last_msg.content[1].source["data"] == "second_img_data"


### PR DESCRIPTION
This Pull Request addresses two related fatal issues when dealing with multimodal/vision inputs (e.g., screenshots or browser tools) in Claude Code sessions routed through text-only OpenRouter models:

1. **Vision Fallback (HTTP 404)**: When a text-only model like `openai/gpt-oss-120b:free` is active, and Claude Code triggers a screenshot, the upstream provider returns `HTTP 404 No endpoints found that support image input`. This PR introduces a configurable `MODEL_FALLBACK_VISION` (e.g., `open_router/moonshotai/kimi-k2.6:free`) to automatically reroute the request to a free vision-capable model.
2. **1-Image Limit Sanitization (HTTP 400)**: Free vision models (like Moonshot Kimi K2.6) strictly allow at most 1 image per prompt. In long chat sessions, Claude Code retains past turn screenshots in the prompt history, causing the upstream provider to reject the request with `HTTP 400 Model supports at most 1 image per prompt`. This PR introduces an image history sanitizer that retains only the most recent screenshot block (current active prompt) and replaces older legacy screenshots with lightweight text placeholders.

### Changes Implemented
* Added `MODEL_FALLBACK_VISION` settings configuration and startup validation checks (`config/settings.py`, `.env`, `.env.example`).
* Implemented `_has_image_block` detection and `_sanitize_old_images` history scrub inside `api/services.py`.
* Added 5 comprehensive unit tests verifying vision fallback triggers, bypasses, and sanitization behavior (`tests/api/test_vision_fallback.py`).
* All code formatting (`ruff format`), lint checks (`ruff check`), static typing (`ty check`), and test suites pass perfectly (1202/1202 tests passed).