### PR TITLE
Disable Hugging Face reasoning replay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -379,7 +379,8 @@ Gateway providers such as Vercel AI Gateway, Hugging Face, Cohere, and GitHub
 Models stay thin when their documented OpenAI-compatible Chat Completions
 behavior matches shared transport policy. Provider-specific gateway quirks, such
 as Cohere's supported `reasoning_effort` values, GitHub's API headers/catalog
-filtering, and unsupported compatibility fields, stay in that provider package.
+filtering, Hugging Face's disabled prior reasoning replay, and unsupported
+compatibility fields, stay in that provider package.
 
 ### Adding A Provider
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Create a Hugging Face token with Inference Providers permission at [huggingface.
 
 Set `MODEL` to a Hugging Face model slug such as `huggingface/openai/gpt-oss-120b:fastest`, `huggingface/Qwen/Qwen3-Coder-480B-A35B-Instruct:fastest`, or `huggingface/deepseek-ai/DeepSeek-R1:fastest`.
 
-Hugging Face routes through the OpenAI-compatible router at `https://router.huggingface.co/v1`. FCC uses the shared OpenAI-chat transport and preserves request `extra_body` for Hugging Face provider options.
+Hugging Face routes through the OpenAI-compatible router at `https://router.huggingface.co/v1`. FCC uses the shared OpenAI-chat transport, preserves request `extra_body` for Hugging Face provider options, and does not replay prior hidden reasoning into Chat Completions because that request field is not documented by Hugging Face. New reasoning emitted by the upstream is still shown as Claude thinking.
 
 If your existing repo `.env` or `~/.fcc/.env` uses the old voice setting `HF_TOKEN`, `fcc-server`/`fcc-init` renames it to `HUGGINGFACE_API_KEY`. Explicit `FCC_ENV_FILE` files are not rewritten automatically; rename the key there manually.
 

--- a/providers/huggingface/client.py
+++ b/providers/huggingface/client.py
@@ -1,19 +1,14 @@
 """Hugging Face Inference Providers implementation."""
 
+from copy import deepcopy
 from typing import Any
 
+from core.anthropic import ReasoningReplayMode, build_base_request_body
+from core.anthropic.conversion import OpenAIConversionError
 from providers.base import ProviderConfig
 from providers.defaults import HUGGINGFACE_DEFAULT_BASE
-from providers.transports.openai_chat import (
-    OpenAIChatRequestPolicy,
-    OpenAIChatTransport,
-    build_openai_chat_request_body,
-)
-
-_REQUEST_POLICY = OpenAIChatRequestPolicy(
-    provider_name="HUGGINGFACE",
-    include_extra_body=True,
-)
+from providers.exceptions import InvalidRequestError
+from providers.transports.openai_chat import OpenAIChatTransport
 
 
 class HuggingFaceProvider(OpenAIChatTransport):
@@ -30,8 +25,23 @@ class HuggingFaceProvider(OpenAIChatTransport):
     def _build_request_body(
         self, request: Any, thinking_enabled: bool | None = None
     ) -> dict:
-        return build_openai_chat_request_body(
-            request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
-            policy=_REQUEST_POLICY,
-        )
+        """Build a Hugging Face Chat Completions body.
+
+        Hugging Face's router documents reasoning controls for supported models
+        but not prior-turn reasoning replay through ``messages[].reasoning_content``.
+        Keep replay disabled while still allowing new streamed reasoning output
+        to map back to Claude thinking in the shared OpenAI-chat stream adapter.
+        """
+        try:
+            body = build_base_request_body(
+                request,
+                reasoning_replay=ReasoningReplayMode.DISABLED,
+            )
+        except OpenAIConversionError as exc:
+            raise InvalidRequestError(str(exc)) from exc
+
+        request_extra = getattr(request, "extra_body", None)
+        if isinstance(request_extra, dict) and request_extra:
+            body["extra_body"] = deepcopy(request_extra)
+
+        return body

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.4.5"
+version = "3.4.6"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/providers/test_huggingface.py
+++ b/tests/providers/test_huggingface.py
@@ -5,14 +5,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from core.anthropic import ReasoningReplayMode
 from providers.base import ProviderConfig
 from providers.huggingface import HUGGINGFACE_DEFAULT_BASE, HuggingFaceProvider
 
 
 class MockMessage:
-    def __init__(self, role, content):
+    def __init__(self, role, content, reasoning_content=None):
         self.role = role
         self.content = content
+        self.reasoning_content = reasoning_content
+
+
+class MockBlock:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 
 class MockRequest:
@@ -89,9 +97,7 @@ def test_init_strips_trailing_slash(huggingface_config):
 
 
 def test_build_request_body_keeps_max_tokens(huggingface_provider):
-    with patch(
-        "providers.transports.openai_chat.request_policy.build_base_request_body"
-    ) as mock_convert:
+    with patch("providers.huggingface.client.build_base_request_body") as mock_convert:
         mock_convert.return_value = {
             "model": "openai/gpt-oss-120b:fastest",
             "messages": [{"role": "user", "name": "alice", "content": "hi"}],
@@ -100,17 +106,68 @@ def test_build_request_body_keeps_max_tokens(huggingface_provider):
 
         body = huggingface_provider._build_request_body(MockRequest())
 
+    mock_convert.assert_called_once()
+    assert (
+        mock_convert.call_args.kwargs["reasoning_replay"]
+        is ReasoningReplayMode.DISABLED
+    )
     assert body["messages"][0].get("name") == "alice"
     assert body["max_tokens"] == 42
     assert "max_completion_tokens" not in body
 
 
 def test_build_request_body_preserves_caller_extra_body(huggingface_provider):
-    req = MockRequest(extra_body={"provider": "auto", "bill_to": "my-org"})
+    extra_body = {"provider": "auto", "routing": {"bill_to": "my-org"}}
+    req = MockRequest(extra_body=extra_body)
 
     body = huggingface_provider._build_request_body(req)
 
-    assert body["extra_body"] == {"provider": "auto", "bill_to": "my-org"}
+    assert body["extra_body"] == extra_body
+    assert body["extra_body"] is not extra_body
+    assert body["extra_body"]["routing"] is not extra_body["routing"]
+
+
+def test_build_request_body_does_not_replay_prior_thinking_blocks(
+    huggingface_provider,
+):
+    req = MockRequest(
+        system=None,
+        messages=[
+            MockMessage(
+                "assistant",
+                [
+                    MockBlock(type="thinking", thinking="hidden prior thought"),
+                    MockBlock(type="text", text="visible answer"),
+                ],
+            )
+        ],
+    )
+
+    body = huggingface_provider._build_request_body(req)
+
+    assert body["messages"] == [{"role": "assistant", "content": "visible answer"}]
+    assert "reasoning_content" not in body["messages"][0]
+    assert "hidden prior thought" not in str(body)
+
+
+def test_build_request_body_does_not_replay_top_level_reasoning_content(
+    huggingface_provider,
+):
+    req = MockRequest(
+        system=None,
+        messages=[
+            MockMessage(
+                "assistant",
+                "visible answer",
+                reasoning_content="hidden prior reasoning",
+            )
+        ],
+    )
+
+    body = huggingface_provider._build_request_body(req)
+
+    assert body["messages"] == [{"role": "assistant", "content": "visible answer"}]
+    assert "hidden prior reasoning" not in str(body)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.4.5"
+version = "3.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Hugging Face Chat Completions does not document replaying prior hidden reasoning through `messages[].reasoning_content`. FCC could send that undocumented field when Claude or Codex history contained thinking.

## Changes

| Before | After |
| --- | --- |
| Hugging Face used the shared OpenAI-chat request builder with reasoning replay enabled when thinking was enabled. | Hugging Face builds requests with reasoning replay disabled at the provider boundary. |
| Prior assistant thinking could be forwarded as `messages[].reasoning_content`. | Prior assistant thinking is omitted from Hugging Face Chat Completions requests. |
| New upstream reasoning output still flowed through the shared stream adapter. | New upstream reasoning output still flows through the shared stream adapter. |
| Docs grouped Hugging Face with fully shared gateway behavior. | Docs call out Hugging Face's provider-owned reasoning replay exception. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables Hugging Face replay of prior hidden reasoning while preserving new streamed reasoning output. The main changes are:

- Hugging Face request bodies now use `ReasoningReplayMode.DISABLED` at the provider boundary.
- Caller-provided `extra_body` is still deep-copied into Hugging Face requests.
- Tests cover omitted thinking blocks, omitted top-level `reasoning_content`, and nested `extra_body` preservation.
- README and architecture docs describe the Hugging Face reasoning replay exception.
- Package metadata is bumped from `3.4.5` to `3.4.6`.
</details>

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge with minimal risk.

No issues were identified. The change is narrowly scoped to Hugging Face request conversion, existing `extra_body` behavior is preserved, tests cover both prior reasoning replay paths and nested `extra_body` copying, and the required patch version and lockfile updates are included.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change payload construction state for HuggingFace reasoning, confirming the payload was not sent in offline pre-change simulation and that the reasoning content key was present.
- Observed the post-change payload construction state, confirming the payload was not sent (offline payload construction only) and that the contains\_reasoning\_content\_key became false and contains\_hidden\_reasoning\_strings are false, with visible content preserved.
- Verified the test run results showing Python 3.14 via uv run and that all focused HuggingFace tests passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/13493696/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| providers/huggingface/client.py | Builds Hugging Face request bodies directly with `ReasoningReplayMode.DISABLED` and preserves caller `extra_body` via deep copy. |
| tests/providers/test_huggingface.py | Adds coverage that Hugging Face disables both block-based and top-level reasoning replay and preserves nested `extra_body` safely. |
| README.md | Updates Hugging Face usage docs to describe disabled hidden reasoning replay while preserving streamed reasoning output. |
| ARCHITECTURE.md | Documents Hugging Face as a provider-owned exception for disabled prior reasoning replay. |
| pyproject.toml | Bumps package patch version for the production provider behavior change. |
| uv.lock | Synchronizes the editable package version with `pyproject.toml`. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Anthropic request
participant HF as HuggingFaceProvider
participant Conv as build_base_request_body
participant Router as HF Chat Completions
participant Stream as OpenAIChatStreamAdapter

Client->>HF: stream_response(request, thinking_enabled)
HF->>Conv: build with ReasoningReplayMode.DISABLED
Conv-->>HF: OpenAI chat body without messages[].reasoning_content
HF->>HF: deep-copy request.extra_body into body
HF->>Router: "chat.completions.create(..., stream=True)"
Router-->>Stream: streamed deltas including new reasoning_content
Stream-->>Client: Claude SSE thinking/text events
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Anthropic request
participant HF as HuggingFaceProvider
participant Conv as build_base_request_body
participant Router as HF Chat Completions
participant Stream as OpenAIChatStreamAdapter

Client->>HF: stream_response(request, thinking_enabled)
HF->>Conv: build with ReasoningReplayMode.DISABLED
Conv-->>HF: OpenAI chat body without messages[].reasoning_content
HF->>HF: deep-copy request.extra_body into body
HF->>Router: "chat.completions.create(..., stream=True)"
Router-->>Stream: streamed deltas including new reasoning_content
Stream-->>Client: Claude SSE thinking/text events
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Disable Hugging Face reasoning replay"](https://github.com/alishahryar1/free-claude-code/commit/5b01e381623dda69287162b7c127f3122743882e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42261390)</sub>

<!-- /greptile_comment -->