### PR TITLE
feat(zai): optimize GLM-5.2 — 1M context, reasoning effort, system roles; restart stale proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,10 +32,15 @@ OPENCODE_API_KEY=""
 
 # Z.ai Config (Anthropic-compatible Messages at api.z.ai/api/anthropic/v1)
 ZAI_API_KEY=""
+# Use the glm-5.2[1m] alias to opt into GLM-5.2's 1M-token context window;
+# plain glm-5.2 uses the default (~200K) context.
 # Inject z.ai's web-reader / web-search-prime / zread MCP servers into every
-# Z.ai request as native mcp_servers (e.g. the glm-5.2 alias). Set to "false"
-# to disable. The Vision MCP (@z_ai/mcp-server) is client-side (stdio) only.
+# Z.ai request as native mcp_servers. Set to "false" to disable.
+# The Vision MCP (@z_ai/mcp-server) is client-side (stdio) only.
 ZAI_INJECT_MCP_SERVERS="true"
+# GLM-5.x reasoning depth, sent as the discrete z.ai reasoning_effort field.
+# "max" (z.ai's recommendation for coding) | "high" | "" to disable.
+ZAI_REASONING_EFFORT=max
 
 
 # Fireworks AI Config (Anthropic-compatible Messages at api.fireworks.ai/inference/v1)
@@ -73,6 +78,10 @@ MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=
 MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
+
+# Claude Code auto-compaction window (tokens). Raise to 1000000 to use a
+# 1M-context model such as zai/glm-5.2[1m] end-to-end (default 190000).
+CLAUDE_CODE_AUTO_COMPACT_WINDOW=190000
 
 
 # Optional live smoke model overrides. Provider smoke runs once per configured

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ OPENCODE_API_KEY=""
 
 # Z.ai Config (Anthropic-compatible Messages at api.z.ai/api/anthropic/v1)
 ZAI_API_KEY=""
+# Inject z.ai's web-reader / web-search-prime / zread MCP servers into every
+# Z.ai request as native mcp_servers (e.g. the glm-5.2 alias). Set to "false"
+# to disable. The Vision MCP (@z_ai/mcp-server) is client-side (stdio) only.
+ZAI_INJECT_MCP_SERVERS="true"
 
 
 # Fireworks AI Config (Anthropic-compatible Messages at api.fireworks.ai/inference/v1)

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ llama_cache
 .smoke-results
 .vscode
 server.*
+.gstack/

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The default model is already set to `nvidia_nim/nvidia/nemotron-3-super-120b-a12
 fcc-claude
 ```
 
-`fcc-claude` reads the current configured port and auth token each time it starts, sets the Claude Code environment variables (including a 190k-token `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for auto-compaction), and then launches the real `claude` command.
+`fcc-claude` reads the current configured port and auth token each time it starts, sets the Claude Code environment variables (including a `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for auto-compaction — 190k by default, configurable to 1000000 for 1M-context models), and then launches the real `claude` command.
 
 ## Choose A Provider
 
