### PR TITLE
Fix Claude auto-mode classifier thinking policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -427,6 +427,12 @@ common low-value client requests before they reach a provider:
 The service runs these only after model routing and after local server-tool
 handling. Each optimization is controlled by settings flags.
 
+Claude Code auto-mode safety-classifier requests are a message-only routing
+policy, not a short-circuit response. After routing, the pipeline detects the
+narrow classifier prompt shape and forces thinking off before provider execution
+so Claude Code receives a parser-readable `<block>yes</block>` or
+`<block>no</block>` verdict.
+
 Local `web_search` and `web_fetch` handling lives under
 [api/web_tools/](api/web_tools/). When `ENABLE_WEB_SERVER_TOOLS` is true, the
 service can stream local Anthropic server-tool responses without sending the

--- a/api/detection.py
+++ b/api/detection.py
@@ -1,7 +1,7 @@
 """Request detection utilities for API optimizations.
 
-Detects quota checks, title generation, prefix detection, suggestion mode,
-and filepath extraction requests to enable fast-path responses.
+Detects quota checks, title generation, prefix detection, safety classifier,
+suggestion mode, and filepath extraction requests to enable targeted handling.
 """
 
 from core.anthropic import extract_text_from_content
@@ -69,6 +69,22 @@ def is_prefix_detection_request(request_data: MessagesRequest) -> tuple[bool, st
             return False, ""
 
     return False, ""
+
+
+def is_safety_classifier_request(request_data: MessagesRequest) -> bool:
+    """Return whether this is Claude Code's auto-mode safety classifier prompt."""
+    if request_data.tools:
+        return False
+
+    system_text = (
+        extract_text_from_content(request_data.system) if request_data.system else ""
+    )
+    messages_text = "".join(
+        extract_text_from_content(message.content) for message in request_data.messages
+    )
+    combined = f"{system_text}\n{messages_text}"
+    has_verdict_instruction = "yes</block>" in combined or "no</block>" in combined
+    return "<transcript>" in combined and has_verdict_instruction
 
 
 def is_suggestion_mode_request(request_data: MessagesRequest) -> bool:

--- a/api/request_pipeline.py
+++ b/api/request_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import traceback
 import uuid
 from collections.abc import AsyncIterator, Callable
+from dataclasses import replace
 from typing import Any
 
 from fastapi import HTTPException
@@ -20,6 +21,7 @@ from core.trace import api_messages_request_snapshot, trace_event, traced_async_
 from providers.base import BaseProvider
 from providers.exceptions import InvalidRequestError, ProviderError
 
+from .detection import is_safety_classifier_request
 from .model_router import ModelRouter, RoutedMessagesRequest
 from .models.anthropic import MessagesRequest, TokenCountRequest
 from .models.openai_responses import OpenAIResponsesRequest
@@ -126,6 +128,7 @@ class ApiRequestPipeline:
         try:
             _require_non_empty_messages(request_data.messages)
             routed = self._model_router.resolve_messages_request(request_data)
+            routed = self._apply_message_routing_policies(routed)
             self._reject_unsupported_server_tools(routed)
 
             intercepted = self._run_message_intercepts(routed)
@@ -271,6 +274,26 @@ class ApiRequestPipeline:
         )
         if tool_err is not None:
             raise InvalidRequestError(tool_err)
+
+    def _apply_message_routing_policies(
+        self, routed: RoutedMessagesRequest
+    ) -> RoutedMessagesRequest:
+        if not is_safety_classifier_request(routed.request):
+            return routed
+        changed = routed.resolved.thinking_enabled
+        trace_event(
+            stage="routing",
+            event="api.optimization.safety_classifier_no_thinking",
+            source="api",
+            model=routed.request.model,
+            changed=changed,
+        )
+        if not changed:
+            return routed
+        return RoutedMessagesRequest(
+            request=routed.request,
+            resolved=replace(routed.resolved, thinking_enabled=False),
+        )
 
     def _run_message_intercepts(self, routed: RoutedMessagesRequest) -> object | None:
         for intercept in self._message_intercepts:

--- a/providers/base.py
+++ b/providers/base.py
@@ -54,16 +54,21 @@ class BaseProvider(ABC):
                 if isinstance(thinking, dict)
                 else getattr(thinking, "type", None)
             )
