### PR TITLE
Retry degraded NVIDIA NIM functions as overloads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -564,9 +564,10 @@ thinking replay selection, `extra_body`, and chat-completion field normalization
 Native Anthropic providers call the native request policy for raw request
 dumping, default tokens, stream flags, thinking payloads, and `extra_body`
 handling. Concrete provider packages keep only true upstream quirks such as
-Gemini thought signatures, NIM tool-schema aliases and retry downgrades, or
-DeepSeek attachment/tool/thinking compatibility. Cloud providers use OpenAI-chat
-unless they are local native runtimes. DeepSeek intentionally uses its
+Gemini thought signatures, NIM tool-schema aliases, retry downgrades, and NVCF
+deployment-failure classification, or DeepSeek attachment/tool/thinking
+compatibility. Cloud providers use OpenAI-chat unless they are local native
+runtimes. DeepSeek intentionally uses its
 OpenAI-compatible Chat Completions endpoint because that is the endpoint that
 reports prompt-cache hit/miss counters; the provider maps those counters back
 into Anthropic usage fields for Claude-compatible clients. Cloudflare uses its
@@ -662,11 +663,21 @@ copyable request-ID diagnostics. Anthropic and Responses packages independently
 map the canonical kind and status to their wire error types.
 
 [providers/failure_policy.py](src/free_claude_code/providers/failure_policy.py)
-is the only owner of raw OpenAI SDK and `httpx` exception classification,
+owns generic raw OpenAI SDK and `httpx` exception classification,
 transient status/body inference, stable provider wording, and final diagnostic
 construction for those failures. Native Anthropic wire errors are instead
 mapped to canonical failures by the Anthropic protocol package, then consumed
 by provider retry/recovery policy.
+Concrete adapters may supply one narrow semantic override for an upstream quirk
+that the shared SDK cannot express correctly. The concrete adapter owns the
+exact upstream marker, while the shared failure policy owns its canonical
+meaning and wording. The limiter uses that meaning for retry qualification and
+its existing provider-wide reactive backoff while retaining the raw exception,
+so exhausted retries still receive the original HTTP status/body through the
+shared redaction and diagnostic path. For NVCF's function-scoped failure this
+deliberately keeps the simple one-limiter-per-provider policy; a degraded NIM
+function can therefore briefly delay other NIM models during backoff. No
+provider-specific marker enters `core/`, another provider, or an API adapter.
 [providers/stream_recovery.py](src/free_claude_code/providers/stream_recovery.py)
 owns the 0.75-second/65,536-byte holdback, four transparent early retries after
 the first attempt, and five midstream recovery attempts. Provider opening keeps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.7"
+version = "3.5.8"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/capabilities.py
+++ b/smoke/capabilities.py
@@ -279,10 +279,13 @@ CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
         "rate_limit_and_disconnect",
         "smart_rate_limiting",
         "free_claude_code.providers.rate_limit.ProviderRateLimiter",
-        "concurrent provider requests and 429/disconnect failures",
-        "proactive throttle, retry, cleanup",
+        "concurrent provider requests and transient upstream/disconnect failures",
+        "provider-specific classification, proactive throttle, retry, cleanup",
         "mapped provider error or smoke skip for upstream disconnect",
