### PR TITLE
Fix nested-session auth leak in fcc-claude launcher; size auto-compact window to local models

### DIFF
--- a/src/free_claude_code/cli/launchers/claude.py
+++ b/src/free_claude_code/cli/launchers/claude.py
@@ -4,13 +4,16 @@ import os
 import sys
 from collections.abc import Mapping, Sequence
 
+import httpx
+
 from free_claude_code.api.admin_urls import local_proxy_root_url
 from free_claude_code.cli.claude_env import (
     CLAUDE_BINARY_NAME,
     CLAUDE_CODE_AUTO_COMPACT_WINDOW,
     claude_auth_token,
 )
-from free_claude_code.config.settings import get_settings
+from free_claude_code.config.model_refs import configured_chat_model_refs
+from free_claude_code.config.settings import Settings, get_settings
 
 from .common import preflight_proxy, resolve_client_binary, run_client_process
 
@@ -44,6 +47,7 @@ def launch(argv: Sequence[str] | None = None) -> None:
             proxy_root_url=proxy_root_url,
             auth_token=settings.anthropic_auth_token,
             base_env=os.environ,
+            auto_compact_window=resolve_auto_compact_window(settings),
         ),
         binary_name=binary_name,
         display_name=_DISPLAY_NAME,
@@ -65,21 +69,104 @@ def build_claude_launcher_command(
     return [binary_path, *argv]
 
 
+# Session-identity vars injected by a live Claude Code session. When fcc-claude
+# is invoked from inside one (e.g. an agent's Bash tool), the nested claude.exe
+# inherits these, decides it is a child session with host-managed OAuth, and
+# ignores ANTHROPIC_AUTH_TOKEN entirely — every request then 401s against the
+# proxy. fcc-claude's contract is a fresh standalone session pointed at the
+# local proxy, so all inherited session/harness vars must be dropped; the two
+# CLAUDE_CODE_* vars the launcher itself needs are re-set explicitly below.
+_SESSION_ENV_VARS = frozenset(
+    {
+        "CLAUDECODE",
+        "CLAUDE_AGENT_SDK_VERSION",
+        "CLAUDE_EFFORT",
+        "AI_AGENT",
+        "BAGGAGE",
+    }
+)
+
+
+def _is_inherited_session_var(key: str) -> bool:
+    return (
+        key in _SESSION_ENV_VARS
+        or key.startswith("ANTHROPIC_")
+        or key.startswith("CLAUDE_CODE_")
+    )
+
+
+def resolve_auto_compact_window(settings: Settings) -> str:
+    """Match Claude Code's auto-compact window to the loaded local model.
+
+    The static default (190000) is far above a locally-loaded context like
+    45k/130k, so Claude Code never compacts before the local ceiling and LM
+    Studio silently truncates the stream. When LM Studio is a configured
+    provider, read the actually-loaded context length and reserve headroom for
+    one large tool-result turn plus generation.
+
+    Checks every configured model slot (MODEL and the MODEL_OPUS/SONNET/HAIKU
+    overrides), not just MODEL: routing sends a Claude request through whichever
+    override matches its tier, so an LM Studio override under a non-LM-Studio
+    default must still get a truthful window. The compact window is a single
+    global env var with no per-tier control, so if *any* slot is LM Studio we
+    size to its ceiling — missing compaction there causes a silent truncation,
+    whereas the same window applied to a large-context cloud model only compacts
+    slightly early, which is harmless.
+    """
+    if not any(
+        ref.provider_id == "lmstudio" for ref in configured_chat_model_refs(settings)
+    ):
+        return CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    try:
+        root = settings.lm_studio_base_url.rstrip("/")
+        root = root[: -len("/v1")] if root.endswith("/v1") else root
+        response = httpx.get(f"{root}/api/v0/models", timeout=2.0)
+        response.raise_for_status()
+        loaded = [
+            model.get("loaded_context_length")
+            for model in response.json().get("data", [])
+            if model.get("state") == "loaded"
+            and isinstance(model.get("loaded_context_length"), int)
+        ]
+        if not loaded:
+            return CLAUDE_CODE_AUTO_COMPACT_WINDOW
+        # Use the SMALLEST loaded context, not the largest: the compact window
+        # is a single global env var applied to every request, so if several
+        # models are loaded at different contexts (e.g. a small haiku-tier model
+        # and a large opus-tier one), a request routed to the smallest one must
+        # still compact before it truncates. Sizing to max() would leave the
+        # small model unprotected — the exact silent truncation this prevents.
+        context_length = min(loaded)
+        window = max(8192, min(int(context_length * 0.85), context_length - 12000))
+        # The 8192 floor above is meant to avoid compacting too early on modest
+        # contexts, not to override a model loaded with an even smaller context
+        # than that. Clamp to context_length so the window can never exceed the
+        # actual ceiling — otherwise Claude Code still wouldn't compact before
+        # LM Studio silently truncates the stream.
+        window = min(window, context_length)
+        return str(window)
+    except Exception:
+        return CLAUDE_CODE_AUTO_COMPACT_WINDOW
+
+
 def build_claude_launcher_env(
     *,
     proxy_root_url: str,
     auth_token: str,
     base_env: Mapping[str, str],
+    auto_compact_window: str | None = None,
 ) -> dict[str, str]:
     """Return a Claude Code environment that targets the local proxy."""
 
     env = {
         key: value
         for key, value in base_env.items()
-        if not key.startswith("ANTHROPIC_")
+        if not _is_inherited_session_var(key)
     }
     env["ANTHROPIC_BASE_URL"] = proxy_root_url
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = (
+        auto_compact_window or CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    )
     env["ANTHROPIC_AUTH_TOKEN"] = claude_auth_token(auth_token)
     return env

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -392,6 +392,224 @@ def test_claude_child_env_uses_sentinel_for_blank_configured_auth_token() -> Non
     assert "ANTHROPIC_API_KEY" not in env
 
 
+def test_claude_child_env_strips_inherited_session_identity_vars() -> None:
+    """A nested fcc-claude invocation (e.g. from inside an agent's shell) must
+    not inherit the parent Claude Code session's identity vars: doing so makes
+    the child process see itself as a host-managed child session and ignore
+    ANTHROPIC_AUTH_TOKEN entirely, 401ing every request against the proxy."""
+    from free_claude_code.cli.launchers.claude import build_claude_launcher_env
+
+    env = build_claude_launcher_env(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        base_env={
+            "PATH": "keep",
+            "CLAUDECODE": "1",
+            "CLAUDE_CODE_CHILD_SESSION": "1",
+            "CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH": "1",
+            "CLAUDE_CODE_OAUTH_SCOPES": "user:inference",
+            "CLAUDE_CODE_SESSION_ID": "abc-123",
+            "CLAUDE_AGENT_SDK_VERSION": "0.3.0",
+            "CLAUDE_EFFORT": "high",
+            "AI_AGENT": "claude-code",
+            "BAGGAGE": "sentry-trace=1",
+        },
+    )
+
+    assert env["PATH"] == "keep"
+    for stripped_key in (
+        "CLAUDECODE",
+        "CLAUDE_CODE_CHILD_SESSION",
+        "CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH",
+        "CLAUDE_CODE_OAUTH_SCOPES",
+        "CLAUDE_CODE_SESSION_ID",
+        "CLAUDE_AGENT_SDK_VERSION",
+        "CLAUDE_EFFORT",
+        "AI_AGENT",
+        "BAGGAGE",
+    ):
+        assert stripped_key not in env
+    # The launcher still re-sets its own two CLAUDE_CODE_* vars explicitly.
+    assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+    assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+
+
+def test_resolve_auto_compact_window_falls_back_for_non_lmstudio_provider() -> None:
+    from free_claude_code.cli.launchers.claude import (
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+        resolve_auto_compact_window,
+    )
+
+    settings = _launcher_settings()  # model="nvidia_nim/test-model"
+
+    assert resolve_auto_compact_window(settings) == CLAUDE_CODE_AUTO_COMPACT_WINDOW
+
+
+def test_resolve_auto_compact_window_uses_lmstudio_loaded_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from free_claude_code.cli.launchers.claude import resolve_auto_compact_window
+
+    settings = Settings.model_construct(
+        host="0.0.0.0",
+        port=8082,
+        anthropic_auth_token="freecc",
+        model="lmstudio/mistralai/devstral-small-2-2512",
+        lm_studio_base_url="http://localhost:1234/v1",
+    )
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            # The not-loaded decoy uses a *small* context so that if the
+            # state=="loaded" filter ever broke, min() would pick it up and the
+            # 28960 assertion would fail — keeping the filter genuinely covered.
+            return {
+                "data": [
+                    {"state": "loaded", "loaded_context_length": 40960},
+                    {"state": "not-loaded", "loaded_context_length": 2048},
+                ]
+            }
+
+    def _fake_get(url: str, timeout: float) -> _FakeResponse:
+        assert url == "http://localhost:1234/api/v0/models"
+        return _FakeResponse()
+
+    monkeypatch.setattr("free_claude_code.cli.launchers.claude.httpx.get", _fake_get)
+
+    # max(8192, min(0.85 * 40960, 40960 - 12000)) == 28960
+    assert resolve_auto_compact_window(settings) == "28960"
+
+
+def test_resolve_auto_compact_window_sizes_to_smallest_loaded_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With several models loaded at different contexts, the single global
+    window must fit the SMALLEST — a request routed to it must still compact
+    before LM Studio truncates. Sizing to the largest leaves it unprotected."""
+    from free_claude_code.cli.launchers.claude import resolve_auto_compact_window
+
+    settings = Settings.model_construct(
+        host="0.0.0.0",
+        port=8082,
+        anthropic_auth_token="freecc",
+        model="lmstudio/mistralai/devstral-small-2-2512",
+        lm_studio_base_url="http://localhost:1234/v1",
+    )
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "data": [
+                    {"state": "loaded", "loaded_context_length": 4096},
+                    {"state": "loaded", "loaded_context_length": 130048},
+                ]
+            }
+
+    monkeypatch.setattr(
+        "free_claude_code.cli.launchers.claude.httpx.get",
+        lambda url, timeout: _FakeResponse(),
+    )
+
+    # min loaded = 4096; window clamps to it, not 98548 (which max() would give).
+    assert resolve_auto_compact_window(settings) == "4096"
+
+
+def test_resolve_auto_compact_window_uses_lmstudio_override_under_non_lmstudio_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Routing sends a request through MODEL_OPUS/SONNET/HAIKU when set, so an
+    LM Studio override under a non-LM-Studio default must still get a truthful
+    window — otherwise override requests miss compaction and truncate."""
+    from free_claude_code.cli.launchers.claude import resolve_auto_compact_window
+
+    settings = Settings.model_construct(
+        host="0.0.0.0",
+        port=8082,
+        anthropic_auth_token="freecc",
+        model="nvidia_nim/test-model",
+        model_haiku="lmstudio/mistralai/devstral-small-2-2512",
+        lm_studio_base_url="http://localhost:1234/v1",
+    )
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"data": [{"state": "loaded", "loaded_context_length": 40960}]}
+
+    def _fake_get(url: str, timeout: float) -> _FakeResponse:
+        assert url == "http://localhost:1234/api/v0/models"
+        return _FakeResponse()
+
+    monkeypatch.setattr("free_claude_code.cli.launchers.claude.httpx.get", _fake_get)
+
+    assert resolve_auto_compact_window(settings) == "28960"
+
+
+def test_resolve_auto_compact_window_clamps_to_a_small_loaded_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model loaded with a context smaller than the 8192 floor must not get
+    a window that exceeds its actual ceiling — otherwise Claude Code still
+    won't compact before LM Studio silently truncates the stream."""
+    from free_claude_code.cli.launchers.claude import resolve_auto_compact_window
+
+    settings = Settings.model_construct(
+        host="0.0.0.0",
+        port=8082,
+        anthropic_auth_token="freecc",
+        model="lmstudio/mistralai/devstral-small-2-2512",
+        lm_studio_base_url="http://localhost:1234/v1",
+    )
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"data": [{"state": "loaded", "loaded_context_length": 4096}]}
+
+    def _fake_get(url: str, timeout: float) -> _FakeResponse:
+        return _FakeResponse()
+
+    monkeypatch.setattr("free_claude_code.cli.launchers.claude.httpx.get", _fake_get)
+
+    # Without the clamp: max(8192, min(0.85*4096, 4096-12000)) == 8192, which
+    # exceeds the real 4096-token ceiling. With it: min(8192, 4096) == 4096.
+    assert resolve_auto_compact_window(settings) == "4096"
+
+
+def test_resolve_auto_compact_window_fails_open_on_lookup_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from free_claude_code.cli.launchers.claude import (
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+        resolve_auto_compact_window,
+    )
+
+    settings = Settings.model_construct(
+        host="0.0.0.0",
+        port=8082,
+        anthropic_auth_token="freecc",
+        model="lmstudio/mistralai/devstral-small-2-2512",
+        lm_studio_base_url="http://localhost:1234/v1",
+    )
+
+    def _raise(*_args: object, **_kwargs: object):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("free_claude_code.cli.launchers.claude.httpx.get", _raise)
+
+    assert resolve_auto_compact_window(settings) == CLAUDE_CODE_AUTO_COMPACT_WINDOW
+
+
 def test_launch_claude_passes_args_and_child_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

