### PR TITLE
feat: add vision support for OpenAI chat conversion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -631,13 +631,20 @@ usage quirks such as DeepSeek prompt-cache counters.
   content/tool/thinking blocks, and Anthropic response envelopes;
 - trace-safe request snapshots stay beside those models so the generic trace
   module remains protocol-independent and import-order safe;
-- content and message conversion for OpenAI-compatible upstreams;
+- text, image, and message conversion for OpenAI-compatible upstreams;
 - request serialization primitives shared by provider request policies;
 - tool schema and tool-result handling;
 - thinking block handling;
 - stream lifecycle through `src/free_claude_code/core/anthropic/streaming`, including the neutral
   stream ledger, Anthropic SSE emitter, continuation-body construction, and tool repair;
 - token counting and Anthropic-owned failure-kind-to-wire mapping.
+
+User image conversion is a pure protocol operation. Core maps Anthropic base64
+and URL image sources to ordered OpenAI `image_url` content parts without
+fetching remote content. Provider adapters do not gate that conversion behind a
+provider-wide vision flag; the selected upstream model owns image capability,
+while any deliberate provider-specific attachment removal remains explicit
+compatibility policy.
 
 Shared stream behavior lives under
 [src/free_claude_code/core/anthropic/streaming/](src/free_claude_code/core/anthropic/streaming/). The shared layer owns the

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 - Switch among 24 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
 - Route Opus, Sonnet, Haiku, and fallback traffic to different models.
-- Keep streaming, tool use, and reasoning support across compatible models.
+- Keep streaming, tool use, reasoning, and image input across compatible models.
 - Connect Claude Code and Codex in VS Code or Claude Code through JetBrains ACP.
 - Optionally run Claude Code sessions through Discord or Telegram with voice-note transcription.
 - Protect the local proxy with optional token authentication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.1.0"
+version = "4.2.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -146,6 +146,33 @@ def _assert_no_forbidden_assistant_block(block: Any) -> None:
         )
 
 
+def _openai_user_image_part(block: Any) -> dict[str, Any]:
+    """Convert one Anthropic user image block without performing I/O."""
+    source = get_block_attr(block, "source", {})
+    source_type = get_block_attr(source, "type")
+
+    if source_type == "base64":
+        media_type = get_block_attr(source, "media_type")
+        if not isinstance(media_type, str) or not media_type.strip():
+            raise OpenAIConversionError(
+                "Base64 image source requires a non-empty media_type."
+            )
+        data = get_block_attr(source, "data")
+        if not isinstance(data, str) or not data.strip():
+            raise OpenAIConversionError("Base64 image source requires non-empty data.")
+        url = f"data:{media_type};base64,{data}"
+    elif source_type == "url":
+        url = get_block_attr(source, "url")
+        if not isinstance(url, str) or not url.strip():
+            raise OpenAIConversionError("URL image source requires a non-empty url.")
+    else:
+        raise OpenAIConversionError(
+            f"Unsupported image source type {source_type!r}; expected 'base64' or 'url'."
+        )
+
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
 class _OpenAIChatHistoryLedger:
     """Assemble OpenAI chat history while respecting tool-result dependencies."""
 
@@ -482,25 +509,31 @@ class AnthropicToOpenAIConverter:
     @staticmethod
     def _convert_user_message(content: list[Any]) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
-        text_parts: list[str] = []
+        content_parts: list[dict[str, Any]] = []
 
-        def flush_text() -> None:
-            if text_parts:
-                result.append({"role": "user", "content": "\n".join(text_parts)})
-                text_parts.clear()
+        def flush_content() -> None:
+            if not content_parts:
+                return
+            if all(part["type"] == "text" for part in content_parts):
+                message_content: str | list[dict[str, Any]] = "\n".join(
+                    part["text"] for part in content_parts
+                )
+            else:
+                message_content = list(content_parts)
+            result.append({"role": "user", "content": message_content})
+            content_parts.clear()
 
         for block in content:
             block_type = get_block_type(block)
 
             if block_type == "text":
-                text_parts.append(get_block_attr(block, "text", ""))
-            elif block_type == "image":
-                raise OpenAIConversionError(
-                    "User message image blocks are not supported for OpenAI chat "
-                    "conversion; remove the image blocks or extend the converter."
+                content_parts.append(
+                    {"type": "text", "text": get_block_attr(block, "text", "")}
                 )
+            elif block_type == "image":
+                content_parts.append(_openai_user_image_part(block))
             elif block_type == "tool_result":
-                flush_text()
+                flush_content()
                 tool_content = get_block_attr(block, "content", "")
                 serialized = serialize_tool_result_content(tool_content)
                 result.append(
@@ -511,7 +544,7 @@ class AnthropicToOpenAIConverter:
                     }
                 )
 
-        flush_text()
+        flush_content()
         return result
 
     @staticmethod

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -698,12 +698,131 @@ def test_assistant_redacted_thinking_omitted_from_openai_chat():
     assert "reasoning_content" not in result[0]
 
 
-def test_convert_user_message_image_raises():
-    content = [
-        MockBlock(type="image", source={"type": "url", "url": "https://example.com/x"})
+@pytest.mark.parametrize(
+    "source,expected_url",
+    [
+        (
+            {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+            "data:image/png;base64,AAAA",
+        ),
+        (
+            {"type": "url", "url": "https://example.com/image.png"},
+            "https://example.com/image.png",
+        ),
+    ],
+)
+def test_convert_user_message_image_sources(source, expected_url):
+    messages = [MockMessage("user", [MockBlock(type="image", source=source)])]
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": expected_url}}],
+        }
     ]
