### PR TITLE
Fix HTTP 400 when max_(completion_)tokens exceeds a model's cap (#955)

### DIFF
--- a/providers/transports/openai_chat/output_cap.py
+++ b/providers/transports/openai_chat/output_cap.py
@@ -1,0 +1,83 @@
+"""Recover from upstream ``max_(completion_)tokens`` too-large 400 rejections.
+
+Some OpenAI-compatible providers (Groq, NVIDIA NIM, ...) cap the per-request
+output token count below what Claude Code asks for and reject the whole request
+with an HTTP 400 that names the allowed maximum, e.g.::
+
+    max_completion_tokens must be less than or equal to 40960, ...
+
+This module parses that maximum and clamps the request body so the transport can
+retry once and succeed. The transport also remembers the learned cap per model
+so later requests clamp proactively instead of paying the 400 every time.
+"""
+
+import json
+import re
+from typing import Any
+
+import openai
+
+# Body keys that carry the output-token budget across OpenAI-compatible policies.
+_OUTPUT_TOKEN_FIELDS = ("max_completion_tokens", "max_tokens")
+
+# Only treat a 400 as an output-cap rejection when it names one of these fields.
+_OUTPUT_TOKEN_KEYWORDS = ("max_completion_tokens", "max_tokens")
+
+# Comparator phrases that precede the allowed maximum in provider error text.
+_CAP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"less than or equal to\s+(\d+)"),
+    re.compile(r"smaller than or equal to\s+(\d+)"),
+    re.compile(r"<=\s*(\d+)"),
+    re.compile(r"at most\s+(\d+)"),
+    re.compile(r"must not exceed\s+(\d+)"),
+    re.compile(r"maximum(?:\s+value)?(?:\s+for\s+\S+)?\s+is\s+(\d+)"),
+    re.compile(r"maximum(?:\s+allowed)?(?:\s+value)?\s+of\s+(\d+)"),
+)
+
+
+def _is_bad_request(error: Exception) -> bool:
+    return isinstance(error, openai.BadRequestError) or (
+        getattr(error, "status_code", None) == 400
+    )
+
+
+def _error_text(error: Exception) -> str:
+    text = str(error)
+    body = getattr(error, "body", None)
+    if body is not None:
+        text = f"{text} {json.dumps(body, default=str)}"
+    return text.lower()
+
+
+def parse_output_token_cap(error: Exception) -> int | None:
+    """Return the allowed output-token maximum named in a 400 rejection, if any."""
+    if not _is_bad_request(error):
+        return None
+
+    text = _error_text(error)
+    if not any(keyword in text for keyword in _OUTPUT_TOKEN_KEYWORDS):
+        return None
+
+    for pattern in _CAP_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            cap = int(match.group(1))
+            if cap > 0:
+                return cap
+    return None
+
+
+def clamp_output_tokens(body: dict[str, Any], cap: int) -> dict[str, Any] | None:
+    """Return a shallow clone with output-token fields clamped to ``cap``.
+
+    Returns ``None`` when nothing needs clamping (no output field exceeds the
+    cap), so callers can avoid a pointless identical retry.
+    """
+    clamped: dict[str, Any] | None = None
+    for field in _OUTPUT_TOKEN_FIELDS:
+        value = body.get(field)
+        if isinstance(value, int) and not isinstance(value, bool) and value > cap:
+            if clamped is None:
+                clamped = dict(body)
+            clamped[field] = cap
+    return clamped

--- a/providers/transports/openai_chat/transport.py
+++ b/providers/transports/openai_chat/transport.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any
 
 import httpx
+from loguru import logger
 from openai import AsyncOpenAI
 
 from core.anthropic.streaming import AnthropicStreamLedger
