### PR TITLE
Fix DeepSeek V4 reasoning handling and tool-call ordering

### DIFF
--- a/core/anthropic/conversion.py
+++ b/core/anthropic/conversion.py
@@ -124,6 +124,9 @@ class _PendingAfterTools:
     def needs_deferred(self) -> bool:
         return bool(self.deferred_blocks) and not self.deferred_emitted
 
+    def awaits_tool_results(self) -> bool:
+        return bool(self.remaining_tool_ids)
+
 
 def _index_first_tool_use(blocks: list[Any]) -> int | None:
     for i, block in enumerate(blocks):
@@ -247,7 +250,9 @@ class AnthropicToOpenAIConverter:
                 result.append(converted)
             elif isinstance(content, list):
                 if role == "user":
-                    if pending is not None and pending.needs_deferred():
+                    if pending is not None and (
+                        pending.needs_deferred() or pending.awaits_tool_results()
+                    ):
                         if not pending.remaining_tool_ids:
                             result.extend(
                                 AnthropicToOpenAIConverter._deferred_post_tool_to_messages(
@@ -332,13 +337,13 @@ class AnthropicToOpenAIConverter:
         pre_msg["tool_calls"] = tool_calls
         if tool_calls and pre_msg.get("content") == " ":
             pre_msg["content"] = ""
+        res_ids: set[str] = set()
+        for tc in tool_calls:
+            tid = tc.get("id")
+            if tid is not None and str(tid).strip() != "":
+                res_ids.add(str(tid))
         pnd: _PendingAfterTools | None = None
-        if deferred_blocks:
-            res_ids: set[str] = set()
-            for tc in tool_calls:
-                tid = tc.get("id")
-                if tid is not None and str(tid).strip() != "":
-                    res_ids.add(str(tid))
+        if res_ids or deferred_blocks:
             pnd = _PendingAfterTools(
                 remaining_tool_ids=res_ids,
                 deferred_blocks=deferred_blocks,
@@ -413,7 +418,7 @@ class AnthropicToOpenAIConverter:
         content: list[Any], pending: _PendingAfterTools
     ) -> dict[str, Any]:
         """Convert user list blocks, emitting deferred assistant after all tool results."""
-        if not pending.needs_deferred() or not pending.remaining_tool_ids:
+        if not pending.remaining_tool_ids:
             return {
                 "messages": AnthropicToOpenAIConverter._convert_user_message(content),
                 "cleared_pending": False,
@@ -439,7 +444,10 @@ class AnthropicToOpenAIConverter:
                     "extend the converter."
                 )
             elif block_type == "tool_result":
-                flush_text()
+                # When this user message answers a pending assistant tool_call,
+                # OpenAI chat requires the tool messages to appear immediately
+                # after that assistant message. Keep any surrounding user text
+                # buffered until after the required tool_result messages.
                 tool_content = get_block_attr(block, "content", "")
                 serialized = _serialize_tool_result_content(tool_content)
                 tuid = get_block_attr(block, "tool_use_id")
@@ -454,12 +462,13 @@ class AnthropicToOpenAIConverter:
                 if tuid_s in pending.remaining_tool_ids:
                     pending.remaining_tool_ids.discard(tuid_s)
                 if not pending.remaining_tool_ids:
-                    result.extend(
-                        AnthropicToOpenAIConverter._deferred_post_tool_to_messages(
-                            pending
+                    if pending.needs_deferred():
+                        result.extend(
+                            AnthropicToOpenAIConverter._deferred_post_tool_to_messages(
+                                pending
+                            )
                         )
-                    )
-                    pending.deferred_emitted = True
+                        pending.deferred_emitted = True
                     cleared = True
             else:
                 pass

--- a/core/anthropic/conversion.py
+++ b/core/anthropic/conversion.py
@@ -77,7 +77,9 @@ def _serialize_tool_result_content(tool_content: Any) -> str:
 def _clean_reasoning_content(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
-    return value if value else None
+    # DeepSeek V4 thinking mode requires reasoning_content to be replayed exactly.
+    # An empty string is still meaningful protocol state and must not be dropped.
+    return value
 
 
 def _think_tag_content(reasoning: str) -> str:
@@ -231,10 +233,13 @@ class AnthropicToOpenAIConverter:
                     pending.deferred_emitted = True
                     pending = None
                 converted = {"role": role, "content": content}
-                if role == "assistant" and reasoning_content:
+                if role == "assistant" and reasoning_content is not None:
                     if reasoning_replay == ReasoningReplayMode.REASONING_CONTENT:
                         converted["reasoning_content"] = reasoning_content
-                    elif reasoning_replay == ReasoningReplayMode.THINK_TAGS:
+                    elif (
+                        reasoning_replay == ReasoningReplayMode.THINK_TAGS
+                        and reasoning_content
+                    ):
                         content_parts = [_think_tag_content(reasoning_content)]
                         if content:
                             content_parts.append(content)
@@ -316,7 +321,7 @@ class AnthropicToOpenAIConverter:
             }
             if reasoning_replay == ReasoningReplayMode.REASONING_CONTENT:
                 replay = reasoning_content
-                if replay:
+                if replay is not None:
                     pre_msg["reasoning_content"] = replay
         else:
             pre_msg = AnthropicToOpenAIConverter._convert_assistant_message(
@@ -384,9 +389,10 @@ class AnthropicToOpenAIConverter:
         if tool_calls:
             msg["tool_calls"] = tool_calls
         if reasoning_replay == ReasoningReplayMode.REASONING_CONTENT:
-            replay_reasoning = reasoning_content or "\n".join(thinking_parts)
-            if replay_reasoning:
-                msg["reasoning_content"] = replay_reasoning
+            if reasoning_content is not None:
+                msg["reasoning_content"] = reasoning_content
+            elif thinking_parts:
+                msg["reasoning_content"] = "\n".join(thinking_parts)
 
         return [msg]
 

--- a/core/openai_responses/input.py
+++ b/core/openai_responses/input.py
@@ -106,44 +106,19 @@ def _append_input_item(
         _append_message_item(role, item.get("content", ""), messages, system_parts)
         return None
     if item_type in {"function_call", "custom_tool_call"}:
-        namespace = optional_str(item.get("namespace"))
-        field_name = f"{item_type}.name"
-        name = required_str(item.get("name"), field_name)
-        if item_type == "custom_tool_call":
-            tool_input = custom_tool_input_to_anthropic(item.get("input"))
-        else:
-            tool_input = parse_arguments(item.get("arguments"))
-        message = {
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "tool_use",
-                    "id": call_id_from_item(item),
-                    "name": responses_tool_name_to_anthropic_name(
-                        name, namespace=namespace
-                    ),
-                    "input": tool_input,
-                }
-            ],
-        }
-        if pending_reasoning is not None:
-            message["reasoning_content"] = pending_reasoning
-        messages.append(message)
+        _append_tool_call_item(item, item_type, messages, pending_reasoning)
         return None
     if item_type in {"function_call_output", "custom_tool_call_output"}:
-        _append_pending_reasoning(messages, pending_reasoning)
-        messages.append(
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": call_id_from_item(item),
-                        "content": item.get("output", ""),
-                    }
-                ],
-            }
-        )
+        # Responses histories can contain a reasoning item after a function_call item
+        # but before the matching function_call_output. OpenAI chat requires
+        # assistant tool_calls to be followed immediately by tool messages, so that
+        # reasoning must be attached to the preceding assistant tool-call message
+        # instead of becoming a separate assistant turn before the tool result.
+        if pending_reasoning is not None and not _attach_reasoning_to_open_tool_call(
+            messages, pending_reasoning
+        ):
+            _append_pending_reasoning(messages, pending_reasoning)
+        _append_tool_result_item(item, messages)
         return None
     if item_type == "reasoning":
         return combine_reasoning(pending_reasoning, reasoning_text_from_item(item))
