### PR TITLE
Disable nonessential Anthropic traffic for FCC Claude sessions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -777,14 +777,19 @@ otherwise the Messages handler rejects them before provider execution.
 
 ## CLI Launchers And Managed Claude
 
+[cli/claude_env.py](src/free_claude_code/cli/claude_env.py) owns the canonical
+Claude Code proxy environment used by every FCC-launched Claude process. It
+strips inherited `ANTHROPIC_*` variables, sets `ANTHROPIC_BASE_URL`, enables
+gateway model discovery, configures the auto-compact window, disables
+nonessential Anthropic traffic, and always sets `ANTHROPIC_AUTH_TOKEN`. Blank
+proxy auth becomes the local-only `fcc-no-auth` sentinel so Claude Code reaches
+the proxy instead of stopping at its login gate.
+
 [cli/launchers/claude.py](src/free_claude_code/cli/launchers/claude.py) owns the installed
 `fcc-claude` launcher:
 
-- `fcc-claude` strips inherited `ANTHROPIC_*` variables, sets
-  `ANTHROPIC_BASE_URL`, enables gateway model discovery, configures the
-  auto-compact window, and always sets `ANTHROPIC_AUTH_TOKEN`. Blank proxy auth
-  becomes the local-only `fcc-no-auth` sentinel so Claude Code reaches the proxy
-  instead of stopping at its login gate.
+- `fcc-claude` applies the shared proxy environment without changing the user's
+  Claude command arguments.
 
 [cli/launchers/codex.py](src/free_claude_code/cli/launchers/codex.py) owns the installed
 `fcc-codex` launcher:
@@ -801,10 +806,9 @@ otherwise the Messages handler rejects them before provider execution.
 - It stores the proxy auth token in `FCC_CODEX_API_KEY` for Codex to read.
 
 [cli/managed/](src/free_claude_code/cli/managed/) owns managed Claude Code subprocesses used by
-Discord and Telegram messaging. Managed task invocations set
-`ANTHROPIC_API_URL`, `ANTHROPIC_BASE_URL`, gateway model discovery,
-non-interactive terminal settings, optional `--resume`, optional
-`--fork-session`, `--model opus`, and `--output-format stream-json`. Messaging
+Discord and Telegram messaging. Managed task invocations extend the same proxy
+environment only with non-interactive terminal settings, optional `--resume`,
+optional `--fork-session`, `--model opus`, and `--output-format stream-json`. Messaging
 pins this Claude tier alias so phone sessions route through `MODEL_OPUS` or the
 `MODEL` fallback instead of inheriting a user's interactive `/model` picker
 state. The managed session parser extracts persistent Claude session IDs and

--- a/README.md
+++ b/README.md
@@ -280,8 +280,6 @@ Match the port and token to the Admin UI, then restart the IDE.
 
 </details>
 
