### PR TITLE
Make application shutdown completion-driven

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -972,14 +972,18 @@ before task creation, which is safe under Python's eager task factory, then
 launches claims returned by the aggregate, cancels the exact matching task,
 drains cleanup outside tree locks, and feeds matching completion back to the
 aggregate. Cancellation before a task body starts has an explicit recovery path;
-the cancellation flag is rechecked after callbacks, and callback failure cannot
-prevent successor launch. If a node processor unexpectedly escapes, the
-processor routes failure through the manager-owned aggregate transition; the
-workflow persists its snapshot and schedules its UI effect as normal queue
-advancement continues. The processor's completion event covers the published
-slot from launch through normal completion, successor publication, and pre-run
-recovery, so terminal workflow close cannot release delivery while cleanup is
-still active. [messaging/trees/node.py](src/free_claude_code/messaging/trees/node.py) owns
+the cancellation flag is rechecked after callbacks, and best-effort UI callback
+failure cannot prevent successor launch. If a node processor unexpectedly
+escapes, the processor routes failure through the manager-owned aggregate
+transition; the workflow persists its snapshot and schedules its UI effect as
+normal queue advancement continues. The processor's completion event covers the
+published slot from launch through normal completion, successor publication,
+and pre-run recovery, so terminal workflow close cannot release delivery while
+cleanup is still active. A failed aggregate-completion callback releases its
+finished task slot, records the failure, and hands it to the terminal waiter
+exactly once; a failed close therefore retains the workflow for reconciliation
+instead of hanging on ownership that no longer exists.
+[messaging/trees/node.py](src/free_claude_code/messaging/trees/node.py) owns
 `MessageNode` and `MessageState`; each node keeps only the copied scope and
 prompt needed by the aggregate rather than retaining a mutable ingress value,
 [messaging/trees/graph.py](src/free_claude_code/messaging/trees/graph.py) owns parent/child and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,7 +86,7 @@ also removes that permission:
 | `config` | none |
 | `core` | none |
 | `application` | `config`, `core` |
-| `messaging` | `config`, `core` |
+| `messaging` | `core` |
 | `providers` | `application`, `config`, `core` |
 | `api` | `application`, `config`, `core` |
 | `cli` | `config`, `core` |
@@ -222,7 +222,11 @@ for local pre-push verification.
 [cli/entrypoints.py](src/free_claude_code/cli/entrypoints.py) starts the FastAPI server with Uvicorn.
 `serve()` migrates legacy env files when needed, loads cached settings, runs a
 supervised server instance, and can restart the server after admin config changes.
-On final shutdown it best-effort kills registered child processes.
+An Admin restart constructs the next instance only when the prior
+`ApplicationRuntime` reports that its complete ownership graph closed. An
+incomplete ASGI shutdown therefore exits the supervisor instead of overlapping
+old and replacement graphs. On final shutdown it best-effort kills registered
+child processes.
 
 [runtime/bootstrap.py](src/free_claude_code/runtime/bootstrap.py) is the single production composition function. The CLI
 supervisor supplies one settings snapshot and its restart callback; bootstrap
@@ -247,7 +251,10 @@ incomplete graph retryable. Teardown stops at a failed dependency gate rather
 than closing resources that still-live upstream work may need, and the ASGI
 adapter reports that incomplete graph as lifespan shutdown failure. Cleanup is
 completion-driven: generic timeouts do not cancel half-closed external resources;
-the process supervisor owns any force-termination deadline.
+the process supervisor owns any force-termination deadline. Optional messaging
+startup remains nonfatal only when every partially constructed messaging owner
+was successfully cleaned; incomplete startup cleanup fails the application
+startup and retains the graph for the next close attempt.
 [runtime/asgi.py](src/free_claude_code/runtime/asgi.py) drives that owner from ASGI lifespan messages and preserves
 the concise startup-failure contract.
 
@@ -788,7 +795,15 @@ state. The managed session parser extracts persistent Claude session IDs and
 yields Claude stream-json events to the messaging event parser. Managed Claude
 also owns subprocess stderr diagnostic classification so known benign Claude
 Code notices do not become messaging task errors, while unknown stderr remains
-fatal.
+fatal. Before subprocess stop, the manager marks the session closing so new
+lookups and aliases cannot borrow it; the session also marks itself terminal so
+an already-issued reference cannot launch again. One lifecycle lock linearizes
+that terminal transition with subprocess publication. Aliases plus PID
+registration remain owned until exit is confirmed. Aggregate shutdown attempts
+every distinct mapped or closing session, removes only confirmed successes,
+reports a count-only failure, and leaves failures available for the next cleanup
+attempt. Real-session registration is collision-safe and becomes durable tree
+state only after the manager accepts it.
 
 Codex is supported through `fcc-codex` and Codex extensions. FCC does not keep an
 internal managed-Codex session runner because no user-facing messaging setting
@@ -804,7 +819,10 @@ the messaging bridge is skipped.
 
 `ApplicationRuntime` privately owns the selected platform runtime, the
 `MessagingWorkflow`, configured `Transcriber`, and managed CLI session manager.
-The workflow owns conversation snapshot restoration and final persistence flush.
+The workflow owns conversation snapshot restoration and terminal close: cancel
+work, stop managed CLI sessions, await every processor-owned claim and recovery
+task, then flush persistence. Interactive `/stop` keeps its bounded task-drain
+behavior; only terminal close waits for full completion.
 The API sees only the application-owned `TaskController` used to preserve
 `/stop` behavior.
 
@@ -877,7 +895,9 @@ the same transition instead of taking a later mutable-node read. Once a stop or
 clear transition commits, its persistence effects are applied before the later
 interruptible global CLI cleanup. At startup it restores and normalizes
 persisted state before ingress begins, then repairs interrupted platform
-statuses after outbound delivery starts.
+statuses after outbound delivery starts. Diagnostic detail policy is captured
+at construction and passed into the processor; messaging does not read global
+settings while executing callbacks or failures.
 
 [messaging/turn_intake.py](src/free_claude_code/messaging/turn_intake.py) owns inbound message
 recording, slash command dispatch, status-echo filtering, initial status
@@ -956,7 +976,10 @@ the cancellation flag is rechecked after callbacks, and callback failure cannot
 prevent successor launch. If a node processor unexpectedly escapes, the
 processor routes failure through the manager-owned aggregate transition; the
 workflow persists its snapshot and schedules its UI effect as normal queue
-advancement continues. [messaging/trees/node.py](src/free_claude_code/messaging/trees/node.py) owns
+advancement continues. The processor's completion event covers the published
+slot from launch through normal completion, successor publication, and pre-run
+recovery, so terminal workflow close cannot release delivery while cleanup is
+still active. [messaging/trees/node.py](src/free_claude_code/messaging/trees/node.py) owns
 `MessageNode` and `MessageState`; each node keeps only the copied scope and
 prompt needed by the aggregate rather than retaining a mutable ingress value,
 [messaging/trees/graph.py](src/free_claude_code/messaging/trees/graph.py) owns parent/child and
@@ -978,9 +1001,15 @@ shares mutable persisted state. Debounced atomic writes live in
 [messaging/session/persistence.py](src/free_claude_code/messaging/session/persistence.py). One writer
 lock serializes physical replaces, and a generation check under that lock
 prevents an older timer snapshot from landing after a newer flush or clear.
+Timer-triggered saves are best effort and leave the store dirty on failure;
+explicit flushes and authoritative writes propagate failure while preserving
+that dirty state for retry. Successful retry writes the current in-memory
+snapshot and is the only operation that marks it clean.
 Global `/clear` performs an early authoritative wipe, detaches and drains every
 tree, then writes an authoritative empty conversation snapshot while preserving
-message IDs recorded after the early wipe.
+message IDs recorded after the early wipe. Once clear commits, ordinary failures
+from final persistence, cancellation effects, and CLI cleanup are all attempted
+and preserved rather than producing a false successful clear.
 Per-chat message ID tracking for `/clear` lives in
 [messaging/session/message_log.py](src/free_claude_code/messaging/session/message_log.py). `/clear`
 guarantees FCC state cleanup and tries tracked platform deletes through the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.3"
+version = "3.5.4"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/entrypoints.py
+++ b/src/free_claude_code/cli/entrypoints.py
@@ -86,7 +86,7 @@ def _schedule_open_admin_browser(settings: Settings) -> None:
 
 
 def _run_supervised_server(settings: Settings, *, open_admin_browser: bool) -> bool:
-    """Run one uvicorn server instance; return whether admin requested restart."""
+    """Run once; restart only after the old ownership graph fully closes."""
 
     restart_requested = False
     server_holder: dict[str, uvicorn.Server] = {}
@@ -110,7 +110,7 @@ def _run_supervised_server(settings: Settings, *, open_admin_browser: bool) -> b
     if open_admin_browser:
         _schedule_open_admin_browser(settings)
     server.run()
-    return restart_requested
+    return restart_requested and asgi_app.runtime.is_closed
 
 
 def init(argv: Sequence[str] | None = None) -> None:

--- a/src/free_claude_code/cli/managed/manager.py
+++ b/src/free_claude_code/cli/managed/manager.py
@@ -52,7 +52,35 @@ class ManagedClaudeSessionManager:
         self._pending_sessions: dict[str, ManagedClaudeSession] = {}
         self._temp_to_real: dict[str, str] = {}
         self._real_to_temp: dict[str, str] = {}
+        self._closing_sessions: set[ManagedClaudeSession] = set()
         self._lock = asyncio.Lock()
+
+    def _session_for_id(self, session_id: str) -> ManagedClaudeSession | None:
+        lookup_id = self._temp_to_real.get(session_id, session_id)
+        session = self._sessions.get(lookup_id)
+        if session is not None:
+            return session
+        return self._pending_sessions.get(lookup_id)
+
+    def _forget_session(self, session: ManagedClaudeSession) -> None:
+        pending_ids = [
+            session_id
+            for session_id, owned in self._pending_sessions.items()
+            if owned is session
+        ]
+        real_ids = [
+            session_id
+            for session_id, owned in self._sessions.items()
+            if owned is session
+        ]
+        for session_id in pending_ids:
+            self._pending_sessions.pop(session_id, None)
+        for real_id in real_ids:
+            self._sessions.pop(real_id, None)
+            temp_id = self._real_to_temp.pop(real_id, None)
+            if temp_id is not None:
+                self._temp_to_real.pop(temp_id, None)
+        self._closing_sessions.discard(session)
 
     async def get_or_create_session(
         self, session_id: str | None = None
@@ -68,9 +96,15 @@ class ManagedClaudeSessionManager:
                 lookup_id = self._temp_to_real.get(session_id, session_id)
 
                 if lookup_id in self._sessions:
-                    return self._sessions[lookup_id], lookup_id, False
+                    session = self._sessions[lookup_id]
+                    if session in self._closing_sessions:
+                        raise RuntimeError("Managed Claude session is closing.")
+                    return session, lookup_id, False
                 if lookup_id in self._pending_sessions:
-                    return self._pending_sessions[lookup_id], lookup_id, False
+                    session = self._pending_sessions[lookup_id]
+                    if session in self._closing_sessions:
+                        raise RuntimeError("Managed Claude session is closing.")
+                    return session, lookup_id, False
 
             temp_id = session_id if session_id else f"pending_{uuid.uuid4().hex[:8]}"
 
@@ -92,11 +126,21 @@ class ManagedClaudeSessionManager:
     ) -> bool:
         """Register the real session ID from CLI output."""
         async with self._lock:
-            if temp_id not in self._pending_sessions:
+            session = self._pending_sessions.get(temp_id)
+            if session is None:
                 logger.warning(f"Temp session {temp_id} not found")
                 return False
+            if session in self._closing_sessions:
+                logger.warning("Cannot register a closing managed Claude session")
+                return False
+            existing = self._session_for_id(real_session_id)
+            if existing is not None and existing is not session:
+                logger.warning(
+                    "Cannot register managed Claude session: real ID is already owned"
+                )
+                return False
 
-            session = self._pending_sessions.pop(temp_id)
+            self._pending_sessions.pop(temp_id)
             self._sessions[real_session_id] = session
             self._temp_to_real[temp_id] = real_session_id
             self._real_to_temp[real_session_id] = temp_id
@@ -107,31 +151,35 @@ class ManagedClaudeSessionManager:
     async def remove_session(self, session_id: str) -> bool:
         """Remove a session from the manager."""
         async with self._lock:
-            if session_id in self._pending_sessions:
-                session = self._pending_sessions.pop(session_id)
-                await session.stop()
-                return True
+            session = self._session_for_id(session_id)
+            if session is None:
+                return False
+            self._closing_sessions.add(session)
+            stopped = await session.stop()
+            if not stopped:
+                return False
+            self._forget_session(session)
+            return True
 
