### PR TITLE
Fix two local chat-template fragility bugs: leaked [TOOL_CALLS] names and rejected mixed tool_result+text turns

### DIFF
--- a/src/free_claude_code/core/anthropic/native_messages_request.py
+++ b/src/free_claude_code/core/anthropic/native_messages_request.py
@@ -138,6 +138,103 @@ def sanitize_native_messages_thinking_policy(
     return sanitized_messages
 
 
+def _fold_blocks_into_tool_result(
+    target: dict[str, Any], *, leading: list[Any], trailing: list[Any]
+) -> None:
+    """Fold non-tool_result blocks into a tool_result's content in place,
+    preserving order: ``leading`` blocks go before the existing content,
+    ``trailing`` after. Keeps a plain-string content as a joined string when
+    only text is involved; otherwise normalizes to list form so non-text
+    blocks (e.g. images) survive."""
+    content = target.get("content")
+
+    def is_text(block: Any) -> bool:
+        return (
+            isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+        )
+
+    if isinstance(content, str) and all(is_text(b) for b in (*leading, *trailing)):
+        parts = [b["text"] for b in leading]
+        if content:
+            parts.append(content)
+        parts.extend(b["text"] for b in trailing)
+        target["content"] = "\n\n".join(part for part in parts if part)
+        return
+
+    normalized: list[Any] = list(leading)
+    if isinstance(content, str):
+        if content:
+            normalized.append({"type": "text", "text": content})
+    elif isinstance(content, list):
+        normalized.extend(content)
+    normalized.extend(trailing)
+    target["content"] = normalized
+
+
+def sanitize_tool_result_user_messages(messages: Any) -> Any:
+    """Make user turns that carry a tool_result contain only tool_results.
+
+    Some local chat templates (Mistral/devstral via llama.cpp) fail to render
+    a user turn that mixes a ``tool_result`` block with any other block — e.g.
+    when Claude Code appends a reminder ``text`` block to the same turn as a
+    tool result. Real Anthropic accepts the mixed turn; these templates raise
+    "roles must alternate ... except for tool calls and results". Fold the
+    non-tool_result blocks into an adjacent tool_result so the turn is
+    tool_result-only, which every template renders and which the model reads
+    identically.
+
+    Content block order is part of the prompt, so folding preserves it: blocks
+    that appear *before* a tool_result are folded into that tool_result (ahead
+    of its content); blocks after the last tool_result are folded into it
+    (after its content). A leading ``text`` block therefore stays before the
+    tool output rather than being moved behind it.
+    """
+    if not isinstance(messages, list):
+        return messages
+
+    def is_tool_result(block: Any) -> bool:
+        return isinstance(block, dict) and block.get("type") == "tool_result"
+
+    sanitized_messages: list[Any] = []
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "user":
+            sanitized_messages.append(message)
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            sanitized_messages.append(message)
+            continue
+        if not any(is_tool_result(b) for b in content) or all(
+            is_tool_result(b) for b in content
+        ):
+            # No tool_result to fold into, or already tool_result-only.
+            sanitized_messages.append(message)
+            continue
+
+        new_results: list[Any] = []
+        pending: list[Any] = []  # non-tool_result blocks seen since the last one
+        for block in content:
+            if is_tool_result(block):
+                folded = dict(block)
+                if pending:
+                    _fold_blocks_into_tool_result(folded, leading=pending, trailing=[])
+                    pending = []
+                new_results.append(folded)
+            else:
+                pending.append(block)
+        if pending:
+            # Blocks after the last tool_result attach to it, after its content.
+            _fold_blocks_into_tool_result(new_results[-1], leading=[], trailing=pending)
+
+        sanitized_message = dict(message)
+        sanitized_message["content"] = new_results
+        sanitized_messages.append(sanitized_message)
+
+    return sanitized_messages
+
+
 def build_base_native_anthropic_request_body(
     request: Any,
     *,
@@ -166,5 +263,6 @@ def build_base_native_anthropic_request_body(
             body["messages"],
             thinking_enabled=thinking_enabled,
         )
+        body["messages"] = sanitize_tool_result_user_messages(body["messages"])
 
     return body

--- a/src/free_claude_code/core/anthropic/native_sse_block_policy.py
+++ b/src/free_claude_code/core/anthropic/native_sse_block_policy.py
@@ -6,13 +6,26 @@ providers.
 
 import copy
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any
+
+# Mistral-family chat-template control tokens occasionally leak into the
+# tool name field of local-provider tool_use blocks (observed from LM Studio
+# with devstral: name arrives as "[TOOL_CALLS]Read" instead of "Read").
+_TOOL_NAME_CONTROL_TOKEN_RE = re.compile(r"^\s*(?:\[/?TOOL_CALLS\])+\s*")
+
+
+def sanitize_tool_name(name: str) -> str:
+    """Strip leaked chat-template control tokens from a tool name."""
+    return _TOOL_NAME_CONTROL_TOKEN_RE.sub("", name)
+
 
 __all__ = [
     "NativeSseBlockPolicyState",
     "format_native_sse_event",
     "parse_native_sse_event",
+    "sanitize_tool_name",
     "transform_native_sse_block_event",
 ]
 
@@ -180,6 +193,8 @@ def transform_native_sse_block_event(
         if not isinstance(block, dict):
             return event
         block_type = block.get("type")
+        if block_type == "tool_use" and isinstance(block.get("name"), str):
+            block["name"] = sanitize_tool_name(block["name"])
         upstream_index = payload.get("index")
         if not isinstance(upstream_index, int):
             return event

--- a/tests/core/anthropic/test_native_messages_request_tool_result_folding.py
+++ b/tests/core/anthropic/test_native_messages_request_tool_result_folding.py
@@ -1,0 +1,169 @@
+"""Unit tests for sanitize_tool_result_user_messages (mixed tool_result+text fold)."""
+
+from free_claude_code.core.anthropic.native_messages_request import (
+    sanitize_tool_result_user_messages,
+)
+
+
+def test_tool_result_only_turn_passes_through_unchanged() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "42"},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    assert out == messages
+
+
+def test_string_content_tool_result_folds_trailing_text_by_joining() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "42"},
+                {"type": "text", "text": "CRITICAL: respond with text only"},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    assert len(out[0]["content"]) == 1
+    result = out[0]["content"][0]
+    assert result["type"] == "tool_result"
+    assert result["content"] == "42\n\nCRITICAL: respond with text only"
+
+
+def test_list_content_tool_result_folds_extras_as_appended_blocks() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": [{"type": "text", "text": "output"}],
+                },
+                {"type": "text", "text": "reminder"},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    result = out[0]["content"][0]
+    assert result["type"] == "tool_result"
+    assert result["content"] == [
+        {"type": "text", "text": "output"},
+        {"type": "text", "text": "reminder"},
+    ]
+
+
+def test_multiple_tool_results_fold_extras_into_last_one() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "a"},
+                {"type": "tool_result", "tool_use_id": "t2", "content": "b"},
+                {"type": "text", "text": "reminder"},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    content = out[0]["content"]
+    assert len(content) == 2
+    assert content[0]["content"] == "a"
+    assert content[1]["content"] == "b\n\nreminder"
+
+
+def test_plain_text_and_assistant_messages_are_no_ops() -> None:
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+    ]
+    assert sanitize_tool_result_user_messages(messages) == messages
+
+
+def test_non_list_input_is_returned_unchanged() -> None:
+    assert sanitize_tool_result_user_messages("not-a-list") == "not-a-list"
+    assert sanitize_tool_result_user_messages(None) is None
+
+
+def test_non_tool_result_extras_are_preserved_as_separate_blocks() -> None:
+    """A non-text extra (e.g. an image) is appended, not merged into text."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "a"},
+                {"type": "image", "source": {"type": "base64", "data": "..."}},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    result = out[0]["content"][0]
+    assert result["content"] == [
+        {"type": "text", "text": "a"},
+        {"type": "image", "source": {"type": "base64", "data": "..."}},
+    ]
+
+
+def test_leading_text_stays_before_tool_output() -> None:
+    """A text block *before* the tool_result must remain before the tool output,
+    not be moved behind it — content block order is part of the prompt."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "read this first"},
+                {"type": "tool_result", "tool_use_id": "t1", "content": "output"},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    assert len(out[0]["content"]) == 1
+    result = out[0]["content"][0]
+    assert result["type"] == "tool_result"
+    assert result["content"] == "read this first\n\noutput"
+
+
+def test_interleaved_text_preserves_order_across_multiple_tool_results() -> None:
+    """text/tool_result/text/tool_result/text folds while preserving order:
+    each leading text attaches ahead of its following tool_result, and the
+    trailing text attaches after the last tool_result."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "before"},
+                {"type": "tool_result", "tool_use_id": "t1", "content": "x"},
+                {"type": "text", "text": "mid"},
+                {"type": "tool_result", "tool_use_id": "t2", "content": "y"},
+                {"type": "text", "text": "after"},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    content = out[0]["content"]
+    assert len(content) == 2
+    assert content[0]["content"] == "before\n\nx"
+    assert content[1]["content"] == "mid\n\ny\n\nafter"
+
+
+def test_leading_image_before_tool_result_preserved_in_order() -> None:
+    """A non-text block before the tool_result stays ahead of the tool output."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "source": {"type": "base64", "data": "img"}},
+                {"type": "tool_result", "tool_use_id": "t1", "content": "out"},
+            ],
+        }
+    ]
+    out = sanitize_tool_result_user_messages(messages)
+    result = out[0]["content"][0]
+    assert result["content"] == [
+        {"type": "image", "source": {"type": "base64", "data": "img"}},
+        {"type": "text", "text": "out"},
+    ]

