### PR TITLE
Update GLM 5.2 model references

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,13 +378,13 @@ This provider calls Cloudflare's account-scoped **OpenAI-compatible** Chat Compl
 
 Get an API key at [Z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list).
 
-In the Admin UI, paste it into `ZAI_API_KEY`, then set `MODEL` to a Z.ai model slug such as `zai/glm-5.1`.
+In the Admin UI, paste it into `ZAI_API_KEY`, then set `MODEL` to a Z.ai model slug such as `zai/glm-5.2`.
 
 This provider calls Z.ai's **Anthropic-compatible** Messages API (`https://api.z.ai/api/anthropic/v1/messages`). The former OpenAI Coding Plan base (`https://api.z.ai/api/coding/paas/v4`) is **not** used by this gateway.
 
 Popular examples:
 
-- `zai/glm-5.1`
+- `zai/glm-5.2`
 - `zai/glm-5-turbo`
 
 Browse models at [Z.ai](https://z.ai).
@@ -420,7 +420,7 @@ In the Admin UI, keep or update `OLLAMA_BASE_URL`, then set `MODEL` to the same 
 
 Each model tier can use a different provider by setting `MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU` in the Admin UI. Leave a tier blank to inherit `MODEL`. These tier overrides apply to Claude model names that contain `opus`, `sonnet`, or `haiku`. Codex uses the Admin `MODEL` default through `fcc-codex` unless a session requests a provider-prefixed slug directly.
 
-For example, you can route Opus to `nvidia_nim/moonshotai/kimi-k2.6`, Sonnet to `open_router/openrouter/free`, Haiku to `lmstudio/qwen3.5-coder`, and keep the fallback `MODEL` on `zai/glm-5.1`.
+For example, you can route Opus to `nvidia_nim/moonshotai/kimi-k2.6`, Sonnet to `open_router/openrouter/free`, Haiku to `lmstudio/qwen3.5-coder`, and keep the fallback `MODEL` on `zai/glm-5.2`.
 
 <a id="connect-your-client"></a>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.3.0"
+version = "3.3.1"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -102,7 +102,7 @@ uv run pytest smoke/product -n 0 -s --tb=short
 ```powershell
 $env:FCC_LIVE_SMOKE = "1"
 $env:FCC_SMOKE_TARGETS = "nvidia_nim_cli"
-$env:FCC_SMOKE_NIM_MODELS = "z-ai/glm-5.1,moonshotai/kimi-k2.6,minimaxai/minimax-m2.7,nvidia/nemotron-3-super-120b-a12b,deepseek-ai/deepseek-v4-pro,deepseek-ai/deepseek-v4-flash"
+$env:FCC_SMOKE_NIM_MODELS = "z-ai/glm-5.2,moonshotai/kimi-k2.6,minimaxai/minimax-m2.7,nvidia/nemotron-3-super-120b-a12b,deepseek-ai/deepseek-v4-pro,deepseek-ai/deepseek-v4-flash"
 uv run pytest smoke/product -n 0 -s --tb=short
 ```
 

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -57,7 +57,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "huggingface": "huggingface/openai/gpt-oss-120b:fastest",
     "cohere": "cohere/command-a-plus-05-2026",
     "github_models": "github_models/openai/gpt-4.1",
-    "zai": "zai/glm-5.1",
+    "zai": "zai/glm-5.2",
     "gemini": "gemini/models/gemini-3.1-flash-lite",
     "groq": "groq/llama-3.3-70b-versatile",
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
@@ -66,7 +66,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
 }
 
 NVIDIA_NIM_CLI_DEFAULT_MODELS: tuple[str, ...] = (
-    "z-ai/glm-5.1",
+    "z-ai/glm-5.2",
     "moonshotai/kimi-k2.6",
     "minimaxai/minimax-m2.7",
     "nvidia/nemotron-3-super-120b-a12b",

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -463,7 +463,7 @@ def test_admin_apply_omits_stale_zai_base_url(monkeypatch, tmp_path):
     env_file.write_text(
         "\n".join(
             [
-                "MODEL=zai/glm-5.1",
+                "MODEL=zai/glm-5.2",
                 "ZAI_API_KEY=zai-secret",
                 "ZAI_BASE_URL=https://custom.zai.invalid/v1",
                 "",
@@ -475,7 +475,7 @@ def test_admin_apply_omits_stale_zai_base_url(monkeypatch, tmp_path):
 
     response = _local_client(app).post(
         "/admin/api/config/apply",
-        json={"values": {"MODEL": "zai/glm-5.1"}},
+        json={"values": {"MODEL": "zai/glm-5.2"}},
     )
 
     assert response.status_code == 200

--- a/tests/contracts/test_nvidia_nim_cli_matrix.py
+++ b/tests/contracts/test_nvidia_nim_cli_matrix.py
@@ -45,8 +45,8 @@ def test_nvidia_nim_cli_matrix_report_shape_and_redaction(
         duration_s=1.25,
     )
     outcome = make_outcome(
-        model="z-ai/glm-5.1",
-        full_model="nvidia_nim/z-ai/glm-5.1",
+        model="z-ai/glm-5.2",
+        full_model="nvidia_nim/z-ai/glm-5.2",
         source="nvidia_nim_cli_default",
         feature="basic_text",
         marker="FCC_NIM_BASIC",
@@ -65,7 +65,7 @@ def test_nvidia_nim_cli_matrix_report_shape_and_redaction(
 
     assert path.name.startswith("nvidia-nim-cli-matrix-test-worker-")
     assert payload["target"] == "nvidia_nim_cli"
-    assert payload["models"] == ["nvidia_nim/z-ai/glm-5.1"]
+    assert payload["models"] == ["nvidia_nim/z-ai/glm-5.2"]
     saved = payload["outcomes"][0]
     assert saved["feature"] == "basic_text"
     assert saved["classification"] == "passed"
@@ -114,8 +114,8 @@ def test_cli_matrix_normalizes_missing_captured_output(
         tools="",
     )
     outcome = make_outcome(
-        model="z-ai/glm-5.1",
-        full_model="nvidia_nim/z-ai/glm-5.1",
+        model="z-ai/glm-5.2",
+        full_model="nvidia_nim/z-ai/glm-5.2",
         source="nvidia_nim_cli_default",
         feature="basic_text",
         marker="FCC_NIM_BASIC",
@@ -183,8 +183,8 @@ def test_nvidia_nim_cli_matrix_regression_detection(tmp_path: Path) -> None:
         duration_s=0.1,
     )
     outcome = make_outcome(
-        model="z-ai/glm-5.1",
-        full_model="nvidia_nim/z-ai/glm-5.1",
+        model="z-ai/glm-5.2",
+        full_model="nvidia_nim/z-ai/glm-5.2",
         source="nvidia_nim_cli_default",
         feature="basic_text",
         marker="FCC_NIM_BASIC",
@@ -195,7 +195,7 @@ def test_nvidia_nim_cli_matrix_regression_detection(tmp_path: Path) -> None:
 
     assert outcome.classification == "product_failure"
     assert regression_failures([outcome]) == [
-        "nvidia_nim/z-ai/glm-5.1 basic_text: product_failure"
+        "nvidia_nim/z-ai/glm-5.2 basic_text: product_failure"
     ]
 
 
@@ -210,8 +210,8 @@ def test_nvidia_nim_cli_matrix_model_feature_failures_do_not_regress(
         duration_s=0.1,
     )
     outcome = make_outcome(
-        model="z-ai/glm-5.1",
-        full_model="nvidia_nim/z-ai/glm-5.1",
+        model="z-ai/glm-5.2",
+        full_model="nvidia_nim/z-ai/glm-5.2",
         source="nvidia_nim_cli_default",
         feature="tool_use_roundtrip",
         marker="FCC_NIM_TOOL",
@@ -236,13 +236,13 @@ def test_nvidia_nim_cli_raw_payload_log_counts_as_proxy_request(
         duration_s=0.1,
     )
     outcome = make_outcome(
-        model="z-ai/glm-5.1",
-        full_model="nvidia_nim/z-ai/glm-5.1",
+        model="z-ai/glm-5.2",
+        full_model="nvidia_nim/z-ai/glm-5.2",
         source="nvidia_nim_cli_default",
         feature="subagent_task",
         marker="FCC_NIM_TASK",
         run=run,
-        log_delta="API_REQUEST: request_id=req_1 model=z-ai/glm-5.1 messages=2",
+        log_delta="API_REQUEST: request_id=req_1 model=z-ai/glm-5.2 messages=2",
         log_path=tmp_path / "server.log",
         requires_task=True,
     )
@@ -428,13 +428,13 @@ def test_nvidia_nim_cli_timeout_is_not_model_missing(
         timed_out=True,
     )
     outcome = make_outcome(
-        model="z-ai/glm-5.1",
-        full_model="nvidia_nim/z-ai/glm-5.1",
+        model="z-ai/glm-5.2",
+        full_model="nvidia_nim/z-ai/glm-5.2",
         source="nvidia_nim_cli_default",
         feature="tool_use_roundtrip",
         marker="FCC_NIM_TOOL",
         run=run,
-        log_delta="API_REQUEST: request_id=req_1 model=z-ai/glm-5.1 messages=2",
+        log_delta="API_REQUEST: request_id=req_1 model=z-ai/glm-5.2 messages=2",
         log_path=tmp_path / "server.log",
     )
 
@@ -452,14 +452,14 @@ def test_nvidia_nim_cli_success_beats_verbose_timeout_words(tmp_path: Path) -> N
         duration_s=0.1,
     )
     outcome = make_outcome(
-        model="z-ai/glm-5.1",
-        full_model="nvidia_nim/z-ai/glm-5.1",
+        model="z-ai/glm-5.2",
+        full_model="nvidia_nim/z-ai/glm-5.2",
         source="nvidia_nim_cli_default",
         feature="thinking",
         marker="FCC_NIM_THINK",
         run=run,
         log_delta=(
-            "API_REQUEST: request_id=req_1 model=z-ai/glm-5.1 messages=1 "
+            "API_REQUEST: request_id=req_1 model=z-ai/glm-5.2 messages=1 "
             "read_timeout_s=300"
         ),
         log_path=tmp_path / "server.log",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -420,17 +420,17 @@ def test_nvidia_nim_cli_default_models_are_normalized() -> None:
 def test_nvidia_nim_cli_models_override_and_append() -> None:
     refs = nvidia_nim_cli_model_refs(
         {
-            "FCC_SMOKE_NIM_MODELS": "z-ai/glm-5.1,nvidia_nim/custom/model",
-            "FCC_SMOKE_NIM_EXTRA_MODELS": "moonshotai/kimi-k2.6,z-ai/glm-5.1",
+            "FCC_SMOKE_NIM_MODELS": "z-ai/glm-5.2,nvidia_nim/custom/model",
+            "FCC_SMOKE_NIM_EXTRA_MODELS": "moonshotai/kimi-k2.6,z-ai/glm-5.2",
         }
     )
 
     assert tuple(refs) == (
-        "nvidia_nim/z-ai/glm-5.1",
+        "nvidia_nim/z-ai/glm-5.2",
         "nvidia_nim/custom/model",
         "nvidia_nim/moonshotai/kimi-k2.6",
     )
-    assert refs["nvidia_nim/z-ai/glm-5.1"] == "FCC_SMOKE_NIM_MODELS"
+    assert refs["nvidia_nim/z-ai/glm-5.2"] == "FCC_SMOKE_NIM_MODELS"
     assert refs["nvidia_nim/moonshotai/kimi-k2.6"] == ("FCC_SMOKE_NIM_EXTRA_MODELS")
 
 
@@ -457,7 +457,7 @@ def test_smoke_config_returns_nvidia_nim_cli_provider_models(monkeypatch) -> Non
     monkeypatch.delenv("FCC_SMOKE_NIM_EXTRA_MODELS", raising=False)
     config = _smoke_config(
         settings=_settings(
-            model="nvidia_nim/z-ai/glm-5.1",
+            model="nvidia_nim/z-ai/glm-5.2",
             nvidia_nim_api_key="nim-key",
             ollama_base_url="",
         )
@@ -466,7 +466,7 @@ def test_smoke_config_returns_nvidia_nim_cli_provider_models(monkeypatch) -> Non
     models = config.nvidia_nim_cli_models()
 
     assert models[0].provider == "nvidia_nim"
-    assert models[0].full_model == "nvidia_nim/z-ai/glm-5.1"
+    assert models[0].full_model == "nvidia_nim/z-ai/glm-5.2"
     assert models[0].source == "nvidia_nim_cli_default"
 
 

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -69,12 +69,12 @@ def test_model_list_headers(zai_provider):
 
 def test_build_request_body_native(zai_provider):
     request = MessagesRequest(
-        model="glm-5.1",
+        model="glm-5.2",
         max_tokens=100,
         messages=[Message(role="user", content="Hello")],
     )
     body = zai_provider._build_request_body(request)
-    assert body["model"] == "glm-5.1"
+    assert body["model"] == "glm-5.2"
     assert body["stream"] is True
     assert body["max_tokens"] == 100
 

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Z.ai and NVIDIA NIM smoke defaults still referenced GLM 5.1, which has reached end of life and can fail live verification runs.

## Changes

| Before | After |
| --- | --- |
| Z.ai README examples pointed users at `zai/glm-5.1`. | Z.ai README examples point users at `zai/glm-5.2`. |
| Smoke defaults and NIM matrix fixtures used `z-ai/glm-5.1`. | Smoke defaults and NIM matrix fixtures use `z-ai/glm-5.2`. |
| Package metadata stayed at `3.3.0`. | Package metadata and lockfile move to `3.3.1`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates GLM model references from 5.1 to 5.2. The main changes are:

- Z.ai README examples now use `zai/glm-5.2`.
- Smoke defaults and NVIDIA NIM matrix fixtures now use `z-ai/glm-5.2`.
- Package metadata and lockfile version move to `3.3.1`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrow model-reference and package-version updates, and the reviewed docs, constants, tests, and lockfile are consistent.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification for the pull request.
- T-Rex did not upload local artifact references alongside the verification results.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates Z.ai documentation examples and tier-routing fallback example from `glm-5.1` to `glm-5.2`; no issues found. |
| pyproject.toml | Bumps package version from `3.3.0` to `3.3.1`; no issues found. |
| smoke/README.md | Updates the NVIDIA NIM live smoke command example to use `z-ai/glm-5.2`; no issues found. |
| smoke/lib/config.py | Updates Z.ai and NVIDIA NIM smoke default model constants to GLM 5.2; no issues found. |
| tests/api/test_admin.py | Adjusts Z.ai admin apply regression fixture to the new GLM 5.2 model slug; no issues found. |
| tests/contracts/test_nvidia_nim_cli_matrix.py | Updates NVIDIA NIM CLI matrix report fixtures and assertions to `z-ai/glm-5.2`; no issues found. |
| tests/contracts/test_smoke_config.py | Updates smoke config contract tests for GLM 5.2 default and override behavior; no issues found. |
| tests/providers/test_zai.py | Updates Z.ai request-body unit test model fixture to `glm-5.2`; no issues found. |
| uv.lock | Synchronizes the editable package version to `3.3.1`; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Update GLM 5.2 model references"](https://github.com/alishahryar1/free-claude-code/commit/b77b6db04662fd320a49466c76e4297fc6a09b1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41968762)</sub>

<!-- /greptile_comment -->