### PR TITLE
Add vision support for NVIDIA NIM proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,7 @@ ENABLE_MODEL_THINKING=true
 
 # Provider config
 # Per-provider proxy support: http and socks5, example: "http://username:password@host:port"
+ENABLE_VISION=false
 NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""
 MISTRAL_PROXY=""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.14"
+version = "3.5.15"
 description = "Local proxy connecting Claude Code and Codex to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.15"
+version = "3.6.0"
 description = "Local proxy connecting Claude Code and Codex to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -133,7 +133,7 @@ function Invoke-SuppressionsCheck {
         $matches = Get-ChildItem -Path . -Recurse -Filter *.py -File |
             Where-Object {
                 $full = $_.FullName
-                $full -notmatch '[\\/]\.venv[\\/]' -and
+                $full -notmatch '[\\/]\.venv[^\\/]*[\\/]' -and
                     $full -notmatch '[\\/]\.git[\\/]'
             } |
             Select-String -Pattern $pattern

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -127,10 +127,10 @@ run_suppressions() {
     step "Ban suppressions and legacy annotations"
     pattern='# type: ignore|# ty: ignore|from __future__ import annotations'
     print_command grep -rE "$pattern" --include='*.py' . \
-        --exclude-dir=.venv --exclude-dir=.git
+        --exclude-dir='.venv*' --exclude-dir=.git
     if [ "$dry_run" -eq 0 ]; then
         if grep -rE "$pattern" --include='*.py' . \
-            --exclude-dir=.venv --exclude-dir=.git; then
+            --exclude-dir='.venv*' --exclude-dir=.git; then
             fail "type: ignore / ty: ignore comments and legacy future annotations are not allowed. Fix the underlying type/import issue instead."
         fi
     fi

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -137,6 +137,18 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         default="true",
     ),
     ConfigFieldSpec(
+        "ENABLE_VISION",
+        "Enable Vision",
+        "providers",
+        "boolean",
+        settings_attr="enable_vision",
+        default="false",
+        description=(
+            "Allow image blocks to be forwarded through OpenAI-compatible provider "
+            "requests for vision-capable models such as NVIDIA NIM."
+        ),
+    ),
+    ConfigFieldSpec(
         "ENABLE_OPUS_THINKING",
         "Opus Thinking",
         "thinking",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -165,6 +165,7 @@ class Settings(BaseSettings):
     enable_model_thinking: bool = Field(
         default=True, validation_alias="ENABLE_MODEL_THINKING"
     )
+    enable_vision: bool = Field(default=False, validation_alias="ENABLE_VISION")
     enable_opus_thinking: bool | None = Field(
         default=None, validation_alias="ENABLE_OPUS_THINKING"
     )

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -1,7 +1,7 @@
 """Message and tool format converters."""
 
-import json
 import ipaddress
+import json
 import socket
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -149,21 +149,193 @@ def _assert_no_forbidden_assistant_block(block: Any) -> None:
         )
 
 
+def _normalize_media_type(media_type: Any) -> str:
+    if not isinstance(media_type, str):
+        return "image/png"
+    mt = media_type.split(";")[0].strip().lower()
+    if mt.count("/") != 1:
+        return "image/png"
+    parts = mt.split("/")
+    allowed_chars = set("abcdefghijklmnopqrstuvwxyz0123456789-._+")
+    for part in parts:
+        if not part or not set(part).issubset(allowed_chars):
+            return "image/png"
+    return mt
+
+
+def _fetch_image_as_data_url(url: str) -> str:
+    """Fetch an image from url, checking for private IPs at every step and redirect.
+    Returns a data: URL format.
+    """
+    import base64
+    import ipaddress
+    import urllib.request
+    from urllib.parse import urljoin
+
+    current_url = url
+    max_redirects = 5
+    timeout = 5.0
+
+    # Custom HTTP handler to prevent automatic redirecting
+    class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            # Return None to block automatic redirection so we can handle it manually with IP/DNS validation
+            return None
+
+    opener = urllib.request.build_opener(NoRedirectHandler)
+
+    for _ in range(max_redirects):
+        parsed = urlsplit(current_url)
+        scheme = (parsed.scheme or "").lower()
+        if scheme not in {"http", "https"}:
+            raise OpenAIConversionError("User image URL source must use http or https")
+
+        host = parsed.hostname
+        if host is None or host == "":
+            raise OpenAIConversionError("User image URL source must include a host")
+
+        normalized_host = host.strip().lower()
+        if (
+            normalized_host == "localhost"
+            or normalized_host.endswith(".localhost")
+            or normalized_host.endswith(".local")
+        ):
+            raise OpenAIConversionError(
+                "User image URL source must not target localhost"
+            )
+
+        # Check raw IP
+        try:
+            ip = ipaddress.ip_address(normalized_host.strip("[]"))
+        except ValueError:
+            ip = None
+
+        if ip is not None:
+            if _is_non_public_ip(ip):
+                raise OpenAIConversionError(
+                    "User image URL source must not target local or private network addresses"
+                )
+        else:
+            # Resolve host DNS and check all IPs
+            resolved_ips = []
+            resolved_port = (
+                parsed.port
+                if parsed.port is not None
+                else (443 if scheme == "https" else 80)
+            )
+            try:
+                infos = socket.getaddrinfo(
+                    normalized_host,
+                    resolved_port,
+                    type=socket.SOCK_STREAM,
+                    proto=socket.IPPROTO_TCP,
+                )
+                for *_, sockaddr in infos:
+                    resolved_host_ip = sockaddr[0]
+                    try:
+                        resolved_ip = ipaddress.ip_address(resolved_host_ip)
+                        resolved_ips.append(resolved_ip)
+                    except ValueError:
+                        continue
+            except OSError as exc:
+                raise OpenAIConversionError(
+                    f"Could not resolve image URL host {normalized_host!r}: {exc}"
+                ) from exc
+
+            if not resolved_ips:
+                raise OpenAIConversionError(
+                    f"No IP addresses resolved for host {normalized_host!r}"
+                )
+
+            for resolved_ip in resolved_ips:
+                if _is_non_public_ip(resolved_ip):
+                    raise OpenAIConversionError(
+                        f"User image URL source resolves to a non-public address ({resolved_ip})"
+                    )
+
+        # Build request with custom User-Agent to avoid generic python blocks
+        req = urllib.request.Request(
+            current_url, headers={"User-Agent": "free-claude-code-proxy/1.0"}
+        )
+
+        try:
+            with opener.open(req, timeout=timeout) as response:
+                status = getattr(response, "status", getattr(response, "code", 200))
+                if status in {301, 302, 303, 307, 308}:
+                    new_url = response.getheader("Location") or response.info().get(
+                        "Location"
+                    )
+                    if not new_url:
+                        raise OpenAIConversionError(
+                            "Redirect response missing Location header"
+                        )
+                    current_url = urljoin(current_url, new_url)
+                    continue
+
+                if status != 200:
+                    raise OpenAIConversionError(
+                        f"Failed to fetch user image URL, status code: {status}"
+                    )
+
+                # Read body, subject to maximum size (e.g. 5MB)
+                max_bytes = 5 * 1024 * 1024
+                data = response.read(max_bytes + 1)
+                if len(data) > max_bytes:
+                    raise OpenAIConversionError(
+                        "User image size exceeds maximum allowed size of 5MB"
+                    )
+
+                content_type = (
+                    response.getheader("Content-Type")
+                    or response.info().get("Content-Type")
+                    or "image/png"
+                )
+                media_type = _normalize_media_type(content_type)
+
+                encoded_data = base64.b64encode(data).decode("utf-8")
+                return f"data:{media_type};base64,{encoded_data}"
+
+        except urllib.request.HTTPError as exc:
+            if exc.code in {301, 302, 303, 307, 308}:
+                new_url = exc.headers.get("Location") or exc.headers.get("location")
+                if not new_url:
+                    raise OpenAIConversionError(
+                        "Redirect response missing Location header"
+                    ) from exc
+                current_url = urljoin(current_url, new_url)
+                continue
+            raise OpenAIConversionError(
+                f"HTTP error fetching image URL: {exc.code} {exc.reason}"
+            ) from exc
+        except urllib.request.URLError as exc:
+            raise OpenAIConversionError(
+                f"Network error fetching image URL: {exc.reason}"
+            ) from exc
+        except Exception as exc:
+            if isinstance(exc, OpenAIConversionError):
+                raise
+            raise OpenAIConversionError(f"Error fetching image URL: {exc}") from exc
+
+    raise OpenAIConversionError("Too many redirects fetching image URL")
+
+
 def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
     source_type = str(source.get("type") or "").strip().lower()
     if source_type == "url":
         url = source.get("url")
         if not isinstance(url, str) or not (url := url.strip()):
             raise OpenAIConversionError("User image URL source must include a URL")
