### PR TITLE
Fix stream:false requests returning malformed response (matches #917, #868, #771, #497 symptom)

### DIFF
--- a/api/handlers/messages.py
+++ b/api/handlers/messages.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import replace
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, replace
 
 from fastapi.responses import JSONResponse
 from loguru import logger
@@ -28,14 +28,26 @@ from core.trace import trace_event
 from providers.base import BaseProvider
 from providers.exceptions import InvalidRequestError, ProviderError
 
-ProviderGetter = Callable[[str], BaseProvider]
-MessageIntercept = Callable[[RoutedMessagesRequest], object | None]
-
 _OPENAI_CHAT_UPSTREAM_IDS = frozenset(
     provider_id
     for provider_id, descriptor in PROVIDER_CATALOG.items()
     if descriptor.transport_type == "openai_chat"
 )
+
+
+@dataclass(frozen=True)
+class _MessagesStreamResult:
+    body: AsyncIterator[str]
+
+
+@dataclass(frozen=True)
+class _MessagesCompleteResult:
+    response: object
+
+
+ProviderGetter = Callable[[str], BaseProvider]
+_MessagesResult = _MessagesStreamResult | _MessagesCompleteResult
+MessageIntercept = Callable[[RoutedMessagesRequest], _MessagesResult | None]
 
 
 class MessagesHandler:
@@ -71,37 +83,42 @@ class MessagesHandler:
             routed = self._apply_message_routing_policies(routed)
             self._reject_unsupported_server_tools(routed)
 
-            intercepted = self._run_message_intercepts(routed)
-            if intercepted is not None:
-                return intercepted
-
-            logger.debug("No optimization matched, routing to provider")
-            provider_stream = self._provider_execution.stream(
-                routed,
-                wire_api="messages",
-                raw_log_label="FULL_PAYLOAD",
-                raw_log_payload=routed.request.model_dump(),
-            )
-            if request_data.stream is False:
-                # Non-streaming clients (e.g. Claude Code utility calls) need a
-                # complete JSON Message; the internal pipeline is always SSE, so
-                # serving that raw here breaks the client SDK's response parse.
-                message, error = await aggregate_anthropic_sse_to_message(
-                    provider_stream
-                )
-                if error is not None and not message.get("content"):
-                    return JSONResponse(
-                        status_code=502,
-                        content={"type": "error", "error": error},
+            result = self._run_message_intercepts(routed)
+            if result is None:
+                logger.debug("No optimization matched, routing to provider")
+                result = _MessagesStreamResult(
+                    self._provider_execution.stream(
+                        routed,
+                        wire_api="messages",
+                        raw_log_label="FULL_PAYLOAD",
+                        raw_log_payload=routed.request.model_dump(),
                     )
-                return JSONResponse(content=message)
-            return anthropic_sse_streaming_response(provider_stream)
+                )
+            return await self._to_public_response(result, stream=request_data.stream)
         except ProviderError:
             raise
         except Exception as exc:
             raise unexpected_http_exception(
                 self._settings, exc, context="CREATE_MESSAGE_ERROR"
             ) from exc
+
+    async def _to_public_response(
+        self, result: _MessagesResult, *, stream: bool | None
+    ) -> object:
+        if isinstance(result, _MessagesCompleteResult):
+            return result.response
+        if stream is False:
+            # Non-streaming clients (e.g. Claude Code utility calls) need a
+            # complete JSON Message; the internal pipeline is always SSE, so
+            # serving that raw here breaks the client SDK's response parse.
+            message, error = await aggregate_anthropic_sse_to_message(result.body)
+            if error is not None and not message.get("content"):
+                return JSONResponse(
+                    status_code=502,
+                    content={"type": "error", "error": error},
+                )
+            return JSONResponse(content=message)
+        return anthropic_sse_streaming_response(result.body)
 
     def _reject_unsupported_server_tools(self, routed: RoutedMessagesRequest) -> None:
         if routed.resolved.provider_id not in _OPENAI_CHAT_UPSTREAM_IDS:
@@ -133,7 +150,9 @@ class MessagesHandler:
             resolved=replace(routed.resolved, thinking_enabled=False),
         )
 
-    def _run_message_intercepts(self, routed: RoutedMessagesRequest) -> object | None:
+    def _run_message_intercepts(
+        self, routed: RoutedMessagesRequest
+    ) -> _MessagesResult | None:
         for intercept in self._message_intercepts:
             result = intercept(routed)
             if result is not None:
@@ -142,7 +161,7 @@ class MessagesHandler:
 
     def _intercept_web_server_tool(
         self, routed: RoutedMessagesRequest
-    ) -> object | None:
+    ) -> _MessagesResult | None:
         if not self._settings.enable_web_server_tools:
             return None
         if not is_web_server_tool_request(routed.request):
@@ -163,7 +182,7 @@ class MessagesHandler:
                 self._settings.web_fetch_allowed_schemes
             ),
         )