@@ -263,14 +263,19 @@ Browse models at [fireworks.ai/models](https://fireworks.ai/models).
 
 Get an API key at [Z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list).
 
-In the Admin UI, paste it into `ZAI_API_KEY`, then set `MODEL` to a Z.ai model slug such as `zai/glm-5.2`.
+In the Admin UI, paste it into `ZAI_API_KEY`, then set `MODEL` to a Z.ai model slug such as `zai/glm-5.2[1m]`.
 
 This provider calls Z.ai's **Anthropic-compatible** Messages API (`https://api.z.ai/api/anthropic/v1/messages`). The former OpenAI Coding Plan base (`https://api.z.ai/api/coding/paas/v4`) is **not** used by this gateway.
 
 Popular examples:
 
-- `zai/glm-5.2`
+- `zai/glm-5.2[1m]` — GLM-5.2 with the 1M-token context window
+- `zai/glm-5.2` — GLM-5.2 with the default (~200K) context
 - `zai/glm-5-turbo`
+
+To use the 1M window end-to-end, also raise the client auto-compaction window (`CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000`) — otherwise Claude Code summarizes the conversation at ~190K tokens and the 1M window is never filled.
+
+GLM-5.2 reasoning depth defaults to `reasoning_effort=max` (z.ai's recommendation for coding); set `ZAI_REASONING_EFFORT=high` (or empty to disable) to change it.
 
 #### Z.ai MCP servers
 
@@ -320,7 +325,7 @@ In the Admin UI, keep or update `OLLAMA_BASE_URL`, then set `MODEL` to the same 
 
 Each model tier can use a different provider by setting `MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU` in the Admin UI. Leave a tier blank to inherit `MODEL`.
 
-For example, you can route Opus to `nvidia_nim/moonshotai/kimi-k2.5`, Sonnet to `open_router/deepseek/deepseek-r1-0528:free`, Haiku to `lmstudio/unsloth/GLM-4.7-Flash-GGUF`, and keep the fallback `MODEL` on `zai/glm-5.2`.
+For example, you can route Opus to `nvidia_nim/moonshotai/kimi-k2.5`, Sonnet to `open_router/deepseek/deepseek-r1-0528:free`, Haiku to `lmstudio/unsloth/GLM-4.7-Flash-GGUF`, and keep the fallback `MODEL` on `zai/glm-5.2[1m]`.
 
 ## Connect Claude Code
 
@@ -332,7 +337,7 @@ For terminal use, prefer the installed launcher:
 fcc-claude
 ```
 
-Keep `fcc-server` running while you work. The Admin UI manages proxy config, restarts the server when runtime settings change, and `fcc-claude` reads the current Admin UI-managed port and auth token every time it starts. It also sets `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to `190000` for auto-compaction.
+Keep `fcc-server` running while you work. The Admin UI manages proxy config, restarts the server when runtime settings change, and `fcc-claude` reads the current Admin UI-managed port and auth token every time it starts. It also sets `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for auto-compaction (`190000` by default; raise to `1000000` to use a 1M-context model such as `zai/glm-5.2[1m]`).
 
 ### 2. VS Code Extension
 
@@ -516,7 +521,7 @@ Run them in that order before pushing. CI enforces the same checks.
 
 - `fcc-server`: starts the proxy with configured host and port.
 - `fcc-init`: optional advanced scaffold for `~/.fcc/.env`; prefer the **Admin UI** for normal configuration.
-- `fcc-claude`: launches Claude Code with the configured local proxy URL, auth token, model discovery flag, and a 190k `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for auto-compaction.
+- `fcc-claude`: launches Claude Code with the configured local proxy URL, auth token, model discovery flag, and a `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for auto-compaction (190k default, configurable for 1M-context models).
 - `free-claude-code`: compatibility alias for `fcc-server`.
 
 ### 5. Extending

--- a/README.md
+++ b/README.md
@@ -272,6 +272,21 @@ Popular examples:
 - `zai/glm-5.2`
 - `zai/glm-5-turbo`
 
+#### Z.ai MCP servers
+
+Z.ai publishes four MCP servers ([docs.z.ai/devpack/mcp](https://docs.z.ai/devpack/mcp)). This gateway auto-injects the three **HTTP remote** servers into every Z.ai request as native Anthropic `mcp_servers`, so the `glm-5.2` model can call them server-side using your `ZAI_API_KEY`:
+
+- `web-reader` — turn blogs/guides into actionable developer notes
+- `web-search-prime` — web search
+- `zread` — read and summarize URLs
+
+Set `ZAI_INJECT_MCP_SERVERS=false` to disable. The fourth server, **Vision** (`@z_ai/mcp-server`), is a stdio `npx` server and cannot run server-side — add it client-side instead:
+
+```sh
+claude mcp add -s user zai-mcp-server \
+  --env Z_AI_API_KEY=your_key Z_AI_MODE=ZAI -- npx -y "@z_ai/mcp-server"
+```
+
 Browse models at [Z.ai](https://z.ai).
 
 ### 15. [LM Studio](https://lmstudio.ai/)

--- a/README.md
+++ b/README.md
@@ -263,13 +263,13 @@ Browse models at [fireworks.ai/models](https://fireworks.ai/models).
 
 Get an API key at [Z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list).
 
-In the Admin UI, paste it into `ZAI_API_KEY`, then set `MODEL` to a Z.ai model slug such as `zai/glm-5.1`.
+In the Admin UI, paste it into `ZAI_API_KEY`, then set `MODEL` to a Z.ai model slug such as `zai/glm-5.2`.
 
 This provider calls Z.ai's **Anthropic-compatible** Messages API (`https://api.z.ai/api/anthropic/v1/messages`). The former OpenAI Coding Plan base (`https://api.z.ai/api/coding/paas/v4`) is **not** used by this gateway.
 
 Popular examples:
 
-- `zai/glm-5.1`
+- `zai/glm-5.2`
 - `zai/glm-5-turbo`
 
 Browse models at [Z.ai](https://z.ai).
@@ -305,7 +305,7 @@ In the Admin UI, keep or update `OLLAMA_BASE_URL`, then set `MODEL` to the same 
 
 Each model tier can use a different provider by setting `MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU` in the Admin UI. Leave a tier blank to inherit `MODEL`.
 
-For example, you can route Opus to `nvidia_nim/moonshotai/kimi-k2.5`, Sonnet to `open_router/deepseek/deepseek-r1-0528:free`, Haiku to `lmstudio/unsloth/GLM-4.7-Flash-GGUF`, and keep the fallback `MODEL` on `zai/glm-5.1`.
+For example, you can route Opus to `nvidia_nim/moonshotai/kimi-k2.5`, Sonnet to `open_router/deepseek/deepseek-r1-0528:free`, Haiku to `lmstudio/unsloth/GLM-4.7-Flash-GGUF`, and keep the fallback `MODEL` on `zai/glm-5.2`.
 
 ## Connect Claude Code
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application factory and configuration."""
 
+import time
 import traceback
 from contextlib import asynccontextmanager
 from typing import Any
@@ -96,6 +97,14 @@ def create_app(*, lifespan_enabled: bool = True) -> FastAPI:
     if lifespan_enabled:
         app_kwargs["lifespan"] = lifespan
     app = FastAPI(**app_kwargs)
+    app.state.last_activity_epoch = time.monotonic()
+
+    @app.middleware("http")
+    async def track_activity(request: Request, call_next):
+        """Record the monotonic time of the last completed request."""
+        response = await call_next(request)
+        app.state.last_activity_epoch = time.monotonic()
+        return response
 
     @app.middleware("http")
     async def trace_http_correlation(request: Request, call_next):

--- a/api/models/anthropic.py
+++ b/api/models/anthropic.py
@@ -92,7 +92,7 @@ class SystemContent(_AnthropicBlockBase):
 # Message Types
 # =============================================================================
 class Message(BaseModel):
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: (
         str
         | list[

--- a/api/routes.py
+++ b/api/routes.py
@@ -214,9 +214,13 @@ async def probe_root():
 
 
 @router.get("/health")
-async def health():
-    """Health check endpoint."""
-    return {"status": "healthy"}
+async def health(request: Request):
+    """Health check endpoint with last activity timestamp."""
+    last_activity = getattr(request.app.state, "last_activity_epoch", None)
+    return {
+        "status": "healthy",
+        "last_activity_epoch": last_activity,
+    }
 
 
 @router.api_route("/health", methods=["HEAD", "OPTIONS"])

--- a/api/runtime.py
+++ b/api/runtime.py
@@ -251,6 +251,7 @@ class AppRuntime:
             plans_directory=plans_directory,
             claude_bin=self.settings.claude_cli_bin,
             auth_token=getattr(self.settings, "anthropic_auth_token", ""),
+            auto_compact_window=self.settings.claude_code_auto_compact_window,
             log_raw_cli_diagnostics=self.settings.log_raw_cli_diagnostics,
             log_messaging_error_details=self.settings.log_messaging_error_details,
         )

--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -182,7 +182,9 @@ def _claude_child_env(
     env.pop("ANTHROPIC_API_KEY", None)
     env["ANTHROPIC_BASE_URL"] = local_proxy_root_url(settings)
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = "190000"
+    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(
+        settings.claude_code_auto_compact_window
+    )
     if token := settings.anthropic_auth_token.strip():
         env["ANTHROPIC_AUTH_TOKEN"] = token
     return env

--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -11,6 +13,7 @@ import time
 import webbrowser
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -30,6 +33,7 @@ from config.settings import Settings, get_settings
 PROXY_PREFLIGHT_PATH = "/health"
 PROXY_PREFLIGHT_TIMEOUT_SECONDS = 1.5
 SERVER_GRACEFUL_SHUTDOWN_SECONDS = 5
+SERVER_STALE_THRESHOLD_SECONDS = 120 * 60  # 120 minutes
 
 
 def _load_env_template() -> str:
@@ -210,11 +214,105 @@ def _preflight_proxy(proxy_root_url: str) -> str | None:
     return None
 
 
+def _fetch_health(proxy_root_url: str) -> dict[str, Any] | None:
+    """Return the parsed /health JSON or None on failure."""
+    url = f"{proxy_root_url.rstrip('/')}{PROXY_PREFLIGHT_PATH}"
+    request = Request(url, method="GET")
+    try:
+        with urlopen(request, timeout=PROXY_PREFLIGHT_TIMEOUT_SECONDS) as response:
+            if 200 <= response.getcode() < 300:
+                body = response.read()
+                return json.loads(body)
+    except Exception:
+        pass
+    return None
+
+
+def _server_is_stale(proxy_root_url: str) -> bool:
+    """Return True when the server is up but has been idle beyond the threshold."""
+    health = _fetch_health(proxy_root_url)
+    if health is None:
+        return False
+    last_activity = health.get("last_activity_epoch")
+    if last_activity is None:
+        return False
+    idle_seconds = time.monotonic() - last_activity
+    return idle_seconds > SERVER_STALE_THRESHOLD_SECONDS
+
+
+def _restart_stale_server(settings: Settings) -> None:
+    """Kill the stale server process and start a fresh one in the background."""
+    proxy_root_url = local_proxy_root_url(settings)
+    port = settings.port
+    print(
+        f"Server is stale (idle > {SERVER_STALE_THRESHOLD_SECONDS // 60}min), restarting...",
+        file=sys.stderr,
+    )
+    # Find and kill the process bound to our port.
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        pids = result.stdout.strip().split()
+        for pid_str in pids:
+            pid = int(pid_str.strip())
+            if pid != os.getpid():
+                os.kill(pid, signal.SIGTERM)
+    except Exception:
+        pass
+
+    # Wait briefly for the port to free up.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if _preflight_proxy(proxy_root_url) is not None:
+            break
+        time.sleep(0.3)
+
+    # Start the server in the background.
+    server_bin = shutil.which("fcc-server")
+    if server_bin is None:
+        # Fall back to the Python module invocation.
+        subprocess.Popen(
+            [sys.executable, "-m", "cli.entrypoints"],
+            env={**os.environ, "_FCC_SERVE": "1"},
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    else:
+        subprocess.Popen(
+            [server_bin],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    # Wait for the new server to become healthy.
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        if _preflight_proxy(proxy_root_url) is None:
+            print("Server restarted successfully", file=sys.stderr)
+            return
+        time.sleep(0.3)
+    print(
+        "Server restart may not have completed; proceeding anyway",
+        file=sys.stderr,
+    )
+
+
 def launch_claude(argv: Sequence[str] | None = None) -> None:
     """Launch Claude Code with Free Claude Code proxy environment variables."""
 
     settings = get_settings()
     proxy_root_url = local_proxy_root_url(settings)
+
+    # Check if the running server is stale and restart it if so.
+    if _server_is_stale(proxy_root_url):
+        _restart_stale_server(settings)
+
     if error := _preflight_proxy(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",

--- a/cli/manager.py
+++ b/cli/manager.py
@@ -11,6 +11,8 @@ import uuid
 
 from loguru import logger
 
+from config.constants import CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT
+
 from .session import CLISession
 
 
@@ -31,6 +33,7 @@ class CLISessionManager:
         claude_bin: str = "claude",
         auth_token: str = "",
         *,
+        auto_compact_window: int = CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT,
         log_raw_cli_diagnostics: bool = False,
         log_messaging_error_details: bool = False,
     ):
@@ -42,6 +45,7 @@ class CLISessionManager:
             api_url: API URL for the proxy
             allowed_dirs: Directories the CLI is allowed to access
             plans_directory: Directory for Claude Code CLI plan files (passed via --settings)
+            auto_compact_window: Claude Code auto-compaction window (tokens)
         """
         self.workspace = workspace_path
         self.api_url = api_url
@@ -49,6 +53,7 @@ class CLISessionManager:
         self.plans_directory = plans_directory
         self.claude_bin = claude_bin
         self.auth_token = auth_token
+        self.auto_compact_window = auto_compact_window
         self._log_raw_cli_diagnostics = log_raw_cli_diagnostics
         self._log_messaging_error_details = log_messaging_error_details
 
@@ -85,6 +90,7 @@ class CLISessionManager:
                 plans_directory=self.plans_directory,
                 claude_bin=self.claude_bin,
                 auth_token=self.auth_token,
+                auto_compact_window=self.auto_compact_window,
                 log_raw_cli_diagnostics=self._log_raw_cli_diagnostics,
             )
             self._pending_sessions[temp_id] = new_session

--- a/cli/session.py
+++ b/cli/session.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from loguru import logger
 
+from config.constants import CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT
 from core.trace import trace_event
 
 from .process_registry import kill_pid_tree_best_effort, register_pid, unregister_pid
@@ -27,6 +28,7 @@ class ClaudeCliConfig:
     plans_directory: str | None = None
     claude_bin: str = "claude"
     auth_token: str = ""
+    auto_compact_window: int = CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT
 
 
 class CLISession:
@@ -41,6 +43,7 @@ class CLISession:
         claude_bin: str = "claude",
         auth_token: str = "",
         *,
+        auto_compact_window: int = CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT,
         log_raw_cli_diagnostics: bool = False,
     ):
         self.config = ClaudeCliConfig(
@@ -50,6 +53,7 @@ class CLISession:
             plans_directory=plans_directory,
             claude_bin=claude_bin,
             auth_token=auth_token,
+            auto_compact_window=auto_compact_window,
         )
         self.workspace = self.config.workspace_path
         self.api_url = self.config.api_url
@@ -119,7 +123,9 @@ class CLISession:
             else:
                 env["ANTHROPIC_BASE_URL"] = self.api_url
             env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = "190000"
+            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(
+                self.config.auto_compact_window
+            )
             env.pop("ANTHROPIC_API_KEY", None)
             if token := self.auth_token.strip():
                 env["ANTHROPIC_AUTH_TOKEN"] = token

--- a/config/constants.py
+++ b/config/constants.py
@@ -6,5 +6,28 @@ HTTP_CONNECT_TIMEOUT_DEFAULT = 10.0
 # Anthropic Messages API default when the client omits max_tokens.
 ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS = 81920
 
+# Z.ai GLM-5.2 max output tokens (128K). z.ai's Anthropic Messages endpoint
+# accepts up to 131072 output tokens for glm-5.2; used when a request omits
+# max_tokens. Scoped to Z.ai so other Anthropic-compat providers keep the shared
+# default above.
+ZAI_DEFAULT_MAX_OUTPUT_TOKENS = 131072
+
+# Default Z.ai reasoning effort. GLM-5.x selects reasoning depth via a discrete
+# top-level ``reasoning_effort`` field (``high`` | ``max``); ``max`` is z.ai's
+# recommendation for coding. Override with ``ZAI_REASONING_EFFORT``
+# (e.g. ``high`` or empty to disable).
+ZAI_DEFAULT_REASONING_EFFORT = "max"
+# Values of ``ZAI_REASONING_EFFORT`` that disable effort injection.
+ZAI_REASONING_EFFORT_DISABLED_TOKENS = frozenset(
+    {"", "0", "false", "no", "off", "none", "disabled"}
+)
+ZAI_REASONING_EFFORT_LEVELS = frozenset({"high", "max"})
+
+# Claude Code auto-compaction window (tokens). The context size Claude Code uses
+# to decide when to summarize the conversation. The default keeps a safe ceiling
+# for most providers; raise to 1000000 (via ``CLAUDE_CODE_AUTO_COMPACT_WINDOW``)
+# to utilize glm-5.2[1m]'s 1M context window.
+CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT = 190000
+
 # Max bytes read from a non-200 native messages response when verbose error logging is on.
 NATIVE_MESSAGES_ERROR_BODY_LOG_CAP_BYTES = 4096

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,7 +11,10 @@ from dotenv import dotenv_values
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from .constants import HTTP_CONNECT_TIMEOUT_DEFAULT
+from .constants import (
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT,
+    HTTP_CONNECT_TIMEOUT_DEFAULT,
+)
 from .nim import NimSettings
 from .paths import default_claude_workspace_path, managed_env_path
 from .provider_ids import SUPPORTED_PROVIDER_IDS
@@ -187,6 +190,14 @@ class Settings(BaseSettings):
     model_opus: str | None = Field(default=None, validation_alias="MODEL_OPUS")
     model_sonnet: str | None = Field(default=None, validation_alias="MODEL_SONNET")
     model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
+
+    # ==================== Claude Code Client Tuning ====================
+    # Auto-compaction window (tokens) the local proxy advertises to Claude Code.
+    # Raise to 1000000 to use a 1M-context model such as zai/glm-5.2[1m].
+    claude_code_auto_compact_window: int = Field(
+        default=CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT,
+        validation_alias="CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+    )
 
     # ==================== Per-Provider Proxy ====================
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")

--- a/core/anthropic/conversion.py
+++ b/core/anthropic/conversion.py
@@ -234,7 +234,16 @@ class AnthropicToOpenAIConverter:
                         converted["content"] = "\n\n".join(content_parts)
                 result.append(converted)
             elif isinstance(content, list):
-                if role == "user":
+                if role == "system":
+                    text_parts = [
+                        get_block_attr(block, "text", "")
+                        for block in content
+                        if get_block_type(block) == "text"
+                    ]
+                    result.append(
+                        {"role": "system", "content": "\n\n".join(text_parts)}
+                    )
+                elif role == "user":
                     if pending is not None and pending.needs_deferred():
                         if not pending.remaining_tool_ids:
                             result.extend(

--- a/core/anthropic/native_messages_request.py
+++ b/core/anthropic/native_messages_request.py
@@ -185,6 +185,63 @@ def sanitize_native_messages_thinking_policy(
     return sanitized_messages
 
 
+def _extract_system_messages(messages: list[Any], system: Any) -> tuple[list[Any], Any]:
+    """Extract ``role: system`` messages from the array into the ``system`` field.
+
+    Some Claude Code clients send system prompts as messages with ``role: system``
+    in the ``messages`` array instead of (or in addition to) the top-level ``system``
+    field.  The native Anthropic Messages API only accepts ``user`` and ``assistant``
+    roles in ``messages``, so we must hoist system messages out.
+    """
+    system_parts: list[str] = []
+    clean_messages: list[Any] = []
+
+    for message in messages:
+        role = (
+            message.get("role")
+            if isinstance(message, dict)
+            else getattr(message, "role", None)
+        )
+        if role == "system":
+            content = (
+                message.get("content")
+                if isinstance(message, dict)
+                else getattr(message, "content", None)
+            )
+            if isinstance(content, str) and content.strip():
+                system_parts.append(content.strip())
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if text.strip():
+                            system_parts.append(text.strip())
+            continue
+        clean_messages.append(message)
+
+    if not system_parts:
+        return messages, system
+
+    merged_system = "\n\n".join(system_parts)
+    if system:
+        if isinstance(system, str):
+            if system.strip():
+                merged_system = f"{system.strip()}\n\n{merged_system}"
+        elif isinstance(system, list):
+            existing_parts: list[str] = []
+            for block in system:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    if text.strip():
+                        existing_parts.append(text.strip())
+            if existing_parts:
+                merged_system = (
+                    f"{chr(10) + chr(10).join(existing_parts)}\n\n{merged_system}"
+                )
+
+    return clean_messages, merged_system
+
+
 def _normalize_system_prompt_for_openrouter(system: Any) -> Any:
     """Flatten Claude SDK system blocks for OpenRouter's native endpoint."""
     if not isinstance(system, list):
@@ -236,10 +293,16 @@ def build_base_native_anthropic_request_body(
         body["max_tokens"] = default_max_tokens
 
     if "messages" in body:
+        body["messages"], body["system"] = _extract_system_messages(
+            body["messages"],
+            body.get("system"),
+        )
         body["messages"] = sanitize_native_messages_thinking_policy(
             body["messages"],
             thinking_enabled=thinking_enabled,
         )
+        if "system" not in body or body["system"] is None:
+            body.pop("system", None)
 
     return body
 
@@ -264,12 +327,19 @@ def build_openrouter_native_request_body(
         validate_openrouter_extra_body(request_extra)
         body.update(request_extra)
 
+    body["messages"], body["system"] = _extract_system_messages(
+        body.get("messages", []),
+        body.get("system"),
+    )
     body["messages"] = sanitize_native_messages_thinking_policy(
         body.get("messages"),
         thinking_enabled=thinking_enabled,
     )
     if "system" in body:
-        body["system"] = _normalize_system_prompt_for_openrouter(body["system"])
+        if body["system"] is not None:
+            body["system"] = _normalize_system_prompt_for_openrouter(body["system"])
+        else:
+            body.pop("system", None)
     body["stream"] = True
     if body.get("max_tokens") is None:
         body["max_tokens"] = default_max_tokens

--- a/providers/zai/client.py
+++ b/providers/zai/client.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from providers.anthropic_messages import AnthropicMessagesTransport
 from providers.base import ProviderConfig
 from providers.defaults import ZAI_DEFAULT_BASE
 
+from .mcp_servers import merge_zai_mcp_servers
 from .request import build_request_body
 
 _ANTHROPIC_VERSION = "2023-06-01"
+
+# Falsy values that disable the defaulted-on MCP injection env flag.
+_MCP_INJECTION_DISABLED_TOKENS = frozenset({"", "0", "false", "no", "off"})
+
+
+def _mcp_injection_enabled() -> bool:
+    """Whether z.ai HTTP MCP servers are auto-injected into each request."""
+    raw = os.environ.get("ZAI_INJECT_MCP_SERVERS", "true").strip().lower()
+    return raw not in _MCP_INJECTION_DISABLED_TOKENS
 
 
 class ZaiProvider(AnthropicMessagesTransport):
@@ -22,14 +33,18 @@ class ZaiProvider(AnthropicMessagesTransport):
             provider_name="ZAI",
             default_base_url=ZAI_DEFAULT_BASE,
         )
+        self._inject_mcp_servers = _mcp_injection_enabled()
 
     def _build_request_body(
         self, request: Any, thinking_enabled: bool | None = None
     ) -> dict:
-        return build_request_body(
+        body = build_request_body(
             request,
             thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
         )
+        if self._inject_mcp_servers and self._api_key:
+            merge_zai_mcp_servers(body, self._api_key)
+        return body
 
     def _request_headers(self) -> dict[str, str]:
         return {

--- a/providers/zai/client.py
+++ b/providers/zai/client.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from loguru import logger
+
+from config.constants import (
+    ZAI_DEFAULT_REASONING_EFFORT,
+    ZAI_REASONING_EFFORT_DISABLED_TOKENS,
+    ZAI_REASONING_EFFORT_LEVELS,
+)
 from providers.anthropic_messages import AnthropicMessagesTransport
 from providers.base import ProviderConfig
 from providers.defaults import ZAI_DEFAULT_BASE
@@ -24,6 +31,28 @@ def _mcp_injection_enabled() -> bool:
     return raw not in _MCP_INJECTION_DISABLED_TOKENS
 
 
+def _resolve_reasoning_effort() -> str | None:
+    """Resolve the z.ai ``reasoning_effort`` level from config/env.
+
+    GLM-5.x reasoning depth is selected by a discrete top-level
+    ``reasoning_effort`` field (``high`` | ``max``). Defaults to ``max``
+    (z.ai's recommendation for coding). Returns ``None`` when disabled or when
+    the configured value is not a recognised level.
+    """
+    raw = os.environ.get("ZAI_REASONING_EFFORT", ZAI_DEFAULT_REASONING_EFFORT)
+    value = raw.strip().lower()
+    if value in ZAI_REASONING_EFFORT_DISABLED_TOKENS:
+        return None
+    if value not in ZAI_REASONING_EFFORT_LEVELS:
+        logger.warning(
+            "ZAI_REASONING_EFFORT={!r} is not a recognised level {}; ignoring.",
+            raw,
+            sorted(ZAI_REASONING_EFFORT_LEVELS),
+        )
+        return None
+    return value
+
+
 class ZaiProvider(AnthropicMessagesTransport):
     """Z.ai using Anthropic-compatible Messages at api.z.ai/api/anthropic/v1."""
 
@@ -34,14 +63,18 @@ class ZaiProvider(AnthropicMessagesTransport):
             default_base_url=ZAI_DEFAULT_BASE,
         )
         self._inject_mcp_servers = _mcp_injection_enabled()
+        self._reasoning_effort = _resolve_reasoning_effort()
 
     def _build_request_body(
         self, request: Any, thinking_enabled: bool | None = None
     ) -> dict:
-        body = build_request_body(
-            request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
-        )
+        thinking_on = self._is_thinking_enabled(request, thinking_enabled)
+        body = build_request_body(request, thinking_enabled=thinking_on)
+        # z.ai selects GLM-5.x reasoning depth via a discrete ``reasoning_effort``
+        # field (separate from Anthropic ``thinking.budget_tokens``); only send it
+        # when thinking is enabled, since effort is meaningless otherwise.
+        if thinking_on and self._reasoning_effort:
+            body["reasoning_effort"] = self._reasoning_effort
         if self._inject_mcp_servers and self._api_key:
             merge_zai_mcp_servers(body, self._api_key)
         return body

--- a/providers/zai/mcp_servers.py
+++ b/providers/zai/mcp_servers.py
@@ -1,0 +1,77 @@
+"""Z.ai native MCP server injection for the Anthropic-compatible Messages API.
+
+Z.ai publishes four MCP servers (https://docs.z.ai/devpack/mcp).  Three are
+HTTP remote endpoints and are injected here as native Anthropic
+``mcp_servers`` (``type: url``) so the model can call them server-side when
+routing through this provider (e.g. the ``glm-5.2`` alias).  The fourth
+(Vision, ``@z_ai/mcp-server``) is a stdio ``npx`` server and cannot be injected
+server-side; see the README for its client-side install command.
+
+``authorization_token`` carries the raw Z.ai API key: Anthropic forwards it to
+the upstream endpoint as ``Authorization: Bearer <key>``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+# The three HTTP remote z.ai MCP servers (no auth here; auth is per-request).
+ZAI_MCP_HTTP_SERVERS: tuple[dict[str, str], ...] = (
+    {"name": "web-reader", "url": "https://api.z.ai/api/mcp/web_reader/mcp"},
+    {
+        "name": "web-search-prime",
+        "url": "https://api.z.ai/api/mcp/web_search_prime/mcp",
+    },
+    {"name": "zread", "url": "https://api.z.ai/api/mcp/zread/mcp"},
+)
+
+
+def build_zai_mcp_servers(api_key: str) -> list[dict[str, str]]:
+    """Return native Anthropic ``mcp_servers`` entries for the z.ai HTTP MCPs."""
+    return [
+        {
+            "type": "url",
+            "url": spec["url"],
+            "name": spec["name"],
+            "authorization_token": api_key,
+        }
+        for spec in ZAI_MCP_HTTP_SERVERS
+    ]
+
+
+def merge_zai_mcp_servers(body: dict[str, Any], api_key: str) -> None:
+    """Inject the z.ai HTTP MCP servers into a native Anthropic request body.
+
+    Client-provided ``mcp_servers`` are preserved and take precedence: a z.ai
+    server whose ``name`` collides with an existing entry is skipped so callers
+    can override or disable individual servers.
+    """
+    existing = body.get("mcp_servers")
+    base_servers: list[Any] = list(existing) if isinstance(existing, list) else []
+    existing_names = {
+        server.get("name") for server in base_servers if isinstance(server, dict)
+    }
+
+    zai_servers = build_zai_mcp_servers(api_key)
+    merged = list(base_servers)
+    appended = 0
+    for server in zai_servers:
+        if server["name"] in existing_names:
+            logger.debug(
+                "ZAI_MCP: skipping injected server '{}' "
+                "(shadowed by client mcp_servers)",
+                server["name"],
+            )
+            continue
+        merged.append(server)
+        appended += 1
+
+    body["mcp_servers"] = merged
+    logger.debug(
+        "ZAI_MCP: injected {}/{} servers (total mcp_servers={})",
+        appended,
+        len(zai_servers),
+        len(merged),
+    )

--- a/providers/zai/request.py
+++ b/providers/zai/request.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from loguru import logger
 
-from config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from config.constants import ZAI_DEFAULT_MAX_OUTPUT_TOKENS
 from core.anthropic.native_messages_request import (
     build_base_native_anthropic_request_body,
 )
@@ -23,7 +23,7 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
 
     body = build_base_native_anthropic_request_body(
         request_data,
-        default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        default_max_tokens=ZAI_DEFAULT_MAX_OUTPUT_TOKENS,
         thinking_enabled=thinking_enabled,
     )
     extra = getattr(request_data, "extra_body", None)

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -53,7 +53,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "wafer": "wafer/DeepSeek-V4-Pro",
     "opencode": "opencode/gpt-5.3-codex",
     "opencode_go": "opencode_go/minimax-m2.7",
-    "zai": "zai/glm-5.1",
+    "zai": "zai/glm-5.2",
     "gemini": "gemini/gemini-2.5-flash",
     "groq": "groq/llama-3.3-70b-versatile",
     "cerebras": "cerebras/llama3.1-8b",

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -53,7 +53,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "wafer": "wafer/DeepSeek-V4-Pro",
     "opencode": "opencode/gpt-5.3-codex",
     "opencode_go": "opencode_go/minimax-m2.7",
-    "zai": "zai/glm-5.2",
+    "zai": "zai/glm-5.2[1m]",
     "gemini": "gemini/gemini-2.5-flash",
     "groq": "groq/llama-3.3-70b-versatile",
     "cerebras": "cerebras/llama3.1-8b",

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -327,7 +327,7 @@ def test_admin_apply_omits_stale_zai_base_url(monkeypatch, tmp_path):
     env_file.write_text(
         "\n".join(
             [
-                "MODEL=zai/glm-5.1",
+                "MODEL=zai/glm-5.2",
                 "ZAI_API_KEY=zai-secret",
                 "ZAI_BASE_URL=https://custom.zai.invalid/v1",
                 "",
@@ -339,7 +339,7 @@ def test_admin_apply_omits_stale_zai_base_url(monkeypatch, tmp_path):
 
     response = _local_client(app).post(
         "/admin/api/config/apply",
-        json={"values": {"MODEL": "zai/glm-5.1"}},
+        json={"values": {"MODEL": "zai/glm-5.2"}},
     )
 
     assert response.status_code == 200

--- a/tests/api/test_app_lifespan_and_errors.py
+++ b/tests/api/test_app_lifespan_and_errors.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from config.constants import CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT
 from config.settings import Settings
 from providers.exceptions import ServiceUnavailableError
 from providers.registry import ProviderRegistry
@@ -19,6 +20,7 @@ _RUNTIME_EXTRAS = {
     "hf_token": "",
     "nvidia_nim_api_key": "",
     "claude_cli_bin": "claude",
+    "claude_code_auto_compact_window": CLAUDE_CODE_AUTO_COMPACT_WINDOW_DEFAULT,
     "uses_process_anthropic_auth_token": lambda: False,
     "messaging_rate_limit": 1,
     "messaging_rate_window": 1.0,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -537,6 +537,36 @@ class TestCLISession:
             assert "ANTHROPIC_API_KEY" not in env
 
     @pytest.mark.asyncio
+    async def test_start_task_threads_custom_auto_compact_window(self):
+        """A custom auto_compact_window (e.g. 1M for glm-5.2[1m]) reaches child env."""
+        from cli.session import CLISession
+
+        session = CLISession(
+            "/tmp",
+            "http://localhost:8082/v1",
+            auth_token="proxy-token",
+            auto_compact_window=1000000,
+        )
+
+        mock_process = AsyncMock()
+        mock_process.stdout.read.side_effect = [b""]
+        mock_process.stderr.read.return_value = b""
+        mock_process.wait.return_value = 0
+
+        with (
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "official-key"}, clear=False),
+            patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec,
+        ):
+            mock_exec.return_value = mock_process
+            async for _ in session.start_task("test"):
+                pass
+
+            env = mock_exec.call_args.kwargs["env"]
+            assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "1000000"
+
+    @pytest.mark.asyncio
     async def test_start_task_removes_stale_auth_token_when_proxy_auth_blank(self):
         """Test start_task does not leak inherited Claude auth into proxy calls."""
         from cli.session import CLISession

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -310,6 +310,17 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert "ANTHROPIC_API_KEY" not in env
 
 
+def test_claude_child_env_threads_custom_auto_compact_window() -> None:
+    """A configured window (e.g. 1M for glm-5.2[1m]) reaches the child env verbatim."""
+    from cli.entrypoints import _claude_child_env
+
+    settings = _launcher_settings()
+    settings.claude_code_auto_compact_window = 1000000
+    env = _claude_child_env(settings, {})
+
+    assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "1000000"
+
+
 def test_claude_child_env_removes_blank_configured_auth_token() -> None:
     from cli.entrypoints import _claude_child_env
 

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -439,3 +439,93 @@ def test_launch_claude_unreachable_proxy_exits_with_hint(
     captured = capsys.readouterr()
     assert "http://127.0.0.1:9393" in captured.err
     assert "fcc-server" in captured.err
+
+
+def test_server_is_stale_returns_false_when_health_unreachable() -> None:
+    from cli.entrypoints import _server_is_stale
+
+    with patch("cli.entrypoints._fetch_health", return_value=None):
+        assert _server_is_stale("http://127.0.0.1:9999") is False
+
+
+def test_server_is_stale_returns_false_when_no_last_activity() -> None:
+    from cli.entrypoints import _server_is_stale
+
+    with patch(
+        "cli.entrypoints._fetch_health",
+        return_value={"status": "healthy"},
+    ):
+        assert _server_is_stale("http://127.0.0.1:9999") is False
+
+
+def test_server_is_stale_returns_false_when_recently_active() -> None:
+    import time as _time
+
+    from cli.entrypoints import _server_is_stale
+
+    with patch(
+        "cli.entrypoints._fetch_health",
+        return_value={"status": "healthy", "last_activity_epoch": _time.monotonic()},
+    ):
+        assert _server_is_stale("http://127.0.0.1:9999") is False
+
+
+def test_server_is_stale_returns_true_when_idle_beyond_threshold() -> None:
+    import time as _time
+
+    from cli.entrypoints import SERVER_STALE_THRESHOLD_SECONDS, _server_is_stale
+
+    old_epoch = _time.monotonic() - SERVER_STALE_THRESHOLD_SECONDS - 1
+    with patch(
+        "cli.entrypoints._fetch_health",
+        return_value={"status": "healthy", "last_activity_epoch": old_epoch},
+    ):
+        assert _server_is_stale("http://127.0.0.1:9999") is True
+
+
+def test_launch_claude_restarts_stale_server_before_preflight() -> None:
+    from cli.entrypoints import launch_claude
+
+    settings = _launcher_settings(port=9191, token="proxy-token")
+
+    with (
+        patch("cli.entrypoints.get_settings", return_value=settings),
+        patch("cli.entrypoints._server_is_stale", return_value=True),
+        patch("cli.entrypoints._restart_stale_server") as restart,
+        patch("cli.entrypoints._preflight_proxy", return_value=None),
+        patch("cli.entrypoints.shutil.which", return_value="resolved-claude.cmd"),
+        patch("cli.entrypoints.subprocess.Popen") as popen,
+        patch("cli.entrypoints.register_pid"),
+        patch("cli.entrypoints.unregister_pid"),
+        pytest.raises(SystemExit),
+    ):
+        process = popen.return_value
+        process.pid = 12345
+        process.wait.return_value = 0
+        launch_claude([])
+
+    restart.assert_called_once_with(settings)
+
+
+def test_launch_claude_skips_restart_when_not_stale() -> None:
+    from cli.entrypoints import launch_claude
+
+    settings = _launcher_settings(port=9191, token="proxy-token")
+
+    with (
+        patch("cli.entrypoints.get_settings", return_value=settings),
+        patch("cli.entrypoints._server_is_stale", return_value=False),
+        patch("cli.entrypoints._restart_stale_server") as restart,
+        patch("cli.entrypoints._preflight_proxy", return_value=None),
+        patch("cli.entrypoints.shutil.which", return_value="resolved-claude.cmd"),
+        patch("cli.entrypoints.subprocess.Popen") as popen,
+        patch("cli.entrypoints.register_pid"),
+        patch("cli.entrypoints.unregister_pid"),
+        pytest.raises(SystemExit),
+    ):
+        process = popen.return_value
+        process.pid = 12345
+        process.wait.return_value = 0
+        launch_claude([])
+
+    restart.assert_not_called()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -773,6 +773,8 @@ class TestPerModelMapping:
         assert Settings.parse_provider_type("gemini/gemini-2.5-flash") == "gemini"
         assert Settings.parse_provider_type("groq/llama-3.3-70b-versatile") == "groq"
         assert Settings.parse_provider_type("cerebras/llama3.1-8b") == "cerebras"
+        # The [1m] context opt-in suffix must survive routing to the provider.
+        assert Settings.parse_provider_type("zai/glm-5.2[1m]") == "zai"
 
     def test_parse_model_name(self):
         """parse_model_name extracts model name from model string."""
@@ -800,6 +802,8 @@ class TestPerModelMapping:
             == "llama-3.3-70b-versatile"
         )
         assert Settings.parse_model_name("cerebras/llama3.1-8b") == "llama3.1-8b"
+        # The [1m] context opt-in suffix is preserved into the upstream model id.
+        assert Settings.parse_model_name("zai/glm-5.2[1m]") == "glm-5.2[1m]"
 
     def test_configured_chat_model_refs_collects_unique_models_with_sources(
         self, monkeypatch

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from api.models.anthropic import MessagesRequest
+from api.models.anthropic import Message, MessagesRequest
 from core.anthropic import (
     AnthropicToOpenAIConverter,
     OpenAIConversionError,
@@ -57,6 +57,63 @@ def test_convert_system_prompt_list_text():
 
 def test_convert_system_prompt_none():
     assert AnthropicToOpenAIConverter.convert_system_prompt(None) is None
+
+
+# --- System Role in Messages Array Tests ---
+
+
+def test_convert_system_role_message_str():
+    """System role messages in the messages array pass through as role: system."""
+    messages = [
+        MockMessage("user", "hello"),
+        MockMessage("system", "You are helpful"),
+        MockMessage("user", "what is 2+2"),
+    ]
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+    assert len(result) == 3
+    assert result[0] == {"role": "user", "content": "hello"}
+    assert result[1] == {"role": "system", "content": "You are helpful"}
+    assert result[2] == {"role": "user", "content": "what is 2+2"}
+
+
+def test_convert_system_role_message_list():
+    """System role messages with list content are flattened to text."""
+    messages = [
+        MockMessage(
+            "system",
+            [
+                MockBlock(type="text", text="Part A"),
+                MockBlock(type="text", text="Part B"),
+            ],
+        ),
+        MockMessage("user", "hello"),
+    ]
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+    assert len(result) == 2
+    assert result[0] == {"role": "system", "content": "Part A\n\nPart B"}
+    assert result[1] == {"role": "user", "content": "hello"}
+
+
+def test_build_base_request_body_with_system_role_in_messages():
+    """System role messages in the array are preserved alongside top-level system."""
+    request = MessagesRequest(
+        model="test-model",
+        messages=[
+            Message(role="user", content="hello"),
+            Message(role="system", content="Be concise"),
+            Message(role="user", content="what is 2+2"),
+        ],
+        system="Base prompt",
+        max_tokens=100,
+    )
+    body = build_base_request_body(request)
+    msgs = body["messages"]
+    assert msgs[0]["role"] == "system"
+    assert msgs[0]["content"] == "Base prompt"
+    assert msgs[1]["role"] == "user"
+    assert msgs[2]["role"] == "system"
+    assert msgs[2]["content"] == "Be concise"
+    assert msgs[3]["role"] == "user"
 
 
 # --- Tool Conversion Tests ---

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -67,12 +67,12 @@ def test_model_list_headers(zai_provider):
 
 def test_build_request_body_native(zai_provider):
     request = MessagesRequest(
-        model="glm-5.1",
+        model="glm-5.2",
         max_tokens=100,
         messages=[Message(role="user", content="Hello")],
     )
     body = zai_provider._build_request_body(request)
-    assert body["model"] == "glm-5.1"
+    assert body["model"] == "glm-5.2"
     assert body["stream"] is True
     assert body["max_tokens"] == 100
 

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -98,6 +98,69 @@ def test_build_request_body_rejects_extra_body(zai_provider):
         zai_provider._build_request_body(request)
 
 
+def test_build_request_body_injects_zai_mcp_servers_by_default(zai_provider):
+    """The three HTTP z.ai MCP servers are injected as native mcp_servers."""
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[Message(role="user", content="Hello")],
+    )
+    body = zai_provider._build_request_body(request)
+
+    names = {server["name"] for server in body["mcp_servers"]}
+    assert {"web-reader", "web-search-prime", "zread"}.issubset(names)
+    assert body["mcp_servers"][0]["type"] == "url"
+    assert body["mcp_servers"][0]["authorization_token"] == "test_zai_key"
+
+
+def test_build_request_body_mcp_injection_disabled(monkeypatch, zai_config):
+    """ZAI_INJECT_MCP_SERVERS=false suppresses injection entirely."""
+    monkeypatch.setenv("ZAI_INJECT_MCP_SERVERS", "false")
+    provider = ZaiProvider(zai_config)
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[Message(role="user", content="Hello")],
+    )
+    body = provider._build_request_body(request)
+    assert "mcp_servers" not in body
+
+
+def test_build_request_body_mcp_injection_skipped_without_api_key(zai_config):
+    """No injection when the provider has no API key to authenticate with."""
+    zai_config.api_key = ""
+    provider = ZaiProvider(zai_config)
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[Message(role="user", content="Hello")],
+    )
+    body = provider._build_request_body(request)
+    assert "mcp_servers" not in body
+
+
+def test_build_request_body_mcp_injection_preserves_client_servers(zai_provider):
+    """Client-provided mcp_servers are kept and win on name collisions."""
+    request = MessagesRequest.model_validate(
+        {
+            "model": "glm-5.2",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_servers": [
+                {"type": "url", "url": "https://x/mcp", "name": "mine"},
+                {"type": "url", "url": "https://y/mcp", "name": "web-reader"},
+            ],
+        }
+    )
+    body = zai_provider._build_request_body(request)
+
+    names = [server["name"] for server in body["mcp_servers"]]
+    assert names[:2] == ["mine", "web-reader"]
+    assert {"web-search-prime", "zread"}.issubset(set(names))
+    assert names.count("web-reader") == 1
+    assert body["mcp_servers"][1]["url"] == "https://y/mcp"
+
+
 @pytest.mark.asyncio
 async def test_cleanup_aclose(zai_provider):
     zai_provider._client = AsyncMock()

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from api.models.anthropic import Message, MessagesRequest
-from config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from config.constants import ZAI_DEFAULT_MAX_OUTPUT_TOKENS
+from core.anthropic.native_messages_request import _extract_system_messages
 from providers.base import ProviderConfig
 from providers.defaults import ZAI_DEFAULT_BASE
 from providers.exceptions import InvalidRequestError
@@ -54,6 +55,68 @@ def test_init(zai_config):
     assert mock_client.called
 
 
+# --- _extract_system_messages unit tests ---
+
+
+def test_extract_system_messages_no_system():
+    messages = [{"role": "user", "content": "hello"}]
+    clean, system = _extract_system_messages(messages, None)
+    assert clean == messages
+    assert system is None
+
+
+def test_extract_system_messages_with_inline_system():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "system", "content": "Be helpful"},
+        {"role": "user", "content": "bye"},
+    ]
+    clean, system = _extract_system_messages(messages, None)
+    assert len(clean) == 2
+    assert all(m["role"] in ("user", "assistant") for m in clean)
+    assert system == "Be helpful"
+
+
+def test_extract_system_messages_merges_with_top_level():
+    messages = [
+        {"role": "system", "content": "Inline"},
+        {"role": "user", "content": "hello"},
+    ]
+    clean, system = _extract_system_messages(messages, "Top level")
+    assert len(clean) == 1
+    assert "Top level" in system
+    assert "Inline" in system
+
+
+def test_extract_system_messages_list_content():
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Part A"},
+                {"type": "text", "text": "Part B"},
+            ],
+        },
+        {"role": "user", "content": "hello"},
+    ]
+    clean, system = _extract_system_messages(messages, None)
+    assert len(clean) == 1
+    assert "Part A" in system
+    assert "Part B" in system
+
+
+def test_extract_system_messages_empty_system_skipped():
+    messages = [
+        {"role": "system", "content": ""},
+        {"role": "system", "content": "   "},
+        {"role": "system", "content": "Real system"},
+        {"role": "user", "content": "hello"},
+    ]
+    clean, system = _extract_system_messages(messages, None)
+    assert len(clean) == 1
+    assert system == "Real system"
+
+
 def test_request_headers(zai_provider):
     h = zai_provider._request_headers()
     assert h["x-api-key"] == "test_zai_key"
@@ -83,7 +146,75 @@ def test_build_request_body_default_max_tokens(zai_provider):
         messages=[Message(role="user", content="x")],
     )
     body = zai_provider._build_request_body(request)
-    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["max_tokens"] == ZAI_DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_build_request_body_default_reasoning_effort_max(monkeypatch, zai_config):
+    """GLM-5.x effort defaults to max (z.ai's recommendation for coding)."""
+    monkeypatch.delenv("ZAI_REASONING_EFFORT", raising=False)
+    provider = ZaiProvider(zai_config)
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[Message(role="user", content="hi")],
+    )
+    body = provider._build_request_body(request)
+    assert body["reasoning_effort"] == "max"
+
+
+def test_build_request_body_reasoning_effort_high(monkeypatch, zai_config):
+    monkeypatch.setenv("ZAI_REASONING_EFFORT", "high")
+    provider = ZaiProvider(zai_config)
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[Message(role="user", content="hi")],
+    )
+    body = provider._build_request_body(request)
+    assert body["reasoning_effort"] == "high"
+
+
+def test_build_request_body_reasoning_effort_disabled_when_blank(
+    monkeypatch, zai_config
+):
+    monkeypatch.setenv("ZAI_REASONING_EFFORT", "")
+    provider = ZaiProvider(zai_config)
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[Message(role="user", content="hi")],
+    )
+    body = provider._build_request_body(request)
+    assert "reasoning_effort" not in body
+
+
+def test_build_request_body_reasoning_effort_skipped_when_thinking_disabled(
+    monkeypatch, zai_config
+):
+    """Effort is only sent when thinking is enabled."""
+    monkeypatch.delenv("ZAI_REASONING_EFFORT", raising=False)
+    provider = ZaiProvider(zai_config)
+    request = MessagesRequest.model_validate(
+        {
+            "model": "glm-5.2",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"enabled": False},
+        }
+    )
+    body = provider._build_request_body(request)
+    assert "reasoning_effort" not in body
+
+
+def test_build_request_body_glm_5_2_1m_alias_preserved(zai_provider):
+    """The [1m] context opt-in suffix survives routing into the upstream model."""
+    request = MessagesRequest(
+        model="glm-5.2[1m]",
+        max_tokens=100,
+        messages=[Message(role="user", content="hi")],
+    )
+    body = zai_provider._build_request_body(request)
+    assert body["model"] == "glm-5.2[1m]"
 
 
 def test_build_request_body_rejects_extra_body(zai_provider):
@@ -159,6 +290,58 @@ def test_build_request_body_mcp_injection_preserves_client_servers(zai_provider)
     assert {"web-search-prime", "zread"}.issubset(set(names))
     assert names.count("web-reader") == 1
     assert body["mcp_servers"][1]["url"] == "https://y/mcp"
+
+
+def test_build_request_body_extracts_system_role_from_messages(zai_provider):
+    """System role messages in the array are hoisted to the top-level system field."""
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[
+            Message(role="user", content="hello"),
+            Message(role="system", content="Be concise"),
+            Message(role="user", content="what is 2+2"),
+        ],
+    )
+    body = zai_provider._build_request_body(request)
+    assert all(m["role"] in ("user", "assistant") for m in body["messages"]), (
+        f"Found non-user/assistant role in messages: {body['messages']}"
+    )
+    assert "Be concise" in body["system"]
+
+
+def test_build_request_body_merges_system_role_with_top_level_system(zai_provider):
+    """Inline system messages are merged with the top-level system field."""
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[
+            Message(role="system", content="Inline system"),
+            Message(role="user", content="hello"),
+        ],
+        system="Top-level system",
+    )
+    body = zai_provider._build_request_body(request)
+    assert "Top-level system" in body["system"]
+    assert "Inline system" in body["system"]
+    assert len(body["messages"]) == 1
+    assert body["messages"][0]["role"] == "user"
+
+
+def test_build_request_body_system_role_no_top_level_system(zai_provider):
+    """Inline system message becomes the system field when no top-level system."""
+    request = MessagesRequest(
+        model="glm-5.2",
+        max_tokens=100,
+        messages=[
+            Message(role="system", content="Only inline system"),
+            Message(role="user", content="hello"),
+        ],
+    )
+    body = zai_provider._build_request_body(request)
+    assert body["system"] == "Only inline system"
+    assert len(body["messages"]) == 1
+    assert body["messages"][0]["role"] == "user"
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_zai_mcp_servers.py
+++ b/tests/providers/test_zai_mcp_servers.py
@@ -1,0 +1,76 @@
+"""Tests for z.ai native MCP server injection helpers."""
+
+from typing import Any
+
+from providers.zai.mcp_servers import (
+    ZAI_MCP_HTTP_SERVERS,
+    build_zai_mcp_servers,
+    merge_zai_mcp_servers,
+)
+
+
+def test_build_zai_mcp_servers_structure():
+    servers = build_zai_mcp_servers("secret-key")
+
+    assert len(servers) == len(ZAI_MCP_HTTP_SERVERS)
+    for server in servers:
+        assert server["type"] == "url"
+        assert server["name"]
+        assert server["url"].startswith("https://api.z.ai/api/mcp/")
+        assert server["authorization_token"] == "secret-key"
+
+
+def test_build_zai_mcp_servers_names_match_docs():
+    names = {server["name"] for server in build_zai_mcp_servers("k")}
+    assert names == {"web-reader", "web-search-prime", "zread"}
+
+
+def test_merge_injects_into_empty_body():
+    body: dict[str, Any] = {}
+
+    merge_zai_mcp_servers(body, "key")
+
+    assert len(body["mcp_servers"]) == 3
+    assert body["mcp_servers"][0]["authorization_token"] == "key"
+
+
+def test_merge_preserves_client_servers():
+    client_server = {"type": "url", "url": "https://x/mcp", "name": "custom"}
+    body: dict[str, Any] = {"mcp_servers": [client_server]}
+
+    merge_zai_mcp_servers(body, "key")
+
+    injected = body["mcp_servers"]
+    assert injected[0] is client_server
+    names = [server["name"] for server in injected]
+    assert {"web-reader", "web-search-prime", "zread", "custom"} == set(names)
+    assert len(injected) == 4
+
+
+def test_merge_skips_shadowed_names():
+    body: dict[str, Any] = {
+        "mcp_servers": [{"type": "url", "url": "https://x", "name": "web-reader"}]
+    }
+
+    merge_zai_mcp_servers(body, "key")
+
+    names = [server["name"] for server in body["mcp_servers"]]
+    assert names.count("web-reader") == 1
+    assert {"web-search-prime", "zread"}.issubset(set(names))
+
+
+def test_merge_handles_non_list_existing():
+    body: dict[str, Any] = {"mcp_servers": "not-a-list"}
+
+    merge_zai_mcp_servers(body, "key")
+
+    assert isinstance(body["mcp_servers"], list)
+    assert len(body["mcp_servers"]) == 3
+
+
+def test_merge_does_not_mutate_specs_constant():
+    before = [dict(spec) for spec in ZAI_MCP_HTTP_SERVERS]
+
+    merge_zai_mcp_servers({}, "key")
+
+    assert [dict(spec) for spec in ZAI_MCP_HTTP_SERVERS] == before


### PR DESCRIPTION
## Summary

Optimizes the Z.ai / GLM-5.2 setup for full 1M-context, max-effort coding use, and hardens the proxy lifecycle. Delivered as two focused commits on top of the earlier `glm-5.2` alias + native MCP-server injection.

### 1. `feat(zai): optimize GLM-5.2 for 1M context, reasoning effort, and system roles`

A review of the GLM-5.2 config found the model was **not** actually using its 1M context window, was missing z.ai's recommended reasoning depth, and rejected `role: system` messages that Claude Code clients send. All four fixed:

- **1M context, end-to-end.** Adopt the `glm-5.2[1m]` model alias (server-side opt-in). The `[1m]` suffix survives model routing. The client-side auto-compaction window is now configurable via `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (default `190000`; set to `1000000` to actually utilize the 1M window — otherwise Claude Code compacts at ~190K regardless of the model). Threaded through the launcher and both CLI session managers.
- **Reasoning effort.** Inject z.ai's discrete top-level `reasoning_effort` field (`high` | `max`), defaulting to **`max`** (z.ai's recommendation for coding). Override or disable via `ZAI_REASONING_EFFORT` (e.g. `high`, or blank to disable). Only sent when thinking is enabled. Verified against the live z.ai Anthropic endpoint.
- **Max-output floor.** Raise the z.ai-scoped default `max_tokens` to **131072** (GLM-5.2's 128K output ceiling) when a request omits `max_tokens`. Scoped to Z.ai so other Anthropic-compatible providers keep the shared default.
- **System-role extraction.** Hoist `role: system` messages out of the `messages` array into the top-level `system` field (the native Anthropic Messages API only accepts `user`/`assistant` roles). `Message.role` now permits `system`; handled on both the native and OpenAI conversion paths.

### 2. `feat(cli): auto-restart stale proxy before launching Claude`

The launcher treats a running proxy as stale when it has been idle longer than `SERVER_STALE_THRESHOLD_SECONDS` (120 min) and restarts it before the preflight. A new middleware records `app.state.last_activity_epoch`, surfaced via `GET /health`. Also ignores the local `.gstack/` tooling cache.

## Config knobs

| Env var | Default | Purpose |
| --- | --- | --- |
| `MODEL` / `MODEL_*` | — | Use `zai/glm-5.2[1m]` to opt into 1M context |
| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `190000` | Raise to `1000000` for 1M-context models |
| `ZAI_REASONING_EFFORT` | `max` | `high` \| `max` \| (blank to disable) |
| `ZAI_INJECT_MCP_SERVERS` | `true` | Inject z.ai web-reader / web-search-prime / zread MCP servers |

## Test plan

CI gate run in order — all green:
- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ty check` — all checks passed
- [x] `uv run pytest` — **1464 passed**

Coverage added: z.ai reasoning-effort levels (default `max` / `high` / disabled / skipped-when-thinking-off), `glm-5.2[1m]` alias routing, 131072 max-output floor, system-role extraction + conversion, configurable auto-compact window (launcher + CLISession), stale-server detection/restart, and health activity tracking. Each commit verified independently green for bisectability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Despite a `chore` title scoped to a model alias bump, this PR delivers several substantial new capabilities for the Z.ai provider alongside the glm-5.1→5.2 rename: native MCP-server injection, a configurable `reasoning_effort` field, a new `CLAUDE_CODE_AUTO_COMPACT_WINDOW` setting, stale-server auto-restart in `fcc-claude`, and a system-role hoisting pass for the native Anthropic messages path.

- **Model & provider additions** (`smoke/lib/config.py`, `providers/zai/request.py`, `providers/zai/client.py`, `providers/zai/mcp_servers.py`): default smoke model updated to `zai/glm-5.2[1m]`, ZAI max-output-tokens constant raised to 131 072, `reasoning_effort` injected when thinking is enabled, and three HTTP MCP servers auto-injected as native `mcp_servers` (suppressible via `ZAI_INJECT_MCP_SERVERS=false`).
- **Stale-server restart** (`api/app.py`, `api/routes.py`, `cli/entrypoints.py`): `/health` now returns `last_activity_epoch`; `fcc-claude` reads it and restarts the proxy when idle beyond 120 minutes — but the epoch is recorded with `time.monotonic()` on the server and compared with `time.monotonic()` in a different client process, which is undefined cross-process behavior (see inline comments).
- **System-role support** (`core/anthropic/native_messages_request.py`, `api/models/anthropic.py`, `core/anthropic/conversion.py`): `role: system` messages inside the `messages` array are now hoisted to the top-level `system` field for native Anthropic requests and passed through as-is in OpenAI conversions.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the time.monotonic() / time.time() mismatch between server and client processes; all other changes are additive and well-tested.

The stale-server detection records `last_activity_epoch` with `time.monotonic()` in the server process, then reads it back in the `fcc-claude` client process and subtracts its own `time.monotonic()`. Python documents the reference point as undefined — the two processes can have different origins, making the elapsed-time calculation wrong. On Linux/macOS both clocks happen to start at boot so it works today, but fixing it to `time.time()` is a one-line change that removes the reliance on undocumented OS behavior. Everything else in the PR — the GLM-5.2 alias bump, MCP injection, reasoning_effort, auto-compact window configurability, and system-role hoisting — looks correct and is well-covered by tests.

api/app.py and cli/entrypoints.py — the time.monotonic() pair that spans the server/client process boundary

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cli/entrypoints.py | Adds stale-server detection and auto-restart logic; uses time.monotonic() to compare across server/client processes, which is undefined behavior per Python docs |
| api/app.py | Records last_activity_epoch via time.monotonic() for the /health endpoint; this value is compared in a different process (cli/entrypoints.py) — should be time.time() for cross-process correctness |
| providers/zai/mcp_servers.py | New file that injects z.ai HTTP MCP servers into native Anthropic requests; name-collision deduplication and empty-body handling are correct |
| providers/zai/client.py | Adds reasoning_effort and MCP-injection logic; both values are cached at init time, and reasoning_effort is correctly gated on thinking_enabled |
| core/anthropic/native_messages_request.py | Adds _extract_system_messages() to hoist role:system messages out of the messages array into the top-level system field; logic and edge cases look correct |
| api/routes.py | Exposes last_activity_epoch on the /health endpoint; straightforward additive change |
| config/constants.py | Adds ZAI-specific constants (max output tokens, reasoning effort levels, auto-compact window default); well-documented and scoped correctly |
| smoke/lib/config.py | Updates ZAI smoke default from glm-5.1 to glm-5.2[1m]; single targeted change matching PR intent |
| tests/providers/test_zai.py | Good coverage of new reasoning_effort, MCP injection, system-role extraction, and the [1m] alias preservation; test naming and assertions are clear |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CC as fcc-claude (client process)
    participant Health as /health endpoint
    participant Server as fcc-server process
    participant ZAI as Z.ai API

    CC->>Health: GET /health
    Health-->>CC: "{status, last_activity_epoch (time.monotonic())}"
    CC->>CC: "idle = time.monotonic() - last_activity_epoch"
    alt "idle > 120 min"
        CC->>Server: lsof + SIGTERM
        CC->>Server: Popen fcc-server (new process)
        CC->>Health: poll until healthy
    end

    CC->>Server: Claude Code request
    Server->>Server: _extract_system_messages()
    Server->>Server: inject reasoning_effort (if thinking on)
    Server->>Server: merge_zai_mcp_servers() (if enabled)
    Server->>ZAI: "POST /api/anthropic/v1/messages {model, reasoning_effort, mcp_servers}"
    ZAI-->>Server: SSE stream
    Server-->>CC: proxied response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CC as fcc-claude (client process)
    participant Health as /health endpoint
    participant Server as fcc-server process
    participant ZAI as Z.ai API

    CC->>Health: GET /health
    Health-->>CC: "{status, last_activity_epoch (time.monotonic())}"
    CC->>CC: "idle = time.monotonic() - last_activity_epoch"
    alt "idle > 120 min"
        CC->>Server: lsof + SIGTERM
        CC->>Server: Popen fcc-server (new process)
        CC->>Health: poll until healthy
    end

    CC->>Server: Claude Code request
    Server->>Server: _extract_system_messages()
    Server->>Server: inject reasoning_effort (if thinking on)
    Server->>Server: merge_zai_mcp_servers() (if enabled)
    Server->>ZAI: "POST /api/anthropic/v1/messages {model, reasoning_effort, mcp_servers}"
    ZAI-->>Server: SSE stream
    Server-->>CC: proxied response
```

</a>

<sub>Reviews (2): Last reviewed commit: ["feat(cli): auto-restart stale proxy befo..."](https://github.com/alishahryar1/free-claude-code/commit/0cc49310fec5df0e072c4f343dc6815bc30a474e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37437278)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->