-        return {"type": "image_url", "image_url": {"url": _normalize_user_image_url(url)}}
+        data_url = _fetch_image_as_data_url(url)
+        return {"type": "image_url", "image_url": {"url": data_url}}
 
     if source_type == "base64":
         data = source.get("data") or source.get("base64")
         if not isinstance(data, str) or not (data := data.strip()):
             raise OpenAIConversionError("User base64 image source must include data")
-        media_type = source.get("media_type") or source.get("mime_type") or "image/png"
-        if not isinstance(media_type, str) or not (media_type := media_type.strip()):
-            media_type = "image/png"
+
+        media_type = _normalize_media_type(
+            source.get("media_type") or source.get("mime_type") or "image/png"
+        )
         return {
             "type": "image_url",
             "image_url": {
@@ -174,64 +346,6 @@ def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
     raise OpenAIConversionError(
         "User image blocks must use a url or base64 source for OpenAI chat conversion"
     )
-
-
-def _normalize_user_image_url(url: str) -> str:
-    parsed = urlsplit(url)
-    scheme = (parsed.scheme or "").lower()
-    if scheme not in {"http", "https"}:
-        raise OpenAIConversionError(
-            "User image URL source must use http or https"
-        )
-
-    host = parsed.hostname
-    if host is None:
-        raise OpenAIConversionError("User image URL source must include a host")
-
-    normalized_host = host.strip().lower()
-    if normalized_host == "localhost" or normalized_host.endswith(".localhost"):
-        raise OpenAIConversionError("User image URL source must not target localhost")
-
-    try:
-        ip = ipaddress.ip_address(normalized_host.strip("[]"))
-    except ValueError:
-        ip = None
-
-    if ip is not None:
-        if _is_non_public_ip(ip):
-            raise OpenAIConversionError(
-                "User image URL source must not target local or private network addresses"
-            )
-        return url
-
-    infos = _resolve_user_image_host(normalized_host, parsed.port)
-    for *_, sockaddr in infos:
-        resolved_host = sockaddr[0]
-        try:
-            resolved_ip = ipaddress.ip_address(resolved_host)
-        except ValueError:
-            continue
-        if _is_non_public_ip(resolved_ip):
-            raise OpenAIConversionError(
-                f"User image URL source resolves to a non-public address ({resolved_ip})"
-            )
-
-    return url
-
-
-def _resolve_user_image_host(host: str, port: int | None) -> list[tuple]:
-    resolved_port = port if port is not None else 443
-    try:
-        return socket.getaddrinfo(
-            host,
-            resolved_port,
-            type=socket.SOCK_STREAM,
-            proto=socket.IPPROTO_TCP,
-        )
-    except OSError as exc:
-        raise OpenAIConversionError(
-            f"Could not resolve image URL host {host!r}: {exc}"
-        ) from exc
 
 
 def _is_non_public_ip(ip: ipaddress._BaseAddress) -> bool:

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -1,10 +1,12 @@
 """Message and tool format converters."""
 
 import json
+import ipaddress
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
+from urllib.parse import urlsplit
 
 from .content import get_block_attr, get_block_type
 from .models import MessagesRequest
@@ -152,7 +154,7 @@ def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
         url = source.get("url")
         if not isinstance(url, str) or not (url := url.strip()):
             raise OpenAIConversionError("User image URL source must include a URL")
-        return {"type": "image_url", "image_url": {"url": url}}
+        return {"type": "image_url", "image_url": {"url": _normalize_user_image_url(url)}}
 
     if source_type == "base64":
         data = source.get("data") or source.get("base64")
@@ -171,6 +173,42 @@ def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
     raise OpenAIConversionError(
         "User image blocks must use a url or base64 source for OpenAI chat conversion"
     )
+
+
+def _normalize_user_image_url(url: str) -> str:
+    parsed = urlsplit(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        raise OpenAIConversionError(
+            "User image URL source must use http or https"
+        )
+
+    host = parsed.hostname
+    if host is None:
+        raise OpenAIConversionError("User image URL source must include a host")
+
+    normalized_host = host.strip().lower()
+    if normalized_host == "localhost" or normalized_host.endswith(".localhost"):
+        raise OpenAIConversionError("User image URL source must not target localhost")
+
+    try:
+        ip = ipaddress.ip_address(normalized_host.strip("[]"))
+    except ValueError:
+        return url
+
+    if (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    ):
+        raise OpenAIConversionError(
+            "User image URL source must not target local or private network addresses"
+        )
+
+    return url
 
 
 class _OpenAIChatHistoryLedger:

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -159,9 +159,7 @@ class PinnedHTTPConnection(http.client.HTTPConnection):
         super().__init__(*args, **kwargs)
         self._create_connection = self._pinned_create_connection
 
-    def _pinned_create_connection(
-        self, address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None
-    ):
+    def _pinned_create_connection(self, address, timeout=None, source_address=None):
         if self.pinned_ip:
             address = (self.pinned_ip, address[1])
         return socket.create_connection(address, timeout, source_address)
@@ -175,9 +173,7 @@ class PinnedHTTPSConnection(http.client.HTTPSConnection):
         super().__init__(*args, **kwargs)
         self._create_connection = self._pinned_create_connection
 
-    def _pinned_create_connection(
-        self, address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None
-    ):
+    def _pinned_create_connection(self, address, timeout=None, source_address=None):
         if self.pinned_ip:
             address = (self.pinned_ip, address[1])
         return socket.create_connection(address, timeout, source_address)
@@ -205,7 +201,15 @@ class PinnedHTTPSHandler(urllib.request.HTTPSHandler):
         super().__init__(debuglevel, context, check_hostname)
 
     def https_open(self, req):
-        return self.do_open(self._get_connection, req)
+        # Pass context and check_hostname to ensure full HTTPS/TLS verification
+        ctx = getattr(self, "_context", None)
+        chk = getattr(self, "_check_hostname", None)
+        return self.do_open(
+            self._get_connection,
+            req,
+            context=ctx,
+            check_hostname=chk,
+        )
 
     def _get_connection(self, host, **kwargs):
         return PinnedHTTPSConnection(host, pinned_ip=self.pinned_ip, **kwargs)
@@ -231,6 +235,7 @@ def _fetch_image_as_data_url(url: str) -> str:
     """
     import base64
     import ipaddress
+    import urllib.error
     import urllib.request
     from urllib.parse import urljoin
 
@@ -317,6 +322,9 @@ def _fetch_image_as_data_url(url: str) -> str:
 
         # Build custom opener with custom HTTP and HTTPS handlers pinned specifically to pinned_ip_str
         opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler(
+                {}
+            ),  # Explicitly disable any ambient proxy handlers to prevent bypassing the pinned DNS fetch
             NoRedirectHandler,
             PinnedHTTPHandler(pinned_ip_str),
             PinnedHTTPSHandler(pinned_ip_str),
@@ -364,7 +372,7 @@ def _fetch_image_as_data_url(url: str) -> str:
                 encoded_data = base64.b64encode(data).decode("utf-8")
                 return f"data:{media_type};base64,{encoded_data}"
 
-        except urllib.request.HTTPError as exc:
+        except urllib.error.HTTPError as exc:
             if exc.code in {301, 302, 303, 307, 308}:
                 new_url = exc.headers.get("Location") or exc.headers.get("location")
                 if not new_url:
@@ -376,7 +384,7 @@ def _fetch_image_as_data_url(url: str) -> str:
             raise OpenAIConversionError(
                 f"HTTP error fetching image URL: {exc.code} {exc.reason}"
             ) from exc
-        except urllib.request.URLError as exc:
+        except urllib.error.URLError as exc:
             raise OpenAIConversionError(
                 f"Network error fetching image URL: {exc.reason}"
             ) from exc
@@ -392,19 +400,26 @@ def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
     source_type = str(source.get("type") or "").strip().lower()
     if source_type == "url":
         url = source.get("url")
-        if not isinstance(url, str) or not (url := url.strip()):
+        if not isinstance(url, str):
+            raise OpenAIConversionError("User image URL source must include a URL")
+        url = url.strip()
+        if not url:
             raise OpenAIConversionError("User image URL source must include a URL")
         data_url = _fetch_image_as_data_url(url)
         return {"type": "image_url", "image_url": {"url": data_url}}
 
     if source_type == "base64":
         data = source.get("data") or source.get("base64")
-        if not isinstance(data, str) or not (data := data.strip()):
+        if not isinstance(data, str):
+            raise OpenAIConversionError("User base64 image source must include data")
+        data = data.strip()
+        if not data:
             raise OpenAIConversionError("User base64 image source must include data")
 
-        media_type = _normalize_media_type(
-            source.get("media_type") or source.get("mime_type") or "image/png"
-        )
+        raw_media_type = source.get("media_type") or source.get("mime_type")
+        if not isinstance(raw_media_type, str):
+            raw_media_type = ""
+        media_type = _normalize_media_type(raw_media_type.strip())
         return {
             "type": "image_url",
             "image_url": {
@@ -417,15 +432,28 @@ def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
     )
 
 
-def _is_non_public_ip(ip: ipaddress._BaseAddress) -> bool:
-    return (
+def _is_non_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if (
         ip.is_loopback
         or ip.is_private
         or ip.is_link_local
         or ip.is_multicast
         or ip.is_reserved
         or ip.is_unspecified
-    )
+    ):
+        return True
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        mapped = ip.ipv4_mapped
+        if (
+            mapped.is_loopback
+            or mapped.is_private
+            or mapped.is_link_local
+            or mapped.is_multicast
+            or mapped.is_reserved
+            or mapped.is_unspecified
+        ):
+            return True
+    return False
 
 
 class _OpenAIChatHistoryLedger:

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -2,6 +2,7 @@
 
 import json
 import ipaddress
+import socket
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -194,21 +195,54 @@ def _normalize_user_image_url(url: str) -> str:
     try:
         ip = ipaddress.ip_address(normalized_host.strip("[]"))
     except ValueError:
+        ip = None
+
+    if ip is not None:
+        if _is_non_public_ip(ip):
+            raise OpenAIConversionError(
+                "User image URL source must not target local or private network addresses"
+            )
         return url
 
-    if (
+    infos = _resolve_user_image_host(normalized_host, parsed.port)
+    for *_, sockaddr in infos:
+        resolved_host = sockaddr[0]
+        try:
+            resolved_ip = ipaddress.ip_address(resolved_host)
+        except ValueError:
+            continue
+        if _is_non_public_ip(resolved_ip):
+            raise OpenAIConversionError(
+                f"User image URL source resolves to a non-public address ({resolved_ip})"
+            )
+
+    return url
+
+
+def _resolve_user_image_host(host: str, port: int | None) -> list[tuple]:
+    resolved_port = port if port is not None else 443
+    try:
+        return socket.getaddrinfo(
+            host,
+            resolved_port,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except OSError as exc:
+        raise OpenAIConversionError(
+            f"Could not resolve image URL host {host!r}: {exc}"
+        ) from exc
+
+
+def _is_non_public_ip(ip: ipaddress._BaseAddress) -> bool:
+    return (
         ip.is_loopback
         or ip.is_private
         or ip.is_link_local
         or ip.is_multicast
         or ip.is_reserved
         or ip.is_unspecified
-    ):
-        raise OpenAIConversionError(
-            "User image URL source must not target local or private network addresses"
-        )
-
-    return url
+    )
 
 
 class _OpenAIChatHistoryLedger:

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -150,15 +150,17 @@ def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
     source_type = str(source.get("type") or "").strip().lower()
     if source_type == "url":
         url = source.get("url")
-        if not isinstance(url, str) or not url.strip():
+        if not isinstance(url, str) or not (url := url.strip()):
             raise OpenAIConversionError("User image URL source must include a URL")
         return {"type": "image_url", "image_url": {"url": url}}
 
     if source_type == "base64":
         data = source.get("data") or source.get("base64")
-        if not isinstance(data, str) or not data.strip():
+        if not isinstance(data, str) or not (data := data.strip()):
             raise OpenAIConversionError("User base64 image source must include data")
         media_type = source.get("media_type") or source.get("mime_type") or "image/png"
+        if not isinstance(media_type, str) or not (media_type := media_type.strip()):
+            media_type = "image/png"
         return {
             "type": "image_url",
             "image_url": {

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -1,8 +1,10 @@
 """Message and tool format converters."""
 
+import http.client
 import ipaddress
 import json
 import socket
+import urllib.request
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -149,6 +151,66 @@ def _assert_no_forbidden_assistant_block(block: Any) -> None:
         )
 
 
+class PinnedHTTPConnection(http.client.HTTPConnection):
+    """An HTTPConnection that forces connections to a pinned IP address."""
+
+    def __init__(self, *args, **kwargs):
+        self.pinned_ip = kwargs.pop("pinned_ip", None)
+        super().__init__(*args, **kwargs)
+        self._create_connection = self._pinned_create_connection
+
+    def _pinned_create_connection(
+        self, address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None
+    ):
+        if self.pinned_ip:
+            address = (self.pinned_ip, address[1])
+        return socket.create_connection(address, timeout, source_address)
+
+
+class PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """An HTTPSConnection that forces connections to a pinned IP address while keeping original SNI/headers."""
+
+    def __init__(self, *args, **kwargs):
+        self.pinned_ip = kwargs.pop("pinned_ip", None)
+        super().__init__(*args, **kwargs)
+        self._create_connection = self._pinned_create_connection
+
+    def _pinned_create_connection(
+        self, address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None
+    ):
+        if self.pinned_ip:
+            address = (self.pinned_ip, address[1])
+        return socket.create_connection(address, timeout, source_address)
+
+
+class PinnedHTTPHandler(urllib.request.HTTPHandler):
+    """custom HTTPHandler that instantiates PinnedHTTPConnection."""
+
+    def __init__(self, pinned_ip):
+        self.pinned_ip = pinned_ip
+        super().__init__()
+
+    def http_open(self, req):
+        return self.do_open(self._get_connection, req)
+
+    def _get_connection(self, host, **kwargs):
+        return PinnedHTTPConnection(host, pinned_ip=self.pinned_ip, **kwargs)
+
+
+class PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    """custom HTTPSHandler that instantiates PinnedHTTPSConnection."""
+
+    def __init__(self, pinned_ip, debuglevel=0, context=None, check_hostname=None):
+        self.pinned_ip = pinned_ip
+        super().__init__(debuglevel, context, check_hostname)
+
+    def https_open(self, req):
+        return self.do_open(self._get_connection, req)
+
+    def _get_connection(self, host, **kwargs):
+        return PinnedHTTPSConnection(host, pinned_ip=self.pinned_ip, **kwargs)
+
+
 def _normalize_media_type(media_type: Any) -> str:
     if not isinstance(media_type, str):
         return "image/png"
@@ -182,8 +244,6 @@ def _fetch_image_as_data_url(url: str) -> str:
             # Return None to block automatic redirection so we can handle it manually with IP/DNS validation
             return None
 
-    opener = urllib.request.build_opener(NoRedirectHandler)
-
     for _ in range(max_redirects):
         parsed = urlsplit(current_url)
         scheme = (parsed.scheme or "").lower()
@@ -215,6 +275,7 @@ def _fetch_image_as_data_url(url: str) -> str:
                 raise OpenAIConversionError(
                     "User image URL source must not target local or private network addresses"
                 )
+            pinned_ip_str = str(ip)
         else:
             # Resolve host DNS and check all IPs
             resolved_ips = []
@@ -252,6 +313,14 @@ def _fetch_image_as_data_url(url: str) -> str:
                     raise OpenAIConversionError(
                         f"User image URL source resolves to a non-public address ({resolved_ip})"
                     )
+            pinned_ip_str = str(resolved_ips[0])
+
+        # Build custom opener with custom HTTP and HTTPS handlers pinned specifically to pinned_ip_str
+        opener = urllib.request.build_opener(
+            NoRedirectHandler,
+            PinnedHTTPHandler(pinned_ip_str),
+            PinnedHTTPSHandler(pinned_ip_str),
+        )
 
         # Build request with custom User-Agent to avoid generic python blocks
         req = urllib.request.Request(

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -146,13 +146,39 @@ def _assert_no_forbidden_assistant_block(block: Any) -> None:
         )
 
 
+def _convert_user_image_source(source: dict[str, Any]) -> dict[str, Any]:
+    source_type = str(source.get("type") or "").strip().lower()
+    if source_type == "url":
+        url = source.get("url")
+        if not isinstance(url, str) or not url.strip():
+            raise OpenAIConversionError("User image URL source must include a URL")
+        return {"type": "image_url", "image_url": {"url": url}}
+
+    if source_type == "base64":
+        data = source.get("data") or source.get("base64")
+        if not isinstance(data, str) or not data.strip():
+            raise OpenAIConversionError("User base64 image source must include data")
+        media_type = source.get("media_type") or source.get("mime_type") or "image/png"
+        return {
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:{media_type};base64,{data}",
+            },
+        }
+
+    raise OpenAIConversionError(
+        "User image blocks must use a url or base64 source for OpenAI chat conversion"
+    )
+
+
 class _OpenAIChatHistoryLedger:
     """Assemble OpenAI chat history while respecting tool-result dependencies."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, vision_enabled: bool = False) -> None:
         self._output: list[dict[str, Any]] = []
         self._segments: list[_TranscriptSegment] = []
         self._tool_results: dict[str, dict[str, Any]] = {}
+        self._vision_enabled = vision_enabled
 
     def add_plain(self, messages: list[dict[str, Any]]) -> None:
         if messages:
@@ -194,7 +220,12 @@ class _OpenAIChatHistoryLedger:
     def _add_text_blocks(self, blocks: list[Any]) -> None:
         if not blocks:
             return
-        self.add_plain(AnthropicToOpenAIConverter._convert_user_message(blocks))
+        self.add_plain(
+            AnthropicToOpenAIConverter._convert_user_message(
+                blocks,
+                vision_enabled=self._vision_enabled,
+            )
+        )
         blocks.clear()
 
     def _record_tool_result(self, block: Any) -> None:
@@ -282,9 +313,10 @@ class AnthropicToOpenAIConverter:
     def convert_messages(
         messages: list[Any],
         *,
+        vision_enabled: bool = False,
         reasoning_replay: ReasoningReplayMode = ReasoningReplayMode.THINK_TAGS,
     ) -> list[dict[str, Any]]:
-        ledger = _OpenAIChatHistoryLedger()
+        ledger = _OpenAIChatHistoryLedger(vision_enabled=vision_enabled)
 
         for msg in messages:
             role = msg.role
@@ -300,6 +332,7 @@ class AnthropicToOpenAIConverter:
             segments = AnthropicToOpenAIConverter._convert_message_to_segments(
                 role,
                 content,
+                vision_enabled=vision_enabled,
                 reasoning_content=reasoning_content,
                 reasoning_replay=reasoning_replay,
             )
@@ -316,6 +349,7 @@ class AnthropicToOpenAIConverter:
         role: str,
         content: Any,
         *,
+        vision_enabled: bool,
         reasoning_content: str | None,
         reasoning_replay: ReasoningReplayMode,
     ) -> list[_TranscriptSegment]:
@@ -346,7 +380,12 @@ class AnthropicToOpenAIConverter:
             ]
         if role == "user" and isinstance(content, list):
             return [
-                _PlainSegment(AnthropicToOpenAIConverter._convert_user_message(content))
+                _PlainSegment(
+                    AnthropicToOpenAIConverter._convert_user_message(
+                        content,
+                        vision_enabled=vision_enabled,
+                    )
+                )
             ]
         if isinstance(content, str):
             converted = {"role": role, "content": content}
@@ -480,14 +519,47 @@ class AnthropicToOpenAIConverter:
         )
 
     @staticmethod
