### PR TITLE
feat: Add Xiaomi MiMo provider support

### DIFF
--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -118,6 +118,21 @@ SECTIONS: tuple[ConfigSectionSpec, ...] = (
 
 FIELDS: tuple[ConfigFieldSpec, ...] = (
     ConfigFieldSpec(
+        "XIAOMI_API_KEY",
+        "Xiaomi MiMo API Key",
+        "providers",
+        "secret",
+        settings_attr="xiaomi_api_key",
+        secret=True,
+    ),
+    ConfigFieldSpec(
+        "XIAOMI_BASE_URL",
+        "Xiaomi Base URL",
+        "providers",
+        "text",
+        settings_attr="xiaomi_base_url",
+    ),
+    ConfigFieldSpec(
         "NVIDIA_NIM_API_KEY",
         "NVIDIA NIM API Key",
         "providers",
@@ -412,7 +427,7 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         "Default Model",
         "models",
         settings_attr="model",
-        default="nvidia_nim/nvidia/nemotron-3-super-120b-a12b",
+        default="nvidia_nim/z-ai/glm4.7",
         description="Fallback provider/model route for all Claude model names.",
     ),
     ConfigFieldSpec(

--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -434,7 +434,7 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         "Default Model",
         "models",
         settings_attr="model",
-        default="nvidia_nim/z-ai/glm4.7",
+        default="nvidia_nim/nvidia/nemotron-3-super-120b-a12b",
         description="Fallback provider/model route for all Claude model names.",
     ),
     ConfigFieldSpec(

--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -133,6 +133,13 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         settings_attr="xiaomi_base_url",
     ),
     ConfigFieldSpec(
+        "XIAOMI_PROXY",
+        "Xiaomi Proxy",
+        "providers",
+        "text",
+        settings_attr="xiaomi_proxy",
+    ),
+    ConfigFieldSpec(
         "NVIDIA_NIM_API_KEY",
         "NVIDIA NIM API Key",
         "providers",

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -13,6 +13,7 @@ TransportType = Literal["openai_chat", "anthropic_messages"]
 
 # Default upstream base URLs (also re-exported via :mod:`providers.defaults`)
 NVIDIA_NIM_DEFAULT_BASE = "https://integrate.api.nvidia.com/v1"
+XIAOMI_DEFAULT_BASE = "https://api.xiaomimimo.com/v1"
 # Moonshot Kimi Anthropic-compatible Messages API (POST …/messages).
 KIMI_DEFAULT_BASE = "https://api.moonshot.ai/anthropic/v1"
 WAFER_DEFAULT_BASE = "https://pass.wafer.ai/v1"
@@ -55,6 +56,16 @@ class ProviderDescriptor:
 
 
 PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
+    "xiaomi": ProviderDescriptor(
+        provider_id="xiaomi",
+        transport_type="openai_chat",
+        credential_env="XIAOMI_API_KEY",
+        credential_url="https://platform.xiaomimimo.com/",
+        credential_attr="xiaomi_api_key",
+        default_base_url=XIAOMI_DEFAULT_BASE,
+        base_url_attr="xiaomi_base_url",
+        capabilities=("chat", "streaming", "tools", "thinking", "rate_limit"),
+    ),
     "nvidia_nim": ProviderDescriptor(
         provider_id="nvidia_nim",
         transport_type="openai_chat",

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -64,6 +64,7 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="xiaomi_api_key",
         default_base_url=XIAOMI_DEFAULT_BASE,
         base_url_attr="xiaomi_base_url",
+        proxy_attr="xiaomi_proxy",
         capabilities=("chat", "streaming", "tools", "thinking", "rate_limit"),
     ),
     "nvidia_nim": ProviderDescriptor(

--- a/config/settings.py
+++ b/config/settings.py
@@ -105,6 +105,7 @@ def _removed_env_var_message(model_config: Mapping[str, Any]) -> str | None:
 
 
 class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
     # ==================== Xiaomi MiMo Config ====================
     xiaomi_api_key: str = Field(default="", validation_alias="XIAOMI_API_KEY")
     xiaomi_base_url: str = Field(default="https://api.xiaomimimo.com/v1", validation_alias="XIAOMI_BASE_URL")
@@ -183,7 +184,7 @@ class Settings(BaseSettings):
     # ==================== Model ====================
     # All Claude model requests are mapped to this single model (fallback)
     # Format: provider_type/model/name
-    model: str = "nvidia_nim/z-ai/glm4.7"
+    model: str = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 
     # Per-model overrides (optional, falls back to MODEL)
     # Each can use a different provider

--- a/config/settings.py
+++ b/config/settings.py
@@ -105,7 +105,10 @@ def _removed_env_var_message(model_config: Mapping[str, Any]) -> str | None:
 
 
 class Settings(BaseSettings):
-    """Application settings loaded from environment variables."""
+    # ==================== Xiaomi MiMo Config ====================
+    xiaomi_api_key: str = Field(default="", validation_alias="XIAOMI_API_KEY")
+    xiaomi_base_url: str = Field(default="https://api.xiaomimimo.com/v1", validation_alias="XIAOMI_BASE_URL")
+    xiaomi_proxy: str = Field(default="", validation_alias="XIAOMI_PROXY")
 
     # ==================== OpenRouter Config ====================
     open_router_api_key: str = Field(default="", validation_alias="OPENROUTER_API_KEY")
@@ -180,7 +183,7 @@ class Settings(BaseSettings):
     # ==================== Model ====================
     # All Claude model requests are mapped to this single model (fallback)
     # Format: provider_type/model/name
-    model: str = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
+    model: str = "nvidia_nim/z-ai/glm4.7"
 
     # Per-model overrides (optional, falls back to MODEL)
     # Each can use a different provider

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -32,6 +32,12 @@ ProviderFactory = Callable[[ProviderConfig, Settings], BaseProvider]
 PROVIDER_DESCRIPTORS: dict[str, ProviderDescriptor] = PROVIDER_CATALOG
 
 
+def _create_xiaomi(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+    from providers.xiaomi import XiaomiProvider
+
+    return XiaomiProvider(config)
+
+
 def _create_nvidia_nim(config: ProviderConfig, settings: Settings) -> BaseProvider:
     from providers.nvidia_nim import NvidiaNimProvider
 
@@ -137,6 +143,7 @@ def _create_cerebras(config: ProviderConfig, _settings: Settings) -> BaseProvide
 
 
 PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
+    "xiaomi": _create_xiaomi,
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
     "gemini": _create_gemini,

--- a/providers/xiaomi.py
+++ b/providers/xiaomi.py
@@ -22,7 +22,7 @@ class XiaomiProvider(OpenAIChatTransport):
         self, request: Any, thinking_enabled: bool | None = None
     ) -> dict:
         effective_thinking = self._is_thinking_enabled(request, thinking_enabled)
-        
+
         try:
             body = build_base_request_body(
                 request,
@@ -32,7 +32,7 @@ class XiaomiProvider(OpenAIChatTransport):
             )
         except OpenAIConversionError as exc:
             raise InvalidRequestError(str(exc)) from exc
-        
+
         return body
 
     async def list_model_infos(self) -> frozenset[ProviderModelInfo]:

--- a/providers/xiaomi.py
+++ b/providers/xiaomi.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+from typing import Any
+from providers.openai_compat import OpenAIChatTransport
+from providers.base import ProviderConfig
+from providers.model_listing import ProviderModelInfo
+from core.anthropic import ReasoningReplayMode, build_base_request_body
+from core.anthropic.conversion import OpenAIConversionError
+from providers.exceptions import InvalidRequestError
+
+class XiaomiProvider(OpenAIChatTransport):
+    """Xiaomi MiMo provider using OpenAI-compatible chat completions."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="XIAOMI",
+            base_url=config.base_url,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        try:
+            body = build_base_request_body(
+                request,
+                reasoning_replay=ReasoningReplayMode.REASONING_CONTENT
+                if thinking_enabled
+                else ReasoningReplayMode.DISABLED,
+            )
+        except OpenAIConversionError as exc:
+            raise InvalidRequestError(str(exc)) from exc
+        
+        return body
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        """Hardcode Xiaomi models to bypass potential list_models API issues."""
+        return frozenset([
+            ProviderModelInfo(model_id="mimo-v2.5-pro", supports_thinking=True),
+            ProviderModelInfo(model_id="mimo-v2.5", supports_thinking=True),
+            ProviderModelInfo(model_id="mimo-v2-flash", supports_thinking=False),
+        ])

--- a/providers/xiaomi.py
+++ b/providers/xiaomi.py
@@ -21,8 +21,6 @@ class XiaomiProvider(OpenAIChatTransport):
     def _build_request_body(
         self, request: Any, thinking_enabled: bool | None = None
     ) -> dict:
-        # Greptile Bot is correct: thinking_enabled can be None here.
-        # We must resolve the effective state using the base class helper.
         effective_thinking = self._is_thinking_enabled(request, thinking_enabled)
         
         try:

--- a/providers/xiaomi.py
+++ b/providers/xiaomi.py
@@ -21,11 +21,15 @@ class XiaomiProvider(OpenAIChatTransport):
     def _build_request_body(
         self, request: Any, thinking_enabled: bool | None = None
     ) -> dict:
+        # Greptile Bot is correct: thinking_enabled can be None here.
+        # We must resolve the effective state using the base class helper.
+        effective_thinking = self._is_thinking_enabled(request, thinking_enabled)
+        
         try:
             body = build_base_request_body(
                 request,
                 reasoning_replay=ReasoningReplayMode.REASONING_CONTENT
-                if thinking_enabled
+                if effective_thinking
                 else ReasoningReplayMode.DISABLED,
             )
         except OpenAIConversionError as exc:


### PR DESCRIPTION
## Description

This PR introduces native support for Xiaomi MiMo models (e.g., `mimo-v2.5-pro`, `mimo-v2.5`) by leveraging the OpenAI-compatible chat transport. This enables developers to use Claude Code functionalities backed by Xiaomi's powerful reasoning models.

### Key Changes:
- **Provider Implementation**: Added `providers/xiaomi.py` extending `OpenAIChatTransport`, ensuring proper handling of the `reasoning_content` block during tool execution.
- **Provider Catalog**: Registered `XIAOMI` with its default base URL pointing to the Token Plan endpoint.
- **Admin UI Integration**: Added `XIAOMI_API_KEY` and `XIAOMI_BASE_URL` to `config/settings.py` and `api/admin_config.py` so users can easily configure the provider directly from the dashboard.
- **Registry Update**: Linked the Xiaomi factory method in `providers/registry.py`.

Tested locally with a `tp-*` Token Plan API key and confirmed successful reasoning and tool execution.