### PR TITLE
feat: add AgentRouter provider (Anthropic-compatible Messages)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,10 @@ GROQ_API_KEY=""
 CEREBRAS_API_KEY=""
 
 
+# AgentRouter (Anthropic-compatible Messages at agentrouter.org/v1)
+AGENTROUTER_API_KEY=""
+
+
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
@@ -64,7 +68,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "wafer" | "kimi" | "cerebras" | "groq" | "fireworks" | "zai" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "wafer" | "kimi" | "cerebras" | "groq" | "fireworks" | "zai" | "lmstudio" | "llamacpp" | "ollama" | "agentrouter"
 MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=
@@ -90,6 +94,7 @@ FCC_SMOKE_MODEL_FIREWORKS=
 FCC_SMOKE_MODEL_GEMINI=
 FCC_SMOKE_MODEL_GROQ=
 FCC_SMOKE_MODEL_CEREBRAS=
+FCC_SMOKE_MODEL_AGENTROUTER=
 FCC_SMOKE_NIM_MODELS=
 FCC_SMOKE_NIM_EXTRA_MODELS=
 FCC_SMOKE_OPENROUTER_FREE_MODELS=
@@ -122,6 +127,7 @@ FIREWORKS_PROXY=""
 GEMINI_PROXY=""
 GROQ_PROXY=""
 CEREBRAS_PROXY=""
+AGENTROUTER_PROXY=""
 
 PROVIDER_RATE_LIMIT=1
 PROVIDER_RATE_WINDOW=3

--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -252,6 +252,18 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         ),
     ),
     ConfigFieldSpec(
+        "AGENTROUTER_API_KEY",
+        "AgentRouter API Key",
+        "providers",
+        "secret",
+        settings_attr="agentrouter_api_key",
+        secret=True,
+        description=(
+            "AgentRouter API key for Anthropic-compatible Messages "
+            "at agentrouter.org/v1."
+        ),
+    ),
+    ConfigFieldSpec(
         "LM_STUDIO_BASE_URL",
         "LM Studio Base URL",
         "providers",
@@ -404,6 +416,15 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         "providers",
         "secret",
         settings_attr="cerebras_proxy",
+        secret=True,
+        advanced=True,
+    ),
+    ConfigFieldSpec(
+        "AGENTROUTER_PROXY",
+        "AgentRouter Proxy",
+        "providers",
+        "secret",
+        settings_attr="agentrouter_proxy",
         secret=True,
         advanced=True,
     ),

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -36,6 +36,7 @@ ZAI_DEFAULT_BASE = "https://api.z.ai/api/anthropic/v1"
 GEMINI_DEFAULT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai/"
 GROQ_DEFAULT_BASE = "https://api.groq.com/openai/v1"
 CEREBRAS_DEFAULT_BASE = "https://api.cerebras.ai/v1"
+AGENTROUTER_DEFAULT_BASE = "https://agentrouter.org/v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -244,6 +245,21 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
             "thinking",
             "native_anthropic",
             "local",
+        ),
+    ),
+    "agentrouter": ProviderDescriptor(
+        provider_id="agentrouter",
+        transport_type="anthropic_messages",
+        credential_env="AGENTROUTER_API_KEY",
+        credential_attr="agentrouter_api_key",
+        default_base_url=AGENTROUTER_DEFAULT_BASE,
+        proxy_attr="agentrouter_proxy",
+        capabilities=(
+            "chat",
+            "streaming",
+            "tools",
+            "thinking",
+            "native_anthropic",
         ),
     ),
 }

--- a/config/settings.py
+++ b/config/settings.py
@@ -144,6 +144,9 @@ class Settings(BaseSettings):
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
 
