### PR TITLE
Add install script for fcc only based on original install.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ irm "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.
 
 Review the installers at [scripts/install.sh](https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh) and [scripts/install.ps1](https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.ps1). They install Claude Code and Codex when missing, then install or update the proxy. Re-run these commands to update to the latest version.
 
-To remove only Free Claude Code (not uv, Claude Code, Codex, or the uv-managed Python runtime):
+Windows PowerShell FCC only:
+```powershell
+irm "https://github.com/tspry/free-claude-code/blob/main/scripts/install-fcc-only.ps1?raw=1" | iex
+```
+
+##To remove only Free Claude Code (not uv, Claude Code, Codex, or the uv-managed Python runtime):
 
 macOS/Linux:
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Windows PowerShell FCC only:
 irm "https://github.com/tspry/free-claude-code/blob/main/scripts/install-fcc-only.ps1?raw=1" | iex
 ```
 
-##To remove only Free Claude Code (not uv, Claude Code, Codex, or the uv-managed Python runtime):
+#### To remove only Free Claude Code (not uv, Claude Code, Codex, or the uv-managed Python runtime):
 
 macOS/Linux:
 

--- a/scripts/install-fcc-only.ps1
+++ b/scripts/install-fcc-only.ps1
@@ -1,0 +1,381 @@
+param(
+    [switch] $VoiceNim,
+    [switch] $VoiceLocal,
+    [switch] $VoiceAll,
+    [string] $TorchBackend = "",
+    [switch] $DryRun,
+    [switch] $Help,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [object[]] $RemainingArgs = @()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$RepoGitUrl = "git+https://github.com/Alishahryar1/free-claude-code.git"
+$PythonVersion = "3.14.0"
+$MinUvVersion = "0.11.0"
+$UvInstallUrl = "https://astral.sh/uv/install.ps1"
+
+function Show-Usage {
+    @"
+Usage: install.ps1 [options]
+
+Installs or updates uv, Python 3.14.0, and Free Claude Code.
+
+Options:
+  -VoiceNim              Install NVIDIA NIM voice transcription support.
+  -VoiceLocal            Install local Whisper voice transcription support.
+  -VoiceAll              Install all voice transcription backends.
+  -TorchBackend VALUE    Use a uv PyTorch backend, such as cu130. Requires local voice.
+  -DryRun                Print commands without running them.
+  -Help                  Show this help text.
+"@
+}
+
+function Write-Step {
+    param([string] $Message)
+
+    Write-Host ""
+    Write-Host "==> $Message"
+}
+
+function Format-Argument {
+    param([string] $Value)
+
+    if ($Value -match '^[A-Za-z0-9_./:@%+=,\[\]-]+$') {
+        return $Value
+    }
+
+    return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function Invoke-InstallCommand {
+    param(
+        [string] $FilePath,
+        [string[]] $Arguments = @()
+    )
+
+    $parts = @($FilePath) + $Arguments
+    $commandText = ($parts | ForEach-Object { Format-Argument ([string] $_) }) -join " "
+    Write-Host "+ $commandText"
+
+    if (-not $DryRun) {
+        & $FilePath @Arguments
+    }
+}
+
+function Invoke-UvInstaller {
+    Write-Host "+ irm $UvInstallUrl | iex"
+
+    if (-not $DryRun) {
+        Invoke-RestMethod $UvInstallUrl | Invoke-Expression
+    }
+}
+
+function Add-PathEntry {
+    param([string] $PathEntry)
+
+    if ([string]::IsNullOrWhiteSpace($PathEntry)) {
+        return
+    }
+
+    $separator = [IO.Path]::PathSeparator
+    $entries = @()
+    if (-not [string]::IsNullOrEmpty($env:Path)) {
+        $entries = $env:Path -split [regex]::Escape([string] $separator)
+    }
+
+    if ($entries -notcontains $PathEntry) {
+        $env:Path = "$PathEntry$separator$env:Path"
+    }
+}
+
+function Add-UvToPath {
+    Add-PathEntry (Join-Path $HOME ".local\bin")
+    Add-PathEntry (Join-Path $HOME ".cargo\bin")
+}
+
+function Invoke-ProbeCommand {
+    param(
+        [string] $FilePath,
+        [string[]] $Arguments = @()
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+
+    try {
+        $output = & $FilePath @Arguments 2>$null
+        return [pscustomobject] @{
+            ExitCode = $LASTEXITCODE
+            Output = ($output | Out-String)
+        }
+    }
+    catch {
+        return [pscustomobject] @{
+            ExitCode = 1
+            Output = ""
+        }
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+}
+
+function Convert-UvVersionOutput {
+    param([string] $Output)
+
+    if ([string]::IsNullOrWhiteSpace($Output)) {
+        return ""
+    }
+
+    if ($Output -match '(?m)(?:^|\s)(?:uv\s+)?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)\b') {
+        return $Matches["version"]
+    }
+
+    return ""
+}
+
+function Get-InstalledUvVersion {
+    $version = ""
+
+    $selfVersionProbe = Invoke-ProbeCommand -FilePath "uv" -Arguments @("self", "version", "--short")
+    if ($selfVersionProbe.ExitCode -eq 0) {
+        $version = Convert-UvVersionOutput $selfVersionProbe.Output
+    }
+
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        $versionProbe = Invoke-ProbeCommand -FilePath "uv" -Arguments @("--version")
+        if ($versionProbe.ExitCode -eq 0) {
+            $version = Convert-UvVersionOutput $versionProbe.Output
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        throw "Unable to determine uv version."
+    }
+
+    return $version
+}
+
+function Test-UvVersionAtLeast {
+    param(
+        [string] $Version,
+        [string] $Minimum
+    )
+
+    $normalizedVersion = Convert-UvVersionOutput $Version
+    $normalizedMinimum = Convert-UvVersionOutput $Minimum
+    if ([string]::IsNullOrWhiteSpace($normalizedVersion) -or [string]::IsNullOrWhiteSpace($normalizedMinimum)) {
+        throw "Unable to compare uv versions."
+    }
+
+    $normalizedVersion = $normalizedVersion -replace '[-+].*$', ''
+    $normalizedMinimum = $normalizedMinimum -replace '[-+].*$', ''
+    return ([version] $normalizedVersion) -ge ([version] $normalizedMinimum)
+}
+
+function Test-UvVersionSatisfiesMinimum {
+    $version = Get-InstalledUvVersion
+    return Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion
+}
+
+function Assert-MinUvVersion {
+    if ($DryRun) {
+        return
+    }
+
+    $version = Get-InstalledUvVersion
+    if (-not (Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion)) {
+        throw "uv $MinUvVersion or newer is required; found uv $version. Upgrade uv with its installer or package manager, then rerun this installer."
+    }
+}
+
+function Test-UvSelfUpdateSupported {
+    $probe = Invoke-ProbeCommand -FilePath "uv" -Arguments @("self", "update", "--dry-run")
+    return $probe.ExitCode -eq 0
+}
+
+function Test-UvInstalledByScoop {
+    if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+
+    $probe = Invoke-ProbeCommand -FilePath "scoop" -Arguments @("list", "uv")
+    return ($probe.ExitCode -eq 0) -and ($probe.Output -match '(^|\s)uv(\s|$)')
+}
+
+function Test-UvInstalledByWinget {
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+
+    $probe = Invoke-ProbeCommand -FilePath "winget" -Arguments @("list", "--id", "astral-sh.uv", "-e")
+    return ($probe.ExitCode -eq 0) -and ($probe.Output -match 'astral-sh\.uv')
+}
+
+function Test-UvInstalledByPipx {
+    if (-not (Get-Command pipx -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+
+    $probe = Invoke-ProbeCommand -FilePath "pipx" -Arguments @("list")
+    return ($probe.ExitCode -eq 0) -and ($probe.Output -match '(?m)\bpackage uv\b')
+}
+
+function Test-UvInstalledInActiveVirtualenv {
+    if ([string]::IsNullOrWhiteSpace($env:VIRTUAL_ENV)) {
+        return $false
+    }
+
+    $uvCommand = Get-Command uv -ErrorAction SilentlyContinue
+    if (-not $uvCommand) {
+        return $false
+    }
+
+    $uvPath = [IO.Path]::GetFullPath($uvCommand.Source)
+    $venvPath = ([IO.Path]::GetFullPath($env:VIRTUAL_ENV)).TrimEnd(
+        [IO.Path]::DirectorySeparatorChar,
+        [IO.Path]::AltDirectorySeparatorChar
+    )
+    $nativePrefix = "$venvPath$([IO.Path]::DirectorySeparatorChar)"
+    $alternatePrefix = "$venvPath$([IO.Path]::AltDirectorySeparatorChar)"
+
+    return $uvPath.StartsWith($nativePrefix, [StringComparison]::OrdinalIgnoreCase) -or
+        $uvPath.StartsWith($alternatePrefix, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Update-ExistingUv {
+    if (Test-UvSelfUpdateSupported) {
+        Invoke-InstallCommand -FilePath "uv" -Arguments @("self", "update")
+        return
+    }
+
+    if (Test-UvInstalledByScoop) {
+        Invoke-InstallCommand -FilePath "scoop" -Arguments @("update", "uv")
+        return
+    }
+
+    if (Test-UvInstalledByWinget) {
+        Invoke-InstallCommand -FilePath "winget" -Arguments @(
+            "upgrade",
+            "--id",
+            "astral-sh.uv",
+            "-e",
+            "--accept-package-agreements",
+            "--accept-source-agreements"
+        )
+        return
+    }
+
+    if (Test-UvInstalledByPipx) {
+        Invoke-InstallCommand -FilePath "pipx" -Arguments @("upgrade", "uv")
+        return
+    }
+
+    if (Test-UvInstalledInActiveVirtualenv) {
+        Invoke-InstallCommand -FilePath "python" -Arguments @("-m", "pip", "install", "--upgrade", "uv")
+        return
+    }
+
+    if (Test-UvVersionSatisfiesMinimum) {
+        Write-Host "uv is already installed and satisfies >=$MinUvVersion; skipping automatic uv update because the install source was not detected."
+        return
+    }
+
+    $version = "unknown"
+    try {
+        $version = Get-InstalledUvVersion
+    }
+    catch {
+        $version = "unknown"
+    }
+    throw "uv $MinUvVersion or newer is required; found uv $version. The existing uv install source was not detected. Upgrade uv manually with the package manager that installed it, then rerun this installer."
+}
+
+function Install-OrUpdateUv {
+    Add-UvToPath
+
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        Update-ExistingUv
+        Assert-MinUvVersion
+        return
+    }
+
+    Invoke-UvInstaller
+    Add-UvToPath
+
+    if ((-not $DryRun) -and (-not (Get-Command uv -ErrorAction SilentlyContinue))) {
+        throw "uv was installed, but it is not available on PATH. Open a new terminal or add uv's bin directory to PATH."
+    }
+
+    Assert-MinUvVersion
+}
+
+function Get-PackageSpec {
+    $includeNim = $VoiceNim
+    $includeLocal = $VoiceLocal
+
+    if ($VoiceAll) {
+        $includeNim = $true
+        $includeLocal = $true
+    }
+
+    if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not $includeLocal)) {
+        throw "-TorchBackend requires -VoiceLocal or -VoiceAll."
+    }
+
+    if ($includeNim -and $includeLocal) {
+        return "free-claude-code[voice,voice_local] @ $RepoGitUrl"
+    }
+
+    if ($includeNim) {
+        return "free-claude-code[voice] @ $RepoGitUrl"
+    }
+
+    if ($includeLocal) {
+        return "free-claude-code[voice_local] @ $RepoGitUrl"
+    }
+
+    return $RepoGitUrl
+}
+
+function Install-FreeClaudeCode {
+    $packageSpec = Get-PackageSpec
+    $toolArgs = @("tool", "install", "--force")
+
+    if (-not [string]::IsNullOrWhiteSpace($TorchBackend)) {
+        $toolArgs += @("--torch-backend", $TorchBackend)
+    }
+
+    $toolArgs += $packageSpec
+    Invoke-InstallCommand -FilePath "uv" -Arguments $toolArgs
+}
+
+if ($Help) {
+    Show-Usage
+    return
+}
+
+if ($RemainingArgs.Count -gt 0) {
+    Show-Usage
+    throw "Unknown option: $($RemainingArgs -join ' ')"
+}
+
+if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not ($VoiceLocal -or $VoiceAll))) {
+    throw "-TorchBackend requires -VoiceLocal or -VoiceAll."
+}
+
+Write-Step "Installing uv if missing, updating if present"
+Install-OrUpdateUv
+
+Write-Step "Installing Python $PythonVersion"
+Invoke-InstallCommand -FilePath "uv" -Arguments @("python", "install", $PythonVersion)
+
+Write-Step "Installing or updating Free Claude Code"
+Install-FreeClaudeCode
+
+Write-Host ""
+Write-Host "Free Claude Code is installed. Start the proxy with: fcc-server"
+Write-Host "Run Claude Code with: fcc-claude"


### PR DESCRIPTION
Free Claude Code only install/update script

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Windows FCC-only install path. The main changes are:

- Adds `scripts/install-fcc-only.ps1` to install or update `uv`, Python `3.14.0`, and Free Claude Code.
- Omits the Claude Code and Codex npm install steps from the FCC-only script.
- Adds a README PowerShell command for the FCC-only installer.

<h3>Confidence Score: 0/5</h3>







<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a dry-run workflow for the fcc-only install and reviewed the harness to confirm the intended command, pwsh availability blocker, and static fallbacks for uv, Python 3.14.0, and the uv tool install construction.
- Inspected the base state by git-showing the base commit's install-fcc-only.ps1 and then ran a head-option harness with mocked uv; observed that the script was not present on base (exit 128) and that pwsh/powershell were not available, causing 127 exits before code execution.
- Cross-checked the README-driven command reference and repository origin; confirmed the base state shows install\_snippet\_status and script\_status as absent, and noted pwsh unavailability led to a safe executable-content check via git resolution and PowerShell markers.

<a href="https://app.greptile.com/trex/runs/12463338/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **README FCC-only PowerShell install command points to the wrong GitHub repository**

   - **Bug**
     - The new Windows PowerShell FCC-only install snippet in `README.md` points users to `https://github.com/tspry/free-claude-code/blob/main/scripts/install-fcc-only.ps1?raw=1`, while the repository under validation is `Alishahryar1/free-claude-code` and the local script is present at `scripts/install-fcc-only.ps1`. Users copying the documented command may fetch a script from a different repository or fail to get the intended changed script.
   - **Cause**
     - The README snippet was added with the `tspry/free-claude-code` GitHub owner instead of the project’s repository owner/path used by the rest of the README install links and by the script’s `$RepoGitUrl`.
   - **Fix**
     - Update the README line to reference the project repository, e.g. `irm "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install-fcc-only.ps1?raw=1" | iex`, or otherwise align it with the canonical repository path for this project.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Change section header for Free Claude Co..."](https://github.com/alishahryar1/free-claude-code/commit/f0b0024d209e4e33eceff1625990cff328a0efaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39891175)</sub>

<!-- /greptile_comment -->