@@ -185,14 +160,148 @@ def _append_message_item(
 def _append_pending_reasoning(
     messages: list[dict[str, Any]], pending_reasoning: str | None
 ) -> None:
+    if pending_reasoning is None:
+        return
+    if _last_message_is_tool_call_assistant(messages):
+        _attach_reasoning_to_open_tool_call(messages, pending_reasoning)
+        return
+    messages.append(
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": pending_reasoning,
+        }
+    )
+
+
+def _append_tool_call_item(
+    item: Mapping[str, Any],
+    item_type: str,
+    messages: list[dict[str, Any]],
+    pending_reasoning: str | None,
+) -> None:
+    tool_use = _tool_use_block_from_call_item(item, item_type)
+    if _last_message_is_tool_call_assistant(messages):
+        content = messages[-1]["content"]
+        if isinstance(content, list):
+            content.append(tool_use)
+        if pending_reasoning is not None:
+            _merge_reasoning_into_message(messages[-1], pending_reasoning)
+        return
+
+    message: dict[str, Any] = {"role": "assistant", "content": [tool_use]}
     if pending_reasoning is not None:
-        messages.append(
-            {
-                "role": "assistant",
-                "content": "",
-                "reasoning_content": pending_reasoning,
-            }
+        message["reasoning_content"] = pending_reasoning
+    messages.append(message)
+
+
+def _tool_use_block_from_call_item(
+    item: Mapping[str, Any], item_type: str
+) -> dict[str, Any]:
+    namespace = optional_str(item.get("namespace"))
+    field_name = f"{item_type}.name"
+    name = required_str(item.get("name"), field_name)
+    if item_type == "custom_tool_call":
+        tool_input = custom_tool_input_to_anthropic(item.get("input"))
+    else:
+        tool_input = parse_arguments(item.get("arguments"))
+    return {
+        "type": "tool_use",
+        "id": call_id_from_item(item),
+        "name": responses_tool_name_to_anthropic_name(name, namespace=namespace),
+        "input": tool_input,
+    }
+
+
+def _append_tool_result_item(
+    item: Mapping[str, Any], messages: list[dict[str, Any]]
+) -> None:
+    tool_result = {
+        "type": "tool_result",
+        "tool_use_id": call_id_from_item(item),
+        "content": item.get("output", ""),
+    }
+    if _last_message_is_tool_result_user(messages):
+        content = messages[-1]["content"]
+        if isinstance(content, list):
+            content.append(tool_result)
+        return
+    messages.append({"role": "user", "content": [tool_result]})
+
+
+def _last_message_is_tool_call_assistant(messages: list[dict[str, Any]]) -> bool:
+    if not messages:
+        return False
+    message = messages[-1]
+    return _is_tool_call_assistant_message(message)
+
+
+def _last_message_is_tool_result_user(messages: list[dict[str, Any]]) -> bool:
+    if not messages:
+        return False
+    message = messages[-1]
+    if message.get("role") != "user":
+        return False
+    content = message.get("content")
+    return (
+        isinstance(content, list)
+        and bool(content)
+        and all(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in content
         )
+    )
+
+
+def _is_tool_call_assistant_message(message: Mapping[str, Any]) -> bool:
+    if message.get("role") != "assistant":
+        return False
+    content = message.get("content")
+    return (
+        isinstance(content, list)
+        and bool(content)
+        and all(
+            isinstance(block, dict) and block.get("type") == "tool_use"
+            for block in content
+        )
+    )
+
+
+def _attach_reasoning_to_open_tool_call(
+    messages: list[dict[str, Any]], pending_reasoning: str
+) -> bool:
+    for message in reversed(messages):
+        if _is_tool_call_assistant_message(message):
+            _merge_reasoning_into_message(message, pending_reasoning)
+            return True
+        if not _is_tool_result_user_message(message):
+            return False
+    return False
+
+
+def _is_tool_result_user_message(message: Mapping[str, Any]) -> bool:
+    if message.get("role") != "user":
+        return False
+    content = message.get("content")
+    return (
+        isinstance(content, list)
+        and bool(content)
+        and all(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in content
+        )
+    )
+
+
+def _merge_reasoning_into_message(
+    message: dict[str, Any], pending_reasoning: str
+) -> None:
+    message["reasoning_content"] = combine_reasoning(
+        message.get("reasoning_content")
+        if isinstance(message.get("reasoning_content"), str)
+        else None,
+        pending_reasoning,
+    )
 
 
 def _iter_input_items(value: Any) -> list[Any]:

--- a/core/openai_responses/input.py
+++ b/core/openai_responses/input.py
@@ -126,7 +126,7 @@ def _append_input_item(
                 }
             ],
         }
