### PR TITLE
Use task status as the sole stop confirmation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -938,10 +938,16 @@ cancel and join every older voice handoff; they then cancel any tree that won
 admission during the join. Reply-scoped commands first join the matching voice
 claim and then resolve its authoritative tree, so either the voice cancellation
 or the admitted-tree transition wins and the same scoped request is never
-double-counted. Epoch validation, tree admission, processor publication, and
-persistence of the detached snapshot complete as one workflow-owned operation;
-caller cancellation is restored only after that transaction finishes. Stop and
-clear use the same completion-driven boundary, so caller cancellation cannot
+double-counted. Stop operations return one typed outcome after assigning every
+terminal status owner. The outcome records which message scopes own terminal
+status feedback. Existing task statuses are the sole success UI when every
+affected status is in the invoking scope; the command adapter sends a message
+for a no-op, any cross-scope work, or the rare voice cancellation that wins
+before a status ID is bound. Epoch validation, tree admission, processor
+publication, and persistence of the detached snapshot complete as one
+workflow-owned operation; caller cancellation is restored only after that
+transaction finishes. Stop and clear use the same completion-driven boundary,
+so caller cancellation cannot
 leave a committed state transition without its remaining persistence or CLI
 cleanup. At startup it restores and normalizes
 persisted state before ingress begins, then repairs interrupted platform

--- a/README.md
+++ b/README.md
@@ -312,7 +312,9 @@ Configure integrations from **Admin UI → Messaging**, then click **Validate** 
 Bot commands: standalone `/stop` cancels all work, standalone `/clear` resets all
 sessions, and `/stats` shows session state. Reply with `/stop` to cancel only
 that request while other queued requests continue. Reply with `/clear` to
-remove that conversation branch.
+remove that conversation branch. A successful stop updates the affected task
+status instead of posting a second confirmation message. A no-op, or a global
+stop whose affected statuses are in another chat, still replies explicitly.
 
 <details>
 <summary><strong>Voice notes</strong></summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.8"
+version = "3.5.9"
 description = "Middleware between Claude Code CLI (Anthropic API) and NVIDIA NIM"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/capabilities.py
+++ b/smoke/capabilities.py
@@ -376,8 +376,8 @@ CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
         "messaging_commands",
         "free_claude_code.messaging.commands",
         "/stop, /clear, /stats command messages",
