### PR TITLE
fix(deepseek): Claude Code 2.1.152 multi-turn 400 error - inject placeholder thinking blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__
 agent_workspace
 .env
 server.log
+server_err.log
+server_diag.log
 debug-*.log
 .coverage
 llama_cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,70 @@
+# Changelog — Luiz-crypto-cmd fork
+
+## Fix: Claude Code 2.1.152 + DeepSeek thinking — multi-turn 400 error (2026-05-27)
+
+### Problem
+
+After Claude Code auto-updated to **2.1.152** on May 27, 2026, all multi-turn conversations with
+DeepSeek (deepseek-v4-pro / deepseek-reasoner) started failing with:
+
+```
+● Invalid request sent to provider.
+  Request ID: req_xxxxxxxx
+```
+
+The underlying HTTP error from DeepSeek:
+```json
+{"error": {"message": "The `content[].thinking` in the thinking mode must be passed back to the API.", "type": "invalid_request_error"}}
+```
+
+### Root cause
+
+Claude Code **2.1.152** added a cryptographic signature requirement for thinking blocks:
+it only stores thinking blocks in conversation history if they carry a valid `signature` field
+signed by Anthropic's infrastructure.
+
+DeepSeek's Anthropic-compatible API does **not** emit `signature_delta` events (it's not
+Anthropic's real infrastructure). So:
+
+1. Turn 1: DeepSeek generates thinking → proxy forwards it → Claude Code **discards it** (no signature)
+2. Turn 2: Claude Code sends history without thinking blocks → DeepSeek requires them → **HTTP 400**
+
+deepseek-v4-pro is an always-on reasoning model: it requires prior thinking blocks in **all**
+assistant turns with tool_use, regardless of whether thinking is explicitly requested in the
+current turn.
+
+### Fix (2 files)
+
+**`providers/deepseek/request.py`** — `_inject_placeholder_thinking_blocks()`
+
+When the proxy detects assistant messages in history that have `tool_use` blocks but no
+`thinking` block (because Claude Code dropped them), it injects a minimal placeholder:
+
+```python
+{"type": "thinking", "thinking": "(prior reasoning not available)"}
+```
+
+This satisfies DeepSeek's history validation. The model still generates full real thinking
+on every new response.
+
+**`core/anthropic/native_sse_block_policy.py`** — synthetic `signature_delta`
+
+Injects a `signature_delta` SSE event before each `content_block_stop` for thinking blocks.
+This causes Claude Code to store thinking blocks in history when the signature validation
+is not strictly enforced (forward-compatibility fix).
+
+**`config/logging_config.py`** — Windows restart fix
+
+Replaced manual `Path.write_text("")` truncation with `mode="w"` on the loguru file sink,
+fixing a `PermissionError` on Windows when restarting the gateway while the previous
+process still held the log file handle.
+
+### Affected versions
+
+- Claude Code ≥ 2.1.152
+- DeepSeek provider (deepseek-v4-pro, deepseek-reasoner, any always-on reasoning model)
+- All other providers unaffected
+
+### Upstream
+
+Based on [free-claude-code](https://github.com/Alishahryar1/free-claude-code) by Ali Khokhar (MIT).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,85 @@
 # Changelog — Luiz-crypto-cmd fork
 
+## Fix: AVG HTTPS-scanning breaks DeepSeek streams — "empty or malformed response" (2026-07-22)
+
+### Problem
+
+Claude Code suddenly started failing with:
+
+```
+API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request
+```
+
+Symptoms:
+- Small/fast requests mostly worked; large conversations (200+ messages) reliably stalled.
+- A stalled request produced **zero log output** in `server.log` — no error, no exception —
+  the client just retried the same message count ~5 minutes later (matching `HTTP_READ_TIMEOUT`).
+- Restarting the proxy made it worse: freshly-spawned `python.exe` crashed on startup with only
+  `OPENSSL_Uplink(...): no OPENSSL_Applink` on stderr and no Python traceback at all — even
+  though the *already-running* process had been serving requests fine for hours.
+
+### Root cause
+
+**AVG Antivirus's HTTPS Scanning (Web Shield) does full TLS interception (MITM) on this
+machine**, including on connections to `api.deepseek.com`. Two distinct failures stack on top
+of each other:
+
+1. **`SSLKEYLOGFILE` crash.** AVG sets this env var system-wide to a named pipe
+   (`\\.\avgMonFltProxy\<id>`) so its driver can log TLS session keys. OpenSSL's Uplink
+   mechanism tries to open that path as a regular file during process init and aborts
+   immediately — before Python's own exception machinery ever gets control (no traceback,
+   exit code 1). The long-running process that was already up had been started before this
+   condition applied (or before AVG re-armed it), so it never hit this path — only *fresh*
+   `python.exe` starts crash.
+2. **Malformed MITM root certificate.** AVG's interception CA
+   (`C:\ProgramData\AVG\Antivirus\wscert.pem`) has its `Basic Constraints` extension marked
+   non-critical, which is out of spec (RFC 5280). Windows' own certificate chain building is
+   lenient and accepts it (so `curl`/Node — via `NODE_EXTRA_CA_CERTS` — work fine), but
+   **OpenSSL 3.x's `VERIFY_X509_STRICT` flag, on by default in `ssl.create_default_context()`
+   since Python 3.13**, rejects it outright: `CERTIFICATE_VERIFY_FAILED`. This project pins
+   Python 3.14, so every fresh TLS handshake through `httpx`'s default context is rejected.
+   On a long SSE stream this doesn't always surface as a clean exception — it can just stall
+   until the read times out, which is why nothing was ever logged.
+
+Confirmed by reproducing directly: `httpx.get("https://api.deepseek.com/...")` failed with
+`CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate`, and after adding AVG's CA
+to `certifi`'s bundle, with `Basic Constraints of CA cert not marked critical` — i.e. rejected
+for being present-but-non-compliant, not for being untrusted.
+
+### Fix (2 places)
+
+**`providers/anthropic_messages.py`** — `AnthropicMessagesTransport`
+
+- Added `_build_relaxed_ssl_context()`: builds the same context httpx would build by default
+  (`ssl.create_default_context(cafile=certifi.where())`) but clears
+  `ssl.VERIFY_X509_STRICT`. Hostname verification and normal chain-of-trust checks stay fully
+  enabled — only the Basic-Constraints-criticality nitpick is relaxed. Passed as
+  `verify=` to the provider's `httpx.AsyncClient`. (AVG's CA also needs to be present in the
+  trust store for this to matter — see workaround below.)
+- Added an explicit `except asyncio.CancelledError:` branch in `stream_response()` before the
+  general `except Exception`, since `CancelledError` is `BaseException` in Python 3.8+ and was
+  silently swallowing client-disconnect/stream-cancellation events with zero log trace. This
+  doesn't change behavior (still re-raises) — it just makes future stalls diagnosable instead
+  of leaving a completely empty `server.log`.
+
+**Per-machine workaround (not code, do this once):**
+1. Append AVG's root cert to the venv's `certifi` bundle so it's trusted at all:
+   `cat /c/ProgramData/AVG/Antivirus/wscert.pem >> .venv/Lib/site-packages/certifi/cacert.pem`
+   (gets wiped on `certifi` reinstall/upgrade — reapply if that ever happens).
+2. `Start-FreeCC` (PowerShell profile) now clears `SSLKEYLOGFILE` for the spawned proxy
+   process before launching uvicorn, to avoid the startup crash.
+
+**Better long-term fix:** disable AVG's "HTTPS Scanning" / "Web Shield" SSL inspection
+entirely (AVG settings → Protections → Web/Email Shield). This removes both failure modes at
+the source for every app on the machine, not just this proxy, and stops AVG from
+man-in-the-middling your dev traffic in general.
+
+### Affected versions
+
+- Any machine with AVG (or likely Avast, same engine) HTTPS Scanning enabled
+- Python 3.13+ (`VERIFY_X509_STRICT` default) — Python ≤3.12 masked this bug
+- Any provider using `AnthropicMessagesTransport` (DeepSeek, Kimi, Z.ai, Zhipu)
+
 ## Fix: Claude Code 2.1.152 + DeepSeek thinking — multi-turn 400 error (2026-05-27)
 
 ### Problem

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Use Claude Code CLI, VS Code, JetBrains ACP, or chat bots through your own Anthropic-compatible proxy.
 
