### PR TITLE
fix: handle null tool_call index from Gemini (openai-compat streaming)

### DIFF
--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -235,6 +235,8 @@ class OpenAIChatTransport(BaseProvider):
     ) -> Iterator[str]:
         """Process a single tool call delta and yield SSE events."""
         tc_index = tc.get("index", 0)
+        if tc_index is None:
+            tc_index = 0
         if tc_index < 0:
             tc_index = len(sse.blocks.tool_states)
 

--- a/tests/providers/test_openai_compat_tool_index.py
+++ b/tests/providers/test_openai_compat_tool_index.py
@@ -1,0 +1,85 @@
+"""Regression tests for tool_call ``index`` handling in ``_process_tool_call``.
+
+Gemini's OpenAI-compatible streaming emits tool_call deltas where ``index`` is
+an explicit ``null`` (the key is present with value ``None``) rather than an
+integer. ``dict.get("index", 0)`` returns ``None`` for an explicit null -- the
+default only applies to a *missing* key -- so the downstream ``if tc_index < 0``
+raised::
+
+    TypeError: '<' not supported between instances of 'NoneType' and 'int'
+
+A simple text response never hits this path, which is why the symptom was
+"plain replies work but any tool call crashes" on Gemini. The fix coerces a
+``None`` index to ``0`` before the comparison.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from config.nim import NimSettings
+from core.anthropic import ContentBlockManager
+from providers.base import ProviderConfig
+from providers.nvidia_nim import NvidiaNimProvider
+
+
+# ``_process_tool_call`` lives on the shared ``OpenAIChatTransport`` base, so any
+# concrete subclass exercises it; NvidiaNimProvider is the lightest to build.
+def _provider() -> NvidiaNimProvider:
+    return NvidiaNimProvider(ProviderConfig(api_key="test"), nim_settings=NimSettings())
+
+
+def _sse() -> MagicMock:
+    sse = MagicMock()
+    sse.blocks = ContentBlockManager()
+    return sse
+
+
+def test_process_tool_call_handles_null_index():
+    """A delta with ``index: None`` (Gemini) must not raise and lands at 0."""
+    provider = _provider()
+    sse = _sse()
+
+    tc = {
+        "index": None,  # Gemini openai-compat sends an explicit null here
+        "id": "tool_123",
+        "function": {"name": "Read", "arguments": json.dumps({"file_path": "x.py"})},
+    }
+
+    # Before the fix this raised TypeError on ``None < 0``.
+    list(provider._process_tool_call(tc, sse))
+
+    # The null index is coerced to 0, so the tool block is registered at index 0.
+    assert 0 in sse.blocks.tool_states
+    assert sse.start_tool_block.call_args[0][0] == 0
+
+
+def test_process_tool_call_missing_index_defaults_to_zero():
+    """An absent ``index`` key keeps the pre-existing default-to-0 behavior."""
+    provider = _provider()
+    sse = _sse()
+
+    tc = {
+        "id": "tool_456",
+        "function": {"name": "Read", "arguments": "{}"},
+    }
+
+    list(provider._process_tool_call(tc, sse))
+
+    assert 0 in sse.blocks.tool_states
+
+
+def test_process_tool_call_preserves_integer_index():
+    """A normal integer index (OpenAI-spec providers) is untouched."""
+    provider = _provider()
+    sse = _sse()
+
+    tc = {
+        "index": 2,
+        "id": "tool_789",
+        "function": {"name": "Read", "arguments": "{}"},
+    }
+
+    list(provider._process_tool_call(tc, sse))
+
+    assert 2 in sse.blocks.tool_states
+    assert sse.start_tool_block.call_args[0][0] == 2


### PR DESCRIPTION
## Summary

Tool calls crash on **Gemini** (via its OpenAI-compatible endpoint) with:

```
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

Plain-text replies work fine; the crash happens the moment the model returns a
tool call. That makes it look provider-specific, and it is: Gemini's
openai-compat stream emits tool_call deltas with an explicit **`"index": null`**,
whereas OpenAI-spec providers send an integer (or omit the key).

## Root cause

In `OpenAIChatTransport._process_tool_call` (`providers/openai_compat.py`):

```python
tc_index = tc.get("index", 0)
if tc_index < 0:        # None < 0  -> TypeError
```

`dict.get("index", 0)` only falls back to `0` when the key is **missing**. With
an explicit `null` the call returns `None`, and `None < 0` raises.

## Fix

Coerce a `None` index to `0` before the comparison. Existing behavior is
preserved (missing key -> 0, negative index -> append):

```python
tc_index = tc.get("index", 0)
if tc_index is None:
    tc_index = 0
if tc_index < 0:
    tc_index = len(sse.blocks.tool_states)
```

## Tests

Adds `tests/providers/test_openai_compat_tool_index.py`:

- `index: null` -> no longer raises; tool block lands at index 0
  (fails on `main` with the exact `TypeError` above)
- missing `index` -> still defaults to 0
- integer `index` -> preserved

```
3 passed
```

## Repro

Configure any Gemini model and ask Claude Code to use a tool (e.g. "create a
file"). Before this patch the request 500s with the `TypeError`; after, the
tool call streams normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
