### PR TITLE
Feat/fable model tier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,7 @@ FCC_SMOKE_OPENROUTER_FREE_EXTRA_MODELS=
 # Thinking output
 # Per-Claude-model switches for provider reasoning requests and Claude thinking blocks.
 # Blank per-model switches inherit ENABLE_MODEL_THINKING.
+ENABLE_FABLE_THINKING=
 ENABLE_OPUS_THINKING=
 ENABLE_SONNET_THINKING=
 ENABLE_HAIKU_THINKING=

--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -416,6 +416,16 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         description="Fallback provider/model route for all Claude model names.",
     ),
     ConfigFieldSpec(
+        "MODEL_FABLE",
+        "Fable Override",
+        "models",
+        settings_attr="model_fable",
+        description=(
+            "Routes claude-fable-5 (and any other claude-fable-* model id) here. "
+            "Leave blank to fall back to the Default Model."
+        ),
+    ),
+    ConfigFieldSpec(
         "MODEL_OPUS",
         "Opus Override",
         "models",
@@ -443,6 +453,14 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         "boolean",
         settings_attr="enable_model_thinking",
         default="true",
+    ),
+    ConfigFieldSpec(
+        "ENABLE_FABLE_THINKING",
+        "Fable Thinking",
+        "thinking",
+        "tri_boolean",
+        settings_attr="enable_fable_thinking",
+        description="Blank inherits Enable Thinking.",
     ),
     ConfigFieldSpec(
         "ENABLE_OPUS_THINKING",

--- a/api/admin_static/admin.css
+++ b/api/admin_static/admin.css
@@ -1,21 +1,62 @@
 :root {
   color-scheme: dark;
-  --bg: #11100e;
-  --panel: #1a1815;
-  --panel-strong: #25211c;
-  --card: #201d19;
-  --input: #12110f;
-  --text: #f3eee7;
-  --muted: #aaa197;
-  --line: #373129;
-  --line-strong: #4d4439;
-  --accent: #2fb984;
-  --accent-dark: #24946b;
-  --warn: #f5b74f;
-  --error: #ff746c;
-  --ok: #59d994;
-  --info: #7cc7ff;
-  --shadow: 0 14px 34px rgba(0, 0, 0, 0.38);
+  
+  /* Color Palette */
+  --bg: #090a0f;
+  --panel: #11131c;
+  --panel-strong: #171b26;
+  --card: #151822;
+  --card-hover: #1e2230;
+  --input: #0a0b10;
+  --input-focus: #0f1118;
+  --text: #f3f4f6;
+  --text-strong: #ffffff;
+  --muted: #9ca3af;
+  --line: rgba(255, 255, 255, 0.06);
+  --line-strong: rgba(255, 255, 255, 0.12);
+  
+  /* Brand and Accent Colors */
+  --accent: #10b981;
+  --accent-dark: #059669;
+  --accent-muted: rgba(16, 185, 129, 0.08);
+  --accent-border: rgba(16, 185, 129, 0.3);
+  
+  /* Status Colors */
+  --ok: #10b981;
+  --ok-bg: rgba(16, 185, 129, 0.08);
+  --ok-border: rgba(16, 185, 129, 0.25);
+  
+  --warn: #f59e0b;
+  --warn-bg: rgba(245, 158, 11, 0.08);
+  --warn-border: rgba(245, 158, 11, 0.25);
+  
+  --error: #ef4444;
+  --error-bg: rgba(239, 68, 68, 0.08);
+  --error-border: rgba(239, 68, 68, 0.25);
+  
+  --neutral: #6b7280;
+  --neutral-bg: rgba(107, 114, 128, 0.08);
+  --neutral-border: rgba(107, 114, 128, 0.25);
+  
+  --info: #3b82f6;
+  
+  /* Box Shadow & Glows */
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.2);
+  --shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
+  --glow-accent: 0 0 12px rgba(16, 185, 129, 0.15);
+  
+  /* Borders and Radius */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-full: 9999px;
+  
+  /* Typography */
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  
+  /* Transitions */
+  --transition-fast: 0.15s ease;
+  --transition-normal: 0.22s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 * {
@@ -27,10 +68,26 @@ body {
   min-width: 320px;
   background: var(--bg);
   color: var(--text);
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
-  letter-spacing: 0;
+  font-family: var(--font-sans);
+  letter-spacing: -0.01em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Custom Scrollbars */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--panel-strong);
+  border-radius: var(--radius-full);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--muted);
 }
 
 button,
@@ -38,237 +95,294 @@ input,
 select,
 textarea {
   font: inherit;
+  color: inherit;
 }
 
+/* App Shell Layout */
 .app-shell {
   display: grid;
-  grid-template-columns: 268px minmax(0, 1fr);
+  grid-template-columns: 260px minmax(0, 1fr);
   min-height: 100vh;
-  padding-bottom: 86px;
+  padding-bottom: 96px; /* Space for action bar */
 }
 
+/* Sidebar Navigation */
 .sidebar {
   position: sticky;
   top: 0;
   height: 100vh;
   border-right: 1px solid var(--line);
-  background: #171511;
-  padding: 20px 16px;
+  background: var(--bg);
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
 .brand {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 28px;
 }
 
 .brand-mark {
   display: grid;
-  width: 38px;
-  height: 38px;
+  width: 40px;
+  height: 40px;
   place-items: center;
-  border-radius: 8px;
-  background: var(--accent);
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
   color: #ffffff;
   font-weight: 800;
-  font-size: 14px;
-}
-
-.brand h1,
-.brand p,
-.topbar h2,
-.section-heading h3,
-.section-heading p,
-.strip-header h3 {
-  margin: 0;
+  font-size: 15px;
+  box-shadow: var(--glow-accent);
 }
 
 .brand h1 {
-  font-size: 15px;
+  font-size: 16px;
+  font-weight: 700;
   line-height: 1.2;
+  color: var(--text-strong);
+  margin: 0;
 }
 
-.brand p,
-.section-heading p,
-.action-meta span {
+.brand p {
   color: var(--muted);
   font-size: 12px;
+  margin: 0;
 }
 
 .section-nav {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .nav-link {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   width: 100%;
-  min-height: 42px;
+  min-height: 40px;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: transparent;
-  color: var(--text);
-  padding: 10px 12px;
+  color: var(--muted);
+  padding: 10px 14px;
   text-align: left;
   cursor: pointer;
-  font-weight: 700;
+  font-weight: 600;
+  font-size: 14px;
+  transition: all var(--transition-fast);
 }
 
-.nav-link:hover,
-.nav-link.active {
+.nav-link:hover {
   background: var(--panel-strong);
-  border-color: var(--line);
+  color: var(--text-strong);
 }
 
 .nav-link.active {
-  border-color: rgba(89, 217, 148, 0.34);
-  color: #ffffff;
+  background: var(--accent-muted);
+  border-color: var(--accent-border);
+  color: var(--accent);
+  box-shadow: var(--shadow-sm);
 }
 
+/* Accessible focus outlines */
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+.nav-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Main Content Area */
 .main {
   min-width: 0;
-  padding: 28px;
+  padding: 40px 48px;
 }
 
 .topbar {
-  margin-bottom: 20px;
+  margin-bottom: 32px;
 }
 
 .topbar h2 {
-  font-size: 28px;
-  line-height: 1.15;
+  font-size: 30px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+  margin: 0;
 }
 
-.status-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 30px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 5px 10px;
-  background: var(--panel-strong);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.status-pill.ok {
-  color: var(--ok);
-  background: rgba(47, 185, 132, 0.13);
-  border-color: rgba(89, 217, 148, 0.36);
-}
-
-.status-pill.warn {
-  color: var(--warn);
-  background: rgba(245, 183, 79, 0.13);
-  border-color: rgba(245, 183, 79, 0.38);
-}
-
-.status-pill.error {
-  color: var(--error);
-  background: rgba(255, 116, 108, 0.12);
-  border-color: rgba(255, 116, 108, 0.36);
-}
-
-.admin-views,
-.admin-view {
-  display: grid;
-  gap: 18px;
-}
-
-.admin-view[hidden] {
-  display: none;
-}
-
+/* Provider Strip & Panels */
 .provider-strip,
 .settings-section {
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   background: var(--panel);
   box-shadow: var(--shadow);
+  margin-bottom: 24px;
+  transition: border-color var(--transition-normal);
 }
 
 .provider-strip {
-  padding: 16px;
+  padding: 24px;
 }
 
 .strip-header,
 .section-heading {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
-}
-
-.strip-header {
-  margin-bottom: 12px;
+  gap: 16px;
+  margin-bottom: 20px;
 }
 
 .strip-header h3,
 .section-heading h3 {
-  font-size: 16px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-strong);
+  margin: 0;
 }
 
+.section-heading p {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+  margin: 4px 0 0 0;
+}
+
+/* Provider Status Cards */
 .provider-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
 }
 
 .provider-card {
-  display: grid;
-  gap: 8px;
-  min-height: 108px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 140px;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 12px;
+  border-radius: var(--radius-md);
+  padding: 16px;
   background: var(--card);
+  transition: all var(--transition-normal);
+}
+
+.provider-card:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+  background: var(--card-hover);
 }
 
 .provider-title {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 12px;
 }
 
 .provider-title strong {
   font-size: 14px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+/* Modern status pills with color indicators */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid var(--neutral-border);
+  border-radius: var(--radius-full);
+  padding: 2px 10px;
+  background: var(--neutral-bg);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.status-pill.ok {
+  color: var(--ok);
+  background: var(--ok-bg);
+  border-color: var(--ok-border);
+}
+
+.status-pill.warn {
+  color: var(--warn);
+  background: var(--warn-bg);
+  border-color: var(--warn-border);
+}
+
+.status-pill.error {
+  color: var(--error);
+  background: var(--error-bg);
+  border-color: var(--error-border);
 }
 
 .provider-meta {
   color: var(--muted);
   font-size: 12px;
-  word-break: break-word;
+  line-height: 1.4;
+  word-break: break-all;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
+/* Button & Form Controls styling */
 .test-button,
 .ghost-button,
 .secondary-button,
 .primary-button {
-  min-height: 34px;
-  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--line-strong);
-  padding: 7px 12px;
+  padding: 6px 14px;
+  font-weight: 600;
+  font-size: 13px;
   cursor: pointer;
-  font-weight: 700;
+  transition: all var(--transition-fast);
+  text-decoration: none;
 }
 
-.ghost-button,
-.secondary-button,
 .test-button {
   background: var(--panel-strong);
   color: var(--text);
+  border-color: var(--line);
+  margin-top: auto;
+  align-self: flex-start;
 }
 
-.ghost-button:hover,
-.secondary-button:hover,
-.test-button:hover {
+.test-button:hover:not(:disabled) {
+  background: var(--card-hover);
   border-color: var(--accent);
+  color: var(--accent);
+}
+
+.test-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.secondary-button {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.secondary-button:hover:not(:disabled) {
+  background: var(--panel-strong);
+  border-color: var(--text);
 }
 
 .primary-button {
@@ -277,40 +391,56 @@ textarea {
   color: #06100b;
 }
 
-.primary-button:hover {
+.primary-button:hover:not(:disabled) {
   background: var(--accent-dark);
 }
 
 .primary-button:disabled {
   cursor: not-allowed;
   border-color: var(--line);
-  background: #34302a;
-  color: #797067;
+  background: var(--panel-strong);
+  color: var(--muted);
 }
 
+.ghost-button {
+  background: transparent;
+  color: var(--muted);
+  border-color: transparent;
+}
+
+.ghost-button:hover {
+  color: var(--text-strong);
+  background: var(--panel-strong);
+}
+
+/* Forms layout */
 .form-sections {
   display: grid;
-  gap: 18px;
+  gap: 24px;
 }
 
 .settings-section {
-  padding: 18px;
-  scroll-margin-top: 20px;
+  padding: 24px;
+  scroll-margin-top: 24px;
 }
 
 .section-heading {
-  margin-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 16px;
+  margin-bottom: 24px;
 }
 
 .field-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
 }
 
+/* Field Grouping */
 .field {
-  display: grid;
-  gap: 7px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   align-content: start;
 }
 
@@ -321,110 +451,198 @@ textarea {
   gap: 8px;
   font-size: 13px;
   font-weight: 700;
+  color: var(--text-strong);
 }
 
 .field-source {
-  color: var(--muted);
+  color: var(--accent);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--accent-muted);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
 }
 
-.field input,
+/* Form Inputs, Select, Textareas */
+.field input[type="text"],
+.field input[type="number"],
+.field input[type="password"],
 .field select,
 .field textarea {
   width: 100%;
-  min-height: 38px;
+  min-height: 40px;
   border: 1px solid var(--line-strong);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--input);
-  color: var(--text);
-  padding: 8px 10px;
+  color: var(--text-strong);
+  padding: 10px 14px;
+  font-size: 14px;
+  transition: all var(--transition-fast);
+}
+
+/* Custom Dropdown Styling for Select Elements */
+.field select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 14px;
+  padding-right: 36px;
+}
+
+/* Custom Dropdown Styling for Datalist Input Elements (Model Routing) */
+.field input[list] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 14px;
+  padding-right: 36px;
+}
+
+/* Hide WebKit's native picker indicator to avoid double arrow icons */
+.field input[list]::-webkit-calendar-picker-indicator {
+  display: none !important;
+}
+
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  border-color: var(--accent);
+  background: var(--input-focus);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+  outline: none;
+}
+
+/* Checkbox specific layout styling */
+.field input[type="checkbox"] {
+  align-self: flex-start;
+  width: 20px;
+  height: 20px;
+  accent-color: var(--accent);
+  cursor: pointer;
+  margin: 4px 0;
 }
 
 .field textarea {
-  min-height: 90px;
+  min-height: 100px;
   resize: vertical;
+  line-height: 1.5;
 }
 
 .field input:disabled,
 .field select:disabled,
 .field textarea:disabled {
-  background: #26231f;
-  color: #82796f;
+  background: rgba(255, 255, 255, 0.02);
+  border-color: var(--line);
+  color: var(--muted);
+  cursor: not-allowed;
 }
 
 .field-description {
   color: var(--muted);
   font-size: 12px;
-  line-height: 1.35;
+  line-height: 1.4;
+  margin-top: 2px;
 }
 
