### PR TITLE
Fix NIM reasoning budget fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -356,6 +356,9 @@ DeepSeek attachment/tool/thinking compatibility. DeepSeek intentionally uses its
 OpenAI-compatible Chat Completions endpoint because that is the endpoint that
 reports prompt-cache hit/miss counters; the provider maps those counters back
 into Anthropic usage fields for Claude-compatible clients.
+NIM reasoning budget control is also treated as a provider-owned best-effort
+downgrade: if an upstream NIM deployment rejects explicit budget control, FCC
+retries without the budget while preserving thinking enablement.
 
 Shared provider responsibilities include upstream rate limiting, model listing,
 safe error mapping, transport cleanup, thinking/tool handling, retry or recovery

--- a/providers/nvidia_nim/client.py
+++ b/providers/nvidia_nim/client.py
@@ -56,8 +56,9 @@ class NvidiaNimProvider(OpenAIChatTransport):
     def _get_retry_request_body(self, error: Exception, body: dict) -> dict | None:
         """Retry once with a downgraded body when NIM rejects a known field."""
         status_code = getattr(error, "status_code", None)
-        if not isinstance(error, openai.BadRequestError) and status_code != 400:
-            return None
+        bad_request_like = isinstance(error, openai.BadRequestError) or (
+            status_code == 400
+        )
 
         error_text = str(error)
         error_body = getattr(error, "body", None)
@@ -65,14 +66,19 @@ class NvidiaNimProvider(OpenAIChatTransport):
             error_text = f"{error_text} {json.dumps(error_body, default=str)}"
         error_text = error_text.lower()
 
-        if "reasoning_budget" in error_text:
+        if _is_reasoning_budget_rejection(error_text) and (
+            bad_request_like or status_code == 500
+        ):
             retry_body = clone_body_without_reasoning_budget(body)
             if retry_body is None:
                 return None
             logger.warning(
-                "NIM_STREAM: retrying without reasoning_budget after 400 error"
+                "NIM_STREAM: retrying without reasoning budget after upstream rejection"
             )
             return retry_body
+
+        if not bad_request_like:
+            return None
 
         if "chat_template" in error_text:
             retry_body = clone_body_without_chat_template(body)
@@ -91,3 +97,10 @@ class NvidiaNimProvider(OpenAIChatTransport):
             return retry_body
 
         return None
+
+
+def _is_reasoning_budget_rejection(error_text: str) -> bool:
+    """Return whether NIM rejected optional thinking budget control."""
+    if "reasoning_budget" in error_text:
+        return True
+    return "thinking_token_budget" in error_text and "reasoning_config" in error_text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.4.2"
+version = "2.4.3"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/providers/test_nvidia_nim.py
+++ b/tests/providers/test_nvidia_nim.py
@@ -97,6 +97,21 @@ def _make_bad_request_error(message: str) -> openai.BadRequestError:
     return openai.BadRequestError(message, response=response, body=body)
 
 
+def _make_internal_server_error(message: str) -> openai.InternalServerError:
+    response = Response(
+        status_code=500,
+        request=Request("POST", f"{NVIDIA_NIM_DEFAULT_BASE}/chat/completions"),
+    )
+    body = {
+        "error": {
+            "message": message,
+            "type": "internal_server_error",
+            "code": 500,
+        }
+    }
+    return openai.InternalServerError(message, response=response, body=body)
+
+
 @pytest.fixture(autouse=True)
 def mock_rate_limiter():
     """Mock the global rate limiter to prevent waiting."""
@@ -713,6 +728,51 @@ async def test_stream_response_retries_without_reasoning_budget(nim_provider):
 
 
 @pytest.mark.asyncio