+            if isinstance(thinking, dict):
+                enabled = thinking.get("enabled")
+                enabled_supplied = "enabled" in thinking
+            else:
+                enabled = getattr(thinking, "enabled", None)
+                fields_set = getattr(thinking, "model_fields_set", None)
+                enabled_supplied = (
+                    "enabled" in fields_set
+                    if isinstance(fields_set, set | frozenset)
+                    else enabled is not None
+                )
+            if enabled_supplied and enabled is not None:
+                request_enabled = bool(enabled)
             if thinking_type == "disabled":
                 request_enabled = False
-
-            enabled = (
-                thinking.get("enabled")
-                if isinstance(thinking, dict)
-                else getattr(thinking, "enabled", None)
-            )
-            if enabled is not None:
-                request_enabled = bool(enabled)
         return config_enabled and request_enabled
 
     def preflight_stream(

--- a/providers/transports/anthropic_messages/transport.py
+++ b/providers/transports/anthropic_messages/transport.py
@@ -119,6 +119,15 @@ class AnthropicMessagesTransport(BaseProvider):
     ) -> dict:
         """Build a native Anthropic request body."""
         thinking_enabled = self._is_thinking_enabled(request, thinking_enabled)
+        return self._build_request_body_with_resolved_thinking(
+            request,
+            thinking_enabled=thinking_enabled,
+        )
+
+    def _build_request_body_with_resolved_thinking(
+        self, request: Any, *, thinking_enabled: bool
+    ) -> dict:
+        """Build a native Anthropic request body after thinking is resolved."""
         return build_base_native_anthropic_request_body(
             request,
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,

--- a/providers/wafer/client.py
+++ b/providers/wafer/client.py
@@ -23,9 +23,19 @@ class WaferProvider(AnthropicMessagesTransport):
         self, request: Any, thinking_enabled: bool | None = None
     ) -> dict:
         """Build native body; Wafer rejects omitted thinking as ``reasoning_effort=none``."""
-        body = super()._build_request_body(request, thinking_enabled=thinking_enabled)
+        effective_thinking_enabled = self._is_thinking_enabled(
+            request, thinking_enabled
+        )
+        body = self._build_request_body_with_resolved_thinking(
+            request,
+            thinking_enabled=effective_thinking_enabled,
+        )
         if "thinking" not in body:
