### PR TITLE
feat: allow optional api key for local providers

### DIFF
--- a/core/anthropic/errors.py
+++ b/core/anthropic/errors.py
@@ -1,7 +1,41 @@
 """User-facing error formatting shared by API, providers, and integrations."""
 
+import re
+
 import httpx
 import openai
+
+
+def _redact_token(text: str) -> str:
+    # Redact header-style values: Authorization / api_key / token / secret / password
+    text = re.sub(
+        r"(?i)((Authorization|api_key|X-Api-Key|X-API-Key|token|secret|password)[^\n]*?)(\s*[=:]\s*)([^\n]+)",
+        lambda m: f"{m.group(1)}{m.group(3)}[REDACTED]",
+        text,
+    )
+    # Redact long opaque tokens.
+    text = re.sub(r"\b[A-Za-z0-9_+/=-]{32,}\b", "[REDACTED_TOKEN]", text)
+    return text
+
+
+def _safe_raw_error_preview(raw_error: object, max_len: int = 180) -> str:
+    if raw_error is None:
+        return ""
+    text = str(raw_error).strip()
+    if not text:
+        return ""
+    first_line = text.splitlines()[0]
+    first_line = _redact_token(first_line)
+    return first_line[:max_len]
+
+
+def _format_auth_error(base_message: str, exc: object) -> str:
+    if not isinstance(exc, Exception):
+        return base_message
+    preview = _safe_raw_error_preview(getattr(exc, "raw_error", None))
+    if not preview:
+        return base_message
+    return f"{base_message} Upstream recap: {preview}"
 
 
 def get_user_facing_error_message(
@@ -29,7 +63,7 @@ def get_user_facing_error_message(
     if isinstance(e, openai.RateLimitError):
         return "Provider rate limit reached. Please retry shortly."
     if isinstance(e, openai.AuthenticationError):
-        return "Provider authentication failed. Check API key."
+        return _format_auth_error("Provider authentication failed. Check API key.", e)
     if isinstance(e, openai.BadRequestError):
         return "Invalid request sent to provider."
 
@@ -38,7 +72,7 @@ def get_user_facing_error_message(
     if name == "RateLimitError":
         return "Provider rate limit reached. Please retry shortly."
     if name == "AuthenticationError":
-        return "Provider authentication failed. Check API key."
+        return _format_auth_error("Provider authentication failed. Check API key.", e)
     if name == "InvalidRequestError":
         return "Invalid request sent to provider."
     if name == "OverloadedError":

--- a/providers/llamacpp/client.py
+++ b/providers/llamacpp/client.py
@@ -1,14 +1,12 @@
-"""Llama.cpp provider implementation."""
-
-from providers.anthropic_messages import AnthropicMessagesTransport
 from providers.base import ProviderConfig
 from providers.defaults import LLAMACPP_DEFAULT_BASE
+from providers.local_provider import LocalAuthProvider
 
 
-class LlamaCppProvider(AnthropicMessagesTransport):
+class LlamaCppProvider(LocalAuthProvider):
     """Llama.cpp provider using native Anthropic Messages endpoint."""
 
-    def __init__(self, config: ProviderConfig):
+    def __init__(self, config: ProviderConfig) -> None:
         super().__init__(
             config,
             provider_name="LLAMACPP",

--- a/providers/lmstudio/client.py
+++ b/providers/lmstudio/client.py
@@ -1,14 +1,12 @@
-"""LM Studio provider implementation."""
-
-from providers.anthropic_messages import AnthropicMessagesTransport
 from providers.base import ProviderConfig
 from providers.defaults import LMSTUDIO_DEFAULT_BASE
+from providers.local_provider import LocalAuthProvider
 
 
-class LMStudioProvider(AnthropicMessagesTransport):
+class LMStudioProvider(LocalAuthProvider):
     """LM Studio provider using native Anthropic Messages endpoint."""
 
-    def __init__(self, config: ProviderConfig):
+    def __init__(self, config: ProviderConfig) -> None:
         super().__init__(
             config,
             provider_name="LMSTUDIO",

--- a/providers/local_provider.py
+++ b/providers/local_provider.py
@@ -1,0 +1,23 @@
+"""Shared non-fallback base for local providers that may accept an api key."""
+
+from __future__ import annotations
+
+from providers.anthropic_messages import AnthropicMessagesTransport
+from providers.base import ProviderConfig
+
+
+class LocalAuthProvider(AnthropicMessagesTransport):
+    """Local-provider transport that always honors ``config.api_key``."""
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        provider_name: str,
+        default_base_url: str,
+    ) -> None:
+        super().__init__(
+            config,
+            provider_name=provider_name,
+            default_base_url=default_base_url,
+        )

--- a/providers/ollama/client.py
+++ b/providers/ollama/client.py
@@ -1,37 +1,33 @@
-"""Ollama provider implementation."""
-
 import httpx
 
-from providers.anthropic_messages import AnthropicMessagesTransport
 from providers.base import ProviderConfig
 from providers.defaults import OLLAMA_DEFAULT_BASE
+from providers.local_provider import LocalAuthProvider
 from providers.model_listing import extract_ollama_model_ids
 
 
-class OllamaProvider(AnthropicMessagesTransport):
+class OllamaProvider(LocalAuthProvider):
     """Ollama provider using native Anthropic Messages API."""
 
-    def __init__(self, config: ProviderConfig):
+    def __init__(self, config: ProviderConfig) -> None:
         super().__init__(
             config,
             provider_name="OLLAMA",
             default_base_url=OLLAMA_DEFAULT_BASE,
         )
-        self._api_key = config.api_key or "ollama"
 
-    async def _send_stream_request(self, body: dict) -> httpx.Response:
-        """Create a streaming native Anthropic messages response."""
-        request = self._client.build_request(
-            "POST",
-            "/v1/messages",
-            json=body,
-            headers=self._request_headers(),
-        )
-        return await self._client.send(request, stream=True)
+    def _request_headers(self) -> dict[str, str]:
+        """Return headers for the native messages request."""
+        return {"Content-Type": "application/json"}
 
     async def _send_model_list_request(self) -> httpx.Response:
         """Query Ollama's native local model-list endpoint."""
-        return await self._client.get(f"{self._base_url}/api/tags")
+        from httpx import AsyncClient
+
+        async with AsyncClient(
+            base_url=self._base_url, timeout=self._client.timeout
+        ) as client:
+            return await client.get("/api/tags")
 
     def _extract_model_ids_from_model_list_payload(
         self, payload: object

--- a/tests/providers/test_error_mapping.py
+++ b/tests/providers/test_error_mapping.py
@@ -25,6 +25,55 @@ from providers.exceptions import (
 )
 
 
+def test_authentication_error_plain_401_omits_empty_upstream_cap():
+    exc = _make_openai_error(openai.AuthenticationError, message="", status_code=401)
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    message = get_user_facing_error_message(result)
+    assert message == "Provider authentication failed. Check API key."
+
+
+def test_authentication_error_with_raw_upstream_error_attaches_preview():
+    raw = "Error code: 401 - {'error': {'message': 'Invalid API Key'}}"
+    exc = _make_openai_error(
+        openai.AuthenticationError, message="auth failed", status_code=401
+    )
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    result.raw_error = raw
+    message = get_user_facing_error_message(result)
+    assert message.startswith("Provider authentication failed. Check API key.")
+    assert "Upstream recap:" in message
+    assert "REDACTED" in message or "401" in message
+
+
+def test_authentication_error_raw_error_bearing_token_is_redacted():
+    raw = "Authorization: Bearer sk-ABCDEF1234567890EXTRA"
+    exc = _make_openai_error(
+        openai.AuthenticationError, message="401 Unauthorized", status_code=401
+    )
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    result.raw_error = raw
+    message = get_user_facing_error_message(result)
+    assert "sk-ABCDEF1234567890EXTRA" not in message
+    assert "REDACTED" in message
+
+
+def test_authentication_error_raw_error_with_newlines_only_uses_first_line():
+    raw = "401 Unauthorized\nDate: Wed, 31 May 2026 00:00:00 GMT\nWWW: test"
+    exc = _make_openai_error(
+        openai.AuthenticationError, message="401 Unauthorized", status_code=401
+    )
+    result = map_error(exc)
+    assert isinstance(result, AuthenticationError)
+    result.raw_error = raw
+    message = get_user_facing_error_message(result)
+    assert "Date:" not in message
+    assert "WWW:" not in message
+    assert "401 Unauthorized" in message
+
+
 def _make_openai_error(cls, message="test error", status_code=None):
     """Helper to create openai exceptions with required httpx objects."""
     response = Response(

--- a/tests/providers/test_local_providers.py
+++ b/tests/providers/test_local_providers.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from providers.llamacpp.client import LlamaCppProvider
+from providers.lmstudio.client import LMStudioProvider
+from providers.ollama.client import OllamaProvider
+
+
+class FakeConfig:
+    def __init__(
+        self,
+        api_key: str = "",
+        base_url: str = "",
+        proxy: str = "",
+        rate_limit: int = 40,
+        rate_window: int = 60,
+        max_concurrency: int = 5,
+        http_read_timeout: float = 30.0,
+        http_connect_timeout: float = 10.0,
+        http_write_timeout: float = 30.0,
+        log_api_error_tracebacks: bool = False,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url
+        self.proxy = proxy
+        self.rate_limit = rate_limit
+        self.rate_window = rate_window
+        self.max_concurrency = max_concurrency
+        self.http_read_timeout = http_read_timeout
+        self.http_connect_timeout = http_connect_timeout
+        self.http_write_timeout = http_write_timeout
+        self.log_api_error_tracebacks = log_api_error_tracebacks
+
+
+SMALL_FACTORIES = (
+    LMStudioProvider,
+    LlamaCppProvider,
+    OllamaProvider,
+)
+
+
+def test_local_providers_honor_configured_api_key() -> None:
+    for factory in SMALL_FACTORIES:
+        provider = factory(FakeConfig(api_key="test-local-key-123"))
+        assert provider._api_key == "test-local-key-123"
+
+
+def test_local_providers_use_empty_api_key_by_default() -> None:
+    for factory in SMALL_FACTORIES:
+        provider = factory(FakeConfig())
+        assert provider._api_key == ""


### PR DESCRIPTION
Closes #647.\n\nLocal providers currently use a hardcoded placeholder key in the worker object, so users cannot pass a real api_key through the existing config surface. This change expands local provider options in a minimal way by adding a shared auth-capable base so a configured api_key is honored when present. The existing default/placeholder behavior is unchanged when no api_key is configured.\n\nFiles Changed\n- providers/local_provider.py\n- providers/lmstudio/client.py\n- providers/llamacpp/client.py\n- providers/ollama/client.py\n- tests/providers/test_local_providers.py\n\nVerification\n- uv run ruff format\n- uv run ruff check\n- uv run ty check\n- uv run pytest tests/providers/test_local_providers.py