+    # ==================== AgentRouter (Anthropic-compatible Messages) ====================
+    agentrouter_api_key: str = Field(default="", validation_alias="AGENTROUTER_API_KEY")
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord" | "none"
     messaging_platform: str = Field(
@@ -204,6 +207,7 @@ class Settings(BaseSettings):
     gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")
     groq_proxy: str = Field(default="", validation_alias="GROQ_PROXY")
     cerebras_proxy: str = Field(default="", validation_alias="CEREBRAS_PROXY")
+    agentrouter_proxy: str = Field(default="", validation_alias="AGENTROUTER_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")

--- a/providers/agentrouter/__init__.py
+++ b/providers/agentrouter/__init__.py
@@ -1,0 +1,7 @@
+"""AgentRouter provider - Anthropic-compatible native transport."""
+
+from providers.defaults import AGENTROUTER_DEFAULT_BASE
+
+from .client import AgentRouterProvider
+
+__all__ = ["AGENTROUTER_DEFAULT_BASE", "AgentRouterProvider"]

--- a/providers/agentrouter/client.py
+++ b/providers/agentrouter/client.py
@@ -110,16 +110,6 @@ class AgentRouterProvider(AnthropicMessagesTransport):
         """Return whether *line* is a spurious ``data: null`` sentinel."""
         return line.strip() in _NULL_DATA_LINES
 
-    async def _iter_sse_lines(self, response: httpx.Response) -> AsyncIterator[str]:
-        """Yield SSE lines, silently dropping ``data: null`` sentinel lines."""
-        async for line in response.aiter_lines():
-            if self._is_null_data_line(line):
-                continue
-            if line:
-                yield f"{line}\n"
-            else:
-                yield "\n"
-
     async def _iter_sse_events(self, response: httpx.Response) -> AsyncIterator[str]:
         """Group SSE lines into events, filtering ``data: null`` sentinels."""
         event_lines: list[str] = []

--- a/providers/agentrouter/client.py
+++ b/providers/agentrouter/client.py
@@ -1,0 +1,136 @@
+"""AgentRouter provider implementation (native Anthropic-compatible Messages).
+
+AgentRouter proxies Anthropic-compatible models (Claude, DeepSeek, GLM, etc.)
+and expects Claude CLI-style headers for authentication and routing.  The SSE
+stream may contain spurious ``data: null`` lines which are filtered out before
+forwarding to downstream consumers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+from providers.anthropic_messages import AnthropicMessagesTransport
+from providers.base import ProviderConfig
+from providers.defaults import AGENTROUTER_DEFAULT_BASE
+
+# ---------------------------------------------------------------------------
+# Claude CLI fingerprint headers (mirrored from the OpenCode JS plugin)
+# ---------------------------------------------------------------------------
+
+_ANTHROPIC_VERSION = "2023-06-01"
+_ANTHROPIC_BETA = "claude-code-20250219,oauth-2025-04-20"
+_USER_AGENT = "claude-cli/1.0.108 (external, cli)"
+
+_STAINLESS_HEADERS: dict[str, str] = {
+    "x-app": "cli",
+    "x-stainless-lang": "js",
+    "x-stainless-package-version": "0.55.1",
+    "x-stainless-os": "Windows",
+    "x-stainless-arch": "x64",
+    "x-stainless-runtime": "node",
+    "x-stainless-runtime-version": "v22.0.0",
+}
+
+# Sentinel values emitted by AgentRouter that must be stripped from the SSE
+# stream to avoid confusing downstream parsers.
+_NULL_DATA_LINES = frozenset({"data: null", "data:null"})
+
+# Default thinking budget when the client sends ``thinking.type=enabled``
+# without a ``budget_tokens`` value.  AgentRouter requires this field.
+_DEFAULT_THINKING_BUDGET_TOKENS = 10000
+
+
+class AgentRouterProvider(AnthropicMessagesTransport):
+    """AgentRouter using ``https://agentrouter.org/v1/messages``."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="AGENTROUTER",
+            default_base_url=AGENTROUTER_DEFAULT_BASE,
+        )
+
+    # ------------------------------------------------------------------
+    # Request body
+    # ------------------------------------------------------------------
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        """Build native body; ensure ``budget_tokens`` is always present.
+
+        AgentRouter rejects ``thinking.type=enabled`` without a
+        ``budget_tokens`` value, so we inject a default when the client
+        (Claude Code CLI) omits it.
+        """
+        body = super()._build_request_body(request, thinking_enabled=thinking_enabled)
+        thinking = body.get("thinking")
+        if isinstance(thinking, dict) and thinking.get("type") == "enabled":
+            thinking.setdefault("budget_tokens", _DEFAULT_THINKING_BUDGET_TOKENS)
+        return body
+
+    # ------------------------------------------------------------------
+    # Headers
+    # ------------------------------------------------------------------
+
+    def _request_headers(self) -> dict[str, str]:
+        """Return Claude CLI-compatible headers required by AgentRouter."""
+        return {
+            "Accept": "text/event-stream",
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": _USER_AGENT,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "anthropic-beta": _ANTHROPIC_BETA,
+            "anthropic-dangerous-direct-browser-access": "true",
+            **_STAINLESS_HEADERS,
+        }
+
+    def _model_list_headers(self) -> dict[str, str]:
+        """Return auth headers for the ``/models`` endpoint."""
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "User-Agent": _USER_AGENT,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "anthropic-beta": _ANTHROPIC_BETA,
+            "anthropic-dangerous-direct-browser-access": "true",
+            **_STAINLESS_HEADERS,
+        }
+
+    # ------------------------------------------------------------------
+    # SSE filtering - strip ``data: null`` noise from the event stream
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_null_data_line(line: str) -> bool:
+        """Return whether *line* is a spurious ``data: null`` sentinel."""
+        return line.strip() in _NULL_DATA_LINES
+
+    async def _iter_sse_lines(self, response: httpx.Response) -> AsyncIterator[str]:
+        """Yield SSE lines, silently dropping ``data: null`` sentinel lines."""
+        async for line in response.aiter_lines():
+            if self._is_null_data_line(line):
+                continue
+            if line:
+                yield f"{line}\n"
+            else:
+                yield "\n"
+
+    async def _iter_sse_events(self, response: httpx.Response) -> AsyncIterator[str]:
+        """Group SSE lines into events, filtering ``data: null`` sentinels."""
+        event_lines: list[str] = []
+        async for line in response.aiter_lines():
+            if self._is_null_data_line(line):
+                continue
+            if line:
+                event_lines.append(line)
+                continue
+            if event_lines:
+                yield "\n".join(event_lines) + "\n\n"
+                event_lines.clear()
+        if event_lines:
+            yield "\n".join(event_lines) + "\n\n"