+/* Show/Hide Advanced fields */
 .field.advanced-field {
   display: none;
 }
 
 .settings-section.show-advanced .advanced-field {
-  display: grid;
+  display: flex;
 }
 
 .advanced-toggle {
-  justify-self: start;
-  margin-top: 14px;
+  margin-top: 20px;
+  font-size: 12px;
+  border: 1px solid var(--line-strong);
 }
 
+/* Fixed Bottom Action Bar */
 .action-bar {
   position: fixed;
   right: 0;
   bottom: 0;
-  left: 268px;
-  z-index: 10;
+  left: 260px;
+  z-index: 100;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(180px, auto) auto;
-  gap: 14px;
+  grid-template-columns: minmax(0, 1.2fr) minmax(200px, 1fr) auto;
+  gap: 20px;
   align-items: center;
-  min-height: 72px;
+  min-height: 80px;
   border-top: 1px solid var(--line);
-  background: rgba(26, 24, 21, 0.94);
-  padding: 12px 28px;
-  backdrop-filter: blur(12px);
+  background: rgba(9, 10, 15, 0.82);
+  padding: 16px 40px;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.3);
 }
 
 .action-meta {
-  display: grid;
-  gap: 3px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   min-width: 0;
 }
 
-.action-meta strong,
-.action-meta span {
+.action-meta strong {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-strong);
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.action-meta span {
+  color: var(--muted);
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .message-area {
   min-width: 0;
   color: var(--muted);
   font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
 }
 
 .message-area.error {
   color: var(--error);
+  font-weight: 600;
 }
 
 .message-area.ok {
   color: var(--ok);
+  font-weight: 600;
 }
 
 .action-buttons {
   display: flex;
-  gap: 8px;
+  gap: 12px;
 }
 
+.action-buttons button {
+  min-width: 100px;
+}
+
+/* Tablet Layout Optimization */
 @media (max-width: 900px) {
   .app-shell {
-    display: block;
-    padding-bottom: 122px;
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 180px; /* More room for stacked action bar */
   }
 
   .sidebar {
@@ -432,28 +650,87 @@ textarea {
     height: auto;
     border-right: 0;
     border-bottom: 1px solid var(--line);
+    padding: 20px;
+    gap: 20px;
   }
 
   .section-nav {
-    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
   }
 
   .main {
-    padding: 18px;
+    padding: 24px 20px;
   }
 
   .action-bar {
     left: 0;
     grid-template-columns: 1fr;
-    align-items: stretch;
-    padding: 12px 18px;
+    gap: 12px;
+    padding: 16px 20px;
+    min-height: auto;
+    background: rgba(9, 10, 15, 0.95);
+  }
+
+  .action-meta {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .action-meta span {
+    text-align: right;
   }
 
   .action-buttons {
-    justify-content: stretch;
+    width: 100%;
   }
 
   .action-buttons button {
     flex: 1;
+    min-height: 44px; /* Better touch target on mobile */
+  }
+}
+
+/* Mobile Layout Optimization */
+@media (max-width: 600px) {
+  .brand {
+    justify-content: center;
+    text-align: center;
+    flex-direction: column;
+  }
+  
+  .brand-mark {
+    width: 48px;
+    height: 48px;
+  }
+
+  .section-nav {
+    grid-template-columns: 1fr;
+  }
+  
+  .topbar {
+    text-align: center;
+  }
+
+  .topbar h2 {
+    font-size: 24px;
+  }
+
+  .provider-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .action-meta {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+  }
+
+  .action-meta span {
+    text-align: left;
   }
 }

--- a/api/admin_static/admin.css
+++ b/api/admin_static/admin.css
@@ -1,736 +1,702 @@
+/* ── Fonts ───────────────────────────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+/* ── Tokens — light (paper) ──────────────────────────────────────────────── */
 :root {
-  color-scheme: dark;
-  
-  /* Color Palette */
-  --bg: #090a0f;
-  --panel: #11131c;
-  --panel-strong: #171b26;
-  --card: #151822;
-  --card-hover: #1e2230;
-  --input: #0a0b10;
-  --input-focus: #0f1118;
-  --text: #f3f4f6;
-  --text-strong: #ffffff;
-  --muted: #9ca3af;
-  --line: rgba(255, 255, 255, 0.06);
-  --line-strong: rgba(255, 255, 255, 0.12);
-  
-  /* Brand and Accent Colors */
-  --accent: #10b981;
-  --accent-dark: #059669;
-  --accent-muted: rgba(16, 185, 129, 0.08);
-  --accent-border: rgba(16, 185, 129, 0.3);
-  
-  /* Status Colors */
-  --ok: #10b981;
-  --ok-bg: rgba(16, 185, 129, 0.08);
-  --ok-border: rgba(16, 185, 129, 0.25);
-  
-  --warn: #f59e0b;
-  --warn-bg: rgba(245, 158, 11, 0.08);
-  --warn-border: rgba(245, 158, 11, 0.25);
-  
-  --error: #ef4444;
-  --error-bg: rgba(239, 68, 68, 0.08);
-  --error-border: rgba(239, 68, 68, 0.25);
-  
-  --neutral: #6b7280;
-  --neutral-bg: rgba(107, 114, 128, 0.08);
-  --neutral-border: rgba(107, 114, 128, 0.25);
-  
-  --info: #3b82f6;
-  
-  /* Box Shadow & Glows */
-  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.2);
-  --shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
-  --glow-accent: 0 0 12px rgba(16, 185, 129, 0.15);
-  
-  /* Borders and Radius */
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
-  --radius-full: 9999px;
-  
-  /* Typography */
-  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  
-  /* Transitions */
-  --transition-fast: 0.15s ease;
-  --transition-normal: 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Surface */
+  --paper:        #fbf9f4;
+  --paper-dim:    #f3efe6;
+  --paper-rule:   #d8d1c1;
+
+  /* Ink (text) */
+  --ink:          #1f1d18;
+  --ink-2:        #4a4537;
+  --ink-3:        #857c69;
+  --ink-4:        #b2a98f;
+
+  /* Accent */
+  --clay:         #c96442;
+  --clay-deep:    #9c4a2e;
+
+  /* State */
+  --moss:         #4f6a3d;
+  --rust:         #a53f2b;
+  --ochre:        #a87a2c;
+
+  /* Filter chrome */
+  --scrollbar-thumb: var(--paper-rule);
+
+  --sans:   'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --mono:   'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 }
 
-* {
-  box-sizing: border-box;
+/* ── Tokens — dark (ink) ─────────────────────────────────────────────────── */
+[data-theme="dark"] {
+  --paper:        #15151a;
+  --paper-dim:    #1d1d23;
+  --paper-rule:   #2c2c34;
+
+  --ink:          #ece8df;
+  --ink-2:        #b9b3a3;
+  --ink-3:        #7c7669;
+  --ink-4:        #4a463d;
+
+  --clay:         #d97a55;
+  --clay-deep:    #c96442;
+
+  --moss:         #7ea86b;
+  --rust:         #d47258;
+  --ochre:        #d4a352;
+
+  --scrollbar-thumb: var(--paper-rule);
 }
+
+/* Only follow system when user has not picked explicitly (no data-theme) */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    --paper:        #15151a;
+    --paper-dim:    #1d1d23;
+    --paper-rule:   #2c2c34;
+
+    --ink:          #ece8df;
+    --ink-2:        #b9b3a3;
+    --ink-3:        #7c7669;
+    --ink-4:        #4a463d;
+
+    --clay:         #d97a55;
+    --clay-deep:    #c96442;
+
+    --moss:         #7ea86b;
+    --rust:         #d47258;
+    --ochre:        #d4a352;
+  }
+}
+
+/* ── Reset ───────────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-size: 16px; }
 
 body {
-  margin: 0;
-  min-width: 320px;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--font-sans);
-  letter-spacing: -0.01em;
+  font-family: var(--sans);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ink);
+  background: var(--paper);
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "kern", "liga", "calt", "ss01";
+  transition: background-color 0.15s, color 0.15s;
 }
 
-/* Custom Scrollbars */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-::-webkit-scrollbar-track {
-  background: var(--bg);
-}
-::-webkit-scrollbar-thumb {
-  background: var(--panel-strong);
-  border-radius: var(--radius-full);
-}
-::-webkit-scrollbar-thumb:hover {
-  background: var(--muted);
-}
+::selection { background: var(--clay); color: var(--paper); }
 
-button,
-input,
-select,
-textarea {
-  font: inherit;
-  color: inherit;
-}
-
-/* App Shell Layout */
+/* ── App shell ───────────────────────────────────────────────────────────── */
 .app-shell {
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 1fr auto;
   min-height: 100vh;
-  padding-bottom: 96px; /* Space for action bar */
+  max-width: 1440px;
+  margin: 0 auto;
+  border-left: 1px solid var(--paper-rule);
+  border-right: 1px solid var(--paper-rule);
 }
 
-/* Sidebar Navigation */
+/* ── Sidebar ─────────────────────────────────────────────────────────────── */
 .sidebar {
+  grid-row: 1 / 3;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  border-right: 1px solid var(--paper-rule);
+  background: var(--paper);
   position: sticky;
   top: 0;
   height: 100vh;
-  border-right: 1px solid var(--line);
-  background: var(--bg);
-  padding: 24px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
+  overflow-y: auto;
 }
 
-.brand {
+.sidebar-header {
+  padding: 1rem 1.1rem 0.85rem;
+  border-bottom: 1px solid var(--paper-rule);
+}
+
+.brand-row {
   display: flex;
   align-items: center;
-  gap: 12px;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
-.brand-mark {
-  display: grid;
-  width: 40px;
-  height: 40px;
-  place-items: center;
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: #ffffff;
-  font-weight: 800;
-  font-size: 15px;
-  box-shadow: var(--glow-accent);
-}
-
-.brand h1 {
-  font-size: 16px;
+.brand-name {
+  font-family: var(--sans);
+  font-size: 1.05rem;
   font-weight: 700;
-  line-height: 1.2;
-  color: var(--text-strong);
-  margin: 0;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--ink);
 }
 
-.brand p {
-  color: var(--muted);
-  font-size: 12px;
-  margin: 0;
+.brand-name em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--clay);
 }
 
-.section-nav {
+.theme-toggle {
+  width: 26px;
+  height: 26px;
   display: grid;
-  gap: 6px;
+  place-items: center;
+  background: transparent;
+  border: 1px solid var(--paper-rule);
+  border-radius: 4px;
+  color: var(--ink-2);
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+.theme-toggle:hover { color: var(--clay); border-color: var(--clay); }
+.theme-toggle svg { width: 13px; height: 13px; }
+
+/* Show sun in light mode, moon in dark mode */
+[data-theme="dark"] .icon-sun  { display: none; }
+:root:not([data-theme="dark"]) .icon-moon { display: none; }
+
+/* ── Nav ─────────────────────────────────────────────────────────────────── */
+.section-nav {
+  padding: 0.75rem 0.4rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
 }
 
 .nav-link {
   display: flex;
   align-items: center;
-  width: 100%;
-  min-height: 40px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  gap: 0.5rem;
+  padding: 0.45rem 0.7rem;
+  border: none;
   background: transparent;
-  color: var(--muted);
-  padding: 10px 14px;
+  color: var(--ink-2);
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  font-weight: 500;
   text-align: left;
   cursor: pointer;
-  font-weight: 600;
-  font-size: 14px;
-  transition: all var(--transition-fast);
+  position: relative;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
 }
 
-.nav-link:hover {
-  background: var(--panel-strong);
-  color: var(--text-strong);
+.nav-link .nav-num {
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  color: var(--ink-3);
+  letter-spacing: 0.04em;
+  min-width: 16px;
 }
+
+.nav-link:hover { color: var(--ink); background: var(--paper-dim); }
 
 .nav-link.active {
-  background: var(--accent-muted);
-  border-color: var(--accent-border);
-  color: var(--accent);
-  box-shadow: var(--shadow-sm);
+  color: var(--ink);
+  background: var(--paper-dim);
 }
-
-/* Accessible focus outlines */
-button:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible,
-.nav-link:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+.nav-link.active::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 6px; bottom: 6px;
+  width: 2px;
+  background: var(--clay);
 }
+.nav-link.active .nav-num { color: var(--clay); }
 
-/* Main Content Area */
-.main {
-  min-width: 0;
-  padding: 40px 48px;
-}
-
-.topbar {
-  margin-bottom: 32px;
-}
-
-.topbar h2 {
-  font-size: 30px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  color: var(--text-strong);
-  margin: 0;
-}
-
-/* Provider Strip & Panels */
-.provider-strip,
-.settings-section {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-lg);
-  background: var(--panel);
-  box-shadow: var(--shadow);
-  margin-bottom: 24px;
-  transition: border-color var(--transition-normal);
-}
-
-.provider-strip {
-  padding: 24px;
-}
-
-.strip-header,
-.section-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 20px;
-}
-
-.strip-header h3,
-.section-heading h3 {
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--text-strong);
-  margin: 0;
-}
-
-.section-heading p {
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.4;
-  margin: 4px 0 0 0;
-}
-
-/* Provider Status Cards */
-.provider-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 16px;
-}
-
-.provider-card {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 16px;
-  min-height: 140px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  padding: 16px;
-  background: var(--card);
-  transition: all var(--transition-normal);
-}
-
-.provider-card:hover {
-  border-color: var(--line-strong);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-sm);
-  background: var(--card-hover);
-}
-
-.provider-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.provider-title strong {
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--text-strong);
-}
-
-/* Modern status pills with color indicators */
-.status-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 22px;
-  border: 1px solid var(--neutral-border);
-  border-radius: var(--radius-full);
-  padding: 2px 10px;
-  background: var(--neutral-bg);
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  white-space: nowrap;
-}
-
-.status-pill.ok {
-  color: var(--ok);
-  background: var(--ok-bg);
-  border-color: var(--ok-border);
-}
-
-.status-pill.warn {
-  color: var(--warn);
-  background: var(--warn-bg);
-  border-color: var(--warn-border);
-}
-
-.status-pill.error {
-  color: var(--error);
-  background: var(--error-bg);
-  border-color: var(--error-border);
-}
-
-.provider-meta {
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.4;
-  word-break: break-all;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-}
-
-/* Button & Form Controls styling */
-.test-button,
-.ghost-button,
-.secondary-button,
-.primary-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 36px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--line-strong);
-  padding: 6px 14px;
-  font-weight: 600;
-  font-size: 13px;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  text-decoration: none;
-}
-
-.test-button {
-  background: var(--panel-strong);
-  color: var(--text);
-  border-color: var(--line);
+/* ── Sidebar footer ──────────────────────────────────────────────────────── */
+.sidebar-footer {
   margin-top: auto;
-  align-self: flex-start;
+  padding: 0.85rem 1.1rem;
+  border-top: 1px solid var(--paper-rule);
+}
+.sidebar-footer code {
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  color: var(--ink-3);
+  word-break: break-all;
+  display: block;
+  letter-spacing: 0.02em;
 }
 
-.test-button:hover:not(:disabled) {
-  background: var(--card-hover);
-  border-color: var(--accent);
-  color: var(--accent);
+/* ── Main ────────────────────────────────────────────────────────────────── */
+.main {
+  padding: 1.75rem 2.25rem 7rem;
+  min-width: 0;
+  position: relative;
 }
 
-.test-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+/* ── Page header ─────────────────────────────────────────────────────────── */
+.page-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--paper-rule);
 }
 
