### PR TITLE
feat(anthropic): support system role in messages array

### DIFF
--- a/api/models/anthropic.py
+++ b/api/models/anthropic.py
@@ -92,7 +92,7 @@ class SystemContent(_AnthropicBlockBase):
 # Message Types
 # =============================================================================
 class Message(BaseModel):
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: (
         str
         | list[

--- a/core/anthropic/conversion.py
+++ b/core/anthropic/conversion.py
@@ -234,7 +234,16 @@ class AnthropicToOpenAIConverter:
                         converted["content"] = "\n\n".join(content_parts)
                 result.append(converted)
             elif isinstance(content, list):
-                if role == "user":
+                if role == "system":
+                    text_parts = [
+                        get_block_attr(b, "text", "")
+                        for b in content
+                        if get_block_type(b) == "text"
+                    ]
+                    result.append(
+                        {"role": "system", "content": "\n\n".join(text_parts).strip()}
+                    )
+                elif role == "user":
                     if pending is not None and pending.needs_deferred():
                         if not pending.remaining_tool_ids:
                             result.extend(


### PR DESCRIPTION
## Summary
- Allow `role: "system"` in the `Message` Pydantic model, so inline system messages in the messages array pass validation (previously only `"user"` and `"assistant"` were accepted)
- Handle list-content system messages in the Anthropic→OpenAI converter, extracting text blocks and emitting `{"role": "system", "content": "..."}` instead of silently dropping them

## Context
Claude Code recently started injecting `{"role": "system", ...}` messages directly into the messages array (not just as the top-level `system` field). This is used for features like prompt caching and context injection across turns. The existing Pydantic model rejected these, causing request validation failures.

## Test plan
- [ ] Send a request with `{"role": "system", "content": "..."}` in the messages array — should accept without validation error
- [ ] Send a request with `{"role": "system", "content": [{"type": "text", "text": "..."}]}` — list-content system messages should convert correctly for OpenAI upstreams
- [ ] Existing requests with only `user`/`assistant` messages continue to work unchanged