### PR TITLE
fix: preserve HTTPException status in proxy service error wrapping

### DIFF
--- a/api/services.py
+++ b/api/services.py
@@ -209,6 +209,11 @@ class ClaudeProxyService:
 
         except ProviderError:
             raise
+        except HTTPException:
+            # Provider resolution raises curated HTTPExceptions (e.g. 503 with a
+            # config hint when a provider key is missing); preserve their status
+            # instead of re-wrapping as a generic 500.
+            raise
         except Exception as e:
             _log_unexpected_service_exception(
                 self._settings, e, context="CREATE_MESSAGE_ERROR"
@@ -248,6 +253,8 @@ class ClaudeProxyService:
                 )
                 return TokenCountResponse(input_tokens=tokens)
             except ProviderError:
+                raise
+            except HTTPException:
                 raise
             except Exception as e:
                 _log_unexpected_service_exception(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.2.42"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/api/test_safe_logging.py
+++ b/tests/api/test_safe_logging.py
@@ -147,6 +147,55 @@ def test_create_message_unexpected_error_always_returns_500():
     assert excinfo.value.status_code == 500
 
 
+def test_create_message_preserves_http_exception_status_and_detail():
+    """Curated HTTPExceptions (e.g. 503 missing-key hints) must not become 500s."""
+    detail = "NVIDIA_NIM_API_KEY is not set. Add it to your .env file."
+
+    def getter_boom(_provider_id):
+        raise HTTPException(status_code=503, detail=detail)
+
+    settings = Settings()
+    service = ClaudeProxyService(settings, provider_getter=getter_boom)
+    request = MessagesRequest(
+        model="claude-3-haiku-20240307",
+        max_tokens=10,
+        messages=[Message(role="user", content="hi")],
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        service.create_message(request)
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == detail
+
+
+def test_count_tokens_preserves_http_exception_status_and_detail():
+    """count_tokens must re-raise HTTPException without re-wrapping as 500."""
+    from api.models.anthropic import TokenCountRequest
+
+    detail = "service temporarily unavailable"
+
+    def counter_boom(*_a, **_kw):
+        raise HTTPException(status_code=503, detail=detail)
+
+    settings = Settings()
+    service = ClaudeProxyService(
+        settings,
+        provider_getter=lambda _: MagicMock(),
+        token_counter=counter_boom,
+    )
+    request = TokenCountRequest(
+        model="claude-3-haiku-20240307",
+        messages=[Message(role="user", content="hi")],
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        service.count_tokens(request)
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == detail
+
+
 def test_parse_cli_event_error_logs_metadata_by_default():
     """CLI parser must not log raw error text unless LOG_RAW_CLI_DIAGNOSTICS is on."""
     from messaging.event_parser import parse_cli_event

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.2.42"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
When provider resolution fails (e.g. a provider API key is missing), api.dependencies._resolve_with_registry raises a curated HTTPException 503 whose detail is an actionable config hint ("NVIDIA_NIM_API_KEY is not set. Add it to your .env file."). ClaudeProxyService.create_message and count_tokens caught it in the generic `except Exception` handler and re-wrapped it as HTTPException(500, "503: <detail>") - clients saw an opaque 500 Internal Server Error with the real status embedded in the message text (as reported in #754).

Re-raise HTTPException before the generic handler so the curated status and detail reach the client unchanged. Claude Code then receives a proper 503 and can surface the configuration hint instead of failing sub-agent runs with a generic 500.

- api/services.py: add `except HTTPException: raise` ahead of the generic wrapper in create_message and count_tokens
- tests: 503 status and detail preserved end-to-end for both paths

Refs #754