### PR TITLE
Document Claude login workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ For terminal use, start `fcc-server`, then prefer `fcc-claude` or `fcc-codex`. U
 <details>
 <summary><strong>Claude Code in VS Code</strong></summary>
 
-Install the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code). In VS Code settings, edit `claudeCode.environmentVariables`:
+Install the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code). Open VS Code's user settings as JSON and add:
 
 ```json
+"claudeCode.disableLoginPrompt": true,
 "claudeCode.environmentVariables": [
   { "name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082" },
   { "name": "ANTHROPIC_AUTH_TOKEN", "value": "freecc" },
@@ -222,7 +223,7 @@ Install the [Claude Code extension](https://marketplace.visualstudio.com/items?i
 ]
 ```
 
-Match the port and authentication token to the Admin UI, then reload the extension. If prompted to log in, choose the Anthropic Console path once; FCC still handles model traffic.
+Match the port and authentication token to the Admin UI, then reload the extension.
 
 </details>
 
@@ -274,6 +275,32 @@ Set the environment for `acp.registry.claude-acp`:
 ```
 
 Match the port and token to the Admin UI, then restart the IDE.
+
+</details>
+
+<details>
+<summary><strong>Claude Code still asks you to log in</strong></summary>
+
+If Claude Code asks you to log in after you configure the FCC URL and token, open its state file:
+
+- Windows: `%USERPROFILE%\.claude.json`
+- macOS/Linux/WSL: `~/.claude.json`
+
+Merge this property into the existing JSON without removing its other fields:
+
+```json
+"hasCompletedOnboarding": true
+```
+
+If the file does not exist, create it with a complete JSON object:
+
+```json
+{
+  "hasCompletedOnboarding": true
+}
+```
+
+Restart Claude Code or the IDE after saving the file.
 
 </details>
 


### PR DESCRIPTION
## Problem

Claude Code can show an Anthropic login prompt after customers configure FCC. The VS Code guide incorrectly told customers to complete an unrelated Anthropic Console login.

## Changes

| Before | After |
| --- | --- |
| VS Code left its third-party-provider login prompt enabled. | VS Code explicitly disables its login prompt while retaining the FCC connection environment. |
| Customers had no documented recovery for Claude's first-run onboarding gate. | Customers can safely mark onboarding complete without replacing their existing Claude state. |
| The guide told customers to select Anthropic Console when prompted. | The guide keeps authentication and model traffic within the FCC setup. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the README guidance for Claude Code login prompts. The main changes are:

- Adds the VS Code `claudeCode.disableLoginPrompt` setting.
- Removes the Anthropic Console login workaround.
- Documents how to set `hasCompletedOnboarding` in Claude Code state.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after small documentation clarifications.

The change only updates README guidance, and the VS Code setting plus FCC environment variables are documented in a reasonable shape.

README.md has clarity gaps that can cause users to edit the wrong JSON location or shape.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the Claude onboarding README excerpt to confirm the updated onboarding paths and the complete JSON object were captured.
- Parsed the Claude onboarding JSON to confirm section\_found is true, json\_fence\_count is 2, and complete\_object\_parse is ok, with exit code 0.
- Validated the README formatting check by running ruff, which completed with exit code 0.
- Ran the minimal pytest smoke test suite, which reported 4 tests passing and exit code 0.

<a href="https://app.greptile.com/trex/runs/14169739/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates Claude Code VS Code setup and onboarding recovery documentation, with minor clarity gaps around manual state-file edits. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fdocument-claude-login-workarounds%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fdocument-claude-login-workarounds%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A289-293%0A**State%20Merge%20Can%20Break%20JSON**%0A%0AWhen%20an%20existing%20%60.claude.json%60%20already%20has%20fields%2C%20copying%20the%20shown%20bare%20property%20outside%20the%20existing%20braces%20creates%20invalid%20JSON.%20The%20onboarding%20flag%20is%20then%20ignored%20or%20the%20state%20file%20fails%20to%20load%2C%20so%20the%20login%20prompt%20can%20keep%20appearing%20even%20though%20the%20user%20followed%20this%20recovery%20step.%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A287%0A**WSL%20State%20File%20Ambiguity**%0A%0AFor%20VS%20Code%20remote%20WSL%20sessions%2C%20%60~%2F.claude.json%60%20means%20the%20WSL%20home%20directory%2C%20not%20the%20Windows%20%60%25USERPROFILE%25%60%20file.%20Without%20saying%20to%20edit%20the%20file%20in%20the%20environment%20where%20Claude%20Code%20runs%2C%20Windows%2BWSL%20users%20can%20update%20the%20wrong%20state%20file%20and%20still%20see%20the%20login%20prompt.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1082&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Document Claude login workarounds"](https://github.com/alishahryar1/free-claude-code/commit/7ca8a11812e0a692b962585d56401f5a16475c00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43679029)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->