`fcc-claude`'s launcher env-builder (`build_claude_launcher_env` in
`cli/launchers/claude.py`) only strips `ANTHROPIC_*`-prefixed vars before
handing the child environment to `claude.exe`. If `fcc-claude` is invoked
from *inside* an already-running Claude Code session — for example, an
agent driving its own shell/Bash tool, which is a real and increasingly
common way people use fcc for local-model agent loops — the child process
inherits the parent session's identity vars: `CLAUDECODE`,
`CLAUDE_CODE_CHILD_SESSION`, `CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH`,
`CLAUDE_CODE_OAUTH_SCOPES`, `CLAUDE_AGENT_SDK_VERSION`, `CLAUDE_EFFORT`,
`AI_AGENT`, `BAGGAGE`.

With those present, the nested `claude.exe` decides it's a host-managed
child session and tries to authenticate via the parent's real Anthropic
OAuth credentials instead of respecting `ANTHROPIC_AUTH_TOKEN` — so every
request 401s against the local proxy, regardless of how `ANTHROPIC_AUTH_TOKEN`
/`ANTHROPIC_API_KEY` are set. This is invisible from the proxy side: the
token is configured correctly, the proxy is healthy, and a plain `curl` with
the same token succeeds — only the nested `claude.exe`/`fcc-claude` fails.

