### PR TITLE
Prepare CI for merge queue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@
 - Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced in `tests.yml` on push/merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- Branch protection: set **required status checks** to **all** of those statuses (e.g. **Ban type ignore suppressions**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
+- GitHub CI runs on `push`, `pull_request`, and `merge_group` so required checks validate merge queue candidates before they land.
+- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
+- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban type ignore suppressions**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 
 ## IDENTITY & CONTEXT
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@
 - Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced in `tests.yml` on push/merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- Branch protection: set **required status checks** to **all** of those statuses (e.g. **Ban type ignore suppressions**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
+- GitHub CI runs on `push`, `pull_request`, and `merge_group` so required checks validate merge queue candidates before they land.
+- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
+- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban type ignore suppressions**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 
 ## IDENTITY & CONTEXT
 


### PR DESCRIPTION
## Problem

Merge queue requires required checks to run on merge-group candidates. The CI workflow only ran on push and pull request events, so queued merges could fail to report required checks.

## Changes

| Before | After |
| --- | --- |
| CI ran on `push` and `pull_request` events. | CI also runs on `merge_group` events. |
| Repo guidance described classic branch protection only. | Repo guidance describes non-bypassable queue/check rulesets plus review-only bypass. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prepares CI and repo guidance for GitHub merge queue use. The main changes are:

- Adds `merge_group` to the CI workflow triggers.
- Documents that required checks run for merge queue candidates.
- Updates `AGENTS.md` and `CLAUDE.md` with ruleset-based protection guidance.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The workflow change is limited to adding the expected `merge_group` trigger, and the documentation updates stay synchronized across both guide files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the Merge queue CI validation after-rerun log and confirmed it reports detected workflow triggers \['merge\_group', 'pull\_request', 'push'\] and shows alignment with the expected job IDs, status labels, matrix commands, and documentation guidance.
- Verified the CI script contract tests after log show the contract tests ran and passed.
- Checked the CI dry-run after log and confirmed the local dry-run execution completed with exit code 0, including suppression of printing and steps for Ruff format/check-fix, ty, and pytest.

<a href="https://app.greptile.com/trex/runs/13301287/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/tests.yml | Adds the `merge_group` trigger so existing CI checks run for merge queue candidates. |
| AGENTS.md | Updates repository guidance to describe merge queue CI and ruleset-based protection. |
| CLAUDE.md | Mirrors the merge queue and ruleset guidance from `AGENTS.md`. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Dev as Pull request / push
participant MQ as GitHub merge queue
participant CI as CI workflow
participant Checks as Required status checks

Dev->>CI: push or pull_request event
MQ->>CI: merge_group event
CI->>Checks: Ban type ignore suppressions
CI->>Checks: ruff-format / ruff-check / ty / pytest
Checks-->>MQ: report required statuses before merge
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Dev as Pull request / push
participant MQ as GitHub merge queue
participant CI as CI workflow
participant Checks as Required status checks

Dev->>CI: push or pull_request event
MQ->>CI: merge_group event
CI->>Checks: Ban type ignore suppressions
CI->>Checks: ruff-format / ruff-check / ty / pytest
Checks-->>MQ: report required statuses before merge
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: prepare required checks for merge qu..."](https://github.com/alishahryar1/free-claude-code/commit/53452c2103ac2fd06ba3c575e2b3bc6ddb35cc86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41871944)</sub>

<!-- /greptile_comment -->