-    def _convert_user_message(content: list[Any]) -> list[dict[str, Any]]:
+    def _convert_user_message(
+        content: list[Any],
+        *,
+        vision_enabled: bool = False,
+    ) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
         text_parts: list[str] = []
+        image_parts: list[dict[str, Any]] | None = None
 
-        def flush_text() -> None:
-            if text_parts:
+        def flush_user_message() -> None:
+            nonlocal image_parts
+            if not text_parts and image_parts is None:
+                return
+            if image_parts is None:
                 result.append({"role": "user", "content": "\n".join(text_parts)})
+            else:
+                if text_parts:
+                    image_parts.append(
+                        {"type": "text", "text": "\n\n".join(text_parts)}
+                    )
+                result.append({"role": "user", "content": image_parts})
+            text_parts.clear()
+            image_parts = None
+
+        def append_image_part(block: Any) -> None:
+            nonlocal image_parts
+            if not vision_enabled:
+                raise OpenAIConversionError(
+                    "User message image blocks are not supported for OpenAI chat "
+                    "conversion; use a vision-capable native Anthropic provider or "
+                    "enable vision support."
+                )
+            source = get_block_attr(block, "source", {})
+            if not isinstance(source, dict):
+                raise OpenAIConversionError("User image block source must be a mapping")
+            if image_parts is None:
+                image_parts = []
+            if text_parts:
+                image_parts.append({"type": "text", "text": "\n\n".join(text_parts)})
                 text_parts.clear()