-The nonessential-traffic setting disables Claude Code telemetry, error reporting, feedback, and automatic update checks for FCC sessions. Update Claude Code separately when needed.
-
 <details>
 <summary><strong>Claude Code still asks you to log in</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ Install the [Claude Code extension](https://marketplace.visualstudio.com/items?i
   { "name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082" },
   { "name": "ANTHROPIC_AUTH_TOKEN", "value": "freecc" },
   { "name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1" },
-  { "name": "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "value": "190000" }
+  { "name": "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "value": "190000" },
+  { "name": "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "value": "1" }
 ]
 ```
 
@@ -270,13 +271,16 @@ Set the environment for `acp.registry.claude-acp`:
   "ANTHROPIC_BASE_URL": "http://localhost:8082",
   "ANTHROPIC_AUTH_TOKEN": "freecc",
   "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
-  "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000"
+  "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000",
+  "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
 }
 ```
 
 Match the port and token to the Admin UI, then restart the IDE.
 
 </details>
+
+The nonessential-traffic setting disables Claude Code telemetry, error reporting, feedback, and automatic update checks for FCC sessions. Update Claude Code separately when needed.
 
 <details>
 <summary><strong>Claude Code still asks you to log in</strong></summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.15"
+version = "3.5.16"
 description = "Local proxy connecting Claude Code and Codex to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/claude_cli_matrix.py
+++ b/smoke/lib/claude_cli_matrix.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from free_claude_code.cli.claude_env import build_claude_proxy_env
 from smoke.lib.child_process import run_captured_text
 from smoke.lib.config import ProviderModel, SmokeConfig, redacted
 from smoke.lib.server import RunningServer
@@ -117,14 +118,11 @@ def run_claude_cli(
         )
     )
 
-    env = os.environ.copy()
-    env["ANTHROPIC_BASE_URL"] = server.base_url
-    env["ANTHROPIC_API_URL"] = f"{server.base_url}/v1"
-    env.pop("ANTHROPIC_API_KEY", None)
-    if config.settings.anthropic_auth_token:
-        env["ANTHROPIC_AUTH_TOKEN"] = config.settings.anthropic_auth_token
-    else:
-        env.pop("ANTHROPIC_AUTH_TOKEN", None)
+    env = build_claude_proxy_env(
+        proxy_root_url=server.base_url,
+        auth_token=config.settings.anthropic_auth_token,
+        base_env=os.environ,
+    )
     env["TERM"] = "dumb"
     env["NO_COLOR"] = "1"
     env["PYTHONIOENCODING"] = "utf-8"

--- a/smoke/lib/e2e.py
+++ b/smoke/lib/e2e.py
@@ -16,6 +16,7 @@ from typing import Any
 import httpx
 import pytest
 
+from free_claude_code.cli.claude_env import build_claude_proxy_env
 from free_claude_code.config.provider_catalog import SUPPORTED_PROVIDER_IDS
 from free_claude_code.core.anthropic.stream_contracts import (
     SSEEvent,
@@ -278,15 +279,11 @@ class ClientProtocolDriver:
         prompt: str,
         model: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        env = os.environ.copy()
-        env["ANTHROPIC_BASE_URL"] = server.base_url
-        env["ANTHROPIC_API_URL"] = f"{server.base_url}/v1"
-        env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
-        env.pop("ANTHROPIC_API_KEY", None)
-        if config.settings.anthropic_auth_token:
-            env["ANTHROPIC_AUTH_TOKEN"] = config.settings.anthropic_auth_token
-        else:
-            env.pop("ANTHROPIC_AUTH_TOKEN", None)
+        env = build_claude_proxy_env(
+            proxy_root_url=server.base_url,
+            auth_token=config.settings.anthropic_auth_token,
+            base_env=os.environ,
+        )
         command = [
             claude_bin,
             "--bare",

--- a/smoke/prereq/test_cli_prereq_live.py
+++ b/smoke/prereq/test_cli_prereq_live.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from free_claude_code.cli.claude_env import build_claude_proxy_env
 from smoke.lib.child_process import (
     cmd_fcc_init,
     cmd_free_claude_code_serve,
@@ -58,10 +59,11 @@ def test_claude_cli_prompt_when_available(
         env_overrides={"MODEL": models[0].full_model, "MESSAGING_PLATFORM": "none"},
         name="claude-cli",
     ) as server:
-        env = os.environ.copy()
-        env["ANTHROPIC_BASE_URL"] = server.base_url
-        if smoke_config.settings.anthropic_auth_token:
-            env["ANTHROPIC_AUTH_TOKEN"] = smoke_config.settings.anthropic_auth_token
+        env = build_claude_proxy_env(
+            proxy_root_url=server.base_url,
+            auth_token=smoke_config.settings.anthropic_auth_token,
+            base_env=os.environ,
+        )
         result = run_captured_text(
             [claude_bin, "-p", "Reply with exactly FCC_SMOKE_PONG"],
             cwd=tmp_path,

--- a/smoke/product/test_cli_package_product_live.py
+++ b/smoke/product/test_cli_package_product_live.py
@@ -52,7 +52,7 @@ def test_entrypoint_version_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 async def test_cli_session_resume_fork_e2e(tmp_path: Path) -> None:
-    session = ManagedClaudeSession(str(tmp_path), "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession(str(tmp_path), "http://127.0.0.1:8082")
     process = AsyncMock()
     process.stdout.read.side_effect = [b""]
     process.stderr.read.return_value = b""
@@ -79,7 +79,7 @@ async def test_cli_session_resume_fork_e2e(tmp_path: Path) -> None:
 async def test_cli_process_cleanup_e2e(tmp_path: Path) -> None:
     manager = ManagedClaudeSessionManager(
         workspace_path=str(tmp_path),
-        api_url="http://127.0.0.1:8082/v1",
+        proxy_root_url="http://127.0.0.1:8082",
     )
     session, pending_id, is_new = await manager.get_or_create_session()
     assert is_new is True
@@ -99,7 +99,7 @@ async def test_cli_process_cleanup_e2e(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_cli_session_stop_kills_child_e2e(tmp_path: Path) -> None:
-    session = ManagedClaudeSession(str(tmp_path), "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession(str(tmp_path), "http://127.0.0.1:8082")
     process = MagicMock()
     process.pid = 123456
     process.returncode = None

--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -1,6 +1,7 @@
 """Shared Claude Code environment policy for FCC client surfaces."""
 
 CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1"
 CLAUDE_BINARY_NAME = "claude"
 CLAUDE_NO_AUTH_SENTINEL = "fcc-no-auth"
 

--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -1,9 +1,34 @@
 """Shared Claude Code environment policy for FCC client surfaces."""
 
+from collections.abc import Mapping
+
 CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"
 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1"
 CLAUDE_BINARY_NAME = "claude"
 CLAUDE_NO_AUTH_SENTINEL = "fcc-no-auth"
+
+
+def build_claude_proxy_env(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    base_env: Mapping[str, str],
+) -> dict[str, str]:
+    """Return the canonical environment for Claude Code proxy sessions."""
+
+    env = {
+        key: value
+        for key, value in base_env.items()
+        if not key.startswith("ANTHROPIC_")
+    }
+    env["ANTHROPIC_BASE_URL"] = proxy_root_url
+    env["ANTHROPIC_AUTH_TOKEN"] = claude_auth_token(auth_token)
+    env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
+    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = (
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+    )
+    return env
 
 
 def claude_auth_token(auth_token: str) -> str:

--- a/src/free_claude_code/cli/launchers/claude.py
+++ b/src/free_claude_code/cli/launchers/claude.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from free_claude_code.cli.claude_env import (
     CLAUDE_BINARY_NAME,
     CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
     claude_auth_token,
 )
 from free_claude_code.config.server_urls import local_proxy_root_url
@@ -81,5 +82,8 @@ def build_claude_launcher_env(
     env["ANTHROPIC_BASE_URL"] = proxy_root_url
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = (
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+    )
     env["ANTHROPIC_AUTH_TOKEN"] = claude_auth_token(auth_token)
     return env

--- a/src/free_claude_code/cli/launchers/claude.py
+++ b/src/free_claude_code/cli/launchers/claude.py
@@ -2,13 +2,11 @@
 
 import os
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 
 from free_claude_code.cli.claude_env import (
     CLAUDE_BINARY_NAME,
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW,
-    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
-    claude_auth_token,
+    build_claude_proxy_env,
 )
 from free_claude_code.config.server_urls import local_proxy_root_url
 from free_claude_code.config.settings import get_settings
@@ -41,7 +39,7 @@ def launch(argv: Sequence[str] | None = None) -> None:
     args = list(sys.argv[1:] if argv is None else argv)
     run_client_process(
         command=build_claude_launcher_command(binary_path=binary_path, argv=args),
-        env=build_claude_launcher_env(
+        env=build_claude_proxy_env(
             proxy_root_url=proxy_root_url,
             auth_token=settings.anthropic_auth_token,
             base_env=os.environ,
@@ -64,26 +62,3 @@ def build_claude_launcher_command(
     """Return the Claude wrapper command without changing user arguments."""
 
     return [binary_path, *argv]
-
-
-def build_claude_launcher_env(
-    *,
-    proxy_root_url: str,
-    auth_token: str,
-    base_env: Mapping[str, str],
-) -> dict[str, str]:
-    """Return a Claude Code environment that targets the local proxy."""
-
-    env = {
-        key: value
-        for key, value in base_env.items()
-        if not key.startswith("ANTHROPIC_")
-    }
-    env["ANTHROPIC_BASE_URL"] = proxy_root_url
-    env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = CLAUDE_CODE_AUTO_COMPACT_WINDOW
-    env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = (
-        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
-    )
-    env["ANTHROPIC_AUTH_TOKEN"] = claude_auth_token(auth_token)
-    return env

--- a/src/free_claude_code/cli/managed/claude.py
+++ b/src/free_claude_code/cli/managed/claude.py
@@ -9,8 +9,7 @@ from loguru import logger
 
 from free_claude_code.cli.claude_env import (
     CLAUDE_BINARY_NAME,
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW,
-    claude_auth_token,
+    build_claude_proxy_env,
 )
 
 MANAGED_CLAUDE_MODEL_TIER = "opus"
@@ -40,7 +39,7 @@ class ManagedClaudeConfig:
     """Configuration for a managed Claude Code subprocess."""
 
     workspace_path: str
-    api_url: str
+    proxy_root_url: str
     allowed_dirs: list[str] = field(default_factory=list)
     plans_directory: str | None = None
     claude_bin: str = CLAUDE_BINARY_NAME
@@ -79,7 +78,7 @@ def build_managed_claude_invocation(
     return ManagedClaudeInvocation(
         argv=tuple(cmd),
         env=build_managed_claude_env(
-            api_url=config.api_url,
+            proxy_root_url=config.proxy_root_url,
             auth_token=config.auth_token,
             base_env=base_env,
         ),
@@ -99,19 +98,17 @@ def build_managed_claude_invocation(
 
 def build_managed_claude_env(
     *,
-    api_url: str,
+    proxy_root_url: str,
     auth_token: str,
     base_env: Mapping[str, str],
 ) -> dict[str, str]:
     """Return a Claude Code task environment that targets the local proxy."""
 
-    env = dict(base_env)
-    env["ANTHROPIC_API_URL"] = api_url
-    env["ANTHROPIC_BASE_URL"] = api_url[:-3] if api_url.endswith("/v1") else api_url
-    env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = CLAUDE_CODE_AUTO_COMPACT_WINDOW
-    env.pop("ANTHROPIC_API_KEY", None)
-    env["ANTHROPIC_AUTH_TOKEN"] = claude_auth_token(auth_token)
+    env = build_claude_proxy_env(
+        proxy_root_url=proxy_root_url,
+        auth_token=auth_token,
+        base_env=base_env,
+    )
     env["TERM"] = "dumb"
     env["PYTHONIOENCODING"] = "utf-8"
     return env

--- a/src/free_claude_code/cli/managed/manager.py
+++ b/src/free_claude_code/cli/managed/manager.py
@@ -21,7 +21,7 @@ class ManagedClaudeSessionManager:
     def __init__(
         self,
         workspace_path: str,
-        api_url: str,
+        proxy_root_url: str,
         allowed_dirs: list[str] | None = None,
         plans_directory: str | None = None,
         claude_bin: str = CLAUDE_BINARY_NAME,
@@ -35,12 +35,12 @@ class ManagedClaudeSessionManager:
 
         Args:
             workspace_path: Working directory for CLI processes
-            api_url: API URL for the proxy
+            proxy_root_url: Root URL for the local proxy
             allowed_dirs: Directories the CLI is allowed to access
             plans_directory: Directory for Claude Code CLI plan files (passed via --settings)
         """
         self.workspace = workspace_path
-        self.api_url = api_url
+        self.proxy_root_url = proxy_root_url
         self.allowed_dirs = allowed_dirs or []
         self.plans_directory = plans_directory
         self.claude_bin = claude_bin
@@ -110,7 +110,7 @@ class ManagedClaudeSessionManager:
 
             new_session = ManagedClaudeSession(
                 workspace_path=self.workspace,
-                api_url=self.api_url,
+                proxy_root_url=self.proxy_root_url,
                 allowed_dirs=self.allowed_dirs,
                 plans_directory=self.plans_directory,
                 claude_bin=self.claude_bin,

--- a/src/free_claude_code/cli/managed/session.py
+++ b/src/free_claude_code/cli/managed/session.py
@@ -32,7 +32,7 @@ class ManagedClaudeSession:
     def __init__(
         self,
         workspace_path: str,
-        api_url: str,
+        proxy_root_url: str,
         allowed_dirs: list[str] | None = None,
         plans_directory: str | None = None,
         claude_bin: str = "claude",
@@ -42,14 +42,14 @@ class ManagedClaudeSession:
     ):
         self.config = ManagedClaudeConfig(
             workspace_path=os.path.normpath(os.path.abspath(workspace_path)),
-            api_url=api_url,
+            proxy_root_url=proxy_root_url,
             allowed_dirs=[os.path.normpath(d) for d in (allowed_dirs or [])],
             plans_directory=plans_directory,
             claude_bin=claude_bin,
             auth_token=auth_token,
         )
         self.workspace = self.config.workspace_path
-        self.api_url = self.config.api_url
+        self.proxy_root_url = self.config.proxy_root_url
         self.allowed_dirs = self.config.allowed_dirs
         self.plans_directory = self.config.plans_directory
         self.claude_bin = self.config.claude_bin

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -28,7 +28,7 @@ from free_claude_code.config.env_files import (
 )
 from free_claude_code.config.model_refs import parse_provider_type
 from free_claude_code.config.paths import default_claude_workspace_path
-from free_claude_code.config.server_urls import local_admin_url
+from free_claude_code.config.server_urls import local_admin_url, local_proxy_root_url
 from free_claude_code.config.settings import Settings, get_settings
 from free_claude_code.messaging.platforms import factory as messaging_platform_factory
 from free_claude_code.messaging.platforms.factory import MessagingPlatformOptions
@@ -369,7 +369,7 @@ class ApplicationRuntime:
 
         self._cli_manager = cli_managed.ManagedClaudeSessionManager(
             workspace_path=workspace,
-            api_url=f"http://{settings.host}:{settings.port}/v1",
+            proxy_root_url=local_proxy_root_url(settings),
             allowed_dirs=allowed_dirs,
             plans_directory=os.path.relpath(plans_dir_abs, workspace),
             auth_token=settings.anthropic_auth_token,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -157,11 +157,11 @@ class TestManagedClaudeSession:
 
         session = ManagedClaudeSession(
             workspace_path="/tmp/test",
-            api_url="http://localhost:8082/v1",
+            proxy_root_url="http://localhost:8082",
             allowed_dirs=["/home/user/projects"],
         )
         assert session.workspace == os.path.normpath(os.path.abspath("/tmp/test"))
-        assert session.api_url == "http://localhost:8082/v1"
+        assert session.proxy_root_url == "http://localhost:8082"
         assert not session.is_busy
 
     def test_session_extract_session_id(self):
@@ -201,7 +201,7 @@ class TestManagedClaudeSession:
         """Test start_task running a basic command flow."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         # Mock subprocess
         mock_process = AsyncMock()
@@ -245,7 +245,7 @@ class TestManagedClaudeSession:
         """Test resuming an existing session."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [
@@ -272,7 +272,7 @@ class TestManagedClaudeSession:
         """Test resuming an existing session and forking."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [b""]  # Immediate EOF
@@ -299,7 +299,7 @@ class TestManagedClaudeSession:
         """Test process exit with error code and stderr output."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [b""]  # No stdout
@@ -327,7 +327,7 @@ class TestManagedClaudeSession:
         """Stderr is drained concurrently so stdout streaming is not blocked."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [
@@ -356,7 +356,7 @@ class TestManagedClaudeSession:
         """Known Claude diagnostics on stderr are not surfaced as task failures."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [
@@ -384,7 +384,7 @@ class TestManagedClaudeSession:
         """Benign stderr diagnostics are filtered without hiding real failures."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [b""]
@@ -412,7 +412,7 @@ class TestManagedClaudeSession:
         """A benign stderr line is not duplicated as the process failure reason."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [b""]
@@ -466,7 +466,7 @@ class TestManagedClaudeSession:
         """Test stopping the session process."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = MagicMock()
         mock_process.returncode = None  # Running
@@ -489,7 +489,7 @@ class TestManagedClaudeSession:
         """Test force kill if terminate times out."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = MagicMock()
         mock_process.returncode = None
@@ -519,7 +519,7 @@ class TestManagedClaudeSession:
         """Test handling of JSON split across chunks."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         # Split json: {"type": "mess... age"}
@@ -548,7 +548,7 @@ class TestManagedClaudeSession:
         """Test handling of buffer remnant at EOF (no newline at end)."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [
@@ -571,11 +571,10 @@ class TestManagedClaudeSession:
             assert events[0]["content"] == "Remnant"
 
     @pytest.mark.asyncio
-    async def test_start_task_non_v1_url(self):
-        """Test start_task with a non-v1 URL."""
+    async def test_start_task_targets_proxy_root(self):
+        """Test start_task passes the configured proxy root to Claude Code."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        # URL not ending in /v1
         session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
@@ -601,7 +600,7 @@ class TestManagedClaudeSession:
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
         session = ManagedClaudeSession(
-            "/tmp", "http://localhost:8082/v1", auth_token="proxy-token"
+            "/tmp", "http://localhost:8082", auth_token="proxy-token"
         )
 
         mock_process = AsyncMock()
@@ -630,9 +629,7 @@ class TestManagedClaudeSession:
         """Test start_task does not leak inherited Claude auth into proxy calls."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession(
-            "/tmp", "http://localhost:8082/v1", auth_token=""
-        )
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082", auth_token="")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [b""]
@@ -658,7 +655,7 @@ class TestManagedClaudeSession:
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
         session = ManagedClaudeSession(
-            "/tmp", "http://localhost:8082/v1", allowed_dirs=["/dir1", "/dir2"]
+            "/tmp", "http://localhost:8082", allowed_dirs=["/dir1", "/dir2"]
         )
 
         mock_process = AsyncMock()
@@ -685,7 +682,7 @@ class TestManagedClaudeSession:
 
         session = ManagedClaudeSession(
             "/tmp",
-            "http://localhost:8082/v1",
+            "http://localhost:8082",
             plans_directory="./agent_workspace/plans",
         )
 
@@ -713,7 +710,7 @@ class TestManagedClaudeSession:
         """Test handling of non-JSON output from free_claude_code.cli."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = AsyncMock()
         mock_process.stdout.read.side_effect = [b"Not valid json\n", b""]
@@ -735,7 +732,7 @@ class TestManagedClaudeSession:
         """Test exception handling during stop."""
         from free_claude_code.cli.managed.session import ManagedClaudeSession
 
-        session = ManagedClaudeSession("/tmp", "http://localhost:8082/v1")
+        session = ManagedClaudeSession("/tmp", "http://localhost:8082")
 
         mock_process = MagicMock()
         mock_process.returncode = None
@@ -760,7 +757,7 @@ class TestManagedClaudeSessionManager:
 
         manager = ManagedClaudeSessionManager(
             workspace_path="/tmp/test",
-            api_url="http://localhost:8082/v1",
+            proxy_root_url="http://localhost:8082",
         )
 
         session, sid, is_new = await manager.get_or_create_session()
@@ -775,7 +772,7 @@ class TestManagedClaudeSessionManager:
 
         manager = ManagedClaudeSessionManager(
             workspace_path="/tmp/test",
-            api_url="http://localhost:8082/v1",
+            proxy_root_url="http://localhost:8082",
         )
 
         # Create first session
@@ -794,7 +791,7 @@ class TestManagedClaudeSessionManager:
 
         manager = ManagedClaudeSessionManager(
             workspace_path="/tmp/test",
-            api_url="http://localhost:8082/v1",
+            proxy_root_url="http://localhost:8082",
         )
 
         stats = manager.get_stats()

--- a/tests/cli/test_cli_manager_edge_cases.py
+++ b/tests/cli/test_cli_manager_edge_cases.py
@@ -16,7 +16,9 @@ async def test_register_real_session_id_moves_pending_to_active_and_maps():
         mock_session_cls.return_value = mock_session
 
         manager = ManagedClaudeSessionManager(
-            workspace_path="/tmp", api_url="http://x/v1", auth_token="proxy-token"
+            workspace_path="/tmp",
+            proxy_root_url="http://x",
+            auth_token="proxy-token",
         )
         session, temp_id, is_new = await manager.get_or_create_session()
         assert session is mock_session
@@ -38,7 +40,9 @@ async def test_register_real_session_id_moves_pending_to_active_and_maps():
 async def test_register_real_session_id_missing_temp_id_returns_false():
     from free_claude_code.cli.managed.manager import ManagedClaudeSessionManager
 
-    manager = ManagedClaudeSessionManager(workspace_path="/tmp", api_url="http://x/v1")
+    manager = ManagedClaudeSessionManager(
+        workspace_path="/tmp", proxy_root_url="http://x"
+    )
     ok = await manager.register_real_session_id("missing", "real_1")
     assert ok is False
 
@@ -56,7 +60,7 @@ async def test_remove_session_pending_stops_and_returns_true():
         mock_session_cls.return_value = mock_session
 
         manager = ManagedClaudeSessionManager(
-            workspace_path="/tmp", api_url="http://x/v1"
+            workspace_path="/tmp", proxy_root_url="http://x"
         )
         _, temp_id, _ = await manager.get_or_create_session()
 
@@ -78,7 +82,7 @@ async def test_remove_session_active_removes_temp_mapping():
         mock_session_cls.return_value = mock_session
 
         manager = ManagedClaudeSessionManager(
-            workspace_path="/tmp", api_url="http://x/v1"
+            workspace_path="/tmp", proxy_root_url="http://x"
         )
         _, temp_id, _ = await manager.get_or_create_session()
         await manager.register_real_session_id(temp_id, "real_1")
@@ -96,7 +100,9 @@ async def test_remove_session_active_removes_temp_mapping():
 async def test_stop_all_reports_and_retains_stop_exceptions():
     from free_claude_code.cli.managed.manager import ManagedClaudeSessionManager
 
-    manager = ManagedClaudeSessionManager(workspace_path="/tmp", api_url="http://x/v1")
+    manager = ManagedClaudeSessionManager(
+        workspace_path="/tmp", proxy_root_url="http://x"
+    )
 
     s1 = MagicMock()
     s1.stop = AsyncMock(side_effect=RuntimeError("boom"))

--- a/tests/cli/test_cli_ownership.py
+++ b/tests/cli/test_cli_ownership.py
@@ -6,14 +6,14 @@ from free_claude_code.cli.managed.session import ManagedClaudeSession
 def test_cli_session_owns_typed_runner_config(tmp_path: Path) -> None:
     session = ManagedClaudeSession(
         workspace_path=str(tmp_path),
-        api_url="http://127.0.0.1:8082/v1",
+        proxy_root_url="http://127.0.0.1:8082",
         allowed_dirs=[str(tmp_path)],
         plans_directory=".plans",
         claude_bin="claude-test",
     )
 
     assert session.config.workspace_path == str(tmp_path)
-    assert session.config.api_url == "http://127.0.0.1:8082/v1"
+    assert session.config.proxy_root_url == "http://127.0.0.1:8082"
     assert session.config.allowed_dirs == [str(tmp_path)]
     assert session.config.plans_directory == ".plans"
     assert session.config.claude_bin == "claude-test"

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -449,13 +449,14 @@ def test_serve_handles_keyboard_interrupt_without_traceback() -> None:
 
 
 def test_claude_child_env_targets_current_proxy_config() -> None:
-    from free_claude_code.cli.launchers.claude import build_claude_launcher_env
+    from free_claude_code.cli.claude_env import build_claude_proxy_env
 
-    env = build_claude_launcher_env(
+    env = build_claude_proxy_env(
         proxy_root_url="http://127.0.0.1:9090",
         auth_token=" proxy-token ",
         base_env={
             "PATH": "keep",
+            "ANTHROPIC_API_URL": "https://api.anthropic.com/v1",
             "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
             "ANTHROPIC_AUTH_TOKEN": "old-token",
             "ANTHROPIC_API_KEY": "official-key",
@@ -469,13 +470,14 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
     assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert "ANTHROPIC_API_URL" not in env
     assert "ANTHROPIC_API_KEY" not in env
 
 
 def test_claude_child_env_uses_sentinel_for_blank_configured_auth_token() -> None:
-    from free_claude_code.cli.launchers.claude import build_claude_launcher_env
+    from free_claude_code.cli.claude_env import build_claude_proxy_env
 
-    env = build_claude_launcher_env(
+    env = build_claude_proxy_env(
         proxy_root_url="http://127.0.0.1:8082",
         auth_token="",
         base_env={

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -459,6 +459,7 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
             "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
             "ANTHROPIC_AUTH_TOKEN": "old-token",
             "ANTHROPIC_API_KEY": "official-key",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "0",
         },
     )
 
@@ -467,6 +468,7 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+    assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
     assert "ANTHROPIC_API_KEY" not in env
 
 
@@ -525,6 +527,7 @@ def test_launch_claude_passes_args_and_child_env(
     assert child_env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert child_env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert child_env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+    assert child_env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
     assert child_env["KEEP_ME"] == "yes"
     register_pid.assert_called_once_with(12345)
     unregister_pid.assert_called_once_with(12345)

--- a/tests/cli/test_managed_claude.py
+++ b/tests/cli/test_managed_claude.py
@@ -1,5 +1,6 @@
 import os
 
+from free_claude_code.cli.claude_env import build_claude_proxy_env
 from free_claude_code.cli.managed.claude import (
     MANAGED_CLAUDE_MODEL_TIER,
     ManagedClaudeConfig,
@@ -15,7 +16,7 @@ from free_claude_code.cli.managed.diagnostics import classify_managed_claude_std
 
 def _config(**overrides: object) -> ManagedClaudeConfig:
     workspace_path = overrides.get("workspace_path", os.path.normpath("/tmp/workspace"))
-    api_url = overrides.get("api_url", "http://localhost:8082/v1")
+    proxy_root_url = overrides.get("proxy_root_url", "http://localhost:8082")
     raw_allowed_dirs = overrides.get("allowed_dirs")
     allowed_dirs: list[str] = []
     if raw_allowed_dirs is not None:
@@ -28,13 +29,13 @@ def _config(**overrides: object) -> ManagedClaudeConfig:
     auth_token = overrides.get("auth_token", "proxy-token")
 
     assert isinstance(workspace_path, str)
-    assert isinstance(api_url, str)
+    assert isinstance(proxy_root_url, str)
     assert plans_directory is None or isinstance(plans_directory, str)
     assert isinstance(claude_bin, str)
     assert isinstance(auth_token, str)
     return ManagedClaudeConfig(
         workspace_path=workspace_path,
-        api_url=api_url,
+        proxy_root_url=proxy_root_url,
         allowed_dirs=allowed_dirs,
         plans_directory=plans_directory,
         claude_bin=claude_bin,
@@ -65,9 +66,12 @@ def test_managed_claude_builds_new_task_command_and_env() -> None:
     assert os.path.normpath("/tmp/extra") in invocation.argv
     assert "--settings" in invocation.argv
     assert invocation.env["PATH"] == "keep"
-    assert invocation.env["ANTHROPIC_API_URL"] == "http://localhost:8082/v1"
     assert invocation.env["ANTHROPIC_BASE_URL"] == "http://localhost:8082"
     assert invocation.env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
+    assert invocation.env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+    assert invocation.env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+    assert invocation.env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert "ANTHROPIC_API_URL" not in invocation.env
     assert "ANTHROPIC_API_KEY" not in invocation.env
     assert invocation.trace_metadata["client_cli_id"] == "claude"
     assert invocation.trace_metadata["claude_binary"] == "claude"
@@ -111,12 +115,38 @@ def test_managed_claude_builds_resume_and_fork_commands() -> None:
 
 def test_managed_claude_env_uses_sentinel_when_proxy_auth_blank() -> None:
     env = build_managed_claude_env(
-        api_url="http://localhost:8082/v1",
+        proxy_root_url="http://localhost:8082",
         auth_token="",
         base_env={"ANTHROPIC_AUTH_TOKEN": "stale"},
     )
 
     assert env["ANTHROPIC_AUTH_TOKEN"] == "fcc-no-auth"
+
+
+def test_managed_claude_env_only_adds_noninteractive_process_settings() -> None:
+    base_env = {
+        "PATH": "keep",
+        "ANTHROPIC_API_URL": "https://api.anthropic.com/v1",
+        "ANTHROPIC_API_KEY": "official-key",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "0",
+    }
+    proxy_env = build_claude_proxy_env(
+        proxy_root_url="http://localhost:8082",
+        auth_token="proxy-token",
+        base_env=base_env,
+    )
+
+    managed_env = build_managed_claude_env(
+        proxy_root_url="http://localhost:8082",
+        auth_token="proxy-token",
+        base_env=base_env,
+    )
+
+    assert managed_env == {
+        **proxy_env,
+        "TERM": "dumb",
+        "PYTHONIOENCODING": "utf-8",
+    }
 
 
 def test_managed_claude_stderr_classifier_filters_known_benign_notice() -> None:

--- a/tests/cli/test_managed_session_shutdown.py
+++ b/tests/cli/test_managed_session_shutdown.py
@@ -10,7 +10,7 @@ from free_claude_code.cli.managed.session import ManagedClaudeSession
 def _manager() -> ManagedClaudeSessionManager:
     return ManagedClaudeSessionManager(
         workspace_path="/tmp",
-        api_url="http://127.0.0.1:8082/v1",
+        proxy_root_url="http://127.0.0.1:8082",
     )
 
 
@@ -33,7 +33,7 @@ def _completed_process(pid: int) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_stop_is_idempotent_without_a_live_process() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
 
     assert await session.stop() is True
 
@@ -58,7 +58,7 @@ async def test_stop_is_idempotent_without_a_live_process() -> None:
 
 @pytest.mark.asyncio
 async def test_stopped_session_reference_cannot_launch_a_new_process() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
 
     assert await session.stop() is True
 
@@ -80,7 +80,7 @@ async def test_stopped_session_reference_cannot_launch_a_new_process() -> None:
 
 @pytest.mark.asyncio
 async def test_launch_publication_wins_before_concurrent_stop() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
     launch_entered = asyncio.Event()
     release_launch = asyncio.Event()
     release_stream = asyncio.Event()
@@ -137,7 +137,7 @@ async def test_launch_publication_wins_before_concurrent_stop() -> None:
 
 @pytest.mark.asyncio
 async def test_concurrent_stop_wins_before_launch_publication() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
     stop_entered = asyncio.Event()
     release_stop = asyncio.Event()
     process = MagicMock()
@@ -179,7 +179,7 @@ async def test_concurrent_stop_wins_before_launch_publication() -> None:
 
 @pytest.mark.asyncio
 async def test_normal_sequential_starts_remain_allowed_before_stop() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
     processes = [_completed_process(104), _completed_process(105)]
 
     with (
@@ -207,7 +207,7 @@ async def _collect_session_events(
 
 @pytest.mark.asyncio
 async def test_failed_stop_keeps_pid_registered_until_retry_confirms_exit() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
     process = MagicMock()
     process.pid = 202
     process.returncode = None
@@ -228,7 +228,7 @@ async def test_failed_stop_keeps_pid_registered_until_retry_confirms_exit() -> N
 
 @pytest.mark.asyncio
 async def test_cancelled_stop_keeps_pid_registered_and_can_be_retried() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
     process = MagicMock()
     process.pid = 303
     process.returncode = None
@@ -261,7 +261,7 @@ async def test_cancelled_stop_keeps_pid_registered_and_can_be_retried() -> None:
 
 @pytest.mark.asyncio
 async def test_task_failure_keeps_unconfirmed_process_pid_registered() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
     process = MagicMock()
     process.pid = 404
     process.returncode = None
@@ -286,7 +286,7 @@ async def test_task_failure_keeps_unconfirmed_process_pid_registered() -> None:
 
 @pytest.mark.asyncio
 async def test_completed_task_wait_unregisters_confirmed_process_pid() -> None:
-    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082/v1")
+    session = ManagedClaudeSession("/tmp", "http://127.0.0.1:8082")
     process = MagicMock()
     process.pid = 405
     process.returncode = None

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -912,7 +912,7 @@ async def test_composition_publishes_startup_notice_after_runtime_and_repair() -
         patch(
             "free_claude_code.runtime.application.cli_managed.ManagedClaudeSessionManager",
             return_value=cli_manager,
-        ),
+        ) as manager_constructor,
         patch("free_claude_code.runtime.application.messaging_session.SessionStore"),
         patch(
             "free_claude_code.runtime.application.messaging_workflow_module.MessagingWorkflow",
@@ -928,5 +928,9 @@ async def test_composition_publishes_startup_notice_after_runtime_and_repair() -
         "workflow.notice",
     ]
     workflow.publish_startup_notice.assert_awaited_once_with(notice)
+    assert manager_constructor.call_args.kwargs["proxy_root_url"] == (
+        "http://127.0.0.1:8082"
+    )
+    assert "api_url" not in manager_constructor.call_args.kwargs
 
     assert await runtime.close() is True

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.15"
+version = "3.5.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Claude proxy environment policy was duplicated between `fcc-claude`, managed messaging, and live smoke drivers. Managed messaging preserved a legacy endpoint variable, inherited more Anthropic state, and did not disable nonessential traffic, so FCC-launched Claude sessions could drift apart.

## Changes

| Before | After |
| --- | --- |
| `fcc-claude` and managed messaging assembled proxy environments independently. | One shared owner strips inherited Anthropic variables and configures proxy URL, auth, discovery, compaction, and nonessential-traffic policy. |
| Managed messaging carried a `/v1` API URL and converted it back to a proxy root while also setting a legacy endpoint variable. | Managed messaging receives the loopback-safe proxy root and uses the supported `ANTHROPIC_BASE_URL` contract directly. |
| Managed and interactive policy could diverge while smoke drivers duplicated both shapes. | `fcc-claude`, messaging, and Claude smoke drivers use the same canonical environment builder. |
| Managed execution concerns were mixed with shared proxy policy. | Messaging adds only noninteractive process settings and keeps `--model opus` plus stream-JSON flags in command construction. |
| IDE examples left nonessential Anthropic traffic enabled. | VS Code and JetBrains examples disable nonessential Anthropic traffic. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes Claude Code proxy environment setup for FCC-launched sessions. The main changes are:

- Adds one shared builder for Claude proxy environment variables.
- Routes managed messaging sessions through the same proxy policy as `fcc-claude`.
- Strips inherited `ANTHROPIC_*` state before launching Claude.
- Sets the nonessential-traffic disable flag for managed and interactive Claude launches.
- Updates smoke tests, docs, and version metadata for the new proxy-root URL shape.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. Managed Claude launches now use the shared environment builder, and the managed path now sets the nonessential-traffic disable flag.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The executable harness claude\_env\_policy\_harness.py was generated to enable direct module-level runtime proof without requiring a real Claude binary or live Anthropic credentials.
- A focused pytest run was executed, and it completed with 14 tests passing and exit code 0, validating the harness workflow.

<a href="https://app.greptile.com/trex/runs/14173386/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/claude_env.py | Adds the shared Claude proxy environment builder and canonical traffic-disable policy. |
| src/free_claude_code/cli/managed/claude.py | Delegates managed Claude environment construction to the shared proxy builder. |
| src/free_claude_code/runtime/application.py | Passes the loopback-safe proxy root into the managed Claude session manager. |
| src/free_claude_code/cli/managed/session.py | Renames managed session URL state to use the proxy-root contract. |
| src/free_claude_code/cli/managed/manager.py | Carries the proxy-root URL through manager-created managed sessions. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Keep README focused on client setup"](https://github.com/alishahryar1/free-claude-code/commit/83739a2f8953771ec9e447fc83a2057b08708891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43684511)</sub>

<!-- /greptile_comment -->