### PR TITLE
Pin managed messaging to Opus tier

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -545,11 +545,14 @@ and native Anthropic Messages transports may receive them.
 Discord and Telegram messaging. Managed task invocations set
 `ANTHROPIC_API_URL`, `ANTHROPIC_BASE_URL`, gateway model discovery,
 non-interactive terminal settings, optional `--resume`, optional
-`--fork-session`, and `--output-format stream-json`. The managed session parser
-extracts persistent Claude session IDs and yields Claude stream-json events to
-the messaging event parser. Managed Claude also owns subprocess stderr
-diagnostic classification so known benign Claude Code notices do not become
-messaging task errors, while unknown stderr remains fatal.
+`--fork-session`, `--model opus`, and `--output-format stream-json`. Messaging
+pins this Claude tier alias so phone sessions route through `MODEL_OPUS` or the
+`MODEL` fallback instead of inheriting a user's interactive `/model` picker
+state. The managed session parser extracts persistent Claude session IDs and
+yields Claude stream-json events to the messaging event parser. Managed Claude
+also owns subprocess stderr diagnostic classification so known benign Claude
+Code notices do not become messaging task errors, while unknown stderr remains
+fatal.
 
 Codex is supported through `fcc-codex` and Codex extensions. FCC does not keep an
 internal managed-Codex session runner because no user-facing messaging setting

--- a/cli/managed/claude.py
+++ b/cli/managed/claude.py
@@ -13,6 +13,8 @@ from cli.claude_env import (
     claude_auth_token,
 )
 
+MANAGED_CLAUDE_MODEL_TIER = "opus"
+
 
 @dataclass(frozen=True, slots=True)
 class ManagedClaudeTaskRequest:
@@ -89,6 +91,7 @@ def build_managed_claude_invocation(
             "prompt": request.prompt,
             "cwd": config.workspace_path,
             "claude_binary": config.claude_bin,
+            "managed_model_tier": MANAGED_CLAUDE_MODEL_TIER,
             "cli_argv": cmd,
         },
     )