-            body["thinking"] = {"type": "enabled"}
+            body["thinking"] = (
+                {"type": "enabled"}
+                if effective_thinking_enabled
+                else {"type": "disabled"}
+            )
         return body
 
     def _request_headers(self) -> dict[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.3.11"
+version = "2.3.12"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/api/test_detection.py
+++ b/tests/api/test_detection.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from api.detection import (
     is_filepath_extraction_request,
     is_prefix_detection_request,
+    is_safety_classifier_request,
 )
 from api.models.anthropic import Message, MessagesRequest
 
@@ -50,6 +51,47 @@ class TestIsPrefixDetectionRequest:
             is_req, cmd = is_prefix_detection_request(req)
         assert is_req is False
         assert cmd == ""
+
+
+class TestIsSafetyClassifierRequest:
+    _SYSTEM = (
+        "You are a security monitor. Respond with <block>yes</block> "
+        "or <block>no</block>."
+    )
+    _USER = (
+        "<transcript>\nUser: review the repo\n"
+        "WebFetch https://example.com: fetch\n</transcript>\n<block> immediately."
+    )
+
+    def test_classifier_request_detected(self):
+        req = _make_request(self._USER, system=self._SYSTEM)
+        assert is_safety_classifier_request(req) is True
+
+    def test_markers_split_across_system_and_user(self):
+        req = _make_request(
+            "<transcript>\nWebFetch x\n</transcript>", system=self._SYSTEM
+        )
+        assert is_safety_classifier_request(req) is True
+
+    def test_request_with_tools_is_not_classifier(self):
+        req = _make_request(self._USER, system=self._SYSTEM, tools=[{"name": "search"}])
+        assert is_safety_classifier_request(req) is False
+
+    def test_missing_transcript_marker(self):
+        req = _make_request("<block> immediately", system=self._SYSTEM)
+        assert is_safety_classifier_request(req) is False
+
+    def test_missing_verdict_instruction(self):
+        req = _make_request(
+            "<transcript>\nWebFetch x\n</transcript>", system="just chatting"
+        )
+        assert is_safety_classifier_request(req) is False
+
+    def test_xml_content_without_verdict_instruction(self):
+        req = _make_request(
+            "Explain this format: <transcript> ... </transcript> and a <block> tag."
+        )
+        assert is_safety_classifier_request(req) is False
 
 
 class TestIsFilepathExtractionRequest:

--- a/tests/api/test_request_pipeline.py
+++ b/tests/api/test_request_pipeline.py
@@ -13,6 +13,14 @@ from api.request_pipeline import ApiRequestPipeline
 from config.settings import Settings
 from providers.base import BaseProvider, ProviderConfig
 
+_CLASSIFIER_SYSTEM = (
+    "You are a security monitor. Respond with <block>yes</block> or <block>no</block>."
+)
+_CLASSIFIER_USER = (
+    "<transcript>\nUser: review the repo\nWebFetch https://example.com: fetch\n"
+    "</transcript>\n<block> immediately."
+)
+
 
 class FakeProvider(BaseProvider):
     def __init__(self) -> None:
@@ -62,6 +70,14 @@ async def _streaming_body_text(response: StreamingResponse) -> str:
     return "".join(parts)
 
 
+def _trace_events(trace_mock: MagicMock, event: str) -> list[dict[str, Any]]:
+    return [
+        dict(call.kwargs)
+        for call in trace_mock.call_args_list
+        if call.kwargs.get("event") == event
+    ]
+
+
 @pytest.mark.asyncio
 async def test_pipeline_provider_execution_passes_routed_request_and_stream_metadata():
     provider = FakeProvider()
@@ -82,6 +98,102 @@ async def test_pipeline_provider_execution_passes_routed_request_and_stream_meta
     assert provider.stream_kwargs[0]["request_id"].startswith("req_")
     assert provider.stream_kwargs[0]["thinking_enabled"] is True
     assert len(provider.preflight_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_forces_no_thinking_for_safety_classifier_messages():
+    provider = FakeProvider()
+    pipeline = ApiRequestPipeline(Settings(), provider_getter=lambda _: provider)
+    request = MessagesRequest(
+        model="nvidia_nim/test-model",
+        max_tokens=100,
+        system=_CLASSIFIER_SYSTEM,
+        messages=[Message(role="user", content=_CLASSIFIER_USER)],
+    )
+
+    with patch("api.request_pipeline.trace_event") as trace_mock:
+        response = pipeline.create_message(request)
+        assert isinstance(response, StreamingResponse)
+        await _streaming_body_text(response)
+
+    assert provider.preflight_calls[0][1] is False
+    assert provider.stream_kwargs[0]["thinking_enabled"] is False
+    assert provider.requests[0].model == "test-model"
+    assert provider.requests[0].system == _CLASSIFIER_SYSTEM
+    assert _trace_events(
+        trace_mock, "api.optimization.safety_classifier_no_thinking"
+    ) == [
+        {
+            "stage": "routing",
+            "event": "api.optimization.safety_classifier_no_thinking",
+            "source": "api",
+            "model": "test-model",
+            "changed": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_preserves_thinking_for_non_classifier_messages():
+    provider = FakeProvider()
+    pipeline = ApiRequestPipeline(Settings(), provider_getter=lambda _: provider)
+    request = MessagesRequest(
+        model="nvidia_nim/test-model",
+        max_tokens=100,
+        system="Explain XML formats.",
+        messages=[
+            Message(
+                role="user",
+                content=(
+                    "Explain <transcript>...</transcript> and a <block> tag "
+                    "without making a verdict."
+                ),
+            )
+        ],
+    )
+
+    with patch("api.request_pipeline.trace_event") as trace_mock:
+        response = pipeline.create_message(request)
+        assert isinstance(response, StreamingResponse)
+        await _streaming_body_text(response)
+
+    assert provider.preflight_calls[0][1] is True
+    assert provider.stream_kwargs[0]["thinking_enabled"] is True
+    assert (
+        _trace_events(trace_mock, "api.optimization.safety_classifier_no_thinking")
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_keeps_existing_no_thinking_for_classifier_messages():
+    provider = FakeProvider()
+    pipeline = ApiRequestPipeline(Settings(), provider_getter=lambda _: provider)
+    request = MessagesRequest(
+        model="claude-3-freecc-no-thinking/nvidia_nim/test-model",
+        max_tokens=100,
+        system=_CLASSIFIER_SYSTEM,
+        messages=[Message(role="user", content=_CLASSIFIER_USER)],
+    )
+
+    with patch("api.request_pipeline.trace_event") as trace_mock:
+        response = pipeline.create_message(request)
+        assert isinstance(response, StreamingResponse)
+        await _streaming_body_text(response)
+
+    assert provider.preflight_calls[0][1] is False
+    assert provider.stream_kwargs[0]["thinking_enabled"] is False
+    assert _trace_events(
+        trace_mock, "api.optimization.safety_classifier_no_thinking"
+    ) == [
+        {
+            "stage": "routing",
+            "event": "api.optimization.safety_classifier_no_thinking",
+            "source": "api",
+            "model": "test-model",
+            "changed": False,
+        }
+    ]
 
 
 def test_pipeline_message_optimization_intercepts_before_provider_execution():
@@ -120,3 +232,28 @@ async def test_pipeline_responses_bypass_message_only_optimizations():
     body = await _streaming_body_text(response)
     assert "response.completed" in body
     assert provider.requests[0].messages[0].content == "quota check"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_responses_do_not_apply_safety_classifier_policy():
+    provider = FakeProvider()
+    pipeline = ApiRequestPipeline(Settings(), provider_getter=lambda _: provider)
+
+    with patch("api.request_pipeline.trace_event") as trace_mock:
+        response = await pipeline.create_response(
+            request_data=OpenAIResponsesRequest(
+                model="nvidia_nim/test-model",
+                input=_CLASSIFIER_USER,
+                instructions=_CLASSIFIER_SYSTEM,
+            )
+        )
+
+        assert isinstance(response, StreamingResponse)
+        await _streaming_body_text(response)
+
+    assert provider.preflight_calls[0][1] is True
+    assert provider.stream_kwargs[0]["thinking_enabled"] is True
+    assert (
+        _trace_events(trace_mock, "api.optimization.safety_classifier_no_thinking")
+        == []
+    )

--- a/tests/providers/test_wafer.py
+++ b/tests/providers/test_wafer.py
@@ -1,6 +1,7 @@
 """Tests for Wafer native Anthropic Messages provider."""
 
 from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -41,6 +42,18 @@ class FakeResponse:
             text=self._text,
         )
         response.raise_for_status()
+
+
+class CountingWaferProvider(WaferProvider):
+    def __init__(self, config: ProviderConfig):
+        super().__init__(config)
+        self.thinking_checks = 0
+
+    def _is_thinking_enabled(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> bool:
+        self.thinking_checks += 1
+        return super()._is_thinking_enabled(request, thinking_enabled)
 
 
 @pytest.fixture
@@ -145,7 +158,22 @@ def test_build_request_body_drops_reasoning_effort_none(wafer_provider):
     assert body["thinking"] == {"type": "enabled"}
 
 
-def test_build_request_body_keeps_upstream_thinking_enabled_when_client_disables_it(
+def test_build_request_body_honors_effective_no_thinking(
+    wafer_provider,
+):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "DeepSeek-V4-Pro",
+            "messages": [{"role": "user", "content": "Explore the codebase."}],
+        }
+    )
+
+    body = wafer_provider._build_request_body(request, thinking_enabled=False)
+
+    assert body["thinking"] == {"type": "disabled"}
+
+
+def test_build_request_body_preserves_request_disabled_thinking(
     wafer_provider,
 ):
     request = MessagesRequest.model_validate(
@@ -156,9 +184,51 @@ def test_build_request_body_keeps_upstream_thinking_enabled_when_client_disables
         }
     )
 
+    body = wafer_provider._build_request_body(request, thinking_enabled=True)
+
+    assert body["thinking"] == {"type": "disabled"}
+
+
+def test_build_request_body_resolves_thinking_once(wafer_config):
+    provider = CountingWaferProvider(wafer_config)
+    request = MessagesRequest.model_validate(
+        {
+            "model": "DeepSeek-V4-Pro",
+            "messages": [{"role": "user", "content": "Explore the codebase."}],
+        }
+    )
+
+    body = provider._build_request_body(request, thinking_enabled=False)
+
+    assert body["thinking"] == {"type": "disabled"}
+    assert provider.thinking_checks == 1
+
+
+def test_build_request_body_classifier_no_thinking_uses_disabled_payload(
+    wafer_provider,
+):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "DeepSeek-V4-Pro",
+            "system": (
+                "You are a security monitor. Respond with <block>yes</block> "
+                "or <block>no</block>."
+            ),
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "<transcript>\nWebFetch https://example.com\n"
+                        "</transcript>\n<block> immediately."
+                    ),
+                }
+            ],
+        }
+    )
+
     body = wafer_provider._build_request_body(request, thinking_enabled=False)
 
