### PR TITLE
feat: added flags to give user the option to install codex OR claude code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.4.8"
+version = "3.4.9"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,6 @@
 param(
+    [switch] $ClaudeOnly,
+    [switch] $CodexOnly,
     [switch] $VoiceNim,
     [switch] $VoiceLocal,
     [switch] $VoiceAll,
@@ -24,6 +26,8 @@ Usage: install.ps1 [options]
 Installs Claude Code and Codex if missing, installs or updates uv, Python 3.14.0, and Free Claude Code.
 
 Options:
+  -ClaudeOnly            Install only Claude Code (skip Codex).
+  -CodexOnly             Install only Codex (skip Claude Code).
   -VoiceNim              Install NVIDIA NIM voice transcription support.
   -VoiceLocal            Install local Whisper voice transcription support.
   -VoiceAll              Install all voice transcription backends.
@@ -395,11 +399,16 @@ if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not ($VoiceLocal -
     throw "-TorchBackend requires -VoiceLocal or -VoiceAll."
 }
 
-Write-Step "Installing Claude Code if missing"
-Install-ClaudeIfMissing
+# ponytail: if both passed, skips both. simple.
+if (-not $CodexOnly) {
+    Write-Step "Installing Claude Code if missing"
+    Install-ClaudeIfMissing
+}
 
-Write-Step "Installing Codex if missing"
-Install-CodexIfMissing
+if (-not $ClaudeOnly) {
+    Write-Step "Installing Codex if missing"
+    Install-CodexIfMissing
+}
 
 Write-Step "Installing uv if missing, updating if present"
 Install-OrUpdateUv

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -399,7 +399,10 @@ if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not ($VoiceLocal -
     throw "-TorchBackend requires -VoiceLocal or -VoiceAll."
 }
 
-# ponytail: if both passed, skips both. simple.
+if ($ClaudeOnly -and $CodexOnly) {
+    throw "-ClaudeOnly and -CodexOnly are mutually exclusive. Omit both flags to install everything."
+}
+
 if (-not $CodexOnly) {
     Write-Step "Installing Claude Code if missing"
     Install-ClaudeIfMissing

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,8 @@ voice_nim=0
 voice_local=0
 voice_all=0
 torch_backend=""
+install_claude=1
+install_codex=1
 
 show_usage() {
     cat <<'USAGE'
@@ -19,6 +21,8 @@ Usage: install.sh [options]
 Installs Claude Code and Codex if missing, installs or updates uv, Python 3.14.0, and Free Claude Code.
 
 Options:
+  --claude-only            Install only Claude Code (skip Codex).
+  --codex-only             Install only Codex (skip Claude Code).
   --voice-nim              Install NVIDIA NIM voice transcription support.
   --voice-local            Install local Whisper voice transcription support.
   --voice-all              Install all voice transcription backends.
@@ -260,6 +264,12 @@ parse_args() {
                 torch_backend="${1#*=}"
                 [ -n "$torch_backend" ] || fail "--torch-backend requires a non-empty value."
                 ;;
+            --claude-only)
+                install_codex=0
+                ;;
+            --codex-only)
+                install_claude=0
+                ;;
             --dry-run)
                 dry_run=1
                 ;;
@@ -325,11 +335,15 @@ install_free_claude_code() {
 parse_args "$@"
 validate_args
 
-step "Installing Claude Code if missing"
-install_claude_if_missing
+if [ "$install_claude" -eq 1 ]; then
+    step "Installing Claude Code if missing"
+    install_claude_if_missing
+fi
 
-step "Installing Codex if missing"
-install_codex_if_missing
+if [ "$install_codex" -eq 1 ]; then
+    step "Installing Codex if missing"
+    install_codex_if_missing
+fi
 
 step "Installing uv if missing, updating if present"
 install_or_update_uv

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -287,6 +287,10 @@ parse_args() {
 }
 
 validate_args() {
+    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ]; then
+        fail "--claude-only and --codex-only are mutually exclusive. Omit both flags to install everything."
+    fi
+
     include_local=$voice_local
 
     if [ "$voice_all" -eq 1 ]; then

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -41,7 +41,7 @@ def test_install_sh_installs_claude_only_when_missing() -> None:
     assert "run npm install -g @anthropic-ai/claude-code" in body
     assert body.index("command -v claude") < body.index("run npm install")
     assert body.index("return 0") < body.index("run npm install")
-    assert 'step "Installing Claude Code if missing"\ninstall_claude_if_missing' in main
+    assert 'if [ "$install_claude" -eq 1 ]; then\n    step "Installing Claude Code if missing"\n    install_claude_if_missing\nfi' in main
     assert "npm install -g @anthropic-ai/claude-code" not in main
 
 
@@ -56,7 +56,7 @@ def test_install_sh_installs_codex_only_when_missing() -> None:
     assert "run npm install -g @openai/codex" in body
     assert body.index("command -v codex") < body.index("run npm install")
     assert body.index("return 0") < body.index("run npm install")
-    assert 'step "Installing Codex if missing"\ninstall_codex_if_missing' in main
+    assert 'if [ "$install_codex" -eq 1 ]; then\n    step "Installing Codex if missing"\n    install_codex_if_missing\nfi' in main
     assert "npm install -g @openai/codex" not in main
     assert "fcc-claude" in text
     assert "fcc-codex" in text
@@ -125,7 +125,7 @@ def test_install_ps1_installs_claude_only_when_missing() -> None:
     assert body.index("Get-Command claude") < body.index("Invoke-InstallCommand")
     assert body.index("return") < body.index("Invoke-InstallCommand")
     assert (
-        'Write-Step "Installing Claude Code if missing"\nInstall-ClaudeIfMissing'
+        'if (-not $CodexOnly) {\n    Write-Step "Installing Claude Code if missing"\n    Install-ClaudeIfMissing\n}'
         in text
     )
 
@@ -143,7 +143,7 @@ def test_install_ps1_installs_codex_only_when_missing() -> None:
     ) in body
     assert body.index("Get-Command codex") < body.index("Invoke-InstallCommand")
     assert body.index("return") < body.index("Invoke-InstallCommand")
-    assert 'Write-Step "Installing Codex if missing"\nInstall-CodexIfMissing' in text
+    assert 'if (-not $ClaudeOnly) {\n    Write-Step "Installing Codex if missing"\n    Install-CodexIfMissing\n}' in text
     assert "fcc-claude" in text
     assert "fcc-codex" in text
 

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.0"
+version = "3.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -350,34 +350,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.4.8"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds installer flags for choosing which AI client to install. The main changes are:

- Bash installer support for `--claude-only` and `--codex-only`.
- PowerShell installer support for `-ClaudeOnly` and `-CodexOnly`.
- Mutual-exclusion checks when both install-selection flags are passed.
- Updated installer tests for the guarded install blocks.
- Updated lockfile platform markers for NVIDIA optional dependencies.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The bash and PowerShell installers expose matching selection flags, conflicting selection flags stop before install steps run, and the updated tests match the guarded installer call shape.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex validated the installer CLI by running the default dry-run and the Claude-only and Codex-only variants, and confirmed the side-by-side evidence and the mutual-exclusion error when both specialized flags are used.
- T-Rex captured individual installer command transcripts for each requested dry-run invocation to preserve command-level evidence.
- T-Rex reviewed the installer tests and confirmed the focused installer test file completed with exit code 0 and 10 passed, 1 skipped.
- T-Rex noted a PowerShell blocker indicating the executable was not found on PATH.

<a href="https://app.greptile.com/trex/runs/13641573/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/install.sh | Adds install-selection flags, rejects conflicting flag combinations, and guards Claude/Codex install calls. |
| scripts/install.ps1 | Adds matching PowerShell install-selection switches, validation, and guarded install calls. |
| tests/scripts/test_installers.py | Updates static installer assertions to match the new guarded call shape. |
| uv.lock | Updates platform markers for NVIDIA optional dependency entries. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/choose-pla..."](https://github.com/alishahryar1/free-claude-code/commit/118cd5223331191fc7fec3a73975ac50880d8fb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42463206)</sub>

<!-- /greptile_comment -->