### PR TITLE
Fix #1020: guarantee terminal SSE frame when egress stream raises

### DIFF
--- a/api/handlers/responses.py
+++ b/api/handlers/responses.py
@@ -13,7 +13,10 @@ from api.request_errors import (
     log_unexpected_api_exception,
     require_non_empty_messages,
 )
-from api.response_streams import openai_responses_sse_streaming_response
+from api.response_streams import (
+    EGRESS_STREAM_INTERRUPTED_MESSAGE,
+    openai_responses_sse_streaming_response,
+)
 from config.settings import Settings
 from core.anthropic import get_user_facing_error_message
 from core.openai_responses import OpenAIResponsesAdapter
@@ -78,6 +81,9 @@ class ResponsesHandler:
                     request_payload,
                 ),
                 headers=self._responses_adapter.sse_headers,
+                emit_error_frame=lambda: self._responses_adapter.egress_error_frame(
+                    EGRESS_STREAM_INTERRUPTED_MESSAGE
+                ),
             )
         except OpenAIResponsesAdapter.ConversionError as exc:
             invalid_request = InvalidRequestError(str(exc))

--- a/api/response_streams.py
+++ b/api/response_streams.py
@@ -1,16 +1,84 @@
 """FastAPI streaming response wrappers for public API wire formats."""
 
-from collections.abc import AsyncIterator, Mapping
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 
 from fastapi.responses import StreamingResponse
 
-from core.anthropic.streaming import ANTHROPIC_SSE_RESPONSE_HEADERS
+from core.anthropic.streaming import (
+    ANTHROPIC_SSE_RESPONSE_HEADERS,
+    anthropic_terminal_error_frame,
+)
+from core.trace import trace_event
+
+EGRESS_STREAM_INTERRUPTED_MESSAGE = (
+    "The upstream response stream ended unexpectedly; the request could not be "
+    "completed."
+)
+
+
+def _trace_egress_failure(exc: BaseException) -> None:
+    trace_event(
+        stage="egress",
+        event="api.response.egress_error_frame_emitted",
+        source="api",
+        exc_type=type(exc).__name__,
+    )
+
+
+async def _stream_with_terminal_error_frame(
+    body: AsyncIterator[str],
+    *,
+    emit_error_frame: Callable[[], str],
+) -> AsyncGenerator[str]:
+    """Yield ``body`` unchanged, guaranteeing a terminal SSE frame on failure.
+
+    A pure passthrough on success: each upstream chunk is yielded verbatim. When
+    the body raises after the streaming response has already committed HTTP 200
+    and headers (so the error can no longer be surfaced as a non-200 response),
+    emit exactly one protocol-specific terminal error frame via
+    ``emit_error_frame`` so the client observes a parseable terminal event
+    instead of a truncated or empty body (issue #1020), then re-raise so the
+    server-side traceback and the request-correlated
+    ``api.response.stream_interrupted`` trace still fire.
+
+    ``GeneratorExit`` and ``asyncio.CancelledError`` (the client has
+    disconnected or the task was cancelled) are re-raised without writing: the
+    frame would either fail to flush or loop while nothing is reading.
+    ``BaseExceptionGroup`` is matched before ``Exception`` (it subclasses
+    ``BaseException``, not ``Exception``) because escaped exception groups have
+    been observed from fan-out in tool-call assembly and midstream recovery.
+    """
+    try:
+        async for chunk in body:
+            yield chunk
+    except GeneratorExit:
+        raise
+    except asyncio.CancelledError:
+        raise
+    except BaseExceptionGroup as exc:
+        _trace_egress_failure(exc)
+        yield emit_error_frame()
+        raise
+    except Exception as exc:
+        _trace_egress_failure(exc)
+        yield emit_error_frame()
+        raise
 
 
 def anthropic_sse_streaming_response(body: AsyncIterator[str]) -> StreamingResponse:
-    """Return a streaming response for Anthropic-style SSE streams."""
+    """Return a streaming response for Anthropic-style SSE streams.
+
+    Guarantees a terminal ``error`` SSE event if the body raises after the
+    response has started (issue #1020).
+    """
     return StreamingResponse(
-        body,
+        _stream_with_terminal_error_frame(
+            body,
+            emit_error_frame=lambda: anthropic_terminal_error_frame(
+                EGRESS_STREAM_INTERRUPTED_MESSAGE
+            ),
+        ),
         media_type="text/event-stream",
         headers=ANTHROPIC_SSE_RESPONSE_HEADERS,
     )
