### PR TITLE
improve auth error messages with safe upstream context

### DIFF
--- a/core/anthropic/errors.py
+++ b/core/anthropic/errors.py
@@ -1,7 +1,41 @@
 """User-facing error formatting shared by API, providers, and integrations."""
 
+import re
+
 import httpx
 import openai
+
+
+def _redact_token(text: str) -> str:
+    # Redact header-style values: Authorization / api_key / token / secret / password
+    text = re.sub(
+        r"(?i)((Authorization|api_key|X-Api-Key|X-API-Key|token|secret|password)[^\n]*?)(\s*[=:]\s*)([^\n]+)",
+        lambda m: f"{m.group(1)}{m.group(3)}[REDACTED]",
+        text,
+    )
+    # Redact long opaque tokens.
+    text = re.sub(r"\b[A-Za-z0-9_+/=-]{32,}\b", "[REDACTED_TOKEN]", text)
+    return text
+
+
+def _safe_raw_error_preview(raw_error: object, max_len: int = 180) -> str:
+    if raw_error is None:
+        return ""
+    text = str(raw_error).strip()
+    if not text:
+        return ""
+    first_line = text.splitlines()[0]
+    first_line = _redact_token(first_line)
+    return first_line[:max_len]
+
+
+def _format_auth_error(base_message: str, exc: object) -> str:
+    if not isinstance(exc, Exception):
+        return base_message
+    preview = _safe_raw_error_preview(getattr(exc, "raw_error", None))
+    if not preview:
+        return base_message
+    return f"{base_message} Upstream recap: {preview}"
 
 
 def get_user_facing_error_message(
@@ -29,7 +63,7 @@ def get_user_facing_error_message(
     if isinstance(e, openai.RateLimitError):
         return "Provider rate limit reached. Please retry shortly."
     if isinstance(e, openai.AuthenticationError):
-        return "Provider authentication failed. Check API key."
+        return _format_auth_error("Provider authentication failed. Check API key.", e)
     if isinstance(e, openai.BadRequestError):
         return "Invalid request sent to provider."
 
@@ -38,7 +72,7 @@ def get_user_facing_error_message(
     if name == "RateLimitError":
         return "Provider rate limit reached. Please retry shortly."
     if name == "AuthenticationError":
-        return "Provider authentication failed. Check API key."
+        return _format_auth_error("Provider authentication failed. Check API key.", e)
     if name == "InvalidRequestError":
         return "Invalid request sent to provider."
     if name == "OverloadedError":

--- a/tests/providers/test_error_mapping.py
+++ b/tests/providers/test_error_mapping.py
@@ -25,6 +25,55 @@ from providers.exceptions import (
 )
 
 
+def test_authentication_error_plain_401_omits_empty_upstream_cap():
+    exc = _make_openai_error(openai.AuthenticationError, message="", status_code=401)
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    message = get_user_facing_error_message(result)
+    assert message == "Provider authentication failed. Check API key."
+
+
+def test_authentication_error_with_raw_upstream_error_attaches_preview():
+    raw = "Error code: 401 - {'error': {'message': 'Invalid API Key'}}"
+    exc = _make_openai_error(
+        openai.AuthenticationError, message="auth failed", status_code=401
+    )
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    result.raw_error = raw
+    message = get_user_facing_error_message(result)
+    assert message.startswith("Provider authentication failed. Check API key.")
+    assert "Upstream recap:" in message
+    assert "REDACTED" in message or "401" in message
+
+
+def test_authentication_error_raw_error_bearing_token_is_redacted():
+    raw = "Authorization: Bearer sk-ABCDEF1234567890EXTRA"
+    exc = _make_openai_error(
+        openai.AuthenticationError, message="401 Unauthorized", status_code=401
+    )
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    result.raw_error = raw
+    message = get_user_facing_error_message(result)
+    assert "sk-ABCDEF1234567890EXTRA" not in message
+    assert "REDACTED" in message
+
+
+def test_authentication_error_raw_error_with_newlines_only_uses_first_line():
+    raw = "401 Unauthorized\nDate: Wed, 31 May 2026 00:00:00 GMT\nWWW: test"
+    exc = _make_openai_error(
+        openai.AuthenticationError, message="401 Unauthorized", status_code=401
+    )
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    result.raw_error = raw
+    message = get_user_facing_error_message(result)
+    assert "Date:" not in message
+    assert "WWW:" not in message
+    assert "401 Unauthorized" in message
+
+
 def _make_openai_error(cls, message="test error", status_code=None):
     """Helper to create openai exceptions with required httpx objects."""
     response = Response(

--- a/tests/providers/test_error_mapping.py
+++ b/tests/providers/test_error_mapping.py
@@ -44,7 +44,7 @@ def test_authentication_error_with_raw_upstream_error_attaches_preview():
     message = get_user_facing_error_message(result)
     assert message.startswith("Provider authentication failed. Check API key.")
     assert "Upstream recap:" in message
-    assert "REDACTED" in message or "401" in message
+    assert "REDACTED" in message and "401" in message
 
 
 def test_authentication_error_raw_error_bearing_token_is_redacted():


### PR DESCRIPTION
Closes #650.

When a provider returns 401/403, users currently get the same hardcoded string for every failure mode. This change appends a sanitized preview of the upstream error when available, redacting secrets and truncating to one line.

Files Changed
- core/anthropic/errors.py
- tests/providers/test_error_mapping.py

Verification
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest tests/providers/test_error_mapping.py