-        if pending_reasoning:
+        if pending_reasoning is not None:
             message["reasoning_content"] = pending_reasoning
         messages.append(message)
         return None
@@ -177,7 +177,7 @@ def _append_message_item(
         "role": normalized_role,
         "content": _convert_message_content(content),
     }
-    if normalized_role == "assistant" and reasoning_content:
+    if normalized_role == "assistant" and reasoning_content is not None:
         message["reasoning_content"] = reasoning_content
     messages.append(message)
 
@@ -185,7 +185,7 @@ def _append_message_item(
 def _append_pending_reasoning(
     messages: list[dict[str, Any]], pending_reasoning: str | None
 ) -> None:
-    if pending_reasoning:
+    if pending_reasoning is not None:
         messages.append(
             {
                 "role": "assistant",

--- a/core/openai_responses/input.py
+++ b/core/openai_responses/input.py
@@ -239,18 +239,7 @@ def _last_message_is_tool_call_assistant(messages: list[dict[str, Any]]) -> bool
 def _last_message_is_tool_result_user(messages: list[dict[str, Any]]) -> bool:
     if not messages:
         return False
-    message = messages[-1]
-    if message.get("role") != "user":
-        return False
-    content = message.get("content")
-    return (
-        isinstance(content, list)
-        and bool(content)
-        and all(
-            isinstance(block, dict) and block.get("type") == "tool_result"
-            for block in content
-        )
-    )
+    return _is_tool_result_user_message(messages[-1])
 
 
 def _is_tool_call_assistant_message(message: Mapping[str, Any]) -> bool:

--- a/core/openai_responses/reasoning.py
+++ b/core/openai_responses/reasoning.py
@@ -23,10 +23,15 @@ def reasoning_text_from_item(item: Mapping[str, Any]) -> str | None:
 
 
 def combine_reasoning(existing: str | None, addition: str | None) -> str | None:
-    if not addition:
+    # Empty-string reasoning is valid replay state for DeepSeek V4 thinking mode.
+    if addition is None:
         return existing
-    if not existing:
+    if existing is None:
         return addition
+    if existing == "":
+        return addition
+    if addition == "":
+        return existing
     return f"{existing}\n{addition}"
 
 
@@ -47,6 +52,6 @@ def _text_parts_from_items(value: Any, *, item_type: str) -> list[str]:
     for item in value:
         if isinstance(item, dict) and item.get("type") == item_type:
             text = optional_str(item.get("text"))
-            if text:
+            if text is not None:
                 parts.append(text)
     return parts

--- a/providers/opencode/client.py
+++ b/providers/opencode/client.py
@@ -29,3 +29,7 @@ class OpenCodeProvider(OpenAIChatTransport):
             request,
             thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
         )
+
+    def _preserve_empty_reasoning_content(self, body: dict[str, Any]) -> bool:
+        """DeepSeek V4 treats even empty reasoning_content as required replay state."""
+        return "deepseek" in str(body.get("model", "")).lower()

--- a/providers/transports/openai_chat/recovery.py
+++ b/providers/transports/openai_chat/recovery.py
@@ -46,7 +46,7 @@ class OpenAIChatRecovery:
                     if delta is None:
                         continue
                     reasoning = getattr(delta, "reasoning_content", None)
-                    if isinstance(reasoning, str) and reasoning:
+                    if isinstance(reasoning, str):
                         thinking_parts.append(reasoning)
                     content = getattr(delta, "content", None)
                     if isinstance(content, str) and content:

--- a/providers/transports/openai_chat/stream.py
+++ b/providers/transports/openai_chat/stream.py
@@ -83,6 +83,9 @@ class OpenAIChatStreamRunner:
         thinking_enabled = self._transport._is_thinking_enabled(
             self._request, self._thinking_enabled
         )
+        preserve_empty_reasoning = self._transport._preserve_empty_reasoning_content(
+            body
+        )
         trace_event(
             stage="provider",
             event="provider.request.sent",
@@ -128,11 +131,18 @@ class OpenAIChatStreamRunner:
                             logger.debug("{} finish_reason: {}", tag, finish_reason)
 
                         reasoning = getattr(delta, "reasoning_content", None)
-                        if thinking_enabled and reasoning:
+                        if (
+                            thinking_enabled
+                            and isinstance(reasoning, str)
+                            and (reasoning or preserve_empty_reasoning)
+                        ):
                             for event in hold_events(sse.ensure_thinking_block()):
                                 yield event
-                            for event in hold_event(sse.emit_thinking_delta(reasoning)):
-                                yield event
+                            if reasoning:
+                                for event in hold_event(
+                                    sse.emit_thinking_delta(reasoning)
+                                ):
+                                    yield event
 
                         for event in self._transport._handle_extra_reasoning(
                             delta,

--- a/providers/transports/openai_chat/transport.py
+++ b/providers/transports/openai_chat/transport.py
@@ -98,6 +98,10 @@ class OpenAIChatTransport(BaseProvider):
         """Return the body passed to the upstream OpenAI-compatible client."""
         return body
 
+    def _preserve_empty_reasoning_content(self, body: dict[str, Any]) -> bool:
+        """Whether empty reasoning_content is meaningful for this upstream request."""
+        return False
+
     def _record_tool_call_extra_content(
         self, tool_call_id: str, extra_content: dict[str, Any]
     ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.3.15"
+version = "2.3.16"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.3.14"
+version = "2.3.15"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.3.16"
+version = "2.3.15"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/api/test_openai_responses.py
+++ b/tests/api/test_openai_responses.py
@@ -381,6 +381,47 @@ def test_create_response_replays_prior_reasoning_as_reasoning_content() -> None:
     assert routed.messages[3].content == "continue"
 
 
+def test_create_response_replays_empty_reasoning_content() -> None:
+    provider = FakeProvider(_anthropic_text_stream("done"))
+    app = create_app(lifespan_enabled=False)
+    with (
+        patch("api.dependencies.resolve_provider", return_value=provider),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "nvidia_nim/test-model",
+                "input": [
+                    {
+                        "id": "rs_empty",
+                        "type": "reasoning",
+                        "summary": [],
+                        "content": [{"type": "reasoning_text", "text": ""}],
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "echo",
+                        "arguments": "{}",
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_1",
+                        "output": "ok",
+                    },
+                ],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    routed = provider.requests[0]
+    assert routed.messages[0].role == "assistant"
+    assert routed.messages[0].content[0].type == "tool_use"
+    assert routed.messages[0].reasoning_content == ""
+
+
 @pytest.mark.parametrize(
     ("reasoning", "expected_type", "expected_enabled"),
     [

--- a/tests/core/openai_responses/test_conversion.py
+++ b/tests/core/openai_responses/test_conversion.py
@@ -378,6 +378,114 @@ def test_responses_prior_custom_tool_call_flattens_tool_use_name() -> None:
     ]
 
 
+def test_responses_reasoning_between_tool_call_and_output_attaches_to_tool_call() -> (
+    None
+):
+    payload = _ADAPTER.to_anthropic_payload(
+        {
+            "model": "opencode/deepseek-v4-flash-free",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "echo",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "reasoning",
+                    "summary": [],
+                    "content": [{"type": "reasoning_text", "text": ""}],
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "ok",
+                },
+            ],
+        }
+    )
+
+    assert payload["messages"] == [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "echo",
+                    "input": {},
+                }
+            ],
+            "reasoning_content": "",
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "call_1", "content": "ok"}
+            ],
+        },
+    ]
+
+
+def test_responses_consecutive_function_calls_are_grouped_for_openai_chat() -> None:
+    payload = _ADAPTER.to_anthropic_payload(
+        {
+            "model": "opencode/deepseek-v4-flash-free",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_2",
+                    "name": "git_status",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "file",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_2",
+                    "output": "clean",
+                },
+            ],
+        }
+    )
+
+    assert payload["messages"] == [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "read_file",
+                    "input": {},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "call_2",
+                    "name": "git_status",
+                    "input": {},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "call_1", "content": "file"},
+                {"type": "tool_result", "tool_use_id": "call_2", "content": "clean"},
+            ],
+        },
+    ]
+
+
 def test_responses_unsupported_tool_type_is_clear() -> None:
     with pytest.raises(_CONVERSION_ERROR, match="Unsupported Responses tool type"):
         _ADAPTER.to_anthropic_payload(

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -266,6 +266,46 @@ def test_convert_assistant_top_level_reasoning_content_is_preserved():
     ]
 
 