@@ -17,6 +18,7 @@ from providers.error_mapping import (
 from providers.model_listing import extract_openai_model_ids
 from providers.rate_limit import GlobalRateLimiter
 
+from .output_cap import clamp_output_tokens, parse_output_token_cap
 from .stream import OpenAIChatStreamAdapter
 
 
@@ -36,6 +38,9 @@ class OpenAIChatTransport(BaseProvider):
         self._provider_name = provider_name
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
+        # Learned per-model output-token caps from upstream 400 rejections, so
+        # later requests clamp proactively instead of paying the 400 each time.
+        self._model_output_caps: dict[str, int] = {}
         self._global_rate_limiter = GlobalRateLimiter.get_scoped_instance(
             provider_name.lower(),
             rate_limit=config.rate_limit,
@@ -113,6 +118,7 @@ class OpenAIChatTransport(BaseProvider):
 
     async def _create_stream(self, body: dict) -> tuple[Any, dict]:
         """Create a streaming chat completion, optionally retrying once."""
+        body = self._apply_learned_output_cap(body)
         try:
             create_body = self._prepare_create_body(body)
             stream = await self._global_rate_limiter.execute_with_retry(
@@ -120,7 +126,9 @@ class OpenAIChatTransport(BaseProvider):
             )
             return stream, body
         except Exception as error:
-            retry_body = self._get_retry_request_body(error, body)
+            retry_body = self._retry_body_for_output_cap(error, body)
+            if retry_body is None:
+                retry_body = self._get_retry_request_body(error, body)
             if retry_body is None:
                 raise
 
@@ -129,6 +137,37 @@ class OpenAIChatTransport(BaseProvider):
                 self._client.chat.completions.create, **create_retry_body, stream=True
             )
             return stream, retry_body
+
+    def _apply_learned_output_cap(self, body: dict) -> dict:
+        """Clamp output tokens to a previously learned cap for this model."""
+        model = body.get("model")
+        if not isinstance(model, str):
+            return body
+        cap = self._model_output_caps.get(model)
+        if cap is None:
+            return body
+        clamped = clamp_output_tokens(body, cap)
+        return clamped if clamped is not None else body
+
+    def _retry_body_for_output_cap(self, error: Exception, body: dict) -> dict | None:
+        """Learn an upstream output-token cap from a 400 and clamp for one retry."""
+        cap = parse_output_token_cap(error)
+        if cap is None:
+            return None
+        model = body.get("model")
+        if isinstance(model, str):
+            previous = self._model_output_caps.get(model)
+            cap = cap if previous is None else min(previous, cap)
+            self._model_output_caps[model] = cap
+        clamped = clamp_output_tokens(body, cap)
+        if clamped is None:
+            return None
+        logger.warning(
+            "{}_STREAM: clamping output tokens to {} after upstream cap rejection",
+            self._provider_name,
+            cap,
+        )
+        return clamped
 
     def _openai_error_message(self, error: Exception, request_id: str | None) -> str:
         mapped_error = map_error(error, rate_limiter=self._global_rate_limiter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.2.0"
+version = "3.2.1"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -1,0 +1,207 @@
+"""Tests for OpenAI-compatible output-token cap recovery (issue #955).
+
+Covers the pure parse/clamp helpers and the transport behavior that clamps
+``max_completion_tokens``/``max_tokens`` to the upstream maximum, retries once,
+and learns the cap so later requests clamp proactively.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from providers.base import ProviderConfig
+from providers.groq import GROQ_DEFAULT_BASE, GroqProvider
+from providers.transports.openai_chat.output_cap import (
+    clamp_output_tokens,
+    parse_output_token_cap,
+)
+
+
+class _BadRequest(Exception):
+    """Stand-in for openai.BadRequestError (status_code + optional JSON body)."""
+
+    def __init__(self, message: str, body: object | None = None):
+        super().__init__(message)
+        self.status_code = 400
+        self.body = body
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_cap_from_groq_message():
+    error = _BadRequest(
+        "max_completion_tokens must be less than or equal to 40960, the maximum "
+        "value for max_completion_tokens is less than the context_window for this model"
+    )
+    assert parse_output_token_cap(error) == 40960
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("max_tokens: maximum value is 8192", 8192),
+        ("max_tokens must not exceed 16000", 16000),
+        ("`max_completion_tokens` <= 4096 required", 4096),
+        ("max_tokens at most 2048 allowed", 2048),
+        ("maximum allowed value of 32768 for max_tokens", 32768),
+    ],
+)
+def test_parse_cap_various_phrasings(message, expected):
+    assert parse_output_token_cap(_BadRequest(message)) == expected
+
+
+def test_parse_cap_reads_json_body():
+    error = _BadRequest(
+        "invalid request",
+        body={"error": {"param": "max_completion_tokens", "message": "<= 12000"}},
+    )
+    assert parse_output_token_cap(error) == 12000
+
+
+def test_parse_cap_ignores_non_400():
+    error = _BadRequest("max_tokens must be less than or equal to 40960")
+    error.status_code = 500
+    assert parse_output_token_cap(error) is None
+
+
+def test_parse_cap_ignores_unrelated_400():
+    assert parse_output_token_cap(_BadRequest("temperature must be <= 2")) is None
+
+
+def test_parse_cap_returns_none_without_number():
+    assert (
+        parse_output_token_cap(_BadRequest("max_tokens is larger than allowed")) is None
+    )
+
+
+def test_clamp_reduces_max_completion_tokens():
+    assert clamp_output_tokens({"max_completion_tokens": 64000}, 40960) == {
+        "max_completion_tokens": 40960
+    }
+
+
+def test_clamp_reduces_max_tokens():
+    assert clamp_output_tokens({"max_tokens": 100000}, 8192) == {"max_tokens": 8192}
+
+
+def test_clamp_noop_when_within_cap_returns_none():
+    assert clamp_output_tokens({"max_completion_tokens": 1000}, 40960) is None
+
+
+def test_clamp_does_not_mutate_input():
+    body = {"max_tokens": 99999, "model": "m"}
+    clamped = clamp_output_tokens(body, 8192)
+    assert body["max_tokens"] == 99999
+    assert clamped is not None
+    assert clamped["max_tokens"] == 8192
+
+
+def test_clamp_ignores_bool_values():
+    assert clamp_output_tokens({"max_tokens": True}, 8192) is None
+
+
+# --------------------------------------------------------------------------- #
+# Transport integration (via GroqProvider, which uses max_completion_tokens)
+# --------------------------------------------------------------------------- #
+
+
+class MockMessage:
+    def __init__(self, role, content):
+        self.role = role
+        self.content = content
+
+
+class MockRequest:
+    def __init__(self, max_tokens=64000):
+        self.model = "llama-3.3-70b-versatile"
+        self.messages = [MockMessage("user", "Hello")]
+        self.max_tokens = max_tokens
+        self.temperature = 0.5
+        self.top_p = 0.9
+        self.system = "System prompt"
+        self.stop_sequences = None
+        self.tools = []
+        self.thinking = MagicMock()
+        self.thinking.enabled = False
+
+
+@pytest.fixture(autouse=True)
+def mock_rate_limiter():
+    @asynccontextmanager
+    async def _slot():
+        yield
+
+    with patch("providers.transports.openai_chat.transport.GlobalRateLimiter") as mock:
+        instance = mock.get_scoped_instance.return_value
+
+        async def _passthrough(fn, *args, **kwargs):
+            return await fn(*args, **kwargs)
+
+        instance.execute_with_retry = AsyncMock(side_effect=_passthrough)
+        instance.concurrency_slot.side_effect = _slot
+        yield instance
+
+
+@pytest.fixture
+def groq_provider():
+    return GroqProvider(
+        ProviderConfig(
+            api_key="test_groq_key",
+            base_url=GROQ_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+            enable_thinking=False,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_stream_clamps_and_learns_on_cap_rejection(groq_provider):
+    body = groq_provider._build_request_body(MockRequest(max_tokens=64000))
+    assert body["max_completion_tokens"] == 64000
+    model = body["model"]
+
+    error = _BadRequest("max_completion_tokens must be less than or equal to 40960")
+    create = AsyncMock(side_effect=[error, object()])
+
+    with patch.object(groq_provider._client.chat.completions, "create", create):
+        _stream, used_body = await groq_provider._create_stream(body)
+
+    assert create.call_count == 2
+    assert create.call_args_list[1].kwargs["max_completion_tokens"] == 40960
+    assert used_body["max_completion_tokens"] == 40960
+    assert groq_provider._model_output_caps[model] == 40960
+
+
+@pytest.mark.asyncio
+async def test_learned_cap_clamps_next_request_without_a_400(groq_provider):
+    body = groq_provider._build_request_body(MockRequest(max_tokens=64000))
+    model = body["model"]
+    groq_provider._model_output_caps[model] = 40960
+
+    create = AsyncMock(return_value=object())
+    with patch.object(groq_provider._client.chat.completions, "create", create):
+        _stream, used_body = await groq_provider._create_stream(body)
+
+    assert create.call_count == 1
+    assert create.call_args.kwargs["max_completion_tokens"] == 40960
+    assert used_body["max_completion_tokens"] == 40960
+
+
+@pytest.mark.asyncio
+async def test_unrelated_400_is_not_clamped_and_propagates(groq_provider):
+    body = groq_provider._build_request_body(MockRequest(max_tokens=100))
+    create = AsyncMock(side_effect=_BadRequest("messages: invalid role 'wizard'"))
+
+    with (
+        patch.object(groq_provider._client.chat.completions, "create", create),
+        pytest.raises(Exception, match="wizard"),
+    ):
+        await groq_provider._create_stream(body)
+
+    assert create.call_count == 1
+    assert groq_provider._model_output_caps == {}

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.2.0"
+version = "3.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fixes #955.

## Problem

Groq and NVIDIA NIM (and other OpenAI-compatible upstreams) cap per-request output tokens below what Claude Code asks for, and reject the **entire** request with an HTTP 400 that names the allowed maximum:

```
max_completion_tokens must be less than or equal to 40960, the maximum value
for max_completion_tokens is less than the context_window for this model
```

Because Claude Code routinely sends a large `max_tokens` (e.g. 64000), affected models returned 400 on *every* request — "I get this error when I send one letter to groq."

## Fix

Handled once in the shared `openai_chat` transport, so all OpenAI-compatible providers benefit (Groq, NVIDIA NIM, Cerebras, SambaNova, …):

1. On a 400, parse the allowed maximum from the upstream message (`providers/transports/openai_chat/output_cap.py`).
2. Clamp `max_completion_tokens`/`max_tokens` to that cap and **retry once**.
3. **Learn** the cap per model on the reused provider instance, so subsequent requests clamp proactively and never pay the 400 again — only the first request for a given model costs a round-trip.

Unrelated 400s still fall through to each provider's existing `_get_retry_request_body` (e.g. NIM's `chat_template`/`reasoning_content` retries), which is unchanged.

## [Files Changed]

- `providers/transports/openai_chat/output_cap.py` (new) — pure `parse_output_token_cap` / `clamp_output_tokens` helpers.
- `providers/transports/openai_chat/transport.py` — learned-cap cache, proactive clamp before the first call, reactive clamp-and-retry, then fall back to the provider retry hook.
- `pyproject.toml` + `uv.lock` — PATCH bump `3.1.0` → `3.1.1`.

## [Logic Altered]

Only the retry seam in `_create_stream`: output-cap recovery runs before the existing per-provider retry hook; both still fire for their respective error classes. No change to request building or streaming.

## [Verification Method]

`scripts/ci.sh` green — suppression grep, ruff-format, ruff-check, ty, pytest (**1818 passed**). New `tests/providers/test_openai_chat_output_cap.py` covers: cap parsing across phrasings + JSON body, non-400/unrelated-400/no-number rejection, clamp semantics (incl. no-op and bool guard), and transport behavior — reactive clamp+learn, proactive clamp with no second 400, and unrelated-400 propagation.

## [Residual Risks]

Recovery relies on the upstream stating a numeric maximum; a provider that rejects without a number won't be auto-clamped (falls through to normal error surfacing) — none observed among current providers. Not exercised against live Groq/NIM (no keys); coverage is unit-level, consistent with the transport's other retry paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds shared recovery for OpenAI-compatible output-token cap errors. The main changes are:

- Parses cap-bearing HTTP 400 responses for `max_completion_tokens` and `max_tokens`.
- Clamps oversized output-token fields and retries the request once.
- Caches learned caps per model so later requests clamp before calling upstream.
- Adds tests for parsing, clamping, reactive retry, proactive clamping, and unrelated 400 handling.
- Bumps the package patch version and lockfile entry.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

No issues were identified. The change is localized to the shared OpenAI chat retry path, preserves provider-specific retry hooks, and includes focused tests for the new behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a Pytest validation for the OpenAI chat output cap and confirmed the suite completed with exit code 0 and 18 tests passing.
- Ran a Ruff validation for the OpenAI chat output cap and confirmed all checks passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/13334298/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| providers/transports/openai_chat/output_cap.py | Adds focused parsing and clamping helpers for output-token cap 400 responses; no functional issues found. |
| providers/transports/openai_chat/transport.py | Adds learned per-model output-token cap clamping and a single reactive retry before provider-specific retry hooks; no functional issues found. |
| tests/providers/test_openai_chat_output_cap.py | Adds helper and transport tests covering parsing, clamping, learned proactive clamping, and unrelated 400 propagation. |
| pyproject.toml | Bumps the package patch version for the production fix, matching repository versioning guidance. |
| uv.lock | Updates the editable package version in the lockfile to match `pyproject.toml`. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller as Stream caller
participant Transport as OpenAIChatTransport
participant CapCache as Per-model cap cache
participant Upstream as OpenAI-compatible API
participant ProviderHook as Provider retry hook

Caller->>Transport: _create_stream(body)
Transport->>CapCache: lookup learned cap for body.model
alt cap exists and token field exceeds cap
    Transport->>Transport: clamp max_(completion_)tokens
end
Transport->>Upstream: "chat.completions.create(stream=True)"
alt success
    Upstream-->>Transport: stream
    Transport-->>Caller: stream, used_body
else 400 names output-token cap
    Upstream-->>Transport: BadRequest with cap
    Transport->>CapCache: store min(previous cap, parsed cap)
    Transport->>Transport: clamp output-token fields
    Transport->>Upstream: retry once with clamped body
    Upstream-->>Transport: stream
    Transport-->>Caller: stream, retry_body
else other retryable provider-specific error
    Upstream-->>Transport: error
    Transport->>ProviderHook: _get_retry_request_body(error, body)
    ProviderHook-->>Transport: provider retry body
    Transport->>Upstream: retry once with provider body
    Upstream-->>Transport: stream
    Transport-->>Caller: stream, retry_body
else unrecoverable error
    Upstream-->>Transport: error
    Transport-->>Caller: raise
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller as Stream caller
participant Transport as OpenAIChatTransport
participant CapCache as Per-model cap cache
participant Upstream as OpenAI-compatible API
participant ProviderHook as Provider retry hook

Caller->>Transport: _create_stream(body)
Transport->>CapCache: lookup learned cap for body.model
alt cap exists and token field exceeds cap
    Transport->>Transport: clamp max_(completion_)tokens
end
Transport->>Upstream: "chat.completions.create(stream=True)"
alt success
    Upstream-->>Transport: stream
    Transport-->>Caller: stream, used_body
else 400 names output-token cap
    Upstream-->>Transport: BadRequest with cap
    Transport->>CapCache: store min(previous cap, parsed cap)
    Transport->>Transport: clamp output-token fields
    Transport->>Upstream: retry once with clamped body
    Upstream-->>Transport: stream
    Transport-->>Caller: stream, retry_body
else other retryable provider-specific error
    Upstream-->>Transport: error
    Transport->>ProviderHook: _get_retry_request_body(error, body)
    ProviderHook-->>Transport: provider retry body
    Transport->>Upstream: retry once with provider body
    Upstream-->>Transport: stream
    Transport-->>Caller: stream, retry_body
else unrecoverable error
    Upstream-->>Transport: error
    Transport-->>Caller: raise
end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Fix HTTP 400 when max\_(completion\_)token..."](https://github.com/alishahryar1/free-claude-code/commit/59eea83d6a869702910293b9bfe2b5b5d0c0eef4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41925009)</sub>

<!-- /greptile_comment -->