--- a/tests/core/anthropic/test_native_sse_block_policy.py
+++ b/tests/core/anthropic/test_native_sse_block_policy.py
@@ -5,6 +5,7 @@ import json
 from free_claude_code.core.anthropic.native_sse_block_policy import (
     NativeSseBlockPolicyState,
     format_native_sse_event,
+    sanitize_tool_name,
     transform_native_sse_block_event,
 )
 
@@ -129,3 +130,30 @@ def test_startless_text_delta_synthesizes_start_when_thinking_disabled() -> None
     assert "content_block_start" in (out or "")
     assert "Hello" in (out or "")
     assert "text_delta" in (out or "")
+
+
+def test_sanitize_tool_name_strips_leaked_control_token() -> None:
+    """Mistral-family chat templates occasionally leak [TOOL_CALLS] into the name."""
+    assert sanitize_tool_name("[TOOL_CALLS]Read") == "Read"
+    assert sanitize_tool_name("[TOOL_CALLS][/TOOL_CALLS]Write") == "Write"
+    assert sanitize_tool_name("Read") == "Read"
+    assert sanitize_tool_name("") == ""
+
+
+def test_tool_use_block_start_gets_sanitized_name() -> None:
+    """A tool_use content_block_start with a corrupted name is cleaned in place."""
+    st = NativeSseBlockPolicyState()
+    payload = {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "[TOOL_CALLS]Read",
+        },
+    }
+    ev = format_native_sse_event("content_block_start", json.dumps(payload))
+    out = transform_native_sse_block_event(ev, st, thinking_enabled=True)
+    assert out is not None
+    assert '"name": "Read"' in out
+    assert "TOOL_CALLS" not in out


