### PR TITLE
Make provider retry tests deterministic

### DIFF
--- a/tests/providers/support.py
+++ b/tests/providers/support.py
@@ -31,6 +31,23 @@ class PassthroughProviderRateLimiter(ProviderRateLimiter):
         return await fn(*args, **kwargs)
 
 
+class ImmediateRetryProviderRateLimiter(ProviderRateLimiter):
+    """Run the real retry policy without exercising wall-clock backoff."""
+
+    async def execute_with_retry(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        kwargs.update(base_delay=0.0, max_delay=0.0, jitter=0.0)
+        return await super().execute_with_retry(fn, *args, **kwargs)
+
+    def extend_reactive_block(self, seconds: float) -> None:
+        """Leave reactive timing to the limiter's dedicated unit tests."""
+        del seconds
+
+
 def passthrough_rate_limiter() -> ProviderRateLimiter:
     """Return a fresh limiter test double for one provider instance."""
     return PassthroughProviderRateLimiter()
@@ -51,8 +68,8 @@ def profiled_provider(
 
 
 def retrying_rate_limiter() -> ProviderRateLimiter:
-    """Return a fresh real limiter for provider retry-policy tests."""
-    return ProviderRateLimiter(
+    """Return a limiter that exercises retry policy without elapsed time."""
+    return ImmediateRetryProviderRateLimiter(
         rate_limit=1_000_000,
         rate_window=1.0,
         max_concurrency=1_000,

--- a/tests/providers/test_openai_compat_5xx_retry.py
+++ b/tests/providers/test_openai_compat_5xx_retry.py
@@ -68,7 +68,6 @@ async def test_nim_stream_retries_on_openai_5xx_then_streams(status_code):
             "create",
             new_callable=AsyncMock,
         ) as mock_create,
-        patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         mock_create.side_effect = [_internal_5xx(status_code), mock_stream()]
         events = [e async for e in provider.stream_response(req)]
@@ -113,7 +112,6 @@ async def test_nim_stream_retries_on_pre_stream_connection_error_then_streams():
             "create",
             new_callable=AsyncMock,
         ) as mock_create,
-        patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         mock_create.side_effect = [_connection_error(), mock_stream()]
         events = [e async for e in provider.stream_response(req)]
@@ -148,7 +146,6 @@ async def test_nim_stream_connection_error_exhausted_emits_cause_chain():
             new_callable=AsyncMock,
             side_effect=error,
         ) as mock_create,
-        patch("asyncio.sleep", new_callable=AsyncMock),
         patch("free_claude_code.providers.openai_chat.provider.trace_event") as trace,
         pytest.raises(ExecutionFailure) as exc_info,
     ):
@@ -202,7 +199,6 @@ async def test_nim_stream_openai_5xx_exhausted_emits_user_message(
             "create",
             new_callable=AsyncMock,
         ) as mock_create,
-        patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         mock_create.side_effect = _internal_5xx(status_code)
         with pytest.raises(ExecutionFailure) as exc_info:


### PR DESCRIPTION
## Problem

Provider retry integration tests mocked `asyncio.sleep` while reactive deadlines still used `time.monotonic`. Serial runs busy-waited through real backoffs and could exceed validation timeouts despite passing.

## Changes

| Before | After |
| --- | --- |
| Tests globally mocked sleep without advancing the limiter clock. | A deterministic test limiter runs real retry classification and attempt accounting with zero delay. |
| Provider integration tests also exercised reactive timing already covered by limiter tests. | Provider integration tests focus on retry and terminal-error contracts; limiter timing remains in its dedicated suite. |
| Serial retry validation could take minutes. | The complete retry file finishes in about two seconds including startup. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes provider retry tests run without wall-clock backoff. The main changes are:

- Adds an immediate retry limiter for provider tests.
- Forces retry backoff parameters to zero in that test limiter.
- Skips reactive block timing in provider retry tests.
- Removes broad `asyncio.sleep` mocks from the OpenAI-compatible retry tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the provider retry test and captured a log showing the exact command, working directory, timestamp, Pytest output, elapsed time, and exit code.

<a href="https://app.greptile.com/trex/runs/14126948/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/providers/support.py | Adds a test-only limiter that keeps retry classification and attempt accounting while removing elapsed-time behavior. |
| tests/providers/test_openai_compat_5xx_retry.py | Removes sleep mocks from retry tests that now rely on the immediate retry limiter. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Make provider retry tests deterministic"](https://github.com/alishahryar1/free-claude-code/commit/e5f8c05ec5900586df8d4e1e7689288f38eeab15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43584603)</sub>

<!-- /greptile_comment -->