### PR TITLE
Add permission checks for npm global installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,7 +206,14 @@ install_claude_if_missing() {
     fi
 
     require_command npm
-    run npm install -g @anthropic-ai/claude-code
+
+    npm_root=$(npm root -g 2>/dev/null || echo "/usr/local/lib/node_modules")
+    if [ -w "$npm_root" ] || [ -w "${npm_root%/*}" ]; then
+        run npm install -g @anthropic-ai/claude-code
+    else
+        printf 'Global npm directory (%s) is not writable. Elevating privileges with sudo...\n' "$npm_root"
+        run sudo npm install -g @anthropic-ai/claude-code
+    fi
 }
 
 install_codex_if_missing() {
@@ -216,7 +223,14 @@ install_codex_if_missing() {
     fi
 
     require_command npm
-    run npm install -g @openai/codex
+
+    npm_root=$(npm root -g 2>/dev/null || echo "/usr/local/lib/node_modules")
+    if [ -w "$npm_root" ] || [ -w "${npm_root%/*}" ]; then
+        run npm install -g @openai/codex
+    else
+        printf 'Global npm directory (%s) is not writable. Elevating privileges with sudo...\n' "$npm_root"
+        run sudo npm install -g @openai/codex
+    fi
 }
 
 install_or_update_uv() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -207,12 +207,22 @@ install_claude_if_missing() {
 
     require_command npm
 
-    npm_root=$(npm root -g 2>/dev/null || echo "/usr/local/lib/node_modules")
-    if [ -w "$npm_root" ] || [ -w "${npm_root%/*}" ]; then
+    if [ "$dry_run" -eq 1 ]; then
         run npm install -g @anthropic-ai/claude-code
+        return 0
+    fi
+
+    npm_path=$(command -v npm)
+    npm_root=$("$npm_path" root -g 2>/dev/null || echo "/usr/local/lib/node_modules")
+    npm_prefix=$("$npm_path" config get prefix 2>/dev/null || echo "/usr/local")
+    npm_bin="$npm_prefix/bin"
+
+    if [ -w "$npm_root" ] && [ -w "$npm_bin" ]; then
+        run "$npm_path" install -g @anthropic-ai/claude-code
     else
-        printf 'Global npm directory (%s) is not writable. Elevating privileges with sudo...\n' "$npm_root"
-        run sudo npm install -g @anthropic-ai/claude-code
+        command -v sudo >/dev/null 2>&1 || fail "Global npm directories are not writable and sudo is missing. Please fix permissions manually."
+        printf 'Global npm directories are not writable. Elevating privileges with sudo...\n'
+        run sudo env "PATH=$PATH" "$npm_path" install -g @anthropic-ai/claude-code
     fi
 }
 
@@ -224,12 +234,22 @@ install_codex_if_missing() {
 
     require_command npm
 
-    npm_root=$(npm root -g 2>/dev/null || echo "/usr/local/lib/node_modules")
-    if [ -w "$npm_root" ] || [ -w "${npm_root%/*}" ]; then
+    if [ "$dry_run" -eq 1 ]; then
         run npm install -g @openai/codex
+        return 0
+    fi
+
+    npm_path=$(command -v npm)
+    npm_root=$("$npm_path" root -g 2>/dev/null || echo "/usr/local/lib/node_modules")
+    npm_prefix=$("$npm_path" config get prefix 2>/dev/null || echo "/usr/local")
+    npm_bin="$npm_prefix/bin"
+
+    if [ -w "$npm_root" ] && [ -w "$npm_bin" ]; then
+        run "$npm_path" install -g @openai/codex
     else
-        printf 'Global npm directory (%s) is not writable. Elevating privileges with sudo...\n' "$npm_root"
-        run sudo npm install -g @openai/codex
+        command -v sudo >/dev/null 2>&1 || fail "Global npm directories are not writable and sudo is missing. Please fix permissions manually."
+        printf 'Global npm directories are not writable. Elevating privileges with sudo...\n'
+        run sudo env "PATH=$PATH" "$npm_path" install -g @openai/codex
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -199,6 +199,14 @@ update_existing_uv() {
     fail "uv $MIN_UV_VERSION or newer is required; found uv $version. The existing uv install source was not detected. Upgrade uv manually with the package manager that installed it, then rerun this installer."
 }
 
+is_writable() {
+    _target="$1"
+    while [ -n "$_target" ] && [ ! -d "$_target" ]; do
+        _target="${_target%/*}"
+    done
+    [ -w "${_target:-/}" ]
+}
+
 install_claude_if_missing() {
     if command -v claude >/dev/null 2>&1; then
         printf 'Claude Code already found on PATH; skipping install.\n'
@@ -217,12 +225,13 @@ install_claude_if_missing() {
     npm_prefix=$("$npm_path" config get prefix 2>/dev/null || echo "/usr/local")
     npm_bin="$npm_prefix/bin"
 
-    if [ -w "$npm_root" ] && [ -w "$npm_bin" ]; then
+    if is_writable "$npm_root" && is_writable "$npm_bin"; then
         run "$npm_path" install -g @anthropic-ai/claude-code
     else
         command -v sudo >/dev/null 2>&1 || fail "Global npm directories are not writable and sudo is missing. Please fix permissions manually."
         printf 'Global npm directories are not writable. Elevating privileges with sudo...\n'
-        run sudo env "PATH=$PATH" "$npm_path" install -g @anthropic-ai/claude-code
+        npm_dir="${npm_path%/*}"
+        run sudo env "PATH=$npm_dir:/usr/bin:/bin:/usr/sbin:/sbin" "$npm_path" install -g @anthropic-ai/claude-code
     fi
 }
 
@@ -244,12 +253,13 @@ install_codex_if_missing() {
     npm_prefix=$("$npm_path" config get prefix 2>/dev/null || echo "/usr/local")
     npm_bin="$npm_prefix/bin"
 
-    if [ -w "$npm_root" ] && [ -w "$npm_bin" ]; then
+    if is_writable "$npm_root" && is_writable "$npm_bin"; then
         run "$npm_path" install -g @openai/codex
     else
         command -v sudo >/dev/null 2>&1 || fail "Global npm directories are not writable and sudo is missing. Please fix permissions manually."
         printf 'Global npm directories are not writable. Elevating privileges with sudo...\n'
-        run sudo env "PATH=$PATH" "$npm_path" install -g @openai/codex
+        npm_dir="${npm_path%/*}"
+        run sudo env "PATH=$npm_dir:/usr/bin:/bin:/usr/sbin:/sbin" "$npm_path" install -g @openai/codex
     fi
 }
 


### PR DESCRIPTION
Type of Change:
Bug fix (non-breaking change which fixes an issue)
The Problem:
The previous attempt to fix the global npm EACCES permission error suggested running the entire installation script with sudo sh. As pointed out during the review, this introduces security risks, breaks user-scoped tool paths (like uv installing to root's home directory), and can regress environment paths for nvm users.
The Solution:
Reverted the global sudo sh installation command in README.md to keep the initial remote script execution safe and user-scoped.
Moved the privilege escalation logic directly inside scripts/install.sh.
Updated install_claude_if_missing and install_codex_if_missing functions to dynamically check if the global npm root directory is writable ([ -w ]).
The script now only uses sudo for the specific npm install -g commands if the current user lacks write permissions, keeping setups like nvm unaffected and the overall installation process safe.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates `scripts/install.sh` to handle npm global install permissions inside the installer.
- Adds writable-target checks for npm global root/bin locations before choosing normal install versus sudo fallback.
- Keeps dry-run behavior passive for npm install paths and uses the resolved npm executable for Claude Code and Codex installs.

<h3>Confidence Score: 5/5</h3>

The installer changes are narrowly scoped to npm global install permission handling and do not introduce broader behavior changes.

No code issues were identified in the changed installer logic.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline run confirmed that npm install -g was invoked plainly for both packages, with no npm root or config probing, covering non-writable and sudo-missing scenarios.
- In writable claude/codex environments, T-Rex probed npm root -g and npm config get prefix, then ran npm install -g without sudo.
- In non-writable root/bin scenarios, T-Rex used a sudo PATH override to run npm install -g for claude/codex, observed sudo-missing exit with a clear error, and performed a dry-run showing + npm install -g @anthropic-ai/claude-code with no fake npm/sudo log entries.

<a href="https://app.greptile.com/trex/runs/11790014/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Update install.sh"](https://github.com/alishahryar1/free-claude-code/commit/2572f06661657e01fbd9ab1fdbcd26c9d0aa56f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38906819)</sub>

<!-- /greptile_comment -->