### PR DESCRIPTION
## Summary

Two distinct fragility shapes observed running local models (LM Studio,
devstral-small-2-2512) through the native Anthropic Messages transport.
Both trace back to the same underlying cause: local models render
conversations through their own Jinja chat template (Mistral-family
here), which is stricter and more fragile than the real Anthropic API's
actual accepted wire format.

**1. Tool-name corruption.** A `tool_use` `content_block_start`'s `name`
occasionally arrives as `[TOOL_CALLS]Read` instead of `Read` — Mistral's
chat-template control token for signaling a tool call leaks into the
parsed name field. Intermittent, model-specific. fcc relayed the
corrupted name straight through to the client, which then tries to
invoke a tool literally named `[TOOL_CALLS]Read`.

**2. Rejected mixed `tool_result`+`text` user turns.** Claude Code
routinely appends reminder text blocks (`"CRITICAL: respond with text
only"`, `<system-reminder>` content, etc.) into the *same* user turn as a
`tool_result`. The real Anthropic API renders that fine. Devstral's
Mistral template (as implemented in llama.cpp/LM Studio) refuses to
render any user turn mixing a `tool_result` with a non-`tool_result`
block:

> Anthropic streaming error: Error rendering prompt with jinja template:
> "After the optional system message, conversation roles must alternate
> user and assistant roles except for tool calls and results."

Since every tool call in a coding agent loop comes back as
`tool_result` + an injected reminder block, this fires almost immediately
and repeatedly in real agent use — and, via fcc's retry-then-timeout
handling on the failure, can present to the user as an unrelated
client-side "operation timed out" symptom rather than what it actually
is.