+            image_parts.append(_convert_user_image_source(source))
 
         for block in content:
             block_type = get_block_type(block)
@@ -495,12 +567,9 @@ class AnthropicToOpenAIConverter:
             if block_type == "text":
                 text_parts.append(get_block_attr(block, "text", ""))
             elif block_type == "image":
-                raise OpenAIConversionError(
-                    "User message image blocks are not supported for OpenAI chat "
-                    "conversion; remove the image blocks or extend the converter."
-                )
+                append_image_part(block)
             elif block_type == "tool_result":
-                flush_text()
+                flush_user_message()
                 tool_content = get_block_attr(block, "content", "")
                 serialized = serialize_tool_result_content(tool_content)
                 result.append(
@@ -511,7 +580,7 @@ class AnthropicToOpenAIConverter:
                     }
                 )
 
-        flush_text()
+        flush_user_message()
         return result
 
     @staticmethod
@@ -566,12 +635,14 @@ def build_base_request_body(
     request_data: MessagesRequest,
     *,
     default_max_tokens: int | None = None,
+    vision_enabled: bool = False,
     reasoning_replay: ReasoningReplayMode = ReasoningReplayMode.THINK_TAGS,
 ) -> dict[str, Any]:
     """Build the common parts of an OpenAI-format request body."""
     _openai_reject_native_only_top_level_fields(request_data)
     messages = AnthropicToOpenAIConverter.convert_messages(
         request_data.messages,
+        vision_enabled=vision_enabled,
         reasoning_replay=reasoning_replay,
     )
 

