### PR TITLE
FCC install success or fail classifier & change in execution steps

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -304,19 +304,32 @@ package_spec() {
 
 install_free_claude_code() {
     spec=$(package_spec)
+    
+    is_success=0
 
     if [ -n "$torch_backend" ]; then
-        run uv tool install --force --torch-backend "$torch_backend" "$spec"
+        if run uv tool install --force --torch-backend "$torch_backend" "$spec"; then
+            is_success=1
+        fi
     else
-        run uv tool install --force "$spec"
+        if run uv tool install --force "$spec"; then
+            is_success=1
+        fi
+    fi
+
+    if [ "$is_success" -eq 1 ]; then
+        printf '\nSuccess! Free Claude Code is installed. Start the proxy with: fcc-server\n\n'
+        return 0
+    else
+        printf '\nFailed Install! Free Claude Code was not installed due to some error. Take help of the guide:{Guide link here} and check the Caused By error above\n\n'
+        return 1
     fi
 }
 
 parse_args "$@"
 validate_args
 
-step "Installing Claude Code if missing"
-install_claude_if_missing
+# This would be the right order. uv, python, claude, FCC
 
 step "Installing uv if missing, updating if present"
 install_or_update_uv
@@ -324,7 +337,8 @@ install_or_update_uv
 step "Installing Python $PYTHON_VERSION"
 run uv python install "$PYTHON_VERSION"
 
+step "Installing Claude Code if missing"
+install_claude_if_missing
+
 step "Installing or updating Free Claude Code"
 install_free_claude_code
-
-printf '\nFree Claude Code is installed. Start the proxy with: fcc-server\n'


### PR DESCRIPTION
1. In previous code, it returned "Success" even when it FCC_install actually failed cause it had no function to check the success status.

is_success returns the success value and prints success and fail accordingly.

we should also add an error guide like, git error or node.js not installed error. Say it and I will start working on it.

2. Made some changes in Step execution order

Previous: claude-install > uv-install> py-check > fcc-install this creates a problem/confusion as to install claude in first step we requires uv, if uv is not previously installed then it will be out at first step.

New: uv-install > py-install > claude-install > fcc-install

this wont have the same issue