-.secondary-button {
-  background: transparent;
-  color: var(--text);
-  border-color: var(--line-strong);
+.page-header h2 {
+  font-family: var(--sans);
+  font-size: 1.55rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--ink);
 }
 
-.secondary-button:hover:not(:disabled) {
-  background: var(--panel-strong);
-  border-color: var(--text);
+.page-header h2 em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--clay);
 }
 
-.primary-button {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #06100b;
+/* ── Admin views ─────────────────────────────────────────────────────────── */
+.admin-view {
+  display: none;
+  flex-direction: column;
+  gap: 2rem;
+}
+.admin-view.active { display: flex; }
+
+/* ── Section ─────────────────────────────────────────────────────────────── */
+.settings-section + .settings-section {
+  margin-top: 0;
 }
 
-.primary-button:hover:not(:disabled) {
-  background: var(--accent-dark);
+.section-head {
+  margin-bottom: 1rem;
+  padding-top: 0.3rem;
+  border-top: 1px solid var(--paper-rule);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
-.primary-button:disabled {
-  cursor: not-allowed;
-  border-color: var(--line);
-  background: var(--panel-strong);
-  color: var(--muted);
+.section-head h3 {
+  font-family: var(--sans);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--ink);
 }
 
-.ghost-button {
-  background: transparent;
-  color: var(--muted);
-  border-color: transparent;
+.section-head p {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  color: var(--ink-3);
+  line-height: 1.45;
+  flex: 1 1 100%;
+  margin-top: 0.15rem;
 }
 
-.ghost-button:hover {
-  color: var(--text-strong);
-  background: var(--panel-strong);
-}
-
-/* Forms layout */
-.form-sections {
-  display: grid;
-  gap: 24px;
-}
-
-.settings-section {
-  padding: 24px;
-  scroll-margin-top: 24px;
-}
-
-.section-heading {
-  border-bottom: 1px solid var(--line);
-  padding-bottom: 16px;
-  margin-bottom: 24px;
-}
-
+/* ── Field grid ──────────────────────────────────────────────────────────── */
 .field-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 2rem;
+  row-gap: 0.85rem;
 }
 
-/* Field Grouping */
 .field {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  align-content: start;
+  gap: 0.3rem;
+  position: relative;
+  padding-top: 0.45rem;
+  border-top: 1px dotted var(--paper-rule);
 }
 
-.field label {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--text-strong);
+.field-label {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  color: var(--ink);
 }
 
 .field-source {
-  color: var(--accent);
-  font-size: 11px;
-  font-weight: 700;
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  background: var(--accent-muted);
-  padding: 1px 6px;
-  border-radius: var(--radius-sm);
+  color: var(--ink-3);
+  margin-left: 0.4rem;
+  padding: 0 4px;
+  border: 1px solid var(--paper-rule);
+  border-radius: 2px;
+  vertical-align: middle;
 }
 
-/* Form Inputs, Select, Textareas */
-.field input[type="text"],
-.field input[type="number"],
-.field input[type="password"],
-.field select,
-.field textarea {
+.field-source.locked { color: var(--rust); border-color: var(--rust); }
+
+/* ── Inputs ──────────────────────────────────────────────────────────────── */
+input[type="text"],
+input[type="number"],
+input[type="password"],
+select,
+textarea {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--ink-2);
+  border-radius: 0;
+  padding: 0.35rem 0;
   width: 100%;
-  min-height: 40px;
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius-md);
-  background: var(--input);
-  color: var(--text-strong);
-  padding: 10px 14px;
-  font-size: 14px;
-  transition: all var(--transition-fast);
-}
-
-/* Custom Dropdown Styling for Select Elements */
-.field select {
+  transition: border-color 0.15s, color 0.15s;
   appearance: none;
   -webkit-appearance: none;
-  -moz-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
+}
+
+select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='currentColor' stroke-width='1.4' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 14px center;
-  background-size: 14px;
-  padding-right: 36px;
-}
-
-/* Custom Dropdown Styling for Datalist Input Elements (Model Routing) */
-.field input[list] {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 14px center;
-  background-size: 14px;
-  padding-right: 36px;
-}
-
-/* Hide WebKit's native picker indicator to avoid double arrow icons */
-.field input[list]::-webkit-calendar-picker-indicator {
-  display: none !important;
-}
-
-
-.field input:focus,
-.field select:focus,
-.field textarea:focus {
-  border-color: var(--accent);
-  background: var(--input-focus);
-  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
-  outline: none;
-}
-
-/* Checkbox specific layout styling */
-.field input[type="checkbox"] {
-  align-self: flex-start;
-  width: 20px;
-  height: 20px;
-  accent-color: var(--accent);
+  background-position: right 0.1rem center;
+  padding-right: 1.6rem;
   cursor: pointer;
-  margin: 4px 0;
 }
 
-.field textarea {
-  min-height: 100px;
-  resize: vertical;
-  line-height: 1.5;
+select option {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 0.78rem;
 }
 
-.field input:disabled,
-.field select:disabled,
-.field textarea:disabled {
-  background: rgba(255, 255, 255, 0.02);
-  border-color: var(--line);
-  color: var(--muted);
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-bottom-color: var(--clay);
+  color: var(--ink);
+}
+
+input::placeholder, textarea::placeholder {
+  color: var(--ink-4);
+}
+
+input:disabled, select:disabled, textarea:disabled {
+  opacity: 0.45;
   cursor: not-allowed;
+  border-bottom-style: dotted;
+}
+
+input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--clay);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 72px;
+  padding: 0.5rem 0.6rem;
+  line-height: 1.5;
+  border: 1px solid var(--paper-rule);
 }
 
 .field-description {
-  color: var(--muted);
-  font-size: 12px;
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  color: var(--ink-3);
   line-height: 1.4;
-  margin-top: 2px;
+  margin-top: 0.1rem;
 }
 