-        ("tests/providers/test_provider_rate_limit.py",),
+        (
+            "tests/providers/test_provider_rate_limit.py",
+            "tests/providers/test_nvidia_nim_degraded_retry.py",
+        ),
         ("test_client_disconnect_mid_stream_does_not_crash_server",),
     ),
     CapabilityContract(

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -183,9 +183,12 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
     ),
     FeatureCoverage(
         "smart_rate_limiting",
-        "Disconnect and limiter cleanup preserve follow-up requests",
+        "Transient retries and disconnect cleanup preserve follow-up requests",
         "public_surface",
-        ("tests/providers/test_provider_rate_limit.py",),
+        (
+            "tests/providers/test_provider_rate_limit.py",
+            "tests/providers/test_nvidia_nim_degraded_retry.py",
+        ),
         ("test_client_disconnect_mid_stream_does_not_crash_server",),
         ("test_provider_disconnect_e2e",),
         ("rate_limit", "providers"),

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -17,6 +17,7 @@ from free_claude_code.core.diagnostics import (
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
 
 MarkRateLimited = Callable[[float], None]
+ProviderFailureOverride = Callable[[Exception], ExecutionFailure | None]
 
 _RATE_LIMIT_MARKERS = frozenset({"rate_limit", "rate limit", "too many requests"})
 _OVERLOAD_MARKERS = frozenset(
@@ -42,19 +43,28 @@ def classify_provider_failure(
     read_timeout_s: float | None,
     request_id: str | None,
     mark_rate_limited: MarkRateLimited,
+    provider_failure_override: ProviderFailureOverride | None = None,
 ) -> ExecutionFailure:
     """Return one detailed canonical failure after provider retries are exhausted."""
-    failure = _classify_provider_failure(
-        exc,
-        read_timeout_s=read_timeout_s,
-        mark_rate_limited=mark_rate_limited,
-    )
     if isinstance(exc, ExecutionFailure):
+        failure = exc
         message = failure.message
         request_id_line = f"Request ID: {request_id}" if request_id else None
         if request_id_line and request_id_line not in message:
             message = f"{message}\n\n{request_id_line}"
         return replace(failure, message=message)
+
+    failure = (
+        provider_failure_override(exc)
+        if provider_failure_override is not None
+        else None
+    )
+    if failure is None:
+        failure = _classify_provider_failure(
+            exc,
+            read_timeout_s=read_timeout_s,
+            mark_rate_limited=mark_rate_limited,
+        )
     message = format_execution_failure_message(
         failure,
         extract_upstream_error_detail(exc),
@@ -62,6 +72,11 @@ def classify_provider_failure(
         request_id=request_id,
     )
     return replace(failure, message=message)
+
+
+def overloaded_provider_failure() -> ExecutionFailure:
+    """Return the canonical provider-overload meaning and stable wording."""
+    return _failure(FailureKind.OVERLOADED, 529, _OVERLOADED_MESSAGE, True)
 
 
 def retryable_transient_status(exc: BaseException) -> int | None:
@@ -221,7 +236,7 @@ def _classify_provider_failure(
     if isinstance(exc, openai.InternalServerError):
         status = retryable_transient_status(exc) or getattr(exc, "status_code", None)
         if is_transient_overload_error(exc):
-            return _failure(FailureKind.OVERLOADED, 529, _OVERLOADED_MESSAGE, True)
+            return overloaded_provider_failure()
         if isinstance(status, int) and 500 <= status <= 599:
             return _failure(
                 FailureKind.UPSTREAM,
@@ -236,7 +251,7 @@ def _classify_provider_failure(
             mark_rate_limited(60)
             return _failure(FailureKind.RATE_LIMIT, 429, _RATE_LIMIT_MESSAGE, True)
         if is_transient_overload_error(exc):
-            return _failure(FailureKind.OVERLOADED, 529, _OVERLOADED_MESSAGE, True)
+            return overloaded_provider_failure()
         effective_status = status or getattr(exc, "status_code", None)
         if not isinstance(effective_status, int):
             effective_status = 500
@@ -261,7 +276,7 @@ def _classify_provider_failure(
                 FailureKind.INVALID_REQUEST, 400, _INVALID_REQUEST_MESSAGE, False
             )
         if status in (502, 503, 504):
-            return _failure(FailureKind.OVERLOADED, 529, _OVERLOADED_MESSAGE, True)
+            return overloaded_provider_failure()
         return _failure(
             FailureKind.UPSTREAM,
             status,

--- a/src/free_claude_code/providers/nvidia_nim/client.py
+++ b/src/free_claude_code/providers/nvidia_nim/client.py
@@ -1,6 +1,7 @@
 """NVIDIA NIM provider implementation."""
 
 import json
+from collections.abc import Mapping
 from typing import Any
 
 import openai
@@ -8,8 +9,12 @@ from loguru import logger
 
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.defaults import NVIDIA_NIM_DEFAULT_BASE
+from free_claude_code.providers.failure_policy import (
+    overloaded_provider_failure,
+)
 from free_claude_code.providers.rate_limit import ProviderRateLimiter
 from free_claude_code.providers.transports.openai_chat import OpenAIChatTransport
 
@@ -23,6 +28,8 @@ from .tool_schema import (
     body_without_nim_tool_argument_aliases,
     nim_tool_argument_aliases_from_body,
 )
+
+_DEGRADED_FUNCTION_STATE = "degraded function cannot be invoked"
 
 
 class NvidiaNimProvider(OpenAIChatTransport):
@@ -106,6 +113,29 @@ class NvidiaNimProvider(OpenAIChatTransport):
             return retry_body
 
         return None
+
+    def _provider_failure_override(self, error: Exception) -> ExecutionFailure | None:
+        """Map NVIDIA Cloud Function deployment failure onto canonical overload."""
+        if not isinstance(error, openai.BadRequestError):
+            return None
+        if getattr(error, "status_code", None) != 400:
+            return None
+        body = getattr(error, "body", None)
+        if not isinstance(body, Mapping):
+            return None
+        detail = body.get("detail")
+        if not isinstance(detail, str):
+            return None
+        function_ref, separator, state = detail.lower().partition(": ")
+        function_id = function_ref.removeprefix("function id ").strip(" '\"")
+        if (
+            not separator
+            or not function_ref.startswith("function id ")
+            or not function_id
+            or state.strip() != _DEGRADED_FUNCTION_STATE
+        ):
+            return None
+        return overloaded_provider_failure()
 
 
 def _is_reasoning_budget_rejection(error_text: str) -> bool:

--- a/src/free_claude_code/providers/rate_limit.py
+++ b/src/free_claude_code/providers/rate_limit.py
@@ -12,6 +12,7 @@ from loguru import logger
 from free_claude_code.core.rate_limit import StrictSlidingWindowLimiter
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.failure_policy import (
+    ProviderFailureOverride,
     retryable_upstream_status,
     retryable_upstream_transport_error,
 )
@@ -133,6 +134,7 @@ class ProviderRateLimiter:
         self,
         fn: Callable[..., Any],
         *args: Any,
+        provider_failure_override: ProviderFailureOverride | None = None,
         max_retries: int = DEFAULT_UPSTREAM_MAX_RETRIES,
         base_delay: float = 2.0,
         max_delay: float = 60.0,
@@ -149,6 +151,8 @@ class ProviderRateLimiter:
 
         Args:
             fn: Async callable to execute.
+            provider_failure_override: Optional provider-specific semantic
+                classifier applied before shared retry qualification.
             max_retries: Maximum number of retry attempts after the first failure.
             base_delay: Base delay in seconds for exponential backoff.
             max_delay: Maximum delay cap in seconds.
@@ -169,9 +173,16 @@ class ProviderRateLimiter:
             try:
                 return await fn(*args, **kwargs)
             except Exception as e:
-                status = retryable_upstream_status(e)
+                effective_error = (
+                    provider_failure_override(e)
+                    if provider_failure_override is not None
+                    else None
+                )
+                if effective_error is None:
+                    effective_error = e
+                status = retryable_upstream_status(effective_error)
                 transport_error = status is None and retryable_upstream_transport_error(
-                    e
+                    effective_error
                 )
                 if status is None and not transport_error:
                     raise

--- a/src/free_claude_code/providers/transports/openai_chat/transport.py
+++ b/src/free_claude_code/providers/transports/openai_chat/transport.py
@@ -27,6 +27,7 @@ from free_claude_code.core.anthropic.streaming import (
     parse_complete_tool_input,
     tool_schemas_by_name,
 )
+from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.trace import provider_chat_body_snapshot, trace_event
 from free_claude_code.providers.base import BaseProvider, ProviderConfig
 from free_claude_code.providers.failure_policy import classify_provider_failure
@@ -140,6 +141,10 @@ class OpenAIChatTransport(BaseProvider):
         """Return a modified request body for one retry, or None."""
         return None
 
+    def _provider_failure_override(self, error: Exception) -> ExecutionFailure | None:
+        """Return provider-specific failure semantics, or defer to shared policy."""
+        return None
+
     def _prepare_create_body(self, body: dict[str, Any]) -> dict[str, Any]:
         """Return the body passed to the upstream OpenAI-compatible client."""
         return body
@@ -166,7 +171,10 @@ class OpenAIChatTransport(BaseProvider):
             try:
                 create_body = self._prepare_create_body(body)
                 stream = await self._rate_limiter.execute_with_retry(
-                    self._client.chat.completions.create, **create_body, stream=True
+                    self._client.chat.completions.create,
+                    provider_failure_override=self._provider_failure_override,
+                    **create_body,
+                    stream=True,
                 )
                 return stream, body
             except Exception as error:
@@ -492,6 +500,9 @@ class _OpenAIChatStreamRunner:
                         request_id=self._request_id,
                         mark_rate_limited=(
                             self._transport._rate_limiter.extend_reactive_block
+                        ),
+                        provider_failure_override=(
+                            self._transport._provider_failure_override
                         ),
                     )
                     error_trace: dict[str, Any] = {

--- a/tests/providers/support.py
+++ b/tests/providers/support.py
@@ -22,6 +22,7 @@ class PassthroughProviderRateLimiter(ProviderRateLimiter):
         *args: Any,
         **kwargs: Any,
     ) -> Any:
+        kwargs.pop("provider_failure_override", None)
         return await fn(*args, **kwargs)
 
 

--- a/tests/providers/test_nvidia_nim_degraded_retry.py
+++ b/tests/providers/test_nvidia_nim_degraded_retry.py
@@ -1,0 +1,289 @@
+"""NVIDIA Cloud Function deployment failures use provider-owned retry semantics."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import openai
+import pytest
+
+from free_claude_code.config.nim import NimSettings
+from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.failure_policy import (
+    overloaded_provider_failure,
+    retryable_upstream_status,
+)
+from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
+from free_claude_code.providers.open_router import OpenRouterProvider
+from free_claude_code.providers.rate_limit import (
+    DEFAULT_UPSTREAM_MAX_RETRIES,
+    UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS,
+    ProviderRateLimiter,
+)
+from tests.providers.request_factory import make_messages_request
+
+_FUNCTION_ID = "87ea0ddc-cff1-4bca-bf8b-3bd98a35ddd0"
+_DEGRADED_DETAIL = f"Function id '{_FUNCTION_ID}': DEGRADED function cannot be invoked"
+
+
+def _config(base_url: str) -> ProviderConfig:
+    return ProviderConfig(
+        api_key="test_key",
+        base_url=base_url,
+        rate_limit=1_000_000,
+        rate_window=1,
+        max_concurrency=1_000,
+        http_read_timeout=30.0,
+        http_write_timeout=15.0,
+        http_connect_timeout=5.0,
+    )
+
+
+def _limiter() -> ProviderRateLimiter:
+    return ProviderRateLimiter(
+        rate_limit=1_000_000,
+        rate_window=1.0,
+        max_concurrency=1_000,
+    )
+
+
+def _bad_request(
+    detail: str = _DEGRADED_DETAIL,
+    *,
+    body_extra: dict[str, str] | None = None,
+) -> openai.BadRequestError:
+    request = httpx.Request(
+        "POST", "https://integrate.api.nvidia.com/v1/chat/completions"
+    )
+    response = httpx.Response(400, request=request)
+    body: dict[str, object] = {
+        "status": 400,
+        "title": "Bad Request",
+        "detail": detail,
+    }
+    if body_extra is not None:
+        body.update(body_extra)
+    return openai.BadRequestError("Bad Request", response=response, body=body)
+
+
+def _successful_stream(text: str = "Recovered"):
+    chunk = MagicMock()
+    chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content=text, reasoning_content=""),
+            finish_reason="stop",
+        )
+    ]
+    chunk.usage = None
+
+    async def stream():
+        yield chunk
+
+    return stream()
+
+
+def _nim(limiter: ProviderRateLimiter) -> NvidiaNimProvider:
+    return NvidiaNimProvider(
+        _config("https://integrate.api.nvidia.com/v1"),
+        nim_settings=NimSettings(),
+        rate_limiter=limiter,
+    )
+
+
+@pytest.mark.asyncio
+async def test_degraded_function_retries_unchanged_request_then_succeeds() -> None:
+    limiter = _limiter()
+    provider = _nim(limiter)
+
+    with (
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[_bad_request(), _successful_stream()],
+        ) as create,
+        patch.object(limiter, "extend_reactive_block") as extend_block,
+        patch(
+            "free_claude_code.providers.rate_limit.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep,
+    ):
+        events = [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), request_id="req_recovered"
+            )
+        ]
+
+    assert create.await_count == 2
+    assert create.call_args_list[0].kwargs == create.call_args_list[1].kwargs
+    extend_block.assert_called_once()
+    sleep.assert_awaited_once()
+    event_text = "".join(events)
+    assert "Recovered" in event_text
+    assert "event: message_stop" in event_text
+    assert "event: error" not in event_text
+
+
+@pytest.mark.asyncio
+async def test_degraded_function_exhaustion_is_detailed_redacted_overload() -> None:
+    limiter = _limiter()
+    provider = _nim(limiter)
+    error = _bad_request(
+        body_extra={
+            "authorization": "Bearer NIM_AUTH_SECRET",
+            "api_key": "NIM_API_SECRET",
+        }
+    )
+
+    with (
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=error,
+        ) as create,
+        patch.object(limiter, "extend_reactive_block") as extend_block,
+        patch(
+            "free_claude_code.providers.rate_limit.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep,
+        patch(
+            "free_claude_code.providers.transports.openai_chat.transport.trace_event"
+        ) as trace,
+        pytest.raises(ExecutionFailure) as exc_info,
+    ):
+        [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), request_id="req_degraded"
+            )
+        ]
+
+    assert create.await_count == UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS
+    assert extend_block.call_count == DEFAULT_UPSTREAM_MAX_RETRIES
+    assert sleep.await_count == DEFAULT_UPSTREAM_MAX_RETRIES
+
+    failure = exc_info.value
+    assert failure.kind is FailureKind.OVERLOADED
+    assert failure.status_code == 529
+    assert failure.retryable is True
+    assert "Upstream provider NIM returned HTTP 400." in failure.message
+    assert _DEGRADED_DETAIL in failure.message
+    assert "Request ID: req_degraded" in failure.message
+    assert "NIM_AUTH_SECRET" not in failure.message
+    assert "NIM_API_SECRET" not in failure.message
+
+    error_traces = [
+        call.kwargs
+        for call in trace.call_args_list
+        if call.kwargs.get("event") == "provider.response.error"
+    ]
+    assert error_traces[-1]["exc_type"] == "BadRequestError"
+    assert error_traces[-1]["failure_kind"] == "overloaded"
+    assert error_traces[-1]["status_code"] == 529
+    assert error_traces[-1]["provider_retryable"] is True
+    assert "error_message" not in error_traces[-1]
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "Unsupported field: top_k",
+        "Validation failed: DEGRADED function cannot be invoked",
+        f"Function id '{_FUNCTION_ID}': DEGRADING function cannot be invoked",
+        f"Function id '{_FUNCTION_ID}': DEGRADED function is waiting",
+    ],
+)
+@pytest.mark.asyncio
+async def test_unrelated_nim_bad_request_is_not_retried(detail: str) -> None:
+    limiter = _limiter()
+    provider = _nim(limiter)
+
+    with (
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=_bad_request(detail),
+        ) as create,
+        patch.object(limiter, "extend_reactive_block") as extend_block,
+        patch(
+            "free_claude_code.providers.rate_limit.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep,
+        pytest.raises(ExecutionFailure) as exc_info,
+    ):
+        [event async for event in provider.stream_response(make_messages_request())]
+
+    assert create.await_count == 1
+    extend_block.assert_not_called()
+    sleep.assert_not_awaited()
+    assert exc_info.value.kind is FailureKind.INVALID_REQUEST
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_degraded_wording_remains_non_retryable_for_other_providers() -> None:
+    limiter = _limiter()
+    provider = OpenRouterProvider(
+        _config("https://openrouter.ai/api/v1"), rate_limiter=limiter
+    )
+    error = _bad_request()
+
+    assert retryable_upstream_status(error) is None
+
+    with (
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=error,
+        ) as create,
+        patch.object(limiter, "extend_reactive_block") as extend_block,
+        patch(
+            "free_claude_code.providers.rate_limit.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep,
+        pytest.raises(ExecutionFailure) as exc_info,
+    ):
+        [event async for event in provider.stream_response(make_messages_request())]
+
+    assert create.await_count == 1
+    extend_block.assert_not_called()
+    sleep.assert_not_awaited()
+    assert exc_info.value.kind is FailureKind.INVALID_REQUEST
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_limiter_override_preserves_raw_exception_after_exhaustion() -> None:
+    limiter = _limiter()
+    errors = (_bad_request(), _bad_request())
+    attempts = 0
+
+    async def fail() -> None:
+        nonlocal attempts
+        error = errors[attempts]
+        attempts += 1
+        raise error
+
+    override = Mock(return_value=overloaded_provider_failure())
+    with (
+        patch.object(limiter, "extend_reactive_block"),
+        patch(
+            "free_claude_code.providers.rate_limit.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+        pytest.raises(openai.BadRequestError) as exc_info,
+    ):
+        await limiter.execute_with_retry(
+            fail,
+            provider_failure_override=override,
+            max_retries=1,
+        )
+
+    assert attempts == 2
+    assert override.call_count == 2
+    assert exc_info.value is errors[-1]

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.7"
+version = "3.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

NVIDIA NVCF can return HTTP 400 when a deployed function is DEGRADED, even though the failure is transient. FCC treated that response as a deterministic invalid request and never used its provider-owned retry budget. Fixes #1057.

## Changes

| Before | After |
| --- | --- |
| Every NVIDIA HTTP 400 was non-retryable. | The NVIDIA adapter recognizes only the structured NVCF `Function id …: DEGRADED function cannot be invoked` response. |
| A degraded function failed after one attempt. | The shared limiter applies its existing five-attempt exponential backoff without mutating the request or adding another retry loop. |
| Exhaustion returned `INVALID_REQUEST / 400`. | Exhaustion returns canonical `OVERLOADED / 529` while preserving the redacted upstream HTTP 400 detail and request ID. |
| NVIDIA-specific wording could have leaked into shared classification. | The exact marker stays NVIDIA-owned; shared provider policy owns canonical semantics, diagnostics, and scheduling, while API wire mapping remains unchanged. |
| The degraded-function boundary had no deterministic coverage. | Tests cover recovery, exact exhaustion, near misses, provider isolation, raw exception preservation, trace metadata, and credential redaction; all five CI gates pass with 2,214 tests passed and 7 skipped. |
| Package version was 3.5.7. | Package version is 3.5.8 with an updated lockfile. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR teaches NVIDIA NIM degraded-function failures to use the shared overload retry path. The main changes are:

- Adds a provider-specific failure override hook.
- Maps the exact NVCF degraded-function HTTP 400 marker to canonical overload semantics.
- Threads the override through shared retry and final failure classification.
- Adds focused tests for retry, exhaustion, near misses, provider isolation, redaction, and trace metadata.
- Updates docs, smoke coverage metadata, package version, and lockfile.
</details>


<h3>Confidence Score: 5/5</h3>

This looks safe to merge after considering the narrow NVIDIA error-body match.

The retry and final classification flow preserve the raw upstream error, and non-NVIDIA providers keep the existing 400 behavior.

src/free_claude_code/providers/nvidia_nim/client.py should harden the degraded marker lookup for nested SDK error bodies.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the corresponding review comment.
- A contract-validation proof was captured showing the full command transcript with timestamps, working directory, commands, pytest verbose output, and exit codes.
- The focused Nvidia degraded retry test ran and completed with 8 passed in 2.43s.
- A broader test run reported worker crashes, with 3 failed and 70 passed.
- A serial test for test\_openai\_compat\_5xx\_retry.py timed out after a hang, exiting at 124.

<a href="https://app.greptile.com/trex/runs/14112472/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/nvidia_nim/client.py | Adds NVIDIA-specific degraded-function detection; the match is narrow and only reads a top-level `detail` field. |
| src/free_claude_code/providers/rate_limit.py | Uses provider overrides for retry qualification while preserving the raw exception after retry exhaustion. |
| src/free_claude_code/providers/failure_policy.py | Adds the shared override type and final classification hook, plus a reusable overloaded-provider failure constructor. |
| src/free_claude_code/providers/transports/openai_chat/transport.py | Passes provider-specific failure overrides into stream creation retries and final failure mapping. |
| tests/providers/test_nvidia_nim_degraded_retry.py | Adds coverage for NVIDIA degraded-function retry success, retry exhaustion, non-matching 400s, provider isolation, redaction, and traces. |

</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Adjacent OpenAI-compatible 5xx exhaustion test crashes workers and hangs serially**

   - **Bug**
     - The requested adjacent retry/rate-limit coverage is not stable on current head. Under xdist, three parameters of `test_nim_stream_openai_5xx_exhausted_emits_user_message` caused workers to terminate unexpectedly, producing an exit code 1. A follow-up serial rerun passed the 500 parameter but timed out after 60 seconds while running the 502 parameter, indicating the exhausted 5xx path can hang or terminate the worker rather than completing deterministically.
   - **Cause**
     - The executed evidence points to the OpenAI-compatible NIM 5xx exhaustion path exercised by `tests/providers/test_openai_compat_5xx_retry.py::test_nim_stream_openai_5xx_exhausted_emits_user_message`. The exact root cause was not isolated within the validation budget, but the affected area overlaps changed retry/transport handling files.
   - **Fix**
     - Investigate the OpenAI-compatible streaming 5xx exhaustion path for non-terminating retry/stream cleanup or worker-fatal behavior. Ensure exhausted 5xx cases raise the expected user-facing error promptly for all status parameters, then rerun the adjacent command and the targeted serial parametrized test.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fretry-nim-degraded-function%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fretry-nim-degraded-function%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffree_claude_code%2Fproviders%2Fnvidia_nim%2Fclient.py%3A126-127%0A**Nested%20Error%20Body%20Misses%20Retry**%0A%0AWhen%20the%20OpenAI%20SDK%20exposes%20a%20400%20response%20as%20the%20common%20nested%20error%20shape%2C%20such%20as%20%60%7B%22error%22%3A%20%7B%22message%22%3A%20%22Function%20id%20...%3A%20DEGRADED%20function%20cannot%20be%20invoked%22%7D%7D%60%2C%20this%20lookup%20never%20sees%20the%20degraded%20marker.%20That%20path%20falls%20back%20to%20the%20shared%20400%20handling%2C%20so%20a%20transient%20degraded%20NVCF%20function%20still%20fails%20after%20one%20attempt%20instead%20of%20using%20the%20provider%20retry%20budget.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1064&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Retry degraded NVIDIA NIM functions as o..."](https://github.com/alishahryar1/free-claude-code/commit/2cc7f056a73d1baefb1e1395b181d26efc32dc9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43555691)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->