### PR TITLE
Add Azure AI Foundry provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,14 @@ GROQ_API_KEY=""
 CEREBRAS_API_KEY=""
 
 
+# Azure AI Foundry (OpenAI-compatible v1 surface at <resource>.services.ai.azure.com/openai/v1)
+# Deploy a model (e.g. Moonshot Kimi) in Azure AI Foundry, then set the resource endpoint and key.
+AZURE_FOUNDRY_API_KEY=""
+AZURE_FOUNDRY_BASE_URL="https://<resource>.services.ai.azure.com/openai/v1"
+# Optional: cap requested output tokens (Azure rejects over-budget max_tokens with a 400). Blank disables.
+AZURE_FOUNDRY_MAX_TOKENS=""
+
+
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
@@ -69,7 +77,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "wafer" | "kimi" | "cerebras" | "groq" | "fireworks" | "cloudflare" | "zai" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "wafer" | "kimi" | "cerebras" | "groq" | "fireworks" | "cloudflare" | "zai" | "azure_foundry" | "lmstudio" | "llamacpp" | "ollama"
 MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=
@@ -96,6 +104,7 @@ FCC_SMOKE_MODEL_CLOUDFLARE=
 FCC_SMOKE_MODEL_GEMINI=
 FCC_SMOKE_MODEL_GROQ=
 FCC_SMOKE_MODEL_CEREBRAS=
+FCC_SMOKE_MODEL_AZURE_FOUNDRY=
 FCC_SMOKE_NIM_MODELS=
 FCC_SMOKE_NIM_EXTRA_MODELS=
 FCC_SMOKE_OPENROUTER_FREE_MODELS=
@@ -129,6 +138,7 @@ CLOUDFLARE_PROXY=""
 GEMINI_PROXY=""
 GROQ_PROXY=""
 CEREBRAS_PROXY=""
+AZURE_FOUNDRY_PROXY=""
 
 PROVIDER_RATE_LIMIT=1
 PROVIDER_RATE_WINDOW=3

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Free Claude Code routes Anthropic Messages API traffic from Claude Code (CLI and
 - Drop-in proxy for Claude Code's Anthropic API calls (`/v1/messages`, `/v1/models`).
 - Drop-in proxy for Codex via the OpenAI Responses API (`/v1/responses`).
 - `fcc-claude` and `fcc-codex` launchers that read the current Admin UI port and auth token each time they start.
-- 18 provider backends: NVIDIA NIM, OpenRouter, Google AI Studio (Gemini), DeepSeek, Mistral La Plateforme, Mistral Codestral, OpenCode Zen, OpenCode Go, Wafer, Kimi, Cerebras Inference, Groq, Fireworks AI, Cloudflare, Z.ai, LM Studio, llama.cpp, and Ollama.
+- 19 provider backends: NVIDIA NIM, OpenRouter, Google AI Studio (Gemini), DeepSeek, Mistral La Plateforme, Mistral Codestral, OpenCode Zen, OpenCode Go, Wafer, Kimi, Cerebras Inference, Groq, Fireworks AI, Cloudflare, Z.ai, Azure AI Foundry, LM Studio, llama.cpp, and Ollama.
 - Per-model routing for Claude Code: send Opus, Sonnet, Haiku, and fallback traffic to different providers.
 - Native Claude Code `/model` picker support through the proxy's `/v1/models` endpoint (see [Model Picker](#model-picker)).
 - Native Codex `/model` picker support when launched through `fcc-codex`, using a generated local model catalog.

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -246,6 +246,20 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
             "rate_limit",
         ),
     ),