--- a/src/free_claude_code/providers/nvidia_nim/client.py
+++ b/src/free_claude_code/providers/nvidia_nim/client.py
@@ -44,8 +44,8 @@ class NvidiaNimProvider(OpenAIChatProvider):
         config: ProviderConfig,
         *,
         nim_settings: NimSettings,
-        enable_vision: bool = False,
         rate_limiter: ProviderRateLimiter,
+        enable_vision: bool = False,
     ):
         super().__init__(
             config,

--- a/src/free_claude_code/providers/nvidia_nim/client.py
+++ b/src/free_claude_code/providers/nvidia_nim/client.py
@@ -44,6 +44,7 @@ class NvidiaNimProvider(OpenAIChatProvider):
         config: ProviderConfig,
         *,
         nim_settings: NimSettings,
+        enable_vision: bool = False,
         rate_limiter: ProviderRateLimiter,
     ):
         super().__init__(
@@ -52,6 +53,7 @@ class NvidiaNimProvider(OpenAIChatProvider):
             rate_limiter=rate_limiter,
         )
         self._nim_settings = nim_settings
+        self._enable_vision = enable_vision
 
     def _build_request_body(
         self, request: MessagesRequest, thinking_enabled: bool | None = None
@@ -60,6 +62,7 @@ class NvidiaNimProvider(OpenAIChatProvider):
         return build_nim_request_body(
             request,
             self._nim_settings,
+            vision_enabled=self._enable_vision,
             thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
         )
 

--- a/src/free_claude_code/providers/nvidia_nim/request_options.py
+++ b/src/free_claude_code/providers/nvidia_nim/request_options.py
@@ -19,14 +19,14 @@ def build_nim_request_body(
     request_data: MessagesRequest,
     nim: NimSettings,
     *,
-    vision_enabled: bool = False,
     thinking_enabled: bool,
+    vision_enabled: bool = False,
 ) -> dict[str, Any]:
     """Build OpenAI-format request body from Anthropic request plus NIM settings."""
     return build_openai_chat_request_body(
         request_data,
-        vision_enabled=vision_enabled,
         thinking_enabled=thinking_enabled,
+        vision_enabled=vision_enabled,
         policy=_REQUEST_POLICY,
         postprocessors=(
             lambda body, request, enabled: apply_nim_request_options(

--- a/src/free_claude_code/providers/nvidia_nim/request_options.py
+++ b/src/free_claude_code/providers/nvidia_nim/request_options.py
@@ -16,11 +16,16 @@ _REQUEST_POLICY = OpenAIChatRequestPolicy(provider_name="NIM")
 
 
 def build_nim_request_body(
-    request_data: MessagesRequest, nim: NimSettings, *, thinking_enabled: bool
+    request_data: MessagesRequest,
+    nim: NimSettings,
+    *,
+    vision_enabled: bool = False,
+    thinking_enabled: bool,
 ) -> dict[str, Any]:
     """Build OpenAI-format request body from Anthropic request plus NIM settings."""
     return build_openai_chat_request_body(
         request_data,
+        vision_enabled=vision_enabled,
         thinking_enabled=thinking_enabled,
         policy=_REQUEST_POLICY,
         postprocessors=(

--- a/src/free_claude_code/providers/openai_chat/request_policy.py
+++ b/src/free_claude_code/providers/openai_chat/request_policy.py
@@ -36,6 +36,7 @@ class OpenAIChatRequestPolicy:
 def build_openai_chat_request_body(
     request_data: MessagesRequest,
     *,
+    vision_enabled: bool = False,
     thinking_enabled: bool,
     policy: OpenAIChatRequestPolicy,
     postprocessors: Iterable[OpenAIChatPostprocessor] = (),
@@ -59,6 +60,7 @@ def build_openai_chat_request_body(
             request_data,
             default_max_tokens=policy.default_max_tokens,
             reasoning_replay=reasoning_replay,
+            vision_enabled=vision_enabled,
         )
     except OpenAIConversionError as exc:
         raise InvalidRequestError(str(exc)) from exc

--- a/src/free_claude_code/providers/openai_chat/request_policy.py
+++ b/src/free_claude_code/providers/openai_chat/request_policy.py
@@ -37,9 +37,9 @@ def build_openai_chat_request_body(
     request_data: MessagesRequest,
     *,
     thinking_enabled: bool,
-    vision_enabled: bool = False,
     policy: OpenAIChatRequestPolicy,
     postprocessors: Iterable[OpenAIChatPostprocessor] = (),
+    vision_enabled: bool = False,
 ) -> dict[str, Any]:
     """Build an OpenAI-compatible chat request body from an Anthropic request."""
     logger.debug(

--- a/src/free_claude_code/providers/openai_chat/request_policy.py
+++ b/src/free_claude_code/providers/openai_chat/request_policy.py
@@ -36,8 +36,8 @@ class OpenAIChatRequestPolicy:
 def build_openai_chat_request_body(
     request_data: MessagesRequest,
     *,
-    vision_enabled: bool = False,
     thinking_enabled: bool,
+    vision_enabled: bool = False,
     policy: OpenAIChatRequestPolicy,
     postprocessors: Iterable[OpenAIChatPostprocessor] = (),
 ) -> dict[str, Any]:

--- a/src/free_claude_code/providers/runtime/factory.py
+++ b/src/free_claude_code/providers/runtime/factory.py
@@ -29,6 +29,7 @@ def _create_nvidia_nim(
     return NvidiaNimProvider(
         config,
         nim_settings=settings.nim,
+        enable_vision=settings.enable_vision,
         rate_limiter=rate_limiter,
     )
 

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -32,6 +32,7 @@ def _clear_process_config(monkeypatch) -> None:
         "FCC_ENV_FILE",
         "CLOUDFLARE_API_TOKEN",
         "CLOUDFLARE_ACCOUNT_ID",
+        "ENABLE_VISION",
         "GITHUB_MODELS_TOKEN",
         "SAMBANOVA_API_KEY",
         "HOST",
@@ -116,6 +117,7 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
     assert "FIREWORKS_API_KEY" in keys
     assert "CLOUDFLARE_API_TOKEN" in keys
     assert "CLOUDFLARE_ACCOUNT_ID" in keys
+    assert "ENABLE_VISION" in keys
     assert "GITHUB_MODELS_TOKEN" in keys
     assert "GEMINI_API_KEY" in keys
     assert "GROQ_API_KEY" in keys
@@ -149,6 +151,7 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
         "LOG_RAW_CLI_DIAGNOSTICS",
         "LOG_MESSAGING_ERROR_DETAILS",
     } <= restart_required
+    assert "ENABLE_VISION" not in restart_required
 
 
 def test_admin_config_preserves_managed_env_source_contract(monkeypatch, tmp_path):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -48,6 +48,7 @@ class TestSettings:
         assert isinstance(settings.nim.temperature, float)
         assert isinstance(settings.fast_prefix_detection, bool)
         assert isinstance(settings.enable_model_thinking, bool)
+        assert settings.enable_vision is False
         assert settings.http_read_timeout == 120.0
         assert settings.http_connect_timeout == HTTP_CONNECT_TIMEOUT_DEFAULT
         assert settings.enable_web_server_tools is False
@@ -277,6 +278,14 @@ class TestSettings:
         monkeypatch.setenv("ENABLE_MODEL_THINKING", "false")
         settings = Settings()
         assert settings.enable_model_thinking is False
+
+    def test_enable_vision_from_env(self, monkeypatch):
+        """ENABLE_VISION env var is loaded into settings."""
+        from free_claude_code.config.settings import Settings
+
+        monkeypatch.setenv("ENABLE_VISION", "true")
+        settings = Settings()
+        assert settings.enable_vision is True
 
     def test_wafer_api_key_from_env(self, monkeypatch):
         """WAFER_API_KEY env var is loaded into settings."""

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -729,6 +729,24 @@ def test_convert_user_message_image_url_when_vision_enabled():
     ]
 
 
+@pytest.mark.parametrize(
+    ("bad_url", "match"),
+    [
+        ("http://169.254.169.254/latest/meta-data", "private network"),
+        ("https://localhost/image.png", "localhost"),
+        ("ftp://example.com/image.png", "http or https"),
+    ],
+)
+def test_convert_user_message_image_url_policy_blocks_private_and_unsupported(
+    bad_url, match
+):
+    content = [MockBlock(type="image", source={"type": "url", "url": bad_url})]
+    messages = [MockMessage("user", content)]
+
+    with pytest.raises(OpenAIConversionError, match=match):
+        AnthropicToOpenAIConverter.convert_messages(messages, vision_enabled=True)
+
+
 def test_convert_user_message_image_base64_when_vision_enabled():
     content = [
         MockBlock(
@@ -757,6 +775,26 @@ def test_convert_user_message_image_base64_when_vision_enabled():
             ],
         }
     ]
+
+
+def test_convert_user_message_image_source_trims_whitespace():
+    content = [
+        MockBlock(
+            type="image",
+            source={
+                "type": "base64",
+                "media_type": " image/png \n",
+                "data": " YQ== ",
+            },
+        )
+    ]
+    messages = [MockMessage("user", content)]
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages,
+        vision_enabled=True,
+    )
+
+    assert result[0]["content"][0]["image_url"]["url"] == "data:image/png;base64,YQ=="
 
 
 def test_convert_assistant_text_after_tool_use_requires_matching_tool_result():

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -707,6 +707,58 @@ def test_convert_user_message_image_raises():
         AnthropicToOpenAIConverter.convert_messages(messages)
 
 
+def test_convert_user_message_image_url_when_vision_enabled():
+    content = [
+        MockBlock(type="text", text="Describe this picture"),
+        MockBlock(type="image", source={"type": "url", "url": "https://example.com/x"}),
+    ]
+    messages = [MockMessage("user", content)]
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages,
+        vision_enabled=True,
+    )
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this picture"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/x"}},
+            ],
+        }
+    ]
+
+
+def test_convert_user_message_image_base64_when_vision_enabled():
+    content = [
+        MockBlock(
+            type="image",
+            source={
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "YQ==",
+            },
+        )
+    ]
+    messages = [MockMessage("user", content)]
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages,
+        vision_enabled=True,
+    )
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,YQ=="},
+                }
+            ],
+        }
+    ]
+
+
 def test_convert_assistant_text_after_tool_use_requires_matching_tool_result():
     """Dangling post-tool assistant text cannot be replayed as valid OpenAI chat."""
     content = [

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -1,4 +1,5 @@
 import json
+import socket
 
 import pytest
 
@@ -745,6 +746,60 @@ def test_convert_user_message_image_url_policy_blocks_private_and_unsupported(
 
     with pytest.raises(OpenAIConversionError, match=match):
         AnthropicToOpenAIConverter.convert_messages(messages, vision_enabled=True)
+
+
+def test_convert_user_message_image_url_policy_blocks_private_dns_resolution(
+    monkeypatch,
+):
+    content = [
+        MockBlock(type="image", source={"type": "url", "url": "https://images.example"})
+    ]
+    messages = [MockMessage("user", content)]
+
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("169.254.169.254", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(OpenAIConversionError, match="non-public address"):
+        AnthropicToOpenAIConverter.convert_messages(messages, vision_enabled=True)
+
+
+def test_convert_user_message_image_url_policy_allows_public_dns_resolution(
+    monkeypatch,
+):
+    content = [
+        MockBlock(type="image", source={"type": "url", "url": "https://images.example"})
+    ]
+    messages = [MockMessage("user", content)]
+
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages,
+        vision_enabled=True,
+    )
+
+    assert result[0]["content"][0]["image_url"]["url"] == "https://images.example"
 
 
 def test_convert_user_message_image_base64_when_vision_enabled():

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import socket
 
@@ -1451,3 +1452,41 @@ def test_fetch_image_as_data_url_redirect_blocked_by_private_ip(monkeypatch):
         OpenAIConversionError, match=r"not target localhost|local or private"
     ):
         _fetch_image_as_data_url("https://images.example/first")
+
+
+def test_pinned_http_and_https_connections_override_address(monkeypatch):
+    import socket
+
+    from free_claude_code.core.anthropic.conversion import (
+        PinnedHTTPConnection,
+        PinnedHTTPSConnection,
+    )
+
+    created_addresses = []
+
+    def mock_create_connection(address, timeout=None, source_address=None):
+        created_addresses.append(address)
+
+        # Create a dummy socket-like object that satisfies basic wrapper requirements without connecting
+        class DummySocket:
+            def close(self):
+                pass
+
+            def setsockopt(self, *args, **kwargs):
+                pass
+
+        return DummySocket()
+
+    monkeypatch.setattr(socket, "create_connection", mock_create_connection)
+
+    # Test HTTP Connection
+    conn = PinnedHTTPConnection("example.com", port=80, pinned_ip="1.2.3.4")
+    with contextlib.suppress(Exception):
+        conn.connect()
+    assert ("1.2.3.4", 80) in created_addresses
+
+    # Test HTTPS Connection
+    conn_s = PinnedHTTPSConnection("example.com", port=443, pinned_ip="5.6.7.8")
+    with contextlib.suppress(Exception):
+        conn_s.connect()
+    assert ("5.6.7.8", 443) in created_addresses

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -1490,3 +1490,82 @@ def test_pinned_http_and_https_connections_override_address(monkeypatch):
     with contextlib.suppress(Exception):
         conn_s.connect()
     assert ("5.6.7.8", 443) in created_addresses
+
+
+def test_is_non_public_ip_ipv4_mapped_ipv6():
+    import ipaddress
+
+    from free_claude_code.core.anthropic.conversion import _is_non_public_ip
+
+    # IPv4 mapped IPv6 loopback
+    ip_mapped_loopback = ipaddress.ip_address("::ffff:127.0.0.1")
+    assert _is_non_public_ip(ip_mapped_loopback) is True
+
+    # IPv4 mapped IPv6 private address
+    ip_mapped_private = ipaddress.ip_address("::ffff:192.168.1.100")
+    assert _is_non_public_ip(ip_mapped_private) is True
+
+    # Normal public IPv6 address
+    ip_public = ipaddress.ip_address("2001:4860:4860::8888")
+    assert _is_non_public_ip(ip_public) is False
+
+
+def test_fetch_image_as_data_url_explicitly_disables_proxies(monkeypatch):
+    import urllib.request
+
+    from free_claude_code.core.anthropic.conversion import _fetch_image_as_data_url
+
+    built_handlers = []
+
+    def mock_build_opener(*handlers):
+        built_handlers.extend(handlers)
+
+        # return a dummy opener
+        class DummyOpener:
+            def open(self, req, timeout=None):
+                class DummyResponse:
+                    status = 200
+                    code = 200
+
+                    def getheader(self, *args, **kwargs):
+                        return "image/png"
+
+                    def info(self):
+                        return {}
+
+                    def read(self, *args, **kwargs):
+                        return b"dummy"
+
+                    def __enter__(self):
+                        return self
+
+                    def __exit__(self, *args):
+                        pass
+
+                return DummyResponse()
+
+        return DummyOpener()
+
+    monkeypatch.setattr(urllib.request, "build_opener", mock_build_opener)
+
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    _fetch_image_as_data_url("https://images.example/explicit")
+
+    # Verify that ProxyHandler with empty dict was passed to disable ambient proxies
+    proxy_handlers = [
+        h for h in built_handlers if isinstance(h, urllib.request.ProxyHandler)
+    ]
+    assert len(proxy_handlers) == 1
+    assert proxy_handlers[0].proxies == {}

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -708,7 +708,11 @@ def test_convert_user_message_image_raises():
         AnthropicToOpenAIConverter.convert_messages(messages)
 
 
-def test_convert_user_message_image_url_when_vision_enabled():
+def test_convert_user_message_image_url_when_vision_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "free_claude_code.core.anthropic.conversion._fetch_image_as_data_url",
+        lambda url: f"data:image/png;base64,mocked_{url}",
+    )
     content = [
         MockBlock(type="text", text="Describe this picture"),
         MockBlock(type="image", source={"type": "url", "url": "https://example.com/x"}),
@@ -724,7 +728,12 @@ def test_convert_user_message_image_url_when_vision_enabled():
             "role": "user",
             "content": [
                 {"type": "text", "text": "Describe this picture"},
-                {"type": "image_url", "image_url": {"url": "https://example.com/x"}},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,mocked_https://example.com/x"
+                    },
+                },
             ],
         }
     ]
