### PR TITLE
Isolate nested Codex launches from parent task context

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -767,6 +767,8 @@ keeps product policy independent of provider IDs and transport implementation.
 `fcc-codex` launcher:
 
 - `fcc-codex` strips official OpenAI and Codex credential variables.
+- It strips parent-only Codex thread, shell, permission, and origin context so
+  each launched client owns an independent runtime identity.
 - It creates an ephemeral `fcc` model provider with `wire_api = "responses"` and
   a base URL pointing at the local proxy `/v1` path.
 - After proxy health succeeds, it fetches `/v1/models`, writes a generated Codex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.2"
+version = "3.5.3"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/codex.py
+++ b/src/free_claude_code/cli/launchers/codex.py
@@ -30,6 +30,10 @@ _STRIPPED_CODEX_ENV_KEYS = frozenset(
         "OPENAI_ORG_ID",
         "OPENAI_ORGANIZATION",
         "CODEX_API_KEY",
+        "CODEX_INTERNAL_ORIGINATOR_OVERRIDE",
+        "CODEX_PERMISSION_PROFILE",
+        "CODEX_SHELL",
+        "CODEX_THREAD_ID",
         _CODEX_AUTH_ENV_KEY,
     }
 )

--- a/src/free_claude_code/cli/launchers/codex.py
+++ b/src/free_claude_code/cli/launchers/codex.py
@@ -22,6 +22,7 @@ _CODEX_AUTH_ENV_KEY = "FCC_CODEX_API_KEY"
 _DISPLAY_NAME = "Codex CLI"
 _DEFAULT_BINARY = "codex"
 _INSTALL_HINT = "Install Codex with: npm install -g @openai/codex"
+# Preserve CODEX_HOME: it owns durable user configuration, not parent-task identity.
 _STRIPPED_CODEX_ENV_KEYS = frozenset(
     {
         "OPENAI_API_KEY",

--- a/tests/cli/test_codex_model_catalog.py
+++ b/tests/cli/test_codex_model_catalog.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import subprocess
 from collections.abc import Mapping
@@ -150,6 +151,17 @@ def test_generated_catalog_schema_is_accepted_by_installed_codex(
         catalog_path,
         build_codex_model_catalog(_models_payload("anthropic/nvidia_nim/test-model")),
     )
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    codex_env = os.environ.copy()
+    for key in (
+        "CODEX_THREAD_ID",
+        "CODEX_INTERNAL_ORIGINATOR_OVERRIDE",
+        "CODEX_SHELL",
+        "CODEX_PERMISSION_PROFILE",
+    ):
+        codex_env.pop(key, None)
+    codex_env["CODEX_HOME"] = str(codex_home)
 
     result = subprocess.run(
         [
@@ -161,6 +173,9 @@ def test_generated_catalog_schema_is_accepted_by_installed_codex(
         ],
         capture_output=True,
         check=False,
+        encoding="utf-8",
+        env=codex_env,
+        errors="replace",
         text=True,
         timeout=10,
     )

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -493,6 +493,10 @@ def test_launch_codex_passes_responses_config_and_child_env(
     monkeypatch.setenv("OPENAI_API_KEY", "official-key")
     monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
     monkeypatch.setenv("CODEX_HOME", "keep-home")
+    monkeypatch.setenv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "Codex Desktop")
+    monkeypatch.setenv("CODEX_PERMISSION_PROFILE", "danger-full-access")
+    monkeypatch.setenv("CODEX_SHELL", "1")
+    monkeypatch.setenv("CODEX_THREAD_ID", "parent-thread")
     settings = _launcher_settings(port=9191, token="proxy-token")
     catalog_path = tmp_path / "codex-model-catalog.json"
     requests: list[Request] = []
@@ -565,6 +569,10 @@ def test_launch_codex_passes_responses_config_and_child_env(
     child_env = popen.call_args.kwargs["env"]
     assert child_env["FCC_CODEX_API_KEY"] == "proxy-token"
     assert child_env["CODEX_HOME"] == "keep-home"
+    assert "CODEX_INTERNAL_ORIGINATOR_OVERRIDE" not in child_env
+    assert "CODEX_PERMISSION_PROFILE" not in child_env
+    assert "CODEX_SHELL" not in child_env
+    assert "CODEX_THREAD_ID" not in child_env
     assert "OPENAI_API_KEY" not in child_env
     assert "OPENAI_BASE_URL" not in child_env
     register_pid.assert_called_once_with(12345)

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.2"
+version = "3.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem\n\nNested Codex launches inherited the parent task's thread, shell, permission, and origin identity. This could attach a new client or compatibility probe to the parent task, hang startup, or decode probe output with the wrong Windows locale.\n\n## Changes\n\n| Before | After |\n| --- | --- |\n| cc-codex forwarded parent-only Codex task context. | cc-codex removes parent-only task context while preserving user configuration such as CODEX_HOME. |\n| The installed-Codex probe inherited the parent task and user Codex home. | The probe runs with a standalone task identity and isolated Codex home. |\n| The probe decoded output with the platform default encoding. | The probe decodes output as UTF-8 with safe replacement. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR isolates nested Codex launches from parent task identity. The main changes are:

- Strips Codex thread, shell, permission, and origin context from launched child environments.
- Preserves `CODEX_HOME` as durable user configuration.
- Runs the installed Codex catalog probe with an isolated home and cleaned task context.
- Decodes probe output as UTF-8 with replacement.
- Updates architecture notes and bumps the package version to `3.5.3`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Logged the proof with exact commands, the working directory, timestamps, and test and lint summaries, including exit codes.
- The first pytest capture showed tests passed but the shell wrapper exited with code 2 because /bin/sh does not support ${PIPESTATUS\[0\]}.
- Re-ran the proof under bash, and the run exited with code 0.
- Artifacts containing the three proof logs were created for review.

<a href="https://app.greptile.com/trex/runs/14092911/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/launchers/codex.py | Strips parent-only Codex context variables from the child launcher environment while keeping `CODEX_HOME`. |
| tests/cli/test_entrypoints.py | Adds launcher coverage for stripped Codex task variables and preserved `CODEX_HOME`. |
| tests/cli/test_codex_model_catalog.py | Runs the installed Codex catalog probe with a cleaned environment, isolated home, and UTF-8 replacement decoding. |
| ARCHITECTURE.md | Documents the Codex launcher context-isolation behavior. |
| pyproject.toml | Bumps the project version to `3.5.3`. |
| uv.lock | Updates the locked editable package version to `3.5.3`. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Document Codex home ownership"](https://github.com/alishahryar1/free-claude-code/commit/2140315b1f33c4162e74ca8f816228f50c38c0a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43513448)</sub>

<!-- /greptile_comment -->