### PR TITLE
feat: add OPENROUTER_MAX_TOKENS cap to prevent 402 credit errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ NVIDIA_NIM_API_KEY=""
 
 # OpenRouter Config
 OPENROUTER_API_KEY=""
+# Optional cap on max_tokens forwarded to OpenRouter (e.g. 8192). Empty = no cap.
+# Prevents 402 "can only afford N tokens" errors when account credits are low.
+OPENROUTER_MAX_TOKENS=""
 
 
 # Mistral La Plateforme Config (Experiment plan free tier – rate limits; OpenAI-compatible at api.mistral.ai/v1)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ In the Admin UI, paste it into `OPENROUTER_API_KEY`, then set `MODEL` to an Open
 
 Browse [all models](https://openrouter.ai/models) or [free models](https://openrouter.ai/collections/free-models).
 
+Optional: set `OPENROUTER_MAX_TOKENS` (e.g. `8192`) to cap the `max_tokens` forwarded to OpenRouter. OpenRouter rejects requests with a 402 error when the requested output budget exceeds what your remaining credits can afford — capping it keeps low-credit accounts working.
+
 ### 3. [Google AI Studio (Gemini)](https://aistudio.google.com/)
 
 Get a Gemini API key at [Google AI Studio](https://aistudio.google.com/apikey) (see Google's [Gemini OpenAI compatibility](https://ai.google.dev/gemini-api/docs/openai) docs).

--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -135,6 +135,19 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         secret=True,
     ),
     ConfigFieldSpec(
+        "OPENROUTER_MAX_TOKENS",
+        "OpenRouter Max Tokens Cap",
+        "providers",
+        "number",
+        settings_attr="open_router_max_tokens",
+        advanced=True,
+        description=(
+            "Optional cap on max_tokens forwarded to OpenRouter. Prevents 402 "
+            "errors when remaining credits cannot afford the requested output "
+            "budget. Empty = no cap."
+        ),
+    ),
+    ConfigFieldSpec(
         "MISTRAL_API_KEY",
         "Mistral API Key",
         "providers",

--- a/config/settings.py
+++ b/config/settings.py
@@ -79,6 +79,11 @@ class Settings(BaseSettings):
 
     # ==================== OpenRouter Config ====================
     open_router_api_key: str = Field(default="", validation_alias="OPENROUTER_API_KEY")
+    # Optional cap on max_tokens forwarded to OpenRouter. Prevents 402
+    # "can only afford N tokens" rejections when account credits are low.
+    open_router_max_tokens: int | None = Field(
+        default=None, ge=1, validation_alias="OPENROUTER_MAX_TOKENS"
+    )
 
     # ==================== Mistral La Plateforme ====================
     mistral_api_key: str = Field(default="", validation_alias="MISTRAL_API_KEY")
@@ -323,9 +328,11 @@ class Settings(BaseSettings):
             return None
         return v
 
-    @field_validator("max_message_log_entries_per_chat", mode="before")
+    @field_validator(
+        "max_message_log_entries_per_chat", "open_router_max_tokens", mode="before"
+    )
     @classmethod
-    def parse_optional_log_cap(cls, v: Any) -> Any:
+    def parse_optional_int(cls, v: Any) -> Any:
         if v == "" or v is None:
             return None
         return v

--- a/config/settings.py
+++ b/config/settings.py
@@ -333,6 +333,8 @@ class Settings(BaseSettings):
     )
     @classmethod
     def parse_optional_int(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            v = v.strip()
         if v == "" or v is None:
             return None
         return v

--- a/providers/open_router/client.py
+++ b/providers/open_router/client.py
@@ -31,12 +31,13 @@ class OpenRouterProvider(AnthropicMessagesTransport):
 
     stream_chunk_mode: StreamChunkMode = "event"
 
-    def __init__(self, config: ProviderConfig):
+    def __init__(self, config: ProviderConfig, *, max_tokens_cap: int | None = None):
         super().__init__(
             config,
             provider_name="OPENROUTER",
             default_base_url=OPENROUTER_DEFAULT_BASE,
         )
+        self._max_tokens_cap = max_tokens_cap
 
     def _build_request_body(
         self, request: Any, thinking_enabled: bool | None = None
@@ -45,6 +46,7 @@ class OpenRouterProvider(AnthropicMessagesTransport):
         return build_request_body(
             request,
             thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            max_tokens_cap=self._max_tokens_cap,
         )
 
     def _request_headers(self) -> dict[str, str]:

--- a/providers/open_router/request.py
+++ b/providers/open_router/request.py
@@ -39,8 +39,18 @@ def build_request_body(
         raise InvalidRequestError(str(exc)) from exc
 
     # OpenRouter-specific max_tokens: cap against OPENROUTER_MAX_TOKENS
-    if max_tokens_cap is not None and isinstance(body.get("max_tokens"), int):
-        body["max_tokens"] = min(body["max_tokens"], max_tokens_cap)
+    if max_tokens_cap is not None:
+        if isinstance(body.get("max_tokens"), int):
+            body["max_tokens"] = min(body["max_tokens"], max_tokens_cap)
+        else:
+            # max_tokens always exists as an int after body construction unless
+            # extra_body overrode it; surface the skipped cap instead of hiding it.
+            logger.warning(
+                "OPENROUTER_REQUEST: max_tokens cap {} skipped, "
+                "non-integer max_tokens in body: {!r}",
+                max_tokens_cap,
+                body.get("max_tokens"),
+            )
 
     logger.debug(
         "OPENROUTER_REQUEST: conversion done model={} msgs={} tools={}",

--- a/providers/open_router/request.py
+++ b/providers/open_router/request.py
@@ -16,7 +16,12 @@ from core.anthropic.native_messages_request import (
 from providers.exceptions import InvalidRequestError
 
 
-def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
+def build_request_body(
+    request_data: Any,
+    *,
+    thinking_enabled: bool,
+    max_tokens_cap: int | None = None,
+) -> dict:
     """Build an Anthropic-format request body for OpenRouter's messages API."""
     logger.debug(
         "OPENROUTER_REQUEST: conversion start model={} msgs={}",
@@ -32,6 +37,10 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
         )
     except OpenRouterExtraBodyError as exc:
         raise InvalidRequestError(str(exc)) from exc
+
+    # OpenRouter-specific max_tokens: cap against OPENROUTER_MAX_TOKENS
+    if max_tokens_cap is not None and isinstance(body.get("max_tokens"), int):
+        body["max_tokens"] = min(body["max_tokens"], max_tokens_cap)
 
     logger.debug(
         "OPENROUTER_REQUEST: conversion done model={} msgs={} tools={}",

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -38,10 +38,10 @@ def _create_nvidia_nim(config: ProviderConfig, settings: Settings) -> BaseProvid
     return NvidiaNimProvider(config, nim_settings=settings.nim)
 
 
-def _create_open_router(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+def _create_open_router(config: ProviderConfig, settings: Settings) -> BaseProvider:
     from providers.open_router import OpenRouterProvider
 
-    return OpenRouterProvider(config)
+    return OpenRouterProvider(config, max_tokens_cap=settings.open_router_max_tokens)
 
 
 def _create_mistral(config: ProviderConfig, _settings: Settings) -> BaseProvider:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.3.0"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -165,6 +165,30 @@ class TestSettings:
         settings = Settings()
         assert settings.nim.seed is None or isinstance(settings.nim.seed, int)
 
+    def test_open_router_max_tokens_defaults_to_none(self, monkeypatch):
+        """Test OPENROUTER_MAX_TOKENS is unset by default (no cap)."""
+        from config.settings import Settings
+
+        monkeypatch.delenv("OPENROUTER_MAX_TOKENS", raising=False)
+        settings = Settings()
+        assert settings.open_router_max_tokens is None
+
+    def test_open_router_max_tokens_empty_string_is_none(self, monkeypatch):
+        """Test OPENROUTER_MAX_TOKENS="" parses as None."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("OPENROUTER_MAX_TOKENS", "")
+        settings = Settings()
+        assert settings.open_router_max_tokens is None
+
+    def test_open_router_max_tokens_parses_int(self, monkeypatch):
+        """Test OPENROUTER_MAX_TOKENS parses to an int."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("OPENROUTER_MAX_TOKENS", "8192")
+        settings = Settings()
+        assert settings.open_router_max_tokens == 8192
+
     def test_model_setting(self):
         """Test model setting exists and is a string."""
         from config.settings import Settings

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -205,6 +205,22 @@ class TestSettings:
         with pytest.raises(ValidationError):
             Settings()
 
+    def test_open_router_max_tokens_strips_whitespace(self, monkeypatch):
+        """Test OPENROUTER_MAX_TOKENS=" 8192 " parses to an int."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("OPENROUTER_MAX_TOKENS", " 8192 ")
+        settings = Settings()
+        assert settings.open_router_max_tokens == 8192
+
+    def test_open_router_max_tokens_whitespace_only_is_none(self, monkeypatch):
+        """Test OPENROUTER_MAX_TOKENS="   " parses as None (no cap)."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("OPENROUTER_MAX_TOKENS", "   ")
+        settings = Settings()
+        assert settings.open_router_max_tokens is None
+
     def test_model_setting(self):
         """Test model setting exists and is a string."""
         from config.settings import Settings

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -189,6 +189,22 @@ class TestSettings:
         settings = Settings()
         assert settings.open_router_max_tokens == 8192
 
+    def test_open_router_max_tokens_rejects_zero(self, monkeypatch):
+        """Test OPENROUTER_MAX_TOKENS=0 fails the ge=1 constraint."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("OPENROUTER_MAX_TOKENS", "0")
+        with pytest.raises(ValidationError):
+            Settings()
+
+    def test_open_router_max_tokens_rejects_negative(self, monkeypatch):
+        """Test OPENROUTER_MAX_TOKENS=-1 fails the ge=1 constraint."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("OPENROUTER_MAX_TOKENS", "-1")
+        with pytest.raises(ValidationError):
+            Settings()
+
     def test_model_setting(self):
         """Test model setting exists and is a string."""
         from config.settings import Settings

--- a/tests/providers/test_open_router.py
+++ b/tests/providers/test_open_router.py
@@ -212,6 +212,41 @@ def test_build_request_body_default_max_tokens(open_router_provider):
     assert body["max_tokens"] == OPENROUTER_DEFAULT_MAX_TOKENS
 
 
+def test_build_request_body_max_tokens_capped(open_router_config):
+    provider = OpenRouterProvider(open_router_config, max_tokens_cap=8192)
+    req = MockRequest(max_tokens=32000)
+
+    body = provider._build_request_body(req)
+
+    assert body["max_tokens"] == 8192
+
+
+def test_build_request_body_max_tokens_below_cap_unchanged(open_router_config):
+    provider = OpenRouterProvider(open_router_config, max_tokens_cap=8192)
+    req = MockRequest(max_tokens=100)
+
+    body = provider._build_request_body(req)
+
+    assert body["max_tokens"] == 100
+
+
+def test_build_request_body_cap_applies_to_default_max_tokens(open_router_config):
+    provider = OpenRouterProvider(open_router_config, max_tokens_cap=8192)
+    req = MockRequest(max_tokens=None)
+
+    body = provider._build_request_body(req)
+
+    assert body["max_tokens"] == 8192
+
+
+def test_build_request_body_no_cap_by_default(open_router_provider):
+    req = MockRequest(max_tokens=32000)
+
+    body = open_router_provider._build_request_body(req)
+
+    assert body["max_tokens"] == 32000
+
+
 def test_build_request_body_strips_unsigned_thinking_history(open_router_provider):
     req = MockRequest(
         messages=[

--- a/tests/providers/test_open_router.py
+++ b/tests/providers/test_open_router.py
@@ -236,7 +236,7 @@ def test_build_request_body_cap_applies_to_default_max_tokens(open_router_config
 
     body = provider._build_request_body(req)
 
-    assert body["max_tokens"] == 8192
+    assert body["max_tokens"] == min(OPENROUTER_DEFAULT_MAX_TOKENS, 8192)
 
 
 def test_build_request_body_no_cap_by_default(open_router_provider):

--- a/tests/providers/test_open_router.py
+++ b/tests/providers/test_open_router.py
@@ -247,6 +247,21 @@ def test_build_request_body_no_cap_by_default(open_router_provider):
     assert body["max_tokens"] == 32000
 
 
+def test_build_request_body_cap_skipped_warns_on_non_integer_max_tokens(
+    open_router_config,
+):
+    """A configured cap that cannot apply must warn instead of silently skipping."""
+    provider = OpenRouterProvider(open_router_config, max_tokens_cap=8192)
+    req = MockRequest(max_tokens=12.5)
+
+    with patch("providers.open_router.request.logger.warning") as mock_warning:
+        body = provider._build_request_body(req)
+
+    assert body["max_tokens"] == 12.5
+    assert mock_warning.call_count == 1
+    assert "cap" in str(mock_warning.call_args)
+
+
 def test_build_request_body_strips_unsigned_thinking_history(open_router_provider):
     req = MockRequest(
         messages=[

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Claude Code clients send large max_tokens budgets (e.g. 32000) which the proxy forwards verbatim. OpenRouter validates the requested output budget against remaining account credits and rejects the request with HTTP 402 ("You requested up to 32000 tokens, but can only afford N") before any generation happens, so even trivial prompts fail on low-credit accounts.

Add an optional OPENROUTER_MAX_TOKENS setting that caps the max_tokens forwarded to OpenRouter, mirroring the existing NIM max_tokens capping pattern (min(requested, cap)). Unset/empty means no cap (current behavior unchanged).

- config/settings.py: open_router_max_tokens (int or None, ge=1); extend the optional-int empty-string-to-None validator to cover it
- providers/open_router: plumb max_tokens_cap through the provider into build_request_body and clamp after body construction
- providers/registry.py: pass settings.open_router_max_tokens
- api/admin_config.py: expose as advanced number field in Admin UI
- .env.example, README.md: document the new variable
- tests: cap applied, value below cap unchanged, cap applies to default max_tokens, no cap by default; settings parsing (unset/empty/int)

Fixes #752