-    assert body["thinking"] == {"type": "enabled"}
+    assert body["thinking"] == {"type": "disabled"}
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.3.11"
+version = "2.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Claude Code auto-mode classifier requests need plain-text `<block>` verdicts. Thinking-capable models can emit the verdict through reasoning output, and Wafer re-enabled thinking even when routing disabled it.

## Changes

| Before | After |
| --- | --- |
| Classifier-shaped `/v1/messages` requests used the routed model thinking setting. | Classifier-shaped `/v1/messages` requests force routed thinking off before provider execution. |
| Wafer re-added enabled thinking when the native body omitted thinking. | Wafer sends enabled or disabled thinking from the effective routed policy. |
| The classifier issue was covered by stale service tests from an outdated PR shape. | Detection, pipeline handoff, Responses exclusion, and Wafer payload behavior are covered in current tests. |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs: the safety-classifier pipeline now forces `thinking_enabled=False` before provider execution so Claude Code always receives a parseable `<block>yes/no</block>` verdict, and Wafer's fallback insertion now uses `{"type": "disabled"}` when thinking is off instead of unconditionally injecting `{"type": "enabled"}`.

- **Detection & pipeline policy** (`api/detection.py`, `api/request_pipeline.py`): `is_safety_classifier_request` identifies the narrow classifier prompt shape; `_apply_message_routing_policies` (inserted after routing, before intercepts) overrides `thinking_enabled=False` on the resolved request and emits a trace event in both the changed and already-disabled paths.
- **Wafer client fix** (`providers/wafer/client.py`, `providers/transports/anthropic_messages/transport.py`): `_build_request_body_with_resolved_thinking` is extracted so Wafer can call the body builder with a pre-resolved flag, eliminating the prior double-call and ensuring the `thinking` fallback respects the effective policy.
- **`_is_thinking_enabled` correctness** (`providers/base.py`): The check now uses `enabled_supplied` to distinguish an absent field from `None`, and moves `type=="disabled"` after the `enabled` override so an explicit disabled type always wins.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are guarded by targeted heuristics and well-covered tests; no behavioral regressions observed.