@@ -134,6 +137,8 @@ def build_managed_claude_command(
         if fork_session:
             cmd.append("--fork-session")
         cmd += [
+            "--model",
+            MANAGED_CLAUDE_MODEL_TIER,
             "-p",
             prompt,
             "--output-format",
@@ -144,6 +149,8 @@ def build_managed_claude_command(
     else:
         cmd = [
             claude_bin,
+            "--model",
+            MANAGED_CLAUDE_MODEL_TIER,
             "-p",
             prompt,
             "--output-format",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.4.9"
+version = "3.4.10"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/cli/test_managed_claude.py
+++ b/tests/cli/test_managed_claude.py
@@ -1,6 +1,7 @@
 import os
 
 from cli.managed.claude import (
+    MANAGED_CLAUDE_MODEL_TIER,
     ManagedClaudeConfig,
     ManagedClaudeParseState,
     ManagedClaudeTaskRequest,
@@ -51,7 +52,12 @@ def test_managed_claude_builds_new_task_command_and_env() -> None:
         base_env={"PATH": "keep", "ANTHROPIC_API_KEY": "official"},
     )
 
-    assert invocation.argv[:2] == ("claude", "-p")
+    assert invocation.argv[:4] == (
+        "claude",
+        "--model",
+        MANAGED_CLAUDE_MODEL_TIER,
+        "-p",
+    )
     assert "hello" in invocation.argv
     assert "--output-format" in invocation.argv
     assert "stream-json" in invocation.argv
@@ -65,6 +71,7 @@ def test_managed_claude_builds_new_task_command_and_env() -> None:
     assert "ANTHROPIC_API_KEY" not in invocation.env
     assert invocation.trace_metadata["client_cli_id"] == "claude"
     assert invocation.trace_metadata["claude_binary"] == "claude"
+    assert invocation.trace_metadata["managed_model_tier"] == MANAGED_CLAUDE_MODEL_TIER
 
 
 def test_managed_claude_builds_resume_and_fork_commands() -> None:
@@ -81,9 +88,24 @@ def test_managed_claude_builds_resume_and_fork_commands() -> None:
         base_env={},
     )
 
-    assert resume.argv[:3] == ("claude", "--resume", "sess_1")
+    assert resume.argv[:6] == (
+        "claude",
+        "--resume",
+        "sess_1",
+        "--model",
+        MANAGED_CLAUDE_MODEL_TIER,
+        "-p",
+    )
     assert "--fork-session" not in resume.argv
-    assert fork.argv[:3] == ("claude", "--resume", "sess_1")
+    assert fork.argv[:7] == (
+        "claude",
+        "--resume",
+        "sess_1",
+        "--fork-session",
+        "--model",
+        MANAGED_CLAUDE_MODEL_TIER,
+        "-p",
+    )
     assert "--fork-session" in fork.argv
 
 

--- a/tests/contracts/test_import_boundaries.py
+++ b/tests/contracts/test_import_boundaries.py
@@ -608,6 +608,11 @@ def test_cli_surfaces_are_explicit_launchers_and_managed_claude() -> None:
     claude_env_text = (cli_root / "claude_env.py").read_text(encoding="utf-8")
     assert 'CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"' in claude_env_text
     assert 'CLAUDE_NO_AUTH_SENTINEL = "fcc-no-auth"' in claude_env_text
+    managed_claude_text = (cli_root / "managed" / "claude.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'MANAGED_CLAUDE_MODEL_TIER = "opus"' in managed_claude_text
+    assert '"managed_model_tier": MANAGED_CLAUDE_MODEL_TIER' in managed_claude_text
     for path in {
         cli_root / "launchers" / "claude.py",
         cli_root / "managed" / "claude.py",

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.4.9"
+version = "3.4.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Phone and messaging sessions inherited Claude Code's globally persisted `/model` picker selection. A direct provider model picked in an interactive CLI could bypass Admin `MODEL_OPUS` and `MODEL` routing for managed messaging.

## Changes

| Before | After |
| --- | --- |
| Managed messaging launched Claude Code without an explicit model. | Managed messaging launches Claude Code with `--model opus`. |
| Phone sessions could inherit `~/.claude/settings.json` model state. | Phone sessions route through the Opus tier and FCC Admin overrides. |
| Managed Claude traces did not identify the pinned tier. | Managed Claude traces include `managed_model_tier=opus`. |
| Architecture docs described managed Claude command flags without model ownership. | Architecture docs describe messaging tier pinning and fallback routing. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR pins managed Claude messaging sessions to the Opus tier. The main changes are:

- Adds `MANAGED_CLAUDE_MODEL_TIER = "opus"` for managed Claude invocations.
- Passes `--model opus` for new, resumed, and forked managed Claude commands.
- Records `managed_model_tier` in trace metadata.
- Updates tests, contracts, architecture docs, and package version files.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to managed Claude command construction and trace metadata. Tests and contract checks cover the new `--model opus` behavior. Version files were updated consistently with the production change.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The general contract validation proof verifies that the focused Claude Pytest suite passed with exit code 0 and that the runtime invocation probe recorded model\_values as \["opus"\] and trace\_metadata.managed\_model\_tier as "opus" for new, resume, and fork runs; the probe source is provided for inspection.

<a href="https://app.greptile.com/trex/runs/13639488/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| cli/managed/claude.py | Adds the managed Claude model tier constant, passes `--model opus`, and includes the tier in trace metadata. |
| tests/cli/test_managed_claude.py | Updates command and trace metadata tests for the pinned Opus tier. |
| tests/contracts/test_import_boundaries.py | Adds contract checks for the managed Claude model tier constant and metadata wiring. |
| ARCHITECTURE.md | Documents managed messaging pinning to `--model opus` and fallback routing through admin model settings. |
| pyproject.toml | Bumps the package version from `3.4.9` to `3.4.10`. |
| uv.lock | Updates the locked editable package version to `3.4.10`. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Messaging as Discord/Telegram managed messaging
participant Builder as build_managed_claude_invocation
participant CLI as Claude Code CLI
participant Proxy as FCC Anthropic proxy
participant Router as ModelRouter
participant Provider as Configured provider

Messaging->>Builder: ManagedClaudeTaskRequest(prompt, session_id?)
Builder->>CLI: claude [--resume id] [--fork-session] --model opus -p prompt --output-format stream-json
Builder->>CLI: "env ANTHROPIC_API_URL / BASE_URL -> local proxy"
CLI->>Proxy: Messages request with model "opus"
Proxy->>Router: resolve("opus")
Router->>Router: use MODEL_OPUS when set, else MODEL
Router->>Provider: forward resolved provider/model request
Provider-->>Proxy: stream response
Proxy-->>CLI: stream-json events
CLI-->>Messaging: parsed session_info + Claude events
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Messaging as Discord/Telegram managed messaging
participant Builder as build_managed_claude_invocation
participant CLI as Claude Code CLI
participant Proxy as FCC Anthropic proxy
participant Router as ModelRouter
participant Provider as Configured provider

Messaging->>Builder: ManagedClaudeTaskRequest(prompt, session_id?)
Builder->>CLI: claude [--resume id] [--fork-session] --model opus -p prompt --output-format stream-json
Builder->>CLI: "env ANTHROPIC_API_URL / BASE_URL -> local proxy"
CLI->>Proxy: Messages request with model "opus"
Proxy->>Router: resolve("opus")
Router->>Router: use MODEL_OPUS when set, else MODEL
Router->>Provider: forward resolved provider/model request
Provider-->>Proxy: stream response
Proxy-->>CLI: stream-json events
CLI-->>Messaging: parsed session_info + Claude events
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Pin managed messaging to opus tier"](https://github.com/alishahryar1/free-claude-code/commit/c628423202d8c280f01faaeb0d969477be9fcbf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42597361)</sub>

<!-- /greptile_comment -->