### PR TITLE
fix(rate-limit): improve 429 error messaging with actionable tips

### DIFF
--- a/core/anthropic/errors.py
+++ b/core/anthropic/errors.py
@@ -27,7 +27,7 @@ def get_user_facing_error_message(
         return "Request timed out."
 
     if isinstance(e, openai.RateLimitError):
-        return "Provider rate limit reached. Please retry shortly."
+        return "Provider rate limit reached. The proxy already retried. Try again in a few moments or switch models."
     if isinstance(e, openai.AuthenticationError):
         return "Provider authentication failed. Check API key."
     if isinstance(e, openai.BadRequestError):
@@ -36,7 +36,7 @@ def get_user_facing_error_message(
     name = type(e).__name__
     status_code = getattr(e, "status_code", None)
     if name == "RateLimitError":
-        return "Provider rate limit reached. Please retry shortly."
+        return "Provider rate limit reached. The proxy already retried. Try again in a few moments or switch models."
     if name == "AuthenticationError":
         return "Provider authentication failed. Check API key."
     if name == "InvalidRequestError":

--- a/providers/error_mapping.py
+++ b/providers/error_mapping.py
@@ -205,6 +205,13 @@ def format_provider_error_message(
     else:
         lines = [f"Upstream provider {provider_name} returned an error."]
 
+    # Add actionable hints for common errors
+    if detail.status_code == 429:
+        lines.append(
+            "\nTip: Rate limit hit after automatic retries. Wait a moment and retry, "
+            "or try a different model/provider via /model in Claude Code."
+        )
+
     category = detail.error_type_hint or _provider_error_category(mapped)
     if category:
         lines.append(f"Category: {category}")


### PR DESCRIPTION
## Problem

Users frequently hit NVIDIA NIM HTTP 429 (Too Many Requests) and the old error
"Provider rate limit reached. Please retry shortly." is not helpful. The proxy
already retries automatically, so users do not know what to do next.

## Changes

- `core/anthropic/errors.py`: Updated `RateLimitError` messages to explain that
  automatic retries already happened and suggest switching models.
- `providers/error_mapping.py`: Added an actionable tip to the formatted error
  output for 429 responses, guiding users to `/model` to pick another provider.

## Testing

- `python -m ast` passes for both files.
