### PR TITLE
feat(providers): support Ollama cloud API key auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,9 @@ LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 LLAMACPP_BASE_URL="http://localhost:8080/v1"
 
 
-# Ollama Config (local provider, no API key required)
+# Ollama Config (local provider, no API key required; set both for Ollama cloud at https://ollama.com)
 OLLAMA_BASE_URL="http://localhost:11434"
+OLLAMA_API_KEY=""
 
 
 # All Claude model requests are mapped to these models, plain model is fallback

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -234,6 +234,8 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
     "ollama": ProviderDescriptor(
         provider_id="ollama",
         transport_type="anthropic_messages",
+        credential_attr="ollama_api_key",
+        credential_url="https://ollama.com/settings/keys",
         static_credential="ollama",
         default_base_url=OLLAMA_DEFAULT_BASE,
         base_url_attr="ollama_base_url",

--- a/config/settings.py
+++ b/config/settings.py
@@ -146,6 +146,8 @@ class Settings(BaseSettings):
         default="http://localhost:11434",
         validation_alias="OLLAMA_BASE_URL",
     )
+    # Optional: required for Ollama cloud (https://ollama.com); local Ollama needs no key.
+    ollama_api_key: str = Field(default="", validation_alias="OLLAMA_API_KEY")
 
     # ==================== Model ====================
     # All Claude model requests are mapped to this single model (fallback)

--- a/providers/ollama/client.py
+++ b/providers/ollama/client.py
@@ -19,6 +19,13 @@ class OllamaProvider(AnthropicMessagesTransport):
         )
         self._api_key = config.api_key or "ollama"
 
+    def _request_headers(self) -> dict[str, str]:
+        return {
+            "Accept": "text/event-stream",
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
     async def _send_stream_request(self, body: dict) -> httpx.Response:
         """Create a streaming native Anthropic messages response."""
         request = self._client.build_request(
@@ -31,7 +38,10 @@ class OllamaProvider(AnthropicMessagesTransport):
 
     async def _send_model_list_request(self) -> httpx.Response:
         """Query Ollama's native local model-list endpoint."""
-        return await self._client.get(f"{self._base_url}/api/tags")
+        return await self._client.get(
+            f"{self._base_url}/api/tags",
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
 
     def _extract_model_ids_from_model_list_payload(
         self, payload: object

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -174,10 +174,12 @@ def _string_attr(settings: Settings, attr_name: str | None, default: str = "") -
 
 
 def _credential_for(descriptor: ProviderDescriptor, settings: Settings) -> str:
+    if descriptor.credential_attr:
+        value = _string_attr(settings, descriptor.credential_attr)
+        if value:
+            return value
     if descriptor.static_credential is not None:
         return descriptor.static_credential
-    if descriptor.credential_attr:
-        return _string_attr(settings, descriptor.credential_attr)
     return ""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.3.14"
+version = "2.4.1"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -47,6 +47,7 @@ def _make_settings(**overrides):
     mock.lm_studio_base_url = "http://localhost:1234/v1"
     mock.llamacpp_base_url = "http://localhost:8080/v1"
     mock.ollama_base_url = "http://localhost:11434"
+    mock.ollama_api_key = ""
     mock.nvidia_nim_proxy = ""
     mock.open_router_proxy = ""
     mock.lmstudio_proxy = ""
@@ -154,6 +155,24 @@ def test_build_provider_config_opencode_go_uses_opencode_api_key() -> None:
     config = build_provider_config(descriptor, settings)
 
     assert config.api_key == "shared-opencode-token"
+
+
+def test_build_provider_config_ollama_falls_back_to_static_credential() -> None:
+    descriptor = PROVIDER_CATALOG["ollama"]
+    settings = _make_settings(ollama_api_key="")
+
+    config = build_provider_config(descriptor, settings)
+
+    assert config.api_key == "ollama"
+
+
+def test_build_provider_config_ollama_uses_configured_api_key() -> None:
+    descriptor = PROVIDER_CATALOG["ollama"]
+    settings = _make_settings(ollama_api_key="cloud-token")
+
+    config = build_provider_config(descriptor, settings)
+
+    assert config.api_key == "cloud-token"
 
 
 def test_create_provider_uses_native_openrouter_by_default():

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.3.14"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Ollama cloud (https://ollama.com) requires a Bearer token; local Ollama needs none. Add OLLAMA_API_KEY setting, wire it into provider credential resolution (configured key takes priority over static "ollama" fallback), and send it via Authorization header on stream and model-list requests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Ollama Cloud API key support. The main changes are:

- Adds `OLLAMA_API_KEY` to settings and the example env file.
- Gives the Ollama provider a credential attribute with static local fallback.
- Sends Bearer auth on Ollama stream and model-list requests.
- Adds registry tests for configured and fallback Ollama credentials.
- Bumps the package version.

<h3>Confidence Score: 3/5</h3>

Not ready to merge until the Ollama local fallback stops being sent as a bearer token and the cloud key is exposed through the admin configuration surface.

The provider changes are focused and tested for registry resolution, but runtime checks show the local fallback is used as real authentication on both stream and model-list requests, and the admin manifest omits the new key setting.

providers/ollama/client.py and config/provider_catalog.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated runtime harness against the Ollama client stream request with OLLAMA\_API\_KEY unset and observed the local mock rejected due to the Authorization header, returning 401 Unauthorized.
- Ran a generated local mock harness against Ollama /api/tags with no API key and observed an Authorization header in the request and a 401 Unauthorized response.
- Ran a focused Python harness to inspect admin config, finding the manifest indicates credential\_attr is ollama\_api\_key while credential\_env is null, and the /admin/api/config endpoint returned 200 OK with OLLAMA\_BASE\_URL present and no API key in the manifest.
- Compared cloud-auth state before and after by reviewing logs, showing Authorization headers changed from None to Bearer cloud-token and both stream and model-list endpoints returned 200 OK.

<a href="https://app.greptile.com/trex/runs/11980339/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(providers): support Ollama cloud AP..."](https://github.com/alishahryar1/free-claude-code/commit/cb1e75dec90ffa104c08fa98d1b4182f3405aa44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39253073)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->