### PR TITLE
feat: add custom OpenAI-compatible provider for user-defined endpoints

### DIFF
--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -251,6 +251,19 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
             "[OpenAI compatibility](https://inference-docs.cerebras.ai/resources/openai)."
         ),
     ),
+    # === Custom / user-defined provider (OpenAI-compatible) ===
+    # Key, URL, and proxy for any OpenAI /v1/chat/completions endpoint.
+    # The user configures these in the admin UI to connect to e.g. freellmapi,
+    # a self-hosted model server, or any third-party OpenAI-compatible API.
+    ConfigFieldSpec(
+        "CUSTOM_OPENAI_API_KEY",
+        "Custom OpenAI API Key",
+        "providers",
+        "secret",
+        settings_attr="custom_openai_api_key",
+        secret=True,
+        description="API Key for the custom OpenAI-compatible endpoint.",
+    ),
     ConfigFieldSpec(
         "LM_STUDIO_BASE_URL",
         "LM Studio Base URL",
@@ -271,6 +284,14 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         "providers",
         settings_attr="ollama_base_url",
         default="http://localhost:11434",
+    ),
+    ConfigFieldSpec(
+        "CUSTOM_OPENAI_API_BASE_URL",
+        "Custom OpenAI Base URL",
+        "providers",
+        settings_attr="custom_openai_base_url",
+        default="http://localhost:3000/v1",
+        description="The base URL of the custom OpenAI-compatible API endpoint.",
     ),
     ConfigFieldSpec(
         "NVIDIA_NIM_PROXY",
@@ -404,6 +425,17 @@ FIELDS: tuple[ConfigFieldSpec, ...] = (
         "providers",
         "secret",
         settings_attr="cerebras_proxy",
+        secret=True,
+        advanced=True,
+    ),
+    # A custom endpoint typically won't need a proxy; this is offered as an
+    # advanced option for corporate or tunneled deployments.
+    ConfigFieldSpec(
+        "CUSTOM_OPENAI_PROXY",
+        "Custom OpenAI Proxy",
+        "providers",
+        "secret",
+        settings_attr="custom_openai_proxy",
         secret=True,
         advanced=True,
     ),

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -33,6 +33,9 @@ LOCAL_PROVIDER_PATHS = {
     "lmstudio": "/models",
     "llamacpp": "/models",
     "ollama": "/api/tags",
+    # The custom_openai provider uses the standard OpenAI /v1/models endpoint
+    # for model discovery, which can be queried to populate the model selector.
+    "custom_openai": "/models",
 }
 
 
@@ -63,13 +66,18 @@ def _origin_is_local(origin: str | None) -> bool:
 
 def require_loopback_admin(request: Request) -> None:
     """Allow admin access only from the local machine."""
+    from loguru import logger
 
     client_host = request.client.host if request.client else None
     if not _is_loopback_host(client_host):
+        logger.warning(
+            "require_loopback_admin: rejected non-loopback client_host={}", client_host
+        )
         raise HTTPException(status_code=403, detail="Admin UI is local-only")
 
     origin = request.headers.get("origin")
     if not _origin_is_local(origin):
+        logger.warning("require_loopback_admin: rejected non-local origin={}", origin)
         raise HTTPException(status_code=403, detail="Admin UI is local-only")
 
 
@@ -250,6 +258,9 @@ def _local_provider_url(provider_id: str, values: dict[str, str]) -> str:
         return values.get("LLAMACPP_BASE_URL", "")
     if provider_id == "ollama":
         return values.get("OLLAMA_BASE_URL", "")
+    # Custom OpenAI endpoint uses a user-defined URL from the admin UI config.
+    if provider_id == "custom_openai":
+        return values.get("CUSTOM_OPENAI_API_BASE_URL", "")
     return ""
 
 

--- a/api/admin_static/admin.js
+++ b/api/admin_static/admin.js
@@ -71,6 +71,7 @@ function providerName(providerId) {
     opencode: "OpenCode Zen",
     opencode_go: "OpenCode Go",
     zai: "Z.ai",
+    custom_openai: "Custom OpenAI-Compatible",  // User-defined OpenAI endpoint (e.g. freellmapi)
   };
   if (names[providerId]) return names[providerId];
   return providerId

--- a/api/services.py
+++ b/api/services.py
@@ -34,7 +34,11 @@ TokenCounter = Callable[[list[Any], str | list[Any] | None, list[Any] | None], i
 ProviderGetter = Callable[[str], BaseProvider]
 
 # Providers that use ``/chat/completions`` + Anthropic-to-OpenAI conversion (not native Messages).
-_OPENAI_CHAT_UPSTREAM_IDS = frozenset({"nvidia_nim", "opencode", "opencode_go"})
+# ``custom_openai`` is included here because even though it's user-defined, it speaks
+# the OpenAI /v1/chat/completions format and needs the same conversion pipeline.
+_OPENAI_CHAT_UPSTREAM_IDS = frozenset(
+    {"nvidia_nim", "opencode", "opencode_go", "custom_openai"}
+)
 
 
 def anthropic_sse_streaming_response(

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -246,6 +246,21 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
             "local",
         ),
     ),
+    # The custom_openai provider lets users connect any OpenAI /v1/chat/completions
+    # endpoint. Unlike the other built-in providers, its URL and key are fully
+    # user-defined — ideal for freellmapi, self-hosted models, or proprietary
+    # OpenAI-compatible services. It reuses the existing Anthropic→OpenAI
+    # conversion pipeline and supports streaming, tools, and extended thinking.
+    "custom_openai": ProviderDescriptor(
+        provider_id="custom_openai",
+        transport_type="openai_chat",
+        credential_env="CUSTOM_OPENAI_API_KEY",
+        credential_attr="custom_openai_api_key",
+        default_base_url="http://localhost:3000/v1",
+        base_url_attr="custom_openai_base_url",
+        proxy_attr="custom_openai_proxy",
+        capabilities=("chat", "streaming", "tools", "thinking", "rate_limit"),
+    ),
 }
 
 # Key order:

--- a/config/settings.py
+++ b/config/settings.py
@@ -114,6 +114,13 @@ class Settings(BaseSettings):
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
 
+    # ==================== Custom Provider Config (OpenAI-compatible) ====================
+    # API key for a user-defined OpenAI-compatible endpoint (e.g. freellmapi, LM Studio).
+    # The user sets this via the admin UI or CUSTOM_OPENAI_API_KEY env var.
+    custom_openai_api_key: str = Field(
+        default="", validation_alias="CUSTOM_OPENAI_API_KEY"
+    )
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord" | "none"
     messaging_platform: str = Field(
@@ -147,6 +154,15 @@ class Settings(BaseSettings):
         validation_alias="OLLAMA_BASE_URL",
     )
 
+    # ==================== Custom Provider URL (OpenAI-compatible) ====================
+    # Base URL of the user-defined OpenAI-compatible API endpoint, configurable
+    # via the admin UI or CUSTOM_OPENAI_API_BASE_URL env var. Default points at
+    # freellmapi's standard port for easy out-of-box setup.
+    custom_openai_base_url: str = Field(
+        default="http://localhost:3000/v1",
+        validation_alias="CUSTOM_OPENAI_API_BASE_URL",
+    )
+
     # ==================== Model ====================
     # All Claude model requests are mapped to this single model (fallback)
     # Format: provider_type/model/name
@@ -174,6 +190,9 @@ class Settings(BaseSettings):
     gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")
     groq_proxy: str = Field(default="", validation_alias="GROQ_PROXY")
     cerebras_proxy: str = Field(default="", validation_alias="CEREBRAS_PROXY")
+    # Proxy URL for the custom OpenAI-compatible endpoint (optional, advanced).
+    # Useful when routing through a corporate proxy or SSH tunnel.
+    custom_openai_proxy: str = Field(default="", validation_alias="CUSTOM_OPENAI_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")

--- a/providers/custom_openai/__init__.py
+++ b/providers/custom_openai/__init__.py
@@ -1,0 +1,12 @@
+"""
+Custom OpenAI-compatible provider adapter.
+
+Allows connecting free-claude-code to any OpenAI-compatible API endpoint
+(e.g., freellmapi, LM Studio, llama.cpp, vLLM, or any service that speaks
+the OpenAI /v1/chat/completions format). The user configures the endpoint
+URL and API key via the admin UI.
+"""
+
+from .client import CustomOpenAIProvider
+
+__all__ = ["CustomOpenAIProvider"]

