### PR TITLE
fix(auth): improve auth error diagnostics and trim credential whitespace

### DIFF
--- a/providers/error_mapping.py
+++ b/providers/error_mapping.py
@@ -205,6 +205,13 @@ def format_provider_error_message(
     else:
         lines = [f"Upstream provider {provider_name} returned an error."]
 
+    # Add actionable hints for common auth errors
+    if detail.status_code in (401, 403):
+        lines.append(
+            "\nTip: Verify your API key in the .env file and restart the proxy. "
+            "Ensure the key is active and has not expired."
+        )
+
     category = detail.error_type_hint or _provider_error_category(mapped)
     if category:
         lines.append(f"Category: {category}")

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -177,7 +177,7 @@ def _credential_for(descriptor: ProviderDescriptor, settings: Settings) -> str:
     if descriptor.static_credential is not None:
         return descriptor.static_credential
     if descriptor.credential_attr:
-        return _string_attr(settings, descriptor.credential_attr)
+        return _string_attr(settings, descriptor.credential_attr).strip()
     return ""
 
 
@@ -186,9 +186,17 @@ def _require_credential(descriptor: ProviderDescriptor, credential: str) -> None
         return
     if credential and credential.strip():
         return
-    message = f"{descriptor.credential_env} is not set. Add it to your .env file."
+    env_var = descriptor.credential_env or "API_KEY"
+    message = (
+        f"{env_var} is not set or empty.\n\n"
+        "1) Set it in your .env file\n"
+    )
     if descriptor.credential_url:
-        message = f"{message} Get a key at {descriptor.credential_url}"
+        message += f"2) Get a key at: {descriptor.credential_url}\n"
+    message += (
+        "3) Restart the proxy after updating .env\n\n"
+        f"Current value length: {len(credential)} chars"
+    )
     raise AuthenticationError(message)
 
 


### PR DESCRIPTION
## Problem

Multiple users report 401 authentication errors (#671, #655, #650, #669) that are hard to diagnose. Common root causes include:

- Copy-pasted API keys with accidental leading/trailing whitespace
- Unclear error messages about which key failed and how to fix it
- No actionable hints when upstream returns 401/403

## Changes

### Registry (`providers/registry.py`)

- **Trim whitespace from credentials**: `_credential_for` now strips leading/trailing whitespace from API keys, preventing a common copy-paste error.
- **Better missing-key error**: `_require_credential` now produces a multi-step, actionable error message including the exact env var name and URL to get a key.

### Error Mapping (`providers/error_mapping.py`)
- **Add auth tip in error output**: When a provider returns HTTP 401/403, the error message now includes a tip reminding users to verify their .env file and restart the proxy.

## Testing

- Syntax validated (`python -m ast` passes for both files).
- Changes are minimal, targeted, and backward-compatible.