+async def test_stream_response_retries_without_budget_for_thinking_token_error(
+    nim_provider,
+):
+    req = MockRequest(model="meta/llama-3.3-70b-instruct")
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content="Recovered", reasoning_content=""),
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=5)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    error = _make_internal_server_error(
+        "ValueError: thinking_token_budget is set but reasoning_config is not "
+        "configured. Please set --reasoning-config to use thinking_token_budget."
+    )
+
+    with patch.object(
+        nim_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.side_effect = [error, mock_stream()]
+
+        events = [e async for e in nim_provider.stream_response(req)]
+
+    assert mock_create.await_count == 2
+    first_call = mock_create.await_args_list[0].kwargs
+    second_call = mock_create.await_args_list[1].kwargs
+    assert (
+        first_call["extra_body"]["chat_template_kwargs"]["reasoning_budget"]
+        == first_call["max_tokens"]
+    )
+    assert "reasoning_budget" not in second_call["extra_body"]
+    assert "reasoning_budget" not in second_call["extra_body"]["chat_template_kwargs"]
+    assert second_call["extra_body"]["chat_template_kwargs"]["thinking"] is True
+    assert second_call["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+    assert any("Recovered" in event for event in events)
+    assert any("message_stop" in event for event in events)
+
+
+@pytest.mark.asyncio
 async def test_stream_response_retries_without_reasoning_content(nim_provider):
     req = MockRequest(
         system=None,
@@ -779,4 +839,44 @@ async def test_stream_response_bad_request_without_reasoning_budget_does_not_ret
 
     assert mock_create.await_count == 1
     assert any("Invalid request sent to provider" in event for event in events)
+    assert any("message_stop" in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_response_unrelated_internal_error_does_not_downgrade(
+    nim_provider,
+):
+    req = MockRequest()
+    error = _make_internal_server_error("unrelated internal provider failure")
+
+    with patch.object(
+        nim_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.side_effect = error
+
+        events = [e async for e in nim_provider.stream_response(req)]
+
+    assert mock_create.await_count == 1
+    assert any("Provider API request failed" in event for event in events)
+    assert any("message_stop" in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_response_internal_reasoning_content_error_does_not_downgrade(
+    nim_provider,
+):
+    req = MockRequest()
+    error = _make_internal_server_error(
+        "reasoning_content could not be processed by the upstream model"
+    )
+
+    with patch.object(
+        nim_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.side_effect = error
+
+        events = [e async for e in nim_provider.stream_response(req)]
+
+    assert mock_create.await_count == 1
+    assert any("Provider API request failed" in event for event in events)
     assert any("message_stop" in event for event in events)

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.4.2"
+version = "2.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

NIM can reject explicit reasoning budget control with a `thinking_token_budget` and `reasoning_config` error. FCC treated that provider-specific budget rejection as a final failure even though thinking can still work without the budget knob.

## Changes

| Before | After |
| --- | --- |
| NIM retried budget rejection only for `400` errors mentioning `reasoning_budget`. | NIM retries budget rejection for the reported `500` `thinking_token_budget` and `reasoning_config` error shape. |
| The retry path removed budget control only for the old error wording. | The retry path removes only budget control while preserving `thinking` and `enable_thinking`. |
| Unrelated internal NIM errors followed the same final error path. | Unrelated internal NIM errors still follow the same final error path. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates NVIDIA NIM reasoning budget fallback behavior. The main changes are:

- Retries recognized NIM reasoning budget rejections, including the reported 500 `thinking_token_budget` and `reasoning_config` error shape.
- Removes only explicit budget fields on retry while preserving `thinking` and `enable_thinking`.
- Keeps unrelated internal NIM errors on the normal final error path.
- Adds regression tests, architecture notes, and the required patch version and lockfile bump.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to NIM retry classification, preserves unrelated error handling, and includes tests for both retry and no-retry paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the baseline scenario1 behavior prior to the change: create\_call\_count is 1, the request included reasoning\_budget: 100, and the final status was provider\_error with HTTP 500.
- Observed the updated scenario1 behavior after the change: create\_call\_count is 2, the second request lacks reasoning\_budget while thinking: true and enable\_thinking: true, and the final status is recovered\_success with a streamed Recovered content.
- Observed scenario3 remained as a 500 with create\_call\_count=1 and final\_status=provider\_error, confirming the new 500 classifier targets budget-rejection text.

<a href="https://app.greptile.com/trex/runs/13222956/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| providers/nvidia_nim/client.py | Extends NIM retry downgrade detection to handle 500 thinking budget rejection while preserving existing 400-only downgrades for chat template and reasoning content. |
| tests/providers/test_nvidia_nim.py | Adds coverage for NIM 500 thinking budget fallback and confirms unrelated 500 errors are not downgraded. |
| ARCHITECTURE.md | Documents NIM reasoning budget fallback as a provider-owned best-effort downgrade. |
| pyproject.toml | Bumps the project patch version for the production bug fix. |
| uv.lock | Synchronizes the editable package version with the pyproject patch bump. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Claude-compatible client
participant FCC as FCC NIM provider
participant NIM as NVIDIA NIM upstream

Client->>FCC: stream_response(request with thinking)
FCC->>NIM: chat.completions.create(extra_body with reasoning_budget)
NIM-->>FCC: 500 thinking_token_budget/reasoning_config rejection
FCC->>FCC: detect reasoning budget rejection
FCC->>FCC: clone body without reasoning_budget only
FCC->>NIM: retry chat.completions.create(thinking still enabled)
NIM-->>FCC: recovered stream chunks
FCC-->>Client: Anthropic SSE events
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Claude-compatible client
participant FCC as FCC NIM provider
participant NIM as NVIDIA NIM upstream

Client->>FCC: stream_response(request with thinking)
FCC->>NIM: chat.completions.create(extra_body with reasoning_budget)
NIM-->>FCC: 500 thinking_token_budget/reasoning_config rejection
FCC->>FCC: detect reasoning budget rejection
FCC->>FCC: clone body without reasoning_budget only
FCC->>NIM: retry chat.completions.create(thinking still enabled)
NIM-->>FCC: recovered stream chunks
FCC-->>Client: Anthropic SSE events
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix NIM reasoning budget fallback"](https://github.com/alishahryar1/free-claude-code/commit/cc9bb0caaf6e085dd7b7e062737af8e2793066a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41698924)</sub>

<!-- /greptile_comment -->