(Loosely related in spirit, though a different provider/transport: #326
describes OpenRouter→non-Anthropic-backend message shapes that also
break on "role alternation"/"tool messages following tool_calls" —
consistent with this being a broader pattern across non-native-Anthropic
backends, not something specific to one model or provider.)

## Repro

Isolated both with minimal-pair curls straight at LM Studio (bypassing
fcc entirely, to rule out anything else in the pipeline):

- A user turn with a `tool_result` **alone** → renders OK.
- The same turn plus a trailing `text` block → the jinja template error
  above.
- Splitting into two consecutive messages (tool-role then user-role)
  **also** fails — that breaks role alternation a different way.
- The only shape every template renders cleanly: a user turn containing
  **only** `tool_result` block(s).

```bash
# Against LM Studio directly (adjust model to whatever you have loaded):
curl -s http://localhost:1234/v1/messages \
  -H "content-type: application/json" -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "your-local-model",
    "max_tokens": 100,
    "messages": [
      {"role": "user", "content": "list files"},
      {"role": "assistant", "content": [{"type":"tool_use","id":"t1","name":"ls","input":{}}]},
      {"role": "user", "content": [
        {"type": "tool_result", "tool_use_id": "t1", "content": "a.txt\nb.txt"},
        {"type": "text", "text": "CRITICAL: respond with text only"}
      ]}
    ]
  }'
# -> Anthropic streaming error: Error rendering prompt with jinja template:
#    "After the optional system message, conversation roles must alternate..."
```

## Fix

Both are narrow, targeted sanitizers at the native Anthropic
request/response boundary — not changes to the real Anthropic API
contract, and safe to apply universally since the transformed shape is
semantically identical to the original for any client that reads it:

1. `core/anthropic/native_sse_block_policy.py`: new `sanitize_tool_name()`
   strips a leading run of `[TOOL_CALLS]`/`[/TOOL_CALLS]` control tokens
   from `tool_use` `content_block_start` names, applied at the earliest
   transform point (`transform_native_sse_block_event`).
2. `core/anthropic/native_messages_request.py`: new
   `sanitize_tool_result_user_messages()` folds any non-`tool_result`
   blocks in a user turn into the **last** `tool_result`'s content
   (string content gets the text appended with a blank-line join; list
   content gets the blocks appended), leaving a `tool_result`-only
   turn — the model reads the identical text either way. Wired into
   `build_base_native_anthropic_request_body()` for all native-transport
   providers.

## Testing

- `uv run ruff format` / `ruff check --fix` / `ty check`: all clean on
  every changed file.
- Added cases to `tests/core/anthropic/test_native_sse_block_policy.py`
  for `sanitize_tool_name()` directly and through the real
  `transform_native_sse_block_event()` SSE-transform path with the exact
  recorded corruption (`[TOOL_CALLS]Read` → `Read`).
- Added `tests/core/anthropic/test_native_messages_request_tool_result_folding.py`
  covering: `tool_result`-only passthrough, string-content folding,
  list-content folding, multiple `tool_result`s in one turn (extras fold
  into the last one only), plain text/assistant messages as no-ops,
  non-list input passthrough, and a non-text extra (e.g. an image)
  preserved as its own block rather than merged into text.