-        "task cancellation, cleanup, or stats response",
-        "best-effort platform cleanup",
+        "task cancellation with status-owned success UI, cleanup, or stats response",
+        "terminal status edit, no-op feedback, or best-effort platform cleanup",
         (
             "tests/messaging/test_handler.py",
             "tests/messaging/test_handler_integration.py",
@@ -385,6 +385,7 @@ CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
         ),
         (
             "test_messaging_commands_stop_clear_stats_e2e",
+            "test_messaging_active_stop_uses_status_only_e2e",
             "test_messaging_queued_scoped_cancel_e2e",
         ),
     ),

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -441,7 +441,7 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
     ),
     FeatureCoverage(
         "messaging_commands",
-        "Messaging /stop, /clear, and /stats operate on product state",
+        "Messaging commands mutate state with task-status-owned stop feedback",
         "public_surface",
         (
             "tests/messaging/test_handler.py",
@@ -451,6 +451,7 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
         (),
         (
             "test_messaging_commands_stop_clear_stats_e2e",
+            "test_messaging_active_stop_uses_status_only_e2e",
             "test_messaging_queued_scoped_cancel_e2e",
         ),
         ("messaging",),

--- a/smoke/product/test_messaging_product_live.py
+++ b/smoke/product/test_messaging_product_live.py
@@ -75,9 +75,78 @@ async def test_messaging_commands_stop_clear_stats_e2e(
 
     sent_text = "\n".join(sent["text"] for sent in driver.platform.sent)
     assert "Stats" in sent_text
-    assert "Stopped" in sent_text
+    assert "Nothing to stop for that message" in sent_text
     assert driver.platform.deletes
     assert driver.session_store.load_conversation_snapshot().trees == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform_name", ["discord", "telegram"])
+async def test_messaging_active_stop_uses_status_only_e2e(
+    platform_name: str,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    driver = FakePlatformDriver(platform_name, tmp_path)
+    started = asyncio.Event()
+
+    class GatedActiveSession(FakeCLISession):
+        async def start_task(
+            self,
+            prompt: str,
+            session_id: str | None = None,
+            fork_session: bool = False,
+        ):
+            self.calls.append(
+                {
+                    "prompt": prompt,
+                    "session_id": session_id,
+                    "fork_session": fork_session,
+                }
+            )
+            self.is_busy = True
+            try:
+                yield {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": "partial answer"}]
+                    },
+                }
+                started.set()
+                await asyncio.Event().wait()
+            finally:
+                self.is_busy = False
+
+    async def controlled_session(session_id: str | None = None):
+        session = GatedActiveSession([])
+        driver.cli_manager.sessions.append(session)
+        return session, session_id or "pending_0", session_id is None
+
+    monkeypatch.setattr(
+        driver.cli_manager,
+        "get_or_create_session",
+        controlled_session,
+    )
+    root = await driver.emit("active work", message_id="root_active")
+    await started.wait()
+    status_id = driver.platform.sent[-1]["message_id"]
+    sent_before_stop = len(driver.platform.sent)
+
+    await driver.emit(
+        "/stop",
+        message_id="stop_active",
+        reply_to=root.message_id,
+    )
+    await driver.wait_for_idle()
+
+    assert len(driver.platform.sent) == sent_before_stop
+    stopped_edits = [
+        edit
+        for edit in driver.platform.edits
+        if edit["message_id"] == status_id and "Stopped" in edit["text"]
+    ]
+    assert stopped_edits
+    assert "partial answer" in stopped_edits[-1]["text"]
 
 
 @pytest.mark.asyncio
@@ -156,16 +225,19 @@ async def test_messaging_queued_scoped_cancel_e2e(
         message_id="cancelled",
         reply_to=root.message_id,
     )
+    cancelled_status_id = driver.platform.sent[-1]["message_id"]
     survivor = await driver.emit(
         "run me",
         message_id="survivor",
         reply_to=root.message_id,
     )
+    sent_before_stop = len(driver.platform.sent)
     await driver.emit(
         "/stop",
         message_id="stop-cancelled",
         reply_to=cancelled.message_id,
     )
+    assert len(driver.platform.sent) == sent_before_stop
 
     release_root.set()
     await driver.wait_for_idle()
@@ -195,6 +267,10 @@ async def test_messaging_queued_scoped_cancel_e2e(
     assert "position 1" in rendered
     assert "position 2" in rendered
     assert "Stopped" in rendered
+    assert any(
+        edit["message_id"] == cancelled_status_id and "Stopped" in edit["text"]
+        for edit in driver.platform.edits
+    )
     driver.session_store.flush_pending_save()
     persisted = driver.session_store.load_conversation_snapshot()
     root_identity = TreeIdentity(scope=root.scope, root_id=root.message_id)
@@ -272,6 +348,7 @@ async def test_voice_platform_fake_e2e(platform_name: str, tmp_path) -> None:
     await driver.send("/clear", message_id="clear_voice", reply_to="voice_msg_1")
 
     driver.platform.seed_pending_voice("chat_1", "voice_msg_2", "voice_status_2")
+    sent_before_stop = len(driver.platform.sent)
     await driver.send("/stop", message_id="stop_voice")
 
     deleted = {entry["message_id"] for entry in driver.platform.deletes}
@@ -279,4 +356,8 @@ async def test_voice_platform_fake_e2e(platform_name: str, tmp_path) -> None:
     assert driver.platform.pending_voice_count == 0
     sent_text = "\n".join(sent["text"] for sent in driver.platform.sent)
     assert "Voice note cancelled" in sent_text
-    assert "Cancelled 1 pending or active requests" in sent_text
+    assert len(driver.platform.sent) == sent_before_stop
+    assert any(
+        edit["message_id"] == "voice_status_2" and "Stopped" in edit["text"]
+        for edit in driver.platform.edits
+    )

--- a/src/free_claude_code/messaging/command_context.py
+++ b/src/free_claude_code/messaging/command_context.py
@@ -17,6 +17,23 @@ class ReplyClearResult:
     tree_cleared: bool
 
 
+@dataclass(frozen=True, slots=True)
+class StopOutcome:
+    """Customer-facing stop result after terminal status ownership is assigned."""
+
+    cancelled_count: int
+    status_feedback_scopes: frozenset[MessageScope]
+    fallback_required: bool
+
+    def requires_confirmation(self, scope: MessageScope) -> bool:
+        """Return whether this scope lacks complete terminal status feedback."""
+        return (
+            self.cancelled_count == 0
+            or self.fallback_required
+            or self.status_feedback_scopes != frozenset({scope})
+        )
+
+
 class MessagingCommandContext(Protocol):
     """Operations commands need from the messaging workflow."""
 
@@ -31,7 +48,7 @@ class MessagingCommandContext(Protocol):
         """Return the render context for command output."""
         ...
 
-    async def stop_all_tasks(self) -> int:
+    async def stop_all_tasks(self) -> StopOutcome:
         """Stop every pending or active messaging task."""
         ...
 
@@ -39,7 +56,7 @@ class MessagingCommandContext(Protocol):
         self,
         scope: MessageScope,
         reply_id: str,
-    ) -> int | None:
+    ) -> StopOutcome:
         """Stop the exact voice/tree owner of a replied-to message."""
         ...
 
@@ -79,4 +96,4 @@ class MessagingCommandContext(Protocol):
         ...
 
 
-__all__ = ["MessagingCommandContext", "ReplyClearResult"]
+__all__ = ["MessagingCommandContext", "ReplyClearResult", "StopOutcome"]

--- a/src/free_claude_code/messaging/commands.py
+++ b/src/free_claude_code/messaging/commands.py
@@ -9,56 +9,62 @@ from .command_context import MessagingCommandContext
 from .models import IncomingMessage
 
 
-async def handle_stop_command(
-    handler: MessagingCommandContext, incoming: IncomingMessage
+async def _send_stop_feedback(
+    handler: MessagingCommandContext,
+    incoming: IncomingMessage,
+    suffix: str,
 ) -> None:
-    """Handle /stop command from messaging platform."""
-    # Reply-scoped stop: reply "/stop" to stop only that task.
-    if incoming.is_reply() and incoming.reply_to_message_id:
-        count = await handler.stop_reply(
-            incoming.scope,
-            incoming.reply_to_message_id,
-        )
-
-        if count is None:
-            msg_id = await handler.outbound.queue_send_message(
-                incoming.chat_id,
-                handler.format_status(
-                    "⏹", "Stopped.", "Nothing to stop for that message."
-                ),
-                fire_and_forget=False,
-                message_thread_id=incoming.message_thread_id,
-            )
-            handler.record_outgoing_message(
-                incoming.platform, incoming.chat_id, msg_id, "command"
-            )
-            return
-
-        noun = "request" if count == 1 else "requests"
-        msg_id = await handler.outbound.queue_send_message(
-            incoming.chat_id,
-            handler.format_status("⏹", "Stopped.", f"Cancelled {count} {noun}."),
-            fire_and_forget=False,
-            message_thread_id=incoming.message_thread_id,
-        )
-        handler.record_outgoing_message(
-            incoming.platform, incoming.chat_id, msg_id, "command"
-        )
-        return
-
-    # Global stop: legacy behavior (stop everything)
-    count = await handler.stop_all_tasks()
+    """Send stop feedback only when no existing status can represent the result."""
     msg_id = await handler.outbound.queue_send_message(
         incoming.chat_id,
-        handler.format_status(
-            "⏹", "Stopped.", f"Cancelled {count} pending or active requests."
-        ),
+        handler.format_status("⏹", "Stopped.", suffix),
         fire_and_forget=False,
         message_thread_id=incoming.message_thread_id,
     )
     handler.record_outgoing_message(
         incoming.platform, incoming.chat_id, msg_id, "command"
     )
+
+
+async def handle_stop_command(
+    handler: MessagingCommandContext, incoming: IncomingMessage
+) -> None:
+    """Handle /stop command from messaging platform."""
+    # Reply-scoped stop: reply "/stop" to stop only that task.
+    if incoming.is_reply() and incoming.reply_to_message_id:
+        outcome = await handler.stop_reply(
+            incoming.scope,
+            incoming.reply_to_message_id,
+        )
+
+        if outcome.cancelled_count == 0:
+            await _send_stop_feedback(
+                handler,
+                incoming,
+                "Nothing to stop for that message.",
+            )
+            return
+
+        if outcome.requires_confirmation(incoming.scope):
+            noun = "request" if outcome.cancelled_count == 1 else "requests"
+            await _send_stop_feedback(
+                handler,
+                incoming,
+                f"Cancelled {outcome.cancelled_count} {noun}.",
+            )
+        return
+
+    # Global stop: legacy behavior (stop everything)
+    outcome = await handler.stop_all_tasks()
+    if outcome.cancelled_count == 0:
+        await _send_stop_feedback(handler, incoming, "Nothing to stop.")
+    elif outcome.requires_confirmation(incoming.scope):
+        noun = "request" if outcome.cancelled_count == 1 else "requests"
+        await _send_stop_feedback(
+            handler,
+            incoming,
+            f"Cancelled {outcome.cancelled_count} pending or active {noun}.",
+        )
 
 
 async def handle_stats_command(

--- a/src/free_claude_code/messaging/workflow.py
+++ b/src/free_claude_code/messaging/workflow.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 from free_claude_code.core.trace import trace_event
 
-from .command_context import ReplyClearResult
+from .command_context import ReplyClearResult, StopOutcome
 from .managed_protocols import ManagedClaudeSessionManagerProtocol
 from .models import IncomingMessage, MessageScope
 from .node_runner import MessagingNodeRunner
@@ -56,6 +56,28 @@ async def _finish_owned_operation[T](
     if cancellation is not None:
         raise cancellation
     return result
+
+
+def _stop_outcome(
+    voices: tuple[VoiceCancellationResult, ...],
+    cancellation: CancellationResult,
+) -> StopOutcome:
+    """Summarize distinct stopped owners and whether existing status UI covers them."""
+    status_coverage: dict[tuple[MessageScope, str], bool] = {}
+    for voice in voices:
+        key = (voice.scope, voice.voice_message_id)
+        status_coverage[key] = (
+            status_coverage.get(key, False) or voice.status_message_id is not None
+        )
+    for effect in cancellation.effects:
+        status_coverage[(effect.node.scope, effect.node.node_id)] = True
+    return StopOutcome(
+        cancelled_count=len(status_coverage),
+        status_feedback_scopes=frozenset(
+            scope for (scope, _owner_id), covered in status_coverage.items() if covered
+        ),
+        fallback_required=any(not covered for covered in status_coverage.values()),
+    )
 
 
 class MessagingWorkflow:
@@ -268,7 +290,7 @@ class MessagingWorkflow:
         self,
         scope: MessageScope,
         reply_id: str,
-    ) -> int | None:
+    ) -> StopOutcome:
         """Stop the exact voice/tree owner of one replied-to message."""
         return await _finish_owned_operation(
             self._stop_reply(scope, reply_id),
@@ -279,7 +301,7 @@ class MessagingWorkflow:
         self,
         scope: MessageScope,
         reply_id: str,
-    ) -> int | None:
+    ) -> StopOutcome:
         voice_result = await self._cancel_pending_voice(scope, reply_id)
         if voice_result is not None:
             self.render_voice_stopped(voice_result)
@@ -287,7 +309,8 @@ class MessagingWorkflow:
         async with self._state_lock:
             node_id = await self._tree_queue.resolve_node_id(scope, reply_id)
             if node_id is None:
-                return 1 if voice_result is not None else None
+                voices = (voice_result,) if voice_result is not None else ()
+                return _stop_outcome(voices, CancellationResult())
             result = await self._tree_queue.cancel_node(
                 scope,
                 node_id,
@@ -295,10 +318,8 @@ class MessagingWorkflow:
             )
             self._apply_cancellation_result(result)
 
-        owners = {(effect.node.scope, effect.node.node_id) for effect in result.effects}
-        if voice_result is not None:
-            owners.add((voice_result.scope, voice_result.voice_message_id))
-        return len(owners)
+        voices = (voice_result,) if voice_result is not None else ()
+        return _stop_outcome(voices, result)
 
     async def clear_reply(
         self,
@@ -343,14 +364,14 @@ class MessagingWorkflow:
             tree_cleared=True,
         )
 
-    async def stop_all_tasks(self) -> int:
+    async def stop_all_tasks(self) -> StopOutcome:
         """Stop every pending and active messaging task."""
         return await _finish_owned_operation(
             self._stop_all_tasks(),
             name="messaging-stop-all",
         )
 
-    async def _stop_all_tasks(self) -> int:
+    async def _stop_all_tasks(self) -> StopOutcome:
         voice_results = await self._cancel_all_pending_voices()
         for voice in voice_results:
             self.render_voice_stopped(voice)
@@ -362,13 +383,7 @@ class MessagingWorkflow:
             self._apply_cancellation_result(result)
             logger.info("Stopping all CLI sessions...")
             await self.cli_manager.stop_all()
-            tree_keys = {
-                (effect.node.scope, effect.node.node_id) for effect in result.effects
-            }
-            voice_keys = {
-                (voice.scope, voice.voice_message_id) for voice in voice_results
-            }
-            return len(tree_keys | voice_keys)
+            return _stop_outcome(voice_results, result)
 
     async def clear_all_state(self, platform: str, chat_id: str) -> frozenset[str]:
         """Clear FCC state atomically with respect to later turn admission."""

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -263,8 +263,8 @@ class ApplicationRuntime:
 
     async def stop_all(self) -> StopResult | None:
         if self._messaging_workflow is not None:
-            count = await self._messaging_workflow.stop_all_tasks()
-            return StopResult(cancelled_count=count)
+            outcome = await self._messaging_workflow.stop_all_tasks()
+            return StopResult(cancelled_count=outcome.cancelled_count)
         if self._cli_manager is not None:
             await self._cli_manager.stop_all()
             return StopResult(source="cli_manager")

--- a/tests/messaging/test_handler.py
+++ b/tests/messaging/test_handler.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
-from free_claude_code.messaging.command_context import ReplyClearResult
+from free_claude_code.messaging.command_context import ReplyClearResult, StopOutcome
 from free_claude_code.messaging.models import MessageScope
 from free_claude_code.messaging.session import SessionStore
 from free_claude_code.messaging.trees import (
@@ -26,6 +26,16 @@ from free_claude_code.messaging.voice import VoiceCancellationResult
 from free_claude_code.messaging.workflow import MessagingWorkflow
 
 _SCOPE = MessageScope(platform="telegram", chat_id="chat_1")
+_OTHER_SCOPE = MessageScope(platform="telegram", chat_id="other_chat")
+
+
+def _stop_outcome(
+    cancelled_count: int,
+    *,
+    scopes: frozenset[MessageScope] = frozenset({_SCOPE}),
+    fallback_required: bool = False,
+) -> StopOutcome:
+    return StopOutcome(cancelled_count, scopes, fallback_required)
 
 
 async def _event_stream(events):
@@ -126,20 +136,83 @@ def test_initial_status_uses_immutable_reply_advice(handler, target, expected):
 
 
 @pytest.mark.asyncio
-async def test_handle_message_stop_command(
+async def test_global_stop_success_uses_existing_status_without_confirmation(
     handler, mock_platform, incoming_message_factory
 ):
     incoming = incoming_message_factory(text="/stop")
-    handler.stop_all_tasks = AsyncMock(return_value=5)
+    handler.stop_all_tasks = AsyncMock(return_value=_stop_outcome(5))
 
     await handler.handle_message(incoming)
 
     handler.stop_all_tasks.assert_awaited_once()
+    mock_platform.queue_send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_feedback_scopes",
+    (
+        frozenset({_OTHER_SCOPE}),
+        frozenset({_SCOPE, _OTHER_SCOPE}),
+    ),
+    ids=("remote-only", "mixed-local-and-remote"),
+)
+async def test_global_stop_reports_cross_chat_work(
+    handler,
+    mock_platform,
+    incoming_message_factory,
+    status_feedback_scopes: frozenset[MessageScope],
+) -> None:
+    incoming = incoming_message_factory(text="/stop")
+    handler.stop_all_tasks = AsyncMock(
+        return_value=_stop_outcome(2, scopes=status_feedback_scopes)
+    )
+
+    await handler.handle_message(incoming)
+
+    assert (
+        "Cancelled 2 pending or active requests"
+        in mock_platform.queue_send_message.call_args.args[1]
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_stop_noop_reports_nothing_to_stop(
+    handler, mock_platform, incoming_message_factory
+) -> None:
+    incoming = incoming_message_factory(text="/stop")
+    handler.stop_all_tasks = AsyncMock(
+        return_value=_stop_outcome(0, scopes=frozenset())
+    )
+
+    await handler.handle_message(incoming)
+
     mock_platform.queue_send_message.assert_awaited_once_with(
         incoming.chat_id,
-        "⏹ *Stopped\\.* Cancelled 5 pending or active requests\\.",
+        "⏹ *Stopped\\.* Nothing to stop\\.",
         fire_and_forget=False,
         message_thread_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_stop_without_status_target_sends_fallback_confirmation(
+    handler, mock_platform, incoming_message_factory
+) -> None:
+    incoming = incoming_message_factory(text="/stop")
+    handler.stop_all_tasks = AsyncMock(
+        return_value=_stop_outcome(
+            1,
+            scopes=frozenset(),
+            fallback_required=True,
+        )
+    )
+
+    await handler.handle_message(incoming)
+
+    assert (
+        "Cancelled 1 pending or active request"
+        in mock_platform.queue_send_message.call_args.args[1]
     )
 
 
@@ -162,8 +235,8 @@ async def test_failed_global_stop_never_reports_success(
 async def test_reply_stop_resolves_and_stops_only_target(
     handler, mock_platform, mock_cli_manager, incoming_message_factory
 ):
-    handler.stop_reply = AsyncMock(return_value=1)
-    handler.stop_all_tasks = AsyncMock(return_value=999)
+    handler.stop_reply = AsyncMock(return_value=_stop_outcome(1))
+    handler.stop_all_tasks = AsyncMock(return_value=_stop_outcome(999))
     incoming = incoming_message_factory(
         text="/stop",
         message_id="stop_msg",
@@ -175,15 +248,15 @@ async def test_reply_stop_resolves_and_stops_only_target(
     handler.stop_reply.assert_awaited_once_with(incoming.scope, "status_root")
     handler.stop_all_tasks.assert_not_awaited()
     mock_cli_manager.stop_all.assert_not_awaited()
-    assert "Cancelled 1 request" in mock_platform.queue_send_message.call_args.args[1]
+    mock_platform.queue_send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_reply_stop_unknown_does_not_stop_all(
     handler, mock_platform, mock_cli_manager, incoming_message_factory
 ):
-    handler.stop_reply = AsyncMock(return_value=None)
-    handler.stop_all_tasks = AsyncMock(return_value=5)
+    handler.stop_reply = AsyncMock(return_value=_stop_outcome(0, scopes=frozenset()))
+    handler.stop_all_tasks = AsyncMock(return_value=_stop_outcome(5))
     incoming = incoming_message_factory(
         text="/stop",
         message_id="stop_msg",
@@ -221,9 +294,32 @@ async def test_reply_stop_cancels_voice_when_no_tree_was_admitted(
     await handler.handle_message(incoming)
     await asyncio.sleep(0)
 
-    assert "Cancelled 1 request" in mock_platform.queue_send_message.call_args.args[1]
+    mock_platform.queue_send_message.assert_not_awaited()
     assert mock_platform.queue_edit_message.call_args.args[1] == "voice_status"
     assert "Stopped" in mock_platform.queue_edit_message.call_args.args[2]
+
+
+@pytest.mark.asyncio
+async def test_reply_stop_without_voice_status_sends_fallback_confirmation(
+    handler,
+    mock_platform,
+    incoming_message_factory,
+) -> None:
+    mock_platform.cancel_pending_voice.return_value = VoiceCancellationResult(
+        scope=_SCOPE,
+        voice_message_id="voice",
+        status_message_id=None,
+    )
+    incoming = incoming_message_factory(
+        text="/stop",
+        message_id="stop_msg",
+        reply_to_message_id="voice",
+    )
+
+    await handler.handle_message(incoming)
+
+    assert "Cancelled 1 request" in mock_platform.queue_send_message.call_args.args[1]
+    mock_platform.queue_edit_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -286,8 +382,7 @@ async def test_reply_stop_resolves_tree_after_joining_voice_handoff(
         reason=CancellationReason.STOP,
     )
     assert events == ["voice", "tree"]
-    assert "Nothing to stop" not in mock_platform.queue_send_message.call_args.args[1]
-    assert "Cancelled 1 request" in mock_platform.queue_send_message.call_args.args[1]
+    mock_platform.queue_send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -615,10 +710,10 @@ async def test_stop_all_applies_immutable_ui_ownership_and_snapshots(
         "cancel_all",
         AsyncMock(return_value=result),
     ) as cancel_all:
-        count = await handler.stop_all_tasks()
+        outcome = await handler.stop_all_tasks()
     await asyncio.sleep(0)
 
-    assert count == 2
+    assert outcome == _stop_outcome(2)
     cancel_all.assert_awaited_once_with(reason=CancellationReason.STOP)
     mock_cli_manager.stop_all.assert_awaited_once()
     assert mock_platform.fire_and_forget.call_count == 1
@@ -636,7 +731,7 @@ async def test_stop_all_joins_voices_before_tree_transaction_and_deduplicates(
     voice = VoiceCancellationResult(
         scope=_SCOPE,
         voice_message_id="voice",
-        status_message_id="voice_status",
+        status_message_id=None,
     )
     tree_result = CancellationResult(
         effects=(
@@ -646,7 +741,7 @@ async def test_stop_all_joins_voices_before_tree_transaction_and_deduplicates(
                     node_id="voice",
                     status_message_id="voice_status",
                 ),
-                ui_owner=CancellationUiOwner.RUNNER,
+                ui_owner=CancellationUiOwner.WORKFLOW,
             ),
         )
     )
@@ -664,10 +759,10 @@ async def test_stop_all_joins_voices_before_tree_transaction_and_deduplicates(
 
     mock_platform.cancel_all_pending_voices.side_effect = cancel_voices
     with patch.object(handler.tree_queue, "cancel_all", side_effect=cancel_trees):
-        count = await handler.stop_all_tasks()
+        outcome = await handler.stop_all_tasks()
     await asyncio.sleep(0)
 
-    assert count == 1
+    assert outcome == _stop_outcome(1)
     assert events == ["voices", "trees"]
     mock_cli_manager.stop_all.assert_awaited_once()
     mock_platform.queue_edit_message.assert_awaited_once()

--- a/tests/messaging/test_handler_markdown_and_status_edges.py
+++ b/tests/messaging/test_handler_markdown_and_status_edges.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from free_claude_code.messaging.command_context import StopOutcome
 from free_claude_code.messaging.models import IncomingMessage, MessageScope
 from free_claude_code.messaging.node_event_pipeline import process_parsed_cli_event
 from free_claude_code.messaging.rendering.telegram_markdown import (
@@ -283,8 +284,12 @@ async def test_stop_all_tasks_saves_tree_for_cancelled_nodes():
         "cancel_all",
         cancel_all,
     ):
-        count = await handler.stop_all_tasks()
-    assert count == 1
+        outcome = await handler.stop_all_tasks()
+    assert outcome == StopOutcome(
+        cancelled_count=1,
+        status_feedback_scopes=frozenset({_SCOPE}),
+        fallback_required=False,
+    )
     cancel_all.assert_awaited_once_with(reason=CancellationReason.STOP)
     cli_manager.stop_all.assert_awaited_once()
     session_store.save_tree_snapshot.assert_called_once_with(snapshot)

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -7,6 +7,7 @@ import pytest
 import free_claude_code.messaging.session.persistence as persistence_module
 from free_claude_code.config.admin.persistence import PreparedAdminUpdate
 from free_claude_code.config.settings import Settings
+from free_claude_code.messaging.command_context import StopOutcome
 from free_claude_code.messaging.platforms.ports import (
     InboundMessageHandler,
     MessagingPlatformComponents,
@@ -152,6 +153,28 @@ def _applied_response(pending_fields: tuple[str, ...] = ()) -> dict[str, object]
         "path": ".env",
         "pending_fields": list(pending_fields),
     }
+
+
+@pytest.mark.asyncio
+async def test_stop_all_maps_messaging_outcome_to_application_count() -> None:
+    manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    workflow = MagicMock()
+    workflow.stop_all_tasks = AsyncMock(
+        return_value=StopOutcome(
+            cancelled_count=3,
+            status_feedback_scopes=frozenset(),
+            fallback_required=False,
+        )
+    )
+    runtime._messaging_workflow = workflow
+
+    result = await runtime.stop_all()
+
+    assert result is not None
+    assert result.cancelled_count == 3
+    workflow.stop_all_tasks.assert_awaited_once()
+    await manager.close()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.8"
+version = "3.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Messaging `/stop` edited each affected task status to `Stopped` and also posted a second success message. The duplicate confirmation added noise even though the existing status already represented the terminal result.

## Changes

| Before | After |
| --- | --- |
| Successful active, queued, global, and bound-voice stops posted a second confirmation. | Successful stops use the affected task status as their sole success UI. |
| Stop commands returned an ambiguous integer or `None`. | A typed `StopOutcome` carries the cancelled count and terminal status ownership. |
| Statusless voice cancellation could become silent if confirmations were removed unconditionally. | Statusless voice cancellation receives one fallback confirmation. |
| A global stop could under-report work when any affected status was in another chat. | The invoking chat receives one summary whenever any affected status is outside its scope. |
| Zero-work global stops reported that zero requests were cancelled. | No-op global and reply stops report that there was nothing to stop. |
| Runtime and product coverage encoded the duplicate message. | Runtime mapping and Discord/Telegram product smokes cover active, queued, voice, no-op, and fallback behavior. |
| The package version was 3.5.8. | The package version is 3.5.9 with an updated lockfile. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes `/stop` so task statuses become the main success feedback. The main changes are:

- Added a typed stop outcome for cancelled counts and status feedback ownership.
- Suppressed duplicate stop confirmations when the invoking chat already has complete status feedback.
- Kept explicit fallback messages for no-op stops, statusless voice cancellations, and cross-chat stop results.
- Updated runtime mapping, docs, product smokes, tests, and the package version.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the live messaging product smoke test with FCC\_LIVE\_SMOKE=1 and FCC\_SMOKE\_TARGETS=messaging, executing the command uv run pytest under /home/user/repo; the run exited with code 0 and 17 tests passed in 1.34s.
- Reviewed the test run log to verify proper shutdown behavior, noting Discord and Telegram stop statuses, a queued trace, and cancellation messages indicating shutdown tasks were being canceled.
- Linked the stop-product-smoke-20260711.log artifact for review of the run's stop behavior.

<a href="https://app.greptile.com/trex/runs/14115543/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/messaging/command_context.py | Adds `StopOutcome` and updates stop command context signatures. |
| src/free_claude_code/messaging/commands.py | Routes stop confirmations through the new outcome and fallback rules. |
| src/free_claude_code/messaging/workflow.py | Builds stop outcomes from voice cancellations and tree cancellation effects. |
| src/free_claude_code/runtime/application.py | Maps the messaging stop outcome back to the runtime stop result count. |
| tests/messaging/test_handler.py | Covers same-chat status feedback, cross-chat fallback, no-op stops, and voice fallback behavior. |
| smoke/product/test_messaging_product_live.py | Updates product smokes for status-only stop success feedback. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Use task status as the sole stop confirm..."](https://github.com/alishahryar1/free-claude-code/commit/98f0acb01b3405c2afd918539eff49b9410bf487) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43560341)</sub>

<!-- /greptile_comment -->