### PR TITLE
feat: Installer windows add functions to persist PATH entries and include uv tool bin directory

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -73,6 +73,43 @@ function Invoke-UvInstaller {
     }
 }
 
+function Add-PersistedPathEntry {
+    param([string] $PathEntry)
+
+    if ($DryRun) {
+        Write-Host "+ [PATH] would persist '$PathEntry' to your permanent user PATH"
+        return
+    }
+
+    try {
+        $separator = [IO.Path]::PathSeparator
+        $persistedPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::User)
+
+        $persistedEntries = @()
+        if (-not [string]::IsNullOrEmpty($persistedPath)) {
+            $persistedEntries = $persistedPath -split [regex]::Escape([string] $separator)
+        }
+
+        if ($persistedEntries -contains $PathEntry) {
+            return
+        }
+
+        $newPersistedPath = if ([string]::IsNullOrEmpty($persistedPath)) {
+            $PathEntry
+        }
+        else {
+            "$persistedPath$separator$PathEntry"
+        }
+
+        [Environment]::SetEnvironmentVariable("Path", $newPersistedPath, [EnvironmentVariableTarget]::User)
+        Write-Host "Persisted '$PathEntry' to your permanent user PATH."
+    }
+    catch {
+        Write-Host "Warning: could not persist '$PathEntry' to your permanent PATH automatically ($($_.Exception.Message))."
+        Write-Host "Add it manually via System Properties > Environment Variables if commands aren't found in new terminals."
+    }
+}
+
 function Add-PathEntry {
     param([string] $PathEntry)
 
@@ -89,11 +126,32 @@ function Add-PathEntry {
     if ($entries -notcontains $PathEntry) {
         $env:Path = "$PathEntry$separator$env:Path"
     }
+
+    # Make the change permanent too, not just for this running process.
+    Add-PersistedPathEntry $PathEntry
 }
 
 function Add-UvToPath {
     Add-PathEntry (Join-Path $HOME ".local\bin")
     Add-PathEntry (Join-Path $HOME ".cargo\bin")
+}
+
+function Add-UvToolBinDirToPath {
+    if ($DryRun) {
+        return
+    }
+
+    $probe = Invoke-ProbeCommand -FilePath "uv" -Arguments @("tool", "dir", "--bin")
+    if ($probe.ExitCode -ne 0) {
+        return
+    }
+
+    $toolBinDir = $probe.Output.Trim()
+    if ([string]::IsNullOrWhiteSpace($toolBinDir)) {
+        return
+    }
+
+    Add-PathEntry $toolBinDir
 }
 
 function Assert-CommandAvailable {
@@ -370,6 +428,8 @@ function Get-PackageSpec {
 }
 
 function Install-FreeClaudeCode {
+    Add-UvToolBinDirToPath
+
     $packageSpec = Get-PackageSpec
     $toolArgs = @("tool", "install", "--force")
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates the Windows installer to persist PATH entries in the user environment.
- Adds uv tool executable directory detection via `uv tool dir --bin`.
- Adds the uv tool bin directory before installing or updating Free Claude Code.

<h3>Confidence Score: 3/5</h3>

The installer changes are localized, but the PATH persistence behavior needs attention before merging.

The review focuses on one changed script and identifies several concrete control-flow and PATH-handling risks around permanent user environment mutation.

scripts/install.ps1

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a dry-run harness to compare installer behavior, but PowerShell pwsh was not installed and apt installation was blocked due to permission to lock apt directories.
- T-Rex retried PATH after an install attempt using a fake uv shim, but PowerShell remained unavailable, so the harness and fake uv script were saved for rerun in a PowerShell-enabled environment.
- T-Rex ran the requested verification, but its local artifact references were not uploaded.
- T-Rex performed separate PATH scope checks and found pwsh and Windows PowerShell were not available; an attempt to install PowerShell via apt failed because the package was not found.
- T-Rex observed PATH changes, with a base path entry being added before the run and a persistent path printed after the head run, while the USER\_PATH remained empty.
- T-Rex documented that the before- and after-path artifact excerpts do not prove the intended PowerShell behavior because they do not execute the changed PowerShell functions.

<a href="https://app.greptile.com/trex/runs/11731597/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `scripts/install.ps1`, line 430-442 ([link](https://github.com/alishahryar1/free-claude-code/blob/89bce9ef24d0624020ba951e12524ea565ddbba0/scripts/install.ps1#L430-L442)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Retry PATH after install**

   The uv tool bin directory is only added before `uv tool install` runs. If that pre-install probe fails or returns nothing, the tool can still install successfully, but the installer never retries the PATH persistence afterward. New terminals can then fail to find `fcc-server`, `fcc-claude`, or `fcc-codex` despite the success message.

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: add functions to persist PATH entr..."](https://github.com/alishahryar1/free-claude-code/commit/89bce9ef24d0624020ba951e12524ea565ddbba0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38823443)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->