-        return anthropic_sse_streaming_response(
+        return _MessagesStreamResult(
             stream_web_server_tool_response(
                 routed.request,
                 input_tokens=input_tokens,
@@ -174,7 +193,7 @@ class MessagesHandler:
 
     def _intercept_local_optimization(
         self, routed: RoutedMessagesRequest
-    ) -> object | None:
+    ) -> _MessagesResult | None:
         optimized = try_optimizations(routed.request, self._settings)
         if optimized is None:
             return None
@@ -184,4 +203,4 @@ class MessagesHandler:
             source="api",
             model=routed.request.model,
         )
-        return optimized
+        return _MessagesCompleteResult(optimized)

--- a/api/handlers/messages.py
+++ b/api/handlers/messages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import replace
 
+from fastapi.responses import JSONResponse
 from loguru import logger
 
 from api.detection import is_safety_classifier_request
@@ -22,7 +23,7 @@ from api.web_tools.request import (
 from api.web_tools.streaming import stream_web_server_tool_response
 from config.provider_catalog import PROVIDER_CATALOG
 from config.settings import Settings
-from core.anthropic import get_token_count
+from core.anthropic import aggregate_anthropic_sse_to_message, get_token_count
 from core.trace import trace_event
 from providers.base import BaseProvider
 from providers.exceptions import InvalidRequestError, ProviderError
@@ -62,7 +63,7 @@ class MessagesHandler:
             self._intercept_local_optimization,
         )
 
-    def create(self, request_data: MessagesRequest) -> object:
+    async def create(self, request_data: MessagesRequest) -> object:
         """Create an Anthropic-compatible message response."""
         try:
             require_non_empty_messages(request_data.messages)
@@ -75,14 +76,26 @@ class MessagesHandler:
                 return intercepted
 
             logger.debug("No optimization matched, routing to provider")
-            return anthropic_sse_streaming_response(
-                self._provider_execution.stream(
-                    routed,
-                    wire_api="messages",
-                    raw_log_label="FULL_PAYLOAD",
-                    raw_log_payload=routed.request.model_dump(),
-                )
+            provider_stream = self._provider_execution.stream(
+                routed,
+                wire_api="messages",
+                raw_log_label="FULL_PAYLOAD",
+                raw_log_payload=routed.request.model_dump(),
             )
+            if request_data.stream is False:
+                # Non-streaming clients (e.g. Claude Code utility calls) need a
+                # complete JSON Message; the internal pipeline is always SSE, so
+                # serving that raw here breaks the client SDK's response parse.
+                message, error = await aggregate_anthropic_sse_to_message(
+                    provider_stream
+                )
+                if error is not None and not message.get("content"):
+                    return JSONResponse(
+                        status_code=502,
+                        content={"type": "error", "error": error},
+                    )
+                return JSONResponse(content=message)
+            return anthropic_sse_streaming_response(provider_stream)
         except ProviderError:
             raise
         except Exception as exc:

--- a/api/routes.py
+++ b/api/routes.py
@@ -69,8 +69,8 @@ async def create_message(
     handler: MessagesHandler = Depends(get_messages_handler),
     _auth=Depends(require_api_key),
 ):
-    """Create a message (always streaming)."""
-    return handler.create(request_data)
+    """Create a message (streaming by default; stream=false gets aggregated JSON)."""
+    return await handler.create(request_data)
 
 
 @router.api_route("/v1/messages", methods=["HEAD", "OPTIONS"])

--- a/core/anthropic/__init__.py
+++ b/core/anthropic/__init__.py
@@ -15,6 +15,7 @@ from .errors import (
 from .native_messages_request import sanitize_native_messages_thinking_policy
 from .provider_stream_error import iter_provider_stream_error_sse_events
 from .request_serialization import serialize_tool_result_content
+from .sse_aggregation import aggregate_anthropic_sse_to_message
 from .streaming import (
     AnthropicStreamLedger,
     StreamBlockLedger,
@@ -38,6 +39,7 @@ __all__ = [
     "StreamBlockLedger",
     "ThinkTagParser",
     "ToolBlockState",
+    "aggregate_anthropic_sse_to_message",
     "append_request_id",
     "build_base_request_body",
     "extract_text_from_content",

--- a/core/anthropic/sse_aggregation.py
+++ b/core/anthropic/sse_aggregation.py
@@ -77,7 +77,9 @@ async def aggregate_anthropic_sse_to_message(
                     if isinstance(message.get("usage"), dict)
                     else {}
                 )
-                merged.update({k: v for k, v in usage.items() if isinstance(v, int)})
+                merged.update(
+                    {k: v for k, v in usage.items() if isinstance(v, int | dict)}
+                )
                 message["usage"] = merged
         elif ptype == "error":
             err = payload.get("error")

--- a/core/anthropic/sse_aggregation.py
+++ b/core/anthropic/sse_aggregation.py
@@ -1,0 +1,135 @@
+"""Fold an Anthropic Messages SSE stream into a single JSON Message body.
+
+Used to honor client requests with ``stream: false``. The internal pipeline
+is always SSE (providers/transports only know how to speak streaming), so
+callers that need a non-streaming response consume the stream here and get
+back the same shape the real Anthropic API returns for a non-streaming
+``messages.create()`` call.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from .native_sse_block_policy import parse_native_sse_event
+
+__all__ = ["aggregate_anthropic_sse_to_message"]
+
+
+async def aggregate_anthropic_sse_to_message(
+    stream: AsyncIterator[str],
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Assemble a complete Messages JSON body from an Anthropic SSE stream.
+
+    Returns ``(message_body, error)`` where ``error`` is the payload of a
+    top-level ``event: error`` if one arrived, else ``None``.
+    """
+    buffer = ""
+    message: dict[str, Any] = {}
+    blocks: dict[int, dict[str, Any]] = {}
+    parts: dict[int, list[str]] = {}
+    error: dict[str, Any] | None = None
+
+    def handle_payload(payload: dict[str, Any]) -> None:
+        nonlocal message, error
+        ptype = payload.get("type")
+        if ptype == "message_start":
+            started = payload.get("message")
+            if isinstance(started, dict):
+                message = dict(started)
+        elif ptype == "content_block_start":
+            idx = payload.get("index")
+            block = payload.get("content_block")
+            if isinstance(idx, int) and isinstance(block, dict):
+                blocks[idx] = dict(block)
+                parts.setdefault(idx, [])
+        elif ptype == "content_block_delta":
+            idx = payload.get("index")
+            delta = payload.get("delta")
+            if not isinstance(idx, int) or not isinstance(delta, dict):
+                return
+            if idx not in blocks:
+                blocks[idx] = {"type": "text", "text": ""}
+                parts[idx] = []
+            dtype = delta.get("type")
+            if dtype == "text_delta":
+                parts[idx].append(str(delta.get("text", "")))
+            elif dtype == "thinking_delta":
+                parts[idx].append(str(delta.get("thinking", "")))
+            elif dtype == "input_json_delta":
+                parts[idx].append(str(delta.get("partial_json", "")))
+            elif dtype == "signature_delta":
+                blocks[idx]["signature"] = str(delta.get("signature", ""))
+        elif ptype == "message_delta":
+            delta = payload.get("delta")
+            if isinstance(delta, dict):
+                if delta.get("stop_reason"):
+                    message["stop_reason"] = delta["stop_reason"]
+                if "stop_sequence" in delta:
+                    message["stop_sequence"] = delta["stop_sequence"]
+            usage = payload.get("usage")
+            if isinstance(usage, dict):
+                merged = (
+                    dict(message["usage"])
+                    if isinstance(message.get("usage"), dict)
+                    else {}
+                )
+                merged.update({k: v for k, v in usage.items() if isinstance(v, int)})
+                message["usage"] = merged
+        elif ptype == "error":
+            err = payload.get("error")
+            error = (
+                err
+                if isinstance(err, dict)
+                else {"type": "api_error", "message": "provider error"}
+            )
+
+    async for chunk in stream:
+        buffer += chunk
+        while "\n\n" in buffer:
+            raw_event, buffer = buffer.split("\n\n", 1)
+            _event_name, data_text = parse_native_sse_event(raw_event + "\n\n")
+            if not data_text:
+                continue
+            try:
+                payload = json.loads(data_text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                handle_payload(payload)
+
+    content: list[dict[str, Any]] = []
+    for idx in sorted(blocks):
+        block = blocks[idx]
+        accumulated = "".join(parts.get(idx, []))
+        btype = block.get("type")
+        if btype == "text":
+            block["text"] = str(block.get("text", "")) + accumulated
+        elif btype == "thinking":
+            block["thinking"] = str(block.get("thinking", "")) + accumulated
+            block.setdefault("signature", "")
+        elif btype == "tool_use":
+            if accumulated.strip():
+                try:
+                    block["input"] = json.loads(accumulated)
+                except json.JSONDecodeError:
+                    block["input"] = block.get("input") or {}
+            elif not isinstance(block.get("input"), dict):
+                block["input"] = {}
+        content.append(block)
+
+    message["content"] = content
+    message.setdefault("id", f"msg_{uuid.uuid4()}")
+    message.setdefault("type", "message")
+    message.setdefault("role", "assistant")
+    message.setdefault("model", "unknown")
+    message.setdefault("stop_reason", "end_turn")
+    message.setdefault("stop_sequence", None)
+    usage = dict(message["usage"]) if isinstance(message.get("usage"), dict) else {}
+    usage.setdefault("input_tokens", 0)
+    usage.setdefault("output_tokens", 0)
+    message["usage"] = usage
+    return message, error

--- a/providers/transports/anthropic_messages/transport.py
+++ b/providers/transports/anthropic_messages/transport.py
@@ -138,10 +138,14 @@ class AnthropicMessagesTransport(BaseProvider):
 
     async def _send_stream_request(self, body: dict) -> httpx.Response:
         """Create a streaming messages response."""
+        # This transport always parses the upstream response as SSE, so the
+        # upstream request must always be streaming — forwarding a client's
+        # stream=false makes native providers return plain JSON that the SSE
+        # reader misreads as a truncated stream.
         request = self._client.build_request(
             "POST",
             "/messages",
-            json=body,
+            json={**body, "stream": True},
             headers=self._request_headers(),
         )
         return await self._client.send(request, stream=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.5.1"
+version = "2.5.2"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/api/test_api_handlers.py
+++ b/tests/api/test_api_handlers.py
@@ -88,7 +88,7 @@ async def test_messages_handler_passes_routed_request_and_stream_metadata() -> N
         messages=[Message(role="user", content="hi")],
     )
 
-    response = handler.create(request)
+    response = await handler.create(request)
     assert isinstance(response, StreamingResponse)
 
     body = await _streaming_body_text(response)
@@ -112,7 +112,7 @@ async def test_messages_handler_forces_no_thinking_for_safety_classifier() -> No
     )
 
     with patch("api.handlers.messages.trace_event") as trace_mock:
-        response = handler.create(request)
+        response = await handler.create(request)
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
@@ -153,7 +153,7 @@ async def test_messages_handler_preserves_thinking_for_non_classifier() -> None:
     )
 
     with patch("api.handlers.messages.trace_event") as trace_mock:
-        response = handler.create(request)
+        response = await handler.create(request)
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
@@ -177,7 +177,7 @@ async def test_messages_handler_keeps_existing_no_thinking_for_classifier() -> N
     )
 
     with patch("api.handlers.messages.trace_event") as trace_mock:
-        response = handler.create(request)
+        response = await handler.create(request)
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
@@ -196,7 +196,10 @@ async def test_messages_handler_keeps_existing_no_thinking_for_classifier() -> N
     ]
 
 
-def test_messages_handler_optimization_intercepts_before_provider_execution() -> None:
+@pytest.mark.asyncio
+async def test_messages_handler_optimization_intercepts_before_provider_execution() -> (
+    None
+):
     provider_getter = MagicMock()
     handler = MessagesHandler(Settings(), provider_getter=provider_getter)
     request = MessagesRequest(
@@ -207,7 +210,7 @@ def test_messages_handler_optimization_intercepts_before_provider_execution() ->
     optimized = object()
 
     with patch("api.handlers.messages.try_optimizations", return_value=optimized):
-        assert handler.create(request) is optimized
+        assert await handler.create(request) is optimized
 
     provider_getter.assert_not_called()
 

--- a/tests/api/test_api_handlers.py
+++ b/tests/api/test_api_handlers.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from api.handlers import MessagesHandler, ResponsesHandler, TokenCountHandler
 from api.models.anthropic import Message, MessagesRequest, TokenCountRequest
 from api.models.openai_responses import OpenAIResponsesRequest
 from config.settings import Settings
+from core.anthropic.streaming import format_sse_event
 from providers.base import BaseProvider, ProviderConfig
 
 _CLASSIFIER_SYSTEM = (
@@ -23,11 +25,15 @@ _CLASSIFIER_USER = (
 
 
 class FakeProvider(BaseProvider):
-    def __init__(self) -> None:
+    def __init__(self, events: list[str] | None = None) -> None:
         super().__init__(ProviderConfig(api_key="test"))
         self.preflight_calls: list[tuple[Any, bool | None]] = []
         self.requests: list[Any] = []
         self.stream_kwargs: list[dict[str, Any]] = []
+        self.events = events or [
+            'event: message_start\ndata: {"type":"message_start"}\n\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+        ]
 
     def preflight_stream(
         self, request: Any, *, thinking_enabled: bool | None = None
@@ -56,8 +62,8 @@ class FakeProvider(BaseProvider):
                 "thinking_enabled": thinking_enabled,
             }
         )
-        yield 'event: message_start\ndata: {"type":"message_start"}\n\n'
-        yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+        for event in self.events:
+            yield event
 
 
 async def _streaming_body_text(response: StreamingResponse) -> str:
@@ -68,6 +74,12 @@ async def _streaming_body_text(response: StreamingResponse) -> str:
         else:
             parts.append(str(chunk))
     return "".join(parts)
+
+
+def _json_response_content(response: JSONResponse) -> dict[str, Any]:
+    content = json.loads(bytes(response.body).decode("utf-8"))
+    assert isinstance(content, dict)
+    return content
 
 
 def _trace_events(trace_mock: MagicMock, event: str) -> list[dict[str, Any]]:
@@ -98,6 +110,110 @@ async def test_messages_handler_passes_routed_request_and_stream_metadata() -> N
     assert provider.stream_kwargs[0]["request_id"].startswith("req_")
     assert provider.stream_kwargs[0]["thinking_enabled"] is True
     assert len(provider.preflight_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_messages_handler_aggregates_provider_stream_when_stream_false() -> None:
+    provider = FakeProvider(
+        [
+            format_sse_event(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_test",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": "test-model",
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 7, "output_tokens": 1},
+                    },
+                },
+            ),
+            format_sse_event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            format_sse_event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "OK"},
+                },
+            ),
+            format_sse_event(
+                "content_block_stop", {"type": "content_block_stop", "index": 0}
+            ),
+            format_sse_event(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                    "usage": {"input_tokens": 7, "output_tokens": 2},
+                },
+            ),
+            format_sse_event("message_stop", {"type": "message_stop"}),
+        ]
+    )
+    handler = MessagesHandler(Settings(), provider_getter=lambda _: provider)
+    request = MessagesRequest(
+        model="nvidia_nim/test-model",
+        max_tokens=100,
+        stream=False,
+        messages=[Message(role="user", content="hi")],
+    )
+
+    response = await handler.create(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.headers["content-type"].startswith("application/json")
+    body = _json_response_content(response)
+    assert body["id"] == "msg_test"
+    assert body["type"] == "message"
+    assert body["role"] == "assistant"
+    assert body["model"] == "test-model"
+    assert body["content"] == [{"type": "text", "text": "OK"}]
+    assert body["stop_reason"] == "end_turn"
+    assert body["usage"] == {"input_tokens": 7, "output_tokens": 2}
+
+
+@pytest.mark.asyncio
+async def test_messages_handler_returns_error_json_for_stream_false_sse_error() -> None:
+    provider = FakeProvider(
+        [
+            format_sse_event(
+                "error",
+                {
+                    "type": "error",
+                    "error": {"type": "api_error", "message": "upstream failed"},
+                },
+            )
+        ]
+    )
+    handler = MessagesHandler(Settings(), provider_getter=lambda _: provider)
+    request = MessagesRequest(
+        model="nvidia_nim/test-model",
+        max_tokens=100,
+        stream=False,
+        messages=[Message(role="user", content="hi")],
+    )
+
+    response = await handler.create(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 502
+    body = _json_response_content(response)
+    assert body == {
+        "type": "error",
+        "error": {"type": "api_error", "message": "upstream failed"},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_safe_logging.py
+++ b/tests/api/test_safe_logging.py
@@ -14,7 +14,8 @@ from config.settings import Settings
 from core.anthropic import AnthropicStreamLedger
 
 
-def test_create_message_skips_full_payload_debug_log_by_default():
+@pytest.mark.asyncio
+async def test_create_message_skips_full_payload_debug_log_by_default():
     settings = Settings()
     assert settings.log_raw_api_payloads is False
     mock_provider = MagicMock()
@@ -32,7 +33,7 @@ def test_create_message_skips_full_payload_debug_log_by_default():
     )
 
     with patch.object(provider_execution.logger, "debug") as mock_debug:
-        service.create(request)
+        await service.create(request)
 
     full_payload_calls = [
         c
@@ -42,7 +43,8 @@ def test_create_message_skips_full_payload_debug_log_by_default():
     assert not full_payload_calls
 
 
-def test_create_message_logs_full_payload_when_opt_in():
+@pytest.mark.asyncio
+async def test_create_message_logs_full_payload_when_opt_in():
     settings = Settings()
     settings.log_raw_api_payloads = True
     mock_provider = MagicMock()
@@ -59,7 +61,7 @@ def test_create_message_logs_full_payload_when_opt_in():
     )
 
     with patch.object(provider_execution.logger, "debug") as mock_debug:
-        service.create(request)
+        await service.create(request)
 
     keys = [c.args[0] for c in mock_debug.call_args_list if c.args]
     assert any(k == "FULL_PAYLOAD [{}]: {}" for k in keys)
@@ -92,7 +94,8 @@ def _flatten_log_calls(mock_log) -> str:
     return " ".join(parts)
 
 
-def test_create_message_unexpected_error_default_logs_exclude_exception_text():
+@pytest.mark.asyncio
+async def test_create_message_unexpected_error_default_logs_exclude_exception_text():
     settings = Settings()
     assert settings.log_api_error_tracebacks is False
     secret = "upstream-secret-token-abc"
@@ -114,14 +117,15 @@ def test_create_message_unexpected_error_default_logs_exclude_exception_text():
         patch.object(request_errors.logger, "error") as log_err,
         pytest.raises(HTTPException),
     ):
-        service.create(request)
+        await service.create(request)
 
     blob = _flatten_log_calls(log_err)
     assert secret not in blob
     assert "RuntimeError" in blob
 
 
-def test_create_message_unexpected_error_always_returns_500():
+@pytest.mark.asyncio
+async def test_create_message_unexpected_error_always_returns_500():
     """Non-provider failures must not leak arbitrary status_code attributes."""
 
     class WeirdError(Exception):
@@ -142,7 +146,7 @@ def test_create_message_unexpected_error_always_returns_500():
     )
 
     with pytest.raises(HTTPException) as excinfo:
