### PR TITLE
Fix: Windows WinError 2 when executing Claude CLI

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -378,7 +378,7 @@ class Settings(BaseSettings):
     def claude_cli_bin(self) -> str:
         """Return the fixed Claude Code binary name."""
 
-        return "claude"
+        return "claude.cmd"
 
     @field_validator("whisper_device")
     @classmethod

--- a/config/settings.py
+++ b/config/settings.py
@@ -378,7 +378,7 @@ class Settings(BaseSettings):
     def claude_cli_bin(self) -> str:
         """Return the fixed Claude Code binary name."""
 
-        return "claude.cmd"
+        return "claude.cmd" if os.name == "nt" else "claude"
 
     @field_validator("whisper_device")
     @classmethod


### PR DESCRIPTION
# Windows: Claude CLI fails with `WinError 2` when using `claude` instead of `claude.cmd`

## Description

On Windows, Free Claude Code may fail to execute Claude Code CLI and return:

```text
Error: [WinError 2] The system cannot find the file specified
```

This issue occurs even when Claude Code is installed correctly and `claude --version` works from PowerShell.

## Environment

* OS: Windows 11
* Claude Code: 2.1.159
* Free Claude Code: 2.0.0

## Investigation

The project currently returns the default Claude binary name from:

```python
Lib/site-packages/config/settings.py
```

```python
def claude_cli_bin(self) -> str:
    """Return the fixed Claude Code binary name."""
    return "claude"
```

However, Python subprocess execution behaves differently on Windows.

### Failing test

```python
import subprocess
subprocess.run(["claude", "--version"])
```

Result:

```text
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

### Working test

```python
import subprocess
subprocess.run(["claude.cmd", "--version"])
```

Result:

```text
2.1.159 (Claude Code)
```

## Root Cause

The application uses `claude` as the default executable name. While PowerShell can resolve the npm shim, Python subprocess execution on Windows does not reliably resolve it.

The actual executable entry point installed by npm is:

```text
C:\Users\<USER>\AppData\Roaming\npm\claude.cmd
```

Therefore subprocess calls fail with `WinError 2`.

## Proposed Fix

Change:

```python
return "claude"
```

To:

```python
return "claude.cmd"
```

or implement a platform-specific fallback:

```python
import os

return "claude.cmd" if os.name == "nt" else "claude"
```

## Result

After replacing `claude` with `claude.cmd`:

* Claude CLI launches correctly on Windows
* Telegram messaging works as expected
* `WinError 2` is eliminated
* Claude tasks execute normally

## Additional Notes

This appears to affect Windows installations where Claude Code is installed through npm and executed through Python subprocess calls.