## Repro (before this fix)

```bash
# 1. fcc-server running normally, ANTHROPIC_AUTH_TOKEN=freecc in ~/.fcc/.env
fcc-server &

# 2. A direct curl with the configured token succeeds fine:
curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8082/v1/messages \
  -H "x-api-key: freecc" -H "content-type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{"model":"claude-3-sonnet","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
# -> 200

# 3. But simulate invoking fcc-claude from inside a live Claude Code session
#    (i.e. with the parent session's own identity vars already in the
#    environment, as they would be for any nested Bash-tool invocation):
CLAUDECODE=1 CLAUDE_CODE_CHILD_SESSION=1 CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH=1 \
CLAUDE_CODE_OAUTH_SCOPES="user:inference user:profile" \
  fcc-claude -p "reply with just the word OK"
# -> Failed to authenticate. API Error: 401 {"detail":"Invalid API key"}
# fcc-server's own log confirms the request never even reaches with a
# matching token: LMSTUDIO/native `x-api-key`/`Authorization` header check
# never matches "freecc" because claude.exe substitutes its own bearer
# token instead of honoring ANTHROPIC_AUTH_TOKEN.
```

After this fix, step 3 succeeds identically to step 2 — no manual `env -u`
workaround needed.

## Fix

- `build_claude_launcher_env` now strips every inherited `CLAUDE_CODE_*`-
  prefixed var plus the fixed set above, then re-sets only the two
  `CLAUDE_CODE_*` vars the launcher itself intentionally configures
  (`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY`,
  `CLAUDE_CODE_AUTO_COMPACT_WINDOW`). `fcc-claude`'s contract is a fresh,
  standalone session pointed at the local proxy — any inherited
  session/harness var undermines that contract.
