### PR TITLE
fix(cli): sync proxy env to ~/.claude/settings.json for agent workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ fcc-claude
 
 `fcc-claude` reads the current configured port and auth token each time it starts, sets the Claude Code environment variables (including a 190k-token `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for auto-compaction), and then launches the real `claude` command. When proxy auth is disabled, it still passes `ANTHROPIC_AUTH_TOKEN=fcc-no-auth` so newer Claude Code versions do not stop at their local login gate before contacting the proxy.
 
+`fcc-claude agents` spawns background workers as plain `claude` processes without inheriting the launcher's env. `fcc-claude` now auto-syncs the same proxy env into `~/.claude/settings.json` on each launch (and when Admin config is applied) so agent workers can reach the proxy without `/login` prompts.
+
 **Codex**
 
 ```bash
@@ -367,6 +369,8 @@ fcc-claude
 ```
 
 The Admin UI manages proxy config, restarts the server when runtime settings change, and `fcc-claude` reads the current Admin UI-managed port and auth token every time it starts. It also sets `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to `190000` for auto-compaction. When proxy auth is blank, `fcc-claude` injects `ANTHROPIC_AUTH_TOKEN=fcc-no-auth` only to satisfy Claude Code's local login check; the proxy still treats blank auth as disabled.
+
+For `fcc-claude agents`, the same proxy env is persisted into `~/.claude/settings.json` automatically so daemon workers inherit it.
 
 ### 2. Codex CLI
 

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -121,11 +121,16 @@ async def apply_admin_config(
         return result
 
     get_cached_settings.cache_clear()
-    # Sync immediately unless the changeset is exclusively PORT/HOST restart fields.
-    # For PORT/HOST-only changes the proxy is still on the old port until restart
-    # completes; the next fcc-claude launch will re-sync with the new address.
-    _RESTART_ONLY_FIELDS = frozenset({"HOST", "PORT"})
-    if not set(filtered.keys()) <= _RESTART_ONLY_FIELDS:
+    # Defer the sync only while a HOST/PORT restart is actually pending: either
+    # from this apply (result["pending_fields"]) or from an earlier apply still
+    # awaiting a manual restart (app.state.admin_pending_fields). Writing the new
+    # address now would point agent workers at a proxy that is not serving yet.
+    # A pending restart is repaired by the serve() supervisor on the next start.
+    _RESTART_FIELDS = frozenset({"HOST", "PORT"})
+    pending_now = set(result["pending_fields"])
+    pending_before = set(getattr(request.app.state, "admin_pending_fields", []))
+    restart_pending = (pending_now | pending_before) & _RESTART_FIELDS
+    if not restart_pending:
         fresh_settings = get_cached_settings()
         sync_claude_settings(
             proxy_root_url=local_proxy_root_url(fresh_settings),

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -115,16 +115,22 @@ async def apply_admin_config(
     background_tasks: BackgroundTasks,
 ):
     require_loopback_admin(request)
-    result = write_managed_env(_filtered_values(payload.values))
+    filtered = _filtered_values(payload.values)
+    result = write_managed_env(filtered)
     if not result["applied"]:
         return result
 
     get_cached_settings.cache_clear()
-    fresh_settings = get_cached_settings()
-    sync_claude_settings(
-        proxy_root_url=local_proxy_root_url(fresh_settings),
-        auth_token=fresh_settings.anthropic_auth_token,
-    )
+    # Sync immediately unless the changeset is exclusively PORT/HOST restart fields.
+    # For PORT/HOST-only changes the proxy is still on the old port until restart
+    # completes; the next fcc-claude launch will re-sync with the new address.
+    _RESTART_ONLY_FIELDS = frozenset({"HOST", "PORT"})
+    if not set(filtered.keys()) <= _RESTART_ONLY_FIELDS:
+        fresh_settings = get_cached_settings()
+        sync_claude_settings(
+            proxy_root_url=local_proxy_root_url(fresh_settings),
+            auth_token=fresh_settings.anthropic_auth_token,
+        )
     restart = _restart_metadata(result["pending_fields"], request)
     result["restart"] = restart
     if restart["required"] and restart["automatic"]:

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -13,6 +13,8 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
+from api.admin_urls import local_proxy_root_url
+from cli.claude_settings_sync import sync_claude_settings
 from config.settings import Settings
 from config.settings import get_settings as get_cached_settings
 from providers.registry import ProviderRegistry
@@ -118,6 +120,11 @@ async def apply_admin_config(
         return result
 
     get_cached_settings.cache_clear()
+    fresh_settings = get_cached_settings()
+    sync_claude_settings(
+        proxy_root_url=local_proxy_root_url(fresh_settings),
+        auth_token=fresh_settings.anthropic_auth_token,
+    )
     restart = _restart_metadata(result["pending_fields"], request)
     result["restart"] = restart
     if restart["required"] and restart["automatic"]:

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -14,7 +14,10 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from api.admin_urls import local_proxy_root_url
-from cli.claude_settings_sync import sync_claude_settings
+from cli.claude_settings_sync import (
+    should_defer_claude_settings_sync,
+    sync_claude_settings,
+)
 from config.settings import Settings
 from config.settings import get_settings as get_cached_settings
 from providers.registry import ProviderRegistry
@@ -120,12 +123,13 @@ async def apply_admin_config(
         return result
 
     get_cached_settings.cache_clear()
-    fresh_settings = get_cached_settings()
-    sync_claude_settings(
-        proxy_root_url=local_proxy_root_url(fresh_settings),
-        auth_token=fresh_settings.anthropic_auth_token,
-    )
     restart = _restart_metadata(result["pending_fields"], request)
+    if not should_defer_claude_settings_sync(result["pending_fields"]):
+        fresh_settings = get_cached_settings()
+        sync_claude_settings(
+            proxy_root_url=local_proxy_root_url(fresh_settings),
+            auth_token=fresh_settings.anthropic_auth_token,
+        )
     result["restart"] = restart
     if restart["required"] and restart["automatic"]:
         callback = request.app.state.admin_restart_callback

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -14,10 +14,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from api.admin_urls import local_proxy_root_url
-from cli.claude_settings_sync import (
-    should_defer_claude_settings_sync,
-    sync_claude_settings,
-)
+from cli.claude_settings_sync import sync_claude_settings
 from config.settings import Settings
 from config.settings import get_settings as get_cached_settings
 from providers.registry import ProviderRegistry
@@ -123,13 +120,12 @@ async def apply_admin_config(
         return result
 
     get_cached_settings.cache_clear()
+    fresh_settings = get_cached_settings()
+    sync_claude_settings(
+        proxy_root_url=local_proxy_root_url(fresh_settings),
+        auth_token=fresh_settings.anthropic_auth_token,
+    )
     restart = _restart_metadata(result["pending_fields"], request)
-    if not should_defer_claude_settings_sync(result["pending_fields"]):
-        fresh_settings = get_cached_settings()
-        sync_claude_settings(
-            proxy_root_url=local_proxy_root_url(fresh_settings),
-            auth_token=fresh_settings.anthropic_auth_token,
-        )
     result["restart"] = restart
     if restart["required"] and restart["automatic"]:
         callback = request.app.state.admin_restart_callback

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -128,13 +128,18 @@ async def apply_admin_config(
     # fresh settings, so a pending HOST/PORT change never points workers at a
     # proxy that is not serving yet. The new address is written by the serve()
     # supervisor once the restarted server is live.
-    live_proxy_root_url = getattr(
-        request.app.state, "live_proxy_root_url", None
-    ) or local_proxy_root_url(fresh_settings)
-    sync_claude_settings(
-        proxy_root_url=live_proxy_root_url,
-        auth_token=fresh_settings.anthropic_auth_token,
-    )
+    # Skip persistent sync when the token comes only from the process environment
+    # (e.g. ANTHROPIC_AUTH_TOKEN=temp fcc-server) so shell-only secrets are never
+    # written into ~/.claude/settings.json and left there after the server restarts
+    # without that token.
+    if not fresh_settings.uses_process_anthropic_auth_token():
+        live_proxy_root_url = getattr(
+            request.app.state, "live_proxy_root_url", None
+        ) or local_proxy_root_url(fresh_settings)
+        sync_claude_settings(
+            proxy_root_url=live_proxy_root_url,
+            auth_token=fresh_settings.anthropic_auth_token,
+        )
     restart = _restart_metadata(result["pending_fields"], request)
     result["restart"] = restart
     if restart["required"] and restart["automatic"]:

--- a/api/admin_routes.py
+++ b/api/admin_routes.py
@@ -121,21 +121,20 @@ async def apply_admin_config(
         return result
 
     get_cached_settings.cache_clear()
-    # Defer the sync only while a HOST/PORT restart is actually pending: either
-    # from this apply (result["pending_fields"]) or from an earlier apply still
-    # awaiting a manual restart (app.state.admin_pending_fields). Writing the new
-    # address now would point agent workers at a proxy that is not serving yet.
-    # A pending restart is repaired by the serve() supervisor on the next start.
-    _RESTART_FIELDS = frozenset({"HOST", "PORT"})
-    pending_now = set(result["pending_fields"])
-    pending_before = set(getattr(request.app.state, "admin_pending_fields", []))
-    restart_pending = (pending_now | pending_before) & _RESTART_FIELDS
-    if not restart_pending:
-        fresh_settings = get_cached_settings()
-        sync_claude_settings(
-            proxy_root_url=local_proxy_root_url(fresh_settings),
-            auth_token=fresh_settings.anthropic_auth_token,
-        )
+    fresh_settings = get_cached_settings()
+    # Always sync so token changes reach agent workers immediately (the proxy
+    # validates the new token live, without a restart). Use the address the
+    # running proxy is actually bound to (captured at server start) rather than
+    # fresh settings, so a pending HOST/PORT change never points workers at a
+    # proxy that is not serving yet. The new address is written by the serve()
+    # supervisor once the restarted server is live.
+    live_proxy_root_url = getattr(
+        request.app.state, "live_proxy_root_url", None
+    ) or local_proxy_root_url(fresh_settings)
+    sync_claude_settings(
+        proxy_root_url=live_proxy_root_url,
+        auth_token=fresh_settings.anthropic_auth_token,
+    )
     restart = _restart_metadata(result["pending_fields"], request)
     result["restart"] = restart
     if restart["required"] and restart["automatic"]:

--- a/api/app.py
+++ b/api/app.py
@@ -20,6 +20,7 @@ from core.trace import extract_claude_session_id_from_headers, trace_event
 from providers.exceptions import ProviderError
 
 from .admin_routes import router as admin_router
+from .admin_urls import local_proxy_root_url
 from .routes import router
 from .runtime import AppRuntime, startup_failure_message
 from .validation_log import summarize_request_validation_body
@@ -97,6 +98,11 @@ def create_app(*, lifespan_enabled: bool = True) -> FastAPI:
     if lifespan_enabled:
         app_kwargs["lifespan"] = lifespan
     app = FastAPI(**app_kwargs)
+    # Record the address this app is bound to at startup so admin apply syncs
+    # ~/.claude/settings.json with the live proxy URL rather than a pending
+    # HOST/PORT that is not serving yet. The serve() supervisor refreshes this
+    # on each (re)start; entry points that bypass it still get a sane value here.
+    app.state.live_proxy_root_url = local_proxy_root_url(settings)
 
     @app.middleware("http")
     async def trace_http_correlation(request: Request, call_next):

--- a/cli/claude_settings_sync.py
+++ b/cli/claude_settings_sync.py
@@ -1,0 +1,83 @@
+"""Sync Free Claude Code proxy env into Claude Code settings.json."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from cli.claude_env import CLAUDE_CODE_AUTO_COMPACT_WINDOW, claude_auth_token
+from config.paths import claude_settings_path
+
+FCC_CLAUDE_ENV_KEYS = frozenset(
+    {
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+    }
+)
+
+
+def build_fcc_claude_env(proxy_root_url: str, auth_token: str) -> dict[str, str]:
+    """Return the FCC-managed Claude Code env keys for settings.json."""
+
+    return {
+        "ANTHROPIC_BASE_URL": proxy_root_url,
+        "ANTHROPIC_AUTH_TOKEN": claude_auth_token(auth_token),
+        "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW": CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+    }
+
+
+def sync_claude_settings(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    settings_path: Path | None = None,
+) -> bool:
+    """Merge FCC proxy env keys into Claude Code settings.json when needed."""
+
+    path = settings_path or claude_settings_path()
+    desired_fcc_env = build_fcc_claude_env(proxy_root_url, auth_token)
+
+    settings: dict[str, object] = {}
+    if path.is_file():
+        try:
+            parsed = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(parsed, dict):
+                settings = parsed
+            else:
+                print(
+                    f"Warning: {path} is not a JSON object; replacing with FCC env sync.",
+                    file=sys.stderr,
+                )
+        except json.JSONDecodeError as exc:
+            print(
+                f"Warning: {path} contains invalid JSON ({exc}); replacing with FCC env sync.",
+                file=sys.stderr,
+            )
+
+    existing_env = settings.get("env")
+    if not isinstance(existing_env, dict):
+        existing_env = {}
+
+    merged_env = dict(existing_env)
+    for key, value in desired_fcc_env.items():
+        merged_env[key] = value
+
+    updated_settings = dict(settings)
+    updated_settings["env"] = merged_env
+
+    if path.is_file() and settings == updated_settings:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(
+        json.dumps(updated_settings, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temp_path, path)
+    return True

--- a/cli/claude_settings_sync.py
+++ b/cli/claude_settings_sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import sys
 from pathlib import Path
 
@@ -19,6 +20,8 @@ FCC_CLAUDE_ENV_KEYS = frozenset(
     }
 )
 
+_SETTINGS_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR
+
 
 def build_fcc_claude_env(proxy_root_url: str, auth_token: str) -> dict[str, str]:
     """Return the FCC-managed Claude Code env keys for settings.json."""
@@ -31,53 +34,120 @@ def build_fcc_claude_env(proxy_root_url: str, auth_token: str) -> dict[str, str]
     }
 
 
+def should_defer_claude_settings_sync(pending_fields: list[str]) -> bool:
+    """Return whether Claude settings sync should wait until proxy restart."""
+
+    return "PORT" in pending_fields
+
+
+def _warn(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def _load_settings_object(path: Path) -> dict[str, object] | None:
+    if path.is_dir():
+        _warn(
+            f"Warning: {path} is a directory; skipping FCC Claude settings sync."
+        )
+        return None
+
+    if not path.is_file():
+        return {}
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _warn(
+            f"Warning: could not read {path} ({exc}); skipping FCC Claude settings sync."
+        )
+        return None
+    except UnicodeDecodeError as exc:
+        _warn(
+            f"Warning: {path} is not valid UTF-8 ({exc}); skipping FCC Claude settings sync."
+        )
+        return None
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _warn(
+            f"Warning: {path} contains invalid JSON ({exc}); skipping FCC Claude settings sync."
+        )
+        return None
+
+    if not isinstance(parsed, dict):
+        _warn(
+            f"Warning: {path} is not a JSON object; skipping FCC Claude settings sync."
+        )
+        return None
+
+    return parsed
+
+
+def _merge_fcc_env(
+    existing_env: dict[str, object], desired_fcc_env: dict[str, str]
+) -> dict[str, str]:
+    merged_env = {
+        key: value
+        for key, value in existing_env.items()
+        if isinstance(key, str)
+        and isinstance(value, str)
+        and not key.startswith("ANTHROPIC_")
+    }
+    merged_env.update(desired_fcc_env)
+    return merged_env
+
+
+def _restrict_settings_permissions(path: Path) -> None:
+    try:
+        os.chmod(path, _SETTINGS_FILE_MODE)
+    except OSError:
+        return
+
+
 def sync_claude_settings(
     *,
     proxy_root_url: str,
     auth_token: str,
     settings_path: Path | None = None,
 ) -> bool:
-    """Merge FCC proxy env keys into Claude Code settings.json when needed."""
+    """Merge FCC proxy env keys into Claude Code settings.json when needed.
+
+    Best-effort only: logs warnings and returns False instead of raising.
+    """
 
     path = settings_path or claude_settings_path()
     desired_fcc_env = build_fcc_claude_env(proxy_root_url, auth_token)
 
-    settings: dict[str, object] = {}
-    if path.is_file():
-        try:
-            parsed = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(parsed, dict):
-                settings = parsed
-            else:
-                print(
-                    f"Warning: {path} is not a JSON object; replacing with FCC env sync.",
-                    file=sys.stderr,
-                )
-        except json.JSONDecodeError as exc:
-            print(
-                f"Warning: {path} contains invalid JSON ({exc}); replacing with FCC env sync.",
-                file=sys.stderr,
-            )
+    settings = _load_settings_object(path)
+    if settings is None:
+        return False
 
     existing_env = settings.get("env")
     if not isinstance(existing_env, dict):
         existing_env = {}
 
-    merged_env = dict(existing_env)
-    for key, value in desired_fcc_env.items():
-        merged_env[key] = value
-
+    merged_env = _merge_fcc_env(existing_env, desired_fcc_env)
     updated_settings = dict(settings)
     updated_settings["env"] = merged_env
 
     if path.is_file() and settings == updated_settings:
         return False
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_suffix(path.suffix + ".tmp")
-    temp_path.write_text(
-        json.dumps(updated_settings, indent=2) + "\n",
-        encoding="utf-8",
-    )
-    os.replace(temp_path, path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_suffix(path.suffix + ".tmp")
+        temp_path.write_text(
+            json.dumps(updated_settings, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        _restrict_settings_permissions(temp_path)
+        os.replace(temp_path, path)
+        _restrict_settings_permissions(path)
+    except OSError as exc:
+        _warn(
+            f"Warning: could not write {path} ({exc}); skipping FCC Claude settings sync."
+        )
+        return False
+
     return True

--- a/cli/claude_settings_sync.py
+++ b/cli/claude_settings_sync.py
@@ -87,13 +87,13 @@ def _load_settings_object(path: Path) -> dict[str, object] | None:
 
 def _merge_fcc_env(
     existing_env: dict[str, object], desired_fcc_env: dict[str, str]
-) -> dict[str, str]:
-    merged_env = {
+) -> dict[str, object]:
+    merged_env: dict[str, object] = {
         key: value
         for key, value in existing_env.items()
         if isinstance(key, str)
-        and isinstance(value, str)
         and not key.startswith("ANTHROPIC_")
+        and key not in FCC_CLAUDE_ENV_KEYS
     }
     merged_env.update(desired_fcc_env)
     return merged_env
@@ -136,12 +136,16 @@ def sync_claude_settings(
         _restrict_settings_permissions(path)
         return False
 
+    # Resolve symlinks so os.replace writes to the real file, not the link path.
+    write_path = path.resolve() if path.is_symlink() else path
+
+    temp_path: Path | None = None
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
+        write_path.parent.mkdir(parents=True, exist_ok=True)
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
-            dir=path.parent,
+            dir=write_path.parent,
             prefix=".fcc-",
             suffix=".tmp",
             delete=False,
@@ -149,12 +153,18 @@ def sync_claude_settings(
             tmp_file.write(json.dumps(updated_settings, indent=2) + "\n")
             temp_path = Path(tmp_file.name)
         _restrict_settings_permissions(temp_path)
-        os.replace(temp_path, path)
-        _restrict_settings_permissions(path)
+        os.replace(temp_path, write_path)
+        temp_path = None  # successfully installed — do not unlink
+        _restrict_settings_permissions(write_path)
     except OSError as exc:
         _warn(
             f"Warning: could not write {path} ({exc}); skipping FCC Claude settings sync."
         )
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
         return False
 
     return True

--- a/cli/claude_settings_sync.py
+++ b/cli/claude_settings_sync.py
@@ -6,6 +6,7 @@ import json
 import os
 import stat
 import sys
+import tempfile
 from pathlib import Path
 
 from cli.claude_env import CLAUDE_CODE_AUTO_COMPACT_WINDOW, claude_auth_token
@@ -37,7 +38,7 @@ def build_fcc_claude_env(proxy_root_url: str, auth_token: str) -> dict[str, str]
 def should_defer_claude_settings_sync(pending_fields: list[str]) -> bool:
     """Return whether Claude settings sync should wait until proxy restart."""
 
-    return "PORT" in pending_fields
+    return bool({"HOST", "PORT"}.intersection(pending_fields))
 
 
 def _warn(message: str) -> None:
@@ -132,15 +133,21 @@ def sync_claude_settings(
     updated_settings["env"] = merged_env
 
     if path.is_file() and settings == updated_settings:
+        _restrict_settings_permissions(path)
         return False
 
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = path.with_suffix(path.suffix + ".tmp")
-        temp_path.write_text(
-            json.dumps(updated_settings, indent=2) + "\n",
+        with tempfile.NamedTemporaryFile(
+            mode="w",
             encoding="utf-8",
-        )
+            dir=path.parent,
+            prefix=".fcc-",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp_file:
+            tmp_file.write(json.dumps(updated_settings, indent=2) + "\n")
+            temp_path = Path(tmp_file.name)
         _restrict_settings_permissions(temp_path)
         os.replace(temp_path, path)
         _restrict_settings_permissions(path)

--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -45,6 +45,8 @@ def _load_env_template() -> str:
 
 def _sync_claude_settings_on_start(settings: Settings) -> None:
     """Best-effort: align ~/.claude/settings.json with this server's live address."""
+    if settings.uses_process_anthropic_auth_token():
+        return
     sync_claude_settings(
         proxy_root_url=local_proxy_root_url(settings),
         auth_token=settings.anthropic_auth_token,

--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -43,16 +43,6 @@ def _load_env_template() -> str:
     raise FileNotFoundError("Could not find bundled or source .env.example template.")
 
 
-def _sync_claude_settings_on_start(settings: Settings) -> None:
-    """Best-effort: align ~/.claude/settings.json with this server's live address."""
-    if settings.uses_process_anthropic_auth_token():
-        return
-    sync_claude_settings(
-        proxy_root_url=local_proxy_root_url(settings),
-        auth_token=settings.anthropic_auth_token,
-    )
-
-
 def serve() -> None:
     """Start the FastAPI server (registered as `fcc-server` script)."""
     opened_admin_browser = False
@@ -61,7 +51,6 @@ def serve() -> None:
             while True:
                 _migrate_legacy_env_if_missing()
                 settings = get_settings()
-                _sync_claude_settings_on_start(settings)
                 if not _run_supervised_server(
                     settings, open_admin_browser=not opened_admin_browser
                 ):
@@ -81,25 +70,36 @@ def _admin_browser_open_enabled() -> bool:
     return raw not in {"", "0", "false", "no"}
 
 
-def _schedule_open_admin_browser(settings: Settings) -> None:
-    """After /health succeeds, open the admin UI in the default browser (daemon thread)."""
+def _schedule_on_server_ready(settings: Settings, *, open_admin_browser: bool) -> None:
+    """After /health succeeds, sync ~/.claude/settings.json and optionally open the browser.
 
-    if not _admin_browser_open_enabled():
-        return
+    Runs in a daemon thread so the main server loop is not blocked. Syncing is
+    deferred until the server is confirmed reachable so that a failed bind does not
+    overwrite settings.json with a proxy URL that is not serving yet.
+    """
 
-    admin_url = local_admin_url(settings)
     proxy_root_url = local_proxy_root_url(settings)
+    should_open_browser = open_admin_browser and _admin_browser_open_enabled()
+    admin_url = local_admin_url(settings) if should_open_browser else ""
+    skip_sync = settings.uses_process_anthropic_auth_token()
+    auth_token = settings.anthropic_auth_token
 
-    def open_when_ready() -> None:
+    def on_ready() -> None:
         deadline = time.monotonic() + 30.0
         while time.monotonic() < deadline:
             if preflight_proxy(proxy_root_url) is None:
-                webbrowser.open(admin_url)
+                if should_open_browser:
+                    webbrowser.open(admin_url)
+                if not skip_sync:
+                    sync_claude_settings(
+                        proxy_root_url=proxy_root_url,
+                        auth_token=auth_token,
+                    )
                 return
             time.sleep(0.15)
 
     threading.Thread(
-        target=open_when_ready, name="fcc-open-admin-browser", daemon=True
+        target=on_ready, name="fcc-server-ready", daemon=True
     ).start()
 
 
@@ -128,8 +128,7 @@ def _run_supervised_server(settings: Settings, *, open_admin_browser: bool) -> b
     )
     server = uvicorn.Server(config)
     server_holder["server"] = server
-    if open_admin_browser:
-        _schedule_open_admin_browser(settings)
+    _schedule_on_server_ready(settings, open_admin_browser=open_admin_browser)
     server.run()
     return restart_requested
 

--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -13,6 +13,7 @@ import uvicorn
 
 from api.admin_urls import local_admin_url, local_proxy_root_url
 from api.app import GracefulLifespanApp, create_app
+from cli.claude_settings_sync import sync_claude_settings
 from cli.launchers.common import preflight_proxy
 from cli.process_registry import (
     kill_all_best_effort,
@@ -42,6 +43,14 @@ def _load_env_template() -> str:
     raise FileNotFoundError("Could not find bundled or source .env.example template.")
 
 
+def _sync_claude_settings_on_start(settings: Settings) -> None:
+    """Best-effort: align ~/.claude/settings.json with this server's live address."""
+    sync_claude_settings(
+        proxy_root_url=local_proxy_root_url(settings),
+        auth_token=settings.anthropic_auth_token,
+    )
+
+
 def serve() -> None:
     """Start the FastAPI server (registered as `fcc-server` script)."""
     opened_admin_browser = False
@@ -50,6 +59,7 @@ def serve() -> None:
             while True:
                 _migrate_legacy_env_if_missing()
                 settings = get_settings()
+                _sync_claude_settings_on_start(settings)
                 if not _run_supervised_server(
                     settings, open_admin_browser=not opened_admin_browser
                 ):

--- a/cli/entrypoints.py
+++ b/cli/entrypoints.py
@@ -115,6 +115,7 @@ def _run_supervised_server(settings: Settings, *, open_admin_browser: bool) -> b
 
     app = create_app(lifespan_enabled=False)
     app.state.admin_restart_callback = request_restart
+    app.state.live_proxy_root_url = local_proxy_root_url(settings)
     asgi_app = GracefulLifespanApp(app)
     config = uvicorn.Config(
         asgi_app,

--- a/cli/launchers/claude.py
+++ b/cli/launchers/claude.py
@@ -31,10 +31,11 @@ def launch(argv: Sequence[str] | None = None) -> None:
         print("Start it in another terminal with: fcc-server", file=sys.stderr)
         raise SystemExit(1)
 
-    sync_claude_settings(
-        proxy_root_url=proxy_root_url,
-        auth_token=settings.anthropic_auth_token,
-    )
+    if not settings.uses_process_anthropic_auth_token():
+        sync_claude_settings(
+            proxy_root_url=proxy_root_url,
+            auth_token=settings.anthropic_auth_token,
+        )
 
     binary_name = claude_binary_name(settings)
     binary_path = resolve_client_binary(

--- a/cli/launchers/claude.py
+++ b/cli/launchers/claude.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 
 from api.admin_urls import local_proxy_root_url
 from cli.claude_env import CLAUDE_CODE_AUTO_COMPACT_WINDOW, claude_auth_token
+from cli.claude_settings_sync import sync_claude_settings
 from config.settings import Settings, get_settings
 
 from .common import preflight_proxy, resolve_client_binary, run_client_process
@@ -29,6 +30,11 @@ def launch(argv: Sequence[str] | None = None) -> None:
         )
         print("Start it in another terminal with: fcc-server", file=sys.stderr)
         raise SystemExit(1)
+
+    sync_claude_settings(
+        proxy_root_url=proxy_root_url,
+        auth_token=settings.anthropic_auth_token,
+    )
 
     binary_name = claude_binary_name(settings)
     binary_path = resolve_client_binary(

--- a/config/paths.py
+++ b/config/paths.py
@@ -50,3 +50,9 @@ def codex_model_catalog_path() -> Path:
     """Return the generated Codex model catalog path."""
 
     return config_dir_path() / CODEX_MODEL_CATALOG_FILENAME
+
+
+def claude_settings_path() -> Path:
+    """Return Claude Code's user settings.json path."""
+
+    return Path.home() / ".claude" / "settings.json"

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -433,6 +433,40 @@ def test_admin_apply_restart_required_reports_manual_fallback(monkeypatch, tmp_p
     }
 
 
+def test_admin_apply_defers_claude_settings_sync_when_port_changes(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_app(lifespan_enabled=False)
+
+    with patch("api.admin_routes.sync_claude_settings") as sync_settings:
+        response = _local_client(app).post(
+            "/admin/api/config/apply",
+            json={"values": {"PORT": "9092"}},
+        )
+
+    assert response.status_code == 200
+    sync_settings.assert_not_called()
+
+
+def test_admin_apply_syncs_claude_settings_for_non_restart_fields(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_app(lifespan_enabled=False)
+
+    with patch("api.admin_routes.sync_claude_settings") as sync_settings:
+        response = _local_client(app).post(
+            "/admin/api/config/apply",
+            json={"values": {"ANTHROPIC_AUTH_TOKEN": "new-token"}},
+        )
+
+    assert response.status_code == 200
+    sync_settings.assert_called_once()
+
+
 def test_admin_process_env_values_are_locked_and_not_written(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -450,7 +450,7 @@ def test_admin_apply_defers_sync_when_only_port_changes(
     sync_settings.assert_not_called()
 
 
-def test_admin_apply_syncs_claude_settings_on_mixed_restart_and_non_restart_fields(
+def test_admin_apply_defers_sync_for_mixed_restart_and_non_restart_fields(
     monkeypatch, tmp_path
 ):
     _set_home(monkeypatch, tmp_path)
@@ -464,7 +464,9 @@ def test_admin_apply_syncs_claude_settings_on_mixed_restart_and_non_restart_fiel
         )
 
     assert response.status_code == 200
-    sync_settings.assert_called_once()
+    # PORT is a pending restart field, so the sync is deferred to the serve()
+    # supervisor after the new server is live; the token is applied then.
+    sync_settings.assert_not_called()
 
 
 def test_admin_apply_syncs_claude_settings_for_non_restart_fields(
@@ -482,6 +484,48 @@ def test_admin_apply_syncs_claude_settings_for_non_restart_fields(
 
     assert response.status_code == 200
     sync_settings.assert_called_once()
+
+
+def test_admin_apply_syncs_when_restart_field_submitted_unchanged(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_app(lifespan_enabled=False)
+    client = _local_client(app)
+
+    current_port = client.get("/admin/api/status").json()["port"]
+
+    with patch("api.admin_routes.sync_claude_settings") as sync_settings:
+        response = client.post(
+            "/admin/api/config/apply",
+            json={"values": {"PORT": str(current_port)}},
+        )
+
+    assert response.status_code == 200
+    # PORT submitted with its existing value yields no pending restart, so the
+    # sync must still run to repair a stale/missing settings.json.
+    sync_settings.assert_called_once()
+
+
+def test_admin_apply_defers_sync_when_restart_pending_from_previous_apply(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_app(lifespan_enabled=False)
+    app.state.admin_pending_fields = ["PORT"]
+
+    with patch("api.admin_routes.sync_claude_settings") as sync_settings:
+        response = _local_client(app).post(
+            "/admin/api/config/apply",
+            json={"values": {"ANTHROPIC_AUTH_TOKEN": "new-token"}},
+        )
+
+    assert response.status_code == 200
+    # A PORT restart from a previous apply is still pending, so a later
+    # token-only apply must defer to avoid writing a not-yet-serving address.
+    sync_settings.assert_not_called()
 
 
 def test_admin_process_env_values_are_locked_and_not_written(monkeypatch, tmp_path):

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -433,12 +433,13 @@ def test_admin_apply_restart_required_reports_manual_fallback(monkeypatch, tmp_p
     }
 
 
-def test_admin_apply_defers_sync_when_only_port_changes(
+def test_admin_apply_syncs_live_url_on_port_change(
     monkeypatch, tmp_path
 ):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)
     app = create_app(lifespan_enabled=False)
+    app.state.live_proxy_root_url = "http://127.0.0.1:8082"
 
     with patch("api.admin_routes.sync_claude_settings") as sync_settings:
         response = _local_client(app).post(
@@ -447,15 +448,19 @@ def test_admin_apply_defers_sync_when_only_port_changes(
         )
 
     assert response.status_code == 200
-    sync_settings.assert_not_called()
+    # The sync uses the live address the proxy is still bound to, not the new
+    # pending port, so agent workers never point at a not-yet-serving proxy.
+    sync_settings.assert_called_once()
+    assert sync_settings.call_args.kwargs["proxy_root_url"] == "http://127.0.0.1:8082"
 
 
-def test_admin_apply_defers_sync_for_mixed_restart_and_non_restart_fields(
+def test_admin_apply_syncs_token_with_live_url_on_mixed_fields(
     monkeypatch, tmp_path
 ):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)
     app = create_app(lifespan_enabled=False)
+    app.state.live_proxy_root_url = "http://127.0.0.1:8082"
 
     with patch("api.admin_routes.sync_claude_settings") as sync_settings:
         response = _local_client(app).post(
@@ -464,9 +469,12 @@ def test_admin_apply_defers_sync_for_mixed_restart_and_non_restart_fields(
         )
 
     assert response.status_code == 200
-    # PORT is a pending restart field, so the sync is deferred to the serve()
-    # supervisor after the new server is live; the token is applied then.
-    sync_settings.assert_not_called()
+    # Token reaches workers immediately (the sync runs now, not deferred), paired
+    # with the live (old) address so there is no auth failure and no premature
+    # port; the new port is written by the serve() supervisor after restart.
+    sync_settings.assert_called_once()
+    assert sync_settings.call_args.kwargs["proxy_root_url"] == "http://127.0.0.1:8082"
+    assert "auth_token" in sync_settings.call_args.kwargs
 
 
 def test_admin_apply_syncs_claude_settings_for_non_restart_fields(
@@ -508,12 +516,13 @@ def test_admin_apply_syncs_when_restart_field_submitted_unchanged(
     sync_settings.assert_called_once()
 
 
-def test_admin_apply_defers_sync_when_restart_pending_from_previous_apply(
+def test_admin_apply_syncs_live_url_when_restart_pending_from_previous_apply(
     monkeypatch, tmp_path
 ):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)
     app = create_app(lifespan_enabled=False)
+    app.state.live_proxy_root_url = "http://127.0.0.1:8082"
     app.state.admin_pending_fields = ["PORT"]
 
     with patch("api.admin_routes.sync_claude_settings") as sync_settings:
@@ -523,9 +532,12 @@ def test_admin_apply_defers_sync_when_restart_pending_from_previous_apply(
         )
 
     assert response.status_code == 200
-    # A PORT restart from a previous apply is still pending, so a later
-    # token-only apply must defer to avoid writing a not-yet-serving address.
-    sync_settings.assert_not_called()
+    # Even with a PORT restart pending from a previous apply, the token sync runs
+    # now against the live address, so the token stays current and the address
+    # keeps pointing at the proxy that is actually serving.
+    sync_settings.assert_called_once()
+    assert sync_settings.call_args.kwargs["proxy_root_url"] == "http://127.0.0.1:8082"
+    assert "auth_token" in sync_settings.call_args.kwargs
 
 
 def test_admin_process_env_values_are_locked_and_not_written(monkeypatch, tmp_path):

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -540,6 +540,26 @@ def test_admin_apply_syncs_live_url_when_restart_pending_from_previous_apply(
     assert "auth_token" in sync_settings.call_args.kwargs
 
 
+def test_admin_apply_skips_sync_when_token_from_process_env(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    # Simulate shell-only token: set in process env, not in any .env file
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "temp-shell-token")
+    app = create_app(lifespan_enabled=False)
+
+    with patch("api.admin_routes.sync_claude_settings") as sync_settings:
+        response = _local_client(app).post(
+            "/admin/api/config/apply",
+            json={"values": {"ANTHROPIC_AUTH_TOKEN": "temp-shell-token"}},
+        )
+
+    assert response.status_code == 200
+    # Shell-only token must never be persisted into ~/.claude/settings.json
+    sync_settings.assert_not_called()
+
+
 def test_admin_process_env_values_are_locked_and_not_written(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -433,7 +433,7 @@ def test_admin_apply_restart_required_reports_manual_fallback(monkeypatch, tmp_p
     }
 
 
-def test_admin_apply_syncs_claude_settings_on_port_change(
+def test_admin_apply_defers_sync_when_only_port_changes(
     monkeypatch, tmp_path
 ):
     _set_home(monkeypatch, tmp_path)
@@ -447,7 +447,7 @@ def test_admin_apply_syncs_claude_settings_on_port_change(
         )
 
     assert response.status_code == 200
-    sync_settings.assert_called_once()
+    sync_settings.assert_not_called()
 
 
 def test_admin_apply_syncs_claude_settings_on_mixed_restart_and_non_restart_fields(

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -433,7 +433,7 @@ def test_admin_apply_restart_required_reports_manual_fallback(monkeypatch, tmp_p
     }
 
 
-def test_admin_apply_defers_claude_settings_sync_when_port_changes(
+def test_admin_apply_syncs_claude_settings_on_port_change(
     monkeypatch, tmp_path
 ):
     _set_home(monkeypatch, tmp_path)
@@ -447,7 +447,24 @@ def test_admin_apply_defers_claude_settings_sync_when_port_changes(
         )
 
     assert response.status_code == 200
-    sync_settings.assert_not_called()
+    sync_settings.assert_called_once()
+
+
+def test_admin_apply_syncs_claude_settings_on_mixed_restart_and_non_restart_fields(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_app(lifespan_enabled=False)
+
+    with patch("api.admin_routes.sync_claude_settings") as sync_settings:
+        response = _local_client(app).post(
+            "/admin/api/config/apply",
+            json={"values": {"PORT": "9093", "ANTHROPIC_AUTH_TOKEN": "new-token"}},
+        )
+
+    assert response.status_code == 200
+    sync_settings.assert_called_once()
 
 
 def test_admin_apply_syncs_claude_settings_for_non_restart_fields(

--- a/tests/cli/test_claude_settings_sync.py
+++ b/tests/cli/test_claude_settings_sync.py
@@ -1,0 +1,177 @@
+"""Tests for cli/claude_settings_sync.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cli.claude_settings_sync import (
+    build_fcc_claude_env,
+    sync_claude_settings,
+)
+
+
+def _settings_path(home: Path) -> Path:
+    return home / ".claude" / "settings.json"
+
+
+def _redirect_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+
+def test_sync_creates_file_when_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+
+    changed = sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    assert changed is True
+    assert settings_path.is_file()
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["env"] == build_fcc_claude_env(
+        "http://127.0.0.1:8082",
+        "proxy-token",
+    )
+
+
+def test_sync_merges_without_clobbering_theme_and_other_env_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps(
+            {
+                "theme": "dark",
+                "env": {
+                    "CUSTOM_FLAG": "1",
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:8082",
+                    "ANTHROPIC_AUTH_TOKEN": "old-token",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="new-token",
+        settings_path=settings_path,
+    )
+
+    assert changed is True
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["theme"] == "dark"
+    assert payload["env"]["CUSTOM_FLAG"] == "1"
+    assert payload["env"]["ANTHROPIC_AUTH_TOKEN"] == "new-token"
+    assert payload["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+    assert payload["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+
+
+def test_sync_updates_when_port_or_token_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps(
+            {
+                "env": build_fcc_claude_env(
+                    "http://127.0.0.1:8082",
+                    "old-token",
+                )
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:9191",
+        auth_token="new-token",
+        settings_path=settings_path,
+    )
+
+    assert changed is True
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9191"
+    assert payload["env"]["ANTHROPIC_AUTH_TOKEN"] == "new-token"
+
+
+def test_sync_uses_fcc_no_auth_when_token_blank(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+
+    sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="",
+        settings_path=settings_path,
+    )
+
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["env"]["ANTHROPIC_AUTH_TOKEN"] == "fcc-no-auth"
+
+
+def test_sync_returns_false_when_already_up_to_date(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    desired_env = build_fcc_claude_env("http://127.0.0.1:8082", "proxy-token")
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps({"env": desired_env}),
+        encoding="utf-8",
+    )
+
+    changed = sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    assert changed is False
+    assert json.loads(settings_path.read_text(encoding="utf-8")) == {"env": desired_env}
+
+
+def test_sync_handles_invalid_json_gracefully(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text("{not-json", encoding="utf-8")
+
+    changed = sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    assert changed is True
+    assert "invalid JSON" in capsys.readouterr().err
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["env"] == build_fcc_claude_env(
+        "http://127.0.0.1:8082",
+        "proxy-token",
+    )

--- a/tests/cli/test_claude_settings_sync.py
+++ b/tests/cli/test_claude_settings_sync.py
@@ -253,6 +253,75 @@ def test_sync_restricts_settings_file_permissions(
     assert mode == stat.S_IRUSR | stat.S_IWUSR
 
 
-def test_should_defer_claude_settings_sync_when_port_changes() -> None:
+@pytest.mark.skipif(os.name == "nt", reason="Unix file modes are not enforced on Windows")
+def test_sync_hardens_permissions_on_up_to_date_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    desired_env = build_fcc_claude_env("http://127.0.0.1:8082", "proxy-token")
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps({"env": desired_env}), encoding="utf-8")
+    os.chmod(settings_path, 0o666)
+
+    changed = sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    assert changed is False
+    mode = stat.S_IMODE(settings_path.stat().st_mode)
+    assert mode == stat.S_IRUSR | stat.S_IWUSR
+
+
+def test_sync_uses_unique_temp_files_for_concurrent_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import threading
+
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+    temp_names: list[str] = []
+    original_replace = os.replace
+
+    def capturing_replace(src: str, dst: str) -> None:
+        temp_names.append(str(src))
+        original_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", capturing_replace)
+
+    barrier = threading.Barrier(2)
+
+    def sync_worker(token: str) -> None:
+        barrier.wait()
+        sync_claude_settings(
+            proxy_root_url="http://127.0.0.1:8082",
+            auth_token=token,
+            settings_path=settings_path,
+        )
+
+    threads = [
+        threading.Thread(target=sync_worker, args=("token-a",)),
+        threading.Thread(target=sync_worker, args=("token-b",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(temp_names) == 2
+    assert temp_names[0] != temp_names[1], "Concurrent syncs must use distinct temp files"
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["env"]["ANTHROPIC_AUTH_TOKEN"] in ("token-a", "token-b")
+
+
+def test_should_defer_claude_settings_sync_when_port_or_host_changes() -> None:
     assert should_defer_claude_settings_sync(["PORT"]) is True
+    assert should_defer_claude_settings_sync(["HOST"]) is True
+    assert should_defer_claude_settings_sync(["HOST", "PORT"]) is True
     assert should_defer_claude_settings_sync(["ANTHROPIC_AUTH_TOKEN"]) is False
+    assert should_defer_claude_settings_sync([]) is False

--- a/tests/cli/test_claude_settings_sync.py
+++ b/tests/cli/test_claude_settings_sync.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
+import stat
 from pathlib import Path
 
 import pytest
 
 from cli.claude_settings_sync import (
     build_fcc_claude_env,
+    should_defer_claude_settings_sync,
     sync_claude_settings,
 )
 
@@ -79,6 +82,40 @@ def test_sync_merges_without_clobbering_theme_and_other_env_keys(
     assert payload["env"]["ANTHROPIC_AUTH_TOKEN"] == "new-token"
     assert payload["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert payload["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+
+
+def test_sync_strips_stale_anthropic_env_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "CUSTOM_FLAG": "1",
+                    "ANTHROPIC_API_KEY": "official-key",
+                    "ANTHROPIC_API_URL": "https://api.anthropic.com/v1",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["env"]["CUSTOM_FLAG"] == "1"
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8082"
+    assert payload["env"]["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
+    assert "ANTHROPIC_API_KEY" not in payload["env"]
+    assert "ANTHROPIC_API_URL" not in payload["env"]
 
 
 def test_sync_updates_when_port_or_token_change(
@@ -152,7 +189,7 @@ def test_sync_returns_false_when_already_up_to_date(
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {"env": desired_env}
 
 
-def test_sync_handles_invalid_json_gracefully(
+def test_sync_skips_invalid_json_without_overwriting(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -160,7 +197,8 @@ def test_sync_handles_invalid_json_gracefully(
     _redirect_home(monkeypatch, tmp_path)
     settings_path = _settings_path(tmp_path)
     settings_path.parent.mkdir(parents=True)
-    settings_path.write_text("{not-json", encoding="utf-8")
+    original = "{not-json"
+    settings_path.write_text(original, encoding="utf-8")
 
     changed = sync_claude_settings(
         proxy_root_url="http://127.0.0.1:8082",
@@ -168,10 +206,53 @@ def test_sync_handles_invalid_json_gracefully(
         settings_path=settings_path,
     )
 
-    assert changed is True
-    assert "invalid JSON" in capsys.readouterr().err
-    payload = json.loads(settings_path.read_text(encoding="utf-8"))
-    assert payload["env"] == build_fcc_claude_env(
-        "http://127.0.0.1:8082",
-        "proxy-token",
+    assert changed is False
+    assert settings_path.read_text(encoding="utf-8") == original
+    assert "skipping FCC Claude settings sync" in capsys.readouterr().err
+
+
+def test_sync_skips_when_settings_path_is_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.mkdir(parents=True)
+
+    changed = sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
     )
+
+    assert changed is False
+    assert settings_path.is_dir()
+    assert "is a directory" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Unix file modes are not enforced on Windows")
+def test_sync_restricts_settings_file_permissions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    old_umask = os.umask(0)
+
+    try:
+        sync_claude_settings(
+            proxy_root_url="http://127.0.0.1:8082",
+            auth_token="proxy-token",
+            settings_path=settings_path,
+        )
+    finally:
+        os.umask(old_umask)
+
+    mode = stat.S_IMODE(settings_path.stat().st_mode)
+    assert mode == stat.S_IRUSR | stat.S_IWUSR
+
+
+def test_should_defer_claude_settings_sync_when_port_changes() -> None:
+    assert should_defer_claude_settings_sync(["PORT"]) is True
+    assert should_defer_claude_settings_sync(["ANTHROPIC_AUTH_TOKEN"]) is False

--- a/tests/cli/test_claude_settings_sync.py
+++ b/tests/cli/test_claude_settings_sync.py
@@ -325,3 +325,85 @@ def test_should_defer_claude_settings_sync_when_port_or_host_changes() -> None:
     assert should_defer_claude_settings_sync(["HOST", "PORT"]) is True
     assert should_defer_claude_settings_sync(["ANTHROPIC_AUTH_TOKEN"]) is False
     assert should_defer_claude_settings_sync([]) is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Symlinks require elevated privileges on Windows")
+def test_sync_follows_symlink_to_write_resolved_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    real_file = tmp_path / "dotfiles" / "claude_settings.json"
+    real_file.parent.mkdir(parents=True)
+    real_file.write_text(json.dumps({}), encoding="utf-8")
+
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.symlink_to(real_file)
+
+    sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    assert settings_path.is_symlink(), "symlink must not be replaced by a regular file"
+    payload = json.loads(real_file.read_text(encoding="utf-8"))
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8082"
+
+
+def test_sync_cleans_up_temp_file_on_replace_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+
+    def failing_replace(src: str, dst: str) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+
+    sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    leftover = list(settings_path.parent.glob(".fcc-*.tmp"))
+    assert leftover == [], f"Temp file(s) leaked: {leftover}"
+
+
+def test_sync_preserves_non_string_env_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _redirect_home(monkeypatch, tmp_path)
+    settings_path = _settings_path(tmp_path)
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "MY_FLAG": True,
+                    "TIMEOUT": 30,
+                    "SOME_STRING": "keep-me",
+                    "ANTHROPIC_BASE_URL": "old-url",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    sync_claude_settings(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        settings_path=settings_path,
+    )
+
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert payload["env"]["MY_FLAG"] is True
+    assert payload["env"]["TIMEOUT"] == 30
+    assert payload["env"]["SOME_STRING"] == "keep-me"
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8082"

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -284,11 +284,26 @@ def test_serve_syncs_claude_settings_on_each_start() -> None:
         ),
         patch.object(entrypoints, "kill_all_best_effort"),
         patch.object(entrypoints, "sync_claude_settings") as sync_settings,
+        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: False),
     ):
         entrypoints.serve()
 
     # One sync per server start: initial boot plus the post-restart boot.
     assert sync_settings.call_count == 2
+
+
+def test_serve_start_sync_skips_for_process_token() -> None:
+    from cli import entrypoints
+
+    settings = _launcher_settings()
+
+    with (
+        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: True),
+        patch.object(entrypoints, "sync_claude_settings") as sync_settings,
+    ):
+        entrypoints._sync_claude_settings_on_start(settings)
+
+    sync_settings.assert_not_called()
 
 
 def test_serve_migrates_legacy_env_before_loading_settings(tmp_path: Path) -> None:
@@ -391,6 +406,7 @@ def test_launch_claude_passes_args_and_child_env(
         patch("cli.launchers.claude.get_settings", return_value=settings),
         patch("cli.launchers.claude.preflight_proxy", return_value=None),
         patch("cli.launchers.claude.sync_claude_settings") as sync_settings,
+        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: False),
         patch("cli.launchers.common.shutil.which", return_value="resolved-claude.cmd"),
         patch("cli.launchers.common.subprocess.Popen") as popen,
         patch("cli.launchers.common.register_pid") as register_pid,
@@ -417,6 +433,34 @@ def test_launch_claude_passes_args_and_child_env(
     assert child_env["KEEP_ME"] == "yes"
     register_pid.assert_called_once_with(12345)
     unregister_pid.assert_called_once_with(12345)
+
+
+def test_launch_claude_skips_sync_when_token_from_process_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cli.launchers.claude import launch
+
+    settings = _launcher_settings(port=9191, token="proxy-token")
+
+    with (
+        patch("cli.launchers.claude.get_settings", return_value=settings),
+        patch("cli.launchers.claude.preflight_proxy", return_value=None),
+        patch("cli.launchers.claude.sync_claude_settings") as sync_settings,
+        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: True),
+        patch("cli.launchers.common.shutil.which", return_value="resolved-claude.cmd"),
+        patch("cli.launchers.common.subprocess.Popen") as popen,
+        patch("cli.launchers.common.register_pid"),
+        patch("cli.launchers.common.unregister_pid"),
+        pytest.raises(SystemExit),
+    ):
+        process = popen.return_value
+        process.pid = 12345
+        process.wait.return_value = 0
+        launch([])
+
+    sync_settings.assert_not_called()
+    child_env = popen.call_args.kwargs["env"]
+    assert child_env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
 
 
 def test_launch_codex_passes_responses_config_and_child_env(

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -253,6 +253,7 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
         patch.object(entrypoints.uvicorn, "Config", side_effect=fake_config),
         patch.object(entrypoints.uvicorn, "Server", side_effect=FakeServer),
         patch.object(entrypoints, "_schedule_open_admin_browser"),
+        patch.object(entrypoints, "sync_claude_settings"),
         patch.object(entrypoints, "kill_all_best_effort") as kill_all,
     ):
         entrypoints.serve()
@@ -260,6 +261,29 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
     assert len(servers) == 2
     get_settings.cache_clear.assert_called_once()
     kill_all.assert_called_once()
+
+
+def test_serve_syncs_claude_settings_on_each_start() -> None:
+    from cli import entrypoints
+
+    settings = _launcher_settings()
+    get_settings = MagicMock(return_value=settings)
+    get_settings.cache_clear = MagicMock()
+
+    with (
+        patch.object(entrypoints, "get_settings", get_settings),
+        patch.object(
+            entrypoints,
+            "_run_supervised_server",
+            side_effect=[True, False],
+        ),
+        patch.object(entrypoints, "kill_all_best_effort"),
+        patch.object(entrypoints, "sync_claude_settings") as sync_settings,
+    ):
+        entrypoints.serve()
+
+    # One sync per server start: initial boot plus the post-restart boot.
+    assert sync_settings.call_count == 2
 
 
 def test_serve_migrates_legacy_env_before_loading_settings(tmp_path: Path) -> None:
@@ -276,6 +300,7 @@ def test_serve_migrates_legacy_env_before_loading_settings(tmp_path: Path) -> No
         patch("pathlib.Path.home", return_value=tmp_path),
         patch.object(entrypoints, "get_settings", get_settings),
         patch.object(entrypoints, "_run_supervised_server", return_value=False),
+        patch.object(entrypoints, "sync_claude_settings"),
         patch.object(entrypoints, "kill_all_best_effort"),
     ):
         entrypoints.serve()
@@ -300,6 +325,7 @@ def test_serve_handles_keyboard_interrupt_without_traceback() -> None:
             "_run_supervised_server",
             side_effect=KeyboardInterrupt,
         ),
+        patch.object(entrypoints, "sync_claude_settings"),
         patch.object(entrypoints, "kill_all_best_effort") as kill_all,
     ):
         entrypoints.serve()

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -178,7 +178,7 @@ def test_cli_scripts_are_registered() -> None:
     assert scripts["fcc-codex"] == "cli.launchers.codex:launch"
 
 
-def test_schedule_open_admin_browser_opens_when_health_ready(
+def test_schedule_on_server_ready_opens_browser_when_health_ready(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Opening /admin runs after /health preflight succeeds."""
@@ -206,13 +206,15 @@ def test_schedule_open_admin_browser_opens_when_health_ready(
             side_effect=lambda url: opened_urls.append(url),
         ),
         patch.object(entrypoints.time, "sleep"),
+        patch.object(entrypoints, "sync_claude_settings"),
+        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: False),
     ):
-        entrypoints._schedule_open_admin_browser(settings)
+        entrypoints._schedule_on_server_ready(settings, open_admin_browser=True)
 
     assert opened_urls == [local_admin_url(settings)]
 
 
-def test_schedule_open_admin_browser_skips_when_disabled(
+def test_schedule_on_server_ready_skips_browser_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("FCC_OPEN_BROWSER", "0")
@@ -220,10 +222,14 @@ def test_schedule_open_admin_browser_skips_when_disabled(
 
     settings = _launcher_settings()
 
-    with patch.object(entrypoints.threading, "Thread") as thread_cls:
-        entrypoints._schedule_open_admin_browser(settings)
+    with (
+        patch.object(entrypoints.threading, "Thread") as thread_cls,
+        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: False),
+    ):
+        entrypoints._schedule_on_server_ready(settings, open_admin_browser=True)
 
-    thread_cls.assert_not_called()
+    # Thread is always started (for the settings sync); browser just won't open inside it.
+    thread_cls.assert_called_once()
 
 
 def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
@@ -252,7 +258,7 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
         patch.object(entrypoints, "get_settings", get_settings),
         patch.object(entrypoints.uvicorn, "Config", side_effect=fake_config),
         patch.object(entrypoints.uvicorn, "Server", side_effect=FakeServer),
-        patch.object(entrypoints, "_schedule_open_admin_browser"),
+        patch.object(entrypoints, "_schedule_on_server_ready"),
         patch.object(entrypoints, "sync_claude_settings"),
         patch.object(entrypoints, "kill_all_best_effort") as kill_all,
     ):
@@ -268,40 +274,51 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
     )
 
 
-def test_serve_syncs_claude_settings_on_each_start() -> None:
+def _make_sync_thread_class():
+    """Return a Thread replacement that runs target() synchronously in start()."""
+
+    class SyncThread:
+        def __init__(self, target, name="", daemon=False):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    return SyncThread
+
+
+def test_schedule_on_server_ready_syncs_when_server_reachable() -> None:
     from cli import entrypoints
 
     settings = _launcher_settings()
-    get_settings = MagicMock(return_value=settings)
-    get_settings.cache_clear = MagicMock()
 
     with (
-        patch.object(entrypoints, "get_settings", get_settings),
-        patch.object(
-            entrypoints,
-            "_run_supervised_server",
-            side_effect=[True, False],
-        ),
-        patch.object(entrypoints, "kill_all_best_effort"),
+        patch.object(entrypoints, "preflight_proxy", return_value=None),
         patch.object(entrypoints, "sync_claude_settings") as sync_settings,
+        patch.object(entrypoints.threading, "Thread", _make_sync_thread_class()),
         patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: False),
+        patch.object(entrypoints, "webbrowser"),
     ):
-        entrypoints.serve()
+        entrypoints._schedule_on_server_ready(settings, open_admin_browser=False)
 
-    # One sync per server start: initial boot plus the post-restart boot.
-    assert sync_settings.call_count == 2
+    sync_settings.assert_called_once_with(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="freecc",
+    )
 
 
-def test_serve_start_sync_skips_for_process_token() -> None:
+def test_schedule_on_server_ready_skips_sync_for_process_token() -> None:
     from cli import entrypoints
 
     settings = _launcher_settings()
 
     with (
-        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: True),
+        patch.object(entrypoints, "preflight_proxy", return_value=None),
         patch.object(entrypoints, "sync_claude_settings") as sync_settings,
+        patch.object(entrypoints.threading, "Thread", _make_sync_thread_class()),
+        patch.object(Settings, "uses_process_anthropic_auth_token", new=lambda self: True),
     ):
-        entrypoints._sync_claude_settings_on_start(settings)
+        entrypoints._schedule_on_server_ready(settings, open_admin_browser=False)
 
     sync_settings.assert_not_called()
 

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -359,6 +359,7 @@ def test_launch_claude_passes_args_and_child_env(
     with (
         patch("cli.launchers.claude.get_settings", return_value=settings),
         patch("cli.launchers.claude.preflight_proxy", return_value=None),
+        patch("cli.launchers.claude.sync_claude_settings") as sync_settings,
         patch("cli.launchers.common.shutil.which", return_value="resolved-claude.cmd"),
         patch("cli.launchers.common.subprocess.Popen") as popen,
         patch("cli.launchers.common.register_pid") as register_pid,
@@ -370,6 +371,10 @@ def test_launch_claude_passes_args_and_child_env(
         process.wait.return_value = 7
         launch(["--model", "sonnet"])
 
+    sync_settings.assert_called_once_with(
+        proxy_root_url="http://127.0.0.1:9191",
+        auth_token="proxy-token",
+    )
     assert exc_info.value.code == 7
     popen.assert_called_once()
     assert popen.call_args.args[0] == ["resolved-claude.cmd", "--model", "sonnet"]

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -261,6 +261,11 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
     assert len(servers) == 2
     get_settings.cache_clear.assert_called_once()
     kill_all.assert_called_once()
+    from api.admin_urls import local_proxy_root_url
+
+    assert servers[0].config.app.app.state.live_proxy_root_url == (
+        local_proxy_root_url(settings)
+    )
 
 
 def test_serve_syncs_claude_settings_on_each_start() -> None:

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -510,6 +510,7 @@ def test_launch_claude_keyboard_interrupt_kills_child_tree() -> None:
     with (
         patch("cli.launchers.claude.get_settings", return_value=settings),
         patch("cli.launchers.claude.preflight_proxy", return_value=None),
+        patch("cli.launchers.claude.sync_claude_settings"),
         patch("cli.launchers.common.shutil.which", return_value="resolved-claude.cmd"),
         patch("cli.launchers.common.subprocess.Popen") as popen,
         patch("cli.launchers.common.register_pid"),
@@ -536,6 +537,7 @@ def test_launch_claude_exits_when_command_cannot_be_resolved(
     with (
         patch("cli.launchers.claude.get_settings", return_value=settings),
         patch("cli.launchers.claude.preflight_proxy", return_value=None),
+        patch("cli.launchers.claude.sync_claude_settings"),
         patch("cli.launchers.common.shutil.which", return_value=None),
         patch("cli.launchers.common.subprocess.Popen") as popen,
         pytest.raises(SystemExit) as exc_info,


### PR DESCRIPTION
## Summary

- Add \cli/claude_settings_sync.py\ to merge FCC proxy \ANTHROPIC_*\ env into \~/.claude/settings.json\ \env\ block.
- Invoke sync on \cc-claude\ launch and on admin apply so agent daemon workers inherit proxy config.
- Add tests and README note.

## Test plan

- [ ] Run unit tests: \	ests/cli/test_claude_settings_sync.py\, \	ests/cli/test_entrypoints.py\
- [ ] Launch \cc-claude\ with proxy env configured; confirm \~/.claude/settings.json\ \env\ updated.
- [ ] Trigger agent workers; confirm no \/login\ prompt when proxy auth is valid.
- [ ] Admin apply path still syncs settings.

Fixes #880

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers `~/.claude/settings.json` writes until the proxy server is confirmed reachable, so a failed bind no longer corrupts agent worker config. It also unifies the admin-browser-open and settings-sync paths into a single `_schedule_on_server_ready` daemon thread.

- `_schedule_on_server_ready` replaces `_schedule_open_admin_browser`; it polls `/health` for up to 30 s before syncing or opening the browser, so a port-in-use error leaves `settings.json` intact.
- Admin apply now always syncs using the live (pre-restart) proxy URL (`app.state.live_proxy_root_url`) and skips sync when the token comes only from the process environment, preventing shell-only secrets from being persisted.

<h3>Confidence Score: 5/5</h3>

The core correctness goal — never writing settings.json before the server is confirmed live — is achieved cleanly; the only finding is an unused helper that should be removed.

The pre-bind sync problem is correctly solved: the daemon thread gates all writes on a successful /health poll, admin apply uses the captured live URL rather than the pending new address, and the process-token guard prevents shell secrets from being persisted. Test coverage is thorough across the new sync paths. The one leftover is should_defer_claude_settings_sync, which is defined, exported, and tested but no longer called from any production code — a dead-code cleanup, not a correctness issue.

cli/claude_settings_sync.py — should_defer_claude_settings_sync and its test in tests/cli/test_claude_settings_sync.py can be removed since the production call site was eliminated in this PR.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cli/claude_settings_sync.py | New module handling atomic settings writes with symlink resolution, temp-file cleanup, permission hardening, and best-effort error handling. should_defer_claude_settings_sync is defined and tested but no longer called from any production path after the admin-apply refactor. |
| cli/entrypoints.py | Core fix lands here: _schedule_open_admin_browser unified into _schedule_on_server_ready which defers all writes until /health succeeds, so a failed bind never overwrites settings.json. |
| api/admin_routes.py | Admin apply now always syncs using the live (pre-restart) proxy URL rather than deferring on pending_fields; skips sync when token is process-only. Clean implementation with appropriate fallback. |
| api/app.py | Captures live_proxy_root_url at app creation time; _run_supervised_server overrides it with the same value, providing a sane default for direct-ASGI entry points. |
| cli/launchers/claude.py | Sync added after preflight_proxy confirms the server is reachable; guarded by uses_process_anthropic_auth_token(). Correct placement. |
| tests/cli/test_claude_settings_sync.py | Comprehensive unit tests covering file creation, merge semantics, symlink handling, permission hardening, concurrent writes, temp-file cleanup, and invalid-JSON skip. Solid coverage. |
| tests/cli/test_entrypoints.py | Tests renamed and updated to match _schedule_on_server_ready; new cases for sync/skip-sync paths use a synchronous thread shim to exercise the callback body. Launcher tests correctly patch the sync function to avoid real file writes. |
| tests/api/test_admin.py | New tests exercise live-URL sync on port change, mixed-field applies, unchanged-PORT applies, previous-restart-pending applies, and process-token skip. Good edge-case coverage. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant serve as serve() loop
    participant rss as _run_supervised_server
    participant thread as fcc-server-ready thread
    participant health as /health
    participant sync as sync_claude_settings
    participant fs as ~/.claude/settings.json

    serve->>rss: "open_admin_browser=True"
    rss->>rss: set app.state.live_proxy_root_url
    rss->>thread: _schedule_on_server_ready(settings)
    rss->>rss: server.run() [blocks]
    thread->>health: preflight_proxy() poll (30s)
    health-->>thread: None (reachable)
    thread->>sync: proxy_root_url, auth_token
    sync->>fs: atomic write (temp + replace)
    Note over serve,fs: Admin apply path
    participant admin as /admin/api/config/apply
    admin->>admin: write_managed_env()
    admin->>admin: cache_clear() + get fresh settings
    admin->>sync: live_proxy_root_url (not pending port)
    sync->>fs: atomic write
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant serve as serve() loop
    participant rss as _run_supervised_server
    participant thread as fcc-server-ready thread
    participant health as /health
    participant sync as sync_claude_settings
    participant fs as ~/.claude/settings.json

    serve->>rss: "open_admin_browser=True"
    rss->>rss: set app.state.live_proxy_root_url
    rss->>thread: _schedule_on_server_ready(settings)
    rss->>rss: server.run() [blocks]
    thread->>health: preflight_proxy() poll (30s)
    health-->>thread: None (reachable)
    thread->>sync: proxy_root_url, auth_token
    sync->>fs: atomic write (temp + replace)
    Note over serve,fs: Admin apply path
    participant admin as /admin/api/config/apply
    admin->>admin: write_managed_env()
    admin->>admin: cache_clear() + get fresh settings
    admin->>sync: live_proxy_root_url (not pending port)
    sync->>fs: atomic write
```

</a>

<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (4)</h3>

1. `tests/cli/test_entrypoints.py`, line 510-524 ([link](https://github.com/alishahryar1/free-claude-code/blob/1ce54d11e7a97d2151c3f7d37b3f5f636a40dceb/tests/cli/test_entrypoints.py#L510-L524)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mock settings sync** in the launcher entrypoint tests that should not touch user state. With this PR, `launch([])` calls the real `sync_claude_settings()` before reaching the patched `Popen` path, and the command-resolution failure test also writes settings before `resolve_client_binary()` returns `None`. These tests do not redirect `HOME` or patch the sync function, so running them can mutate the test runner's real `~/.claude/settings.json` while they are only trying to assert launch behavior. Patch `cli.launchers.claude.sync_claude_settings` or redirect `HOME` for these test cases.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused launcher harness mirroring the affected test without patching settings sync](https://app.greptile.com/trex/artifacts/24557e78-4dad-41eb-8ca3-946b55aa6f13)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: harness output showing fake HOME settings.json creation and synced env contents](https://app.greptile.com/trex/artifacts/9c36736b-d76d-40e1-a4c8-5260d1af1458)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11702288/artifacts?artifact=24557e78-4dad-41eb-8ca3-946b55aa6f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. `api/admin_routes.py`, line 144 ([link](https://github.com/alishahryar1/free-claude-code/blob/bfd99ec7c8458cae4b0158cc0c195cce9625bf25/api/admin_routes.py#L144)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Keep restart pending** until the automatic restart has actually completed. This branch queues the restart callback as a background task, then immediately clears `admin_pending_fields`. If a HOST/PORT apply is followed by another apply while the old server is still running, or if the callback fails/cannot bind the new address, later token-only applies see no pending restart and can sync `~/.claude/settings.json` to the not-yet-serving address. Keep the pending restart state until the supervisor has confirmed the restart, or track a restart-in-progress state that still blocks settings sync.

3. `api/admin_routes.py`, line 141-145 ([link](https://github.com/alishahryar1/free-claude-code/blob/bfd99ec7c8458cae4b0158cc0c195cce9625bf25/api/admin_routes.py#L141-L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Keep restart pending** until the automatic restart has actually succeeded. This branch clears `admin_pending_fields` immediately after scheduling the background callback, before `_invoke_admin_restart_callback()` runs. If that callback raises or fails to make the supervisor restart, or if another Admin apply is processed during that window, the sync guard no longer sees the pending `HOST`/`PORT` restart and can write `~/.claude/settings.json` with the new address even though the old server is still the one serving traffic. Keep the pending fields until the restart callback completes and the new server is live, or track a separate restart-in-progress state for the sync guard.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: executable admin apply harness with failing restart callback and isolated HOME](https://app.greptile.com/trex/artifacts/97e4ec74-b14d-40d9-943b-0464655b5542)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: command output showing callback failure, cleared pending fields, and settings.json written with new port](https://app.greptile.com/trex/artifacts/b07587ec-9050-4131-b969-8de278708758)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11705565/artifacts?artifact=97e4ec74-b14d-40d9-943b-0464655b5542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. `api/app.py`, line 101-105 ([link](https://github.com/alishahryar1/free-claude-code/blob/2fbb799edd1419e15b74a98a3971f8d42adb8df1/api/app.py#L101-L105)) 

   **Avoid guessed live URL**. This stores a proxy URL derived from `Settings`, but the supported direct ASGI path can bind uvicorn with CLI overrides, for example `uvicorn server:app --port 9090` while the config still says `8082`. Admin apply later trusts `app.state.live_proxy_root_url` and syncs `~/.claude/settings.json` to the configured port, so agent workers can be pointed at a proxy URL that is not actually serving. Use an address captured from the serving path/request context, or skip this fallback when the supervisor did not set the live URL.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused runtime harness for direct ASGI admin apply live URL mismatch](https://app.greptile.com/trex/artifacts/b8340750-526e-402d-af98-d024197c25b0)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: runtime output showing HTTP 200 OK and synced configured-port URL despite actual request port 9090](https://app.greptile.com/trex/artifacts/9163a276-433f-40a1-b57d-05b461fbf6a3)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11706283/artifacts?artifact=b8340750-526e-402d-af98-d024197c25b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
<!-- /greptile_failed_comments -->

<sub>Reviews (14): Last reviewed commit: ["fix: defer settings sync until server is..."](https://github.com/alishahryar1/free-claude-code/commit/7fcb5e803af3236448aa85f8c9bdd32a3ad9369a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38775601)</sub>

<!-- /greptile_comment -->