### PR TITLE
Fix Cloudflare Workers AI transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ ZAI_API_KEY=""
 FIREWORKS_API_KEY=""
 
 
-# Cloudflare AI REST Config (Anthropic-compatible Messages at api.cloudflare.com/client/v4/accounts/<id>/ai/v1)
+# Cloudflare Workers AI Config (OpenAI-compatible Chat Completions at api.cloudflare.com/client/v4/accounts/<id>/ai/v1)
 CLOUDFLARE_API_TOKEN=""
 CLOUDFLARE_ACCOUNT_ID=""
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -355,7 +355,10 @@ Gemini thought signatures, NIM tool-schema aliases and retry downgrades, or
 DeepSeek attachment/tool/thinking compatibility. DeepSeek intentionally uses its
 OpenAI-compatible Chat Completions endpoint because that is the endpoint that
 reports prompt-cache hit/miss counters; the provider maps those counters back
-into Anthropic usage fields for Claude-compatible clients.
+into Anthropic usage fields for Claude-compatible clients. Cloudflare uses its
+account-scoped Workers AI OpenAI-compatible Chat Completions endpoint for
+`@cf/...` model IDs, while account ID composition, model search, and
+Cloudflare-specific reasoning deltas stay in the Cloudflare provider client.
 NIM reasoning budget control is also treated as a provider-owned best-effort
 downgrade: if an upstream NIM deployment rejects explicit budget control, FCC
 retries without the budget while preserving thinking enablement.

