### PR TITLE
Update install command for macOS/Linux to use sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Free Claude Code routes Anthropic Messages API traffic from Claude Code (CLI and
 macOS/Linux:
 
 ```bash
-curl -fsSL "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh?raw=1" | sh
+curl -fsSL "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh?raw=1" | sudo sh
 ```
 
 Windows PowerShell:


### PR DESCRIPTION
Hi! First of all, thank you for the great project. 

I am submitting this PR to fix a common permission issue that occurs during the installation process on macOS and standard Linux environments.

**The Problem**
When running the currently documented installation command (`curl ... | sh`), the script eventually triggers `npm install -g @openai/codex`. On systems where npm is installed globally without `nvm` (Node Version Manager), writing to `/usr/local/lib/node_modules` requires root privileges. Because the script is executed by the standard user, npm throws an `EACCES: permission denied` error and the installation fails.

**Why the intuitive workaround fails**
When users see a permission error, their first instinct is often to run `sudo curl ... | sh`. However, because of how pipes work, `sudo` only applies to the `curl` command (the download), while the actual installation script (`sh`) is still executed without root privileges, resulting in the exact same `EACCES` error.

**The Solution**
I have updated the `README.md` to change the installation command to:
`curl -fsSL "..." | sudo sh`

By moving `sudo` after the pipe, we ensure that the shell script itself runs with elevated privileges, allowing npm to successfully install the global package without throwing permission errors. 

Let me know if you'd prefer handling this via a root privilege check inside `install.sh` instead! Best regards.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates the macOS/Linux Quick Start install command in `README.md`.
- Changes the command to pipe the downloaded installer into `sudo sh` so the shell script runs with elevated privileges.

<h3>Confidence Score: 4/5</h3>

The README install command changes affect the main installation path and optional voice installation paths in ways that can break user-scoped installs and broaden privilege exposure.

The changed command is small and localized, and the installer behavior is straightforward enough to assess directly from the documented shell flows.

README.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a generated safe harness to simulate a root-like install environment and verified the installer wrote fcc-server, fcc-claude, and fcc-codex under the root-like HOME .local/bin, with those binaries absent from the normal user's HOME/PATH.
- Demonstrated that the curl ... | sh flow executes as non-root uid 1001 and as root uid 0, showing arbitrary fetched script content can run as root.
- Showed the installer detects a fake nvm npm on PATH and that the normal path uses it to halt before installing, while the sudo-like path empties npm so the install fails with a message that npm is required.
- Validated that the voice install pipeline attempts a global npm install and encounters an EACCES error, exiting the process with code 243.
- Compared readme install command blocks before and after, showing the same macOS/Linux command ending with | sh and later with | sudo sh, supported by a command-extraction script.

<a href="https://app.greptile.com/trex/runs/11752395/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `README.md`, line 518-527 ([link](https://github.com/alishahryar1/free-claude-code/blob/0e2b4e009e005cc8e230fe863bc4b6386cafebe0/README.md#L518-L527)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Voice commands unchanged**

   The optional voice install commands still pipe the same installer into plain `sh -s`. On a fresh system, `install.sh` always runs the Claude/Codex npm install steps before applying the voice extras, so users following these documented commands can still hit the same global npm `EACCES` failure this PR is trying to avoid. Update these sibling install commands consistently or move the privilege handling into the installer itself.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: shell harness for mocked voice install pipeline with npm EACCES](https://app.greptile.com/trex/artifacts/6c8f3705-921a-4b78-97b5-0edfdc478f45)**

   - Contains supporting evidence from the run (text/x-shellscript; charset=utf-8).

   **[Repro: terminal output showing npm EACCES before voice extras](https://app.greptile.com/trex/artifacts/dc0081b8-4466-494c-843a-4d87d99c697b)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11752395/artifacts?artifact=6c8f3705-921a-4b78-97b5-0edfdc478f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Update install command for macOS/Linux t..."](https://github.com/alishahryar1/free-claude-code/commit/0e2b4e009e005cc8e230fe863bc4b6386cafebe0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38852695)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->