### PR TITLE
fix: guard rate_limit=None in GlobalRateLimiter initialization (#654)

### DIFF
--- a/providers/rate_limit.py
+++ b/providers/rate_limit.py
@@ -62,7 +62,7 @@ class GlobalRateLimiter:
 
     def __init__(
         self,
-        rate_limit: int = 40,
+        rate_limit: int | None = None,
         rate_window: float = 60.0,
         max_concurrency: int = 5,
     ):
@@ -70,6 +70,9 @@ class GlobalRateLimiter:
         if hasattr(self, "_initialized"):
             return
 
+        # None means "use the built-in default of 40 req/window"
+        if rate_limit is None:
+            rate_limit = 40
         if rate_limit <= 0:
             raise ValueError("rate_limit must be > 0")
         if rate_window <= 0:

--- a/tests/providers/test_provider_rate_limit.py
+++ b/tests/providers/test_provider_rate_limit.py
@@ -192,10 +192,9 @@ class TestProviderRateLimiter:
 
     @pytest.mark.asyncio
     async def test_init_rate_limit_none_uses_default(self):
-        """rate_limit=None falls back to the built-in default so it never trips the '<=' check."""
+        """rate_limit=None on the constructor must fall back to the default before validation."""
         GlobalRateLimiter.reset_instance()
-        limiter = GlobalRateLimiter.get_instance(rate_limit=None, rate_window=60)
-        # Should be initialized with the default of 40.
+        limiter = GlobalRateLimiter(rate_limit=None, rate_window=60)
         assert limiter._rate_limit == 40
 
     @pytest.mark.asyncio

--- a/tests/providers/test_provider_rate_limit.py
+++ b/tests/providers/test_provider_rate_limit.py
@@ -191,6 +191,14 @@ class TestProviderRateLimiter:
             GlobalRateLimiter(rate_limit=0, rate_window=60)
 
     @pytest.mark.asyncio
+    async def test_init_rate_limit_none_uses_default(self):
+        """rate_limit=None falls back to the built-in default so it never trips the '<=' check."""
+        GlobalRateLimiter.reset_instance()
+        limiter = GlobalRateLimiter.get_instance(rate_limit=None, rate_window=60)
+        # Should be initialized with the default of 40.
+        assert limiter._rate_limit == 40
+
+    @pytest.mark.asyncio
     async def test_init_rate_window_zero_raises(self):
         """rate_window <= 0 raises ValueError."""
         GlobalRateLimiter.reset_instance()


### PR DESCRIPTION
Fixes the TypeError when rate_limit=None reaches the constructor.

The bug: GlobalRateLimiter.__init__ could receive rate_limit=None (for example via config.map() or provider.get_scoped_instance(...)) and crash on the 'rate_limit <= 0' comparison with a misleading TypeError instead of a clean ValueError.

This change makes rate_limit=None resolve to the built-in default (40) before any comparison, so the validation path always sees an int.

Addresses reviewer feedback: updated the regression test to call GlobalRateLimiter(...) directly, bypassing get_instance, so the new None-guard in __init__ is actually exercised by pytest.

Changes
- providers/rate_limit.py: accept rate_limit: int | None = None, resolve None to 40 before comparing
- tests/providers/test_provider_rate_limit.py: regression test exercises the constructor directly

Verification
- uv run pytest tests/providers/test_provider_rate_limit.py: 35 passed
- ruff-format, ruff-check, ty: clean