-        service.create(request)
+        await service.create(request)
 
     assert excinfo.value.status_code == 500
 

--- a/tests/api/test_web_server_tools.py
+++ b/tests/api/test_web_server_tools.py
@@ -105,8 +105,9 @@ def test_web_server_tool_not_detected_when_forced_name_missing_from_tools():
     assert not is_web_server_tool_request(request)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider_id", _OPENAI_CHAT_PROVIDER_IDS)
-def test_service_rejects_forced_server_tool_on_openai_when_disabled(
+async def test_service_rejects_forced_server_tool_on_openai_when_disabled(
     provider_id: str,
 ):
     """OpenAI Chat upstreams cannot run forced server tools without the local handler."""
@@ -130,7 +131,7 @@ def test_service_rejects_forced_server_tool_on_openai_when_disabled(
         tool_choice={"type": "tool", "name": "web_search"},
     )
     with pytest.raises(InvalidRequestError, match="ENABLE_WEB_SERVER_TOOLS"):
-        service.create(request)
+        await service.create(request)
 
 
 @pytest.mark.parametrize(
@@ -593,8 +594,9 @@ async def test_drain_response_body_capped_stops_after_first_chunk_when_oversized
     assert chunk_calls["n"] == 1
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider_id", _OPENAI_CHAT_PROVIDER_IDS)
-def test_service_rejects_listed_server_tools_on_openai_chat(
+async def test_service_rejects_listed_server_tools_on_openai_chat(
     provider_id: str,
 ) -> None:
     settings = Settings()
@@ -610,11 +612,12 @@ def test_service_rejects_listed_server_tools_on_openai_chat(
         tools=[Tool(name="web_search", type="web_search_20250305")],
     )
     with pytest.raises(InvalidRequestError, match="OpenAI Chat upstreams"):
-        service.create(request)
+        await service.create(request)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider_id", _ANTHROPIC_MESSAGES_PROVIDER_IDS)
-def test_listed_server_tools_routed_on_anthropic_messages_providers(
+async def test_listed_server_tools_routed_on_anthropic_messages_providers(
     provider_id: str,
 ) -> None:
     """Native Anthropic transports may receive listed server tool definitions."""
@@ -637,12 +640,13 @@ def test_listed_server_tools_routed_on_anthropic_messages_providers(
         messages=[Message(role="user", content="q")],
         tools=[Tool(name="web_search", type="web_search_20250305")],
     )
-    service.create(request)
+    await service.create(request)
     mock_provider.preflight_stream.assert_called()
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider_id", _ANTHROPIC_MESSAGES_PROVIDER_IDS)
-def test_forced_server_tools_routed_on_anthropic_messages_providers_when_local_disabled(
+async def test_forced_server_tools_routed_on_anthropic_messages_providers_when_local_disabled(
     provider_id: str,
 ) -> None:
     """Native Anthropic transports may receive forced server tools when local tools are off."""
@@ -666,5 +670,5 @@ def test_forced_server_tools_routed_on_anthropic_messages_providers_when_local_d
         tools=[Tool(name="web_search", type="web_search_20250305")],
         tool_choice={"type": "tool", "name": "web_search"},
     )
-    service.create(request)
+    await service.create(request)
     mock_provider.preflight_stream.assert_called()

--- a/tests/api/test_web_server_tools.py
+++ b/tests/api/test_web_server_tools.py
@@ -1,8 +1,10 @@
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from fastapi.responses import JSONResponse, StreamingResponse
 
 import api.web_tools.constants as web_tool_constants
 from api.handlers import MessagesHandler
@@ -178,6 +180,20 @@ def _stream_cm(response: httpx.Response) -> MagicMock:
     cm.__aenter__ = AsyncMock(return_value=response)
     cm.__aexit__ = AsyncMock(return_value=None)
     return cm
+
+
+def _json_body(response: JSONResponse) -> dict[str, Any]:
+    payload = json.loads(bytes(response.body).decode("utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+async def _streaming_body_text(response: StreamingResponse) -> str:
+    parts = [
+        chunk.decode("utf-8") if isinstance(chunk, bytes) else str(chunk)
+        async for chunk in response.body_iterator
+    ]
+    return "".join(parts)
 
 
 def _aiohttp_response(
@@ -374,6 +390,75 @@ async def test_streams_web_search_server_tool_result(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_service_streams_forced_web_search_by_default(monkeypatch):
+    async def fake_search(_query: str) -> list[dict[str, str]]:
+        return [{"title": "DeepSeek V4 Released", "url": "https://example.com/v4"}]
+
+    monkeypatch.setattr("api.web_tools.outbound._run_web_search", fake_search)
+    settings = Settings.model_validate({"ENABLE_WEB_SERVER_TOOLS": True})
+    provider_getter = MagicMock()
+    service = MessagesHandler(
+        settings,
+        provider_getter=provider_getter,
+        model_router=FixedProviderModelRouter(settings, _OPENAI_CHAT_PROVIDER_IDS[0]),
+    )
+    request = MessagesRequest(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=100,
+        messages=[Message(role="user", content="Search for DeepSeek V4")],
+        tools=[Tool(name="web_search", type="web_search_20250305")],
+        tool_choice={"type": "tool", "name": "web_search"},
+    )
+
+    response = await service.create(request)
+
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "text/event-stream"
+    raw = await _streaming_body_text(response)
+    assert "event: message_start" in raw
+    assert "DeepSeek V4 Released" in raw
+    provider_getter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_service_aggregates_forced_web_search_when_stream_false(monkeypatch):
+    async def fake_search(_query: str) -> list[dict[str, str]]:
+        return [{"title": "DeepSeek V4 Released", "url": "https://example.com/v4"}]
+
+    monkeypatch.setattr("api.web_tools.outbound._run_web_search", fake_search)
+    settings = Settings.model_validate({"ENABLE_WEB_SERVER_TOOLS": True})
+    provider_getter = MagicMock()
+    service = MessagesHandler(
+        settings,
+        provider_getter=provider_getter,
+        model_router=FixedProviderModelRouter(settings, _OPENAI_CHAT_PROVIDER_IDS[0]),
+    )
+    request = MessagesRequest(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=100,
+        messages=[Message(role="user", content="Search for DeepSeek V4")],
+        stream=False,
+        tools=[Tool(name="web_search", type="web_search_20250305")],
+        tool_choice={"type": "tool", "name": "web_search"},
+    )
+
+    response = await service.create(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.headers["content-type"].startswith("application/json")
+    body = _json_body(response)
+    assert [block["type"] for block in body["content"]] == [
+        "server_tool_use",
+        "web_search_tool_result",
+        "text",
+    ]
+    assert body["content"][1]["content"][0]["url"] == "https://example.com/v4"
+    assert "DeepSeek V4 Released" in body["content"][2]["text"]
+    assert body["usage"]["server_tool_use"] == {"web_search_requests": 1}
+    provider_getter.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_forced_web_fetch_ignores_stale_url_from_prior_user_turns(monkeypatch):
     """Only the latest user message supplies the URL (not earlier transcript text)."""
     target = "https://new-only.example.com/page"
@@ -415,6 +500,49 @@ async def test_forced_web_fetch_ignores_stale_url_from_prior_user_turns(monkeypa
         ]
     )
     assert target in raw
+
+
+@pytest.mark.asyncio
+async def test_service_aggregates_forced_web_fetch_when_stream_false(monkeypatch):
+    async def fake_fetch(url: str, _egress: WebFetchEgressPolicy) -> dict[str, str]:
+        return {
+            "url": url,
+            "title": "Example Article",
+            "media_type": "text/plain",
+            "data": "Article body",
+        }
+
+    monkeypatch.setattr("api.web_tools.outbound._run_web_fetch", fake_fetch)
+    settings = Settings.model_validate({"ENABLE_WEB_SERVER_TOOLS": True})
+    provider_getter = MagicMock()
+    service = MessagesHandler(
+        settings,
+        provider_getter=provider_getter,
+        model_router=FixedProviderModelRouter(settings, _OPENAI_CHAT_PROVIDER_IDS[0]),
+    )
+    request = MessagesRequest(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=100,
+        messages=[Message(role="user", content="Fetch https://example.com/article")],
+        stream=False,
+        tools=[Tool(name="web_fetch", type="web_fetch_20250910")],
+        tool_choice={"type": "tool", "name": "web_fetch"},
+    )
+
+    response = await service.create(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.headers["content-type"].startswith("application/json")
+    body = _json_body(response)
+    assert [block["type"] for block in body["content"]] == [
+        "server_tool_use",
+        "web_fetch_tool_result",
+        "text",
+    ]
+    assert body["content"][1]["content"]["content"]["title"] == "Example Article"
+    assert body["content"][2]["text"] == "Article body"
+    assert body["usage"]["server_tool_use"] == {"web_fetch_requests": 1}
+    provider_getter.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_anthropic_messages.py
+++ b/tests/providers/test_anthropic_messages.py
@@ -180,6 +180,30 @@ def test_default_request_body_preserves_thinking_budget(provider_config):
 
 
 @pytest.mark.asyncio
+async def test_send_stream_request_forces_upstream_streaming(provider_config):
+    provider = NativeProvider(provider_config)
+    request_obj = httpx.Request("POST", "https://custom.test/v1/messages")
+    response = FakeResponse()
+    body = {"model": "test-model", "stream": False}
+
+    with (
+        patch.object(
+            provider._client, "build_request", return_value=request_obj
+        ) as mock_build,
+        patch.object(
+            provider._client,
+            "send",
+            new_callable=AsyncMock,
+            return_value=response,
+        ),
+    ):
+        await provider._send_stream_request(body)
+
+    assert body["stream"] is False
+    assert mock_build.call_args.kwargs["json"]["stream"] is True
+
+
+@pytest.mark.asyncio
 async def test_stream_uses_retry_builds_request_and_closes_response(
     provider_config,
     mock_rate_limiter,

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.5.1"
+version = "2.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Claude Code CLI makes many internal utility calls (haiku-class summaries,
title generation, probes) via `messages.create()` with `stream: false`,
expecting a plain JSON Message body back. Two things combine to break that:

1. `MessagesHandler.create()` (`api/handlers/messages.py`) always returns an
   SSE `StreamingResponse`, ignoring the client's `stream` field entirely.
2. `providers/transports/anthropic_messages/transport.py` forwards a
   client's `stream: false` upstream unchanged, so any native
   Anthropic-Messages-transport provider answers with a single plain JSON
   body instead of an event stream.

Result: fcc's SSE reader misreads that plain JSON as a truncated stream,
and the client-facing response ends up as leaked raw JSON + an SSE error
tail, served with a `text/event-stream` content-type and HTTP 200. The
Anthropic SDK's non-streaming path validates the response shape
(`content`/`model`/`usage` present, `content` an array) before returning;
handed that malformed body, it throws exactly:

> API Error: API returned an empty or malformed response (HTTP 200) —
> check for a proxy or gateway intercepting the request

This is likely the same root cause behind several existing open reports
with the identical error string, against different providers — since the
bug lives in the provider-agnostic request-handling layer, not any one
backend:
- #917 (NVIDIA NIM)
- #868
- #771
- #497 (OpenRouter)

I haven't personally reproduced their exact setups, so I'm not claiming
this fixes those definitively — flagging as likely-related in case it
helps with triage, happy to dig further if useful.

## Repro

```bash
fcc-server &

curl -s -X POST http://localhost:8082/v1/messages \
  -H "x-api-key: freecc" -H "content-type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "your-configured-model",
    "max_tokens": 10,
    "stream": false,
    "messages": [{"role": "user", "content": "say OK"}]
  }'
```

**Before this fix:** response `content-type` is `text/event-stream`
(should be `application/json` for a `stream:false` request), body is raw
SSE framing / leaked JSON — exactly what trips the Anthropic SDK's
non-streaming shape check client-side.

**After this fix:** `content-type: application/json`, body is a single
well-formed Messages object:
`{"id": ..., "type": "message", "role": "assistant", "content": [...], "model": ..., "stop_reason": ..., "usage": {...}}`.

## Fix

1. `providers/transports/anthropic_messages/transport.py`: the upstream
   request body now always carries `stream: true`. This transport can
   only parse the upstream response as SSE, so forwarding a client's
   `stream:false` upstream was always going to misfire regardless of any
   downstream fix.
2. `api/handlers/messages.py`: `MessagesHandler.create()` is now `async`
   and honors `request_data.stream is False` by consuming the internal
   SSE stream and folding it into a complete Messages JSON body via a new
   `core/anthropic/sse_aggregation.aggregate_anthropic_sse_to_message()`
   helper (kept in `core/anthropic/` per this repo's own convention of
   neutral, provider-agnostic Anthropic protocol logic living there — see
   `AGENTS.md`'s Architecture Principles). A top-level SSE error event
   with no assembled content becomes a proper Anthropic error envelope
   with HTTP 502 instead of a 200. `api/routes.py`'s `create_message`
   route now `await`s `handler.create(...)` accordingly.

## Testing

- `uv run ruff format` / `ruff check --fix` / `ty check`: all clean on
  every changed file.
- `MessagesHandler.create()` becoming async required updating existing
  synchronous call sites in `tests/api/test_api_handlers.py`,
  `tests/api/test_safe_logging.py`, and `tests/api/test_web_server_tools.py`
  to `await` it (marking their enclosing tests `async` where they weren't
  already) — no test assertions changed, only the calling convention.
- Manually verified `aggregate_anthropic_sse_to_message()`'s behavior
  outside pytest (`message_start`/`content_block_start`/
  `content_block_delta`/`message_delta`/`message_stop` folding,
  text/thinking/tool_use block shapes, and the top-level error-event
  path).
- Note: as in my other PR from this same debugging session (#976), I hit
  a pre-existing, environment-specific crash running the full suite
  locally on Windows (`OPENSSL_Uplink ... no OPENSSL_Applink`, inside
  `api.admin_urls`'s import chain) — confirmed unrelated to this change
  (reproduces identically on a clean, unmodified checkout of `main`).
  Verified the changed logic by direct execution outside pytest instead.

## Scope

Second in a small series from the same debugging session (after #976).
This one's a real Anthropic-API spec-compliance bug and is model/provider
-agnostic.

Version bumped `2.4.4` → `2.4.5` per `AGENTS.md`'s versioning rule (bug
fix, no breaking change). Note: #976 also bumps `2.4.4` → `2.4.5`
independently — whichever of these merges second will hit a trivial
version-string conflict in `pyproject.toml`/`uv.lock`; happy to rebase
immediately if that happens.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes non-streaming Messages API responses by folding the internal SSE flow into a JSON response. The main changes are:

- `MessagesHandler.create()` is now async and returns JSON for `stream: false` requests.
- Shared Anthropic SSE aggregation was added under `core/anthropic/`.
- Native Anthropic Messages transport now forces upstream `stream: true` for its SSE parser.
- Route and test call sites were updated to await the async handler.
- Targeted tests cover JSON aggregation, upstream errors, local web tools, and transport request shaping.
- The package version and lockfile were bumped for the bug fix.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge with minimal risk.

The changes are focused on response shaping for `stream: false`, preserve the internal streaming pipeline, include the required patch version bump, and add targeted tests for provider, handler, error, and local web-tool paths. No functional or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the pre-change response for stream:false, recording a StreamingResponse with content\_type text/event-stream and a null json\_body.
- T-Rex captured the post-change response for stream:false, recording a JSONResponse with content\_type application/json and JSON keys including content,id,model,role,stop\_reason,stop\_sequence,type,usage.
- T-Rex ran the Anthrop ic targeted tests and confirmed they completed successfully with exit code 0.
- T-Rex examined the Python-based contract-validation script used to execute the checks.

<a href="https://app.greptile.com/trex/runs/13302683/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/handlers/messages.py | Makes `MessagesHandler.create` async, wraps stream/complete intercept results, and aggregates internal SSE into JSON for `stream: false` requests. |
| api/routes.py | Awaits the now-async messages handler and updates the route description for non-streaming responses. |
| core/anthropic/sse_aggregation.py | Adds provider-neutral folding of Anthropic Messages SSE events into a single non-streaming Message JSON body with error capture. |
| providers/transports/anthropic_messages/transport.py | Forces native Anthropic Messages upstream calls to use streaming so the existing SSE parser always receives SSE. |
| tests/api/test_api_handlers.py | Updates handler tests for async calls and adds coverage for `stream: false` JSON aggregation and upstream error JSON. |
| tests/api/test_web_server_tools.py | Updates web server tool handler tests for async calls and adds non-streaming aggregation coverage for forced web search/fetch. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant Route as api/routes.py
participant Handler as MessagesHandler
participant Provider as ProviderExecutionService / Intercepts
participant Aggregator as aggregate_anthropic_sse_to_message
participant Upstream as Native Anthropic Provider

Client->>Route: POST /v1/messages (stream flag)
Route->>Handler: await create(request)
Handler->>Provider: resolve routing / intercept or stream provider
alt native provider path
    Provider->>Upstream: "/messages with stream=true"
    Upstream-->>Provider: Anthropic SSE events
else local web tool path
    Provider-->>Handler: local Anthropic SSE events
end
alt "request.stream == false"
    Handler->>Aggregator: consume internal SSE
    Aggregator-->>Handler: complete Message JSON / error
    Handler-->>Client: application/json
else streaming/default
    Handler-->>Client: text/event-stream
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant Route as api/routes.py
participant Handler as MessagesHandler
participant Provider as ProviderExecutionService / Intercepts
participant Aggregator as aggregate_anthropic_sse_to_message
participant Upstream as Native Anthropic Provider

Client->>Route: POST /v1/messages (stream flag)
Route->>Handler: await create(request)
Handler->>Provider: resolve routing / intercept or stream provider
alt native provider path
    Provider->>Upstream: "/messages with stream=true"
    Upstream-->>Provider: Anthropic SSE events
else local web tool path
    Provider-->>Handler: local Anthropic SSE events
end
alt "request.stream == false"
    Handler->>Aggregator: consume internal SSE
    Aggregator-->>Handler: complete Message JSON / error
    Handler-->>Client: application/json
else streaming/default
    Handler-->>Client: text/event-stream
end
```

</a>

<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `api/handlers/messages.py`, line 74-76 ([link](https://github.com/alishahryar1/free-claude-code/blob/c453d9bf40e6ec150936329b83c1b57a3ed40e80/api/handlers/messages.py#L74-L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Intercepts bypass aggregation**
   `stream:false` is only honored after `_run_message_intercepts`, so intercepted Messages requests still return the intercept response directly. When local `web_search` or `web_fetch` handles a forced tool request with `ENABLE_WEB_SERVER_TOOLS=true`, this branch returns `anthropic_sse_streaming_response(...)`, so callers still receive `text/event-stream` instead of the JSON Message body this change provides for provider calls.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused MessagesHandler harness for stream:false forced web\_search interception](https://app.greptile.com/trex/artifacts/981e384f-7c0d-4a5a-b71c-56f1443f8567)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: execution log showing HTTP 200 text/event-stream StreamingResponse and SSE body framing](https://app.greptile.com/trex/artifacts/b54d58f3-49f2-4f39-88ca-ce8991f06c99)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/13296878/artifacts?artifact=981e384f-7c0d-4a5a-b71c-56f1443f8567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Fix stream false response shaping for we..."](https://github.com/alishahryar1/free-claude-code/commit/25861827062a5c7f6af0ae99b0abfd9ecdf452a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41863790)</sub>

<!-- /greptile_comment -->