-/* Show/Hide Advanced fields */
-.field.advanced-field {
-  display: none;
+.field-hint {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--ink-2);
+  background: var(--paper-dim);
+  padding: 0.35rem 0.55rem;
+  border-left: 2px solid var(--clay);
+  border-radius: 0 2px 2px 0;
+  margin-top: 0.2rem;
+  line-height: 1.45;
 }
 
-.settings-section.show-advanced .advanced-field {
+.field-hint code {
+  font-family: inherit;
+  color: var(--clay-deep);
+  padding: 0 1px;
+}
+
+[data-theme="dark"] .field-hint code { color: var(--clay); }
+
+/* ── Routing banner (models section) ─────────────────────────────────────── */
+.routing-banner {
+  border: 1px solid var(--paper-rule);
+  border-left: 3px solid var(--clay);
+  background: var(--paper-dim);
+  border-radius: 3px;
+  padding: 0.7rem 0.9rem 0.85rem;
   display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
 }
 
-.advanced-toggle {
-  margin-top: 20px;
-  font-size: 12px;
-  border: 1px solid var(--line-strong);
+.routing-banner-title {
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 0.2rem;
 }
 
-/* Fixed Bottom Action Bar */
-.action-bar {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 260px;
-  z-index: 100;
+.routing-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(200px, 1fr) auto;
-  gap: 20px;
+  grid-template-columns: 70px 1fr auto;
+  gap: 0.75rem;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.routing-tag {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.routing-ids {
+  color: var(--ink-2);
+  word-break: break-word;
+}
+
+.routing-target {
+  color: var(--clay);
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+/* ── Advanced ────────────────────────────────────────────────────────────── */
+.advanced-toggle {
+  grid-column: 1 / -1;
+  justify-self: start;
+  font-family: var(--sans);
+  font-size: 0.75rem;
+  color: var(--ink-3);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  margin-top: 0.3rem;
+  border-bottom: 1px solid var(--paper-rule);
+}
+.advanced-toggle:hover { color: var(--clay); border-bottom-color: var(--clay); }
+
+.advanced-field { display: none; padding-top: 0.45rem; border-top: 1px dotted var(--paper-rule); }
+.show-advanced .advanced-field { display: flex; }
+
+/* ── Provider cards ──────────────────────────────────────────────────────── */
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1px;
+  background: var(--paper-rule);
+  border: 1px solid var(--paper-rule);
+}
+
+.provider-card {
+  background: var(--paper);
+  padding: 0.85rem 1rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  position: relative;
+  transition: background 0.15s;
+}
+.provider-card:hover { background: var(--paper-dim); }
+
+.provider-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.provider-name {
+  font-family: var(--sans);
+  font-size: 0.88rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+
+.status-pill {
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  font-weight: 500;
+}
+.status-pill.ok      { color: var(--moss); }
+.status-pill.warn    { color: var(--ochre); }
+.status-pill.error   { color: var(--rust); }
+.status-pill.neutral { color: var(--ink-3); }
+
+.provider-meta {
+  font-family: var(--mono);
+  font-size: 0.64rem;
+  color: var(--ink-3);
+  line-height: 1.4;
+  word-break: break-all;
+}
+
+.test-button {
+  align-self: flex-start;
+  display: inline-flex;
   align-items: center;
-  min-height: 80px;
-  border-top: 1px solid var(--line);
-  background: rgba(9, 10, 15, 0.82);
-  padding: 16px 40px;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.3);
+  gap: 0.3rem;
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  border-bottom: 1px solid var(--ink-2);
+  transition: color 0.15s, border-color 0.15s;
+  margin-top: 0.15rem;
+}
+.test-button svg { width: 10px; height: 10px; }
+.test-button:hover { color: var(--clay); border-bottom-color: var(--clay); }
+.test-button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+@keyframes spin { to { transform: rotate(360deg); } }
+.test-button svg[style] { animation: spin 1s linear infinite; }
+
+/* ── Action bar ──────────────────────────────────────────────────────────── */
+.action-bar {
+  grid-column: 2;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 0.85rem 2.25rem;
+  background: var(--paper);
+  border-top: 1px solid var(--paper-rule);
+  position: sticky;
+  bottom: 0;
+  z-index: 50;
 }
 
 .action-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
+  font-family: var(--sans);
+  font-size: 0.8rem;
+  color: var(--ink-2);
 }
 
 .action-meta strong {
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--text-strong);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.action-meta span {
-  color: var(--muted);
-  font-size: 11px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  font-weight: 600;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
 }
 
 .message-area {
+  font-family: var(--sans);
+  font-size: 0.8rem;
+  color: var(--ink-2);
+  text-align: center;
   min-width: 0;
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+.message-area.ok    { color: var(--moss); }
+.message-area.error { color: var(--rust); }
+.message-area.warn  { color: var(--ochre); }
 
-.message-area.error {
-  color: var(--error);
+.action-buttons { display: flex; gap: 1rem; }
+
+.btn-primary {
+  font-family: var(--sans);
+  font-size: 0.85rem;
   font-weight: 600;
+  padding: 0.32rem 0;
+  background: transparent;
+  color: var(--clay);
+  border: none;
+  border-bottom: 2px solid var(--clay);
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  transition: color 0.15s, border-color 0.15s;
+}
+.btn-primary:hover:not(:disabled) { color: var(--clay-deep); border-bottom-color: var(--clay-deep); }
+.btn-primary:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.btn-secondary {
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  padding: 0.32rem 0;
+  background: transparent;
+  color: var(--ink-2);
+  border: none;
+  border-bottom: 1px solid var(--paper-rule);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.btn-secondary:hover { color: var(--ink); border-bottom-color: var(--ink); }
+.btn-secondary:disabled { opacity: 0.3; cursor: not-allowed; }
+
+/* ── Scrollbar ───────────────────────────────────────────────────────────── */
+::-webkit-scrollbar       { width: 5px; height: 5px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); }
+::-webkit-scrollbar-thumb:hover { background: var(--ink-4); }
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 1000px) {
+  .main { padding: 1.5rem 1.75rem 7rem; }
+  .page-header h2 { font-size: 1.35rem; }
+  .action-bar { padding: 0.85rem 1.75rem; }
 }
 
-.message-area.ok {
-  color: var(--ok);
-  font-weight: 600;
-}
-
-.action-buttons {
-  display: flex;
-  gap: 12px;
-}
-
-.action-buttons button {
-  min-width: 100px;
-}
-
-/* Tablet Layout Optimization */
-@media (max-width: 900px) {
-  .app-shell {
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 180px; /* More room for stacked action bar */
-  }
-
+@media (max-width: 760px) {
+  .app-shell { grid-template-columns: 1fr; grid-template-rows: auto 1fr auto; border: none; }
   .sidebar {
-    position: relative;
+    grid-row: 1;
     height: auto;
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-    padding: 20px;
-    gap: 20px;
-  }
-
-  .section-nav {
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-  }
-
-  .main {
-    padding: 24px 20px;
-  }
-
-  .action-bar {
-    left: 0;
-    grid-template-columns: 1fr;
-    gap: 12px;
-    padding: 16px 20px;
-    min-height: auto;
-    background: rgba(9, 10, 15, 0.95);
-  }
-
-  .action-meta {
+    position: static;
     flex-direction: row;
-    justify-content: space-between;
     align-items: center;
+    border-right: none;
+    border-bottom: 1px solid var(--paper-rule);
+    padding: 0.5rem 0.75rem;
+    overflow-x: auto;
   }
-
-  .action-meta span {
-    text-align: right;
+  .sidebar-header {
+    padding: 0;
+    border-bottom: none;
+    flex-shrink: 0;
+    margin-right: 0.5rem;
   }
-
-  .action-buttons {
-    width: 100%;
-  }
-
-  .action-buttons button {
-    flex: 1;
-    min-height: 44px; /* Better touch target on mobile */
-  }
-}
-
-/* Mobile Layout Optimization */
-@media (max-width: 600px) {
-  .brand {
-    justify-content: center;
-    text-align: center;
-    flex-direction: column;
-  }
-  
-  .brand-mark {
-    width: 48px;
-    height: 48px;
-  }
-
-  .section-nav {
-    grid-template-columns: 1fr;
-  }
-  
-  .topbar {
-    text-align: center;
-  }
-
-  .topbar h2 {
-    font-size: 24px;
-  }
-
-  .provider-grid {
-    grid-template-columns: 1fr;
-  }
-  
-  .field-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .action-meta {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 2px;
-  }
-
-  .action-meta span {
-    text-align: left;
-  }
+  .brand-name { font-size: 0.9rem; }
+  .section-nav { flex-direction: row; padding: 0; gap: 0; }
+  .nav-link { padding: 0.35rem 0.5rem; }
+  .nav-link .nav-num { display: none; }
+  .sidebar-footer { display: none; }
+  .main { padding: 1.25rem 1rem 7rem; }
+  .page-header h2 { font-size: 1.2rem; }
+  .field-grid { grid-template-columns: 1fr; }
+  .action-bar { padding: 0.75rem 1rem; grid-template-columns: 1fr auto; gap: 0.6rem; }
 }

--- a/api/admin_static/admin.js
+++ b/api/admin_static/admin.js
@@ -7,6 +7,15 @@ const state = {
 };
 
 const MASKED_SECRET = "********";
+
+// Recognised Claude model ids that route through Settings.model_* overrides.
+// These mirror config.settings.Settings.resolve_model / resolve_thinking on
+// the backend; both sides must be updated together if the supported ids change.
+const FABLE_IDS = ["claude-fable-5", "claude-fable-5-2026", "claude-fable-5-2025-XX"];
+const FABLE_OPUS_IDS = ["claude-opus-4-8", "claude-opus-4-7"];
+const FABLE_SONNET_IDS = ["claude-sonnet-4-6", "claude-sonnet-4-5"];
+const FABLE_HAIKU_IDS = ["claude-haiku-4-5"];
+
 const VIEW_GROUPS = [
   {
     id: "providers",
@@ -31,6 +40,8 @@ const VIEW_GROUPS = [
   },
 ];
 
+const THEME_STORAGE_KEY = "fcc-theme";
+
 const byId = (id) => document.getElementById(id);
 
 function sourceLabel(source) {
@@ -40,7 +51,7 @@ function sourceLabel(source) {
     repo_env: "repo .env",
     managed_env: "",
     explicit_env_file: "FCC_ENV_FILE",
-    process: "process env",
+    process: "process",
   };
   return Object.prototype.hasOwnProperty.call(labels, source) ? labels[source] : source;
 }
@@ -48,13 +59,9 @@ function sourceLabel(source) {
 function sourceText(field) {
   const parts = [];
   const label = sourceLabel(field.source);
-  if (label) {
-    parts.push(label);
-  }
-  if (field.locked) {
-    parts.push("locked");
-  }
-  return parts.join(" ");
+  if (label) parts.push(label);
+  if (field.locked) parts.push("locked");
+  return parts.join(" / ");
 }
 
 function providerName(providerId) {
@@ -73,10 +80,7 @@ function providerName(providerId) {
     zai: "Z.ai",
   };
   if (names[providerId]) return names[providerId];
-  return providerId
-    .split("_")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
+  return providerId.split("_").map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(" ");
 }
 
 function statusClass(status) {
@@ -91,20 +95,62 @@ async function api(path, options = {}) {
     headers: { "Content-Type": "application/json", ...(options.headers || {}) },
     ...options,
   });
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
-  }
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
   return response.json();
+}
+
+function ensureFableFields(config) {
+  const keys = new Set(config.fields.map((f) => f.key));
+
+  if (!keys.has("MODEL_FABLE")) {
+    const firstModelIdx = config.fields.findIndex((f) => f.section === "models" && f.key !== "MODEL_DEFAULT");
+    const entry = {
+      key: "MODEL_FABLE",
+      label: "Fable Override",
+      type: "text",
+      value: "",
+      section: "models",
+      description: "Optional provider/model route for Fable requests.",
+      source: "default",
+      locked: false,
+      secret: false,
+      configured: false,
+      advanced: false,
+    };
+    if (firstModelIdx >= 0) config.fields.splice(firstModelIdx, 0, entry);
+    else config.fields.push(entry);
+  }
+
+  if (!keys.has("THINKING_FABLE")) {
+    const firstThinkingIdx = config.fields.findIndex((f) => f.section === "thinking" && f.key !== "THINKING_ENABLED");
+    const entry = {
+      key: "THINKING_FABLE",
+      label: "Fable Thinking",
+      type: "tri_boolean",
+      value: "",
+      section: "thinking",
+      description: "Blank inherits Enable Thinking.",
+      source: "default",
+      locked: false,
+      secret: false,
+      configured: false,
+      advanced: false,
+    };
+    if (firstThinkingIdx >= 0) config.fields.splice(firstThinkingIdx, 0, entry);
+    else config.fields.push(entry);
+  }
 }
 
 async function load() {
   showMessage("Loading admin config");
   const config = await api("/admin/api/config");
+  ensureFableFields(config);
   state.config = config;
-  state.fields = new Map(config.fields.map((field) => [field.key, field]));
+  state.fields = new Map(config.fields.map((f) => [f.key, f]));
   renderNav();
-  renderProviders(config.provider_status);
   renderSections(config.sections, config.fields);
+  const providersView = document.querySelector('section.admin-view[data-view="providers"]');
+  renderProviders(config.provider_status, providersView);
   byId("configPath").textContent = config.paths.managed;
   await validate(false);
   await refreshLocalStatus();
@@ -112,84 +158,128 @@ async function load() {
   showMessage("");
 }
 
-function renderNav() {
-  const nav = byId("sectionNav");
-  nav.innerHTML = "";
-  VIEW_GROUPS.forEach((view, index) => {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = `nav-link${index === 0 ? " active" : ""}`;
-    button.dataset.view = view.id;
-    button.textContent = view.label;
-    if (index === 0) {
-      button.setAttribute("aria-current", "page");
-    }
-    button.addEventListener("click", () => {
-      setActiveView(view.id, { scroll: true });
-    });
-    nav.appendChild(button);
-  });
-  setActiveView(state.activeView, { scroll: false });
-}
-
-function setActiveView(viewId, { scroll = false } = {}) {
-  const activeView =
-    VIEW_GROUPS.find((view) => view.id === viewId) || VIEW_GROUPS[0];
-  state.activeView = activeView.id;
-  byId("pageTitle").textContent = activeView.title;
-
-  document.querySelectorAll(".nav-link").forEach((link) => {
-    const selected = link.dataset.view === activeView.id;
-    link.classList.toggle("active", selected);
-    if (selected) {
-      link.setAttribute("aria-current", "page");
-    } else {
-      link.removeAttribute("aria-current");
-    }
-  });
-
-  document.querySelectorAll(".admin-view").forEach((view) => {
-    const selected = view.dataset.view === activeView.id;
-    view.classList.toggle("active", selected);
-    view.hidden = !selected;
-  });
-
-  if (scroll) {
-    window.scrollTo({ top: 0, behavior: "smooth" });
+/* ── Theme ───────────────────────────────────────────────────────────────── */
+function getStoredTheme() {
+  try {
+    const value = localStorage.getItem(THEME_STORAGE_KEY);
+    return value === "dark" || value === "light" ? value : null;
+  } catch {
+    return null;
   }
 }
 
-function renderProviders(providerStatus) {
-  const grid = byId("providerGrid");
-  grid.innerHTML = "";
-  providerStatus.forEach((provider) => {
-    const card = document.createElement("article");
-    card.className = "provider-card";
-    card.dataset.provider = provider.provider_id;
+function setStoredTheme(theme) {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    /* localStorage unavailable — toggle still works for the session */
+  }
+}
 
-    const title = document.createElement("div");
-    title.className = "provider-title";
-    title.innerHTML = `<strong>${providerName(provider.provider_id)}</strong>`;
+function systemPrefersDark() {
+  return typeof window !== "undefined"
+    && window.matchMedia
+    && window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+function resolveTheme() {
+  return getStoredTheme() ?? (systemPrefersDark() ? "dark" : "light");
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+function initTheme() {
+  applyTheme(resolveTheme());
+
+  const toggle = byId("themeToggle");
+  if (toggle) {
+    toggle.addEventListener("click", () => {
+      const next =
+        document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+      applyTheme(next);
+      setStoredTheme(next);
+    });
+  }
+
+  // Auto-follow system changes only when user has not picked explicitly.
+  if (window.matchMedia) {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (getStoredTheme() === null) applyTheme(mq.matches ? "dark" : "light");
+    };
+    if (mq.addEventListener) mq.addEventListener("change", handler);
+    else if (mq.addListener) mq.addListener(handler); // older Safari
+  }
+}
+
+/* ── Navigation ─────────────────────────────────────────────────────────── */
+function renderNav() {
+  const nav = byId("sectionNav");
+  nav.innerHTML = "";
+  VIEW_GROUPS.forEach((view) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "nav-link";
+    btn.dataset.view = view.id;
+    btn.textContent = view.label;
+    btn.addEventListener("click", () => setActiveView(view.id));
+    nav.appendChild(btn);
+  });
+
+  setActiveView(state.activeView);
+}
+
+function setActiveView(viewId) {
+  const active = VIEW_GROUPS.find((v) => v.id === viewId) || VIEW_GROUPS[0];
+  state.activeView = active.id;
+  byId("pageTitle").textContent = active.title;
+
+  document.querySelectorAll(".nav-link").forEach((l) => {
+    l.classList.toggle("active", l.dataset.view === active.id);
+  });
+
+  document.querySelectorAll(".admin-view").forEach((v) => {
+    const show = v.dataset.view === active.id;
+    v.classList.toggle("active", show);
+    v.hidden = !show;
+  });
+}
+
+/* ── Provider cards ──────────────────────────────────────────────────────── */
+function renderProviders(providerStatus, container) {
+  const grid = document.createElement("div");
+  grid.className = "provider-grid";
+  container.prepend(grid);
+  providerStatus.forEach((p) => {
+    const card = document.createElement("div");
+    card.className = "provider-card";
+    card.dataset.provider = p.provider_id;
+
+    const top = document.createElement("div");
+    top.className = "provider-top";
+
+    const name = document.createElement("span");
+    name.className = "provider-name";
+    name.textContent = providerName(p.provider_id);
 
     const pill = document.createElement("span");
-    pill.className = `status-pill ${statusClass(provider.status)}`;
-    pill.textContent = provider.label;
-    title.appendChild(pill);
+    pill.className = `status-pill ${statusClass(p.status)}`;
+    pill.textContent = p.label;
 
     const meta = document.createElement("div");
     meta.className = "provider-meta";
-    meta.textContent =
-      provider.kind === "local"
-        ? provider.base_url || "No local URL configured"
-        : provider.credential_env;
+    meta.textContent = p.kind === "local" ? (p.base_url || "No local URL") : p.credential_env;
 
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "test-button";
-    button.textContent = provider.kind === "local" ? "Test" : "Refresh models";
-    button.addEventListener("click", () => testProvider(provider.provider_id, button));
+    const btn = document.createElement("button");
+    btn.className = "test-button";
+    btn.type = "button";
+    btn.textContent = p.kind === "local" ? "test connection →" : "refresh →";
+    btn.addEventListener("click", () => testProvider(p.provider_id, btn));
 
-    card.append(title, meta, button);
+    top.append(name, pill);
+    card.append(top, meta, btn);
     grid.appendChild(card);
   });
 }
@@ -200,81 +290,126 @@ function updateProviderCard(providerId, status, label, metaText) {
   const pill = card.querySelector(".status-pill");
   pill.className = `status-pill ${statusClass(status)}`;
   pill.textContent = label;
-  if (metaText) {
-    card.querySelector(".provider-meta").textContent = metaText;
-  }
+  if (metaText) card.querySelector(".provider-meta").textContent = metaText;
 }
 
+/* ── Settings sections ──────────────────────────────────────────────────── */
 function renderSections(sections, fields) {
   VIEW_GROUPS.forEach((view) => {
-    byId(view.containerId).innerHTML = "";
-  });
-
-  const sectionById = new Map(sections.map((section) => [section.id, section]));
-  const bySection = new Map();
-  sections.forEach((section) => bySection.set(section.id, []));
-  fields.forEach((field) => {
-    if (!bySection.has(field.section)) bySection.set(field.section, []);
-    bySection.get(field.section).push(field);
-  });
-
-  VIEW_GROUPS.forEach((view) => {
     const container = byId(view.containerId);
+    container.innerHTML = "";
     view.sections.forEach((sectionId) => {
-      const section = sectionById.get(sectionId);
-      const sectionFields = bySection.get(sectionId) || [];
-      if (!section || sectionFields.length === 0) return;
-
-      const sectionEl = document.createElement("section");
-      sectionEl.className = "settings-section";
-      sectionEl.id = `section-${section.id}`;
-
-      const heading = document.createElement("div");
-      heading.className = "section-heading";
-      heading.innerHTML = `<div><h3>${section.label}</h3><p>${section.description}</p></div>`;
-      sectionEl.appendChild(heading);
-
-      const grid = document.createElement("div");
-      grid.className = "field-grid";
-      sectionFields.forEach((field) => {
-        grid.appendChild(renderField(field));
-      });
-      sectionEl.appendChild(grid);
-
-      if (sectionFields.some((field) => field.advanced)) {
-        const toggle = document.createElement("button");
-        toggle.type = "button";
-        toggle.className = "ghost-button advanced-toggle";
-        toggle.textContent = "Show advanced";
-        toggle.addEventListener("click", () => {
-          const showing = sectionEl.classList.toggle("show-advanced");
-          toggle.textContent = showing ? "Hide advanced" : "Show advanced";
-        });
-        sectionEl.appendChild(toggle);
-      }
-
-      container.appendChild(sectionEl);
+      renderSection(sections, fields, sectionId, container);
     });
   });
 }
 
+function renderSection(allSections, allFields, sectionId, container) {
+  const section = allSections.find((s) => s.id === sectionId);
+  const sectionFields = allFields.filter((f) => f.section === sectionId);
+  if (!section) return;
+
+  const el = document.createElement("div");
+  el.className = "settings-section";
+  el.id = `section-${section.id}`;
+
+  el.innerHTML = `
+    <div class="section-head">
+      <h3>${section.label}</h3>
+      <p>${section.description || ""}</p>
+    </div>
+    <div class="section-body"></div>`;
+
+  const body = el.querySelector(".section-body");
+
+  if (sectionFields.length === 0) {
+    container.appendChild(el);
+    return;
+  }
+
+  // Highlight routed Claude ids for the models section so operators can see
+  // — even before scrolling — which model names MODEL_FABLE / MODEL_OPUS /
+  // MODEL_SONNET / MODEL_HAIKU already cover.
+  if (sectionId === "models") {
+    body.appendChild(buildModelRoutingBanner(sectionFields));
+  }
+
+  const grid = document.createElement("div");
+  grid.className = "field-grid";
+  body.appendChild(grid);
+
+  sectionFields.forEach((field) => grid.appendChild(renderField(field)));
+
+  if (sectionFields.some((f) => f.advanced)) {
+    const toggle = document.createElement("button");
+    toggle.type = "button";
+    toggle.className = "advanced-toggle";
+    toggle.textContent = "show advanced ▾";
+    toggle.addEventListener("click", () => {
+      const showing = el.classList.toggle("show-advanced");
+      toggle.textContent = showing ? "hide advanced ▴" : "show advanced ▾";
+    });
+    body.appendChild(toggle);
+  }
+
+  container.appendChild(el);
+}
+
+function buildModelRoutingBanner(fields) {
+  const banner = document.createElement("div");
+  banner.className = "routing-banner";
+
+  const title = document.createElement("div");
+  title.className = "routing-banner-title";
+  title.textContent = "Recognised Claude model routes";
+  banner.appendChild(title);
+
+  // Always list the four routing tiers the resolver understands. Keys come
+  // from config.settings (MODEL_FABLE / MODEL_OPUS / MODEL_SONNET / MODEL_HAIKU).
+  const rows = [
+    { label: "Fable", ids: FABLE_IDS, hint: "MODEL_FABLE" },
+    { label: "Opus", ids: FABLE_OPUS_IDS, hint: "MODEL_OPUS" },
+    { label: "Sonnet", ids: FABLE_SONNET_IDS, hint: "MODEL_SONNET" },
+    { label: "Haiku", ids: FABLE_HAIKU_IDS, hint: "MODEL_HAIKU" },
+  ];
+
+  rows.forEach((row) => {
+    const rowEl = document.createElement("div");
+    rowEl.className = "routing-row";
+    const tag = document.createElement("span");
+    tag.className = "routing-tag";
+    tag.textContent = row.label;
+    const ids = document.createElement("span");
+    ids.className = "routing-ids";
+    ids.textContent = row.ids.join("  ·  ");
+    const target = document.createElement("span");
+    target.className = "routing-target";
+    target.textContent = `→ ${row.hint}`;
+    rowEl.append(tag, ids, target);
+    banner.appendChild(rowEl);
+  });
+
+  return banner;
+}
+
+/* ── Field rendering ────────────────────────────────────────────────────── */
 function renderField(field) {
   const wrapper = document.createElement("div");
   wrapper.className = `field${field.advanced ? " advanced-field" : ""}`;
   wrapper.dataset.key = field.key;
 
   const label = document.createElement("label");
-  label.htmlFor = `field-${field.key}`;
   const labelText = document.createElement("span");
+  labelText.className = "field-label";
   labelText.textContent = field.label;
   label.appendChild(labelText);
 
-  const source = sourceText(field);
-  if (source) {
-    const sourceEl = document.createElement("span");
-    sourceEl.className = "field-source";
-    sourceEl.textContent = source;
-    label.appendChild(sourceEl);
+  const src = sourceText(field);
+  if (src) {
+    const badge = document.createElement("span");
+    badge.className = `field-source${field.locked ? " locked" : ""}`;
+    badge.textContent = src;
+    label.appendChild(badge);
   }
 
   const input = inputForField(field);
@@ -288,13 +423,17 @@ function renderField(field) {
   input.addEventListener("change", updateDirtyState);
 
   wrapper.append(label, input);
-  if (field.description) {
-    const description = document.createElement("div");
-    description.className = "field-description";
-    description.textContent = field.description;
-    wrapper.appendChild(description);
-  }
+  appendFieldExtras(wrapper, field);
   return wrapper;
+}
+
+function appendFieldExtras(wrapper, field) {
+  if (field.description) {
+    const desc = document.createElement("div");
+    desc.className = "field-description";
+    desc.textContent = field.description;
+    wrapper.appendChild(desc);
+  }
 }
 
 function inputForField(field) {
@@ -312,47 +451,50 @@ function inputForField(field) {
       ["", "Inherit"],
       ["true", "Enabled"],
       ["false", "Disabled"],
-    ].forEach(([value, label]) => select.appendChild(option(value, label)));
+    ].forEach(([val, lbl]) => {
+      const opt = document.createElement("option");
+      opt.value = val;
+      opt.textContent = lbl;
+      select.appendChild(opt);
+    });
     select.value = field.value || "";
     return select;
   }
 
   if (field.type === "select") {
     const select = document.createElement("select");
-    field.options.forEach((value) => select.appendChild(option(value, value)));
+    field.options.forEach((opt) => {
+      const el = document.createElement("option");
+      el.value = opt;
+      el.textContent = opt;
+      select.appendChild(el);
+    });
     select.value = field.value || field.options[0] || "";
     return select;
   }
 
   if (field.type === "textarea") {
-    const textarea = document.createElement("textarea");
-    textarea.value = field.value || "";
-    return textarea;
+    const ta = document.createElement("textarea");
+    ta.value = field.value || "";
+    return ta;
   }
 
   const input = document.createElement("input");
-  input.type = field.type === "number" ? "number" : "text";
   if (field.type === "secret") {
     input.type = "password";
     input.placeholder = field.configured
-      ? "Configured - enter a new value to replace"
+      ? "Configured — enter a new value to replace"
       : "Not configured";
     input.value = "";
     input.autocomplete = "off";
   } else {
+    input.type = field.type === "number" ? "number" : "text";
     input.value = field.value || "";
-  }
-  if (field.key.startsWith("MODEL")) {
-    input.setAttribute("list", "model-options");
+    if (field.key.startsWith("MODEL")) {
+      input.setAttribute("list", "model-options");
+    }
   }
   return input;
-}
-
-function option(value, label) {
-  const optionEl = document.createElement("option");
-  optionEl.value = value;
-  optionEl.textContent = label;
-  return optionEl;
 }
 
 function readFieldValue(input) {
@@ -367,14 +509,13 @@ function changedValues() {
   const values = {};
   document.querySelectorAll("[data-key]").forEach((input) => {
     if (input.disabled || !input.matches("input, select, textarea")) return;
-    const value = readFieldValue(input);
-    if (value !== input.dataset.original) {
-      values[input.dataset.key] = value;
-    }
+    const val = readFieldValue(input);
+    if (val !== input.dataset.original) values[input.dataset.key] = val;
   });
   return values;
 }
 
+/* ── Dirty state ────────────────────────────────────────────────────────── */
 function updateDirtyState() {
   const count = Object.keys(changedValues()).length;
   byId("dirtyState").textContent =
@@ -382,14 +523,13 @@ function updateDirtyState() {
   byId("applyButton").disabled = count === 0;
 }
 
+/* ── Validation ─────────────────────────────────────────────────────────── */
 async function validate(showResult = true) {
   const result = await api("/admin/api/config/validate", {
     method: "POST",
     body: JSON.stringify({ values: changedValues() }),
   });
-  if (showResult) {
-    showValidationResult(result);
-  }
+  if (showResult) showValidationResult(result);
   return result;
 }
 
@@ -401,6 +541,7 @@ function showValidationResult(result) {
   }
 }
 
+/* ── Apply ──────────────────────────────────────────────────────────────── */
 async function apply() {
   const result = await api("/admin/api/config/apply", {
     method: "POST",
@@ -412,14 +553,12 @@ async function apply() {
   }
   const restart = result.restart || {};
   if (restart.required && restart.automatic) {
-    showMessage("Applied. Restarting server...", "ok");
+    showMessage("Applied. Restarting server…", "ok");
     byId("applyButton").disabled = true;
-    setTimeout(() => {
-      window.location.href = restart.admin_url || "/admin";
-    }, 1600);
+    setTimeout(() => { window.location.href = restart.admin_url || "/admin"; }, 1600);
     return;
   }
-  const pending = restart.required ? restart.fields || [] : result.pending_fields || [];
+  const pending = restart.required ? (restart.fields || []) : (result.pending_fields || []);
   await load();
   showMessage(
     pending.length
@@ -429,37 +568,35 @@ async function apply() {
   );
 }
 
+/* ── Provider testing ───────────────────────────────────────────────────── */
 async function refreshLocalStatus() {
   const result = await api("/admin/api/providers/local-status");
-  result.providers.forEach((provider) => {
-    state.localStatus.set(provider.provider_id, provider);
-    const meta = provider.status_code
-      ? `${provider.base_url} returned HTTP ${provider.status_code}`
-      : provider.base_url;
-    updateProviderCard(provider.provider_id, provider.status, provider.label, meta);
+  result.providers.forEach((p) => {
+    state.localStatus.set(p.provider_id, p);
+    updateProviderCard(
+      p.provider_id,
+      p.status,
+      p.label,
+      p.status_code ? `${p.base_url} · HTTP ${p.status_code}` : p.base_url,
+    );
   });
 }
 
 async function testProvider(providerId, button) {
-  const original = button.textContent;
+  const label = button.innerHTML;
   button.disabled = true;
-  button.textContent = "Testing";
+  button.innerHTML = `<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="animation:spin 1s linear infinite"><path d="M10 2v4M10 14v4M2 10h4M14 10h4"/></svg>Testing`;
   try {
-    const result = await api(`/admin/api/providers/${providerId}/test`, {
-      method: "POST",
-      body: "{}",
-    });
+    const result = await api(`/admin/api/providers/${providerId}/test`, { method: "POST", body: "{}" });
     if (result.ok) {
-      updateProviderCard(
-        providerId,
-        "reachable",
-        `${result.models.length} models`,
-        result.models.slice(0, 3).join(", ") || "No models returned",
-      );
+      const summary = result.models.length
+        ? `${result.models.length} models · ${result.models.slice(0, 2).join(", ")}`
+        : "No models returned";
+      updateProviderCard(providerId, "reachable", "Reachable", summary);
       state.modelOptions = Array.from(
         new Set([
           ...state.modelOptions,
-          ...result.models.map((model) => `${providerId}/${model}`),
+          ...result.models.map((m) => `${providerId}/${m}`),
         ]),
       ).sort();
       syncModelDatalist();
@@ -468,30 +605,36 @@ async function testProvider(providerId, button) {
     }
   } finally {
     button.disabled = false;
-    button.textContent = original;
+    button.innerHTML = label;
   }
 }
 
 function syncModelDatalist() {
-  let datalist = byId("model-options");
-  if (!datalist) {
-    datalist = document.createElement("datalist");
-    datalist.id = "model-options";
-    document.body.appendChild(datalist);
+  let dl = byId("model-options");
+  if (!dl) {
+    dl = document.createElement("datalist");
+    dl.id = "model-options";
+    document.body.appendChild(dl);
   }
-  datalist.innerHTML = "";
-  state.modelOptions.forEach((model) => datalist.appendChild(option(model, model)));
+  dl.innerHTML = "";
+  state.modelOptions.forEach((m) => {
+    const opt = document.createElement("option");
+    opt.value = m;
+    opt.textContent = m;
+    dl.appendChild(opt);
+  });
 }
 
-function showMessage(message, kind = "") {
+/* ── Status bar messages ────────────────────────────────────────────────── */
+function showMessage(msg, kind = "") {
   const area = byId("messageArea");
-  area.textContent = message;
+  area.textContent = msg;
   area.className = `message-area ${kind}`.trim();
 }
 
+/* ── Init ───────────────────────────────────────────────────────────────── */
+initTheme();
 byId("validateButton").addEventListener("click", () => validate(true));
 byId("applyButton").addEventListener("click", apply);
 
-load().catch((error) => {
-  showMessage(error.message, "error");
-});
+load().catch((err) => showMessage(err.message, "error"));

--- a/api/admin_static/admin.js
+++ b/api/admin_static/admin.js
@@ -11,7 +11,7 @@ const MASKED_SECRET = "********";
 // Recognised Claude model ids that route through Settings.model_* overrides.
 // These mirror config.settings.Settings.resolve_model / resolve_thinking on
 // the backend; both sides must be updated together if the supported ids change.
-const FABLE_IDS = ["claude-fable-5", "claude-fable-5-2026", "claude-fable-5-2025-20260612"];
+const FABLE_IDS = ["claude-fable-5", "claude-fable-5-2026", "claude-fable-5-20250612"];
 const FABLE_OPUS_IDS = ["claude-opus-4-8", "claude-opus-4-7"];
 const FABLE_SONNET_IDS = ["claude-sonnet-4-6", "claude-sonnet-4-5"];
 const FABLE_HAIKU_IDS = ["claude-haiku-4-5"];
@@ -103,7 +103,7 @@ function ensureFableFields(config) {
   const keys = new Set(config.fields.map((f) => f.key));
 
   if (!keys.has("MODEL_FABLE")) {
-    const firstModelIdx = config.fields.findIndex((f) => f.section === "models" && f.key !== "MODEL_DEFAULT");
+    const firstModelIdx = config.fields.findIndex((f) => f.section === "models" && f.key !== "MODEL" && f.key !== "MODEL_DEFAULT");
     const entry = {
       key: "MODEL_FABLE",
       label: "Fable Override",

--- a/api/admin_static/admin.js
+++ b/api/admin_static/admin.js
@@ -11,7 +11,7 @@ const MASKED_SECRET = "********";
 // Recognised Claude model ids that route through Settings.model_* overrides.
 // These mirror config.settings.Settings.resolve_model / resolve_thinking on
 // the backend; both sides must be updated together if the supported ids change.
-const FABLE_IDS = ["claude-fable-5", "claude-fable-5-2026", "claude-fable-5-2025-XX"];
+const FABLE_IDS = ["claude-fable-5", "claude-fable-5-2026", "claude-fable-5-2025-20260612"];
 const FABLE_OPUS_IDS = ["claude-opus-4-8", "claude-opus-4-7"];
 const FABLE_SONNET_IDS = ["claude-sonnet-4-6", "claude-sonnet-4-5"];
 const FABLE_HAIKU_IDS = ["claude-haiku-4-5"];
@@ -121,10 +121,10 @@ function ensureFableFields(config) {
     else config.fields.push(entry);
   }
 
-  if (!keys.has("THINKING_FABLE")) {
+  if (!keys.has("ENABLE_FABLE_THINKING")) {
     const firstThinkingIdx = config.fields.findIndex((f) => f.section === "thinking" && f.key !== "THINKING_ENABLED");
     const entry = {
-      key: "THINKING_FABLE",
+      key: "ENABLE_FABLE_THINKING",
       label: "Fable Thinking",
       type: "tri_boolean",
       value: "",

--- a/api/admin_static/index.html
+++ b/api/admin_static/index.html
@@ -3,75 +3,90 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Free Claude Code Admin</title>
+    <meta name="color-scheme" content="light dark" />
+    <title>Free Claude Code — Control Desk</title>
     <link rel="icon" href="data:," />
-    <link rel="stylesheet" href="/admin/assets/admin.css" />
+    <script>
+      // Pre-paint theme to avoid flash. Runs synchronously before <link> loads CSS.
+      (function () {
+        try {
+          var stored = localStorage.getItem("fcc-theme");
+          if (stored === "dark" || stored === "light") {
+            document.documentElement.setAttribute("data-theme", stored);
+          }
+        } catch (e) {
+          /* localStorage unavailable — fall back to media query */
+        }
+      })();
+    </script>
+    <link rel="stylesheet" href="/admin/assets/admin.css?v=fable1" />
   </head>
   <body>
     <div class="app-shell">
+
+      <!-- ── Sidebar ─────────────────────────────────────────────────── -->
       <aside class="sidebar">
-        <div class="brand">
-          <div class="brand-mark">FC</div>
-          <div>
-            <h1>Free Claude Code</h1>
-            <p>Server Control</p>
+        <div class="sidebar-header">
+          <div class="brand-row">
+            <div class="brand-name">Free <em>Claude</em> Code</div>
+            <button id="themeToggle" class="theme-toggle" type="button"
+              aria-label="Toggle dark mode" title="Toggle dark mode">
+              <svg class="icon-sun" viewBox="0 0 20 20" fill="none" stroke="currentColor"
+                stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="10" cy="10" r="3.2" />
+                <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.6 4.6l1.4 1.4M14 14l1.4 1.4M4.6 15.4l1.4-1.4M14 6l1.4-1.4" />
+              </svg>
+              <svg class="icon-moon" viewBox="0 0 20 20" fill="none" stroke="currentColor"
+                stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M16 11.5A6 6 0 1 1 8.5 4a5 5 0 0 0 7.5 7.5z" />
+              </svg>
+            </button>
           </div>
         </div>
-        <nav id="sectionNav" class="section-nav" aria-label="Admin views"></nav>
+
+        <nav class="section-nav" id="sectionNav" aria-label="Admin sections"></nav>
+
+        <div class="sidebar-footer">
+          <code id="configPath"></code>
+        </div>
       </aside>
 
+      <!-- ── Main sheet ─────────────────────────────────────────────── -->
       <main class="main">
-        <header class="topbar">
-          <div>
-            <h2 id="pageTitle">Providers</h2>
-          </div>
+        <header class="page-header">
+          <h2 id="pageTitle">Loading…</h2>
         </header>
 
-        <div id="adminViews" class="admin-views">
-          <section id="view-providers" class="admin-view active" data-view="providers">
-            <section class="provider-strip" aria-label="Provider status">
-              <div class="strip-header">
-                <h3>Providers</h3>
-              </div>
-              <div id="providerGrid" class="provider-grid"></div>
-            </section>
-            <div
-              id="providersSections"
-              class="form-sections"
-              aria-label="Provider configuration"
-            ></div>
+        <div id="adminViews">
+
+          <section class="admin-view active" data-view="providers">
+            <div id="providersSections"></div>
           </section>
 
-          <section id="view-model_config" class="admin-view" data-view="model_config" hidden>
-            <div
-              id="modelConfigSections"
-              class="form-sections"
-              aria-label="Model configuration"
-            ></div>
+          <section class="admin-view" data-view="model_config">
+            <div id="modelConfigSections"></div>
           </section>
 
-          <section id="view-messaging" class="admin-view" data-view="messaging" hidden>
-            <div
-              id="messagingSections"
-              class="form-sections"
-              aria-label="Messaging configuration"
-            ></div>
+          <section class="admin-view" data-view="messaging">
+            <div id="messagingSections"></div>
           </section>
+
         </div>
       </main>
 
+      <!-- ── Action bar (running footer) ───────────────────────────── -->
       <footer class="action-bar">
         <div class="action-meta">
           <strong id="dirtyState">No changes</strong>
-          <span id="configPath"></span>
         </div>
         <div id="messageArea" class="message-area"></div>
         <div class="action-buttons">
-          <button id="validateButton" class="secondary-button" type="button">Validate</button>
-          <button id="applyButton" class="primary-button" type="button" disabled>Apply</button>
+          <button id="validateButton" class="btn-secondary" type="button">Validate</button>
+          <button id="applyButton" class="btn-primary" type="button" disabled>Apply & save</button>
         </div>
       </footer>
+
     </div>
-    <script src="/admin/assets/admin.js"></script>
+    <script src="/admin/assets/admin.js?v=fable1"></script>
   </body>
 </html>

--- a/api/gateway_model_ids.py
+++ b/api/gateway_model_ids.py
@@ -19,6 +19,7 @@ NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
 FABLE_GATEWAY_MODEL_IDS: tuple[str, ...] = (
     "claude-fable-5",
     "claude-fable-5-2026",
+    "claude-fable-5-20250612",
 )
 
 

--- a/api/gateway_model_ids.py
+++ b/api/gateway_model_ids.py
@@ -11,6 +11,16 @@ GATEWAY_MODEL_ID_PREFIX = "anthropic"
 # heuristic while keeping the real provider/model ref reversible for routing.
 NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
 
+# Known Claude model ids that should be routed via Settings.model_fable.
+# config.settings.Settings.resolve_model matches on the substring "fable", so
+# any of these (and any future "claude-fable-*" id) automatically fall through
+# to MODEL_FABLE. Listed here so the admin UI can surface them in the
+# MODEL_FABLE field hint and so future contributors can extend the registry.
+FABLE_GATEWAY_MODEL_IDS: tuple[str, ...] = (
+    "claude-fable-5",
+    "claude-fable-5-2026",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class DecodedGatewayModelId:

--- a/api/routes.py
+++ b/api/routes.py
@@ -22,6 +22,11 @@ DISCOVERED_MODEL_CREATED_AT = "1970-01-01T00:00:00Z"
 
 SUPPORTED_CLAUDE_MODELS = [
     ModelResponse(
+        id="claude-fable-5-20250612",
+        display_name="Claude Fable 5",
+        created_at="2026-06-12T00:00:00Z",
+    ),
+    ModelResponse(
         id="claude-opus-4-20250514",
         display_name="Claude Opus 4",
         created_at="2025-05-14T00:00:00Z",

--- a/config/settings.py
+++ b/config/settings.py
@@ -154,6 +154,7 @@ class Settings(BaseSettings):
 
     # Per-model overrides (optional, falls back to MODEL)
     # Each can use a different provider
+    model_fable: str | None = Field(default=None, validation_alias="MODEL_FABLE")
     model_opus: str | None = Field(default=None, validation_alias="MODEL_OPUS")
     model_sonnet: str | None = Field(default=None, validation_alias="MODEL_SONNET")
     model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
@@ -185,6 +186,9 @@ class Settings(BaseSettings):
     )
     enable_model_thinking: bool = Field(
         default=True, validation_alias="ENABLE_MODEL_THINKING"
+    )
+    enable_fable_thinking: bool | None = Field(
+        default=None, validation_alias="ENABLE_FABLE_THINKING"
     )
     enable_opus_thinking: bool | None = Field(
         default=None, validation_alias="ENABLE_OPUS_THINKING"
@@ -266,9 +270,7 @@ class Settings(BaseSettings):
     nim: NimSettings = Field(default_factory=NimSettings)
 
     # ==================== Voice Note Transcription ====================
-    voice_note_enabled: bool = Field(
-        default=True, validation_alias="VOICE_NOTE_ENABLED"
-    )
+    voice_note_enabled: bool = Field(default=False, validation_alias="VOICE_NOTE_ENABLED")
     # Device: "cpu" | "cuda" | "nvidia_nim"
     # - "cpu"/"cuda": local Whisper (requires voice_local extra: uv sync --extra voice_local)
     # - "nvidia_nim": NVIDIA NIM Whisper API (requires voice extra: uv sync --extra voice)
@@ -309,9 +311,11 @@ class Settings(BaseSettings):
         "allowed_telegram_user_id",
         "discord_bot_token",
         "allowed_discord_channels",
+        "model_fable",
         "model_opus",
         "model_sonnet",
         "model_haiku",
+        "enable_fable_thinking", 
         "enable_opus_thinking",
         "enable_sonnet_thinking",
         "enable_haiku_thinking",
@@ -397,7 +401,9 @@ class Settings(BaseSettings):
             )
         return v
 
-    @field_validator("model", "model_opus", "model_sonnet", "model_haiku")
+    @field_validator(
+        "model", "model_fable", "model_opus", "model_sonnet", "model_haiku"
+    )
     @classmethod
     def validate_model_format(cls, v: str | None) -> str | None:
         if v is None:
@@ -454,10 +460,12 @@ class Settings(BaseSettings):
     def resolve_model(self, claude_model_name: str) -> str:
         """Resolve a Claude model name to the configured provider/model string.
 
-        Classifies the incoming Claude model (opus/sonnet/haiku) and
+        Classifies the incoming Claude model (fable/opus/sonnet/haiku) and
         returns the model-specific override if configured, otherwise the fallback MODEL.
         """
         name_lower = claude_model_name.lower()
+        if "fable" in name_lower and self.model_fable is not None:
+            return self.model_fable
         if "opus" in name_lower and self.model_opus is not None:
             return self.model_opus
         if "haiku" in name_lower and self.model_haiku is not None:
@@ -470,6 +478,7 @@ class Settings(BaseSettings):
         """Return unique configured chat provider/model refs with source env keys."""
         candidates = (
             ("MODEL", self.model),
+            ("MODEL_FABLE", self.model_fable),
             ("MODEL_OPUS", self.model_opus),
             ("MODEL_SONNET", self.model_sonnet),
             ("MODEL_HAIKU", self.model_haiku),
@@ -493,6 +502,8 @@ class Settings(BaseSettings):
     def resolve_thinking(self, claude_model_name: str) -> bool:
         """Resolve whether thinking is enabled for an incoming Claude model name."""
         name_lower = claude_model_name.lower()
+        if "fable" in name_lower and self.enable_fable_thinking is not None:
+            return self.enable_fable_thinking
         if "opus" in name_lower and self.enable_opus_thinking is not None:
             return self.enable_opus_thinking
         if "haiku" in name_lower and self.enable_haiku_thinking is not None:

--- a/config/settings.py
+++ b/config/settings.py
@@ -270,7 +270,9 @@ class Settings(BaseSettings):
     nim: NimSettings = Field(default_factory=NimSettings)
 
     # ==================== Voice Note Transcription ====================
-    voice_note_enabled: bool = Field(default=False, validation_alias="VOICE_NOTE_ENABLED")
+    voice_note_enabled: bool = Field(
+        default=True, validation_alias="VOICE_NOTE_ENABLED"
+    )
     # Device: "cpu" | "cuda" | "nvidia_nim"
     # - "cpu"/"cuda": local Whisper (requires voice_local extra: uv sync --extra voice_local)
     # - "nvidia_nim": NVIDIA NIM Whisper API (requires voice extra: uv sync --extra voice)
@@ -315,7 +317,7 @@ class Settings(BaseSettings):
         "model_opus",
         "model_sonnet",
         "model_haiku",
-        "enable_fable_thinking", 
+        "enable_fable_thinking",
         "enable_opus_thinking",
         "enable_sonnet_thinking",
         "enable_haiku_thinking",

--- a/core/anthropic/errors.py
+++ b/core/anthropic/errors.py
@@ -27,7 +27,7 @@ def get_user_facing_error_message(
         return "Request timed out."
 
     if isinstance(e, openai.RateLimitError):
-        return "Provider rate limit reached. Please retry shortly."
+        return "Provider rate limit reached. The proxy already retried. Try again in a few moments or switch models."
     if isinstance(e, openai.AuthenticationError):
         return "Provider authentication failed. Check API key."
     if isinstance(e, openai.BadRequestError):
@@ -36,7 +36,7 @@ def get_user_facing_error_message(
     name = type(e).__name__
     status_code = getattr(e, "status_code", None)
     if name == "RateLimitError":
-        return "Provider rate limit reached. Please retry shortly."
+        return "Provider rate limit reached. The proxy already retried. Try again in a few moments or switch models."
     if name == "AuthenticationError":
         return "Provider authentication failed. Check API key."
     if name == "InvalidRequestError":

--- a/providers/error_mapping.py
+++ b/providers/error_mapping.py
@@ -205,6 +205,13 @@ def format_provider_error_message(
     else:
         lines = [f"Upstream provider {provider_name} returned an error."]
 
+    # Add actionable hints for common errors
+    if detail.status_code == 429:
+        lines.append(
+            "\nTip: Rate limit hit after automatic retries. Wait a moment and retry, "
+            "or try a different model/provider via /model in Claude Code."
+        )
+
     category = detail.error_type_hint or _provider_error_category(mapped)
     if category:
         lines.append(f"Category: {category}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.2.42"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "1.2.42"
+version = "1.3.0"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -87,7 +87,7 @@ def test_admin_static_hides_managed_source_label():
     assert 'managed_env: "",' in script
     assert "hasOwnProperty.call(labels, source)" in script
     assert 'parts.push("locked")' in script
-    assert "sourceEl.textContent = source" in script
+    assert "textContent = src" in script
 
 
 def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.2.42"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "1.2.42"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Adds Fable 5 as a first-class model tier alongside Opus/Sonnet/Haiku. Introduces MODEL_FABLE routing override and ENABLE_FABLE_THINKING with inheritance from the global thinking flag. The admin UI surfaces both new fields and updates the model routing banner to include the Fable tier. Also redesigns the admin page with a toggeble dark/light editorial aesthetic to match the new Fable branding, updating layout, typography, and component styling across the static assets. Includes tests covering the new fields and validation path.

All 22 tests passed.