@@ -20,10 +88,17 @@ def openai_responses_sse_streaming_response(
     body: AsyncIterator[str],
     *,
     headers: Mapping[str, str],
+    emit_error_frame: Callable[[], str],
 ) -> StreamingResponse:
-    """Return a streaming response for OpenAI Responses-style SSE."""
+    """Return a streaming response for OpenAI Responses-style SSE.
+
+    Guarantees a terminal ``response.failed`` SSE event if the body raises after
+    the response has started (issue #1020). ``emit_error_frame`` is supplied by
+    the Responses handler via the shared ``OpenAIResponsesAdapter`` so the frame
+    shape matches normal upstream failures exactly.
+    """
     return StreamingResponse(
-        body,
+        _stream_with_terminal_error_frame(body, emit_error_frame=emit_error_frame),
         media_type="text/event-stream",
         headers=dict(headers),
     )

--- a/core/anthropic/streaming/__init__.py
+++ b/core/anthropic/streaming/__init__.py
@@ -3,6 +3,7 @@
 from .emitter import (
     ANTHROPIC_SSE_RESPONSE_HEADERS,
     AnthropicSseEmitter,
+    anthropic_terminal_error_frame,
     format_sse_event,
     map_stop_reason,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "ToolSchema",
     "TruncatedProviderStreamError",
     "accept_tool_json_repair",
+    "anthropic_terminal_error_frame",
     "continuation_suffix",
     "format_sse_event",
     "is_retryable_stream_error",

--- a/core/anthropic/streaming/emitter.py
+++ b/core/anthropic/streaming/emitter.py
@@ -42,3 +42,18 @@ class AnthropicSseEmitter:
         if self._log_raw_events:
             logger.debug("SSE_EVENT: {} - {}", event_type, event.strip())
         return event
+
+
+def anthropic_terminal_error_frame(message: str) -> str:
+    """Serialize a terminal Anthropic SSE ``error`` event.
+
+    Emitted by the API egress guard when a streaming response body raises after
+    HTTP ``200`` + headers are already committed, so the client observes a
+    parseable terminal event instead of an empty or truncated body (issue #1020).
+    The frame shape matches the Anthropic mid-stream error protocol: a bare
+    ``event: error`` carrying ``{type: error, error: {type, message}}``.
+    """
+    return format_sse_event(
+        "error",
+        {"type": "error", "error": {"type": "api_error", "message": message}},
+    )

--- a/core/openai_responses/adapter.py
+++ b/core/openai_responses/adapter.py
@@ -7,6 +7,7 @@ from .errors import ResponsesConversionError, openai_error_payload
 from .events import OPENAI_RESPONSES_SSE_HEADERS
 from .input import convert_request_to_anthropic_payload
 from .stream import iter_responses_sse_from_anthropic
+from .streaming.assembler import ResponsesStreamAssembler
 
 
 class OpenAIResponsesAdapter:
@@ -27,3 +28,21 @@ class OpenAIResponsesAdapter:
 
     def error_payload(self, *, message: str, error_type: str) -> dict[str, Any]:
         return openai_error_payload(message=message, error_type=error_type)
+
+    def egress_error_frame(self, message: str) -> str:
+        """Build a terminal ``response.failed`` SSE frame for an interrupted stream.
+
+        Reuses the canonical ``ResponsesStreamAssembler.fail_response`` path so the
+        response object shape matches normal upstream failures exactly (DRY). Emitted
+        by the API egress guard when a streaming response body raises after HTTP 200
+        + headers are already committed (issue #1020). The frame is a bare
+        ``response.failed`` with no synthesized ``response.created``: a mid-stream
+        failure has already emitted ``response.created``, and a bare
+        ``response.failed`` remains a parseable terminal event for a pre-start
+        failure.
+        """
+        assembler = ResponsesStreamAssembler({"model": ""})
+        chunks = assembler.fail_response(
+            {"error": {"type": "api_error", "message": message}}
+        )
+        return chunks[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.4.12"
+version = "3.4.13"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/tests/api/test_response_streams.py
+++ b/tests/api/test_response_streams.py
@@ -1,0 +1,459 @@
+"""Tests for the egress terminal-error-frame guard (issue #1020).
+
+The streaming response wrappers in :mod:`api.response_streams` wrap every
+public SSE body in a guard that is a pure passthrough on success but, when the
+body raises *after* HTTP ``200`` + headers are already committed, emits exactly
+one protocol-specific terminal SSE frame and re-raises. This keeps the client
+from observing an empty or truncated body (issue #1020).
+
+Coverage here is at two levels:
+
+* **Iterator level** — drain ``response.body_iterator`` directly and assert the
+  concatenated text plus the re-raised exception.
+* **ASGI end-to-end** — drive the real ``StreamingResponse.__call__`` with a
+  capturing ``send`` to prove the terminal frame is flushed via ``send``
+  before the re-raise closes the connection (no trailing empty
+  ``more_body=False`` body).
+
+Both wire formats (Anthropic Messages and OpenAI Responses) are exercised, plus
+the ``BaseExceptionGroup``-before-``Exception`` ordering and the
+``GeneratorExit`` / ``CancelledError`` no-frame paths that the guard must
+re-raise unwritten.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator, Mapping
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.response_streams import (
+    EGRESS_STREAM_INTERRUPTED_MESSAGE,
+    anthropic_sse_streaming_response,
+    openai_responses_sse_streaming_response,
+)
+from core.anthropic.stream_contracts import parse_sse_text
+from core.anthropic.streaming import anthropic_terminal_error_frame
+from core.openai_responses.adapter import OpenAIResponsesAdapter
+
+
+@pytest.fixture
+def trace_mock() -> Iterator[MagicMock]:
+    """Patch the egress guard's trace sink so tests can assert the trace row."""
+    with patch("api.response_streams.trace_event") as mock:
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# Body / wrapper helpers
+# ---------------------------------------------------------------------------
+
+_ANTHROPIC_FRAME = anthropic_terminal_error_frame(EGRESS_STREAM_INTERRUPTED_MESSAGE)
+# The Responses terminal frame is NOT byte-deterministic: ``egress_error_frame``
+# builds a fresh ``ResponsesStreamAssembler`` per call, minting a new
+# ``response_id`` (uuid) and ``created_at`` (``time.time()``). Tests therefore
+# assert the frame *shape* (parsed event + status/model/error fields) rather
+# than exact text.
+
+
+async def _body_chunks(chunks: list[str]) -> AsyncGenerator[str]:
+    for chunk in chunks:
+        yield chunk
+
+
+async def _body_then_raise(
+    chunks: list[str], exc: BaseException
+) -> AsyncGenerator[str]:
+    for chunk in chunks:
+        yield chunk
+    raise exc
+
+
+def _anthropic_wrapper(body: AsyncIterator[str]):
+    return anthropic_sse_streaming_response(body)
+
+
+def _responses_wrapper(body: AsyncIterator[str]):
+    adapter = OpenAIResponsesAdapter()
+    return openai_responses_sse_streaming_response(
+        body,
+        headers=adapter.sse_headers,
+        emit_error_frame=lambda: adapter.egress_error_frame(
+            EGRESS_STREAM_INTERRUPTED_MESSAGE
+        ),
+    )
+
+
+def _egress_trace_calls(trace_mock: MagicMock) -> list[Mapping[str, object]]:
+    return [
+        call.kwargs
+        for call in trace_mock.call_args_list
+        if call.kwargs.get("event") == "api.response.egress_error_frame_emitted"
+    ]
+
+
+async def _drain(
+    response,
+) -> tuple[str, BaseException | None]:
+    """Drain ``response.body_iterator``; capture concatenated text + any raise."""
+    parts: list[str] = []
+    raised: BaseException | None = None
+    try:
+        async for chunk in response.body_iterator:
+            if isinstance(chunk, bytes | bytearray | memoryview):
+                parts.append(bytes(chunk).decode("utf-8"))
+            else:
+                parts.append(str(chunk))
+    except BaseException as exc:
+        raised = exc
+    return "".join(parts), raised
+
+
+def _assert_anthropic_terminal(text: str) -> None:
+    events = parse_sse_text(text)
+    assert events, "no SSE events parsed from interrupted stream"
+    assert events[-1].event == "error"
+    assert events[-1].data == {
+        "type": "error",
+        "error": {"type": "api_error", "message": EGRESS_STREAM_INTERRUPTED_MESSAGE},
+    }
+
+
+def _assert_responses_terminal(text: str) -> None:
+    events = parse_sse_text(text)
+    assert events, "no SSE events parsed from interrupted stream"
+    last = events[-1]
+    assert last.event == "response.failed"
+    assert last.data["type"] == "response.failed"
+    response = last.data["response"]
+    assert isinstance(response, dict)
+    assert response["status"] == "failed"
+    assert response["model"] == ""
+    assert response["error"] == {
+        "message": EGRESS_STREAM_INTERRUPTED_MESSAGE,
+        "type": "api_error",
+        "param": None,
+        "code": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Passthrough: success is byte-identical, no frame, no trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_passthrough_yields_chunks_unchanged_no_frame(
+    trace_mock: MagicMock,
+) -> None:
+    chunks = ["event: message_start\ndata: {}\n\n", "event: message_stop\ndata: {}\n\n"]
+    response = _anthropic_wrapper(_body_chunks(chunks))
+
+    text, raised = await _drain(response)
+
+    assert raised is None
+    assert text == "".join(chunks)
+    assert "event: error" not in text
+    assert trace_mock.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_responses_passthrough_yields_chunks_unchanged_no_frame(
+    trace_mock: MagicMock,
+) -> None:
+    chunks = [
+        'event: response.created\ndata: {"type":"response.created"}\n\n',
+        'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+    ]
+    response = _responses_wrapper(_body_chunks(chunks))
+
+    text, raised = await _drain(response)
+
+    assert raised is None
+    assert text == "".join(chunks)
+    assert "response.failed" not in text
+    assert trace_mock.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Pre-start raise: body raises before any chunk -> exactly the terminal frame
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_emits_terminal_frame_on_pre_start_raise(
+    trace_mock: MagicMock,
+) -> None:
+    exc = RuntimeError("upstream failed before first byte")
+    response = _anthropic_wrapper(_body_then_raise([], exc))
+
+    text, raised = await _drain(response)
+
+    assert text == _ANTHROPIC_FRAME
+    _assert_anthropic_terminal(text)
+    assert raised is exc
+    calls = _egress_trace_calls(trace_mock)
+    assert len(calls) == 1
+    assert calls[0]["stage"] == "egress"
+    assert calls[0]["source"] == "api"
+    assert calls[0]["exc_type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_responses_emits_terminal_frame_on_pre_start_raise(
+    trace_mock: MagicMock,
+) -> None:
+    exc = RuntimeError("upstream failed before first byte")
+    response = _responses_wrapper(_body_then_raise([], exc))
+
+    text, raised = await _drain(response)
+
+    events = parse_sse_text(text)
+    assert [e.event for e in events] == ["response.failed"]
+    _assert_responses_terminal(text)
+    assert raised is exc
+    calls = _egress_trace_calls(trace_mock)
+    assert len(calls) == 1
+    assert calls[0]["exc_type"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Mid-stream raise: emitted chunks then the terminal frame, then re-raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_emits_frame_after_chunks_on_mid_stream_raise(
+    trace_mock: MagicMock,
+) -> None:
+    chunks = [
+        "event: message_start\ndata: {}\n\n",
+        "event: content_block_start\ndata: {}\n\n",
+    ]
+    response = _anthropic_wrapper(_body_then_raise(chunks, ValueError("mid-stream")))
+
+    text, raised = await _drain(response)
+
+    assert "message_start" in text
+    assert text.endswith(_ANTHROPIC_FRAME)
+    _assert_anthropic_terminal(text)
+    assert isinstance(raised, ValueError)
+    calls = _egress_trace_calls(trace_mock)
+    assert len(calls) == 1
+    assert calls[0]["exc_type"] == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_responses_emits_frame_after_chunks_on_mid_stream_raise(
+    trace_mock: MagicMock,
+) -> None:
+    chunks = ['event: response.created\ndata: {"type":"response.created"}\n\n']
+    response = _responses_wrapper(_body_then_raise(chunks, ValueError("mid-stream")))
+
+    text, raised = await _drain(response)
+
+    assert "response.created" in text
+    _assert_responses_terminal(text)
+    assert isinstance(raised, ValueError)
+    calls = _egress_trace_calls(trace_mock)
+    assert len(calls) == 1
+    assert calls[0]["exc_type"] == "ValueError"
+
+
+# ---------------------------------------------------------------------------
+# ExceptionGroup: matched before Exception (it subclasses BaseException), so
+# the frame is emitted and the group is re-propagated, not swallowed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_emits_frame_on_exception_group_then_re_raises(
+    trace_mock: MagicMock,
+) -> None:
+    inner = RuntimeError("tool-call assembly fan-out")
+    exc = BaseExceptionGroup("escaped fan-out", [inner])
+    response = _anthropic_wrapper(
+        _body_then_raise(["event: message_start\ndata: {}\n\n"], exc)
+    )
+
+    text, raised = await _drain(response)
+
+    _assert_anthropic_terminal(text)
+    assert isinstance(raised, BaseExceptionGroup)
+    assert list(raised.exceptions) == [inner]
+    calls = _egress_trace_calls(trace_mock)
+    assert len(calls) == 1
+    assert calls[0]["exc_type"] == "ExceptionGroup"
+
+
+@pytest.mark.asyncio
+async def test_responses_emits_frame_on_exception_group_then_re_raises(
+    trace_mock: MagicMock,
+) -> None:
+    inner = RuntimeError("tool-call assembly fan-out")
+    exc = BaseExceptionGroup("escaped fan-out", [inner])
+    response = _responses_wrapper(_body_then_raise([], exc))
+
+    text, raised = await _drain(response)
+
+    _assert_responses_terminal(text)
+    assert isinstance(raised, BaseExceptionGroup)
+    assert list(raised.exceptions) == [inner]
+    calls = _egress_trace_calls(trace_mock)
+    assert len(calls) == 1
+    assert calls[0]["exc_type"] == "ExceptionGroup"
+
+
+# ---------------------------------------------------------------------------
+# Disconnect paths: GeneratorExit / CancelledError must re-raise UNWRITTEN
+# (no terminal frame, no egress trace) so we don't flush into a dead socket.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generator_exit_emits_no_frame(trace_mock: MagicMock) -> None:
+    """Closing the guard mid-iteration injects GeneratorExit at the yield.
+
+    The body yields two chunks; after forwarding the first, the guard is
+    suspended at its ``yield`` inside the ``try``. ``aclose()`` throws
+    ``GeneratorExit`` there, the ``except GeneratorExit: raise`` clause
+    re-raises it unwritten, and ``aclose()`` returns normally (successful
+    close). No frame or egress trace is produced.
+    """
+
+    async def _body_two() -> AsyncGenerator[str]:
+        yield "chunk1"
+        yield "chunk2"
+
+    body = _body_two()
+    response = _anthropic_wrapper(body)
+
+    first = await response.body_iterator.__anext__()
+    assert first == "chunk1"
+
+    await response.body_iterator.aclose()
+    await body.aclose()
+
+    assert trace_mock.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_emits_no_frame(trace_mock: MagicMock) -> None:
+    """Cancelling an iterating task injects CancelledError at ``await anext``.
+
+    The body yields one chunk then blocks forever; the consumer task pulls
+    that chunk and re-enters ``await anext(body)``, where cancellation lands.
+    The ``except asyncio.CancelledError: raise`` clause re-raises unwritten,
+    so no frame or egress trace is produced and the task is cancelled.
+    """
+
+    blocked = asyncio.Event()
+
+    async def _body_one_then_block() -> AsyncGenerator[str]:
+        yield "chunk1"
+        blocked.set()
+        await asyncio.Future()
+
+    body = _body_one_then_block()
+    response = _anthropic_wrapper(body)
+
+    produced: asyncio.Queue[str] = asyncio.Queue()
+
+    async def _consume() -> None:
+        async for chunk in response.body_iterator:
+            await produced.put(chunk)
+
+    task = asyncio.create_task(_consume())
+    await asyncio.wait_for(blocked.wait(), timeout=2)
+    assert await asyncio.wait_for(produced.get(), timeout=2) == "chunk1"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await body.aclose()
+
+    assert trace_mock.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# ASGI end-to-end: the terminal frame is flushed through the real
+# StreamingResponse before the re-raise closes the connection.
+# ---------------------------------------------------------------------------
+
+
+async def _drive_asgi(response) -> tuple[list[dict], BaseException | None]:
+    sent: list[dict] = []
+
+    async def send(message: Mapping[str, object]) -> None:
+        sent.append(dict(message))
+
+    async def receive() -> Mapping[str, object]:
+        # Block until the streaming task is cancelled on disconnect.
+        await asyncio.Future()
+        return {"type": "http.disconnect"}
+
+    scope = {"type": "http", "asgi": {"version": "3.0", "spec_version": "2.0"}}
+    raised: BaseException | None = None
+    try:
+        await response(scope, receive, send)
+    except BaseException as exc:
+        raised = exc
+    return sent, raised
+
+
+def _assert_frame_flushed_before_disconnect(
+    sent: list[dict], raised: BaseException | None, leading_chunk: str
+) -> str:
+    """Assert the frame reached ``send`` before the raise closed the body.
+
+    Guards issue #1020 at the ASGI layer: HTTP 200 + the streamed chunks + the
+    terminal frame all reached ``send`` with ``more_body=True``, and the raise
+    propagated out of ``StreamingResponse.__call__`` WITHOUT a final empty
+    ``more_body=False`` body (which Starlette skips when the iterator raises out
+    of the ``async for``). Returns the concatenated rendered body text so each
+    protocol test can assert frame-shape (Anthropic exact, Responses parsed).
+    """
+    assert raised is not None, "interrupted stream did not re-raise to __call__"
+
+    starts = [m for m in sent if m.get("type") == "http.response.start"]
+    assert starts and starts[0]["status"] == 200
+
+    bodies = [m for m in sent if m.get("type") == "http.response.body"]
+    assert bodies, "no body chunks were sent before the connection closed"
+    rendered = b"".join(bytes(by["body"]) for by in bodies).decode("utf-8")
+    assert rendered.startswith(leading_chunk)
+    # The terminal frame was the last thing flushed; Starlette did not send the
+    # trailing empty ``more_body=False`` body, so the socket closes with the
+    # parseable terminal event as its final chunk.
+    assert bodies[-1].get("more_body") is True
+    return rendered
+
+
+@pytest.mark.asyncio
+async def test_anthropic_frame_flushes_through_real_streaming_response(
+    trace_mock: MagicMock,
+) -> None:
+    chunk = "event: message_start\ndata: {}\n\n"
+    response = _anthropic_wrapper(_body_then_raise([chunk], RuntimeError("asgi boom")))
+
+    sent, raised = await _drive_asgi(response)
+
+    rendered = _assert_frame_flushed_before_disconnect(sent, raised, chunk)
+    # Anthropic terminal frame is deterministic, so assert exact bytes.
+    assert rendered == chunk + _ANTHROPIC_FRAME
+    _assert_anthropic_terminal(rendered)
+
+
+@pytest.mark.asyncio
+async def test_responses_frame_flushes_through_real_streaming_response(
+    trace_mock: MagicMock,
+) -> None:
+    chunk = 'event: response.created\ndata: {"type":"response.created"}\n\n'
+    response = _responses_wrapper(_body_then_raise([chunk], RuntimeError("asgi boom")))
+
+    sent, raised = await _drive_asgi(response)
+
+    rendered = _assert_frame_flushed_before_disconnect(sent, raised, chunk)
+    # Responses terminal frame mints a fresh id/created_at per call, so assert
+    # shape (parsed event + status/model/error), not exact bytes.
+    _assert_responses_terminal(rendered)

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.4.12"
+version = "3.4.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #1020.

## Problem

When a streaming response body raises *after* FastAPI has already committed `HTTP 200` + headers, the status code can no longer change — the only thing that can happen is the body gets truncated (or, for a pre-start raise, emitted empty). Claude Code then observes an empty or malformed SSE body and fails to parse a terminal event. The root cause is that the public egress `StreamingResponse` wrappers in `api/response_streams.py` had no terminal-frame guard; `traced_async_stream` re-raises without injecting an SSE event, and unhandled raises (adapter tail, escaped `BaseExceptionGroup`) cut the body short.

## Fix

Wrap every public SSE body in a **protocol-agnostic egress guard** at the correct architectural layer — the egress wrappers, not the individual adapters — so all providers benefit with no cross-protocol duplication.

- `api/response_streams.py` — new `_stream_with_terminal_error_frame`: a pure passthrough on success; on raise emits exactly one protocol-specific terminal frame via a supplied `emit_error_frame` callable, then re-raises (so the server traceback and the request-correlated `api.response.stream_interrupted` trace still fire).
  - `GeneratorExit` / `asyncio.CancelledError` (client disconnect/cancel) re-raise **unwritten** — the frame would fail to flush or loop into a dead socket.
  - `BaseExceptionGroup` is matched **before** `Exception` (it subclasses `BaseException`, not `Exception`); escaped groups have been observed from tool-call assembly / midstream-recovery fan-out.
  - One egress trace row (`api.response.egress_error_frame_emitted`) per frame; request correlation relies on the existing `api.response.stream_interrupted` row.
- **Ownership map (best-practices shape):** each protocol owns its own SSE serialization — `anthropic_terminal_error_frame` in `core/anthropic/streaming/emitter.py`; `OpenAIResponsesAdapter.egress_error_frame` reuses `ResponsesStreamAssembler.fail_response` so the `response.failed` payload matches normal upstream failures exactly (DRY). The guard is protocol-agnostic and has **no import edge** from `api/` into `core/openai_responses`.

## Why the Responses sibling is in this same PR

Both wire formats shared the identical gap, and the responses terminal frame required `response.failed` with an embedded response object (mints a fresh `response_id` / `created_at` per call — non-deterministic, hence shape-asserted in tests). Splitting it into a follow-up would have left the Responses API broken for the same root cause.

## Files Changed
- `api/response_streams.py` — the guard + both wrappers now route through it; Responses wrapper takes `emit_error_frame`.
- `core/anthropic/streaming/emitter.py` + `__init__.py` — `anthropic_terminal_error_frame` + re-export.
- `core/openai_responses/adapter.py` — `egress_error_frame` (reuses `ResponsesStreamAssembler.fail_response`, DRY).
- `api/handlers/responses.py` — passes `emit_error_frame` to the Responses wrapper.
- `tests/api/test_response_streams.py` — 12 tests.
- `pyproject.toml` / `uv.lock` — PATCH `3.4.12 -> 3.4.13`.

## Verification
- Local CI: suppressions, ruff-format, ruff-check, **ty all green**.
- `pytest`: **1923 passed** including all 12 new tests — passthrough (byte-identical, no frame, no trace); pre-start raise → exactly the terminal frame; mid-stream raise → chunks then frame; `BaseExceptionGroup` → frame + re-propagation; `GeneratorExit` / `CancelledError` → no frame; and **ASGI end-to-end** driving the real `StreamingResponse.__call__` to prove the frame flushes through `send` before the re-raise closes the connection (no trailing empty `more_body=False` body) — for both protocols.
- The only 3 failures (`tests/scripts/test_uninstallers.py`) are **environmental**: a live `fcc-server` process short-circuits `uninstall.ps1:96` ("still running"). They reproduce identically on a clean tree with these changes stashed, and pass on a clean CI runner.

## Residual Risks
None.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds terminal SSE error frames for interrupted streaming responses. The main changes are:

- A shared egress guard wraps public Anthropic and OpenAI Responses SSE streams.
- Anthropic streams now emit a terminal `event: error` frame on non-cancellation stream failures.
- OpenAI Responses streams now receive a protocol-specific `response.failed` frame emitter.
- Tests cover passthrough behavior, pre-start and mid-stream failures, exception groups, cancellation, and ASGI flushing.
- The package version is bumped from `3.4.12` to `3.4.13`.
</details>

<h3>Confidence Score: 4/5</h3>

These changes need one Responses stream correctness fix before merging.

The shared guard and Anthropic path are covered by focused tests. The required patch version bump and lockfile update are present. The remaining issue is contained to OpenAI Responses terminal failure frame identity.

`core/openai_responses/adapter.py`; `tests/api/test_response_streams.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I executed a generated runtime harness with uv run python to drive OpenAIResponsesAdapter.iter\_sse\_from\_anthropic through openai\_responses\_sse\_streaming\_response and trigger a mid-stream upstream RuntimeError after response.created.
- I observed the egress guard emit a terminal response.failed frame after the normal response.created chunk and re-raise the simulated upstream failure, with the parsed SSE showing response.created id resp\_b2284e147e2c445683ddb25ea43c5efe and terminal response.failed id resp\_f142f9b2145c4dd4a32f4e815c77e959; ids\_equal was false.
- I reviewed the accompanying artifacts to verify identity preservation and mismatch behavior across the streaming path.
- I ran two contract-validation test suites: the first ran pytest for tests/api/test\_response\_streams.py and reported 12 passed in 3.89s, and the second ran pytest for tests/core/openai\_responses/test\_sse.py and tests/core/anthropic/test\_stream\_recovery.py with 36 passed in 1.90s; a wrapper shell emitted a Bad substitution warning, but the pytest results were successful (exit code 0).

<a href="https://app.greptile.com/trex/runs/13749507/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/handlers/responses.py | Passes a protocol-specific OpenAI Responses terminal-frame emitter into the shared SSE response wrapper. |
| api/response_streams.py | Adds a shared egress guard that emits terminal SSE error frames on stream exceptions while re-raising non-cancellation failures. |
| core/anthropic/streaming/__init__.py | Re-exports the new Anthropic terminal error frame serializer. |
| core/anthropic/streaming/emitter.py | Adds Anthropic `event: error` serialization for terminal egress failures. |
| core/openai_responses/adapter.py | Adds Responses terminal failure frame generation, but currently mints a fresh response identity that can diverge from already-streamed `response.created` events. |
| tests/api/test_response_streams.py | Adds iterator-level and ASGI-level tests for terminal-frame emission, cancellation paths, and exception groups; missing coverage for Responses ID continuity. |
| pyproject.toml | Bumps the package patch version from `3.4.12` to `3.4.13` for the production bug fix. |
| uv.lock | Updates the editable package version in the lockfile to match `pyproject.toml`. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant Handler as API Handler
participant Wrapper as SSE StreamingResponse Wrapper
participant Guard as _stream_with_terminal_error_frame
participant Body as Provider/Adapter Body
participant Emitter as Protocol Error Frame Emitter

Client->>Handler: Start streaming request
Handler->>Wrapper: Build StreamingResponse(body, emit_error_frame)
Wrapper->>Guard: Iterate guarded body
Guard->>Body: async for chunk
Body-->>Guard: SSE chunk(s)
Guard-->>Client: passthrough chunk(s)
Body--xGuard: exception after response start
Guard->>Emitter: emit_error_frame()
Emitter-->>Guard: terminal SSE error frame
Guard-->>Client: terminal frame
Guard--xWrapper: re-raise exception for server tracing
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant Handler as API Handler
participant Wrapper as SSE StreamingResponse Wrapper
participant Guard as _stream_with_terminal_error_frame
participant Body as Provider/Adapter Body
participant Emitter as Protocol Error Frame Emitter

Client->>Handler: Start streaming request
Handler->>Wrapper: Build StreamingResponse(body, emit_error_frame)
Wrapper->>Guard: Iterate guarded body
Guard->>Body: async for chunk
Body-->>Guard: SSE chunk(s)
Guard-->>Client: passthrough chunk(s)
Body--xGuard: exception after response start
Guard->>Emitter: emit_error_frame()
Emitter-->>Guard: terminal SSE error frame
Guard-->>Client: terminal frame
Guard--xWrapper: re-raise exception for server tracing
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22fix%2F1020-terminal-sse-error-frame%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1020-terminal-sse-error-frame%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acore%2Fopenai_responses%2Fadapter.py%3A44-48%0A**Preserve%20response%20identity**%0A%60egress_error_frame%28%29%60%20creates%20a%20fresh%20%60ResponsesStreamAssembler%60%2C%20so%20a%20mid-stream%20failure%20emits%20%60response.failed%60%20with%20a%20new%20%60response.id%60%20instead%20of%20the%20%60response.created%60%20id%20already%20sent%20by%20%60iter_responses_sse_from_anthropic%60.%20The%20changed%20guard%20appends%20this%20frame%20after%20existing%20chunks%2C%20which%20makes%20one%20logical%20Responses%20stream%20contain%20two%20different%20response%20IDs%3B%20clients%20correlating%20terminal%20events%20to%20the%20opened%20response%20will%20see%20an%20invalid%20terminal%20event.%20The%20failure%20frame%20needs%20to%20be%20produced%20from%20the%20same%20assembler%2Fstate%20that%20emitted%20%60response.created%60%2C%20or%20otherwise%20preserve%20that%20response%20identity.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1024&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix #1020: guarantee terminal SSE frame ..."](https://github.com/alishahryar1/free-claude-code/commit/1c8c885476011fffcf7456ed3933ccbc6294b523) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42839651)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->