### PR TITLE
Switch LM Studio to the OpenAI chat transport; add context-budget preflight (fixes silent tool-call text leaks and mid-stream truncation)

### DIFF
--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -267,12 +267,12 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
     "lmstudio": ProviderDescriptor(
         provider_id="lmstudio",
         display_name="LM Studio",
-        transport_type="anthropic_messages",
+        transport_type="openai_chat",
         static_credential="lm-studio",
         default_base_url=LMSTUDIO_DEFAULT_BASE,
         base_url_attr="lm_studio_base_url",
         proxy_attr="lmstudio_proxy",
-        capabilities=("chat", "streaming", "tools", "native_anthropic", "local"),
+        capabilities=("chat", "streaming", "tools", "local"),
     ),
     "llamacpp": ProviderDescriptor(
         provider_id="llamacpp",

--- a/providers/lmstudio/__init__.py
+++ b/providers/lmstudio/__init__.py
@@ -1,4 +1,4 @@
-"""LM Studio provider - Anthropic-compatible local API."""
+"""LM Studio provider - OpenAI-compatible chat completions API."""
 
 from .client import LMStudioProvider
 

--- a/providers/lmstudio/client.py
+++ b/providers/lmstudio/client.py
@@ -1,16 +1,122 @@
-"""LM Studio provider implementation."""
+"""LM Studio provider implementation (OpenAI-compatible chat completions).
 
+Switched from LM Studio's native Anthropic Messages endpoint (2026-07-04):
+the newer ``/v1/messages`` path renders Claude Code conversations through the
+model's jinja chat template with strict role-alternation rules and a fragile
+``[TOOL_CALLS]`` parser — observed leaking control tokens into tool names
+(``[TOOL_CALLS]Read``) and dumping whole tool calls into text
+(``Read[ARGS]{...}``), which ends agent runs silently. The OpenAI
+``/v1/chat/completions`` path is LM Studio's mature parsing route, and fcc's
+OpenAI transport layers its own tool-call assembly, think-tag parsing, and
+heuristic recovery on top.
+"""
+
+import time
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from core.anthropic import (
+    ReasoningReplayMode,
+    build_base_request_body,
+    get_token_count,
+)
+from core.anthropic.conversion import OpenAIConversionError
 from providers.base import ProviderConfig
 from providers.defaults import LMSTUDIO_DEFAULT_BASE
-from providers.transports.anthropic_messages import AnthropicMessagesTransport
+from providers.exceptions import InvalidRequestError
+from providers.transports.openai_chat import OpenAIChatTransport
 
 
-class LMStudioProvider(AnthropicMessagesTransport):
-    """LM Studio provider using native Anthropic Messages endpoint."""
+class LMStudioProvider(OpenAIChatTransport):
+    """LM Studio via its OpenAI-compatible chat completions endpoint."""
+
+    # LM Studio truncates the stream silently (no terminal event) when the
+    # prompt exceeds the loaded context. Refuse clearly over-budget prompts
+    # up front with the same "prompt is too long" invalid_request_error the
+    # real Anthropic API uses, so Claude Code can compact/retry instead of
+    # dying mid-stream.
+    _CONTEXT_CACHE_TTL_S = 30.0
 
     def __init__(self, config: ProviderConfig):
         super().__init__(
             config,
             provider_name="LMSTUDIO",
-            default_base_url=LMSTUDIO_DEFAULT_BASE,
+            base_url=config.base_url or LMSTUDIO_DEFAULT_BASE,
+            api_key=config.api_key or "lm-studio",
         )
+        self._loaded_context_cache: tuple[float, int | None] = (0.0, None)
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        """Build an OpenAI chat body from the Anthropic request.
+
+        Prior-turn thinking is never replayed: Mistral-family templates have
+        no assistant reasoning field, and replaying ``<think>`` text inflates
+        the local context for no benefit. New-response thinking still streams
+        back via ``reasoning_content``/``<think>`` parsing in the transport.
+        """
+        try:
+            return build_base_request_body(
+                request,
+                reasoning_replay=ReasoningReplayMode.DISABLED,
+            )
+        except OpenAIConversionError as exc:
+            raise InvalidRequestError(str(exc)) from exc
+
+    def preflight_stream(
+        self, request: Any, *, thinking_enabled: bool | None = None
+    ) -> None:
+        super().preflight_stream(request, thinking_enabled=thinking_enabled)
+        self._preflight_context_budget(request)
+
+    def _preflight_context_budget(self, request: Any) -> None:
+        loaded_context = self._loaded_context_length()
+        if loaded_context is None:
+            return
+        estimate = get_token_count(
+            getattr(request, "messages", []) or [],
+            getattr(request, "system", None),
+            getattr(request, "tools", None),
+        )
+        # The estimate is cl100k-based and undercounts local tokenizers
+        # (observed ~8% low vs devstral); a request above 90% of the loaded
+        # context is already past where client-side compaction should have
+        # fired, and letting it through risks a silent LM Studio truncation.
+        budget = int(loaded_context * 0.9)
+        if estimate > budget:
+            raise InvalidRequestError(
+                f"prompt is too long: {estimate} tokens > {budget} "
+                f"maximum (90% of loaded LM Studio context {loaded_context})"
+            )
+
+    def _loaded_context_length(self) -> int | None:
+        """Best-effort loaded context length from LM Studio's REST API, cached."""
+        cached_at, cached_value = self._loaded_context_cache
+        if time.monotonic() - cached_at < self._CONTEXT_CACHE_TTL_S:
+            return cached_value
+
+        value: int | None = None
+        try:
+            root = self._base_url
+            root = root[: -len("/v1")] if root.endswith("/v1") else root
+            response = httpx.get(f"{root}/api/v0/models", timeout=2.0)
+            response.raise_for_status()
+            loaded = [
+                model.get("loaded_context_length")
+                for model in response.json().get("data", [])
+                if model.get("state") == "loaded"
+                and isinstance(model.get("loaded_context_length"), int)
+            ]
+            # ponytail: single-model setups in practice; with several loaded
+            # models the most generous ceiling still makes a valid backstop.
+            value = max(loaded) if loaded else None
+        except Exception as error:  # backstop only — never block the request
+            logger.debug(
+                "LMSTUDIO context preflight unavailable: {}", type(error).__name__
+            )
+            value = None
+        self._loaded_context_cache = (time.monotonic(), value)
+        return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "2.5.0"
+version = "2.5.1"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/providers/test_lmstudio.py
+++ b/tests/providers/test_lmstudio.py
@@ -1,15 +1,15 @@
-"""Tests for LM Studio native Anthropic provider."""
+"""Tests for LM Studio (OpenAI-compatible chat completions) provider."""
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
-from core.anthropic.stream_contracts import parse_sse_text
 from providers.base import ProviderConfig
+from providers.exceptions import InvalidRequestError
 from providers.lmstudio import LMStudioProvider
-from tests.stream_contract import assert_canonical_stream_error_envelope
+from providers.lmstudio.client import LMSTUDIO_DEFAULT_BASE
 
 
 class MockMessage:
@@ -28,28 +28,17 @@ class MockRequest:
         self.system = "System prompt"
         self.stop_sequences = None
         self.tools = []
-        self.extra_body = {}
         self.thinking = MagicMock()
         self.thinking.enabled = True
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-
-    def model_dump(self, exclude_none=True):
-        return {
-            "model": self.model,
-            "messages": [{"role": m.role, "content": m.content} for m in self.messages],
-            "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
-            "extra_body": self.extra_body,
-            "thinking": {"enabled": self.thinking.enabled} if self.thinking else None,
-        }
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 
 @pytest.fixture
 def lmstudio_config():
     return ProviderConfig(
         api_key="lm-studio",
-        base_url="http://localhost:1234/v1",
+        base_url=LMSTUDIO_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
     )
@@ -58,16 +47,19 @@ def lmstudio_config():
 @pytest.fixture(autouse=True)
 def mock_rate_limiter():
     """Mock the global rate limiter to prevent waiting."""
-    with patch(
-        "providers.transports.anthropic_messages.transport.GlobalRateLimiter"
-    ) as mock:
+
+    @asynccontextmanager
+    async def _slot():
+        yield
+
+    with patch("providers.transports.openai_chat.transport.GlobalRateLimiter") as mock:
         instance = mock.get_scoped_instance.return_value
-        instance.wait_if_blocked = AsyncMock(return_value=False)
 
         async def _passthrough(fn, *args, **kwargs):
             return await fn(*args, **kwargs)
 
         instance.execute_with_retry = AsyncMock(side_effect=_passthrough)
+        instance.concurrency_slot.side_effect = _slot
         yield instance
 
 
@@ -78,337 +70,151 @@ def lmstudio_provider(lmstudio_config):
 
 def test_init(lmstudio_config):
     """Test provider initialization."""
-    with patch("httpx.AsyncClient"):
+    with patch("providers.transports.openai_chat.transport.AsyncOpenAI") as mock_openai:
         provider = LMStudioProvider(lmstudio_config)
-        assert provider._base_url == "http://localhost:1234/v1"
+        assert provider._api_key == "lm-studio"
+        assert provider._base_url == LMSTUDIO_DEFAULT_BASE
         assert provider._provider_name == "LMSTUDIO"
+        mock_openai.assert_called_once()
 
 
-def test_init_uses_configurable_timeouts():
-    """Test that provider passes configurable read/write/connect timeouts to client."""
-    config = ProviderConfig(
-        api_key="lm-studio",
-        base_url="http://localhost:1234/v1",
-        http_read_timeout=600.0,
-        http_write_timeout=15.0,
-        http_connect_timeout=5.0,
-    )
-    with patch("httpx.AsyncClient") as mock_client:
-        LMStudioProvider(config)
-        call_kwargs = mock_client.call_args[1]
-        timeout = call_kwargs["timeout"]
-        assert timeout.read == 600.0
-        assert timeout.write == 15.0
-        assert timeout.connect == 5.0
+def test_default_base_url_constant():
+    assert LMSTUDIO_DEFAULT_BASE == "http://localhost:1234/v1"
 
 
-def test_init_base_url_strips_trailing_slash():
-    """Config with base_url trailing slash is stored without it."""
-    config = ProviderConfig(
-        api_key="lm-studio",
-        base_url="http://localhost:1234/v1/",
-        rate_limit=10,
-        rate_window=60,
-    )
-    with patch("httpx.AsyncClient"):
-        provider = LMStudioProvider(config)
-        assert provider._base_url == "http://localhost:1234/v1"
-
-
-@pytest.mark.asyncio
-async def test_stream_response_omits_thinking_when_globally_disabled(lmstudio_config):
-    provider = LMStudioProvider(
-        lmstudio_config.model_copy(update={"enable_thinking": False})
-    )
+def test_build_request_body_basic(lmstudio_provider):
     req = MockRequest()
+    body = lmstudio_provider._build_request_body(req)
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-
-    async def empty_aiter():
-        if False:
-            yield ""
-
-    mock_response.aiter_lines = empty_aiter
-
-    with (
-        patch.object(provider._client, "build_request") as mock_build,
-        patch.object(
-            provider._client,
-            "send",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ),
-    ):
-        [e async for e in provider.stream_response(req)]
-
-    _, kwargs = mock_build.call_args
-    assert "thinking" not in kwargs["json"]
+    assert body["model"] == "lmstudio-community/qwen2.5-7b-instruct"
+    assert body["messages"][0]["role"] == "system"
 
 
-@pytest.mark.asyncio
-async def test_stream_response_omits_thinking_when_request_disables_it(
-    lmstudio_provider,
-):
-    req = MockRequest()
-    req.thinking.enabled = False
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-
-    async def empty_aiter():
-        if False:
-            yield ""
-
-    mock_response.aiter_lines = empty_aiter
-
-    with (
-        patch.object(lmstudio_provider._client, "build_request") as mock_build,
-        patch.object(
-            lmstudio_provider._client,
-            "send",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ),
-    ):
-        [e async for e in lmstudio_provider.stream_response(req)]
-
-    _, kwargs = mock_build.call_args
-    assert "thinking" not in kwargs["json"]
-
-
-@pytest.mark.asyncio
-async def test_stream_response(lmstudio_provider):
-    """Test streaming native Anthropic response."""
-    req = MockRequest()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-
-    async def mock_aiter_lines():
-        yield "event: message_start"
-        yield 'data: {"type":"message_start","message":{}}'
-        yield ""
-        yield "event: content_block_delta"
-        yield 'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello World"}}'
-        yield ""
-        yield "event: message_stop"
-        yield 'data: {"type":"message_stop"}'
-        yield ""
-
-    mock_response.aiter_lines = mock_aiter_lines
-
-    with (
-        patch.object(
-            lmstudio_provider._client, "build_request", return_value=MagicMock()
-        ) as mock_build,
-        patch.object(
-            lmstudio_provider._client,
-            "send",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ),
-    ):
-        events = [e async for e in lmstudio_provider.stream_response(req)]
-
-        # Verify request construction
-        mock_build.assert_called_once()
-        args, kwargs = mock_build.call_args
-        assert args[0] == "POST"
-        assert args[1] == "/messages"
-        assert kwargs["json"]["model"] == "lmstudio-community/qwen2.5-7b-instruct"
-        # Verify internal fields are popped
-        assert "extra_body" not in kwargs["json"]
-        assert kwargs["json"]["max_tokens"] == 100
-
-        # Verify internal ThinkingConfig is mapped to Anthropic API format
-        assert kwargs["json"]["thinking"] == {"type": "enabled"}
-
-        assert [event.event for event in parse_sse_text("".join(events))] == [
-            "message_start",
-            "content_block_delta",
-            "message_stop",
-        ]
-        assert "Hello World" in "".join(events)
-
-
-@pytest.mark.asyncio
-async def test_stream_response_adds_max_tokens_if_missing(lmstudio_provider):
-    """Fallback max_tokens to 81920 if not present."""
-    req = MockRequest()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-
-    async def empty_aiter():
-        if False:
-            yield ""
-
-    mock_response.aiter_lines = empty_aiter
-
-    with (
-        patch.object(req, "model_dump", return_value={"model": "test"}),
-        patch.object(lmstudio_provider._client, "build_request") as mock_build,
-        patch.object(
-            lmstudio_provider._client,
-            "send",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ),
-    ):
-        # Just run the generator to completion
-        [e async for e in lmstudio_provider.stream_response(req)]
-
-        _, kwargs = mock_build.call_args
-        assert kwargs["json"]["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
-
-
-@pytest.mark.asyncio
-async def test_stream_error_status_code(lmstudio_provider):
-    """Non-200 status code raises an error that gets caught and yielded as an SSE API error."""
-    req = MockRequest()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 500
-    mock_response.aread = AsyncMock(return_value=b"Internal Server Error")
-    mock_response.raise_for_status = MagicMock(
-        side_effect=httpx.HTTPStatusError(
-            "Internal Server Error", request=MagicMock(), response=mock_response
-        )
-    )
-
-    with (
-        patch.object(
-            lmstudio_provider._client, "build_request", return_value=MagicMock()
-        ),
-        patch.object(
-            lmstudio_provider._client,
-            "send",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ),
-    ):
-        events = [
-            e
-            async for e in lmstudio_provider.stream_response(req, request_id="TEST_ID")
-        ]
-
-        assert_canonical_stream_error_envelope(
-            events, user_message_substr="Provider API request failed"
-        )
-        assert "TEST_ID" in "".join(events)
-
-
-@pytest.mark.asyncio
-async def test_stream_network_error(lmstudio_provider):
-    """Network errors are caught and yielded as SSE API error events."""
-    req = MockRequest()
-
-    with (
-        patch.object(
-            lmstudio_provider._client, "build_request", return_value=MagicMock()
-        ),
-        patch.object(
-            lmstudio_provider._client,
-            "send",
-            new_callable=AsyncMock,
-            side_effect=httpx.ConnectError("Connection refused"),
-        ),
-    ):
-        events = [
-            e
-            async for e in lmstudio_provider.stream_response(req, request_id="TEST_ID2")
-        ]
-
-        blob = "".join(events)
-        assert_canonical_stream_error_envelope(
-            events, user_message_substr="Connection refused"
-        )
-        assert "TEST_ID2" in blob
-
-
-@pytest.mark.asyncio
-async def test_stream_error_405_mentions_upstream_provider(lmstudio_provider):
-    req = MockRequest()
-
-    mock_response = MagicMock()
-    mock_response.status_code = 405
-    mock_response.aread = AsyncMock(return_value=b"Method Not Allowed")
-    mock_response.raise_for_status = MagicMock(
-        side_effect=httpx.HTTPStatusError(
-            "Method Not Allowed", request=MagicMock(), response=mock_response
-        )
-    )
-
-    with (
-        patch.object(
-            lmstudio_provider._client, "build_request", return_value=MagicMock()
-        ),
-        patch.object(
-            lmstudio_provider._client,
-            "send",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ),
-    ):
-        events = [
-            e async for e in lmstudio_provider.stream_response(req, request_id="REQ405")
-        ]
-
-    blob = "".join(events)
-    assert (
-        "Upstream provider LMSTUDIO rejected the request method or endpoint (HTTP 405)."
-        in blob
-    )
-    assert "REQ405" in blob
-
-
-def test_build_request_body_disabled_thinking_strips_native_thinking_history(
-    lmstudio_config,
-):
-    """Disabled thinking must omit prior assistant thinking/redacted blocks in JSON."""
-    provider = LMStudioProvider(
-        lmstudio_config.model_copy(update={"enable_thinking": False})
-    )
+def test_build_request_body_never_replays_prior_thinking(lmstudio_provider):
+    """Mistral-family templates have no assistant reasoning field; prior-turn
+    thinking must never be replayed regardless of the enable_thinking setting."""
     req = MockRequest(
-        system=None,
         messages=[
             MockMessage("user", "hi"),
             MockMessage(
                 "assistant",
-                [
-                    {"type": "thinking", "thinking": "t"},
-                    {"type": "redacted_thinking", "data": "opaque"},
-                ],
+                [{"type": "thinking", "thinking": "prior reasoning", "signature": "s"}],
             ),
-        ],
+        ]
     )
-    body = provider._build_request_body(req, thinking_enabled=False)
-    assert body["messages"][1]["content"] == ""
-    assert "redacted_thinking" not in str(body)
+    body = lmstudio_provider._build_request_body(req)
+
+    roles = [m.get("role") for m in body.get("messages", [])]
+    assert "assistant_reasoning_content" not in roles
+    assert "prior reasoning" not in str(body)
 
 
-def test_build_request_body_preserves_signed_thinking_native_history(lmstudio_config):
-    """When thinking is enabled, signed thinking blocks are kept; unsigned stripped."""
-    provider = LMStudioProvider(lmstudio_config)
-    req = MockRequest(
-        system=None,
-        messages=[
-            MockMessage("user", "hi"),
-            MockMessage(
-                "assistant",
-                [
-                    {
-                        "type": "thinking",
-                        "thinking": "signed",
-                        "signature": "sig",
-                    },
-                    {"type": "redacted_thinking", "data": "opaque"},
-                ],
+@pytest.mark.asyncio
+async def test_stream_response_text(lmstudio_provider):
+    """Text content deltas are emitted as text blocks (via the OpenAI chat transport)."""
+    req = MockRequest()
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(
+                content="Hello back!", reasoning_content=None, tool_calls=None
             ),
-        ],
-    )
-    body = provider._build_request_body(req, thinking_enabled=True)
-    c = body["messages"][1]["content"]
-    assert isinstance(c, list)
-    assert any(isinstance(b, dict) and b.get("type") == "thinking" for b in c)
-    assert any(isinstance(b, dict) and b.get("type") == "redacted_thinking" for b in c)
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=5, prompt_tokens=10)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        lmstudio_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [event async for event in lmstudio_provider.stream_response(req)]
+
+        assert any(
+            '"text_delta"' in event and "Hello back!" in event for event in events
+        )
+
+
+@pytest.mark.asyncio
+async def test_cleanup(lmstudio_provider):
+    lmstudio_provider._client = AsyncMock()
+    await lmstudio_provider.cleanup()
+
+
+# --- Context-budget preflight (new: guards against LM Studio's silent
+# mid-stream truncation when a prompt exceeds the loaded model's context) ---
+
+
+def test_preflight_context_budget_noop_when_context_length_unknown(lmstudio_provider):
+    """No LM Studio /api/v0/models data available -> preflight is a no-op (fail open)."""
+    with patch.object(lmstudio_provider, "_loaded_context_length", return_value=None):
+        lmstudio_provider._preflight_context_budget(MockRequest())  # must not raise
+
+
+def test_preflight_context_budget_allows_request_under_budget(lmstudio_provider):
+    with patch.object(
+        lmstudio_provider, "_loaded_context_length", return_value=100_000
+    ):
+        req = MockRequest(messages=[MockMessage("user", "hi")], system=None, tools=[])
+        lmstudio_provider._preflight_context_budget(req)  # must not raise
+
+
+def test_preflight_context_budget_rejects_request_over_90_percent(lmstudio_provider):
+    with (
+        patch.object(lmstudio_provider, "_loaded_context_length", return_value=1000),
+        patch(
+            "providers.lmstudio.client.get_token_count",
+            return_value=901,
+        ),
+        pytest.raises(InvalidRequestError, match="prompt is too long"),
+    ):
+        lmstudio_provider._preflight_context_budget(MockRequest())
+
+
+def test_loaded_context_length_reads_max_across_loaded_models(lmstudio_provider):
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {
+        "data": [
+            {"state": "loaded", "loaded_context_length": 40960},
+            {"state": "loaded", "loaded_context_length": 8192},
+            {"state": "not-loaded", "loaded_context_length": 999999},
+        ]
+    }
+    with patch(
+        "providers.lmstudio.client.httpx.get", return_value=response
+    ) as mock_get:
+        value = lmstudio_provider._loaded_context_length()
+
+    assert value == 40960
+    mock_get.assert_called_once()
+    assert mock_get.call_args[0][0] == "http://localhost:1234/api/v0/models"
+
+
+def test_loaded_context_length_fails_open_on_error(lmstudio_provider):
+    with patch(
+        "providers.lmstudio.client.httpx.get",
+        side_effect=httpx.ConnectError("refused"),
+    ):
+        assert lmstudio_provider._loaded_context_length() is None
+
+
+def test_loaded_context_length_is_cached_within_ttl(lmstudio_provider):
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {
+        "data": [{"state": "loaded", "loaded_context_length": 40960}]
+    }
+    with patch(
+        "providers.lmstudio.client.httpx.get", return_value=response
+    ) as mock_get:
+        first = lmstudio_provider._loaded_context_length()
+        second = lmstudio_provider._loaded_context_length()
+
+    assert first == second == 40960
+    mock_get.assert_called_once()

--- a/tests/providers/test_model_validation.py
+++ b/tests/providers/test_model_validation.py
@@ -14,7 +14,7 @@ from config.settings import Settings
 from providers.base import BaseProvider, ProviderConfig
 from providers.deepseek import DeepSeekProvider
 from providers.exceptions import ModelListResponseError, ServiceUnavailableError
-from providers.lmstudio import LMStudioProvider
+from providers.llamacpp import LlamaCppProvider
 from providers.model_listing import ProviderModelInfo
 from providers.nvidia_nim import NvidiaNimProvider
 from providers.ollama import OllamaProvider
@@ -75,9 +75,9 @@ async def test_nim_lists_openai_compatible_model_ids() -> None:
 
 
 @pytest.mark.asyncio
-async def test_native_openai_compatible_provider_lists_model_ids() -> None:
-    provider = LMStudioProvider(
-        ProviderConfig(api_key="lm-studio", base_url="http://localhost:1234/v1")
+async def test_native_anthropic_messages_provider_lists_model_ids() -> None:
+    provider = LlamaCppProvider(
+        ProviderConfig(api_key="llamacpp", base_url="http://localhost:8080/v1")
     )
     with patch.object(
         provider._client,
@@ -264,8 +264,8 @@ async def test_ollama_lists_native_tag_model_ids() -> None:
 
 @pytest.mark.asyncio
 async def test_model_listing_rejects_malformed_payload() -> None:
-    provider = LMStudioProvider(
-        ProviderConfig(api_key="lm-studio", base_url="http://localhost:1234/v1")
+    provider = LlamaCppProvider(
+        ProviderConfig(api_key="llamacpp", base_url="http://localhost:8080/v1")
     )
     with (
         patch.object(
@@ -281,8 +281,8 @@ async def test_model_listing_rejects_malformed_payload() -> None:
 
 @pytest.mark.asyncio
 async def test_model_listing_raises_http_status_errors() -> None:
-    provider = LMStudioProvider(
-        ProviderConfig(api_key="lm-studio", base_url="http://localhost:1234/v1")
+    provider = LlamaCppProvider(
+        ProviderConfig(api_key="llamacpp", base_url="http://localhost:8080/v1")
     )
     with (
         patch.object(

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

LM Studio's native `/v1/messages` endpoint renders every conversation
through the loaded model's own Jinja chat template, with strict
role-alternation rules and a fragile `[TOOL_CALLS]` parser. #978 (earlier
in this series) fixes two shapes of that fragility on the native path —
leaked control tokens in tool names, and rejected mixed
`tool_result`+`text` user turns. A third, more severe shape surfaced even
with both of those fixes applied: on one run, devstral's raw Mistral
tool-call syntax leaked into the final answer as plain text:

```
Read[ARGS]{"file_path": "..."}
```

LM Studio's own log shows its `mistralV13ToolsSamplingSwitch` triggering
on `[TOOL_CALLS]`, then the parser dumping the remainder as text. Claude
Code sees a text-only reply, treats it as the final response, and exits
0 — **silent task death, with no error at all to catch or retry.**

This may also be related to #735 (local models via LM Studio/Ollama
reported as "extremely slow or times out ... despite successful model
responses") — a silent text-leak like this would look exactly like that
from the outside: the model responded successfully, but the actual task
never got done, which could easily read as "hanging" from a user's
perspective depending on what they were watching for.

Rather than keep patching around an increasingly fragile parsing layer,
this switches the LM Studio provider to LM Studio's **OpenAI-compatible
`/v1/chat/completions` endpoint** instead — its more mature parsing
route, which also puts fcc's own `OpenAIToolCallAssembler`, think-tag
parser, and heuristic tool-call recovery between the model and the
client (the native path was a much thinner passthrough with no
equivalent safety net).

## Repro / verification

Verified against a real running LM Studio + `devstral-small-2-2512`:
3/3 structured tool calls succeed via the OpenAI endpoint (vs.
intermittent text-leak on the native path). After the switch, a 4-way
battery through the proxy all passed: streaming, `stream:false`
JSON-aggregated (per #977), a mixed `tool_result`+`text` user turn (now
simply valid by construction — the OpenAI conversion never produces that
native-only shape at all), and a structured `tool_use` round-trip.

```bash
# Minimal comparison: same conversation, both LM Studio endpoints
curl -s http://localhost:1234/v1/messages ...       # native — intermittently leaks [TOOL_CALLS]/text
curl -s http://localhost:1234/v1/chat/completions ... # OpenAI-compat — mature parsing, no leak observed
```

## Also included: context-budget preflight

Found necessary alongside the transport switch, same root investigation:
LM Studio **silently truncates the stream** (ends without a terminal
event, no error) when a prompt exceeds the loaded model's context.
Claude Code's own auto-compaction is sized off a static, much larger
default window, so it never fires before that local ceiling is hit.

`preflight_stream` now estimates the request size and rejects anything
above 90% of the model's actual loaded context with the same
Anthropic-style `invalid_request_error` shape the real API uses —
instantly, before any GPU work, instead of a silent mid-stream
truncation:

```json
{"type":"error","error":{"type":"invalid_request_error",
 "message":"prompt is too long: 120006 tokens > 117043 maximum (90% of loaded LM Studio context 130048)"}}
```

The 10% margin covers the `cl100k` token estimate's measured ~8%
undercount against devstral's real tokenizer on a 120k-token prompt. The
loaded-context lookup hits LM Studio's REST API (`GET /api/v0/models`),
is cached for 30s, and **fails open** — a lookup failure never blocks a
request; this is a backstop, not a hard dependency on that endpoint
being reachable.

## Changes

- `config/provider_catalog.py`: `lmstudio` descriptor's `transport_type`
  changed from `"anthropic_messages"` to `"openai_chat"`; the
  `"native_anthropic"` capability removed accordingly.
- `providers/lmstudio/client.py`: `LMStudioProvider` now extends
  `OpenAIChatTransport` (previously `AnthropicMessagesTransport`).
  `_build_request_body` disables prior-turn thinking replay
  (`ReasoningReplayMode.DISABLED`) since Mistral-family templates have no
  assistant reasoning field, and replaying `<think>` text only inflates
  the local context for no benefit. New `preflight_stream` override adds
  the context-budget check above via `_preflight_context_budget()`/
  `_loaded_context_length()`.

## Testing

- `uv run ruff format` / `ruff check --fix` / `ty check`: all clean on
  every changed file.
- `tests/providers/test_lmstudio.py` rewritten to match the new
  transport (the old suite was built entirely around the native
  Anthropic transport's httpx-based `_client.build_request()`/`.send()`
  shape and the native `/messages` endpoint/thinking-block body format,
  none of which apply anymore) — now covers request-body building,
  thinking-replay disabling, a basic OpenAI-chat streaming round-trip
  (matching the existing Groq provider test's pattern, since both share
  `OpenAIChatTransport`), and the new context-budget preflight logic:
  no-op when context length is unknown (fail-open), allows requests
  under budget, rejects requests over the 90% threshold with the correct
  error, reads the max `loaded_context_length` across multiple loaded
  models, fails open on a lookup error, and caches within the TTL window.
- `tests/providers/test_model_validation.py` had 3 tests that used
  `LMStudioProvider` purely as a generic exemplar of the native
  Anthropic-transport's raw-httpx model-listing path (unrelated to
  anything LM-Studio-specific) — switched to `LlamaCppProvider` instead,
  which still uses that native transport unmodified by this change, so
  that code path keeps identical test coverage.
- Manually verified every new/changed assertion by direct execution
  outside pytest (see the note in my other three PRs from this same
  session — #976, #977, #978 — on a pre-existing, environment-specific
  pytest crash on Windows, confirmed unrelated to any of these changes).

## Scope / discussion

This is the most opinionated change in this series (after #976, #977,
#978) — sending it last since it changes which of LM Studio's two
endpoints fcc talks to, not just a narrow bugfix. Happy to discuss
alternatives if you'd rather keep the native transport and extend the
sanitizer approach from #978 further — though the silent-text-leak
failure mode this fixes doesn't really have a sanitizer-shaped fix
available, since there's no error to intercept: the response looks like
a normal, successful text reply.

Version bumped `2.4.4` → `2.4.5` per `AGENTS.md`'s versioning rule — this
arguably borders on MINOR given the transport switch is a behavior
change for existing LM Studio users, but no env vars or CLI surface
changed, so I've kept it PATCH; happy to bump to MINOR instead if you'd
prefer. Note: #976, #977, and #978 also bump `2.4.4` → `2.4.5`
independently — whichever of these four lands last will hit a trivial
version-string conflict in `pyproject.toml`/`uv.lock`; happy to rebase
immediately if that happens.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves LM Studio to the OpenAI-compatible chat completions path and adds a local context preflight. The main changes are:

- LM Studio provider catalog metadata now uses `openai_chat` instead of native Anthropic messages.
- `LMStudioProvider` now extends `OpenAIChatTransport` and disables prior-turn reasoning replay.
- A cached `GET /api/v0/models` lookup estimates loaded context length before streaming.
- Tests were rewritten around OpenAI-chat request building, streaming, and context-budget behavior.
- Package version metadata was bumped in `pyproject.toml` and `uv.lock`.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing the LM Studio context-budget mismatch.

The transport switch follows the existing OpenAI chat transport pattern and has targeted tests. One contained bug remains in the new preflight path when multiple loaded LM Studio models have different context lengths.

providers/lmstudio/client.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The repro reproduced a context budget mismatch by running a narrow repro script against LMStudioProvider.preflight\_stream with a mocked HTTP call, showing that an 8192-context model with a 30000-token prompt estimate exceeds the target budget of 7372 tokens, yet the preflight\_stream path completed without raising an InvalidRequestError.
- After applying changes, a targeted run showed HTTP-level live LM Studio calls were not attempted because the request noted no server or model was available; validation used the PR's provider unit tests with mocked runtime paths, and the after-change logs report exit code 0 with 32 tests passed, including tests like test\_build\_request\_body\_never\_replays\_prior\_thinking, test\_preflight\_context\_budget\_rejects\_request\_over\_90\_percent, test\_preflight\_context\_budget\_noop\_when\_context\_length\_unknown, and test\_stream\_response\_text.

<a href="https://app.greptile.com/trex/runs/13302352/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| config/provider_catalog.py | Switches the LM Studio descriptor from native Anthropic messages to OpenAI chat. |
| providers/lmstudio/client.py | Moves LM Studio onto `OpenAIChatTransport` and adds context preflight, with one budget-selection issue for multi-model setups. |
| tests/providers/test_lmstudio.py | Replaces native endpoint tests with OpenAI-chat body, streaming, cleanup, and preflight coverage. |
| tests/providers/test_model_validation.py | Moves native Anthropic transport model-list coverage from LM Studio to llama.cpp. |
| pyproject.toml | Bumps the package version for the production provider change. |
| uv.lock | Updates the editable package version to match `pyproject.toml`. |
| providers/lmstudio/__init__.py | Updates the package docstring for the OpenAI-compatible LM Studio transport. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Claude Code client
participant API as FCC Messages API
participant Provider as LMStudioProvider
participant Models as LM Studio /api/v0/models
participant Chat as LM Studio /v1/chat/completions

Client->>API: Anthropic Messages request
API->>Provider: preflight_stream(request)
Provider->>Models: GET /api/v0/models
Models-->>Provider: loaded_context_length data
alt "prompt estimate > 90% budget"
    Provider-->>API: invalid_request_error
    API-->>Client: Anthropic-style error
else within budget or lookup unavailable
    API->>Provider: stream_response(request)
    Provider->>Chat: OpenAI chat completion stream
    Chat-->>Provider: OpenAI chunks / tool calls
    Provider-->>API: Anthropic SSE events
    API-->>Client: streamed Anthropic response
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Claude Code client
participant API as FCC Messages API
participant Provider as LMStudioProvider
participant Models as LM Studio /api/v0/models
participant Chat as LM Studio /v1/chat/completions

Client->>API: Anthropic Messages request
API->>Provider: preflight_stream(request)
Provider->>Models: GET /api/v0/models
Models-->>Provider: loaded_context_length data
alt "prompt estimate > 90% budget"
    Provider-->>API: invalid_request_error
    API-->>Client: Anthropic-style error
else within budget or lookup unavailable
    API->>Provider: stream_response(request)
    Provider->>Chat: OpenAI chat completion stream
    Chat-->>Provider: OpenAI chunks / tool calls
    Provider-->>API: Anthropic SSE events
    API-->>Client: streamed Anthropic response
end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Switch LM Studio provider to the OpenAI ..."](https://github.com/alishahryar1/free-claude-code/commit/ed913305999235a1cfabe2a0f93a38c47ea768fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41867316)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->