-            if session_id in self._sessions:
-                session = self._sessions.pop(session_id)
-                await session.stop()
-                temp_id = self._real_to_temp.pop(session_id, None)
-                if temp_id is not None:
-                    self._temp_to_real.pop(temp_id, None)
-                return True
-
-            return False
-
-    async def stop_all(self):
+    async def stop_all(self) -> None:
         """Stop all sessions."""
         async with self._lock:
-            all_sessions = list(self._sessions.values()) + list(
-                self._pending_sessions.values()
+            all_sessions = list(
+                dict.fromkeys(
+                    [
+                        *self._sessions.values(),
+                        *self._pending_sessions.values(),
+                        *self._closing_sessions,
+                    ]
+                )
             )
+            self._closing_sessions.update(all_sessions)
+            failures = 0
             for session in all_sessions:
                 try:
-                    await session.stop()
+                    stopped = await session.stop()
                 except Exception as e:
+                    stopped = False
                     if self._log_messaging_error_details:
                         logger.error(
                             "Error stopping session: {}: {}",
@@ -143,11 +191,15 @@ class ManagedClaudeSessionManager:
                             "Error stopping session: exc_type={}",
                             type(e).__name__,
                         )
+                if stopped:
+                    self._forget_session(session)
+                else:
+                    failures += 1
 
-            self._sessions.clear()
-            self._pending_sessions.clear()
-            self._temp_to_real.clear()
-            self._real_to_temp.clear()
+            if failures:
+                raise RuntimeError(
+                    f"Managed Claude session shutdown failures: {failures}."
+                )
             logger.info("All sessions stopped")
 
     def get_stats(self) -> dict:

--- a/src/free_claude_code/cli/managed/session.py
+++ b/src/free_claude_code/cli/managed/session.py
@@ -59,6 +59,8 @@ class ManagedClaudeSession:
         self.current_session_id: str | None = None
         self._is_busy = False
         self._cli_lock = asyncio.Lock()
+        self._lifecycle_lock = asyncio.Lock()
+        self._closed = False
 
     @staticmethod
     async def _drain_stderr_bounded(
@@ -107,36 +109,42 @@ class ManagedClaudeSession:
             Event dictionaries from the CLI
         """
         async with self._cli_lock:
-            self._is_busy = True
-            invocation = build_managed_claude_invocation(
-                config=self.config,
-                request=ManagedClaudeTaskRequest(
-                    prompt=prompt,
-                    session_id=session_id,
-                    fork_session=fork_session,
-                ),
-                base_env=os.environ,
-            )
-
-            trace_event(
-                stage="claude_cli",
-                event="claude_cli.process.launch",
-                source="claude_cli",
-                **invocation.trace_metadata,
-            )
-
+            process: asyncio.subprocess.Process | None = None
+            termination_confirmed = False
             try:
-                self.process = await asyncio.create_subprocess_exec(
-                    *invocation.argv,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=invocation.cwd,
-                    env=invocation.env,
-                )
-                if self.process and self.process.pid:
-                    register_pid(self.process.pid)
+                async with self._lifecycle_lock:
+                    if self._closed:
+                        raise RuntimeError("Managed Claude session is closed.")
+                    self._is_busy = True
+                    invocation = build_managed_claude_invocation(
+                        config=self.config,
+                        request=ManagedClaudeTaskRequest(
+                            prompt=prompt,
+                            session_id=session_id,
+                            fork_session=fork_session,
+                        ),
+                        base_env=os.environ,
+                    )
 
-                if not self.process or not self.process.stdout:
+                    trace_event(
+                        stage="claude_cli",
+                        event="claude_cli.process.launch",
+                        source="claude_cli",
+                        **invocation.trace_metadata,
+                    )
+
+                    process = await asyncio.create_subprocess_exec(
+                        *invocation.argv,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        cwd=invocation.cwd,
+                        env=invocation.env,
+                    )
+                    self.process = process
+                    if process.pid:
+                        register_pid(process.pid)
+
+                if not process.stdout:
                     yield {"type": "exit", "code": 1}
                     return
 
@@ -145,14 +153,14 @@ class ManagedClaudeSession:
                 )
                 buffer = bytearray()
                 stderr_task: asyncio.Task[bytes] | None = None
-                if self.process.stderr:
+                if process.stderr:
                     stderr_task = asyncio.create_task(
-                        self._drain_stderr_bounded(self.process)
+                        self._drain_stderr_bounded(process)
                     )
 
                 try:
                     while True:
-                        chunk = await self.process.stdout.read(65536)
+                        chunk = await process.stdout.read(65536)
                         if not chunk:
                             if buffer:
                                 line_str = buffer.decode(
@@ -216,7 +224,8 @@ class ManagedClaudeSession:
                         logger.info("CLI_SESSION: Yielding error event from stderr")
                         yield {"type": "error", "error": {"message": stderr_text}}
 
-                return_code = await self.process.wait()
+                return_code = await process.wait()
+                termination_confirmed = True
                 logger.info(
                     f"Claude CLI exited with code {return_code}, stderr_present={bool(stderr_text)}"
                 )
@@ -231,8 +240,12 @@ class ManagedClaudeSession:
                 }
             finally:
                 self._is_busy = False
-                if self.process and self.process.pid:
-                    unregister_pid(self.process.pid)
+                if (
+                    process
+                    and process.pid
+                    and (termination_confirmed or process.returncode is not None)
+                ):
+                    unregister_pid(process.pid)
 
     async def _handle_line_gen(
         self, line_str: str, parse_state: ManagedClaudeParseState
@@ -245,19 +258,28 @@ class ManagedClaudeSession:
                     self.current_session_id = session_id
             yield event
 
-    async def stop(self):
-        """Stop the CLI process."""
-        if self.process and self.process.returncode is None:
+    async def stop(self) -> bool:
+        """Stop the CLI process, retaining PID ownership until exit is confirmed."""
+        async with self._lifecycle_lock:
+            self._closed = True
+            process = self.process
+            if process is None:
+                return True
+            if process.returncode is not None:
+                if process.pid:
+                    unregister_pid(process.pid)
+                return True
+
             try:
-                logger.info(f"Stopping Claude CLI process {self.process.pid}")
-                kill_pid_tree_best_effort(self.process.pid)
+                logger.info(f"Stopping Claude CLI process {process.pid}")
+                kill_pid_tree_best_effort(process.pid)
                 try:
-                    await asyncio.wait_for(self.process.wait(), timeout=5.0)
+                    await asyncio.wait_for(process.wait(), timeout=5.0)
                 except TimeoutError:
-                    self.process.kill()
-                    await self.process.wait()
-                if self.process and self.process.pid:
-                    unregister_pid(self.process.pid)
+                    process.kill()
+                    await process.wait()
+                if process.pid:
+                    unregister_pid(process.pid)
                 return True
             except Exception as e:
                 if self._log_raw_cli_diagnostics:
@@ -272,4 +294,3 @@ class ManagedClaudeSession:
                         type(e).__name__,
                     )
                 return False
-        return False

--- a/src/free_claude_code/messaging/node_event_pipeline.py
+++ b/src/free_claude_code/messaging/node_event_pipeline.py
@@ -35,7 +35,12 @@ async def handle_session_info_event(
     if not real_session_id or not temp_session_id:
         return captured_session_id, temp_session_id
 
-    await cli_manager.register_real_session_id(temp_session_id, real_session_id)
+    registered = await cli_manager.register_real_session_id(
+        temp_session_id,
+        real_session_id,
+    )
+    if not registered:
+        raise RuntimeError("Managed Claude session registration failed.")
     trace_event(
         stage="claude_cli",
         event="claude_cli.session.registered",

--- a/src/free_claude_code/messaging/session/persistence.py
+++ b/src/free_claude_code/messaging/session/persistence.py
@@ -62,24 +62,31 @@ class DebouncedJsonPersistence:
         timer.start()
 
     def flush(self) -> None:
+        self._on_dirty(True)
         pending = self._snapshot_for_write()
         if pending is None:
             return
         self._write_pending(pending)
 
     def _save_from_timer(self, generation: int) -> None:
-        pending = self._snapshot_for_write(expected_generation=generation)
-        if pending is None:
-            return
-        self._write_pending(pending)
+        try:
+            pending = self._snapshot_for_write(expected_generation=generation)
+            if pending is None:
+                return
+            self._write_pending(pending)
+        except Exception as e:
+            self._on_dirty(True)
+            logger.error(
+                "Failed to save sessions: exc_type={}",
+                type(e).__name__,
+            )
 
     def _write_pending(self, pending: _PendingWrite) -> None:
         try:
             written = self._write_if_current(pending)
-        except Exception as e:
-            logger.error("Failed to save sessions: {}", e)
+        except Exception:
             self._on_dirty(True)
-            return
+            raise
         if written:
             self._mark_clean_if_current(pending.generation)
 
@@ -122,6 +129,7 @@ class DebouncedJsonPersistence:
 
     def write_data(self, data: dict[str, Any]) -> None:
         """Write authoritative state after invalidating older pending snapshots."""
+        self._on_dirty(True)
         with self._timer_lock:
             if self._save_timer is not None:
                 self._save_timer.cancel()

--- a/src/free_claude_code/messaging/session/store.py
+++ b/src/free_claude_code/messaging/session/store.py
@@ -159,5 +159,5 @@ class SessionStore:
             self._write_current_state()
 
     def _write_current_state(self) -> None:
-        self._set_dirty(False)
+        self._set_dirty(True)
         self._persistence.write_data(self._snapshot_for_persistence())

--- a/src/free_claude_code/messaging/trees/manager.py
+++ b/src/free_claude_code/messaging/trees/manager.py
@@ -86,6 +86,7 @@ class TreeQueueManager:
         queue_update_callback: QueueUpdateCallback | None = None,
         node_started_callback: NodeStartedCallback | None = None,
         unexpected_failure_callback: Callable[[FailureResult], None] | None = None,
+        log_messaging_error_details: bool = False,
         _repository: TreeRepository | None = None,
         _restored_snapshot: ConversationSnapshot | None = None,
         _restored_stale_targets: tuple[NodeUiTarget, ...] = (),
@@ -98,6 +99,7 @@ class TreeQueueManager:
             claim_finished_callback=self._finish_claim,
             queue_update_callback=queue_update_callback,
             node_started_callback=node_started_callback,
+            log_messaging_error_details=log_messaging_error_details,
         )
         self._restored_snapshot = _restored_snapshot
         self._restored_stale_targets = _restored_stale_targets
@@ -521,6 +523,10 @@ class TreeQueueManager:
     def task_count(self) -> int:
         return self._processor.task_count()
 
+    async def wait_idle(self) -> None:
+        """Wait until every processor-owned claim has finished cleanup."""
+        await self._processor.wait_idle()
+
     async def get_message_ids_for_chat(self, platform: str, chat_id: str) -> set[str]:
         async with self._lock:
             message_ids: set[str] = set()
@@ -544,6 +550,7 @@ class TreeQueueManager:
         queue_update_callback: QueueUpdateCallback | None = None,
         node_started_callback: NodeStartedCallback | None = None,
         unexpected_failure_callback: Callable[[FailureResult], None] | None = None,
+        log_messaging_error_details: bool = False,
     ) -> TreeQueueManager:
         repository, normalized, stale_targets = TreeRepository.from_snapshot(snapshot)
         return cls(
@@ -551,6 +558,7 @@ class TreeQueueManager:
             queue_update_callback=queue_update_callback,
             node_started_callback=node_started_callback,
             unexpected_failure_callback=unexpected_failure_callback,
+            log_messaging_error_details=log_messaging_error_details,
             _repository=repository,
             _restored_snapshot=normalized,
             _restored_stale_targets=stale_targets,

--- a/src/free_claude_code/messaging/trees/processor.py
+++ b/src/free_claude_code/messaging/trees/processor.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from free_claude_code.config.settings import get_settings
-
 from ..safe_diagnostics import format_exception_for_log
 from .runtime import MessageTree
 from .transitions import CancellationReason, NodeClaim, QueueEntry
@@ -51,13 +49,17 @@ class TreeQueueProcessor:
         claim_finished_callback: ClaimFinishedCallback,
         queue_update_callback: QueueUpdateCallback | None = None,
         node_started_callback: NodeStartedCallback | None = None,
+        log_messaging_error_details: bool = False,
     ) -> None:
         self._node_processor = node_processor
         self._claim_failure_callback = claim_failure_callback
         self._claim_finished_callback = claim_finished_callback
         self._queue_update_callback = queue_update_callback
         self._node_started_callback = node_started_callback
+        self._log_messaging_error_details = log_messaging_error_details
         self._tasks: dict[str, _TaskSlot] = {}
+        self._idle = asyncio.Event()
+        self._idle.set()
 
     @staticmethod
     def _key(claim: NodeClaim) -> str:
@@ -77,18 +79,24 @@ class TreeQueueProcessor:
             raise RuntimeError(f"Claim {key} already has a task")
         slot = _TaskSlot(tree=tree, claim=claim)
         self._tasks[key] = slot
+        self._idle.clear()
+        claim_runner = self._run_claim(
+            slot,
+            announce_started=announce_started,
+            queue=queue,
+        )
         try:
             task = asyncio.create_task(
-                self._run_claim(
-                    slot,
-                    announce_started=announce_started,
-                    queue=queue,
-                ),
+                claim_runner,
                 name=(f"messaging-claim-{claim.identity.root_id}-{claim.claim_id[:8]}"),
                 eager_start=False,
             )
         except BaseException:
-            self._tasks.pop(key, None)
+            claim_runner.close()
+            if self._tasks.get(key) is slot:
+                self._tasks.pop(key)
+            if not self._tasks:
+                self._idle.set()
             raise
         slot.task = task
         task.add_done_callback(lambda _task, claim_key=key: self._task_done(claim_key))
@@ -117,10 +125,12 @@ class TreeQueueProcessor:
         try:
             await self._queue_update_callback(queue)
         except Exception as exc:
-            details = get_settings().log_messaging_error_details
             logger.warning(
                 "Queue update callback failed: {}",
-                format_exception_for_log(exc, log_full_message=details),
+                format_exception_for_log(
+                    exc,
+                    log_full_message=self._log_messaging_error_details,
+                ),
             )
 
     async def notify_queue_updated(self, queue: tuple[QueueEntry, ...]) -> None:
@@ -133,10 +143,12 @@ class TreeQueueProcessor:
         try:
             await self._node_started_callback(claim)
         except Exception as exc:
-            details = get_settings().log_messaging_error_details
             logger.warning(
                 "Node started callback failed: {}",
-                format_exception_for_log(exc, log_full_message=details),
+                format_exception_for_log(
+                    exc,
+                    log_full_message=self._log_messaging_error_details,
+                ),
             )
 
     async def _run_claim(
@@ -161,11 +173,13 @@ class TreeQueueProcessor:
             logger.info("Task for node {} was cancelled", claim.node.node_id)
             raise
         except Exception as exc:
-            details = get_settings().log_messaging_error_details
             logger.error(
                 "Error processing node {}: {}",
                 claim.node.node_id,
-                format_exception_for_log(exc, log_full_message=details),
+                format_exception_for_log(
+                    exc,
+                    log_full_message=self._log_messaging_error_details,
+                ),
             )
             await self._claim_failure_callback(claim)
         finally:
@@ -188,7 +202,11 @@ class TreeQueueProcessor:
                 continue
 
         slot.transitioned = True
-        self._tasks.pop(self._key(slot.claim), None)
+        key = self._key(slot.claim)
+        if self._tasks.get(key) is slot:
+            self._tasks.pop(key)
+        if not self._tasks:
+            self._idle.set()
 
     def cancel(
         self,
@@ -222,6 +240,10 @@ class TreeQueueProcessor:
     def task_count(self) -> int:
         """Return the number of attached claims for observability."""
         return len(self._tasks)
+
+    async def wait_idle(self) -> None:
+        """Wait until every published claim and recovery task has finished."""
+        await self._idle.wait()
 
 
 __all__ = ["CancelledTask", "TreeQueueProcessor"]

--- a/src/free_claude_code/messaging/trees/processor.py
+++ b/src/free_claude_code/messaging/trees/processor.py
@@ -58,6 +58,7 @@ class TreeQueueProcessor:
         self._node_started_callback = node_started_callback
         self._log_messaging_error_details = log_messaging_error_details
         self._tasks: dict[str, _TaskSlot] = {}
+        self._completion_failures: list[Exception] = []
         self._idle = asyncio.Event()
         self._idle.set()
 
@@ -191,22 +192,33 @@ class TreeQueueProcessor:
         if current is not None:
             while current.cancelling():
                 current.uncancel()
-        while True:
-            try:
-                await self._claim_finished_callback(slot.tree, slot.claim)
-                break
-            except asyncio.CancelledError:
-                if current is not None:
-                    while current.cancelling():
-                        current.uncancel()
-                continue
-
-        slot.transitioned = True
-        key = self._key(slot.claim)
-        if self._tasks.get(key) is slot:
-            self._tasks.pop(key)
-        if not self._tasks:
-            self._idle.set()
+        try:
+            while True:
+                try:
+                    await self._claim_finished_callback(slot.tree, slot.claim)
+                    slot.transitioned = True
+                    break
+                except asyncio.CancelledError:
+                    if current is not None:
+                        while current.cancelling():
+                            current.uncancel()
+                    continue
+        except Exception as exc:
+            self._completion_failures.append(exc)
+            logger.error(
+                "Claim completion callback failed for node {}: {}",
+                slot.claim.node.node_id,
+                format_exception_for_log(
+                    exc,
+                    log_full_message=self._log_messaging_error_details,
+                ),
+            )
+        finally:
+            key = self._key(slot.claim)
+            if self._tasks.get(key) is slot:
+                self._tasks.pop(key)
+            if not self._tasks:
+                self._idle.set()
 
     def cancel(
         self,
@@ -242,8 +254,15 @@ class TreeQueueProcessor:
         return len(self._tasks)
 
     async def wait_idle(self) -> None:
-        """Wait until every published claim and recovery task has finished."""
+        """Wait for every task and hand completion failures to the caller once."""
         await self._idle.wait()
+        if not self._completion_failures:
+            return
+        failures = self._completion_failures
+        self._completion_failures = []
+        if len(failures) == 1:
+            raise failures[0]
+        raise ExceptionGroup("Messaging claim completion failures", failures)
 
 
 __all__ = ["CancelledTask", "TreeQueueProcessor"]

--- a/src/free_claude_code/messaging/workflow.py
+++ b/src/free_claude_code/messaging/workflow.py
@@ -95,6 +95,7 @@ class MessagingWorkflow:
                 queue_update_callback=self.turn_intake.update_queue_positions,
                 node_started_callback=self.turn_intake.mark_node_processing,
                 unexpected_failure_callback=self._apply_unexpected_failure,
+                log_messaging_error_details=self._log_messaging_error_details,
             )
         return TreeQueueManager.from_snapshot(
             snapshot,
@@ -102,6 +103,7 @@ class MessagingWorkflow:
             queue_update_callback=self.turn_intake.update_queue_positions,
             node_started_callback=self.turn_intake.mark_node_processing,
             unexpected_failure_callback=self._apply_unexpected_failure,
+            log_messaging_error_details=self._log_messaging_error_details,
         )
 
     def format_status(self, emoji: str, label: str, suffix: str | None = None) -> str:
@@ -157,8 +159,10 @@ class MessagingWorkflow:
                     type(exc).__name__,
                 )
 
-    def close(self) -> None:
-        """Flush pending session persistence before runtime shutdown."""
+    async def close(self) -> None:
+        """Finish every owned task and durable write before releasing delivery."""
+        await self.stop_all_tasks()
+        await self._tree_queue.wait_idle()
         self.session_store.flush_pending_save()
 
     async def handle_message(self, incoming: IncomingMessage) -> None:
@@ -299,13 +303,37 @@ class MessagingWorkflow:
             except Exception as exc:
                 logger.warning("Failed to clear session store: {}", type(exc).__name__)
 
-            result = await self._tree_queue.clear_all(reason=CancellationReason.STOP)
+            failures: list[Exception] = []
+            result = CancellationResult()
+            try:
+                result = await self._tree_queue.clear_all(
+                    reason=CancellationReason.STOP
+                )
+            except Exception as exc:
+                failures.append(exc)
             # A runner may terminalize during task draining after the early
             # store clear. The detached manager now rejects later writes; clear
             # this final pre-detach snapshot without erasing newer message logs.
-            self.session_store.clear_conversation_snapshot()
-            self._apply_cancellation_result(result)
-            await self.cli_manager.stop_all()
+            try:
+                self.session_store.clear_conversation_snapshot()
+            except Exception as exc:
+                failures.append(exc)
+                logger.warning(
+                    "Failed to persist final cleared session state: {}",
+                    type(exc).__name__,
+                )
+            try:
+                self._apply_cancellation_result(result)
+            except Exception as exc:
+                failures.append(exc)
+            try:
+                await self.cli_manager.stop_all()
+            except Exception as exc:
+                failures.append(exc)
+            if len(failures) == 1:
+                raise failures[0]
+            if failures:
+                raise ExceptionGroup("Global clear failed", failures)
             return frozenset(message_ids)
 
     def forget_message_ids(

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -126,6 +126,11 @@ class ApplicationRuntime:
     def settings(self) -> Settings:
         return self.provider_manager.current_settings()
 
+    @property
+    def is_closed(self) -> bool:
+        """Whether this runtime released its complete ownership graph."""
+        return self._closed
+
     async def start(self) -> None:
         if self._started:
             return
@@ -306,7 +311,7 @@ class ApplicationRuntime:
             if components is not None:
                 await self._start_messaging_workflow(components)
         except ImportError as exc:
-            await self._cleanup_messaging()
+            cleaned = await self._cleanup_messaging()
             if self.settings.log_api_error_tracebacks:
                 logger.warning("Messaging module import error: {}", exc)
             else:
@@ -314,8 +319,10 @@ class ApplicationRuntime:
                     "Messaging module import error: exc_type={}",
                     type(exc).__name__,
                 )
+            if not cleaned:
+                raise RuntimeError("Messaging startup cleanup incomplete") from exc
         except Exception as exc:
-            await self._cleanup_messaging()
+            cleaned = await self._cleanup_messaging()
             if self.settings.log_api_error_tracebacks:
                 logger.error("Failed to start messaging platform: {}", exc)
                 logger.error(traceback.format_exc())
@@ -324,6 +331,8 @@ class ApplicationRuntime:
                     "Failed to start messaging platform: exc_type={}",
                     type(exc).__name__,
                 )
+            if not cleaned:
+                raise RuntimeError("Messaging startup cleanup incomplete") from exc
 
     def _messaging_options(self) -> MessagingPlatformOptions:
         settings = self.settings
@@ -421,25 +430,14 @@ class ApplicationRuntime:
                 return False
 
         if workflow is not None:
-            drained = await best_effort(
-                "messaging_workflow.stop_all_tasks",
-                workflow.stop_all_tasks(),
+            closed = await best_effort(
+                "messaging_workflow.close",
+                workflow.close(),
                 log_verbose_errors=verbose,
             )
-            if not drained:
+            if not closed:
                 # Active workflow tasks may still need delivery, transcription,
                 # CLI sessions, and providers while a later close retries drain.
-                return False
-            try:
-                workflow.close()
-            except Exception as exc:
-                if verbose:
-                    logger.warning("Session store flush on shutdown: {}", exc)
-                else:
-                    logger.warning(
-                        "Session store flush on shutdown: exc_type={}",
-                        type(exc).__name__,
-                    )
                 return False
             if self._messaging_workflow is workflow:
                 self._messaging_workflow = None

--- a/tests/cli/test_cli_manager_edge_cases.py
+++ b/tests/cli/test_cli_manager_edge_cases.py
@@ -93,7 +93,7 @@ async def test_remove_session_active_removes_temp_mapping():
 
 
 @pytest.mark.asyncio
-async def test_stop_all_handles_stop_exceptions():
+async def test_stop_all_reports_and_retains_stop_exceptions():
     from free_claude_code.cli.managed.manager import ManagedClaudeSessionManager
 
     manager = ManagedClaudeSessionManager(workspace_path="/tmp", api_url="http://x/v1")
@@ -109,8 +109,12 @@ async def test_stop_all_handles_stop_exceptions():
     manager._sessions["a"] = s1
     manager._pending_sessions["b"] = s2
 
-    await manager.stop_all()
+    with pytest.raises(
+        RuntimeError,
+        match=r"^Managed Claude session shutdown failures: 1\.$",
+    ):
+        await manager.stop_all()
     s1.stop.assert_awaited_once()
     s2.stop.assert_awaited_once()
-    assert manager.get_stats()["active_sessions"] == 0
+    assert manager.get_stats()["active_sessions"] == 1
     assert manager.get_stats()["pending_sessions"] == 0

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -277,9 +277,13 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
     servers: list[object] = []
     restart_callbacks: list[Callable[[], None]] = []
 
+    apps: list[SimpleNamespace] = []
+
     def build_asgi_app(_settings: Settings, restart_callback: Callable[[], None]):
         restart_callbacks.append(restart_callback)
-        return MagicMock()
+        app = SimpleNamespace(runtime=SimpleNamespace(is_closed=False))
+        apps.append(app)
+        return app
 
     class FakeServer:
         def __init__(self, config):
@@ -291,6 +295,7 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
             if len(servers) == 1:
                 restart_callbacks[-1]()
                 assert self.should_exit is True
+                self.config.app.runtime.is_closed = True
 
     def fake_config(app, **kwargs):
         return SimpleNamespace(app=app, kwargs=kwargs)
@@ -307,6 +312,47 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
 
     assert len(servers) == 2
     get_settings.cache_clear.assert_called_once()
+    kill_all.assert_called_once()
+
+
+def test_serve_supervisor_refuses_restart_after_incomplete_shutdown() -> None:
+    from free_claude_code.cli import entrypoints
+
+    settings = _launcher_settings()
+    get_settings = MagicMock(return_value=settings)
+    get_settings.cache_clear = MagicMock()
+    servers: list[object] = []
+    restart_callbacks: list[Callable[[], None]] = []
+
+    def build_asgi_app(_settings: Settings, restart_callback: Callable[[], None]):
+        restart_callbacks.append(restart_callback)
+        return SimpleNamespace(runtime=SimpleNamespace(is_closed=False))
+
+    class FakeServer:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit = False
+            servers.append(self)
+
+        def run(self):
+            restart_callbacks[-1]()
+            assert self.should_exit is True
+
+    def fake_config(app, **kwargs):
+        return SimpleNamespace(app=app, kwargs=kwargs)
+
+    with (
+        patch.object(entrypoints, "get_settings", get_settings),
+        patch.object(entrypoints.uvicorn, "Config", side_effect=fake_config),
+        patch.object(entrypoints.uvicorn, "Server", side_effect=FakeServer),
+        patch.object(entrypoints, "build_asgi_app", side_effect=build_asgi_app),
+        patch.object(entrypoints, "_schedule_open_admin_browser"),
+        patch.object(entrypoints, "kill_all_best_effort") as kill_all,
+    ):
+        entrypoints.serve()
+
+    assert len(servers) == 1
+    get_settings.cache_clear.assert_not_called()
     kill_all.assert_called_once()
 
 

--- a/tests/cli/test_managed_session_shutdown.py
+++ b/tests/cli/test_managed_session_shutdown.py
@@ -1,0 +1,471 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from free_claude_code.cli.managed.manager import ManagedClaudeSessionManager
+from free_claude_code.cli.managed.session import ManagedClaudeSession
+
+
+def _manager() -> ManagedClaudeSessionManager:
+    return ManagedClaudeSessionManager(
+        workspace_path="/tmp",
+        api_url="http://127.0.0.1:8082/v1",
+    )
+
+
+def _mock_session(*stop_results: object) -> MagicMock:
+    session = MagicMock(spec=ManagedClaudeSession)
+    session.is_busy = False
+    session.stop = AsyncMock(side_effect=list(stop_results))
+    return session
+
+
+def _completed_process(pid: int) -> MagicMock:
+    process = MagicMock()
+    process.pid = pid
+    process.returncode = 0
+    process.stdout.read = AsyncMock(return_value=b"")
+    process.stderr = None
+    process.wait = AsyncMock(return_value=0)
+    return process
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent_without_a_live_process() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+
+    assert await session.stop() is True
+
+    process = MagicMock()
+    process.pid = 101
+    process.returncode = 0
+    process.wait = AsyncMock()
+    session.process = process
+
+    with (
+        patch(
+            "free_claude_code.cli.managed.session.kill_pid_tree_best_effort"
+        ) as kill_tree,
+        patch("free_claude_code.cli.managed.session.unregister_pid") as unregister,
+    ):
+        assert await session.stop() is True
+
+    kill_tree.assert_not_called()
+    process.wait.assert_not_awaited()
+    unregister.assert_called_once_with(101)
+
+
+@pytest.mark.asyncio
+async def test_stopped_session_reference_cannot_launch_a_new_process() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+
+    assert await session.stop() is True
+
+    with (
+        patch(
+            "free_claude_code.cli.managed.session.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_completed_process(100)),
+        ) as create_process,
+        patch("free_claude_code.cli.managed.session.trace_event") as trace,
+        pytest.raises(RuntimeError, match="closed"),
+    ):
+        async for _ in session.start_task("must not launch"):
+            pass
+
+    create_process.assert_not_awaited()
+    trace.assert_not_called()
+    assert session.is_busy is False
+
+
+@pytest.mark.asyncio
+async def test_launch_publication_wins_before_concurrent_stop() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    launch_entered = asyncio.Event()
+    release_launch = asyncio.Event()
+    release_stream = asyncio.Event()
+    process = MagicMock()
+    process.pid = 102
+    process.returncode = None
+    process.stderr = None
+
+    async def create_process(*_args: object, **_kwargs: object) -> MagicMock:
+        launch_entered.set()
+        await release_launch.wait()
+        return process
+
+    async def read_stdout(*_args: object, **_kwargs: object) -> bytes:
+        await release_stream.wait()
+        return b""
+
+    async def wait_process() -> int:
+        process.returncode = 0
+        return 0
+
+    process.stdout.read = AsyncMock(side_effect=read_stdout)
+    process.wait = AsyncMock(side_effect=wait_process)
+
+    with (
+        patch(
+            "free_claude_code.cli.managed.session.asyncio.create_subprocess_exec",
+            side_effect=create_process,
+        ),
+        patch("free_claude_code.cli.managed.session.kill_pid_tree_best_effort"),
+        patch("free_claude_code.cli.managed.session.register_pid"),
+        patch("free_claude_code.cli.managed.session.unregister_pid"),
+    ):
+        stream_task = asyncio.create_task(
+            _collect_session_events(session, "launch wins")
+        )
+        await launch_entered.wait()
+        stop_task = asyncio.create_task(session.stop())
+        await asyncio.sleep(0)
+        stopped_before_publication = stop_task.done()
+
+        release_launch.set()
+        assert await asyncio.wait_for(stop_task, timeout=1) is True
+        release_stream.set()
+        events = await asyncio.wait_for(stream_task, timeout=1)
+
+        with pytest.raises(RuntimeError, match="closed"):
+            async for _ in session.start_task("cannot relaunch"):
+                pass
+
+    assert events == [{"type": "exit", "code": 0, "stderr": None}]
+    assert stopped_before_publication is False
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stop_wins_before_launch_publication() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    stop_entered = asyncio.Event()
+    release_stop = asyncio.Event()
+    process = MagicMock()
+    process.pid = 103
+    process.returncode = None
+
+    async def wait_process() -> int:
+        stop_entered.set()
+        await release_stop.wait()
+        process.returncode = 0
+        return 0
+
+    process.wait = AsyncMock(side_effect=wait_process)
+    session.process = process
+    unexpected_process = _completed_process(106)
+
+    with (
+        patch(
+            "free_claude_code.cli.managed.session.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=unexpected_process),
+        ) as create_process,
+        patch("free_claude_code.cli.managed.session.kill_pid_tree_best_effort"),
+        patch("free_claude_code.cli.managed.session.unregister_pid"),
+        patch("free_claude_code.cli.managed.session.trace_event") as trace,
+    ):
+        stop_task = asyncio.create_task(session.stop())
+        await stop_entered.wait()
+        stream_task = asyncio.create_task(_collect_session_events(session, "stop wins"))
+        await asyncio.sleep(0)
+
+        release_stop.set()
+        assert await asyncio.wait_for(stop_task, timeout=1) is True
+        with pytest.raises(RuntimeError, match="closed"):
+            await asyncio.wait_for(stream_task, timeout=1)
+
+    create_process.assert_not_awaited()
+    trace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_normal_sequential_starts_remain_allowed_before_stop() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    processes = [_completed_process(104), _completed_process(105)]
+
+    with (
+        patch(
+            "free_claude_code.cli.managed.session.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=processes),
+        ) as create_process,
+        patch("free_claude_code.cli.managed.session.register_pid"),
+        patch("free_claude_code.cli.managed.session.unregister_pid"),
+    ):
+        first = await _collect_session_events(session, "first")
+        second = await _collect_session_events(session, "second")
+
+    assert first == [{"type": "exit", "code": 0, "stderr": None}]
+    assert second == [{"type": "exit", "code": 0, "stderr": None}]
+    assert create_process.await_count == 2
+
+
+async def _collect_session_events(
+    session: ManagedClaudeSession,
+    prompt: str,
+) -> list[dict]:
+    return [event async for event in session.start_task(prompt)]
+
+
+@pytest.mark.asyncio
+async def test_failed_stop_keeps_pid_registered_until_retry_confirms_exit() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    process = MagicMock()
+    process.pid = 202
+    process.returncode = None
+    process.wait = AsyncMock(side_effect=[RuntimeError("wait failed"), 0])
+    session.process = process
+
+    with (
+        patch("free_claude_code.cli.managed.session.kill_pid_tree_best_effort"),
+        patch("free_claude_code.cli.managed.session.unregister_pid") as unregister,
+    ):
+        assert await session.stop() is False
+        unregister.assert_not_called()
+
+        assert await session.stop() is True
+
+    unregister.assert_called_once_with(202)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stop_keeps_pid_registered_and_can_be_retried() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    process = MagicMock()
+    process.pid = 303
+    process.returncode = None
+    wait_entered = asyncio.Event()
+
+    async def wait_until_cancelled() -> int:
+        wait_entered.set()
+        await asyncio.Event().wait()
+        return 0
+
+    process.wait = AsyncMock(side_effect=wait_until_cancelled)
+    session.process = process
+
+    with (
+        patch("free_claude_code.cli.managed.session.kill_pid_tree_best_effort"),
+        patch("free_claude_code.cli.managed.session.unregister_pid") as unregister,
+    ):
+        stopping = asyncio.create_task(session.stop())
+        await wait_entered.wait()
+        stopping.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await stopping
+        unregister.assert_not_called()
+
+        process.wait = AsyncMock(return_value=0)
+        assert await session.stop() is True
+
+    unregister.assert_called_once_with(303)
+
+
+@pytest.mark.asyncio
+async def test_task_failure_keeps_unconfirmed_process_pid_registered() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    process = MagicMock()
+    process.pid = 404
+    process.returncode = None
+    process.stdout.read = AsyncMock(side_effect=RuntimeError("read failed"))
+    process.stderr = None
+
+    with (
+        patch(
+            "free_claude_code.cli.managed.session.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ),
+        patch("free_claude_code.cli.managed.session.register_pid") as register,
+        patch("free_claude_code.cli.managed.session.unregister_pid") as unregister,
+        pytest.raises(RuntimeError, match="read failed"),
+    ):
+        async for _ in session.start_task("hello"):
+            pass
+
+    register.assert_called_once_with(404)
+    unregister.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_completed_task_wait_unregisters_confirmed_process_pid() -> None:
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    process = MagicMock()
+    process.pid = 405
+    process.returncode = None
+    process.stdout.read = AsyncMock(return_value=b"")
+    process.stderr = None
+    process.wait = AsyncMock(return_value=0)
+
+    with (
+        patch(
+            "free_claude_code.cli.managed.session.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ),
+        patch("free_claude_code.cli.managed.session.register_pid") as register,
+        patch("free_claude_code.cli.managed.session.unregister_pid") as unregister,
+    ):
+        events = [event async for event in session.start_task("hello")]
+
+    assert events == [{"type": "exit", "code": 0, "stderr": None}]
+    register.assert_called_once_with(405)
+    unregister.assert_called_once_with(405)
+
+
+@pytest.mark.parametrize(
+    ("first_stop", "raised"),
+    [
+        (False, None),
+        (RuntimeError("stop failed"), RuntimeError),
+        (asyncio.CancelledError(), asyncio.CancelledError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_remove_failure_retains_exact_aliases_and_closes_session_for_reuse(
+    first_stop: object,
+    raised: type[BaseException] | None,
+) -> None:
+    manager = _manager()
+    session = _mock_session(first_stop, True)
+    manager._sessions["real_1"] = session
+    manager._temp_to_real["temp_1"] = "real_1"
+    manager._real_to_temp["real_1"] = "temp_1"
+    expected_sessions = dict(manager._sessions)
+    expected_temp_to_real = dict(manager._temp_to_real)
+    expected_real_to_temp = dict(manager._real_to_temp)
+
+    if raised is None:
+        assert await manager.remove_session("real_1") is False
+    else:
+        with pytest.raises(raised):
+            await manager.remove_session("real_1")
+
+    assert manager._sessions == expected_sessions
+    assert manager._temp_to_real == expected_temp_to_real
+    assert manager._real_to_temp == expected_real_to_temp
+    with pytest.raises(RuntimeError, match="closing"):
+        await manager.get_or_create_session("real_1")
+    with pytest.raises(RuntimeError, match="closing"):
+        await manager.get_or_create_session("temp_1")
+
+    assert await manager.remove_session("temp_1") is True
+    assert manager._sessions == {}
+    assert manager._temp_to_real == {}
+    assert manager._real_to_temp == {}
+    assert session.stop.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_a_pending_session_after_stop_failure() -> None:
+    manager = _manager()
+    session = _mock_session(False)
+    manager._pending_sessions["temp_1"] = session
+
+    assert await manager.remove_session("temp_1") is False
+    assert await manager.register_real_session_id("temp_1", "real_1") is False
+    assert manager._pending_sessions == {"temp_1": session}
+    assert manager._sessions == {}
+    assert manager._temp_to_real == {}
+    assert manager._real_to_temp == {}
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_real_id_owned_by_a_different_session() -> None:
+    manager = _manager()
+    existing = _mock_session(False)
+    pending = _mock_session(True)
+    manager._sessions["real_1"] = existing
+    manager._pending_sessions["temp_2"] = pending
+
+    assert await manager.register_real_session_id("temp_2", "real_1") is False
+
+    assert manager._sessions == {"real_1": existing}
+    assert manager._pending_sessions == {"temp_2": pending}
+    assert manager._temp_to_real == {}
+    assert manager._real_to_temp == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_all_never_loses_a_closing_owner_outside_identity_maps() -> None:
+    manager = _manager()
+    orphaned_owner = _mock_session(False)
+    mapped_owner = _mock_session(True)
+    manager._closing_sessions.add(orphaned_owner)
+    manager._sessions["real_1"] = mapped_owner
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"^Managed Claude session shutdown failures: 1\.$",
+    ):
+        await manager.stop_all()
+
+    orphaned_owner.stop.assert_awaited_once()
+    mapped_owner.stop.assert_awaited_once()
+    assert manager._sessions == {}
+    assert manager._closing_sessions == {orphaned_owner}
+
+    orphaned_owner.stop = AsyncMock(return_value=True)
+    await manager.stop_all()
+
+    orphaned_owner.stop.assert_awaited_once()
+    assert manager._closing_sessions == set()
+
+
+@pytest.mark.asyncio
+async def test_stop_all_attempts_every_session_and_retains_only_failures() -> None:
+    manager = _manager()
+    returned_false = _mock_session(False)
+    raised_error = _mock_session(RuntimeError("secret failure detail"))
+    stopped = _mock_session(True)
+    manager._sessions.update(
+        {
+            "real_error": raised_error,
+            "real_false": returned_false,
+            "real_stopped": stopped,
+        }
+    )
+    manager._temp_to_real.update(
+        {
+            "temp_error": "real_error",
+            "temp_false": "real_false",
+            "temp_stopped": "real_stopped",
+        }
+    )
+    manager._real_to_temp.update(
+        {
+            "real_error": "temp_error",
+            "real_false": "temp_false",
+            "real_stopped": "temp_stopped",
+        }
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await manager.stop_all()
+
+    assert str(exc_info.value) == "Managed Claude session shutdown failures: 2."
+    returned_false.stop.assert_awaited_once()
+    raised_error.stop.assert_awaited_once()
+    stopped.stop.assert_awaited_once()
+    assert manager._sessions == {
+        "real_error": raised_error,
+        "real_false": returned_false,
+    }
+    assert manager._pending_sessions == {}
+    assert manager._temp_to_real == {
+        "temp_error": "real_error",
+        "temp_false": "real_false",
+    }
+    assert manager._real_to_temp == {
+        "real_error": "temp_error",
+        "real_false": "temp_false",
+    }
+    with pytest.raises(RuntimeError, match="closing"):
+        await manager.get_or_create_session("temp_false")
+    with pytest.raises(RuntimeError, match="closing"):
+        await manager.get_or_create_session("temp_error")
+
+    returned_false.stop = AsyncMock(return_value=True)
+    raised_error.stop = AsyncMock(return_value=True)
+    await manager.stop_all()
+
+    assert manager._sessions == {}
+    assert manager._pending_sessions == {}
+    assert manager._temp_to_real == {}
+    assert manager._real_to_temp == {}

--- a/tests/contracts/test_import_boundaries.py
+++ b/tests/contracts/test_import_boundaries.py
@@ -14,7 +14,7 @@ ALLOWED_PACKAGE_DEPENDENCIES: dict[str, set[str]] = {
     "config": set(),
     "core": set(),
     "application": {"config", "core"},
-    "messaging": {"config", "core"},
+    "messaging": {"core"},
     "providers": {"application", "config", "core"},
     "api": {"application", "config", "core"},
     "cli": {"config", "core"},

--- a/tests/messaging/test_handler.py
+++ b/tests/messaging/test_handler.py
@@ -16,6 +16,7 @@ from free_claude_code.messaging.trees import (
     QueueEntry,
     ReplyTarget,
     TreeIdentity,
+    TreeQueueManager,
     TreeSnapshot,
 )
 from free_claude_code.messaging.trees.transitions import CancellationEffect
@@ -138,6 +139,21 @@ async def test_handle_message_stop_command(
         fire_and_forget=False,
         message_thread_id=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_failed_global_stop_never_reports_success(
+    handler, mock_platform, incoming_message_factory
+) -> None:
+    incoming = incoming_message_factory(text="/stop")
+    handler.stop_all_tasks = AsyncMock(
+        side_effect=RuntimeError("Failed to stop 1 managed Claude session.")
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to stop"):
+        await handler.handle_message(incoming)
+
+    mock_platform.queue_send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -428,6 +444,70 @@ async def test_stop_all_persists_committed_transition_before_cli_shutdown(
 
 
 @pytest.mark.asyncio
+async def test_terminal_close_waits_past_interactive_drain_timeout(
+    monkeypatch,
+    mock_platform,
+    mock_cli_manager,
+    mock_session_store,
+    incoming_message_factory,
+) -> None:
+    monkeypatch.setattr(
+        "free_claude_code.messaging.trees.manager.CANCEL_TASK_DRAIN_TIMEOUT_S",
+        0.01,
+    )
+    runner_started = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    cli_stop_seen = asyncio.Event()
+
+    async def cancellation_delayed_runner(_claim: NodeClaim) -> None:
+        runner_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            await release_cleanup.wait()
+            raise
+
+    async def stop_cli() -> None:
+        cli_stop_seen.set()
+
+    mock_platform.queue_send_message.return_value = "status_1"
+    mock_cli_manager.stop_all.side_effect = stop_cli
+    workflow = MessagingWorkflow(
+        mock_platform,
+        mock_cli_manager,
+        mock_session_store,
+        platform_name="telegram",
+    )
+    workflow._tree_queue = TreeQueueManager(cancellation_delayed_runner)
+    await workflow.handle_message(
+        incoming_message_factory(text="work", message_id="work_1")
+    )
+    await runner_started.wait()
+
+    close_task = asyncio.create_task(workflow.close())
+    try:
+        await asyncio.wait_for(cancellation_seen.wait(), timeout=1)
+        await asyncio.wait_for(cli_stop_seen.wait(), timeout=1)
+
+        mock_cli_manager.stop_all.assert_awaited_once()
+        assert close_task.done() is False
+        assert workflow.tree_queue.task_count() == 1
+        mock_session_store.flush_pending_save.assert_not_called()
+
+        release_cleanup.set()
+        await asyncio.wait_for(close_task, timeout=1)
+
+        assert workflow.tree_queue.task_count() == 0
+        mock_session_store.flush_pending_save.assert_called_once()
+    finally:
+        release_cleanup.set()
+        if not close_task.done():
+            await asyncio.wait_for(close_task, timeout=1)
+
+
+@pytest.mark.asyncio
 async def test_node_runner_success_uses_claim_and_semantic_completion(
     handler, mock_cli_manager, mock_platform, mock_session_store
 ):
@@ -536,6 +616,37 @@ async def test_session_info_records_real_session_through_manager(
         ((record_snapshot,), {}),
         ((complete_snapshot,), {}),
     ]
+
+
+@pytest.mark.asyncio
+async def test_session_info_rejects_unregistered_real_session_without_recording_it(
+    handler,
+    mock_cli_manager,
+) -> None:
+    from free_claude_code.messaging.node_event_pipeline import (
+        handle_session_info_event,
+    )
+
+    claim = _claim()
+    record_session = AsyncMock()
+    mock_cli_manager.register_real_session_id.return_value = False
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"^Managed Claude session registration failed\.$",
+    ) as raised:
+        await handle_session_info_event(
+            {"type": "session_info", "session_id": "real_session"},
+            claim,
+            None,
+            "temporary_session",
+            cli_manager=mock_cli_manager,
+            record_session=record_session,
+        )
+
+    assert "real_session" not in str(raised.value)
+    assert "temporary_session" not in str(raised.value)
+    record_session.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -838,6 +949,177 @@ async def test_clear_all_state_is_chat_scoped_for_deletes_and_global_for_fcc_sta
 
 
 @pytest.mark.asyncio
+async def test_global_clear_retries_transient_early_persistence_failure_at_final_write(
+    handler,
+    mock_cli_manager,
+    mock_session_store,
+) -> None:
+    events: list[str] = []
+
+    def fail_early_clear() -> None:
+        events.append("store.clear_all")
+        raise OSError("transient early clear failure")
+
+    async def clear_trees(*, reason: CancellationReason) -> CancellationResult:
+        assert reason is CancellationReason.STOP
+        events.append("trees.clear_all")
+        return CancellationResult()
+
+    def finish_persistence() -> None:
+        events.append("store.clear_conversation_snapshot")
+
+    async def stop_cli() -> None:
+        events.append("cli.stop_all")
+
+    mock_session_store.clear_all.side_effect = fail_early_clear
+    mock_session_store.clear_conversation_snapshot.side_effect = finish_persistence
+    mock_cli_manager.stop_all.side_effect = stop_cli
+
+    with patch.object(handler.tree_queue, "clear_all", side_effect=clear_trees):
+        result = await handler.clear_all_state("telegram", "chat_1")
+
+    assert result == frozenset()
+    assert events == [
+        "store.clear_all",
+        "trees.clear_all",
+        "store.clear_conversation_snapshot",
+        "cli.stop_all",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_global_clear_finishes_cleanup_before_final_persistence_error_escapes(
+    handler,
+    mock_cli_manager,
+    mock_session_store,
+) -> None:
+    events: list[str] = []
+
+    def early_clear() -> None:
+        events.append("store.clear_all")
+
+    async def clear_trees(*, reason: CancellationReason) -> CancellationResult:
+        assert reason is CancellationReason.STOP
+        events.append("trees.clear_all")
+        return CancellationResult()
+
+    def fail_final_clear() -> None:
+        events.append("store.clear_conversation_snapshot")
+        raise OSError("final clear failure")
+
+    async def stop_cli() -> None:
+        events.append("cli.stop_all")
+
+    mock_session_store.clear_all.side_effect = early_clear
+    mock_session_store.clear_conversation_snapshot.side_effect = fail_final_clear
+    mock_cli_manager.stop_all.side_effect = stop_cli
+
+    with (
+        patch.object(handler.tree_queue, "clear_all", side_effect=clear_trees),
+        patch.object(
+            handler,
+            "_apply_cancellation_result",
+            side_effect=lambda _result: events.append("apply_cancellation"),
+        ),
+        pytest.raises(OSError, match="final clear failure"),
+    ):
+        await handler.clear_all_state("telegram", "chat_1")
+
+    assert events == [
+        "store.clear_all",
+        "trees.clear_all",
+        "store.clear_conversation_snapshot",
+        "apply_cancellation",
+        "cli.stop_all",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_global_clear_preserves_final_persistence_and_cli_stop_failures(
+    handler,
+    mock_cli_manager,
+    mock_session_store,
+) -> None:
+    events: list[str] = []
+    persistence_error = OSError("final clear failure")
+    cli_error = RuntimeError("CLI stop failure")
+
+    async def clear_trees(*, reason: CancellationReason) -> CancellationResult:
+        assert reason is CancellationReason.STOP
+        events.append("trees.clear_all")
+        return CancellationResult()
+
+    def fail_final_clear() -> None:
+        events.append("store.clear_conversation_snapshot")
+        raise persistence_error
+
+    async def fail_cli_stop() -> None:
+        events.append("cli.stop_all")
+        raise cli_error
+
+    mock_session_store.clear_conversation_snapshot.side_effect = fail_final_clear
+    mock_cli_manager.stop_all.side_effect = fail_cli_stop
+
+    with (
+        patch.object(handler.tree_queue, "clear_all", side_effect=clear_trees),
+        patch.object(
+            handler,
+            "_apply_cancellation_result",
+            side_effect=lambda _result: events.append("apply_cancellation"),
+        ),
+        pytest.raises(ExceptionGroup) as raised,
+    ):
+        await handler.clear_all_state("telegram", "chat_1")
+
+    assert raised.value.exceptions == (persistence_error, cli_error)
+    assert events == [
+        "trees.clear_all",
+        "store.clear_conversation_snapshot",
+        "apply_cancellation",
+        "cli.stop_all",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_committed_global_clear_attempts_remaining_steps_after_tree_failure(
+    handler,
+    mock_cli_manager,
+    mock_session_store,
+) -> None:
+    events: list[str] = []
+    tree_error = RuntimeError("tree clear failure")
+
+    async def fail_tree_clear(*, reason: CancellationReason) -> CancellationResult:
+        assert reason is CancellationReason.STOP
+        events.append("trees.clear_all")
+        raise tree_error
+
+    mock_session_store.clear_conversation_snapshot.side_effect = lambda: events.append(
+        "store.clear_conversation_snapshot"
+    )
+    mock_cli_manager.stop_all.side_effect = lambda: events.append("cli.stop_all")
+
+    with (
+        patch.object(handler.tree_queue, "clear_all", side_effect=fail_tree_clear),
+        patch.object(
+            handler,
+            "_apply_cancellation_result",
+            side_effect=lambda _result: events.append("apply_cancellation"),
+        ),
+        pytest.raises(RuntimeError, match="tree clear failure") as raised,
+    ):
+        await handler.clear_all_state("telegram", "chat_1")
+
+    assert raised.value is tree_error
+    assert events == [
+        "trees.clear_all",
+        "store.clear_conversation_snapshot",
+        "apply_cancellation",
+        "cli.stop_all",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_cancelled_global_clear_before_commit_preserves_tree_and_store(
     handler,
     mock_cli_manager,
@@ -1115,7 +1397,7 @@ async def test_global_clear_removes_snapshot_saved_during_detach_window(
     finally:
         release_runner.set()
         release_id_read.set()
-        workflow.close()
+        await workflow.close()
 
 
 @pytest.mark.asyncio

--- a/tests/messaging/test_messaging.py
+++ b/tests/messaging/test_messaging.py
@@ -175,9 +175,12 @@ class TestSessionStore:
         snapshot = TreeSnapshot(scope=scope, root_id="r1", nodes={"r1": {}})
         store.save_tree_snapshot(snapshot)
 
-        with patch(
-            "free_claude_code.messaging.session.persistence.os.replace",
-            side_effect=OSError("Disk full"),
+        with (
+            patch(
+                "free_claude_code.messaging.session.persistence.os.replace",
+                side_effect=OSError("Disk full"),
+            ),
+            pytest.raises(OSError, match="Disk full"),
         ):
             store.flush_pending_save()
 

--- a/tests/messaging/test_restart_reply_restore.py
+++ b/tests/messaging/test_restart_reply_restore.py
@@ -275,13 +275,38 @@ async def test_restore_repairs_interrupted_status_after_delivery_starts(
     )
 
 
-def test_workflow_close_flushes_owned_session_store(
+@pytest.mark.asyncio
+async def test_workflow_close_waits_for_claim_cleanup_before_flushing(
     mock_platform,
     mock_cli_manager,
     mock_session_store,
 ) -> None:
     workflow = MessagingWorkflow(mock_platform, mock_cli_manager, mock_session_store)
+    cleanup_release = asyncio.Event()
+    wait_started = asyncio.Event()
+    events: list[str] = []
 
-    workflow.close()
+    async def stop_all() -> int:
+        events.append("stop")
+        return 1
 
+    async def wait_idle() -> None:
+        events.append("wait")
+        wait_started.set()
+        await cleanup_release.wait()
+
+    workflow.stop_all_tasks = AsyncMock(side_effect=stop_all)
+    workflow.tree_queue.wait_idle = AsyncMock(side_effect=wait_idle)
+    mock_session_store.flush_pending_save.side_effect = lambda: events.append("flush")
+
+    close_task = asyncio.create_task(workflow.close())
+    await wait_started.wait()
+
+    assert events == ["stop", "wait"]
+    mock_session_store.flush_pending_save.assert_not_called()
+
+    cleanup_release.set()
+    await close_task
+
+    assert events == ["stop", "wait", "flush"]
     mock_session_store.flush_pending_save.assert_called_once()

--- a/tests/messaging/test_session_store_edge_cases.py
+++ b/tests/messaging/test_session_store_edge_cases.py
@@ -159,17 +159,108 @@ class TestSessionStoreLoadEdgeCases:
 class TestSessionStoreSaveEdgeCases:
     """Tests for save failure handling."""
 
-    def test_save_io_error_handled(self, tmp_store):
-        """Write failure marks pending state dirty without crashing callers."""
+    def test_explicit_flush_reports_io_error_and_keeps_store_dirty(self, tmp_store):
+        """A durability request must not hide that the snapshot was not saved."""
         tmp_store.save_tree_snapshot(
             TreeSnapshot(scope=TELEGRAM_C1, root_id="r1", nodes={"r1": {}})
         )
-        with patch(
-            "free_claude_code.messaging.session.persistence.os.replace",
-            side_effect=OSError("disk full"),
+        with (
+            patch(
+                "free_claude_code.messaging.session.persistence.os.replace",
+                side_effect=OSError("disk full"),
+            ),
+            pytest.raises(OSError, match="disk full"),
         ):
             tmp_store.flush_pending_save()
         assert tmp_store.dirty is True
+
+    def test_explicit_flush_snapshot_failure_is_dirty_and_retryable(
+        self,
+        tmp_path,
+    ) -> None:
+        dirty_states: list[bool] = []
+        should_fail = True
+
+        def snapshot() -> dict[str, Any]:
+            if should_fail:
+                raise RuntimeError("snapshot failed")
+            return {"saved": True}
+
+        persistence = DebouncedJsonPersistence(
+            str(tmp_path / "sessions.json"),
+            snapshot=snapshot,
+            on_dirty=dirty_states.append,
+        )
+
+        with pytest.raises(RuntimeError, match="snapshot failed"):
+            persistence.flush()
+
+        assert dirty_states[-1] is True
+
+        should_fail = False
+        persistence.flush()
+
+        assert dirty_states[-1] is False
+
+    def test_timer_save_io_error_is_best_effort_and_keeps_store_dirty(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """A background timer may report failure without crashing its thread."""
+        FakeTimer.instances = []
+        monkeypatch.setattr(persistence_module.threading, "Timer", FakeTimer)
+        store = SessionStore(storage_path=str(tmp_path / "sessions.json"))
+        store.save_tree_snapshot(
+            TreeSnapshot(scope=TELEGRAM_C1, root_id="r1", nodes={"r1": {}})
+        )
+
+        with patch(
+            "free_claude_code.messaging.session.persistence.os.replace",
+            side_effect=OSError("timer disk full"),
+        ):
+            FakeTimer.instances[-1].fire()
+
+        assert store.dirty is True
+
+        store.flush_pending_save()
+
+        assert store.dirty is False
+        assert (
+            SessionStore(storage_path=store.storage_path)
+            .load_conversation_snapshot()
+            .get_tree(_identity("r1"))
+            is not None
+        )
+
+    def test_timer_snapshot_failure_is_best_effort_type_only_and_stays_dirty(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        FakeTimer.instances = []
+        monkeypatch.setattr(persistence_module.threading, "Timer", FakeTimer)
+        dirty_states: list[bool] = []
+
+        def fail_snapshot() -> dict[str, Any]:
+            raise RuntimeError("SECRET_SNAPSHOT_DETAIL")
+
+        persistence = DebouncedJsonPersistence(
+            str(tmp_path / "sessions.json"),
+            snapshot=fail_snapshot,
+            on_dirty=dirty_states.append,
+        )
+        persistence.schedule_save()
+
+        with patch.object(persistence_module.logger, "error") as error:
+            FakeTimer.instances[-1].fire()
+
+        assert dirty_states[-1] is True
+        error.assert_called_once_with(
+            "Failed to save sessions: exc_type={}",
+            "RuntimeError",
+        )
+        assert "SECRET_SNAPSHOT_DETAIL" not in str(error.call_args)
 
     def test_stale_timer_callback_cannot_clear_newer_timer(self, tmp_path, monkeypatch):
         """An already-running old timer cannot consume the newest save."""
@@ -379,9 +470,12 @@ class TestSessionStoreAtomicWrites:
             TreeSnapshot(scope=TELEGRAM_C1, root_id="r2", nodes={"r2": {}})
         )
 
-        with patch(
-            "free_claude_code.messaging.session.persistence.os.replace",
-            side_effect=OSError("replace failed"),
+        with (
+            patch(
+                "free_claude_code.messaging.session.persistence.os.replace",
+                side_effect=OSError("replace failed"),
+            ),
+            pytest.raises(OSError, match="replace failed"),
         ):
             store.flush_pending_save()
 
@@ -390,6 +484,54 @@ class TestSessionStoreAtomicWrites:
         assert disk_after_failed == disk_after_first
         assert store.dirty is True
         assert store.load_conversation_snapshot().get_tree(_identity("r2")) is not None
+
+    def test_failed_authoritative_clear_is_visible_and_retryable(self, tmp_path):
+        path = str(tmp_path / "sessions.json")
+        store = SessionStore(storage_path=path)
+        store.save_tree_snapshot(
+            TreeSnapshot(scope=TELEGRAM_C1, root_id="r1", nodes={"r1": {}})
+        )
+        store.flush_pending_save()
+
+        with (
+            patch(
+                "free_claude_code.messaging.session.persistence.os.replace",
+                side_effect=OSError("clear replace failed"),
+            ),
+            pytest.raises(OSError, match="clear replace failed"),
+        ):
+            store.clear_all()
+
+        assert store.load_conversation_snapshot().is_empty
+        assert store.dirty is True
+        assert not SessionStore(storage_path=path).load_conversation_snapshot().is_empty
+
+        store.flush_pending_save()
+
+        assert store.dirty is False
+        assert SessionStore(storage_path=path).load_conversation_snapshot().is_empty
+
+    def test_authoritative_snapshot_failure_marks_store_dirty_before_retry(
+        self,
+        tmp_path,
+    ) -> None:
+        store = SessionStore(storage_path=str(tmp_path / "sessions.json"))
+
+        with (
+            patch.object(
+                store,
+                "_snapshot_for_persistence",
+                side_effect=RuntimeError("authoritative snapshot failed"),
+            ),
+            pytest.raises(RuntimeError, match="authoritative snapshot failed"),
+        ):
+            store.clear_all()
+
+        assert store.dirty is True
+
+        store.clear_all()
+
+        assert store.dirty is False
 
 
 class TestSessionStoreClearAll:

--- a/tests/messaging/test_tree_processor.py
+++ b/tests/messaging/test_tree_processor.py
@@ -306,6 +306,64 @@ async def test_wait_idle_spans_pre_run_cancellation_recovery() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("log_messaging_error_details", "secret_is_logged"),
+    [(False, False), (True, True)],
+)
+async def test_wait_idle_surfaces_finish_failure_without_leaking_task_owner(
+    caplog: pytest.LogCaptureFixture,
+    log_messaging_error_details: bool,
+    secret_is_logged: bool,
+) -> None:
+    secret = "unique-finish-callback-secret"
+    finish_error = RuntimeError(secret)
+    finish_calls = 0
+
+    async def process(_claim: NodeClaim) -> None:
+        return
+
+    async def fail_claim(_claim: NodeClaim) -> None:
+        raise AssertionError("successful processing must not fail the claim")
+
+    async def finish_claim(_tree: MessageTree, _claim: NodeClaim) -> None:
+        nonlocal finish_calls
+        finish_calls += 1
+        raise finish_error
+
+    tree = MessageTree(
+        MessageNode(
+            node_id="root",
+            scope=_SCOPE,
+            prompt="prompt root",
+            status_message_id="status-root",
+        )
+    )
+    decision = await tree.enqueue_or_claim("root")
+    assert decision.claim is not None
+    processor = TreeQueueProcessor(
+        process,
+        claim_failure_callback=fail_claim,
+        claim_finished_callback=finish_claim,
+        log_messaging_error_details=log_messaging_error_details,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        processor.launch(tree, decision.claim)
+        with pytest.raises(RuntimeError) as raised:
+            await asyncio.wait_for(processor.wait_idle(), timeout=1)
+
+    assert raised.value is finish_error
+    assert finish_calls == 1
+    assert processor.task_count() == 0
+    await asyncio.wait_for(processor.wait_idle(), timeout=0.1)
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Claim completion callback failed for node root" in messages
+    assert "RuntimeError" in messages
+    assert (secret in messages) is secret_is_logged
+
+
+@pytest.mark.asyncio
 async def test_failed_launch_rolls_idle_state_back(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/messaging/test_tree_processor.py
+++ b/tests/messaging/test_tree_processor.py
@@ -1,6 +1,7 @@
 """Manager-level task and cancellation ownership tests."""
 
 import asyncio
+import logging
 
 import pytest
 
@@ -15,6 +16,10 @@ from free_claude_code.messaging.trees import (
     TreeQueueManager,
 )
 from free_claude_code.messaging.trees import manager as manager_module
+from free_claude_code.messaging.trees import processor as processor_module
+from free_claude_code.messaging.trees.node import MessageNode
+from free_claude_code.messaging.trees.processor import TreeQueueProcessor
+from free_claude_code.messaging.trees.runtime import MessageTree
 
 _SCOPE = MessageScope(platform="telegram", chat_id="chat")
 
@@ -200,3 +205,176 @@ async def test_escaped_processor_failure_persists_effects_through_manager_owner(
     assert failure.snapshot.nodes["root"]["state"] == "error"
     assert failure.snapshot.nodes["child"]["state"] == "error"
     assert queue_updates == [()]
+
+
+@pytest.mark.asyncio
+async def test_wait_idle_spans_successor_publication_and_completion() -> None:
+    root_started = asyncio.Event()
+    release_root = asyncio.Event()
+    child_started = asyncio.Event()
+    release_child = asyncio.Event()
+
+    async def process(claim: NodeClaim) -> None:
+        if claim.node.node_id == "root":
+            root_started.set()
+            await release_root.wait()
+            return
+        child_started.set()
+        await release_child.wait()
+
+    manager = TreeQueueManager(process)
+    await asyncio.wait_for(manager.wait_idle(), timeout=0.1)
+    await manager.admit(_incoming("root"), "status-root")
+    await asyncio.wait_for(root_started.wait(), timeout=1)
+    await manager.admit(
+        _incoming("child", reply_to="root"),
+        "status-child",
+        parent_node_id="root",
+    )
+    idle_task = asyncio.create_task(manager.wait_idle())
+
+    try:
+        await asyncio.sleep(0)
+        assert not idle_task.done()
+
+        release_root.set()
+        await asyncio.wait_for(child_started.wait(), timeout=1)
+        assert not idle_task.done()
+
+        release_child.set()
+        await asyncio.wait_for(idle_task, timeout=1)
+        assert manager.task_count() == 0
+    finally:
+        release_root.set()
+        release_child.set()
+        if not idle_task.done():
+            idle_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await idle_task
+
+
+@pytest.mark.asyncio
+async def test_wait_idle_spans_pre_run_cancellation_recovery() -> None:
+    finish_started = asyncio.Event()
+    release_finish = asyncio.Event()
+
+    async def process(_claim: NodeClaim) -> None:
+        raise AssertionError("pre-run cancellation must not enter the processor")
+
+    async def fail_claim(_claim: NodeClaim) -> None:
+        raise AssertionError("cancellation must not fail the claim")
+
+    async def finish_claim(_tree: MessageTree, _claim: NodeClaim) -> None:
+        finish_started.set()
+        await release_finish.wait()
+
+    tree = MessageTree(
+        MessageNode(
+            node_id="root",
+            scope=_SCOPE,
+            prompt="prompt root",
+            status_message_id="status-root",
+        )
+    )
+    decision = await tree.enqueue_or_claim("root")
+    assert decision.claim is not None
+    processor = TreeQueueProcessor(
+        process,
+        claim_failure_callback=fail_claim,
+        claim_finished_callback=finish_claim,
+    )
+    processor.launch(tree, decision.claim)
+    cancelled = processor.cancel(decision.claim, CancellationReason.STOP)
+    assert cancelled is not None
+    assert cancelled.runner_started is False
+    idle_task = asyncio.create_task(processor.wait_idle())
+
+    try:
+        await asyncio.wait_for(finish_started.wait(), timeout=1)
+        assert not idle_task.done()
+
+        release_finish.set()
+        await asyncio.wait_for(cancelled.task, timeout=1)
+        await asyncio.wait_for(idle_task, timeout=1)
+        assert processor.task_count() == 0
+    finally:
+        release_finish.set()
+        if not idle_task.done():
+            idle_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await idle_task
+
+
+@pytest.mark.asyncio
+async def test_failed_launch_rolls_idle_state_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def process(_claim: NodeClaim) -> None:
+        return
+
+    async def fail_claim(_claim: NodeClaim) -> None:
+        return
+
+    async def finish_claim(_tree: MessageTree, _claim: NodeClaim) -> None:
+        return
+
+    tree = MessageTree(
+        MessageNode(
+            node_id="root",
+            scope=_SCOPE,
+            prompt="prompt root",
+            status_message_id="status-root",
+        )
+    )
+    decision = await tree.enqueue_or_claim("root")
+    assert decision.claim is not None
+    processor = TreeQueueProcessor(
+        process,
+        claim_failure_callback=fail_claim,
+        claim_finished_callback=finish_claim,
+    )
+
+    def fail_create_task(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("launch failed")
+
+    monkeypatch.setattr(
+        processor_module.asyncio,
+        "create_task",
+        fail_create_task,
+    )
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        processor.launch(tree, decision.claim)
+
+    assert processor.task_count() == 0
+    await asyncio.wait_for(processor.wait_idle(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("log_messaging_error_details", "secret_is_logged"),
+    [(False, False), (True, True)],
+)
+async def test_processor_failure_logging_respects_diagnostic_policy(
+    caplog: pytest.LogCaptureFixture,
+    log_messaging_error_details: bool,
+    secret_is_logged: bool,
+) -> None:
+    secret = "unique-processor-exception-secret"
+
+    async def process(_claim: NodeClaim) -> None:
+        raise RuntimeError(secret)
+
+    manager = TreeQueueManager(
+        process,
+        log_messaging_error_details=log_messaging_error_details,
+    )
+    with caplog.at_level(logging.ERROR):
+        await manager.admit(_incoming("root"), "status-root")
+        await asyncio.wait_for(manager.wait_idle(), timeout=1)
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+
+    assert "Error processing node root" in messages
+    assert "RuntimeError" in messages
+    assert (secret in messages) is secret_is_logged

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -4,12 +4,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import free_claude_code.messaging.session.persistence as persistence_module
 from free_claude_code.config.admin.persistence import PreparedAdminUpdate
 from free_claude_code.config.settings import Settings
 from free_claude_code.messaging.platforms.ports import (
     InboundMessageHandler,
     MessagingPlatformComponents,
 )
+from free_claude_code.messaging.session import SessionStore
+from free_claude_code.messaging.workflow import MessagingWorkflow
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
@@ -108,6 +111,17 @@ class TrackingMessagingRuntime:
     @property
     def is_connected(self) -> bool:
         return True
+
+
+class PersistentlyFailingMessagingRuntime(TrackingMessagingRuntime):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(events)
+        self.fail_quiesce = True
+
+    async def quiesce(self) -> None:
+        self.events.append("messaging.quiesce")
+        if self.fail_quiesce:
+            raise RuntimeError("quiesce failed")
 
 
 def _settings(model: str, *, port: int = 8082) -> Settings:
@@ -294,19 +308,16 @@ async def test_close_drains_messaging_before_transcriber_and_is_idempotent() -> 
     runtime = ApplicationRuntime(manager, transcriber=transcriber)
     runtime._messaging_runtime = TrackingMessagingRuntime(events)
     workflow = MagicMock()
-    workflow.stop_all_tasks = AsyncMock(
-        side_effect=lambda: events.append("workflow.stop_all")
-    )
-    workflow.close.side_effect = lambda: events.append("workflow.close")
+    workflow.close = AsyncMock(side_effect=lambda: events.append("workflow.close"))
     runtime._messaging_workflow = workflow
     runtime._cli_manager = MagicMock()
 
+    assert runtime.is_closed is False
     assert await runtime.close() is True
     assert await runtime.close() is True
 
     assert events == [
         "messaging.quiesce",
-        "workflow.stop_all",
         "workflow.close",
         "messaging.close",
         "transcriber.close",
@@ -315,6 +326,7 @@ async def test_close_drains_messaging_before_transcriber_and_is_idempotent() -> 
     assert runtime._transcriber is None
     assert runtime._messaging_runtime is None
     assert runtime._messaging_workflow is None
+    assert runtime.is_closed is True
 
 
 @pytest.mark.asyncio
@@ -369,14 +381,22 @@ async def test_close_retries_runtime_before_closing_later_resources() -> None:
 
 
 @pytest.mark.asyncio
-async def test_close_retries_workflow_drain_before_closing_delivery() -> None:
+async def test_close_retries_workflow_close_before_closing_delivery() -> None:
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(manager, transcriber=None)
     messaging = TrackingMessagingRuntime(events)
     workflow = MagicMock()
-    workflow.stop_all_tasks = AsyncMock(side_effect=[RuntimeError("drain failed"), 0])
-    workflow.close.side_effect = lambda: events.append("workflow.close")
+    close_calls = 0
+
+    async def close_workflow() -> None:
+        nonlocal close_calls
+        close_calls += 1
+        if close_calls == 1:
+            raise RuntimeError("drain failed")
+        events.append("workflow.close")
+
+    workflow.close = AsyncMock(side_effect=close_workflow)
     runtime._messaging_runtime = messaging
     runtime._messaging_workflow = workflow
 
@@ -405,16 +425,13 @@ async def test_close_does_not_drain_workflow_until_ingress_is_quiescent() -> Non
     runtime = ApplicationRuntime(manager, transcriber=None)
     messaging = TrackingMessagingRuntime(events, fail_quiesce_once=True)
     workflow = MagicMock()
-    workflow.stop_all_tasks = AsyncMock(
-        side_effect=lambda: events.append("workflow.stop_all")
-    )
-    workflow.close.side_effect = lambda: events.append("workflow.close")
+    workflow.close = AsyncMock(side_effect=lambda: events.append("workflow.close"))
     runtime._messaging_runtime = messaging
     runtime._messaging_workflow = workflow
 
     assert await runtime.close() is False
 
-    workflow.stop_all_tasks.assert_not_awaited()
+    workflow.close.assert_not_awaited()
     assert runtime._messaging_runtime is messaging
     assert runtime._messaging_workflow is workflow
 
@@ -423,7 +440,6 @@ async def test_close_does_not_drain_workflow_until_ingress_is_quiescent() -> Non
     assert events == [
         "messaging.quiesce",
         "messaging.quiesce",
-        "workflow.stop_all",
         "workflow.close",
         "messaging.close",
     ]
@@ -437,19 +453,16 @@ async def test_close_retries_failed_persistence_before_closing_delivery() -> Non
     runtime = ApplicationRuntime(manager, transcriber=None)
     messaging = TrackingMessagingRuntime(events)
     workflow = MagicMock()
-    workflow.stop_all_tasks = AsyncMock(
-        side_effect=lambda: events.append("workflow.stop_all")
-    )
     close_calls = 0
 
-    def close_workflow() -> None:
+    async def close_workflow() -> None:
         nonlocal close_calls
         close_calls += 1
         if close_calls == 1:
             raise RuntimeError("flush failed")
         events.append("workflow.close")
 
-    workflow.close.side_effect = close_workflow
+    workflow.close = AsyncMock(side_effect=close_workflow)
     runtime._messaging_runtime = messaging
     runtime._messaging_workflow = workflow
 
@@ -463,13 +476,93 @@ async def test_close_retries_failed_persistence_before_closing_delivery() -> Non
 
     assert events == [
         "messaging.quiesce",
-        "workflow.stop_all",
         "messaging.quiesce",
-        "workflow.stop_all",
         "workflow.close",
         "messaging.close",
     ]
     assert runtime._closed is True
+
+
+@pytest.mark.asyncio
+async def test_close_retries_real_workflow_persistence_without_losing_latest_state(
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    messaging = TrackingMessagingRuntime(events)
+    cli_manager = MagicMock()
+    cli_manager.stop_all = AsyncMock()
+    outbound = MagicMock()
+    store_path = tmp_path / "sessions.json"
+    real_replace = persistence_module.os.replace
+    replace_calls = 0
+
+    def fail_first_replace(source: str, target: str) -> None:
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 1:
+            raise OSError("replace failed once")
+        real_replace(source, target)
+
+    with patch.object(persistence_module.threading, "Timer"):
+        store = SessionStore(storage_path=str(store_path))
+        store.record_message_id(
+            "telegram",
+            "chat_1",
+            "old",
+            direction="in",
+            kind="prompt",
+        )
+        store.flush_pending_save()
+        store.record_message_id(
+            "telegram",
+            "chat_1",
+            "latest",
+            direction="in",
+            kind="prompt",
+        )
+        workflow = MessagingWorkflow(outbound, cli_manager, store)
+        runtime._messaging_runtime = messaging
+        runtime._messaging_workflow = workflow
+        runtime._cli_manager = cli_manager
+
+        with patch.object(
+            persistence_module.os,
+            "replace",
+            side_effect=fail_first_replace,
+        ):
+            assert await runtime.close() is False
+
+            assert runtime._messaging_runtime is messaging
+            assert runtime._messaging_workflow is workflow
+            assert runtime._cli_manager is cli_manager
+            assert runtime.is_closed is False
+            assert store.dirty is True
+            assert store.get_message_ids_for_chat("telegram", "chat_1") == [
+                "old",
+                "latest",
+            ]
+            assert SessionStore(storage_path=str(store_path)).get_message_ids_for_chat(
+                "telegram", "chat_1"
+            ) == ["old"]
+
+            assert await runtime.close() is True
+
+        assert runtime._messaging_runtime is None
+        assert runtime._messaging_workflow is None
+        assert runtime._cli_manager is None
+        assert runtime.is_closed is True
+        assert store.dirty is False
+        assert SessionStore(storage_path=str(store_path)).get_message_ids_for_chat(
+            "telegram",
+            "chat_1",
+        ) == ["old", "latest"]
+        assert events == [
+            "messaging.quiesce",
+            "messaging.quiesce",
+            "messaging.close",
+        ]
 
 
 @pytest.mark.asyncio
@@ -560,6 +653,176 @@ async def test_startup_cancellation_cleans_partial_messaging_and_reraises() -> N
     assert runtime._closed is True
     assert runtime._messaging_runtime is None
     assert runtime._transcriber is None
+
+
+@pytest.mark.asyncio
+async def test_public_start_retries_transient_partial_messaging_cleanup() -> None:
+    events: list[str] = []
+    manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    messaging = TrackingMessagingRuntime(events, fail_quiesce_once=True)
+    workflow = MagicMock()
+    workflow.close = AsyncMock(side_effect=lambda: events.append("workflow.close"))
+    cli_manager = MagicMock()
+    components = MessagingPlatformComponents(
+        name="tracking",
+        runtime=messaging,
+        outbound=MagicMock(),
+    )
+    startup_failure = RuntimeError("partial messaging startup failed")
+
+    async def fail_after_publication(
+        published: MessagingPlatformComponents,
+    ) -> None:
+        assert published is components
+        runtime._messaging_runtime = messaging
+        runtime._messaging_workflow = workflow
+        runtime._cli_manager = cli_manager
+        raise startup_failure
+
+    with (
+        patch.object(
+            runtime,
+            "_validate_configured_models_best_effort",
+            AsyncMock(),
+        ),
+        patch.object(manager, "start_model_list_refresh"),
+        patch(
+            "free_claude_code.runtime.application.messaging_platform_factory.create_messaging_components",
+            return_value=components,
+        ),
+        patch.object(
+            runtime,
+            "_start_messaging_workflow",
+            side_effect=fail_after_publication,
+        ),
+        pytest.raises(RuntimeError, match="cleanup incomplete") as raised,
+    ):
+        await runtime.start()
+
+    assert raised.value.__cause__ is startup_failure
+    assert events == [
+        "messaging.quiesce",
+        "messaging.quiesce",
+        "workflow.close",
+        "messaging.close",
+    ]
+    workflow.close.assert_awaited_once()
+    assert runtime._messaging_runtime is None
+    assert runtime._messaging_workflow is None
+    assert runtime._cli_manager is None
+    assert runtime.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_public_start_retains_persistently_unclean_partial_messaging_graph() -> (
+    None
+):
+    events: list[str] = []
+    manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
+    transcriber = TrackingTranscriber(events)
+    runtime = ApplicationRuntime(manager, transcriber=transcriber)
+    messaging = PersistentlyFailingMessagingRuntime(events)
+    workflow = MagicMock()
+    workflow.close = AsyncMock(side_effect=lambda: events.append("workflow.close"))
+    cli_manager = MagicMock()
+    components = MessagingPlatformComponents(
+        name="tracking",
+        runtime=messaging,
+        outbound=MagicMock(),
+    )
+    startup_failure = RuntimeError("partial messaging startup failed")
+
+    async def fail_after_publication(
+        published: MessagingPlatformComponents,
+    ) -> None:
+        assert published is components
+        runtime._messaging_runtime = messaging
+        runtime._messaging_workflow = workflow
+        runtime._cli_manager = cli_manager
+        raise startup_failure
+
+    with (
+        patch.object(
+            runtime,
+            "_validate_configured_models_best_effort",
+            AsyncMock(),
+        ),
+        patch.object(manager, "start_model_list_refresh"),
+        patch(
+            "free_claude_code.runtime.application.messaging_platform_factory.create_messaging_components",
+            return_value=components,
+        ),
+        patch.object(
+            runtime,
+            "_start_messaging_workflow",
+            side_effect=fail_after_publication,
+        ),
+        pytest.raises(RuntimeError, match="cleanup incomplete") as raised,
+    ):
+        await runtime.start()
+
+    assert raised.value.__cause__ is startup_failure
+    assert events == ["messaging.quiesce", "messaging.quiesce"]
+    workflow.close.assert_not_awaited()
+    assert transcriber.close_calls == 0
+    assert runtime._messaging_runtime is messaging
+    assert runtime._messaging_workflow is workflow
+    assert runtime._cli_manager is cli_manager
+    assert runtime._transcriber is transcriber
+    assert runtime._provider_manager_closed is False
+    assert runtime.is_closed is False
+
+    messaging.fail_quiesce = False
+    assert await runtime.close() is True
+
+    assert events == [
+        "messaging.quiesce",
+        "messaging.quiesce",
+        "messaging.quiesce",
+        "workflow.close",
+        "messaging.close",
+        "transcriber.close",
+    ]
+    assert runtime.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_messaging_start_failure_is_nonfatal_after_complete_cleanup() -> None:
+    manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
+    runtime = ApplicationRuntime(manager, transcriber=None)
+
+    with (
+        patch(
+            "free_claude_code.runtime.application.messaging_platform_factory.create_messaging_components",
+            side_effect=RuntimeError("messaging unavailable"),
+        ),
+        patch.object(runtime, "_cleanup_messaging", AsyncMock(return_value=True)),
+    ):
+        await runtime._start_messaging_if_configured()
+
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_messaging_start_failure_fails_closed_when_cleanup_is_incomplete() -> (
+    None
+):
+    manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
+    runtime = ApplicationRuntime(manager, transcriber=None)
+
+    with (
+        patch(
+            "free_claude_code.runtime.application.messaging_platform_factory.create_messaging_components",
+            side_effect=RuntimeError("messaging unavailable"),
+        ),
+        patch.object(runtime, "_cleanup_messaging", AsyncMock(return_value=False)),
+        pytest.raises(RuntimeError, match="cleanup incomplete") as exc_info,
+    ):
+        await runtime._start_messaging_if_configured()
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    await manager.close()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.3"
+version = "3.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem\n\nShutdown could report success after bounded messaging cleanup, hidden persistence failures, or failed managed-process stops. An Admin restart could then construct a replacement while the old runtime still owned work.\n\n## Changes\n\n| Before | After |\n| --- | --- |\n| Runtime reused bounded interactive stop semantics for terminal messaging cleanup. | Workflow close cancels work, stops managed sessions, awaits every claim and recovery task, then flushes persistence. |\n| Explicit persistence failures were logged and treated as successful writes. | Explicit flushes and authoritative writes propagate failure and stay dirty for retry; timer writes remain best effort. |\n| Managed sessions and aliases were removed before subprocess termination was confirmed. | Manager and session terminal states prevent reuse, retain failed owners and PIDs, reject ID collisions, and retry exact sessions. |\n| Admin restart followed the restart request even after incomplete shutdown. | Supervisor restarts only when the prior runtime reports its entire ownership graph closed. |\n| Partial messaging startup cleanup could fail while application startup continued. | Incomplete partial cleanup fails startup and retains the exact graph for a later close attempt. |\n| Messaging task failures read process-global settings. | Runtime injects diagnostic policy and the messaging package depends only on core. |\n| Lifecycle edge cases were verified only in isolated components. | Deterministic and live product coverage proves composed retry, drain, privacy, and customer command behavior. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes application shutdown wait for owned work to finish before restart or exit. The main changes are:

- Runtime close now waits for messaging work, managed sessions, and persistence flushes.
- Admin restart now requires the previous runtime to report full closure.
- Managed Claude sessions now keep aliases and PIDs until stop is confirmed.
- Session persistence now propagates explicit write failures and keeps dirty state for retry.
- Messaging no longer reads global config from task-failure callbacks.
</details>


<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reviewed the general contract validation proof and confirmed that the lifecycle\_session pytest run completed with 73 passed in 2.68s (EXIT\_CODE: 0) and the messaging pytest run completed with 95 passed in 1.96s (EXIT\_CODE: 0).

<a href="https://app.greptile.com/trex/runs/14094038/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/free_claude_code/messaging/trees/processor.py | Completion callback failures now release task ownership and surface through the idle waiter. |
| src/free_claude_code/messaging/workflow.py | Terminal workflow close now cancels tasks, waits for processor cleanup, and flushes persistence. |
| src/free_claude_code/runtime/application.py | Runtime shutdown now keeps incomplete ownership cleanup retryable and exposes closure state. |
| src/free_claude_code/cli/entrypoints.py | The supervisor now restarts only after the old runtime reports full closure. |
| src/free_claude_code/cli/managed/manager.py | Managed session shutdown now blocks reuse and retains failed owners for retry. |
| src/free_claude_code/cli/managed/session.py | Managed sessions now mark terminal state under a lifecycle lock and retain PID ownership until exit. |

</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `src/free_claude_code/messaging/trees/processor.py`, line 194-202 ([link](https://github.com/alishahryar1/free-claude-code/blob/b736bad1aacb66784e7b4d1e09d27a32b2a380c7/src/free_claude_code/messaging/trees/processor.py#L194-L202)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Idle Event Stays Cleared**

   When `_claim_finished_callback` raises a non-cancellation exception, `_finish_and_continue` exits before `slot.transitioned` is set, before the slot is removed from `_tasks`, and before `_idle` is set. `MessagingWorkflow.close()` now waits on `wait_idle()`, so a finish-path error can leave shutdown waiting forever instead of returning a failed close.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: standalone async harness that drives TreeQueueManager and forces a finish callback RuntimeError](https://app.greptile.com/trex/artifacts/da413ba3-7f69-459d-b8c8-3141c2bb6c41)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: uv run output showing finish callback RuntimeError, retained task\_count, cleared idle event, and wait\_idle timeout](https://app.greptile.com/trex/artifacts/35b2beaa-ec52-47bd-b36b-2735b3ebc62c)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14093236/artifacts?artifact=da413ba3-7f69-459d-b8c8-3141c2bb6c41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcompletion-driven-shutdown%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcompletion-driven-shutdown%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffree_claude_code%2Fmessaging%2Ftrees%2Fprocessor.py%0ALine%3A%20194-202%0A%0AComment%3A%0A**Idle%20Event%20Stays%20Cleared**%0A%0AWhen%20%60_claim_finished_callback%60%20raises%20a%20non-cancellation%20exception%2C%20%60_finish_and_continue%60%20exits%20before%20%60slot.transitioned%60%20is%20set%2C%20before%20the%20slot%20is%20removed%20from%20%60_tasks%60%2C%20and%20before%20%60_idle%60%20is%20set.%20%60MessagingWorkflow.close%28%29%60%20now%20waits%20on%20%60wait_idle%28%29%60%2C%20so%20a%20finish-path%20error%20can%20leave%20shutdown%20waiting%20forever%20instead%20of%20returning%20a%20failed%20close.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=alishahryar1%2Ffree-claude-code&pr=1056&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Surface messaging completion failures"](https://github.com/alishahryar1/free-claude-code/commit/39a874c8f0e0614847d80321dd51c9654707a7ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43514893)</sub>

<!-- /greptile_comment -->