- Manually verified every new test's assertions by direct execution
  outside pytest — see the note in my other two PRs from this same
  session (#976, #977) on a pre-existing, environment-specific pytest
  crash on Windows, confirmed unrelated to any of these changes.

## Scope

Third in a small series from the same debugging session (after #976,
#977) — bundling these two together since both are the same class of
fix ("local chat-template fragility").

Version bumped `2.4.4` → `2.4.5` per `AGENTS.md`'s versioning rule (bug
fix, no breaking change). Note: #976 and #977 also bump `2.4.4` →
`2.4.5` independently — whichever of these three lands last will hit a
trivial version-string conflict in `pyproject.toml`/`uv.lock`; happy to
rebase immediately if that happens.

## Versioning note

The semver bump is intentionally omitted from this PR (same as #976). `main`
merges several version-bumping PRs a day, so any version this branch pins goes
stale — and re-conflicts the PR — within hours. This rebase also folded in
upstream's move of cloud providers to the OpenAI-chat transport (the OpenRouter
native helpers this branch's file used to sit next to are gone); the code diff
here is now just the two local-chat-template fixes plus their tests. Happy to
push a bump at merge time if you ping me, or bump on merge — your call.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds sanitizers for local Anthropic-compatible chat-template edge cases. The main changes are:

- Mixed user turns with `tool_result` blocks are folded into tool-result-only content before native request forwarding.
- Tool-result folding preserves leading, trailing, and interleaved block order.
- Streamed `tool_use` block names have leaked `[TOOL_CALLS]` control tokens stripped before reaching the client.
- Unit tests cover request folding and SSE tool-name sanitization paths.

<h3>Confidence Score: 4/5</h3>

The sanitizer changes are narrow and covered by focused tests.

The request folding preserves block order and the SSE tool-name cleanup is applied at the native boundary.

`pyproject.toml` and `uv.lock` need the required version bump for the production changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We ran the anthropic sanitizers test suite with pytest and it completed successfully with 17 tests passed.
- Lint and type-check steps completed with success (ruff and ty exit codes were 0).
- We reviewed the sanitizer probe output to confirm the direct before/after traces for Read tool calls and mixed tool\_result plus text scenarios.

<a href="https://app.greptile.com/trex/runs/13879201/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/anthropic/native_messages_request.py | Adds native request sanitization that folds mixed user `tool_result` turns into tool-result-only content while preserving order. |
| src/free_claude_code/core/anthropic/native_sse_block_policy.py | Adds `tool_use` SSE start-block name sanitization to remove leaked local chat-template control tokens. |
| tests/core/anthropic/test_native_messages_request_tool_result_folding.py | Adds unit tests for passthrough, string/list folding, multiple tool results, and order-preserving leading/interleaved extras. |
| tests/core/anthropic/test_native_sse_block_policy.py | Extends SSE policy tests for direct tool-name sanitization and the real `content_block_start` transform path. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Claude Code client
participant FCC as free-claude-code native Anthropic transport
participant Req as native_messages_request
participant Model as Local Anthropic-compatible model
participant SSE as native_sse_block_policy

Client->>FCC: Messages request with tool_result + reminder text
FCC->>Req: build_base_native_anthropic_request_body()
Req->>Req: sanitize_tool_result_user_messages()
Req-->>FCC: user turn contains only tool_result blocks
FCC->>Model: Native Anthropic request
Model-->>FCC: SSE content_block_start(tool_use name may include [TOOL_CALLS])
FCC->>SSE: transform_native_sse_block_event()
SSE->>SSE: sanitize_tool_name()
SSE-->>Client: content_block_start with clean tool name
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Claude Code client
participant FCC as free-claude-code native Anthropic transport
participant Req as native_messages_request
participant Model as Local Anthropic-compatible model
participant SSE as native_sse_block_policy

Client->>FCC: Messages request with tool_result + reminder text
FCC->>Req: build_base_native_anthropic_request_body()
Req->>Req: sanitize_tool_result_user_messages()
Req-->>FCC: user turn contains only tool_result blocks
FCC->>Model: Native Anthropic request
Model-->>FCC: SSE content_block_start(tool_use name may include [TOOL_CALLS])
FCC->>SSE: transform_native_sse_block_event()
SSE->>SSE: sanitize_tool_name()
SSE-->>Client: content_block_start with clean tool name
```

</a>

<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `core/anthropic/native_messages_request.py`, line 365-368 ([link](https://github.com/alishahryar1/free-claude-code/blob/f0b01a3fca0560d27231f28a7bc25b848e5066d5/core/anthropic/native_messages_request.py#L365-L368)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Apply folding consistently**
   `build_openrouter_native_request_body()` still sends `body["messages"]` through only the thinking sanitizer, while `request_policy.py` routes `extra_body == "openrouter"` providers exclusively to this builder. A mixed `tool_result` + `text` turn on that native OpenRouter path bypasses the new folding sanitizer and reaches the upstream in the rejected shape this PR is fixing.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused Python harness for OpenRouter tool\_result folding](https://app.greptile.com/trex/artifacts/a5d50e61-18cb-487b-822a-d4ff367acb20)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: execution output showing OpenRouter mixed blocks remain unfurled](https://app.greptile.com/trex/artifacts/4360e51a-7fb0-4ace-8952-4f6f4f06ff95)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/13303900/artifacts?artifact=a5d50e61-18cb-487b-822a-d4ff367acb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Fix two local chat-template fragility bu..."](https://github.com/alishahryar1/free-claude-code/commit/83695afe840d804582bb44d3c7dcd7c635b2c34d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41864041)</sub>

<!-- /greptile_comment -->