+    "azure_foundry": ProviderDescriptor(
+        provider_id="azure_foundry",
+        display_name="Azure AI Foundry",
+        transport_type="openai_chat",
+        credential_env="AZURE_FOUNDRY_API_KEY",
+        credential_url="https://ai.azure.com/",
+        credential_attr="azure_foundry_api_key",
+        # No universal default: the endpoint is resource-specific and is supplied
+        # via AZURE_FOUNDRY_BASE_URL (…services.ai.azure.com/openai/v1).
+        default_base_url=None,
+        base_url_attr="azure_foundry_base_url",
+        proxy_attr="azure_foundry_proxy",
+        capabilities=("chat", "streaming", "tools", "thinking", "rate_limit"),
+    ),
     "lmstudio": ProviderDescriptor(
         provider_id="lmstudio",
         display_name="LM Studio",

--- a/config/settings.py
+++ b/config/settings.py
@@ -64,6 +64,20 @@ class Settings(BaseSettings):
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
 
+    # ==================== Azure AI Foundry (OpenAI-compatible v1) ====================
+    # Resource-specific endpoint, e.g. https://<resource>.services.ai.azure.com/openai/v1
+    azure_foundry_api_key: str = Field(
+        default="", validation_alias="AZURE_FOUNDRY_API_KEY"
+    )
+    azure_foundry_base_url: str = Field(
+        default="", validation_alias="AZURE_FOUNDRY_BASE_URL"
+    )
+    # Optional cap on requested output tokens (Azure deployments reject over-budget
+    # max_tokens with a 400); blank/unset disables clamping.
+    azure_foundry_max_tokens: int | None = Field(
+        default=None, validation_alias="AZURE_FOUNDRY_MAX_TOKENS"
+    )
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord" | "none"
     messaging_platform: str = Field(
@@ -125,6 +139,7 @@ class Settings(BaseSettings):
     gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")
     groq_proxy: str = Field(default="", validation_alias="GROQ_PROXY")
     cerebras_proxy: str = Field(default="", validation_alias="CEREBRAS_PROXY")
+    azure_foundry_proxy: str = Field(default="", validation_alias="AZURE_FOUNDRY_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")
@@ -274,9 +289,13 @@ class Settings(BaseSettings):
             return None
         return v
 
-    @field_validator("max_message_log_entries_per_chat", mode="before")
+    @field_validator(
+        "max_message_log_entries_per_chat",
+        "azure_foundry_max_tokens",
+        mode="before",
+    )
     @classmethod
-    def parse_optional_log_cap(cls, v: Any) -> Any:
+    def parse_optional_int(cls, v: Any) -> Any:
         if v == "" or v is None:
             return None
         return v

--- a/providers/azure_foundry/__init__.py
+++ b/providers/azure_foundry/__init__.py
@@ -1,0 +1,5 @@
+"""Azure AI Foundry provider exports."""
+
+from .client import AzureFoundryProvider
+
+__all__ = ("AzureFoundryProvider",)

--- a/providers/azure_foundry/client.py
+++ b/providers/azure_foundry/client.py
@@ -1,0 +1,72 @@
+"""Azure AI Foundry provider (OpenAI-compatible ``/openai/v1`` chat completions).
+
+Azure AI Foundry exposes deployed models (e.g. Moonshot ``Kimi-K2.6``) through an
+OpenAI-compatible surface at ``https://<resource>.services.ai.azure.com/openai/v1``.
+That route accepts ``Authorization: Bearer <key>`` and a standard
+``POST /chat/completions`` body, so the shared OpenAI chat transport drives it
+directly. The base URL is resource-specific and supplied via
+``AZURE_FOUNDRY_BASE_URL`` (no universal default).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers.base import ProviderConfig
+from providers.exceptions import InvalidRequestError
+from providers.transports.openai_chat import (
+    OpenAIChatRequestPolicy,
+    OpenAIChatTransport,
+    build_openai_chat_request_body,
+)
+
+_REQUEST_POLICY = OpenAIChatRequestPolicy(
+    provider_name="AZURE_FOUNDRY",
+    include_extra_body=True,
+    max_tokens_field="max_tokens",
+)
+
+
+class AzureFoundryProvider(OpenAIChatTransport):
+    """Azure AI Foundry models via the OpenAI-compatible v1 surface."""
+
+    def __init__(self, config: ProviderConfig, *, max_tokens: int | None = None):
+        base_url = (config.base_url or "").strip()
+        if not base_url:
+            raise InvalidRequestError(
+                "AZURE_FOUNDRY_BASE_URL is not set. Add your Azure AI Foundry "
+                "OpenAI-compatible endpoint, e.g. "
+                "https://<resource>.services.ai.azure.com/openai/v1"
+            )
+        super().__init__(
+            config,
+            provider_name="AZURE_FOUNDRY",
+            base_url=base_url,
+            api_key=config.api_key,
+        )
+        self._max_tokens = max_tokens
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        return build_openai_chat_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            policy=_REQUEST_POLICY,
+        )
+
+    def _prepare_create_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Clamp the requested output budget to ``AZURE_FOUNDRY_MAX_TOKENS``.
+
+        Claude clients routinely request a far larger ``max_tokens`` than an Azure
+        deployment allows, which Azure rejects with a 400. When a cap is configured
+        we lower any over-budget value (without mutating the caller's body).
+        """
+        if self._max_tokens is None:
+            return body
+        clamped = {**body}
+        for field_name in ("max_tokens", "max_completion_tokens"):
+            value = clamped.get(field_name)
+            if isinstance(value, int) and value > self._max_tokens:
+                clamped[field_name] = self._max_tokens
+        return clamped

--- a/providers/runtime/factory.py
+++ b/providers/runtime/factory.py
@@ -127,6 +127,12 @@ def _create_cerebras(config: ProviderConfig, _settings: Settings) -> BaseProvide
     return CerebrasProvider(config)
 
 
+def _create_azure_foundry(config: ProviderConfig, settings: Settings) -> BaseProvider:
+    from providers.azure_foundry import AzureFoundryProvider
+
+    return AzureFoundryProvider(config, max_tokens=settings.azure_foundry_max_tokens)
+
+
 PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
@@ -143,6 +149,7 @@ PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "fireworks": _create_fireworks,
     "cloudflare": _create_cloudflare,
     "zai": _create_zai,
+    "azure_foundry": _create_azure_foundry,
     "lmstudio": _create_lmstudio,
     "llamacpp": _create_llamacpp,
     "ollama": _create_ollama,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.4.1"
+version = "2.5.0"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -59,6 +59,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "groq": "groq/llama-3.3-70b-versatile",
     "cerebras": "cerebras/llama3.1-8b",
     "cloudflare": "cloudflare/anthropic/claude-sonnet-4-5",
+    "azure_foundry": "azure_foundry/Kimi-K2.6",
 }
 
 NVIDIA_NIM_CLI_DEFAULT_MODELS: tuple[str, ...] = (
@@ -259,6 +260,11 @@ class SmokeConfig:
             return bool(self.settings.groq_api_key.strip())
         if provider == "cerebras":
             return bool(self.settings.cerebras_api_key.strip())
+        if provider == "azure_foundry":
+            return bool(
+                self.settings.azure_foundry_api_key.strip()
+                and self.settings.azure_foundry_base_url.strip()
+            )
         if provider == "cloudflare":
             return bool(
                 self.settings.cloudflare_api_token.strip()

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -20,6 +20,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "fireworks",
     "cloudflare",
     "zai",
+    "azure_foundry",
     "lmstudio",
     "llamacpp",
     "ollama",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -40,6 +40,8 @@ def _settings(**overrides):
         "gemini_api_key": "",
         "groq_api_key": "",
         "cerebras_api_key": "",
+        "azure_foundry_api_key": "",
+        "azure_foundry_base_url": "",
         "fireworks_api_key": "",
         "cloudflare_api_token": "",
         "cloudflare_account_id": "",

--- a/tests/providers/test_azure_foundry.py
+++ b/tests/providers/test_azure_foundry.py
@@ -1,0 +1,78 @@
+"""Tests for the Azure AI Foundry (OpenAI-compatible v1) provider."""
+
+from unittest.mock import patch
+
+import pytest
+
+from api.models.anthropic import Message, MessagesRequest
+from providers.azure_foundry import AzureFoundryProvider
+from providers.base import ProviderConfig
+from providers.exceptions import InvalidRequestError
+
+_BASE_URL = "https://example-resource.services.ai.azure.com/openai/v1"
+
+
+def _config(base_url: str | None = _BASE_URL) -> ProviderConfig:
+    return ProviderConfig(
+        api_key="test_azure_key",
+        base_url=base_url,
+        rate_limit=10,
+        rate_window=60,
+        enable_thinking=True,
+    )
+
+
+@pytest.fixture
+def azure_provider():
+    with patch("providers.transports.openai_chat.transport.AsyncOpenAI"):
+        yield AzureFoundryProvider(_config(), max_tokens=8192)
+
+
+def test_init_sets_base_url_and_key():
+    with patch("providers.transports.openai_chat.transport.AsyncOpenAI") as mock_client:
+        provider = AzureFoundryProvider(_config(), max_tokens=8192)
+    assert provider._api_key == "test_azure_key"
+    assert provider._base_url == _BASE_URL
+    assert mock_client.called
+
+
+def test_missing_base_url_raises_invalid_request():
+    with pytest.raises(InvalidRequestError, match="AZURE_FOUNDRY_BASE_URL is not set"):
+        AzureFoundryProvider(_config(base_url=None))
+
+
+def test_build_request_body_openai_chat(azure_provider):
+    request = MessagesRequest(
+        model="Kimi-K2.6",
+        max_tokens=50,
+        messages=[Message(role="user", content="hi")],
+    )
+    body = azure_provider._build_request_body(request)
+    assert body["model"] == "Kimi-K2.6"
+    assert body["max_tokens"] == 50
+    assert body["messages"][0]["role"] == "user"
+
+
+def test_prepare_create_body_clamps_over_budget(azure_provider):
+    clamped = azure_provider._prepare_create_body({"max_tokens": 64000})
+    assert clamped["max_tokens"] == 8192
+
+
+def test_prepare_create_body_passes_through_under_budget(azure_provider):
+    body = {"max_tokens": 2000}
+    result = azure_provider._prepare_create_body(body)
+    assert result["max_tokens"] == 2000
+    # Must not mutate the caller's body.
+    assert body["max_tokens"] == 2000
+
+
+def test_prepare_create_body_clamps_max_completion_tokens(azure_provider):
+    clamped = azure_provider._prepare_create_body({"max_completion_tokens": 64000})
+    assert clamped["max_completion_tokens"] == 8192
+
+
+def test_no_clamp_when_cap_unset():
+    with patch("providers.transports.openai_chat.transport.AsyncOpenAI"):
+        provider = AzureFoundryProvider(_config(), max_tokens=None)
+    result = provider._prepare_create_body({"max_tokens": 64000})
+    assert result["max_tokens"] == 64000

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -7,6 +7,7 @@ import pytest
 from config.nim import NimSettings
 from config.provider_catalog import PROVIDER_CATALOG, ZAI_DEFAULT_BASE
 from config.provider_ids import SUPPORTED_PROVIDER_IDS
+from providers.azure_foundry import AzureFoundryProvider
 from providers.cerebras import CerebrasProvider
 from providers.cloudflare import CloudflareProvider
 from providers.codestral import CodestralProvider
@@ -68,6 +69,12 @@ def _make_settings(**overrides):
     mock.groq_proxy = ""
     mock.cerebras_api_key = ""
     mock.cerebras_proxy = ""
+    mock.azure_foundry_api_key = "test_azure_key"
+    mock.azure_foundry_base_url = (
+        "https://example-resource.services.ai.azure.com/openai/v1"
+    )
+    mock.azure_foundry_max_tokens = None
+    mock.azure_foundry_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
     mock.provider_max_concurrency = 5
@@ -219,6 +226,7 @@ def test_create_provider_instantiates_each_builtin():
         "gemini": GeminiProvider,
         "groq": GroqProvider,
         "cerebras": CerebrasProvider,
+        "azure_foundry": AzureFoundryProvider,
     }
 
     with (

--- a/uv.lock
+++ b/uv.lock
@@ -350,34 +350,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Adds `azure_foundry` as a supported provider (`MODEL`/`MODEL_OPUS`/`MODEL_SONNET`/`MODEL_HAIKU` can now route to `azure_foundry/<deployment-name>`), reusing the existing `openai_chat` transport since Azure AI Foundry's `/openai/v1` surface is OpenAI Chat Completions-compatible with Bearer auth.
- Configured via `AZURE_FOUNDRY_API_KEY`, `AZURE_FOUNDRY_BASE_URL` (resource-specific — e.g. `https://<resource>.services.ai.azure.com/openai/v1` — no universal default), and an optional `AZURE_FOUNDRY_MAX_TOKENS` cap that clamps an over-budget requested `max_tokens`/`max_completion_tokens` before it reaches the deployment (returns a copy of the request body, never mutates the caller's).
- Wired through the provider catalog/factory/settings sync-invariant (`PROVIDER_CATALOG` == `PROVIDER_FACTORIES` == `SUPPORTED_PROVIDER_IDS`), which automatically surfaces the new credential/base-URL/proxy fields in the Admin UI and provider status checks.
- Added to the smoke-config provider matrix (`PROVIDER_SMOKE_DEFAULT_MODELS`, `has_provider_configuration`) so `azure_foundry` participates in `fcc-server`'s live smoke coverage alongside the other OpenAI-compatible providers.

## Why
Azure AI Foundry is a common way to reach hosted models (including third-party deployments like Moonshot's Kimi) behind an OpenAI-compatible endpoint with per-resource rate limits. This lets `free-claude-code` route Claude Code traffic to any Azure AI Foundry deployment the same way it already does for Cerebras/Groq.

## Test plan
- [x] `ruff format` / `ruff check` clean
- [x] `ty check` clean (no `# type: ignore` added)
- [x] Full `pytest` suite passes (1705 tests), including new `tests/providers/test_azure_foundry.py` and updated provider-runtime/contract tests
- [x] Live end-to-end verification against a real Azure AI Foundry deployment (Kimi-K2.6): provider construction, request-body `max_tokens` clamping, and a full proxied `/v1/messages` call returning a correct streamed response
- [ ] Reviewer: no live-smoke CI credentials for Azure AI Foundry are available in this environment; `smoke/lib/config.py` wiring is unit-testable but the actual `provider` smoke target for `azure_foundry` needs a real deployment to exercise in CI

## Residual risks
- No universal default base URL is possible (resource-specific per Azure tenant), so misconfiguration surfaces as a clear `InvalidRequestError` at provider construction rather than a generic connection failure — documented in `.env.example`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Azure AI Foundry as an OpenAI-compatible provider. The main changes are:

- New `azure_foundry` provider implementation and runtime factory wiring.
- New Azure Foundry settings, env vars, proxy field, and token-cap option.
- Provider catalog, smoke-config, README, and `.env.example` updates.
- Tests for provider construction, request-body generation, clamping, catalog order, and smoke config.
- Package version and lockfile updates.

<h3>Confidence Score: 3/5</h3>

The provider integration is broadly covered, but merge safety is reduced by configuration/readiness edge cases that can make Azure Foundry appear usable while failing at request time.

The changes are localized and accompanied by tests, but the new provider has validation gaps around required base URL configuration and token cap bounds.

config/provider_catalog.py and providers/azure_foundry/client.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Created a focused repro script trex-artifacts/repro\_azure\_foundry\_readiness\_mismatch.py to demonstrate that admin status reports azure\_foundry as configured while create\_provider raises InvalidRequestError for an empty base\_url.
- Ran the azure\_foundry\_routing\_probe.py to validate azure\_foundry routing; observed initial Settings ValidationError rejecting azure\_foundry, followed by a later run that ended with a SyntaxError before provider construction.
- Executed the azure-foundry token clamp probe; the first run failed with ImportError for AzureFoundryProvider, and the second run succeeded with provider construction using max\_tokens 128 and clamped bodies, with no HTTP endpoint involved.
- Ran the Azure Foundry catalog smoke tests; initial state showed azure\_foundry\_presence false across catalog, factory, settings, and smoke defaults, while the after-state showed presence true across all surfaces and sync\_invariant\_equal true, with the smoke matrix indicating complete and complete\_proxy\_cap behavior.

<a href="https://app.greptile.com/trex/runs/12856693/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **README does not document Azure Foundry env vars or provider model format**

   - **Bug**
     - The head validation artifact shows `.env.example` contains `AZURE_FOUNDRY_API_KEY`, `AZURE_FOUNDRY_BASE_URL`, `AZURE_FOUNDRY_MAX_TOKENS`, and `azure_foundry`, but `README.md` checks are all false for those same Azure Foundry env/model-format strings. `README.md` only mentions Azure AI Foundry in the provider list, so users reading the primary docs do not see the required API key/base URL configuration or the `azure_foundry/...` smoke/model format.
   - **Cause**
     - The PR updated `.env.example` and provider wiring but did not add Azure Foundry configuration details to the README documentation surface.
   - **Fix**
     - Add a README section or provider configuration table row documenting `AZURE_FOUNDRY_API_KEY`, `AZURE_FOUNDRY_BASE_URL`, optional proxy/max-token settings, and an example `azure_foundry/<model>` model string.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Add Azure AI Foundry provider"](https://github.com/alishahryar1/free-claude-code/commit/ef78cd7522868f34a7da457cd2a8fb95de607363) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40978669)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/alishahryar1/github/Alishahryar1/free-claude-code/-/custom-context?memory=d2fd24d8-0dec-4faf-8ee4-e085e215a2f8))

<!-- /greptile_comment -->