@@ -776,6 +785,10 @@ def test_convert_user_message_image_url_policy_blocks_private_dns_resolution(
 def test_convert_user_message_image_url_policy_allows_public_dns_resolution(
     monkeypatch,
 ):
+    monkeypatch.setattr(
+        "free_claude_code.core.anthropic.conversion._fetch_image_as_data_url",
+        lambda url: f"data:image/png;base64,mocked_{url}",
+    )
     content = [
         MockBlock(type="image", source={"type": "url", "url": "https://images.example"})
     ]
@@ -799,7 +812,10 @@ def test_convert_user_message_image_url_policy_allows_public_dns_resolution(
         vision_enabled=True,
     )
 
-    assert result[0]["content"][0]["image_url"]["url"] == "https://images.example"
+    assert (
+        result[0]["content"][0]["image_url"]["url"]
+        == "data:image/png;base64,mocked_https://images.example"
+    )
 
 
 def test_convert_user_message_image_base64_when_vision_enabled():
@@ -1189,3 +1205,249 @@ def test_convert_assistant_server_tool_blocks_raise(content) -> None:
     messages = [MockMessage("assistant", content)]
     with pytest.raises(OpenAIConversionError, match="server tool"):
         AnthropicToOpenAIConverter.convert_messages(messages)
+
+
+def test_fetch_image_as_data_url_success(monkeypatch):
+    import socket
+    import urllib.request
+
+    from free_claude_code.core.anthropic.conversion import _fetch_image_as_data_url
+
+    class MockResponse:
+        def __init__(self):
+            self.status = 200
+            self.code = 200
+
+        def getheader(self, name, default=None):
+            if name.lower() == "content-type":
+                return "image/jpeg"
+            return default
+
+        def info(self):
+            return {}
+
+        def read(self, max_bytes=None):
+            return b"fake_image_bytes"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    class MockOpener:
+        def open(self, req, timeout=None):
+            return MockResponse()
+
+    monkeypatch.setattr(
+        urllib.request, "build_opener", lambda *args, **kwargs: MockOpener()
+    )
+
+    # Mock dns resolution to avoid actual network/dns call for images.example
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    result = _fetch_image_as_data_url("https://images.example")
+    # b"fake_image_bytes" base64 encoded is "ZmFrZV9pbWFnZV9ieXRlcw=="
+    assert result == "data:image/jpeg;base64,ZmFrZV9pbWFnZV9ieXRlcw=="
+
+
+def test_fetch_image_as_data_url_too_large(monkeypatch):
+    import socket
+    import urllib.request
+
+    from free_claude_code.core.anthropic.conversion import (
+        OpenAIConversionError,
+        _fetch_image_as_data_url,
+    )
+
+    class MockResponse:
+        def __init__(self):
+            self.status = 200
+            self.code = 200
+
+        def getheader(self, name, default=None):
+            return default
+
+        def info(self):
+            return {}
+
+        def read(self, max_bytes=None):
+            # Return slightly more than 5MB to trigger the limit check
+            return b"x" * (5 * 1024 * 1024 + 1)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    class MockOpener:
+        def open(self, req, timeout=None):
+            return MockResponse()
+
+    monkeypatch.setattr(
+        urllib.request, "build_opener", lambda *args, **kwargs: MockOpener()
+    )
+
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(OpenAIConversionError, match=r"maximum allowed size|exceeds"):
+        _fetch_image_as_data_url("https://images.example")
+
+
+def test_fetch_image_as_data_url_redirect_allowed_then_success(monkeypatch):
+    import socket
+    import urllib.request
+
+    from free_claude_code.core.anthropic.conversion import _fetch_image_as_data_url
+
+    calls = []
+
+    class MockRedirectResponse:
+        def __init__(self, location):
+            self.status = 302
+            self.code = 302
+            self.location = location
+
+        def getheader(self, name, default=None):
+            if name.lower() == "location":
+                return self.location
+            return default
+
+        def info(self):
+            return {"Location": self.location}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    class MockSuccessResponse:
+        def __init__(self):
+            self.status = 200
+            self.code = 200
+
+        def getheader(self, name, default=None):
+            if name.lower() == "content-type":
+                return "image/png"
+            return default
+
+        def info(self):
+            return {}
+
+        def read(self, max_bytes=None):
+            return b"ok"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    class MockOpener:
+        def open(self, req, timeout=None):
+            url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+            calls.append(url)
+            if url == "https://images.example/first":
+                return MockRedirectResponse("https://images.example/second")
+            return MockSuccessResponse()
+
+    monkeypatch.setattr(
+        urllib.request, "build_opener", lambda *args, **kwargs: MockOpener()
+    )
+
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    result = _fetch_image_as_data_url("https://images.example/first")
+    assert calls == ["https://images.example/first", "https://images.example/second"]
+    assert result == "data:image/png;base64,b2s="
+
+
+def test_fetch_image_as_data_url_redirect_blocked_by_private_ip(monkeypatch):
+    import socket
+    import urllib.request
+
+    from free_claude_code.core.anthropic.conversion import (
+        OpenAIConversionError,
+        _fetch_image_as_data_url,
+    )
+
+    class MockRedirectResponse:
+        def __init__(self, location):
+            self.status = 302
+            self.code = 302
+            self.location = location
+
+        def getheader(self, name, default=None):
+            if name.lower() == "location":
+                return self.location
+            return default
+
+        def info(self):
+            return {"Location": self.location}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    class MockOpener:
+        def open(self, req, timeout=None):
+            return MockRedirectResponse("http://127.0.0.1/evil.png")
+
+    monkeypatch.setattr(
+        urllib.request, "build_opener", lambda *args, **kwargs: MockOpener()
+    )
+
+    def fake_getaddrinfo(*args, **kwargs):
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(
+        OpenAIConversionError, match=r"not target localhost|local or private"
+    ):
+        _fetch_image_as_data_url("https://images.example/first")

--- a/tests/providers/test_nvidia_nim_request.py
+++ b/tests/providers/test_nvidia_nim_request.py
@@ -119,6 +119,42 @@ class TestBuildRequestBody:
         body = build_request_body(req, nim, thinking_enabled=True)
         assert body["parallel_tool_calls"] is False
 
+    def test_user_image_blocks_are_serialized_when_vision_enabled(self):
+        request = MessagesRequest.model_validate(
+            {
+                "model": "test",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Describe this"},
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": "YQ==",
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+
+        body = build_request_body(
+            request,
+            NimSettings(),
+            vision_enabled=True,
+            thinking_enabled=False,
+        )
+
+        assert body["messages"][0]["role"] == "user"
+        assert body["messages"][0]["content"] == [
+            {"type": "text", "text": "Describe this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,YQ=="}},
+        ]
+
     def test_tool_schema_boolean_subschemas_are_removed_without_mutating_request(
         self, req
     ):

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -94,6 +94,7 @@ def _make_settings(**overrides):
     mock.http_write_timeout = 10.0
     mock.http_connect_timeout = 10.0
     mock.enable_model_thinking = True
+    mock.enable_vision = False
     mock.log_raw_sse_events = False
     mock.log_api_error_tracebacks = False
     mock.nim = NimSettings()

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -219,6 +219,59 @@ async def test_provider_apply_constructs_before_commit_then_publishes(tmp_path) 
 
 
 @pytest.mark.asyncio
+async def test_enable_vision_apply_hot_reloads_provider_without_restart(
+    tmp_path,
+) -> None:
+    factory = TrackingFactory()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/old"),
+        runtime_factory=factory,
+    )
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    factory.events.clear()
+    prepared = PreparedAdminUpdate(
+        target_values={"MODEL": "nvidia_nim/old", "ENABLE_VISION": "true"},
+        settings=_settings("nvidia_nim/old").model_copy(update={"enable_vision": True}),
+        errors=(),
+        pending_fields=(),
+        path=tmp_path / ".env",
+    )
+
+    def commit(_prepared_update: PreparedAdminUpdate) -> dict[str, object]:
+        factory.events.append("commit")
+        return {
+            "applied": True,
+            "valid": True,
+            "errors": [],
+            "env_preview": "MODEL=nvidia_nim/old\nENABLE_VISION=true\n",
+            "path": str(tmp_path / ".env"),
+            "pending_fields": [],
+        }
+
+    with (
+        patch(
+            "free_claude_code.runtime.application.prepare_admin_update",
+            return_value=prepared,
+        ),
+        patch(
+            "free_claude_code.runtime.application.commit_prepared_admin_update",
+            side_effect=commit,
+        ),
+    ):
+        result = await runtime.apply_admin_config({"ENABLE_VISION": True})
+
+    assert factory.events == ["construct:nvidia_nim/old", "commit"]
+    assert manager.current_settings().enable_vision is True
+    assert result["restart"] == {
+        "required": False,
+        "automatic": False,
+        "admin_url": None,
+        "fields": [],
+    }
+    await manager.close()
+
+
+@pytest.mark.asyncio
 async def test_candidate_failure_never_commits_and_preserves_current(tmp_path) -> None:
     factory = TrackingFactory()
     manager = ProviderRuntimeManager(

--- a/tests/scripts/test_ci_scripts.py
+++ b/tests/scripts/test_ci_scripts.py
@@ -66,7 +66,7 @@ def test_ci_sh_runs_ci_checks_in_order() -> None:
     assert "Fix the underlying type/import issue instead" in text
     assert legacy_future_import in text
     assert "legacy future annotations are not allowed" in text
-    assert "--exclude-dir=.venv" in text
+    assert "--exclude-dir='.venv*'" in text
     assert "--exclude-dir=.git" in text
     assert "uv run ruff format" in text
     assert "uv run ruff format --check" not in text

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.14"
+version = "3.5.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.15"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Add an env-backed `ENABLE_VISION` toggle and wire it through the admin config, provider runtime, and Anthropic→OpenAI conversion path so NVIDIA NIM can accept user image blocks for vision-enabled requests.

Highlights:
- Adds `ENABLE_VISION` to settings, `.env.example`, and the admin panel
- Threads vision capability into the NIM request pipeline
- Serializes Anthropic URL/base64 image blocks into OpenAI chat image parts when enabled
- Keeps image handling disabled by default and preserves existing rejection behavior when off

Verification:
- Focused pytest subset passed
- Full local CI script passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds vision support for NVIDIA NIM requests. The main changes are:

- Adds an `ENABLE_VISION` setting, env default, and admin field.
- Threads the vision flag into the NVIDIA NIM provider runtime.
- Converts Anthropic image blocks into OpenAI chat image parts when vision is enabled.
- Fetches URL images locally and forwards them as inline `data:` URLs.
- Updates tests and bumps the package version to `3.6.0`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the vision-focused PyTest suite across tests/config/test\_config.py, tests/providers/test\_converter.py, tests/providers/test\_nvidia\_nim\_request.py, tests/providers/test\_provider\_runtime.py, and tests/api/test\_admin.py; the run completed with 310 tests passing in 5.06s (exit code 0).
- Executed the vision runtime PyTest suite for tests/runtime/test\_application\_runtime.py and tests/scripts/test\_ci\_scripts.py; the run completed with 32 passed, 4 skipped in 2.29s (exit code 0).

<a href="https://app.greptile.com/trex/runs/14188812/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/anthropic/conversion.py | Adds guarded image URL fetching and vision-aware Anthropic-to-OpenAI conversion. |
| src/free_claude_code/providers/nvidia_nim/client.py | Stores the vision flag on the NVIDIA NIM provider and applies it during request construction. |
| src/free_claude_code/providers/nvidia_nim/request_options.py | Passes the vision flag into the shared OpenAI chat request builder. |
| src/free_claude_code/providers/openai_chat/request_policy.py | Accepts the vision flag and forwards it into base request conversion. |
| src/free_claude_code/config/settings.py | Adds the disabled-by-default `ENABLE_VISION` setting. |
| src/free_claude_code/config/admin/manifest.py | Exposes `ENABLE_VISION` as a provider configuration field. |
| src/free_claude_code/providers/runtime/factory.py | Passes the configured vision flag into NVIDIA NIM provider creation. |
| pyproject.toml | Bumps the package version to `3.6.0` for the new feature. |
| uv.lock | Updates the locked editable package version to match the project version. |

<sub>Reviews (9): Last reviewed commit: ["Merge branch &#39;main&#39; into feature/nim-vis..."](https://github.com/alishahryar1/free-claude-code/commit/ef210b2fe2ddf7f44ca6ba06598aaf1543b9ed29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43590969)</sub>

<!-- /greptile_comment -->