--- a/providers/custom_openai/client.py
+++ b/providers/custom_openai/client.py
@@ -1,0 +1,70 @@
+"""Custom OpenAI-compatible provider implementation.
+
+This provider adapts free-claude-code's Anthropic-format requests into
+OpenAI /v1/chat/completions format and sends them to a user-configured
+endpoint. It extends OpenAIChatTransport (which already handles Anthropic→OpenAI
+conversion) and adds:
+  - A custom request body builder for fine-grained conversion control.
+  - Graceful fallback when the upstream /v1/models endpoint is unavailable,
+    using the user's configured model refs instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers.base import ProviderConfig
+from providers.openai_compat import OpenAIChatTransport
+
+from .request import build_request_body
+
+
+class CustomOpenAIProvider(OpenAIChatTransport):
+    """Provider client for any OpenAI /v1/chat/completions endpoint.
+
+    Use cases:
+      - freellmapi (aggregates free LLM API tiers behind an OpenAI-compatible API).
+      - Self-hosted models via llama.cpp, LM Studio, vLLM, Ollama (OpenAI compat).
+      - Any third-party API that speaks the OpenAI chat completions format.
+    """
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="CUSTOM_OPENAI",
+            base_url=config.base_url or "",
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        """Convert an internal Anthropic-format request to OpenAI chat completions format."""
+        return build_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+        )
+
+    async def list_model_ids(self) -> frozenset[str]:
+        """Query the upstream /v1/models endpoint, falling back on failure.
+
+        If the upstream models endpoint is unreachable (common for lightweight
+        proxies that don't implement it), falls back to any custom_openai models
+        the user has configured via MODEL env vars, or returns sensible defaults
+        so the provider still works.
+        """
+        try:
+            return await super().list_model_ids()
+        except Exception:
+            from config.settings import get_settings
+
+            settings = get_settings()
+            custom_model_ids = {
+                ref.model_id
+                for ref in settings.configured_chat_model_refs()
+                if ref.provider_id == "custom_openai"
+            }
+            if not custom_model_ids:
+                custom_model_ids.add("auto")
+                custom_model_ids.add("gpt-4o-mini")
+            return frozenset(custom_model_ids)

--- a/providers/custom_openai/request.py
+++ b/providers/custom_openai/request.py
@@ -1,0 +1,77 @@
+"""
+Request body builder for the Custom OpenAI-compatible provider.
+
+Converts free-claude-code's internal Anthropic-format request objects into
+OpenAI /v1/chat/completions format so they can be sent to any OpenAI-compatible
+upstream (e.g. freellmapi). The core conversion work is delegated to
+``core.anthropic.build_base_request_body``, with additional handling for:
+  - Reasoning/thinking replay (persisting thinking blocks from prior responses).
+  - Extra body passthrough (allows downstream caller to inject custom fields).
+  - Max-token field normalization (OpenAI uses ``max_completion_tokens``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from core.anthropic import ReasoningReplayMode, build_base_request_body
+from core.anthropic.conversion import OpenAIConversionError
+from providers.exceptions import InvalidRequestError
+
+
+def _normalize_max_completion_tokens(body: dict[str, Any]) -> None:
+    """Normalise max-token fields from Anthropic to OpenAI convention.
+
+    OpenAI /v1/chat/completions uses ``max_completion_tokens`` (not ``max_tokens``).
+    This ensures the upstream receives the correct field name regardless of what
+    the calling code provides.
+    """
+    if "max_completion_tokens" in body:
+        body.pop("max_tokens", None)
+        return
+    if "max_tokens" in body and body["max_tokens"] is not None:
+        body["max_completion_tokens"] = body.pop("max_tokens")
+
+
+def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
+    """Build OpenAI-format request body from an Anthropic request for Custom OpenAI.
+
+    This is the primary conversion entrypoint. It:
+      1. Delegates to ``build_base_request_body`` for the standard Anthropic→OpenAI
+         message/tool/system conversion.
+      2. When thinking is enabled, keeps ``reasoning_content`` blocks so upstream
+         services that support extended thinking can leverage them.
+      3. Passes through any ``extra_body`` from the original request (e.g. service-
+         specific parameters like temperature presets).
+      4. Normalises max-token naming to ``max_completion_tokens``.
+    """
+    logger.debug(
+        "CUSTOM_OPENAI_REQUEST: conversion start model={} msgs={}",
+        getattr(request_data, "model", "?"),
+        len(getattr(request_data, "messages", [])),
+    )
+    try:
+        body = build_base_request_body(
+            request_data,
+            reasoning_replay=ReasoningReplayMode.REASONING_CONTENT
+            if thinking_enabled
+            else ReasoningReplayMode.DISABLED,
+        )
+    except OpenAIConversionError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+
+    request_extra = getattr(request_data, "extra_body", None)
+    if isinstance(request_extra, dict) and request_extra:
+        body["extra_body"] = dict(request_extra)
+
+    _normalize_max_completion_tokens(body)
+
+    logger.debug(
+        "CUSTOM_OPENAI_REQUEST: conversion done model={} msgs={} tools={}",
+        body.get("model"),
+        len(body.get("messages", [])),
+        len(body.get("tools", [])),
+    )
+    return body

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -136,6 +136,17 @@ def _create_cerebras(config: ProviderConfig, _settings: Settings) -> BaseProvide
     return CerebrasProvider(config)
 
 
+def _create_custom_openai(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+    """Factory for the user-defined OpenAI-compatible provider.
+
+    Lazy-imports the adapter module so it's only loaded when this provider
+    is actually used, keeping startup fast for other provider configurations.
+    """
+    from providers.custom_openai import CustomOpenAIProvider
+
+    return CustomOpenAIProvider(config)
+
+
 PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
@@ -154,6 +165,7 @@ PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "lmstudio": _create_lmstudio,
     "llamacpp": _create_llamacpp,
     "ollama": _create_ollama,
+    "custom_openai": _create_custom_openai,
 }
 
 if set(PROVIDER_DESCRIPTORS) != set(SUPPORTED_PROVIDER_IDS) or set(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.3.0"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -57,6 +57,10 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini/models/gemini-3.1-flash-lite",
     "groq": "groq/llama-3.3-70b-versatile",
     "cerebras": "cerebras/llama3.1-8b",
+    # Default model ref for the user-defined OpenAI-compatible provider.
+    # The actual model used is determined by the upstream endpoint (e.g. freellmapi
+    # routes requests to the best available model regardless of this identifier).
+    "custom_openai": "custom_openai/gpt-4o-mini",
 }
 
 NVIDIA_NIM_CLI_DEFAULT_MODELS: tuple[str, ...] = (
@@ -257,6 +261,10 @@ class SmokeConfig:
             return bool(self.settings.groq_api_key.strip())
         if provider == "cerebras":
             return bool(self.settings.cerebras_api_key.strip())
+        # The custom OpenAI provider requires an API key to be set; the URL
+        # defaults are sufficient for local testing but can be overridden.
+        if provider == "custom_openai":
+            return bool(self.settings.custom_openai_api_key.strip())
         return False
 
 

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -22,6 +22,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "lmstudio",
     "llamacpp",
     "ollama",
+    "custom_openai",
 )
 
 

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -41,6 +41,7 @@ def _settings(**overrides):
         "groq_api_key": "",
         "cerebras_api_key": "",
         "fireworks_api_key": "",
+        "custom_openai_api_key": "",
         "lm_studio_base_url": "",
         "llamacpp_base_url": "",
         "ollama_base_url": "http://localhost:11434",

--- a/tests/providers/test_custom_openai.py
+++ b/tests/providers/test_custom_openai.py
@@ -1,0 +1,194 @@
+"""Tests for Custom OpenAI-compatible provider."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from config.settings import ConfiguredChatModelRef
+from providers.base import ProviderConfig
+from providers.custom_openai import CustomOpenAIProvider
+
+
+class MockMessage:
+    def __init__(self, role, content):
+        self.role = role
+        self.content = content
+
+
+class MockRequest:
+    def __init__(self, **kwargs):
+        self.model = "gpt-4o"
+        self.messages = [MockMessage("user", "Hello")]
+        self.max_tokens = 100
+        self.temperature = 0.5
+        self.top_p = 0.9
+        self.system = "System prompt"
+        self.stop_sequences = None
+        self.tools = []
+        self.thinking = MagicMock()
+        self.thinking.enabled = True
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+@pytest.fixture
+def custom_openai_config():
+    return ProviderConfig(
+        api_key="test_custom_openai_key",
+        base_url="http://localhost:3000/v1",
+        rate_limit=10,
+        rate_window=60,
+        enable_thinking=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_rate_limiter():
+    """Mock the global rate limiter to prevent waiting."""
+
+    @asynccontextmanager
+    async def _slot():
+        yield
+
+    with patch("providers.openai_compat.GlobalRateLimiter") as mock:
+        instance = mock.get_scoped_instance.return_value
+
+        async def _passthrough(fn, *args, **kwargs):
+            return await fn(*args, **kwargs)
+
+        instance.execute_with_retry = AsyncMock(side_effect=_passthrough)
+        instance.concurrency_slot.side_effect = _slot
+        yield instance
+
+
+@pytest.fixture
+def custom_openai_provider(custom_openai_config):
+    return CustomOpenAIProvider(custom_openai_config)
+
+
+def test_init(custom_openai_config):
+    """Test provider initialization."""
+    with patch("providers.openai_compat.AsyncOpenAI") as mock_openai:
+        provider = CustomOpenAIProvider(custom_openai_config)
+        assert provider._api_key == "test_custom_openai_key"
+        assert provider._base_url == "http://localhost:3000/v1"
+        assert provider._provider_name == "CUSTOM_OPENAI"
+        mock_openai.assert_called_once()
+
+
+def test_build_request_body_basic(custom_openai_provider):
+    """Basic request body conversion attaches system message from Claude request."""
+    req = MockRequest()
+    body = custom_openai_provider._build_request_body(req)
+
+    assert body["model"] == "gpt-4o"
+    assert body["messages"][0]["role"] == "system"
+    assert "max_completion_tokens" in body
+    assert "max_tokens" not in body
+
+
+def test_build_request_body_thinking_enabled(custom_openai_provider):
+    req = MockRequest()
+    req.thinking.enabled = True
+    body = custom_openai_provider._build_request_body(req, thinking_enabled=True)
+    assert body["model"] == "gpt-4o"
+
+
+def test_build_request_body_thinking_disabled(custom_openai_provider):
+    req = MockRequest()
+    req.thinking.enabled = False
+    body = custom_openai_provider._build_request_body(req, thinking_enabled=False)
+    assert body["model"] == "gpt-4o"
+
+
+def test_build_request_body_preserves_caller_extra_body(custom_openai_provider):
+    req = MockRequest(extra_body={"test_option": True})
+    body = custom_openai_provider._build_request_body(req)
+    eb = body.get("extra_body")
+    assert isinstance(eb, dict)
+    assert eb.get("test_option") is True
+
+
+@pytest.mark.asyncio
+async def test_list_model_ids_success(custom_openai_provider):
+    """Test successful model list retrieval from upstream models.list."""
+    mock_model_list = MagicMock()
+    # Mock return list of models
+    mock_model_1 = MagicMock()
+    mock_model_1.id = "custom-gpt-4o"
+    mock_model_2 = MagicMock()
+    mock_model_2.id = "custom-gpt-4o-mini"
+
+    mock_model_list.data = [mock_model_1, mock_model_2]
+
+    with patch.object(
+        custom_openai_provider._client.models, "list", new_callable=AsyncMock
+    ) as mock_list:
+        mock_list.return_value = mock_model_list
+        model_ids = await custom_openai_provider.list_model_ids()
+        assert model_ids == frozenset({"custom-gpt-4o", "custom-gpt-4o-mini"})
+
+
+@pytest.mark.asyncio
+async def test_list_model_ids_failure_fallback_configured(custom_openai_provider):
+    """Test fallback to configured models when upstream list fails."""
+    mock_settings = MagicMock()
+    mock_settings.configured_chat_model_refs.return_value = (
+        ConfiguredChatModelRef(
+            model_ref="custom_openai/my-model-1",
+            provider_id="custom_openai",
+            model_id="my-model-1",
+            sources=("MODEL",),
+        ),
+        ConfiguredChatModelRef(
+            model_ref="custom_openai/my-model-2",
+            provider_id="custom_openai",
+            model_id="my-model-2",
+            sources=("MODEL_SONNET",),
+        ),
+        ConfiguredChatModelRef(
+            model_ref="nvidia_nim/nim-model",
+            provider_id="nvidia_nim",
+            model_id="nim-model",
+            sources=("MODEL_OPUS",),
+        ),
+    )
+
+    with (
+        patch.object(
+            custom_openai_provider._client.models,
+            "list",
+            new_callable=AsyncMock,
+            side_effect=Exception("API Error"),
+        ),
+        patch("config.settings.get_settings", return_value=mock_settings),
+    ):
+        model_ids = await custom_openai_provider.list_model_ids()
+        assert model_ids == frozenset({"my-model-1", "my-model-2"})
+
+
+@pytest.mark.asyncio
+async def test_list_model_ids_failure_fallback_default(custom_openai_provider):
+    """Test fallback to default gpt-4o-mini when upstream fails and no configured custom_openai models."""
+    mock_settings = MagicMock()
+    mock_settings.configured_chat_model_refs.return_value = (
+        ConfiguredChatModelRef(
+            model_ref="nvidia_nim/nim-model",
+            provider_id="nvidia_nim",
+            model_id="nim-model",
+            sources=("MODEL",),
+        ),
+    )
+
+    with (
+        patch.object(
+            custom_openai_provider._client.models,
+            "list",
+            new_callable=AsyncMock,
+            side_effect=Exception("API Error"),
+        ),
+        patch("config.settings.get_settings", return_value=mock_settings),
+    ):
+        model_ids = await custom_openai_provider.list_model_ids()
+        assert model_ids == frozenset({"auto", "gpt-4o-mini"})

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -9,6 +9,7 @@ from config.provider_catalog import PROVIDER_CATALOG, ZAI_DEFAULT_BASE
 from config.provider_ids import SUPPORTED_PROVIDER_IDS
 from providers.cerebras import CerebrasProvider
 from providers.codestral import CodestralProvider
+from providers.custom_openai import CustomOpenAIProvider
 from providers.deepseek import DeepSeekProvider
 from providers.exceptions import UnknownProviderTypeError
 from providers.fireworks import FireworksProvider
@@ -67,6 +68,9 @@ def _make_settings(**overrides):
     mock.groq_proxy = ""
     mock.cerebras_api_key = ""
     mock.cerebras_proxy = ""
+    mock.custom_openai_api_key = ""
+    mock.custom_openai_base_url = "http://localhost:3000/v1"
+    mock.custom_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
     mock.provider_max_concurrency = 5
@@ -170,6 +174,7 @@ def test_create_provider_instantiates_each_builtin():
         cerebras_api_key="test_cerebras_key",
         fireworks_api_key="test_fireworks_key",
         kimi_api_key="test_kimi_key",
+        custom_openai_api_key="test_custom_openai_key",
     )
     cases = {
         "nvidia_nim": NvidiaNimProvider,
@@ -188,6 +193,7 @@ def test_create_provider_instantiates_each_builtin():
         "gemini": GeminiProvider,
         "groq": GroqProvider,
         "cerebras": CerebrasProvider,
+        "custom_openai": CustomOpenAIProvider,
     }
 
     with (

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "1.2.41"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Adds a new 'custom_openai' provider that allows free-claude-code to connect to any OpenAI /v1/chat/completions endpoint — primarily targeting freellmapi but also usable with LM Studio, llama.cpp, vLLM, or any compatible service.

Changes:
- New providers/custom_openai/ module with provider client and request builder
- Settings fields for API key, base URL, and proxy (admin UI editable)
- Provider catalog entry with full capabilities (chat, streaming, tools, thinking)
- Registry factory with lazy import pattern
- Admin UI: config fields, model discovery path, display name
- Smoke config defaults and credential checks
- Comprehensive test coverage (8 tests) for init, request building, model listing
- Version bumped 1.2.41 -> 1.3.0