+> **🔧 This fork fixes the Claude Code 2.1.152 + DeepSeek thinking breakage.**
+> After the May 27 2026 auto-update, all multi-turn DeepSeek conversations fail with
+> `"Invalid request sent to provider"` / HTTP 400 `"content[].thinking must be passed back"`.
+> See [CHANGES.md](CHANGES.md) for full details and the fix.
+> Original repo: [Alishahryar1/free-claude-code](https://github.com/Alishahryar1/free-claude-code)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Python 3.14](https://img.shields.io/badge/python-3.14-3776ab.svg?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json&style=for-the-badge)](https://github.com/astral-sh/uv)

--- a/api/models/anthropic.py
+++ b/api/models/anthropic.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 # =============================================================================
@@ -92,7 +92,7 @@ class SystemContent(_AnthropicBlockBase):
 # Message Types
 # =============================================================================
 class Message(BaseModel):
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]  # system aceptado, filtrado antes de enviar al provider
     content: (
         str
         | list[
@@ -156,6 +156,14 @@ class MessagesRequest(BaseModel):
     # Beta feature flags sent by Claude Code as a body field; accepted but never forwarded.
     betas: list[str] | None = Field(default=None, exclude=True)
 
+    @model_validator(mode="after")
+    def remove_system_role_messages(self) -> "MessagesRequest":
+        """Elimina mensajes con role=system del historial.
+        Claude Code los inyecta como recordatorios de contexto, pero DeepSeek/OpenAI
+        solo acepta 'user' y 'assistant' en el array messages."""
+        self.messages = [m for m in self.messages if m.role != "system"]
+        return self
+
 
 class TokenCountRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -172,3 +180,8 @@ class TokenCountRequest(BaseModel):
     output_config: dict[str, Any] | None = None
     mcp_servers: list[dict[str, Any]] | None = None
     betas: list[str] | None = Field(default=None, exclude=True)
+
+    @model_validator(mode="after")
+    def remove_system_role_messages(self) -> "TokenCountRequest":
+        self.messages = [m for m in self.messages if m.role != "system"]
+        return self

--- a/api/services.py
+++ b/api/services.py
@@ -18,7 +18,7 @@ from providers.base import BaseProvider
 from providers.exceptions import InvalidRequestError, ProviderError
 
 from .model_router import ModelRouter
-from .models.anthropic import MessagesRequest, TokenCountRequest
+from .models.anthropic import MessagesRequest, SystemContent, TokenCountRequest
 from .models.responses import TokenCountResponse
 from .optimization_handlers import try_optimizations
 from .web_tools.egress import WebFetchEgressPolicy
@@ -34,6 +34,82 @@ ProviderGetter = Callable[[str], BaseProvider]
 
 # Providers that use ``/chat/completions`` + Anthropic-to-OpenAI conversion (not native Messages).
 _OPENAI_CHAT_UPSTREAM_IDS = frozenset({"nvidia_nim"})
+
+_AGENTIC_DIRECTIVE = (
+    "\n\n<agentic_behavior_directive>"
+    "\nYou are an autonomous agent executing multi-step tasks. Rules:"
+    "\n1. NEVER end your turn mid-task. Complete ALL steps before stopping."
+    "\n2. NEVER use run_in_background for tasks whose results you need — run them"
+    " synchronously."
+    "\n3. After each tool result, immediately determine and execute the next step."
+    "\n4. Chain as many tool calls as needed within a single turn."
+    "\n5. Only stop when the entire task is fully complete and verified."
+    "\n</agentic_behavior_directive>"
+)
+
+
+def _message_starts_with_tool_result(m: Any) -> bool:
+    """True if the message's first content block is a tool_result.
+
+    A user message that opens with tool_result blocks is a follow-up to an
+    assistant tool_use turn.  If that assistant turn was trimmed away, the
+    tool_result blocks are orphaned and DeepSeek rejects the request with:
+      "Each tool_result block must have a corresponding tool_use block in the
+       previous message."
+    """
+    content = getattr(m, "content", None)
+    if not isinstance(content, list) or not content:
+        return False
+    first = content[0]
+    return getattr(first, "type", None) == "tool_result"
+
+
+def _truncate_messages(request: MessagesRequest, max_messages: int) -> MessagesRequest:
+    """Trim the conversation history to the most recent ``max_messages`` messages.
+
+    Takes the last ``max_messages`` messages, then advances the start pointer to
+    the first ``user`` message whose first block is NOT a tool_result.  This
+    prevents orphaned tool_result blocks (whose paired assistant tool_use was
+    trimmed) from appearing at position 0, which DeepSeek rejects with HTTP 400.
+    """
+    msgs = request.messages
+    if len(msgs) <= max_messages:
+        return request
+
+    kept = msgs[-max_messages:]
+    # Find the first clean user message (not a tool_result continuation).
+    for i, m in enumerate(kept):
+        if m.role == "user" and not _message_starts_with_tool_result(m):
+            kept = kept[i:]
+            break
+
+    if not kept:
+        kept = msgs[-1:]
+
+    original = len(msgs)
+    logger.info(
+        "CONTEXT_TRIM: truncated %d → %d messages (cap=%d)",
+        original,
+        len(kept),
+        max_messages,
+    )
+    return request.model_copy(update={"messages": kept})
+
+
+def _inject_agentic_directive(request: MessagesRequest) -> MessagesRequest:
+    """Append the agentic directive to the system prompt (only for tool-bearing requests)."""
+    if not request.tools:
+        return request
+    system = request.system
+    if system is None:
+        new_system: str | list[SystemContent] = _AGENTIC_DIRECTIVE.strip()
+    elif isinstance(system, str):
+        new_system = system + _AGENTIC_DIRECTIVE
+    else:
+        new_system = list(system) + [
+            SystemContent(type="text", text=_AGENTIC_DIRECTIVE.strip())
+        ]
+    return request.model_copy(update={"system": new_system})
 
 
 def anthropic_sse_streaming_response(
@@ -102,6 +178,17 @@ class ClaudeProxyService:
         """Create a message response or streaming response."""
         try:
             _require_non_empty_messages(request_data.messages)
+
+            if (
+                self._settings.max_request_messages is not None
+                and len(request_data.messages) > self._settings.max_request_messages
+            ):
+                request_data = _truncate_messages(
+                    request_data, self._settings.max_request_messages
+                )
+
+            if self._settings.inject_agentic_directive:
+                request_data = _inject_agentic_directive(request_data)
 
             routed = self._model_router.resolve_messages_request(request_data)
             if routed.resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS:

--- a/config/logging_config.py
+++ b/config/logging_config.py
@@ -93,16 +93,15 @@ def configure_logging(
     # Remove default loguru handler (writes to stderr)
     logger.remove()
 
-    # Truncate log file on fresh start for clean debugging
-    Path(log_file).write_text("")
-
     # Add file sink: JSON lines, DEBUG level, context vars at top level
+    # mode="w" truncates on open (replaces the manual write_text("") which
+    # caused PermissionError on Windows when the previous process held the handle)
     logger.add(
         log_file,
         level="DEBUG",
         format=_serialize_with_context,
         encoding="utf-8",
-        mode="a",
+        mode="w",
         rotation="50 MB",
     )
 

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -14,6 +14,8 @@ TransportType = Literal["openai_chat", "anthropic_messages"]
 # Default upstream base URLs (also re-exported via :mod:`providers.defaults`)
 NVIDIA_NIM_DEFAULT_BASE = "https://integrate.api.nvidia.com/v1"
 KIMI_DEFAULT_BASE = "https://api.moonshot.ai/v1"
+ZHIPU_DEFAULT_BASE = "https://open.bigmodel.cn/api/paas/v4"
+ZAI_DEFAULT_BASE = "https://api.z.ai/api/anthropic"
 # DeepSeek Anthropic-compatible Messages API (not OpenAI ``/v1`` chat completions).
 DEEPSEEK_ANTHROPIC_DEFAULT_BASE = "https://api.deepseek.com/anthropic"
 # Historical export name: DeepSeek upstream is the native Anthropic path above.
@@ -112,6 +114,25 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=KIMI_DEFAULT_BASE,
         proxy_attr="kimi_proxy",
         capabilities=("chat", "streaming", "tools"),
+    ),
+    "zhipu": ProviderDescriptor(
+        provider_id="zhipu",
+        transport_type="openai_chat",
+        credential_env="ZHIPU_API_KEY",
+        credential_url="https://open.bigmodel.cn/usercenter/apikeys",
+        credential_attr="zhipu_api_key",
+        default_base_url=ZHIPU_DEFAULT_BASE,
+        proxy_attr="zhipu_proxy",
+        capabilities=("chat", "streaming", "tools", "thinking"),
+    ),
+    "z_ai": ProviderDescriptor(
+        provider_id="z_ai",
+        transport_type="anthropic_messages",
+        credential_env="ZAI_API_KEY",
+        credential_url="https://z.ai",
+        credential_attr="zai_api_key",
+        default_base_url=ZAI_DEFAULT_BASE,
+        capabilities=("chat", "streaming", "tools", "thinking", "native_anthropic"),
     ),
 }
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -115,6 +115,12 @@ class Settings(BaseSettings):
     # ==================== Kimi Config ====================
     kimi_api_key: str = Field(default="", validation_alias="KIMI_API_KEY")
 
+    # ==================== Zhipu AI (GLM) Config ====================
+    zhipu_api_key: str = Field(default="", validation_alias="ZHIPU_API_KEY")
+
+    # ==================== Z.ai (GLM-5.2) Config ====================
+    zai_api_key: str = Field(default="", validation_alias="ZAI_API_KEY")
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord" | "none"
     messaging_platform: str = Field(
@@ -165,6 +171,7 @@ class Settings(BaseSettings):
     lmstudio_proxy: str = Field(default="", validation_alias="LMSTUDIO_PROXY")
     llamacpp_proxy: str = Field(default="", validation_alias="LLAMACPP_PROXY")
     kimi_proxy: str = Field(default="", validation_alias="KIMI_PROXY")
+    zhipu_proxy: str = Field(default="", validation_alias="ZHIPU_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")
@@ -207,6 +214,23 @@ class Settings(BaseSettings):
     enable_title_generation_skip: bool = True
     enable_suggestion_mode_skip: bool = True
     enable_filepath_extraction_mock: bool = True
+
+    # ==================== Agentic Directive ====================
+    # When true, appends a system-prompt suffix instructing the model to complete
+    # multi-step agentic tasks without stopping mid-turn.  Targets models (DeepSeek,
+    # GLM, etc.) that end their turn prematurely when using background commands.
+    inject_agentic_directive: bool = Field(
+        default=True, validation_alias="INJECT_AGENTIC_DIRECTIVE"
+    )
+
+    # ==================== Context Window Trim ====================
+    # Maximum number of messages forwarded to the upstream provider per request.
+    # When a Claude Code session grows beyond this, the oldest messages are dropped
+    # (keeping the most recent turns) to prevent multi-MB request bodies and
+    # upstream token-limit errors.  Set to None to disable trimming.
+    max_request_messages: int | None = Field(
+        default=400, validation_alias="MAX_REQUEST_MESSAGES"
+    )
 
     # ==================== Local web server tools (web_search / web_fetch) ====================
     # Off by default: these tools perform outbound HTTP from the proxy (SSRF risk).

--- a/core/anthropic/native_sse_block_policy.py
+++ b/core/anthropic/native_sse_block_policy.py
@@ -302,6 +302,26 @@ def transform_native_sse_block_event(
         if seg is not None and seg.open:
             payload["index"] = seg.down_index
             seg.open = False
+
+            # Claude Code 2.1+ only stores thinking blocks in conversation history
+            # when they carry a ``signature`` field.  DeepSeek's native API does not
+            # emit ``signature_delta`` events, so we inject a synthetic one before
+            # the stop event.  This lets Claude Code replay thinking blocks in
+            # multi-turn conversations, which DeepSeek requires.
+            if seg.block_type == "thinking" and thinking_enabled:
+                sig_payload = {
+                    "type": "content_block_delta",
+                    "index": seg.down_index,
+                    "delta": {
+                        "type": "signature_delta",
+                        "signature": "deepseek-freecc-thinking-sig",
+                    },
+                }
+                sig_event = format_native_sse_event(
+                    "content_block_delta", json.dumps(sig_payload)
+                )
+                return sig_event + format_native_sse_event(event_name, json.dumps(payload))
+
             return format_native_sse_event(event_name, json.dumps(payload))
         if seg is not None:
             # Spurious or duplicate `content_block_stop` for a closed block.

--- a/core/thinking_cache.py
+++ b/core/thinking_cache.py
@@ -1,0 +1,46 @@
+"""Server-side LRU cache for DeepSeek thinking content.
+
+DeepSeek-v4-pro always generates thinking blocks, but Claude Code 2.1+ strips
+them from conversation history before sending to the API.  This cache lets the
+proxy recover the real thinking text when injecting placeholders for prior turns,
+replacing the generic "(prior reasoning not available)" with actual content.
+
+Cache key  : frozenset of tool_use IDs produced during that assistant turn.
+Cache value: the complete thinking text accumulated during that turn's stream.
+
+IDs are unique per turn (DeepSeek assigns them), so the lookup is collision-free
+as long as the history spans fewer than MAX_SIZE completed turns.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+
+_MAX_SIZE = 300
+
+
+class ThinkingCache:
+    """LRU cache mapping tool_use ID sets → thinking text."""
+
+    _lru: OrderedDict[frozenset, str] = OrderedDict()
+
+    @classmethod
+    def store(cls, tool_ids: frozenset[str], thinking: str) -> None:
+        """Store thinking text for a turn identified by its tool_use IDs."""
+        if not tool_ids or not thinking:
+            return
+        if tool_ids in cls._lru:
+            cls._lru.move_to_end(tool_ids)
+        else:
+            if len(cls._lru) >= _MAX_SIZE:
+                cls._lru.popitem(last=False)
+        cls._lru[tool_ids] = thinking
+
+    @classmethod
+    def lookup(cls, tool_ids: frozenset[str]) -> str | None:
+        """Return cached thinking for a given set of tool_use IDs, or None."""
+        if not tool_ids:
+            return None
+        val = cls._lru.get(tool_ids)
+        if val is not None:
+            cls._lru.move_to_end(tool_ids)
+        return val

--- a/providers/anthropic_messages.py
+++ b/providers/anthropic_messages.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import ssl
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, Literal
 
+import certifi
 import httpx
 from loguru import logger
 
@@ -36,6 +39,23 @@ from providers.model_listing import (
 from providers.rate_limit import GlobalRateLimiter
 
 StreamChunkMode = Literal["line", "event"]
+
+
+def _build_relaxed_ssl_context() -> ssl.SSLContext:
+    """SSL context matching httpx's default, with X.509 strict-mode relaxed.
+
+    Some antivirus HTTPS-scanning proxies (observed with AVG) install a root
+    CA whose Basic Constraints extension isn't marked critical. Windows'
+    trust store accepts it, but OpenSSL's VERIFY_X509_STRICT flag (on by
+    default in ssl.create_default_context() since Python 3.13) rejects it,
+    surfacing as CERTIFICATE_VERIFY_FAILED and, mid-stream, as connections
+    that stall until read-timeout with no error ever raised. Hostname
+    verification and chain-of-trust checks stay fully enabled; only that one
+    RFC-5280-strictness check is relaxed.
+    """
+    context = ssl.create_default_context(cafile=certifi.where())
+    context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+    return context
 
 
 def _model_list_json(response: httpx.Response, *, provider_name: str) -> Any:
@@ -73,6 +93,7 @@ class AnthropicMessagesTransport(BaseProvider):
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
             proxy=config.proxy or None,
+            verify=_build_relaxed_ssl_context(),
             timeout=httpx.Timeout(
                 config.http_read_timeout,
                 connect=config.http_connect_timeout,
@@ -429,6 +450,23 @@ class AnthropicMessagesTransport(BaseProvider):
                     from core.thinking_cache import ThinkingCache
                     ThinkingCache.store(frozenset(_tool_ids), "".join(_thinking_parts))
 
+            except asyncio.CancelledError:
+                # Client disconnected or gave up waiting (e.g. its own request
+                # timeout fired) mid-stream. This must stay a bare re-raise:
+                # asyncio.CancelledError is BaseException, not Exception, and
+                # swallowing it here would break task cancellation semantics.
+                # We only add logging so silent stalls are visible in server.log
+                # instead of leaving zero trace of what happened to the request.
+                logger.warning(
+                    "{}_STREAM:{} cancelled (client disconnected or gave up) "
+                    "after receiving upstream data={}",
+                    tag,
+                    req_tag,
+                    sent_any_event,
+                )
+                if response is not None and not response.is_closed:
+                    await response.aclose()
+                raise
             except Exception as error:
                 if not isinstance(error, httpx.HTTPStatusError):
                     self._log_stream_transport_error(tag, req_tag, error)

--- a/providers/anthropic_messages.py
+++ b/providers/anthropic_messages.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, Literal
 
@@ -373,14 +374,60 @@ class AnthropicMessagesTransport(BaseProvider):
                     _validated_stream_send
                 )
 
+                # Accumulate thinking text and tool_use IDs for the thinking cache.
+                # Chunks are individual SSE lines; buffer them until an empty line
+                # marks the end of a complete event, then extract what we need.
+                _ev_lines: list[str] = []
+                _thinking_parts: list[str] = []
+                _tool_ids: set[str] = set()
+
+                def _proc_buf() -> None:
+                    ev_name = None
+                    ev_data = None
+                    for ln in _ev_lines:
+                        if ln.startswith("event:"):
+                            ev_name = ln[6:].strip()
+                        elif ln.startswith("data:"):
+                            ev_data = ln[5:].lstrip()
+                    _ev_lines.clear()
+                    if not ev_name or not ev_data:
+                        return
+                    try:
+                        p = json.loads(ev_data)
+                    except Exception:
+                        return
+                    if ev_name == "content_block_delta":
+                        d = p.get("delta") or {}
+                        if isinstance(d, dict) and d.get("type") == "thinking_delta":
+                            t = d.get("thinking")
+                            if isinstance(t, str):
+                                _thinking_parts.append(t)
+                    elif ev_name == "content_block_start":
+                        blk = p.get("content_block") or {}
+                        if isinstance(blk, dict) and blk.get("type") == "tool_use":
+                            tid = blk.get("id")
+                            if isinstance(tid, str) and tid:
+                                _tool_ids.add(tid)
+
                 async for chunk in self._iter_stream_chunks(
                     response,
                     state=state,
                     thinking_enabled=thinking_enabled,
                 ):
+                    s = chunk.rstrip("\r\n")
+                    if s:
+                        _ev_lines.append(s)
+                    elif _ev_lines:
+                        _proc_buf()
                     sent_any_event = True
                     emitted_tracker.feed(chunk)
                     yield chunk
+
+                if _ev_lines:
+                    _proc_buf()
+                if _thinking_parts and _tool_ids:
+                    from core.thinking_cache import ThinkingCache
+                    ThinkingCache.store(frozenset(_tool_ids), "".join(_thinking_parts))
 
             except Exception as error:
                 if not isinstance(error, httpx.HTTPStatusError):

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -227,7 +227,7 @@ def _has_prior_assistant_without_thinking(data: dict[str, Any]) -> bool:
     conversation history.  Claude Code 2.1+ does not include thinking blocks
     when replaying history, causing DeepSeek to reject the request with:
       "The content[].thinking in the thinking mode must be passed back to the API."
-    When detected, we disable thinking so DeepSeek accepts the conversation.
+    When detected, placeholder thinking blocks are injected into the affected turns.
     """
     messages = data.get("messages") or []
     # Only relevant when there is more than one message (multi-turn conversation).

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -220,6 +220,36 @@ def _has_replayable_tool_thinking(data: dict[str, Any]) -> bool:
     return False
 
 
+def _has_prior_assistant_without_thinking(data: dict[str, Any]) -> bool:
+    """True if there is a prior assistant message with content but no thinking block.
+
+    DeepSeek requires that thinking blocks from prior turns are replayed in the
+    conversation history.  Claude Code 2.1+ does not include thinking blocks
+    when replaying history, causing DeepSeek to reject the request with:
+      "The content[].thinking in the thinking mode must be passed back to the API."
+    When detected, we disable thinking so DeepSeek accepts the conversation.
+    """
+    messages = data.get("messages") or []
+    # Only relevant when there is more than one message (multi-turn conversation).
+    if len(messages) < 2:
+        return False
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        if message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list) or not content:
+            continue
+        has_thinking = any(
+            isinstance(block, dict) and block.get("type") == "thinking"
+            for block in content
+        )
+        if not has_thinking:
+            return True
+    return False
+
+
 def _remove_deepseek_thinking_hints(data: dict[str, Any]) -> None:
     """Remove request hints that can keep DeepSeek in thinking mode after fallback."""
     output_config = data.get("output_config")
@@ -260,10 +290,58 @@ def _remove_deepseek_thinking_hints(data: dict[str, Any]) -> None:
             data.pop("context_management", None)
 
 
+def _inject_placeholder_thinking_blocks(messages: Any) -> Any:
+    """Inject placeholder thinking blocks for assistant turns that have tool_use but no thinking.
+
+    DeepSeek-v4-pro is an always-on reasoning model: it requires thinking blocks in ALL
+    prior assistant turns that contain tool_use blocks.  If Claude Code 2.1+ didn't store
+    the original thinking blocks (because they lacked a valid Anthropic signature), we
+    inject minimal placeholders so DeepSeek accepts the conversation history.
+    """
+    if not isinstance(messages, list):
+        return messages
+
+    result: list[Any] = []
+    injected = 0
+    for msg in messages:
+        if not isinstance(msg, dict):
+            result.append(msg)
+            continue
+        if msg.get("role") != "assistant":
+            result.append(msg)
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            result.append(msg)
+            continue
+
+        has_thinking = any(
+            isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking")
+            for b in content
+        )
+        has_tool_use = any(isinstance(b, dict) and b.get("type") == "tool_use" for b in content)
+
+        if has_tool_use and not has_thinking:
+            placeholder = {"type": "thinking", "thinking": "(prior reasoning not available)"}
+            new_msg = dict(msg)
+            new_msg["content"] = [placeholder] + list(content)
+            result.append(new_msg)
+            injected += 1
+        else:
+            result.append(msg)
+
+    if injected:
+        logger.debug(
+            "DEEPSEEK_REQUEST: injected {} placeholder thinking block(s) for prior tool-use turns",
+            injected,
+        )
+    return result
+
+
 def sanitize_deepseek_messages_for_native(
     messages: Any, *, thinking_enabled: bool
 ) -> Any:
-    """Filter assistant content for DeepSeek: unsigned ``thinking`` is allowed; no ``redacted_thinking``."""
+    """Filter assistant content for DeepSeek: unsigned ``thinking`` is allowed; no ``redacted_thinking``."""  # noqa: E501
     if not isinstance(messages, list):
         return messages
 
@@ -398,18 +476,28 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
 
     has_tool_history = _has_tool_history(data)
     has_replayable_tool_thinking = _has_replayable_tool_thinking(data)
-    unsafe_tool_followup = has_tool_history and not has_replayable_tool_thinking
-    effective_thinking_enabled = thinking_enabled and not unsafe_tool_followup
+    # DeepSeek-v4-pro is an always-on reasoning model: it requires thinking blocks in all
+    # prior assistant turns with tool_use.  Claude Code 2.1+ drops thinking blocks from
+    # history (no valid Anthropic signature).  Instead of disabling thinking (which still
+    # fails because DeepSeek requires prior thinking regardless of the current request
+    # parameter), inject placeholder thinking blocks into incomplete history turns.
+    missing_prior_thinking = thinking_enabled and _has_prior_assistant_without_thinking(data)
+    needs_placeholder_injection = thinking_enabled and (
+        missing_prior_thinking or (has_tool_history and not has_replayable_tool_thinking)
+    )
+    effective_thinking_enabled = thinking_enabled
+
     if thinking_enabled:
-        if unsafe_tool_followup:
+        if needs_placeholder_injection:
             logger.debug(
-                "DEEPSEEK_REQUEST: disabling thinking for tool follow-up without "
-                "replayable thinking model={} msgs={} tools={}",
+                "DEEPSEEK_REQUEST: injecting placeholder thinking for incomplete history "
+                "model={} msgs={} tools={}",
                 data.get("model"),
                 len(data.get("messages", [])),
                 len(data.get("tools", [])),
             )
-            _remove_deepseek_thinking_hints(data)
+            if "messages" in data:
+                data["messages"] = _inject_placeholder_thinking_blocks(data["messages"])
         elif has_tool_history:
             logger.debug(
                 "DEEPSEEK_REQUEST: keeping thinking for tool follow-up with "
@@ -428,11 +516,12 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
             )
 
     thinking_cfg = data.pop("thinking", None)
-    if effective_thinking_enabled and isinstance(thinking_cfg, dict):
+    if effective_thinking_enabled:
         thinking_payload: dict[str, Any] = {"type": "enabled"}
-        budget_tokens = thinking_cfg.get("budget_tokens")
-        if isinstance(budget_tokens, int):
-            thinking_payload["budget_tokens"] = budget_tokens
+        if isinstance(thinking_cfg, dict):
+            budget_tokens = thinking_cfg.get("budget_tokens")
+            if isinstance(budget_tokens, int):
+                thinking_payload["budget_tokens"] = budget_tokens
         data["thinking"] = thinking_payload
 
     if "messages" in data:

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -290,14 +290,29 @@ def _remove_deepseek_thinking_hints(data: dict[str, Any]) -> None:
             data.pop("context_management", None)
 
 
-def _inject_placeholder_thinking_blocks(messages: Any) -> Any:
-    """Inject placeholder thinking blocks for assistant turns that have tool_use but no thinking.
+def _tool_ids_from_content(content: list) -> frozenset[str]:
+    """Extract tool_use IDs from an assistant message content list."""
+    return frozenset(
+        b["id"]
+        for b in content
+        if isinstance(b, dict)
+        and b.get("type") == "tool_use"
+        and isinstance(b.get("id"), str)
+        and b["id"]
+    )
 
-    DeepSeek-v4-pro is an always-on reasoning model: it requires thinking blocks in ALL
-    prior assistant turns that contain tool_use blocks.  If Claude Code 2.1+ didn't store
-    the original thinking blocks (because they lacked a valid Anthropic signature), we
-    inject minimal placeholders so DeepSeek accepts the conversation history.
+
+def _inject_placeholder_thinking_blocks(messages: Any) -> Any:
+    """Inject real or placeholder thinking blocks for assistant turns without thinking.
+
+    DeepSeek-v4-pro requires thinking blocks in ALL prior assistant turns that contain
+    tool_use blocks.  Claude Code 2.1+ strips thinking from conversation history, so we
+    inject them here.  When the thinking cache has the real content (stored server-side
+    during the original stream), we use it; otherwise we fall back to a short placeholder
+    so DeepSeek still accepts the request.
     """
+    from core.thinking_cache import ThinkingCache
+
     if not isinstance(messages, list):
         return messages
 
@@ -322,7 +337,10 @@ def _inject_placeholder_thinking_blocks(messages: Any) -> Any:
         has_tool_use = any(isinstance(b, dict) and b.get("type") == "tool_use" for b in content)
 
         if has_tool_use and not has_thinking:
-            placeholder = {"type": "thinking", "thinking": "(prior reasoning not available)"}
+            tool_ids = _tool_ids_from_content(content)
+            cached = ThinkingCache.lookup(tool_ids) if tool_ids else None
+            thinking_text = cached if cached else "(prior reasoning not available)"
+            placeholder = {"type": "thinking", "thinking": thinking_text}
             new_msg = dict(msg)
             new_msg["content"] = [placeholder] + list(content)
             result.append(new_msg)
@@ -332,7 +350,7 @@ def _inject_placeholder_thinking_blocks(messages: Any) -> Any:
 
     if injected:
         logger.debug(
-            "DEEPSEEK_REQUEST: injected {} placeholder thinking block(s) for prior tool-use turns",
+            "DEEPSEEK_REQUEST: injected {} thinking block(s) for prior tool-use turns",
             injected,
         )
     return result

--- a/providers/defaults.py
+++ b/providers/defaults.py
@@ -9,6 +9,8 @@ from config.provider_catalog import (
     NVIDIA_NIM_DEFAULT_BASE,
     OLLAMA_DEFAULT_BASE,
     OPENROUTER_DEFAULT_BASE,
+    ZAI_DEFAULT_BASE,
+    ZHIPU_DEFAULT_BASE,
 )
 
 __all__ = (
@@ -20,4 +22,6 @@ __all__ = (
     "NVIDIA_NIM_DEFAULT_BASE",
     "OLLAMA_DEFAULT_BASE",
     "OPENROUTER_DEFAULT_BASE",
+    "ZAI_DEFAULT_BASE",
+    "ZHIPU_DEFAULT_BASE",
 )

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -74,6 +74,18 @@ def _create_kimi(config: ProviderConfig, _settings: Settings) -> BaseProvider:
     return KimiProvider(config)
 
 
+def _create_zhipu(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+    from providers.zhipu import ZhipuProvider
+
+    return ZhipuProvider(config)
+
+
+def _create_z_ai(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+    from providers.z_ai import ZAiProvider
+
+    return ZAiProvider(config)
+
+
 PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
@@ -82,6 +94,8 @@ PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "llamacpp": _create_llamacpp,
     "ollama": _create_ollama,
     "kimi": _create_kimi,
+    "zhipu": _create_zhipu,
+    "z_ai": _create_z_ai,
 }
 
 if set(PROVIDER_DESCRIPTORS) != set(SUPPORTED_PROVIDER_IDS) or set(

--- a/providers/z_ai/__init__.py
+++ b/providers/z_ai/__init__.py
@@ -1,0 +1,7 @@
+"""Z.ai (GLM-5.2) provider exports — native Anthropic Messages API."""
+
+from .client import ZAiProvider
+
+__all__ = [
+    "ZAiProvider",
+]

--- a/providers/z_ai/client.py
+++ b/providers/z_ai/client.py
@@ -1,0 +1,44 @@
+"""Z.ai (GLM-5.2) provider — native Anthropic Messages transport.
+
+Z.ai exposes a native Anthropic Messages-compatible endpoint at
+``https://api.z.ai/api/anthropic``, so requests pass through unmodified.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from providers.anthropic_messages import AnthropicMessagesTransport
+from providers.base import ProviderConfig
+
+ZAI_DEFAULT_BASE = "https://api.z.ai/api/anthropic"
+
+
+class ZAiProvider(AnthropicMessagesTransport):
+    """Z.ai provider for GLM-5.2 using native Anthropic Messages API."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="ZAI",
+            default_base_url=ZAI_DEFAULT_BASE,
+        )
+
+    def _request_headers(self) -> dict[str, str]:
+        return {
+            "Accept": "text/event-stream",
+            "Content-Type": "application/json",
+            "x-api-key": self._api_key,
+        }
+
+    async def _send_model_list_request(self) -> httpx.Response:
+        """Z.ai may not expose a /models endpoint; always pass and let discovery fail gracefully."""
+        url = str(
+            httpx.URL(self._base_url).copy_with(
+                path="/models", query=None, fragment=None
+            )
+        )
+        return await self._client.get(url, headers=self._model_list_headers())
+
+    def _model_list_headers(self) -> dict[str, str]:
+        return {"x-api-key": self._api_key}

--- a/providers/zhipu/__init__.py
+++ b/providers/zhipu/__init__.py
@@ -1,0 +1,10 @@
+"""Zhipu AI (GLM) provider exports."""
+
+from providers.defaults import ZHIPU_DEFAULT_BASE
+
+from .client import ZhipuProvider
+
+__all__ = [
+    "ZHIPU_DEFAULT_BASE",
+    "ZhipuProvider",
+]

--- a/providers/zhipu/client.py
+++ b/providers/zhipu/client.py
@@ -1,0 +1,31 @@
+"""Zhipu AI (GLM) provider implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers.base import ProviderConfig
+from providers.defaults import ZHIPU_DEFAULT_BASE
+from providers.openai_compat import OpenAIChatTransport
+
+from .request import build_request_body
+
+
+class ZhipuProvider(OpenAIChatTransport):
+    """Zhipu AI (GLM) provider using the OpenAI-compatible chat completions API."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="ZHIPU",
+            base_url=config.base_url or ZHIPU_DEFAULT_BASE,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        return build_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+        )

--- a/providers/zhipu/request.py
+++ b/providers/zhipu/request.py
@@ -1,0 +1,37 @@
+"""Request builder for Zhipu AI (GLM) provider."""
+
+from typing import Any
+
+from loguru import logger
+
+from core.anthropic import ReasoningReplayMode, build_base_request_body
+from core.anthropic.conversion import OpenAIConversionError
+from providers.exceptions import InvalidRequestError
+
+
+def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
+    """Build OpenAI-format request body from Anthropic request."""
+    logger.debug(
+        "ZHIPU_REQUEST: conversion start model={} msgs={}",
+        getattr(request_data, "model", "?"),
+        len(getattr(request_data, "messages", [])),
+    )
+    try:
+        body = build_base_request_body(
+            request_data,
+            reasoning_replay=(
+                ReasoningReplayMode.REASONING_CONTENT
+                if thinking_enabled
+                else ReasoningReplayMode.DISABLED
+            ),
+        )
+    except OpenAIConversionError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+
+    logger.debug(
+        "ZHIPU_REQUEST: conversion done model={} msgs={} tools={}",
+        body.get("model"),
+        len(body.get("messages", [])),
+        len(body.get("tools", [])),
+    )
+    return body

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastapi[standard]>=0.136.1",
     "uvicorn>=0.46.0",
     "httpx[socks]>=0.28.1",
+    "certifi>=2024.2.2",
     "markdown-it-py>=3.0.0",
     "pydantic>=2.13.3",
     "python-dotenv>=1.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -561,6 +561,7 @@ version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "certifi" },
     { name = "discord-py" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx", extra = ["socks"] },
@@ -602,6 +603,7 @@ dev = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'voice-local'", specifier = ">=1.13.0" },
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "certifi", specifier = ">=2024.2.2" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.1" },
     { name = "grpcio", marker = "extra == 'voice'", specifier = ">=1.80.0" },
@@ -1310,6 +1312,7 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/f9/85f0bf863deed9078f3a25938a9f06206f98bcc39a6541a48cc97143db10/nvidia_riva_client-2.25.1-1-py3-none-any.whl", hash = "sha256:bde1232a8de3fe1561cccf49d3d0e6fe06190b1f0df4ad0ba118b9f5ae5a06aa", size = 55383, upload-time = "2026-04-30T10:27:58.381Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c6/eb4acc0cb884c06109ea123d1c7dbb28974c9dddd73a624b1765a89e023e/nvidia_riva_client-2.25.1-2-py3-none-any.whl", hash = "sha256:5657680ab238b5930c07ce9a4a50d642524f25bff4099c1f818baaa8baad94fe", size = 55462, upload-time = "2026-05-06T12:30:02.948Z" },
     { url = "https://files.pythonhosted.org/packages/08/3b/b267af66a49c2e80e673b85ccd5484059b141be8031e4a4bb84ea4bcf31f/nvidia_riva_client-2.25.1-py3-none-any.whl", hash = "sha256:07c48c9cc7f3ca04cd988ad6d2205b0bcf3f6f25bb97d76b397e87cc696acc9f", size = 55371, upload-time = "2026-03-25T13:05:57.425Z" },
 ]
 


### PR DESCRIPTION
## Problem

After Claude Code auto-updated to **2.1.152** on May 27 2026, all multi-turn DeepSeek conversations fail with `"Invalid request sent to provider"` / HTTP 400:

```
"The content[].thinking in the thinking mode must be passed back to the API."
```

## Root cause

Claude Code 2.1.152 added a cryptographic signature requirement: it only stores thinking blocks in conversation history if they carry a valid `signature` field signed by Anthropic. DeepSeek does not emit `signature_delta` events, so thinking blocks are silently dropped.

`deepseek-v4-pro` is an always-on reasoning model that requires thinking blocks in ALL prior assistant turns with tool_use. With Claude Code dropping them, every multi-turn conversation fails.

## Fix

**`providers/deepseek/request.py`** — adds `_inject_placeholder_thinking_blocks()`

Detects assistant messages with `tool_use` but no `thinking` block and injects a minimal placeholder before forwarding to DeepSeek. Thinking stays enabled so DeepSeek generates real thinking on every new response.

**`core/anthropic/native_sse_block_policy.py`** — synthetic `signature_delta`

Injects a synthetic `signature_delta` event before `content_block_stop` for thinking blocks (forward-compatibility for if Claude Code relaxes signature validation).

**`config/logging_config.py`** — Windows restart fix

Fixes `PermissionError` on Windows when restarting the gateway by using `mode="w"` on the loguru sink instead of manual file truncation.

## Affected

- Claude Code >= 2.1.152
- DeepSeek provider (deepseek-v4-pro, deepseek-reasoner, any always-on reasoning model)
- All other providers unaffected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands provider support and repairs DeepSeek multi-turn reasoning history. The main changes are:

- Placeholder thinking blocks and cached reasoning replay for DeepSeek.
- Synthetic thinking signatures in native SSE streams.
- New Zhipu and Z.ai provider integrations.
- Configurable message trimming and agentic system directives.
- Updated TLS handling and Windows log-file startup behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge based on the eligible follow-up scope.

No additional blocking issue qualifies for a new follow-up comment.

The reviewed provider and DeepSeek changes add the intended request and transport behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The general-contract-validation-proof confirms the forwarder now serializes blocks as \[thinking, text, tool\_use\] and uses cached reasoning associated with toolu\_cc\_2152, with the tool result normalized to 'green'.
- The proof also confirms that after SSE transformation the terminal ordering is signature\_delta followed by content\_block\_stop at downstream index 0.
- The harness phases completed with exit code 0, as documented in the proof.
- Artifacts were reviewed to corroborate the changes, including the Python-based serialization artifact and three harness logs with accessible URLs.

<a href="https://app.greptile.com/trex/runs/15394652/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| providers/deepseek/request.py | Adds placeholder thinking recovery and cached reasoning replay for prior DeepSeek tool-use turns. |
| providers/anthropic_messages.py | Adds TLS context handling, cancellation diagnostics, and streamed reasoning collection. |
| api/services.py | Adds configurable history trimming and an optional agentic system directive. |
| config/provider_catalog.py | Registers the new Zhipu and Z.ai providers and their capabilities. |

<sub>Reviews (4): Last reviewed commit: ["fix(transport): relax X.509 strict mode ..."](https://github.com/alishahryar1/free-claude-code/commit/21a65411a49cdda940102747fa6ddf9df85c771d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34327508)</sub>

<!-- /greptile_comment -->