-    messages = [MockMessage("user", content)]
-    with pytest.raises(OpenAIConversionError):
+
+
+def test_convert_user_message_preserves_interleaved_image_text_order():
+    messages = [
+        MockMessage(
+            "user",
+            [
+                MockBlock(
+                    type="image",
+                    source={
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": "FIRST",
+                    },
+                ),
+                MockBlock(type="text", text="Compare the first image with this one."),
+                MockBlock(
+                    type="image",
+                    source={"type": "url", "url": "https://example.com/second.jpg"},
+                ),
+                MockBlock(type="text", text="Describe the differences."),
+            ],
+        )
+    ]
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,FIRST"},
+                },
+                {
+                    "type": "text",
+                    "text": "Compare the first image with this one.",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/second.jpg"},
+                },
+                {"type": "text", "text": "Describe the differences."},
+            ],
+        }
+    ]
+
+
+def test_convert_user_image_before_tool_result_preserves_message_order():
+    messages = [
+        MockMessage(
+            "user",
+            [
+                MockBlock(type="text", text="Inspect this."),
+                MockBlock(
+                    type="image",
+                    source={"type": "url", "url": "https://example.com/image.png"},
+                ),
+                MockBlock(type="tool_result", tool_use_id="tool_1", content="done"),
+            ],
+        )
+    ]
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Inspect this."},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tool_1", "content": "done"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "source,error",
+    [
+        (
+            {"type": "base64", "media_type": "", "data": "AAAA"},
+            "non-empty media_type",
+        ),
+        (
+            {"type": "base64", "media_type": "image/png", "data": ""},
+            "non-empty data",
+        ),
+        ({"type": "url", "url": ""}, "non-empty url"),
+        ({"type": "file", "file_id": "file_1"}, "Unsupported image source type"),
+        ({}, "Unsupported image source type"),
+    ],
+)
+def test_convert_user_message_rejects_unconvertible_image_sources(source, error):
+    messages = [MockMessage("user", [MockBlock(type="image", source=source)])]
+
+    with pytest.raises(OpenAIConversionError, match=error):
         AnthropicToOpenAIConverter.convert_messages(messages)
 
 
@@ -1011,6 +1130,45 @@ def test_openai_build_accepts_declared_native_top_level_hints() -> None:
     assert "output_config" not in body
     assert "mcp_servers" not in body
     assert body["model"] == "m"
+
+
+def test_openai_build_converts_validated_anthropic_image_block() -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "vision-model",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/webp",
+                                "data": "AAAA",
+                            },
+                        },
+                        {"type": "text", "text": "What is shown?"},
+                    ],
+                }
+            ],
+        }
+    )
+
+    body = build_base_request_body(request)
+
+    assert body["messages"] == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/webp;base64,AAAA"},
+                },
+                {"type": "text", "text": "What is shown?"},
+            ],
+        }
+    ]
 
 
 def test_openai_build_rejects_unknown_top_level_extras() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.1.0"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC rejects Anthropic user image blocks before vision-capable OpenAI-compatible providers can receive them. This blocks pasted images in Claude Code and IDE clients. Fixes #512.

## Changes

| Before | After |
| --- | --- |
| User image blocks fail during Anthropic-to-OpenAI conversion. | Base64 and URL image sources become OpenAI `image_url` parts. |
| Mixed text and image input cannot reach an upstream model. | Mixed content preserves exact block order and text-only behavior. |
| Invalid image sources require ambiguous downstream handling. | Missing or unsupported source fields fail explicitly before execution. |
| Vision support could require flags or proxy-side downloads. | Conversion stays provider-neutral and performs no network I/O. |
| The package remains on `4.1.0`. | The package advances to `4.2.0` with a regenerated lockfile. |
| Converter coverage rejects every user image. | Tests cover source mapping, ordering, tool boundaries, validation, and request construction. |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds OpenAI-compatible vision conversion for Anthropic image blocks. The main changes are:

- Converts base64 image sources into data image URLs.
- Converts URL image sources into OpenAI `image_url` parts.
- Preserves mixed text and image ordering in user messages.
- Rejects unsupported or incomplete image sources.
- Updates converter tests for image and tool-result cases.
- Bumps package metadata to `4.2.0` in both project and lock files.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the initial focused run and confirmed all tests passed, with the wrapper exit code reported as nonzero and retained for traceability.
- Validated the focused rerun completed cleanly with 10 tests passed and exit code 0.
- Validated the full converter run completed with 73 tests passed and exit code 0.

<a href="https://app.greptile.com/trex/runs/14209442/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/anthropic/conversion.py | Adds ordered image conversion for OpenAI-compatible chat content. |
| tests/providers/test_converter.py | Adds tests for image conversion, ordering, validation, and request-body output. |
| pyproject.toml | Updates the package version to `4.2.0`. |
| uv.lock | Updates the locked local package version to `4.2.0`. |
| ARCHITECTURE.md | Documents core image conversion behavior for OpenAI-compatible providers. |
| README.md | Mentions image input support across compatible models. |

<sub>Reviews (8): Last reviewed commit: ["feat: add vision support for OpenAI chat..."](https://github.com/alishahryar1/free-claude-code/commit/4a6b6de14d19ce22e3be5981f84bb6f236a11181) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43544835)</sub>

<!-- /greptile_comment -->