+def test_convert_assistant_empty_reasoning_content_is_preserved():
+    messages = [
+        MockMessage(
+            "assistant",
+            "",
+            reasoning_content="",
+        )
+    ]
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages, reasoning_replay=ReasoningReplayMode.REASONING_CONTENT
+    )
+
+    assert result == [
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "",
+        }
+    ]
+
+
+def test_convert_assistant_tool_call_empty_reasoning_content_is_preserved():
+    content = [
+        MockBlock(
+            type="tool_use",
+            id="call_empty_reasoning",
+            name="search",
+            input={"query": "python"},
+        ),
+    ]
+    messages = [MockMessage("assistant", content, reasoning_content="")]
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages, reasoning_replay=ReasoningReplayMode.REASONING_CONTENT
+    )
+
+    assert result[0]["content"] == ""
+    assert result[0]["reasoning_content"] == ""
+    assert result[0]["tool_calls"][0]["id"] == "call_empty_reasoning"
+
+
 def test_convert_assistant_thinking_tool_use_replays_top_level_reasoning():
     content = [
         MockBlock(type="thinking", thinking="I should call the tool."),

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -671,6 +671,28 @@ def test_convert_assistant_text_after_tool_use_inserts_after_tool_results():
     assert result[2] == {"role": "assistant", "content": "Post-tool commentary"}
 
 
+def test_pending_tool_result_user_text_is_delayed_until_after_tool_messages():
+    messages = [
+        MockMessage(
+            "assistant",
+            [MockBlock(type="tool_use", id="call_z", name="Read", input={})],
+        ),
+        MockMessage(
+            "user",
+            [
+                MockBlock(type="text", text="Tool output follows:"),
+                MockBlock(type="tool_result", tool_use_id="call_z", content="file"),
+            ],
+        ),
+    ]
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert result[0]["role"] == "assistant" and "tool_calls" in result[0]
+    assert result[1] == {"role": "tool", "tool_call_id": "call_z", "content": "file"}
+    assert result[2] == {"role": "user", "content": "Tool output follows:"}
+
+
 def test_openai_build_accepts_declared_native_top_level_hints() -> None:
     """OpenAI conversion ignores known non-OpenAI hints (e.g. context_management) without 400."""
     req = MessagesRequest.model_validate(

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from providers.base import ProviderConfig
+from providers.opencode import OpenCodeProvider
+
+
+class MockMessage:
+    def __init__(self, role, content, reasoning_content=None):
+        self.role = role
+        self.content = content
+        self.reasoning_content = reasoning_content
+
+
+@pytest.mark.asyncio
+async def test_opencode_deepseek_stream_preserves_empty_reasoning_block():
+    provider = OpenCodeProvider(ProviderConfig(api_key="test"))
+    request = SimpleNamespace(
+        model="deepseek-v4-flash-free",
+        messages=[MockMessage("user", "use a tool")],
+        system=None,
+        tools=[],
+        tool_choice=None,
+        max_tokens=None,
+        temperature=None,
+        top_p=None,
+        stop_sequences=None,
+        thinking=None,
+    )
+
+    mock_tc = MagicMock()
+    mock_tc.index = 0
+    mock_tc.id = "call_1"
+    mock_tc.function.name = "search"
+    mock_tc.function.arguments = '{"q":"test"}'
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content=None, reasoning_content="", tool_calls=[mock_tc]),
+            finish_reason="tool_calls",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=5)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+        events = [
+            event
+            async for event in provider.stream_response(request, thinking_enabled=True)
+        ]
+
+    assert any(
+        "event: content_block_start" in event and '"type": "thinking"' in event
+        for event in events
+    )
+    assert any(
+        "event: content_block_start" in event and '"type": "tool_use"' in event
+        for event in events
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.3.14"
+version = "2.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.3.15"
+version = "2.3.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.3.16"
+version = "2.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Hi, this is my first open-source contribution, so please let me know if anything needs to be changed.

I found an issue when using "fcc-codex: with:

opencode/deepseek-v4-flash-free

DeepSeek V4 thinking mode was failing after Codex used tools. The provider returned this error:

<img width="1037" height="438" alt="Screenshot 2026-06-23 062910" src="https://github.com/user-attachments/assets/fdf3a18d-e13c-4e44-aaaa-aea3acde2dc3" />


The problem was that the converted message history could place reasoning content or another message between an assistant tool call and the matching tool result. DeepSeek is strict about this order, so it rejected the request.

This PR fixes the message ordering so tool calls are followed directly by their matching tool responses. It also keeps DeepSeek thinking mode enabled and preserves reasoning content correctly.

I tested this manually with a fresh Codex session using DeepSeek V4 thinking mode, and the previous error is now gone.

I also tried to keep the change safe for other providers by following the normal OpenAI-compatible tool-call format:


Thanks for reviewing!

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates DeepSeek/OpenCode reasoning replay so empty `reasoning_content` can be preserved for thinking mode.
- Reworks Anthropic and OpenAI Responses conversion to keep tool calls and tool outputs closer to OpenAI-compatible ordering expectations.
- Adds stream/recovery handling and regression coverage for reasoning deltas and grouped tool-call histories.

<h3>Confidence Score: 4/5</h3>

Merge should wait for the conversion ordering issues to be fixed because strict chat providers can reject generated histories.

Focused runtime checks reproduced both ordering failures in the conversion paths, giving strong confidence that the reported issues are actionable.

core/anthropic/conversion.py and core/openai_responses/input.py need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the pending tool-call ordering using a focused conversion harness feeding assistant tool\_use, intervening user text, and the matching tool\_result through AnthropicToOpenAIConverter.convert\_messages.
- Reproduced a conversion that groups function\_call results; observed that c1 had tool\_use, c1 and c2 tool\_result were grouped into the following user message, and c2 was reported as unmatched but exit succeeded.
- Compared base vs head artifacts showing reasoning content handling, noting that base used reasoning\_content=None and head used an empty reasoning\_content string following tool\_use then tool\_result for call\_1, with exit code 0.
- Validated changes in opencode-empty-reasoning-stream experiments: after run, the head includes provider\_preserve\_empty\_reasoning\_content\_deepseek True and a thinking block before tool\_use; both runs used mocked streaming with no credentials.
- Observed the reordering and reasoning\_content behavior in emitted messages: head emits assistant tool\_calls followed by the matching tool message and surrounding user text, with reasoning\_content kept empty in both forms.

<a href="https://app.greptile.com/trex/runs/11960001/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (2)</h3>

1. `core/anthropic/conversion.py`, line 229-250 ([link](https://github.com/alishahryar1/free-claude-code/blob/528712ad485595e3de2af67bc76f6d167ac2f0a1/core/anthropic/conversion.py#L229-L250)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Handle pending tools**

   This branch only flushes pending deferred assistant text, but the updated converter now creates pending state for assistant tool calls. When an assistant tool call is followed by plain user text before the matching `tool_result`, this can emit `assistant.tool_calls -> user -> tool`, which is the invalid ordering this PR is trying to prevent. The list-content user branch already checks `pending.awaits_tool_results()`; the string/plain-text path needs equivalent handling so non-tool user text cannot separate a tool call from its result.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused converter script for pending tool call followed by plain user text](https://app.greptile.com/trex/artifacts/13cafa7b-5cea-4e85-bdf9-70ac9fd10eba)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: script output showing assistant.tool\_calls -\> user -\> tool ordering and assertion failure](https://app.greptile.com/trex/artifacts/b8050133-22a2-4a7a-809c-f9de5562ecac)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11959571/artifacts?artifact=13cafa7b-5cea-4e85-bdf9-70ac9fd10eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. `core/anthropic/conversion.py`, line 229-250 ([link](https://github.com/alishahryar1/free-claude-code/blob/2c5de7bf11d3f33a0341924a5e12c059b81a746f/core/anthropic/conversion.py#L229-L250)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Keep pending tools guarded**

   The pending-state checks in the string-message path only run when `pending.needs_deferred()` is true, and the assistant-list path around lines 192-219 has the same issue. This PR now creates `pending` for ordinary assistant tool calls whenever `remaining_tool_ids` is non-empty, even with no deferred blocks. In that common case, a following user text message, assistant text message, or second assistant tool-call message can be emitted before the matching tool result, producing transcripts like `assistant tool_calls -> intervening turn -> tool`. Strict OpenAI-compatible providers reject those tool messages because they no longer immediately follow the assistant message that declared the matching tool call. Treat any non-empty pending tool id set as blocking until the matching tool results are emitted, or buffer/reject intervening turns instead of allowing them to interleave.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused conversion harness for pending tool-call ordering](https://app.greptile.com/trex/artifacts/5a7dee45-2f77-45f8-b326-0f5c5ec51d99)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: harness output showing assistant -\> user -\> tool ordering](https://app.greptile.com/trex/artifacts/80aaa511-ad20-41c5-b05a-d49e05308fd3)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11960001/artifacts?artifact=5a7dee45-2f77-45f8-b326-0f5c5ec51d99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Update uv.lock"](https://github.com/alishahryar1/free-claude-code/commit/2c5de7bf11d3f33a0341924a5e12c059b81a746f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39209982)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->