--- a/README.md
+++ b/README.md
@@ -306,13 +306,13 @@ Fireworks exposes an **Anthropic-compatible** Messages API at `https://api.firew
 
 Browse models at [fireworks.ai/models](https://fireworks.ai/models).
 
-### 14. [Cloudflare](https://developers.cloudflare.com/ai-gateway/)
+### 14. [Cloudflare](https://developers.cloudflare.com/workers-ai/)
 
 Create a Cloudflare API token and copy your account ID from the Cloudflare dashboard.
 
-In the Admin UI, set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, then set `MODEL` to a Cloudflare model slug such as `cloudflare/anthropic/claude-sonnet-4-5`.
+In the Admin UI, set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, then set `MODEL` to a Cloudflare Workers AI model slug such as `cloudflare/@cf/moonshotai/kimi-k2.6`.
 
-This provider calls Cloudflare's account-scoped **Anthropic-compatible** Messages API at `https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1/messages`. The first Cloudflare integration targets third-party Anthropic-compatible models; Cloudflare AI Gateway BYOK/provider-gateway routing is not required.
+This provider calls Cloudflare's account-scoped **OpenAI-compatible** Chat Completions API at `https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1/chat/completions`. Use literal Workers AI model IDs, including the `@cf/` prefix when the catalog model includes it.
 
 ### 15. [Z.ai](https://z.ai/)
 
@@ -571,7 +571,7 @@ Important pieces:
 - `fcc-codex` registers a custom `fcc` provider that points Codex at the local proxy's `/v1/responses` endpoint.
 - Model routing resolves Claude model names to `MODEL_OPUS`, `MODEL_SONNET`, `MODEL_HAIKU`, or `MODEL`.
 - NIM, DeepSeek, OpenCode Zen, and OpenCode Go use OpenAI chat streaming translated into Anthropic SSE.
-- Wafer, OpenRouter, Kimi, Fireworks AI, Cloudflare, Z.ai, LM Studio, llama.cpp, and Ollama use Anthropic Messages style transports where applicable (with provider-specific quirks and model-list URLs).
+- Wafer, OpenRouter, Kimi, Fireworks AI, Z.ai, LM Studio, llama.cpp, and Ollama use Anthropic Messages style transports where applicable (with provider-specific quirks and model-list URLs).
 - The proxy normalizes thinking blocks, tool calls, token usage metadata, and provider errors into the shape each client expects.
 - Request optimizations answer trivial Claude Code probes locally to save latency and quota.
 

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -214,7 +214,7 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
     "cloudflare": ProviderDescriptor(
         provider_id="cloudflare",
         display_name="Cloudflare",
-        transport_type="anthropic_messages",
+        transport_type="openai_chat",
         credential_env="CLOUDFLARE_API_TOKEN",
         credential_url="https://dash.cloudflare.com/profile/api-tokens",
         credential_attr="cloudflare_api_token",
@@ -225,7 +225,6 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
             "streaming",
             "tools",
             "thinking",
-            "native_anthropic",
             "rate_limit",
         ),
     ),

--- a/config/settings.py
+++ b/config/settings.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     # ==================== Fireworks AI Config ====================
     fireworks_api_key: str = Field(default="", validation_alias="FIREWORKS_API_KEY")
 
-    # ==================== Cloudflare AI REST Config ====================
+    # ==================== Cloudflare Workers AI Config ====================
     cloudflare_api_token: str = Field(
         default="", validation_alias="CLOUDFLARE_API_TOKEN"
     )

--- a/providers/cloudflare/client.py
+++ b/providers/cloudflare/client.py
@@ -1,7 +1,8 @@
-"""Cloudflare AI REST provider using Anthropic-compatible Messages."""
+"""Cloudflare Workers AI provider using OpenAI-compatible chat completions."""
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from typing import Any
 from urllib.parse import quote
 
@@ -9,25 +10,28 @@ import httpx
 
 from providers.base import ProviderConfig
 from providers.defaults import CLOUDFLARE_AI_REST_ROOT
-from providers.exceptions import AuthenticationError
-from providers.transports.anthropic_messages import (
-    AnthropicMessagesTransport,
-    NativeMessagesRequestPolicy,
-    build_native_messages_request_body,
+from providers.exceptions import AuthenticationError, ModelListResponseError
+from providers.model_listing import (
+    ProviderModelInfo,
+    extract_openai_model_ids,
+    model_infos_from_ids,
+)
+from providers.transports.http import maybe_await_aclose
+from providers.transports.openai_chat import (
+    OpenAIChatRequestPolicy,
+    OpenAIChatTransport,
+    build_openai_chat_request_body,
 )
 
-_ANTHROPIC_VERSION = "2023-06-01"
-_REQUEST_POLICY = NativeMessagesRequestPolicy(
+_REQUEST_POLICY = OpenAIChatRequestPolicy(
     provider_name="CLOUDFLARE",
-    extra_body="reject",
-    reject_extra_body_message=(
-        "Cloudflare native Messages API does not support extra_body on requests."
-    ),
+    include_extra_body=True,
+    max_tokens_field="max_completion_tokens",
 )
 
 
 def cloudflare_ai_base_url(api_root: str | None, account_id: str) -> str:
-    """Return the account-scoped Cloudflare AI REST base URL."""
+    """Return the account-scoped Cloudflare Workers AI OpenAI-compatible base URL."""
 
     return f"{_cloudflare_account_api_url(api_root, account_id)}/ai/v1"
 
@@ -51,43 +55,105 @@ def _cloudflare_account_api_url(api_root: str | None, account_id: str) -> str:
     return f"{root}/accounts/{encoded_account}"
 
 
-class CloudflareProvider(AnthropicMessagesTransport):
-    """Cloudflare account-scoped AI REST provider."""
+class CloudflareProvider(OpenAIChatTransport):
+    """Cloudflare Workers AI OpenAI-compatible chat provider."""
 
     def __init__(self, config: ProviderConfig, *, account_id: str):
         base_url = cloudflare_ai_base_url(config.base_url, account_id)
         self._model_search_url = _cloudflare_model_search_url(
             config.base_url, account_id
         )
+        self._model_list_client = httpx.AsyncClient(
+            proxy=config.proxy or None,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout,
+                read=config.http_read_timeout,
+                write=config.http_write_timeout,
+            ),
+        )
         super().__init__(
             config.model_copy(update={"base_url": base_url}),
             provider_name="CLOUDFLARE",
-            default_base_url=base_url,
+            base_url=base_url,
+            api_key=config.api_key,
         )
 
-    def _build_request_body(
-        self, request: Any, thinking_enabled: bool | None = None
-    ) -> dict:
-        return build_native_messages_request_body(
-            request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
-            policy=_REQUEST_POLICY,
-        )
+    async def cleanup(self) -> None:
+        """Release provider client resources."""
+        await super().cleanup()
+        await self._model_list_client.aclose()
 
-    def _request_headers(self) -> dict[str, str]:
-        return {
-            "Accept": "text/event-stream",
-            "Authorization": f"Bearer {self._api_key}",
-            "Content-Type": "application/json",
-            "anthropic-version": _ANTHROPIC_VERSION,
-        }
+    async def list_model_ids(self) -> frozenset[str]:
+        """Return Cloudflare Workers AI model ids from account model search."""
+        return frozenset(info.model_id for info in await self.list_model_infos())
 
-    def _model_list_headers(self) -> dict[str, str]:
-        return {"Authorization": f"Bearer {self._api_key}"}
-
-    async def _send_model_list_request(self) -> httpx.Response:
-        return await self._client.get(
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        """Return Cloudflare Workers AI model ids from account model search."""
+        response = await self._model_list_client.get(
             self._model_search_url,
             params={"format": "openrouter"},
             headers=self._model_list_headers(),
         )
+        try:
+            response.raise_for_status()
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise ModelListResponseError(
+                    "CLOUDFLARE model-list response is malformed: invalid JSON"
+                ) from exc
+            return model_infos_from_ids(
+                extract_openai_model_ids(payload, provider_name="CLOUDFLARE")
+            )
+        finally:
+            await maybe_await_aclose(response)
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        return build_openai_chat_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            policy=_REQUEST_POLICY,
+            postprocessors=(_apply_cloudflare_request_quirks,),
+        )
+
+    def _handle_extra_reasoning(
+        self, delta: Any, ledger: Any, *, thinking_enabled: bool
+    ) -> Iterator[str]:
+        """Map Cloudflare's ``reasoning`` delta field to Anthropic thinking."""
+        reasoning = _cloudflare_reasoning(delta)
+        if not thinking_enabled or not reasoning:
+            return
+        yield from ledger.ensure_thinking_block()
+        yield ledger.emit_thinking_delta(reasoning)
+
+    def _model_list_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}"}
+
+
+def _apply_cloudflare_request_quirks(
+    body: dict[str, Any], _request: Any, thinking_enabled: bool
+) -> None:
+    """Attach Cloudflare Workers AI chat-template thinking control."""
+    extra_body = body.setdefault("extra_body", {})
+    if not isinstance(extra_body, dict):
+        return
+    chat_template_kwargs = extra_body.setdefault("chat_template_kwargs", {})
+    if isinstance(chat_template_kwargs, dict):
+        chat_template_kwargs.setdefault("thinking", thinking_enabled)
+
+
+def _cloudflare_reasoning(delta: Any) -> str | None:
+    reasoning = getattr(delta, "reasoning", None)
+    if isinstance(reasoning, str) and reasoning:
+        return reasoning
+
+    model_extra = getattr(delta, "model_extra", None)
+    if isinstance(model_extra, Mapping):
+        reasoning = model_extra.get("reasoning")
+        if isinstance(reasoning, str) and reasoning:
+            return reasoning
+
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.4.3"
+version = "2.4.4"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -58,7 +58,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini/models/gemini-3.1-flash-lite",
     "groq": "groq/llama-3.3-70b-versatile",
     "cerebras": "cerebras/llama3.1-8b",
-    "cloudflare": "cloudflare/anthropic/claude-sonnet-4-5",
+    "cloudflare": "cloudflare/@cf/moonshotai/kimi-k2.6",
 }
 
 NVIDIA_NIM_CLI_DEFAULT_MODELS: tuple[str, ...] = (

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -298,7 +298,7 @@ def test_admin_apply_writes_cloudflare_fields_and_masks_preview(monkeypatch, tmp
         "/admin/api/config/apply",
         json={
             "values": {
-                "MODEL": "cloudflare/anthropic/claude-sonnet-4-5",
+                "MODEL": "cloudflare/@cf/moonshotai/kimi-k2.6",
                 "CLOUDFLARE_API_TOKEN": "cf-secret",
                 "CLOUDFLARE_ACCOUNT_ID": "cf-account",
             }
@@ -312,7 +312,7 @@ def test_admin_apply_writes_cloudflare_fields_and_masks_preview(monkeypatch, tmp
     assert "CLOUDFLARE_ACCOUNT_ID=cf-account" in body["env_preview"]
     env_file = tmp_path / ".fcc" / ".env"
     text = env_file.read_text(encoding="utf-8")
-    assert "MODEL=cloudflare/anthropic/claude-sonnet-4-5" in text
+    assert "MODEL=cloudflare/@cf/moonshotai/kimi-k2.6" in text
     assert "CLOUDFLARE_API_TOKEN=cf-secret" in text
     assert "CLOUDFLARE_ACCOUNT_ID=cf-account" in text
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -684,8 +684,8 @@ class TestPerModelMapping:
             ({"MODEL": "deepseek/deepseek-chat"}, "deepseek/deepseek-chat", None),
             ({"MODEL": "wafer/DeepSeek-V4-Pro"}, "wafer/DeepSeek-V4-Pro", None),
             (
-                {"MODEL": "cloudflare/anthropic/claude-sonnet-4-5"},
-                "cloudflare/anthropic/claude-sonnet-4-5",
+                {"MODEL": "cloudflare/@cf/moonshotai/kimi-k2.6"},
+                "cloudflare/@cf/moonshotai/kimi-k2.6",
                 None,
             ),
             ({"MODEL": "lmstudio/qwen2.5-7b"}, "lmstudio/qwen2.5-7b", None),
@@ -870,8 +870,7 @@ class TestPerModelMapping:
         assert parse_provider_type("ollama/llama3.1") == "ollama"
         assert parse_provider_type("wafer/DeepSeek-V4-Pro") == "wafer"
         assert (
-            parse_provider_type("cloudflare/anthropic/claude-sonnet-4-5")
-            == "cloudflare"
+            parse_provider_type("cloudflare/@cf/moonshotai/kimi-k2.6") == "cloudflare"
         )
         assert parse_provider_type("gemini/models/gemini-3.1-flash-lite") == "gemini"
         assert parse_provider_type("groq/llama-3.3-70b-versatile") == "groq"
@@ -893,8 +892,8 @@ class TestPerModelMapping:
         assert parse_model_name("ollama/llama3.1") == "llama3.1"
         assert parse_model_name("wafer/DeepSeek-V4-Pro") == "DeepSeek-V4-Pro"
         assert (
-            parse_model_name("cloudflare/anthropic/claude-sonnet-4-5")
-            == "anthropic/claude-sonnet-4-5"
+            parse_model_name("cloudflare/@cf/moonshotai/kimi-k2.6")
+            == "@cf/moonshotai/kimi-k2.6"
         )
         assert (
             parse_model_name("gemini/models/gemini-3.1-flash-lite")

--- a/tests/providers/test_cloudflare.py
+++ b/tests/providers/test_cloudflare.py
@@ -1,7 +1,9 @@
-"""Tests for Cloudflare AI REST native Anthropic Messages provider."""
+"""Tests for Cloudflare Workers AI OpenAI-compatible chat provider."""
 
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -14,32 +16,7 @@ from providers.cloudflare import (
     CloudflareProvider,
     cloudflare_ai_base_url,
 )
-from providers.exceptions import AuthenticationError, InvalidRequestError
-
-
-class FakeResponse:
-    def __init__(self, *, status_code: int = 200, lines: list[str] | None = None):
-        self.status_code = status_code
-        self._lines = lines or []
-        self.is_closed = False
-        self.headers = httpx.Headers()
-        self.request = httpx.Request("POST", f"{_BASE_URL}/messages")
-
-    async def aiter_lines(self):
-        for line in self._lines:
-            yield line
-
-    async def aiter_bytes(self, chunk_size: int = 65_536):
-        if False:
-            yield b""
-
-    async def aclose(self):
-        self.is_closed = True
-
-    def raise_for_status(self):
-        response = httpx.Response(self.status_code, request=self.request)
-        response.raise_for_status()
-
+from providers.exceptions import AuthenticationError
 
 _ACCOUNT_ID = "account-123"
 _BASE_URL = f"{CLOUDFLARE_AI_REST_ROOT}/accounts/{_ACCOUNT_ID}/ai/v1"
@@ -63,9 +40,7 @@ def mock_rate_limiter():
     async def _slot():
         yield
 
-    with patch(
-        "providers.transports.anthropic_messages.transport.GlobalRateLimiter"
-    ) as mock:
+    with patch("providers.transports.openai_chat.transport.GlobalRateLimiter") as mock:
         instance = mock.get_scoped_instance.return_value
 
         async def _passthrough(fn, *args, **kwargs):
@@ -81,7 +56,27 @@ def cloudflare_provider(cloudflare_config: ProviderConfig) -> CloudflareProvider
     return CloudflareProvider(cloudflare_config, account_id=_ACCOUNT_ID)
 
 
-def test_cloudflare_ai_base_url_uses_account_scoped_messages_root() -> None:
+def _request(model: str = "@cf/moonshotai/kimi-k2.6") -> MessagesRequest:
+    return MessagesRequest(
+        model=model,
+        max_tokens=100,
+        messages=[Message(role="user", content="hi")],
+    )
+
+
+def _chunk(delta: SimpleNamespace, *, finish_reason: str = "stop") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish_reason)],
+        usage=SimpleNamespace(completion_tokens=5, prompt_tokens=8),
+    )
+
+
+async def _stream(*chunks: SimpleNamespace) -> AsyncIterator[SimpleNamespace]:
+    for chunk in chunks:
+        yield chunk
+
+
+def test_cloudflare_ai_base_url_uses_account_scoped_openai_chat_root() -> None:
     assert cloudflare_ai_base_url(CLOUDFLARE_AI_REST_ROOT, "account/with slash") == (
         f"{CLOUDFLARE_AI_REST_ROOT}/accounts/account%2Fwith%20slash/ai/v1"
     )
@@ -94,80 +89,58 @@ def test_missing_account_id_raises_authentication_error(
         CloudflareProvider(cloudflare_config, account_id=" ")
 
 
-def test_init_composes_account_scoped_base_url(
+def test_init_composes_account_scoped_openai_chat_base_url(
     cloudflare_config: ProviderConfig,
 ) -> None:
-    with patch("httpx.AsyncClient") as mock_client:
+    with (
+        patch("providers.transports.openai_chat.transport.AsyncOpenAI") as mock_openai,
+        patch("httpx.AsyncClient") as mock_httpx_client,
+    ):
         provider = CloudflareProvider(cloudflare_config, account_id=_ACCOUNT_ID)
 
     assert provider._api_key == "test-cloudflare-token"
     assert provider._base_url == _BASE_URL
     assert provider._model_search_url == _MODEL_SEARCH_URL
     assert provider._provider_name == "CLOUDFLARE"
-    assert mock_client.called
+    assert mock_openai.call_args.kwargs["base_url"] == _BASE_URL
+    assert mock_openai.call_args.kwargs["api_key"] == "test-cloudflare-token"
+    assert mock_httpx_client.called
 
 
-def test_request_headers_use_bearer_auth(cloudflare_provider: CloudflareProvider):
-    headers = cloudflare_provider._request_headers()
-
-    assert headers["Authorization"] == "Bearer test-cloudflare-token"
-    assert headers["Accept"] == "text/event-stream"
-    assert headers["Content-Type"] == "application/json"
-    assert headers["anthropic-version"] == "2023-06-01"
-    assert "x-api-key" not in headers
+def test_model_list_headers_use_bearer_auth(
+    cloudflare_provider: CloudflareProvider,
+) -> None:
     assert cloudflare_provider._model_list_headers() == {
         "Authorization": "Bearer test-cloudflare-token"
     }
 
 
-def test_build_request_body_preserves_slash_model_id_and_forwards_thinking(
+def test_build_request_body_preserves_literal_cf_model_id_and_controls_thinking(
     cloudflare_provider: CloudflareProvider,
 ) -> None:
     request = MessagesRequest.model_validate(
         {
-            "model": "anthropic/claude-sonnet-4-5",
-            "messages": [Message(role="user", content="Hello")],
+            "model": "@cf/moonshotai/kimi-k2.6",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 100,
             "thinking": {"type": "enabled", "budget_tokens": 2048},
         }
     )
 
     body = cloudflare_provider._build_request_body(request, thinking_enabled=True)
 
-    assert body["model"] == "anthropic/claude-sonnet-4-5"
-    assert body["stream"] is True
-    assert body["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+    assert body["model"] == "@cf/moonshotai/kimi-k2.6"
+    assert body["max_completion_tokens"] == 100
+    assert "max_tokens" not in body
+    assert body["extra_body"]["chat_template_kwargs"]["thinking"] is True
 
 
-def test_build_request_body_strips_prior_thinking_blocks_when_disabled(
+def test_build_request_body_disabled_thinking_sets_cloudflare_template_flag(
     cloudflare_provider: CloudflareProvider,
 ) -> None:
     request = MessagesRequest.model_validate(
         {
-            "model": "anthropic/claude-sonnet-4-5",
-            "messages": [
-                {
-                    "role": "assistant",
-                    "content": [
-                        {"type": "thinking", "thinking": "hidden"},
-                        {"type": "text", "text": "visible"},
-                    ],
-                },
-                {"role": "user", "content": "Continue"},
-            ],
-        }
-    )
-
-    body = cloudflare_provider._build_request_body(request, thinking_enabled=False)
-
-    assert body["messages"][0]["content"] == [{"type": "text", "text": "visible"}]
-
-
-def test_build_request_body_request_disabled_thinking_suppresses_thinking(
-    cloudflare_provider: CloudflareProvider,
-) -> None:
-    request = MessagesRequest.model_validate(
-        {
-            "model": "anthropic/claude-sonnet-4-5",
+            "model": "@cf/moonshotai/kimi-k2.6",
             "messages": [{"role": "user", "content": "Hello"}],
             "thinking": {"type": "disabled"},
         }
@@ -175,46 +148,51 @@ def test_build_request_body_request_disabled_thinking_suppresses_thinking(
 
     body = cloudflare_provider._build_request_body(request, thinking_enabled=True)
 
-    assert "thinking" not in body
+    assert body["extra_body"]["chat_template_kwargs"]["thinking"] is False
 
 
-def test_build_request_body_rejects_extra_body(
+def test_build_request_body_preserves_user_extra_body_without_overriding_thinking(
     cloudflare_provider: CloudflareProvider,
 ) -> None:
     request = MessagesRequest.model_validate(
         {
-            "model": "anthropic/claude-sonnet-4-5",
+            "model": "@cf/moonshotai/kimi-k2.6",
             "messages": [{"role": "user", "content": "Hello"}],
-            "extra_body": {"custom": True},
+            "extra_body": {"chat_template_kwargs": {"thinking": False}},
         }
     )
 
-    with pytest.raises(InvalidRequestError, match="does not support extra_body"):
-        cloudflare_provider._build_request_body(request)
+    body = cloudflare_provider._build_request_body(request, thinking_enabled=True)
+
+    assert body["extra_body"]["chat_template_kwargs"]["thinking"] is False
 
 
 @pytest.mark.asyncio
 async def test_lists_models_from_cloudflare_model_search_endpoint(
     cloudflare_provider: CloudflareProvider,
 ) -> None:
+    response = httpx.Response(
+        200,
+        json={
+            "object": "list",
+            "data": [
+                {"id": "@cf/moonshotai/kimi-k2.6", "object": "model"},
+                {"id": "@cf/meta/llama-4-scout-17b-16e-instruct", "object": "model"},
+            ],
+        },
+        request=httpx.Request("GET", _MODEL_SEARCH_URL),
+    )
     with patch.object(
-        cloudflare_provider._client,
+        cloudflare_provider._model_list_client,
         "get",
         new_callable=AsyncMock,
-        return_value=httpx.Response(
-            200,
-            json={
-                "object": "list",
-                "data": [
-                    {"id": "anthropic/claude-sonnet-4-5", "object": "model"},
-                    {"id": "anthropic/claude-opus-4-5", "object": "model"},
-                ],
-            },
-            request=httpx.Request("GET", _MODEL_SEARCH_URL),
-        ),
+        return_value=response,
     ) as mock_get:
         assert await cloudflare_provider.list_model_ids() == frozenset(
-            {"anthropic/claude-sonnet-4-5", "anthropic/claude-opus-4-5"}
+            {
+                "@cf/moonshotai/kimi-k2.6",
+                "@cf/meta/llama-4-scout-17b-16e-instruct",
+            }
         )
 
     mock_get.assert_awaited_once_with(
@@ -225,43 +203,115 @@ async def test_lists_models_from_cloudflare_model_search_endpoint(
 
 
 @pytest.mark.asyncio
-async def test_stream_uses_post_messages_path(
+async def test_stream_uses_openai_chat_completions(
     cloudflare_provider: CloudflareProvider,
 ) -> None:
-    request = MessagesRequest(
-        model="anthropic/claude-sonnet-4-5",
-        messages=[Message(role="user", content="hi")],
-    )
-    response = FakeResponse(
-        lines=[
-            "event: message_start",
-            'data: {"type":"message_start"}',
-            "",
-            "event: message_stop",
-            'data: {"type":"message_stop"}',
-            "",
-        ]
+    delta = SimpleNamespace(
+        content="Hello from Cloudflare",
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
     )
 
-    with (
-        patch.object(
-            cloudflare_provider._client, "build_request", return_value=MagicMock()
-        ) as mock_build,
-        patch.object(
-            cloudflare_provider._client,
-            "send",
-            new_callable=AsyncMock,
-            return_value=response,
-        ),
+    with patch.object(
+        cloudflare_provider._client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=_stream(_chunk(delta)),
+    ) as mock_create:
+        events = [
+            event async for event in cloudflare_provider.stream_response(_request())
+        ]
+
+    parsed = parse_sse_text("".join(events))
+    assert any(
+        event.event == "content_block_delta"
+        and event.data.get("delta", {}).get("text") == "Hello from Cloudflare"
+        for event in parsed
+    )
+    assert mock_create.call_args.kwargs["model"] == "@cf/moonshotai/kimi-k2.6"
+    assert mock_create.call_args.kwargs["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_maps_cloudflare_reasoning_delta_to_thinking(
+    cloudflare_provider: CloudflareProvider,
+) -> None:
+    delta = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning="Cloudflare reasoning",
+        tool_calls=None,
+    )
+
+    with patch.object(
+        cloudflare_provider._client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=_stream(_chunk(delta)),
+    ):
+        events = [
+            event async for event in cloudflare_provider.stream_response(_request())
+        ]
+
+    parsed = parse_sse_text("".join(events))
+    assert any(
+        event.event == "content_block_delta"
+        and event.data.get("delta", {}).get("thinking") == "Cloudflare reasoning"
+        for event in parsed
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_maps_openai_tool_calls_to_tool_use(
+    cloudflare_provider: CloudflareProvider,
+) -> None:
+    tool_call = SimpleNamespace(
+        index=0,
+        id="call_1",
+        function=SimpleNamespace(name="echo", arguments='{"value":"x"}'),
+    )
+    delta = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=[tool_call],
+    )
+    request = MessagesRequest.model_validate(
+        {
+            "model": "@cf/moonshotai/kimi-k2.6",
+            "messages": [{"role": "user", "content": "Use the tool"}],
+            "tools": [
+                {
+                    "name": "echo",
+                    "description": "Echo a value",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}},
+                        "required": ["value"],
+                    },
+                }
+            ],
+        }
+    )
+
+    with patch.object(
+        cloudflare_provider._client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=_stream(_chunk(delta, finish_reason="tool_calls")),
     ):
         events = [event async for event in cloudflare_provider.stream_response(request)]
 
-    assert [event.event for event in parse_sse_text("".join(events))] == [
-        "message_start",
-        "message_stop",
-    ]
-    assert response.is_closed
-    assert mock_build.call_args.args[:2] == ("POST", "/messages")
-    assert mock_build.call_args.kwargs["headers"]["Authorization"] == (
-        "Bearer test-cloudflare-token"
+    parsed = parse_sse_text("".join(events))
+    assert any(
+        event.event == "content_block_start"
+        and event.data.get("content_block", {}).get("type") == "tool_use"
+        and event.data.get("content_block", {}).get("name") == "echo"
+        for event in parsed
+    )
+    assert any(
+        event.event == "content_block_delta"
+        and event.data.get("delta", {}).get("partial_json") == '{"value":"x"}'
+        for event in parsed
     )

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -136,10 +136,10 @@ def test_zai_provider_config_ignores_stale_base_url_setting():
 def test_cloudflare_descriptor_uses_api_root_not_account_url():
     descriptor = PROVIDER_CATALOG["cloudflare"]
 
-    assert descriptor.transport_type == "anthropic_messages"
+    assert descriptor.transport_type == "openai_chat"
     assert descriptor.default_base_url == "https://api.cloudflare.com/client/v4"
     assert descriptor.base_url_attr is None
-    assert "native_anthropic" in descriptor.capabilities
+    assert "native_anthropic" not in descriptor.capabilities
     assert "thinking" in descriptor.capabilities
 
 
@@ -149,7 +149,7 @@ def test_create_cloudflare_provider_uses_account_scoped_base_url():
         cloudflare_account_id="test-account",
     )
 
-    with patch("httpx.AsyncClient"):
+    with patch("providers.transports.openai_chat.transport.AsyncOpenAI"):
         provider = create_provider("cloudflare", settings)
 
     assert isinstance(provider, CloudflareProvider)

--- a/uv.lock
+++ b/uv.lock
@@ -350,34 +350,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.4.3"
+version = "2.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Cloudflare Workers AI models such as `@cf/moonshotai/kimi-k2.6` were routed to Cloudflare's Anthropic Messages endpoint. Cloudflare rejects those models there, so the provider failed for the main Workers AI catalog.

## Changes

| Before | After |
| --- | --- |
| Cloudflare used the native Anthropic Messages transport. | Cloudflare uses the OpenAI-compatible chat completions transport. |
| `cloudflare/@cf/...` models were sent to `/ai/v1/messages`. | `cloudflare/@cf/...` models are sent through `/ai/v1/chat/completions`. |
| Cloudflare catalog metadata advertised `native_anthropic`. | Cloudflare catalog metadata advertises the OpenAI-chat transport. |
| Cloudflare docs and smoke defaults used a Claude-shaped model. | Cloudflare docs and smoke defaults use `cloudflare/@cf/moonshotai/kimi-k2.6`. |
| Cloudflare reasoning deltas were not provider-owned on the OpenAI-chat path. | Cloudflare `reasoning` deltas map to Anthropic thinking inside the provider. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the Cloudflare provider to the Workers AI OpenAI-compatible chat completions path. The main changes are:

- Cloudflare catalog metadata now advertises `openai_chat` instead of native Anthropic Messages.
- `CloudflareProvider` now builds OpenAI chat request bodies for literal `@cf/...` model IDs.
- Cloudflare model listing now uses the account model search endpoint.
- Cloudflare `reasoning` stream deltas now map into Anthropic thinking events.
- Docs, smoke defaults, tests, and package version metadata were updated for the new transport.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

No correctness or security issues were found in the changed Cloudflare transport path. The provider change is covered by updated request-building, streaming, model-listing, tool-call, and runtime descriptor tests. Production-file changes include the required package version and lockfile updates.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the before-state log for the Cloudflare provider regression to establish a baseline prior to the after-state run.
- Ran the focused Cloudflare provider regression suite and confirmed the after-state shows tests for OpenAI chat completions, Cloudflare reasoning-to-thinking mapping, account-scoped base URL, and catalog runtime metadata passing.
- Inspected the Cloudflare transport inspection after-state to verify the mocked endpoint usage and thinking\_delta content, including that anthropic\_messages\_endpoint\_used is false and stream is true.
- Validated that the optional config/admin metadata tests passed in the after-state.
- Reviewed the Python test harness artifact used in the provider regression workflow to understand test harness interactions.

<a href="https://app.greptile.com/trex/runs/13257039/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| providers/cloudflare/client.py | Migrates Cloudflare provider implementation to `OpenAIChatTransport`, adds account model listing client, and maps Cloudflare reasoning deltas into Anthropic thinking. |
| config/provider_catalog.py | Changes Cloudflare catalog metadata from Anthropic Messages to OpenAI chat and removes `native_anthropic` capability. |
| tests/providers/test_cloudflare.py | Reworks Cloudflare provider tests around OpenAI chat request construction, streaming, tools, model listing, and reasoning mapping. |
| tests/providers/test_provider_runtime.py | Updates runtime descriptor tests to assert Cloudflare uses OpenAI chat and no longer advertises native Anthropic support. |
| README.md | Revises Cloudflare setup docs and transport description for Workers AI chat completions. |
| pyproject.toml | Bumps package version from `2.4.3` to `2.4.4` for the production Cloudflare provider fix. |
| uv.lock | Reflects the package version bump in the lockfile. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Anthropic-compatible client
participant Proxy as FCC CloudflareProvider
participant CFChat as Cloudflare Workers AI /ai/v1/chat/completions
participant CFModels as Cloudflare /ai/models/search

Client->>Proxy: "MessagesRequest model cloudflare/@cf/..."
Proxy->>Proxy: Strip provider prefix and build OpenAI chat body
Proxy->>Proxy: Add extra_body.chat_template_kwargs.thinking
Proxy->>CFChat: "stream=true chat.completions.create(model=@cf/...)"
CFChat-->>Proxy: OpenAI chat stream deltas
Proxy->>Proxy: Map content/tool_calls/reasoning to Anthropic SSE
Proxy-->>Client: message/content/thinking/tool SSE events

Proxy->>CFModels: "GET format=openrouter"
CFModels-->>Proxy: OpenAI-style model list
Proxy-->>Client: Cloudflare model ids
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Anthropic-compatible client
participant Proxy as FCC CloudflareProvider
participant CFChat as Cloudflare Workers AI /ai/v1/chat/completions
participant CFModels as Cloudflare /ai/models/search

Client->>Proxy: "MessagesRequest model cloudflare/@cf/..."
Proxy->>Proxy: Strip provider prefix and build OpenAI chat body
Proxy->>Proxy: Add extra_body.chat_template_kwargs.thinking
Proxy->>CFChat: "stream=true chat.completions.create(model=@cf/...)"
CFChat-->>Proxy: OpenAI chat stream deltas
Proxy->>Proxy: Map content/tool_calls/reasoning to Anthropic SSE
Proxy-->>Client: message/content/thinking/tool SSE events

Proxy->>CFModels: "GET format=openrouter"
CFModels-->>Proxy: OpenAI-style model list
Proxy-->>Client: Cloudflare model ids
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Cloudflare Workers AI transport"](https://github.com/alishahryar1/free-claude-code/commit/17fb8f646eb206c776de39bb2ce242b24f7c3e74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41783516)</sub>

<!-- /greptile_comment -->