- Also adds `resolve_auto_compact_window()`: when the configured provider
  is `lmstudio`, it queries `GET <lm_studio_base_url>/api/v0/models` for
  the currently loaded model's `loaded_context_length` and sizes
  `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to it (85% proportional reserve, or a
  flat 12k-token reserve at small contexts, whichever is smaller), instead
  of the static `190000` default. A locally-loaded model's real context
  ceiling is usually far below 190k tokens, so without this Claude Code
  never auto-compacts before hitting the local ceiling, and LM Studio
  silently truncates the stream mid-response instead of erroring cleanly.
  Falls back to the static default for every other provider, or on any
  lookup failure (fails open — never blocks a launch).

## Testing

- `uv run ruff format` / `uv run ruff check --fix` / `uv run ty check`:
  all clean on both changed files.
- Added 4 new unit tests in `tests/cli/test_entrypoints.py` covering the
  session-var stripping, the lmstudio-branch window sizing (mocked
  `httpx.get`), the non-lmstudio fallback, and the fail-open behavior on a
  lookup error. Existing `build_claude_launcher_env` tests are
  unmodified and still pass under the new signature (the new
  `auto_compact_window` parameter is optional, defaulting to the old
  static behavior).
- Note: I hit a pre-existing, environment-specific crash running the full
  suite locally on Windows (`OPENSSL_Uplink ... no OPENSSL_Applink`,
  inside `api.admin_urls`'s import chain) — confirmed unrelated to this
  change (reproduces identically on a clean, unmodified checkout of
  `main`). Verified the new/changed logic by direct execution of the
  functions outside pytest instead. Flagging in case it's a known issue
  with this Python/OpenSSL combination on Windows — happy to help debug
  further if useful.
- Version bumped `2.4.4` → `2.4.5` per `AGENTS.md`'s versioning rule (bug
  fix, no breaking change); `uv.lock` regenerated accordingly (note: a
  handful of unrelated `sys_platform` marker lines also changed in
  `uv.lock` — that's `uv lock` resolving with a newer local `uv`
  (0.11.26) than last touched the committed lockfile, not anything from
  this change; happy to hand-revert those lines if you'd rather keep the
  lockfile diff minimal).

## Scope

Single, focused fix — first of a small series I'm planning to send from
the same debugging session (this one's the least controversial / most
universally applicable of the set).

## Versioning note

The semver bump is intentionally omitted from this PR. `main` merges several
version-bumping PRs a day, so any version this branch pins goes stale (and
re-conflicts the PR) within hours — this branch has been rebased over version
conflicts alone several times already. The code change itself never conflicts.
Happy to push a bump at merge time if you ping me, or feel free to bump on
merge — whichever you prefer.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `fcc-claude` launcher to start nested Claude Code sessions with a clean proxy-focused environment. The main changes are:

- Strip inherited `ANTHROPIC_*`, `CLAUDE_CODE_*`, and Claude session identity variables before launching `claude.exe`.
- Re-set only the launcher-owned Claude Code environment variables needed for gateway model discovery and auto-compaction.
- Size `CLAUDE_CODE_AUTO_COMPACT_WINDOW` from loaded LM Studio model context lengths when any configured chat model uses LM Studio.
- Add tests for session variable stripping, LM Studio lookup behavior, model override handling, smallest-context sizing, small-context clamping, and lookup failure fallback.

<h3>Confidence Score: 4/5</h3>

The changed launcher flow is safe to merge after the repository versioning requirement is handled.

The launcher behavior is covered by focused tests and the previously reported auto-compact edge cases are addressed. Confidence is limited because `AGENTS.md` and `CLAUDE.md` require a semver bump and regenerated `uv.lock` for production changes under `src/free_claude_code/cli/`.

`pyproject.toml` and `uv.lock` need attention for the required version bump. The changed files do not need special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Pytest suite for the launcher-auth-auto-compact target and confirmed 6 tests passed in 3.20 seconds with exit code 0.
- Validated Ruff format for the launcher-auth-auto-compact target, noting that 2 files were already formatted and exit code was 0.
- Verified Ruff lint checks for the launcher-auth-auto-compact target passed with all checks successful and exit code 0.
- Validated Ty type-check for the launcher-auth-auto-compact target, confirming all checks passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/13880349/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/launchers/claude.py | Adds inherited Claude session env stripping and LM Studio-aware auto-compact window sizing; no blocking implementation issues found. |
| tests/cli/test_entrypoints.py | Adds tests for session variable stripping, LM Studio sizing, override routing, smallest-context selection, small-context clamping, and fail-open lookup behavior. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Launcher as fcc-claude launcher
participant Env as Child env builder
participant LM as LM Studio /api/v0/models
participant Claude as claude.exe
User->>Launcher: run fcc-claude
Launcher->>Launcher: load settings and proxy URL
alt any configured chat model uses lmstudio
    Launcher->>LM: GET /api/v0/models
    LM-->>Launcher: loaded_context_length values
    Launcher->>Launcher: choose smallest loaded context and compute window
else no lmstudio or lookup fails
    Launcher->>Launcher: use static compact window
end
Launcher->>Env: build_claude_launcher_env(base_env, token, window)
Env->>Env: "drop ANTHROPIC_*, CLAUDE_CODE_*, and session identity vars"
Env-->>Launcher: "proxy auth/base URL and launcher-owned CLAUDE_CODE_* vars"
Launcher->>Claude: start with sanitized environment
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Launcher as fcc-claude launcher
participant Env as Child env builder
participant LM as LM Studio /api/v0/models
participant Claude as claude.exe
User->>Launcher: run fcc-claude
Launcher->>Launcher: load settings and proxy URL
alt any configured chat model uses lmstudio
    Launcher->>LM: GET /api/v0/models
    LM-->>Launcher: loaded_context_length values
    Launcher->>Launcher: choose smallest loaded context and compute window
else no lmstudio or lookup fails
    Launcher->>Launcher: use static compact window
end
Launcher->>Env: build_claude_launcher_env(base_env, token, window)
Env->>Env: "drop ANTHROPIC_*, CLAUDE_CODE_*, and session identity vars"
Env-->>Launcher: "proxy auth/base URL and launcher-owned CLAUDE_CODE_* vars"
Launcher->>Claude: start with sanitized environment
```

</a>

<sub>Reviews (12): Last reviewed commit: ["Fix nested-session auth leak in fcc-clau..."](https://github.com/alishahryar1/free-claude-code/commit/ae48d3e61af8ec48eae0682ae77ef3faf58ac5ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41863454)</sub>

<!-- /greptile_comment -->