### PR TITLE
fix: preserve empty reasoning_content for DeepSeek V4 thinking mode

### DIFF
--- a/core/anthropic/conversion.py
+++ b/core/anthropic/conversion.py
@@ -77,7 +77,7 @@ def _serialize_tool_result_content(tool_content: Any) -> str:
 def _clean_reasoning_content(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
-    return value if value else None
+    return value
 
 
 def _think_tag_content(reasoning: str) -> str:
@@ -384,8 +384,8 @@ class AnthropicToOpenAIConverter:
         if tool_calls:
             msg["tool_calls"] = tool_calls
         if reasoning_replay == ReasoningReplayMode.REASONING_CONTENT:
-            replay_reasoning = reasoning_content or "\n".join(thinking_parts)
-            if replay_reasoning:
+            replay_reasoning = reasoning_content if reasoning_content is not None else "\n".join(thinking_parts)
+            if replay_reasoning is not None:
                 msg["reasoning_content"] = replay_reasoning
 
         return [msg]

--- a/providers/transports/openai_chat/stream.py
+++ b/providers/transports/openai_chat/stream.py
@@ -128,7 +128,7 @@ class OpenAIChatStreamRunner:
                             logger.debug("{} finish_reason: {}", tag, finish_reason)
 
                         reasoning = getattr(delta, "reasoning_content", None)
-                        if thinking_enabled and reasoning:
+                        if thinking_enabled and reasoning is not None:
                             for event in hold_events(sse.ensure_thinking_block()):
                                 yield event
                             for event in hold_event(sse.emit_thinking_delta(reasoning)):


### PR DESCRIPTION
## Summary

This PR fixes the DeepSeek V4 thinking mode HTTP 400 error by preserving empty  strings in multi-turn conversations.

## Problem

DeepSeek API requires  to be passed back in all subsequent requests, even when it's an empty string . However, the codebase uses truthy checks () that filter out empty strings, causing HTTP 400 errors:



## Solution

3 minimal changes to preserve empty :

### 1.  - 


### 2.  - 


### 3. 


## Why This Works

- DeepSeek API requires  to be passed back even when empty
- Empty string  is valid and must be preserved
- Truthy checks () treat empty strings as falsy
- None checks () preserve empty strings

## Testing

- Single turn: ✅ Works
- Multi-turn: ✅ Works (previously failed with HTTP 400)
- Tool calls: ✅ Works

## Comparison with PR #901

This is a minimal 3-line fix that addresses the core issue without refactoring message ordering. PR #901 takes a more comprehensive approach (488 additions, 74 deletions) that also fixes tool-call ordering.

Both fixes solve the same root cause, but this PR is simpler and more targeted.

---

## 요약

DeepSeek V4 thinking 모드 HTTP 400 에러를 멀티턴 대화에서 빈  문자열을 보존하여 수정합니다.

## 문제

DeepSeek API는 reasoning_content가 빈 문자열이더라도 반드시 다시 전달해야 합니다. 하지만 코드베이스에서 truthy 체크()를 사용하여 빈 문자열을 필터링합니다.

## 해결책

3곳의 최소한의 수정:
1. : 빈 문자열 보존
2. : None 체크로 변경
3. : None 체크로 변경

## 테스트 결과

- 1회차: ✅ 정상 동작
- 멀티턴: ✅ 정상 동작 (이전에는 HTTP 400 에러)
- Tool calls: ✅ 정상 동작

이 수정은 PR #901과 동일한 근본 원인을 해결하지만, 더 간단하고 최소한의 수정입니다.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves empty DeepSeek reasoning content during OpenAI-compatible conversion and streaming. The main changes are:

- Keeps empty string values from `_clean_reasoning_content`.
- Replays `reasoning_content` when it is present, including `""`.
- Streams empty `delta.reasoning_content` values when thinking mode is enabled.

<h3>Confidence Score: 4/5</h3>

The change is small and targeted, but one remaining conversion branch still omits empty reasoning content for string-content assistant messages.

The modified streaming and list-content paths are straightforward, and the remaining issue is localized to conversion logic for a specific transcript shape.

core/anthropic/conversion.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused string-content conversion script against the real conversion module with a multi-turn transcript whose assistant string content had reasoning\_content set to an empty string.
- Observed that the converted OpenAI-compatible assistant message kept the content but omitted the reasoning\_content field, and the assertion failed.
- Ran the no-pre-tool split path with an assistant tool\_use message whose reasoning\_content was an empty string.
- Observed that the converted tool-call assistant message also omitted reasoning\_content, and the assertion failed.
- Compared pre-artifact behavior to post-artifact behavior by inspecting logs, confirming that base conversion output changed from omitting reasoning\_content to including reasoning\_content, and that a thinking content block with an empty thinking\_delta was emitted.

<a href="https://app.greptile.com/trex/runs/12272101/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `core/anthropic/conversion.py`, line 234-236 ([link](https://github.com/alishahryar1/free-claude-code/blob/6f23519e538c36aaef4ca4550ee9f968d6fd997e/core/anthropic/conversion.py#L234-L236)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Empty reasoning still drops**
   This branch still uses a truthy guard, so an assistant message with string `content` and `reasoning_content == ""` is converted without `reasoning_content`, reproducing the DeepSeek 400 on that transcript shape. The same pattern remains in the no-pre-tool split path at lines 317-320, so the PR preserves empty reasoning only for list-content messages routed through `_convert_assistant_message`.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/alishahryar1/github/Alishahryar1/free-claude-code/-/custom-context?memory=d2fd24d8-0dec-4faf-8ee4-e085e215a2f8))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Repro: focused string-content conversion script](https://app.greptile.com/trex/artifacts/75931477-39e6-4d61-855d-fd037643548e)**
   
   - Contains supporting evidence from the run (text/x-python; charset=utf-8).
   
   **[Stack trace captured during the T-Rex run](https://app.greptile.com/trex/artifacts/2f038901-da03-44bd-bae4-3d4f536d52d4)**
   
   - Keeps the raw stack trace available without making the summary code-heavy.
   
   **[Repro: focused no-pre-tool split conversion script](https://app.greptile.com/trex/artifacts/b385d9ae-6774-414e-be01-02808d5ec0f8)**
   
   - Contains supporting evidence from the run (text/x-python; charset=utf-8).
   
   **[Stack trace captured during the T-Rex run](https://app.greptile.com/trex/artifacts/f8377368-9fab-481a-afa0-27113fe6e46c)**
   
   - Keeps the raw stack trace available without making the summary code-heavy.
   
   <a href="https://app.greptile.com/trex/runs/12272101/artifacts?artifact=75931477-39e6-4d61-855d-fd037643548e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: preserve empty reasoning\_content fo..."](https://github.com/alishahryar1/free-claude-code/commit/6f23519e538c36aaef4ca4550ee9f968d6fd997e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39797046)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/alishahryar1/github/Alishahryar1/free-claude-code/-/custom-context?memory=d2fd24d8-0dec-4faf-8ee4-e085e215a2f8))

<!-- /greptile_comment -->