--- a/providers/defaults.py
+++ b/providers/defaults.py
@@ -1,6 +1,7 @@
 """Re-exports default upstream base URLs from the config provider catalog."""
 
 from config.provider_catalog import (
+    AGENTROUTER_DEFAULT_BASE,
     CEREBRAS_DEFAULT_BASE,
     CODESTRAL_DEFAULT_BASE,
     DEEPSEEK_ANTHROPIC_DEFAULT_BASE,
@@ -21,6 +22,7 @@ from config.provider_catalog import (
 )
 
 __all__ = (
+    "AGENTROUTER_DEFAULT_BASE",
     "CEREBRAS_DEFAULT_BASE",
     "CODESTRAL_DEFAULT_BASE",
     "DEEPSEEK_ANTHROPIC_DEFAULT_BASE",

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -136,6 +136,12 @@ def _create_cerebras(config: ProviderConfig, _settings: Settings) -> BaseProvide
     return CerebrasProvider(config)
 
 
+def _create_agentrouter(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+    from providers.agentrouter import AgentRouterProvider
+
+    return AgentRouterProvider(config)
+
+
 PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
@@ -154,6 +160,7 @@ PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "lmstudio": _create_lmstudio,
     "llamacpp": _create_llamacpp,
     "ollama": _create_ollama,
+    "agentrouter": _create_agentrouter,
 }
 
 if set(PROVIDER_DESCRIPTORS) != set(SUPPORTED_PROVIDER_IDS) or set(

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -22,6 +22,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "lmstudio",
     "llamacpp",
     "ollama",
+    "agentrouter",
 )
 
 

--- a/tests/providers/test_agentrouter.py
+++ b/tests/providers/test_agentrouter.py
@@ -1,0 +1,333 @@
+"""Tests for AgentRouter native Anthropic Messages provider."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from api.models.anthropic import Message, MessagesRequest, Tool
+from config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from providers.agentrouter import AGENTROUTER_DEFAULT_BASE, AgentRouterProvider
+from providers.base import ProviderConfig
+from tests.stream_contract import assert_canonical_stream_error_envelope
+
+
+class FakeResponse:
+    def __init__(self, *, status_code=200, lines=None, text=""):
+        self.status_code = status_code
+        self._lines = lines or []
+        self._text = text
+        self.is_closed = False
+        self.headers = httpx.Headers()
+        self.request = httpx.Request("POST", "https://agentrouter.org/v1/messages")
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def aclose(self):
+        self.is_closed = True
+
+    async def aiter_bytes(self, chunk_size: int = 65_536):
+        data = self._text.encode("utf-8")
+        for offset in range(0, len(data), chunk_size):
+            yield data[offset : offset + chunk_size]
+
+    def raise_for_status(self):
+        response = httpx.Response(
+            self.status_code,
+            request=self.request,
+            text=self._text,
+        )
+        response.raise_for_status()
+
+
+@pytest.fixture
+def agentrouter_config():
+    return ProviderConfig(
+        api_key="test-agentrouter-key",
+        base_url=AGENTROUTER_DEFAULT_BASE,
+        rate_limit=10,
+        rate_window=60,
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_rate_limiter():
+    @asynccontextmanager
+    async def _slot():
+        yield
+
+    with patch("providers.anthropic_messages.GlobalRateLimiter") as mock:
+        instance = mock.get_scoped_instance.return_value
+
+        async def _passthrough(fn, *args, **kwargs):
+            return await fn(*args, **kwargs)
+
+        instance.execute_with_retry = AsyncMock(side_effect=_passthrough)
+        instance.concurrency_slot.side_effect = _slot
+        yield instance
+
+
+@pytest.fixture
+def agentrouter_provider(agentrouter_config):
+    return AgentRouterProvider(agentrouter_config)
+
+
+def test_default_base_url():
+    assert AGENTROUTER_DEFAULT_BASE == "https://agentrouter.org/v1"
+
+
+def test_init_uses_default_base_url_and_strips_trailing_slash():
+    config = ProviderConfig(
+        api_key="test-agentrouter-key",
+        base_url=f"{AGENTROUTER_DEFAULT_BASE}/",
+    )
+    with patch("httpx.AsyncClient"):
+        provider = AgentRouterProvider(config)
+
+    assert provider._api_key == "test-agentrouter-key"
+    assert provider._base_url == AGENTROUTER_DEFAULT_BASE
+    assert provider._provider_name == "AGENTROUTER"
+
+
+def test_request_headers_contain_claude_cli_fingerprint(agentrouter_provider):
+    headers = agentrouter_provider._request_headers()
+
+    assert headers["Authorization"] == "Bearer test-agentrouter-key"
+    assert headers["Accept"] == "text/event-stream"
+    assert headers["Content-Type"] == "application/json"
+    assert headers["anthropic-version"] == "2023-06-01"
+    assert headers["anthropic-beta"] == "claude-code-20250219,oauth-2025-04-20"
+    assert headers["anthropic-dangerous-direct-browser-access"] == "true"
+    assert headers["User-Agent"] == "claude-cli/1.0.108 (external, cli)"
+    assert headers["x-app"] == "cli"
+    assert headers["x-stainless-lang"] == "js"
+    assert headers["x-stainless-package-version"] == "0.55.1"
+    assert headers["x-stainless-os"] == "Windows"
+    assert headers["x-stainless-arch"] == "x64"
+    assert headers["x-stainless-runtime"] == "node"
+    assert headers["x-stainless-runtime-version"] == "v22.0.0"
+    assert "x-api-key" not in headers
+
+
+def test_model_list_headers_contain_auth_and_fingerprint(agentrouter_provider):
+    headers = agentrouter_provider._model_list_headers()
+
+    assert headers["Authorization"] == "Bearer test-agentrouter-key"
+    assert headers["User-Agent"] == "claude-cli/1.0.108 (external, cli)"
+    assert headers["anthropic-version"] == "2023-06-01"
+    assert headers["anthropic-beta"] == "claude-code-20250219,oauth-2025-04-20"
+    assert headers["x-app"] == "cli"
+
+
+def test_build_request_body_native_shape_and_defaults(agentrouter_provider):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "claude-opus-4-6",
+            "messages": [Message(role="user", content="Hello")],
+            "tools": [
+                Tool(
+                    name="echo",
+                    description="Echo input",
+                    input_schema={"type": "object", "properties": {}},
+                )
+            ],
+            "thinking": {"type": "enabled", "budget_tokens": 2048},
+        }
+    )
+
+    body = agentrouter_provider._build_request_body(request)
+
+    assert body["model"] == "claude-opus-4-6"
+    assert body["messages"][0]["role"] == "user"
+    assert body["tools"][0]["name"] == "echo"
+    assert body["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["stream"] is True
+
+
+def test_build_request_body_injects_default_budget_tokens(agentrouter_provider):
+    """AgentRouter requires budget_tokens; inject default when client omits it."""
+    request = MessagesRequest.model_validate(
+        {
+            "model": "claude-opus-4-6",
+            "messages": [Message(role="user", content="Hello")],
+            "thinking": {"type": "enabled"},
+        }
+    )
+
+    body = agentrouter_provider._build_request_body(request)
+
+    assert body["thinking"]["type"] == "enabled"
+    assert body["thinking"]["budget_tokens"] == 10000
+
+
+def test_build_request_body_preserves_explicit_budget_tokens(agentrouter_provider):
+    """When budget_tokens is explicitly provided, do not override it."""
+    request = MessagesRequest.model_validate(
+        {
+            "model": "claude-opus-4-6",
+            "messages": [Message(role="user", content="Hello")],
+            "thinking": {"type": "enabled", "budget_tokens": 5000},
+        }
+    )
+
+    body = agentrouter_provider._build_request_body(request)
+
+    assert body["thinking"]["budget_tokens"] == 5000
+
+
+@pytest.mark.asyncio
+async def test_lists_models_from_openai_compatible_models_endpoint(
+    agentrouter_provider,
+):
+    with patch.object(
+        agentrouter_provider._client,
+        "get",
+        new_callable=AsyncMock,
+        return_value=httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {"id": "claude-opus-4-6", "object": "model"},
+                    {"id": "deepseek-v4-flash", "object": "model"},
+                ],
+            },
+            request=httpx.Request("GET", "https://agentrouter.org/v1/models"),
+        ),
+    ) as mock_get:
+        assert await agentrouter_provider.list_model_ids() == frozenset(
+            {"claude-opus-4-6", "deepseek-v4-flash"}
+        )
+
+    mock_get.assert_awaited_once()
+    call_headers = mock_get.call_args.kwargs.get(
+        "headers",
+        mock_get.call_args.args[1] if len(mock_get.call_args.args) > 1 else {},
+    )
+    assert call_headers["Authorization"] == "Bearer test-agentrouter-key"
+
+
+@pytest.mark.asyncio
+async def test_stream_uses_post_messages_path(agentrouter_provider):
+    request = MessagesRequest(
+        model="claude-opus-4-6",
+        messages=[Message(role="user", content="hi")],
+    )
+    response = FakeResponse(
+        lines=[
+            "event: message_start",
+            'data: {"type":"message_start"}',
+            "",
+        ]
+    )
+
+    with (
+        patch.object(
+            agentrouter_provider._client,
+            "build_request",
+            return_value=MagicMock(),
+        ) as mock_build,
+        patch.object(
+            agentrouter_provider._client,
+            "send",
+            new_callable=AsyncMock,
+            return_value=response,
+        ),
+    ):
+        events = [
+            event async for event in agentrouter_provider.stream_response(request)
+        ]
+
+    assert events == [
+        "event: message_start\n",
+        'data: {"type":"message_start"}\n',
+        "\n",
+    ]
+    assert response.is_closed
+    assert mock_build.call_args.args[:2] == ("POST", "/messages")
+    assert mock_build.call_args.kwargs["headers"]["Authorization"] == (
+        "Bearer test-agentrouter-key"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_filters_data_null_lines(agentrouter_provider):
+    """AgentRouter may emit ``data: null`` lines that must be stripped."""
+    request = MessagesRequest(
+        model="deepseek-v4-flash",
+        messages=[Message(role="user", content="hi")],
+    )
+    response = FakeResponse(
+        lines=[
+            "event: message_start",
+            'data: {"type":"message_start"}',
+            "",
+            "data: null",
+            "data:null",
+            "event: message_stop",
+            'data: {"type":"message_stop"}',
+            "",
+        ]
+    )
+
+    with (
+        patch.object(
+            agentrouter_provider._client,
+            "build_request",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            agentrouter_provider._client,
+            "send",
+            new_callable=AsyncMock,
+            return_value=response,
+        ),
+    ):
+        events = [
+            event async for event in agentrouter_provider.stream_response(request)
+        ]
+
+    joined = "".join(events)
+    assert "data: null" not in joined
+    assert "data:null" not in joined
+    assert "message_start" in joined
+    assert "message_stop" in joined
+
+
+@pytest.mark.asyncio
+async def test_stream_non_200_maps_to_anthropic_error_event(agentrouter_provider):
+    request = MessagesRequest(
+        model="claude-opus-4-6",
+        messages=[Message(role="user", content="hi")],
+    )
+    response = FakeResponse(status_code=500, text="Internal Server Error")
+
+    with (
+        patch.object(
+            agentrouter_provider._client,
+            "build_request",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            agentrouter_provider._client,
+            "send",
+            new_callable=AsyncMock,
+            return_value=response,
+        ),
+    ):
+        events = [
+            event
+            async for event in agentrouter_provider.stream_response(
+                request, request_id="REQ_AR"
+            )
+        ]
+
+    assert response.is_closed
+    assert_canonical_stream_error_envelope(
+        events, user_message_substr="Provider API request failed"
+    )
+    assert "REQ_AR" in "".join(events)


### PR DESCRIPTION
Adds AgentRouter as a new provider for routing Claude Code requests through agentrouter.org/v1.

## What

AgentRouter proxies Anthropic-compatible models (Claude, DeepSeek, GLM, etc.) via the native Anthropic Messages API at `https://agentrouter.org/v1/messages`.

## Provider features

- **Claude CLI fingerprint headers**: `anthropic-version`, `anthropic-beta`, `User-Agent`, `x-stainless-*` - mirrors the OpenCode JS plugin for proper authentication
- **SSE filtering**: strips spurious `data: null` / `data:null` lines from the stream (mirrors the OpenCode `sanitizeSseBody` transform)
- **Auto-injects `budget_tokens`**: AgentRouter requires `budget_tokens` when `thinking.type=enabled`, but Claude Code CLI often omits it. The provider injects a default of 10000 when missing.

## Files added

- `providers/agentrouter/__init__.py` - exports
- `providers/agentrouter/client.py` - `AgentRouterProvider(AnthropicMessagesTransport)`
- `tests/providers/test_agentrouter.py` - 11 tests

## Files changed

- `config/provider_catalog.py` - `AGENTROUTER_DEFAULT_BASE` + descriptor
- `config/settings.py` - `agentrouter_api_key`, `agentrouter_proxy` fields
- `providers/defaults.py` - re-export
- `providers/registry.py` - factory wiring
- `api/admin_config.py` - admin UI manifest entries (API key + proxy)
- `.env.example` - `AGENTROUTER_API_KEY`, `AGENTROUTER_PROXY`, smoke model
- `tests/contracts/test_provider_catalog_order.py` - canonical order

## Usage

```bash
AGENTROUTER_API_KEY="sk-..."  # in .env or ~/.fcc/.env
MODEL="agentrouter/claude-opus-4-6"  # or deepseek-v4-flash, glm-5.1, etc.
```

## Verification

- `ruff format` - passed
- `ruff check` - passed  
- `ty check` - passed
- `pytest` - 1449/1449 passed (including 11 new agentrouter tests)