The routing-policy insertion, Wafer fallback fix, and _is_thinking_enabled correction are all narrowly scoped. Non-classifier requests are unaffected (early return), Responses-API traffic bypasses the policy entirely, and the CountingWaferProvider test confirms the previously-redundant double call is gone. Tests cover all four distinct code paths.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/detection.py | Adds `is_safety_classifier_request` that detects the auto-mode classifier prompt via `<transcript>` + verdict markers; heuristic is narrow enough to avoid false positives on normal requests. |
| api/request_pipeline.py | Inserts `_apply_message_routing_policies` between routing and tool-validation; correctly forces `thinking_enabled=False` on classifier requests and emits a trace event in both the changed and unchanged paths. |
| providers/base.py | Fixes `_is_thinking_enabled` to distinguish 'field present but None' from 'field absent' via `enabled_supplied`, and moves `type=="disabled"` check after the `enabled` override so that an explicit `type: disabled` now correctly wins. |
| providers/transports/anthropic_messages/transport.py | Extracts `_build_request_body_with_resolved_thinking` so Wafer can call the body builder with a pre-resolved thinking flag, eliminating the parent's double `_is_thinking_enabled` invocation. |
| providers/wafer/client.py | Resolves `effective_thinking_enabled` once and uses it for both body-building and the fallback `thinking` insertion, so a forced `thinking_enabled=False` now correctly inserts `{"type": "disabled"}` instead of always defaulting to `{"type": "enabled"}`. |
| tests/api/test_detection.py | Adds thorough unit tests for `is_safety_classifier_request` covering both positive and all known negative shapes. |
| tests/api/test_request_pipeline.py | Adds four integration-style pipeline tests: forced no-thinking for classifiers, preservation for non-classifiers, already-disabled classifiers, and Responses-API bypass. |
| tests/providers/test_wafer.py | Updates stale test expectations and adds `CountingWaferProvider` to verify `_is_thinking_enabled` is called exactly once per `_build_request_body` invocation. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Pipeline as ApiRequestPipeline
    participant Router as ModelRouter
    participant Policy as _apply_message_routing_policies
    participant Intercepts as MessageIntercepts
    participant Provider as Provider (e.g. Wafer)

    Client->>Pipeline: create_message(request)
    Pipeline->>Router: resolve_messages_request(request)
    Router-->>Pipeline: RoutedMessagesRequest (thinking_enabled from model prefix)
    Pipeline->>Policy: _apply_message_routing_policies(routed)
    alt is_safety_classifier_request
        Policy->>Policy: "emit trace_event(changed=...)"
        Policy->>Policy: "replace(resolved, thinking_enabled=False)"
    end
    Policy-->>Pipeline: "RoutedMessagesRequest (thinking_enabled=False for classifiers)"
    Pipeline->>Intercepts: _run_message_intercepts(routed)
    Intercepts-->>Pipeline: None (no intercept matched)
    Pipeline->>Provider: "preflight_stream(request, thinking_enabled=False)"
    Pipeline->>Provider: "stream(request, thinking_enabled=False)"
    Provider->>Provider: _is_thinking_enabled(request, False) → False
    Provider->>Provider: "_build_request_body_with_resolved_thinking(thinking_enabled=False)"
    Note over Provider: If thinking absent, insert type:disabled
    Provider-->>Client: SSE stream (plain-text block verdict)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Pipeline as ApiRequestPipeline
    participant Router as ModelRouter
    participant Policy as _apply_message_routing_policies
    participant Intercepts as MessageIntercepts
    participant Provider as Provider (e.g. Wafer)

    Client->>Pipeline: create_message(request)
    Pipeline->>Router: resolve_messages_request(request)
    Router-->>Pipeline: RoutedMessagesRequest (thinking_enabled from model prefix)
    Pipeline->>Policy: _apply_message_routing_policies(routed)
    alt is_safety_classifier_request
        Policy->>Policy: "emit trace_event(changed=...)"
        Policy->>Policy: "replace(resolved, thinking_enabled=False)"
    end
    Policy-->>Pipeline: "RoutedMessagesRequest (thinking_enabled=False for classifiers)"
    Pipeline->>Intercepts: _run_message_intercepts(routed)
    Intercepts-->>Pipeline: None (no intercept matched)
    Pipeline->>Provider: "preflight_stream(request, thinking_enabled=False)"
    Pipeline->>Provider: "stream(request, thinking_enabled=False)"
    Provider->>Provider: _is_thinking_enabled(request, False) → False
    Provider->>Provider: "_build_request_body_with_resolved_thinking(thinking_enabled=False)"
    Note over Provider: If thinking absent, insert type:disabled
    Provider-->>Client: SSE stream (plain-text block verdict)
