### PR TITLE
Fix MiniMax Admin UI API description

### DIFF
--- a/api/admin_config/provider_manifest.py
+++ b/api/admin_config/provider_manifest.py
@@ -66,8 +66,8 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
     "MINIMAX_API_KEY": {
         "label": "MiniMax API Key",
         "description": (
-            "MiniMax API key for the Anthropic-compatible Messages API at "
-            "api.minimax.io/anthropic/v1."
+            "MiniMax API key for the OpenAI-compatible Chat Completions API at "
+            "api.minimax.io/v1."
         ),
     },
     "CLOUDFLARE_API_TOKEN": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.4.11"
+version = "3.4.12"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.4.11"
+version = "3.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Admin UI still described MiniMax as an Anthropic Messages provider after MiniMax moved to the OpenAI-chat transport. The provider help text pointed users at the wrong upstream API shape.

## Changes

| Before | After |
| --- | --- |
| MiniMax admin help referenced the Anthropic-compatible Messages API. | MiniMax admin help references the OpenAI-compatible Chat Completions API. |
| MiniMax admin help pointed at `api.minimax.io/anthropic/v1`. | MiniMax admin help points at `api.minimax.io/v1`. |
| Package metadata stayed at `3.4.11`. | Package metadata is bumped to `3.4.12`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the MiniMax Admin UI provider help text and bumps package metadata. The main changes are:

- MiniMax help now references the OpenAI-compatible Chat Completions API.
- MiniMax help now points users to `api.minimax.io/v1`.
- Project metadata and the lockfile are bumped from `3.4.11` to `3.4.12`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to Admin UI help text and a consistent patch version bump. No functional, security, or packaging issues were identified in the changed files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reproduced the pre-proof verification failure by checking out HEAD^ for api/admin\_config/provider\_manifest.py and running the verification script, which showed the old Anthropic-compatible Messages API description.
- T-Rex restored HEAD, re-ran the verification, and confirmed the script passed with the Admin API route returning MINIMAX\_API\_KEY for the OpenAI-compatible Chat Completions API at api.minimax.io/v1.

<a href="https://app.greptile.com/trex/runs/13651440/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/admin_config/provider_manifest.py | Updates the MiniMax Admin UI help text to describe the OpenAI-compatible Chat Completions endpoint; no issues found. |
| pyproject.toml | Bumps the project patch version from `3.4.11` to `3.4.12` in line with the production-file change. |
| uv.lock | Synchronizes the editable package version in the lockfile with `pyproject.toml`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix MiniMax admin API description"](https://github.com/alishahryar1/free-claude-code/commit/2ae33eae15cd115b893415ce17ae004e31bde71c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42622463)</sub>

<!-- /greptile_comment -->