### PR TITLE
fix: handle inline system-role messages in request payload (#616)

### DIFF
--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -206,7 +206,7 @@ def test_create_message_pre_start_provider_error_returns_terminal_json(
 
 
 def test_create_message_accepts_system_role_messages(client: TestClient):
-    """Create message accepts latest-client system messages."""
+    """Regression for #616: inline system-role messages must not return HTTP 422."""
     mock_provider.stream_response = _mock_stream_response
     _stream_response_calls.clear()
     payload = {

--- a/tests/api/test_routes_optimizations.py
+++ b/tests/api/test_routes_optimizations.py
@@ -135,6 +135,28 @@ def test_count_tokens_endpoint(client):
     assert response.json()["input_tokens"] == 5
 
 
+def test_count_tokens_accepts_system_role_messages(client):
+    """Regression for #616 on the count_tokens ingress path."""
+    payload = {
+        "model": "claude-3-sonnet",
+        "messages": [
+            {"role": "user", "content": "context"},
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "hello"},
+        ],
+    }
+    token_counter = MagicMock(return_value=5)
+
+    with patch("free_claude_code.api.routes.get_token_count", token_counter):
+        response = client.post("/v1/messages/count_tokens", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["input_tokens"] == 5
+    messages, system, _tools = token_counter.call_args[0]
+    assert [message.role for message in messages] == ["user", "user"]
+    assert system == "system prompt"
+
+
 def test_count_tokens_error_returns_500(client):
     """When get_token_count raises, count_tokens returns 500."""
     payload = {


### PR DESCRIPTION
## Summary

Closes #616. Duplicate: #618 (closed).

Claude Code (recent versions, subagents/hooks) can send mid-conversation system prompt updates as `role: "system"` entries inside the `messages` array. The proxy Pydantic `Message` model only allows `user`/`assistant`, so FastAPI returned HTTP 422 before any provider saw the request:

```json
{"detail":[{"type":"literal_error","loc":["body","messages",1,"role"],
"msg":"Input should be 'user' or 'assistant'","input":"system"}]}
```

## Root cause

Anthropic Messages API expects system content in the top-level `system` field, not as conversation turns. The ingress schema rejected inline `system` roles at validation time.

## Fix (already on `main` since `cebdc02`)

Sanitization at ingress via `model_validator(mode="before")` on `MessagesRequest` / `TokenCountRequest` in `src/free_claude_code/core/anthropic/models.py`:

- Extract any `messages[]` entries with `role: "system"`
- Merge their content into top-level `system` (newline-separated for strings; block-preserving merge for structured content / `cache_control`)
- Remove those entries from `messages` before strict `Message` validation

Example payload that previously 422'd and now succeeds:

```json
{
  "model": "claude-3-sonnet",
  "max_tokens": 100,
  "messages": [
    {"role": "user", "content": "context"},
    {"role": "system", "content": "system prompt"},
    {"role": "user", "content": "Hi"}
  ]
}
```

After normalization: `messages` = two `user` turns; `system` = "system prompt"`.

## This PR

Adds explicit regression coverage for the `/v1/messages/count_tokens` ingress path (messages path was already covered).

## Tests

- `tests/core/anthropic/test_models.py` — normalization, merge with existing `system`, cache_control preservation
- `tests/api/test_api.py::test_create_message_accepts_system_role_messages` — `/v1/messages` end-to-end (#616)
- `tests/api/test_routes_optimizations.py::test_count_tokens_accepts_system_role_messages` — **new** `/v1/messages/count_tokens` end-to-end

## Verification

```
uv run ruff format
uv run ruff check
uv run ty check
uv run pytest tests/api/test_routes_optimizations.py::test_count_tokens_accepts_system_role_messages tests/api/test_api.py::test_create_message_accepts_system_role_messages tests/core/anthropic/test_models.py -v
```

All checks passed. Full `pytest` run had 3 unrelated failures in `tests/scripts/test_uninstallers.py` because `fcc-server` is running locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds test coverage for inline system-role messages in Anthropic request payloads. The main changes are:

- Updated the existing `/v1/messages` test docstring to name the no-422 regression.
- Added a `/v1/messages/count_tokens` test for inline `role: "system"` entries.
- Checked that token counting receives user-only messages and the extracted system prompt.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. The new test posts through the real route parsing path before the token-count dependency is mocked, and the assertions match the current token-count call shape.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the highest-value count\_tokens regression for the inline-system-role workflow, capturing the command, working directory, pytest output, and a successful EXIT\_CODE.
- Executed the existing messages endpoint regression and Anthropic model normalization coverage, with pytest reporting 18 passed and a successful EXIT\_CODE.
- Ran targeted lint and type checks, with all checks passing as shown by the All checks passed! message and EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14139419/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/api/test_api.py | Only the regression test docstring changed; no test behavior changed. |
| tests/api/test_routes_optimizations.py | Adds a focused count-tokens test for inline system-role message normalization. |

<sub>Reviews (1): Last reviewed commit: ["test: cover inline system-role messages ..."](https://github.com/alishahryar1/free-claude-code/commit/cdacd5450602f0c083c7fba52c008ff15d3683ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43611835)</sub>

<!-- /greptile_comment -->