```

</a>

<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `providers/wafer/client.py`, line 22-36 ([link](https://github.com/alishahryar1/free-claude-code/blob/0a28c842d8a01240c08f5ab454cc22be531fd7de/providers/wafer/client.py#L22-L36)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`_is_thinking_enabled` called twice for every request**

   `effective_thinking_enabled` is computed on line 26-28, and then `super()._build_request_body` recomputes it internally (the parent's `_build_request_body` always calls `self._is_thinking_enabled`). Both calls are deterministic so there is no functional problem, but the double invocation is a small inconsistency. Passing `effective_thinking_enabled` directly to `super()` — `super()._build_request_body(request, thinking_enabled=effective_thinking_enabled)` — would make the intent explicit and eliminate the redundant computation.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fclaude-auto-mode-classifier-no-thinking%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fclaude-auto-mode-classifier-no-thinking%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20providers%2Fwafer%2Fclient.py%0ALine%3A%2022-36%0A%0AComment%3A%0A**%60_is_thinking_enabled%60%20called%20twice%20for%20every%20request**%0A%0A%60effective_thinking_enabled%60%20is%20computed%20on%20line%2026-28%2C%20and%20then%20%60super%28%29._build_request_body%60%20recomputes%20it%20internally%20%28the%20parent's%20%60_build_request_body%60%20always%20calls%20%60self._is_thinking_enabled%60%29.%20Both%20calls%20are%20deterministic%20so%20there%20is%20no%20functional%20problem%2C%20but%20the%20double%20invocation%20is%20a%20small%20inconsistency.%20Passing%20%60effective_thinking_enabled%60%20directly%20to%20%60super%28%29%60%20%E2%80%94%20%60super%28%29._build_request_body%28request%2C%20thinking_enabled%3Deffective_thinking_enabled%29%60%20%E2%80%94%20would%20make%20the%20intent%20explicit%20and%20eliminate%20the%20redundant%20computation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=alishahryar1%2Ffree-claude-code&pr=865&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Fix Claude auto-mode classifier thinking..."](https://github.com/alishahryar1/free-claude-code/commit/63c8a8343205dc6c7aa0578a20a34613011539c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38616537)</sub>

<!-- /greptile_comment -->