### PR TITLE
fix: accept system-role messages and fold into top-level system field

### DIFF
--- a/api/models/anthropic.py
+++ b/api/models/anthropic.py
@@ -142,7 +142,7 @@ def _normalize_system_role_messages(data: Any) -> Any:
 # Message Types
 # =============================================================================
 class Message(BaseModel):
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: (
         str
         | list[

--- a/core/anthropic/conversion.py
+++ b/core/anthropic/conversion.py
@@ -214,6 +214,19 @@ class AnthropicToOpenAIConverter:
                             reasoning_replay=reasoning_replay,
                         )
                     )
+            elif role == "system":
+                # Mid-conversation system messages (context-management edits) cannot be
+                # sent as role:system in OpenAI chat arrays. Re-route as user messages.
+                if isinstance(content, str):
+                    result.append({"role": "user", "content": content})
+                elif isinstance(content, list):
+                    parts = [
+                        get_block_attr(b, "text", "")
+                        for b in content
+                        if isinstance(b, dict) and get_block_type(b) == "text"
+                    ]
+                    if parts:
+                        result.append({"role": "user", "content": "\n\n".join(parts)})
             elif isinstance(content, str):
                 if role == "user" and pending is not None and pending.needs_deferred():
                     result.extend(

--- a/providers/deepseek/request.py
+++ b/providers/deepseek/request.py
@@ -382,6 +382,50 @@ def _strip_reasoning_content_when_native(messages: Any) -> Any:
     return out
 
 
+def _fold_system_messages_to_top_level(messages: Any, existing_system: Any) -> tuple[Any, Any]:
+    """Move ``role: system`` messages out of the messages array into the top-level ``system`` field.
+
+    DeepSeek's native API rejects ``system``-role messages in the conversation array.
+    Claude Code sends them as context-management edits (mid-conversation system updates).
+    """
+    if not isinstance(messages, list):
+        return messages, existing_system
+
+    sys_parts: list[str] = []
+    user_assistant: list[Any] = []
+
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "system":
+            user_assistant.append(message)
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            sys_parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    sys_parts.append(str(block.get("text", "")))
+
+    if not sys_parts:
+        return messages, existing_system
+
+    new_system_parts: list[str] = []
+    if isinstance(existing_system, str):
+        new_system_parts.append(existing_system)
+    elif isinstance(existing_system, list):
+        for block in existing_system:
+            if isinstance(block, dict) and block.get("type") == "text":
+                new_system_parts.append(str(block.get("text", "")))
+    new_system_parts.extend(sys_parts)
+
+    logger.debug(
+        "DEEPSEEK_REQUEST: folded {} system messages → top-level system ({:,} chars)".format(
+            len(messages) - len(user_assistant), sum(len(p) for p in sys_parts)
+        )
+    )
+    return user_assistant, "\n\n".join(new_system_parts)
+
+
 def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
     """Build a DeepSeek ``/v1/messages`` JSON body (Anthropic format)."""
     logger.debug(
@@ -393,6 +437,9 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
     data = dump_raw_messages_request(request_data)
     if "messages" in data:
         data["messages"] = _strip_unsupported_attachment_blocks(data["messages"])
+        data["messages"], data["system"] = _fold_system_messages_to_top_level(
+            data["messages"], data.get("system")
+        )
     _validate_deepseek_native_request_dict(data)
     data.pop("extra_body", None)
 


### PR DESCRIPTION
## Summary

Claude Code sends mid-conversation system prompt updates as `role: "system"` messages in the messages array (context-management edits). The current Pydantic `Message` model rejects these at validation time, returning HTTP 422 before the request reaches any provider.

```
Request validation failed: path=/v1/messages error_locs=[['body', 'messages', 1, 'role']]
message_summary=[{'role': 'user', ...}, {'role': 'system', 'content_kind': 'str', 'content_length': 22119}]
```

## Changes

- **`api/models/anthropic.py`** — allows `"system"` in the `Message.role` Literal so validation passes
- **`providers/deepseek/request.py`** — adds `_fold_system_messages_to_top_level()` which extracts system-role messages from the messages array and appends their content to the top-level `system` field (proper Anthropic format). Called before forwarding to DeepSeek, whose API rejects system-role messages in the conversation array
- **`core/anthropic/conversion.py`** — re-routes mid-conversation system messages as user messages in the OpenAI converter path (OpenAI also rejects system-role messages after the first position)

## Test plan

- [x] Verified proxy starts and serves `/v1/models` after changes
- [x] Existing conversation flow through the proxy continues to work
- [x] No change to behavior for requests without system-role messages (early-return in `_fold_system_messages_to_top_level`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)