### PR TITLE
Make messaging commands easier to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,15 +341,17 @@ Configure integrations from **Admin UI → Messaging**, then click **Validate** 
 
 </details>
 
-Bot commands: standalone `/stop` cancels all work, standalone `/clear` resets all
-FCC state and removes every tracked message in that chat—including user prompts,
-voice notes, FCC replies, Telegram's online notice, and the clear command itself.
-`/stats` shows session state. Reply with `/stop` to cancel only that request while
-other queued requests continue. Reply with `/clear` to delete the selected message
-and its literal platform reply subtree while preserving its ancestors and siblings.
-A successful stop updates the affected task status instead of posting a second
-confirmation message. A no-op, or a global stop whose affected statuses are in
-another chat, still replies explicitly.
+### Messaging commands
+
+| Usage | Behavior |
+| --- | --- |
+| `/stats` | Show session state. |
+| Standalone `/stop` | Cancel all work. |
+| Reply with `/stop` | Cancel only the selected request while other queued requests continue. |
+| Standalone `/clear` | Reset all FCC state and remove every tracked message in that chat, including user prompts, voice notes, FCC replies, Telegram's online notice, and the clear command itself. |
+| Reply with `/clear` | Delete the selected message and its literal platform reply subtree while preserving its ancestors and siblings. |
+
+A successful stop updates the affected task status instead of posting a second confirmation. FCC still replies when there is nothing to stop or when a global stop affects statuses in another chat.
 
 <details>
 <summary><strong>Voice notes</strong></summary>

--- a/README.md
+++ b/README.md
@@ -351,8 +351,6 @@ Configure integrations from **Admin UI → Messaging**, then click **Validate** 
 | Standalone `/clear` | Reset all FCC state and remove every tracked message in that chat, including user prompts, voice notes, FCC replies, Telegram's online notice, and the clear command itself. |
 | Reply with `/clear` | Delete the selected message and its literal platform reply subtree while preserving its ancestors and siblings. |
 
-A successful stop updates the affected task status instead of posting a second confirmation. FCC still replies when there is nothing to stop or when a global stop affects statuses in another chat.
-
 <details>
 <summary><strong>Voice notes</strong></summary>
 


### PR DESCRIPTION
## Problem

Messaging commands were documented in one dense paragraph, making standalone and reply-scoped behavior difficult to compare.

## Changes

| Before | After |
| --- | --- |
| Command behavior was embedded in a long paragraph. | Command behavior is organized in a compact table. |
| Standalone and reply-scoped variants were mixed together. | Standalone and reply-scoped variants are listed separately. |
| Response implementation details extended the usage summary. | The section stays focused on customer-invoked commands. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the messaging command documentation easier to scan. The main changes are:

- Replaces the dense command paragraph with a compact table.
- Separates standalone and reply-scoped `/stop` and `/clear` behavior.
- Keeps the section focused on customer-invoked messaging commands.
</details>

<h3>Confidence Score: 5/5</h3>

The documentation change looks mergeable after restoring the omitted `/stop` feedback behavior.

No runtime code changed, and the only issue found is a user-facing docs gap for when `/stop` replies versus only updating status.

README.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the README Messaging Table validation using the helper script validate\_messaging\_table.py.
- T-Rex inspected the messaging table validation log and confirmed the extracted table lines, parsed rows, PASS result, and exit code 0.
- T-Rex reviewed the pytest collect-only log and verified that 2152 tests were collected in 1.76s with exit code 0.

<a href="https://app.greptile.com/trex/runs/14178430/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Reformats the messaging command docs into a table, with one omitted `/stop` feedback detail. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fstructure-messaging-commands%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fstructure-messaging-commands%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A349-350%0A**Stop%20Feedback%20Becomes%20Undocumented**%0A%0AThe%20new%20%60%2Fstop%60%20rows%20no%20longer%20explain%20that%20a%20same-chat%20successful%20stop%20updates%20the%20existing%20task%20status%20without%20posting%20a%20second%20reply%2C%20while%20no-op%20stops%20and%20cross-chat%20global%20stops%20still%20send%20an%20explicit%20message.%20Users%20following%20this%20table%20can%20treat%20the%20silent%20success%20path%20as%20an%20ignored%20command%20or%20miss%20why%20%60%2Fstop%60%20sometimes%20replies%20and%20sometimes%20only%20updates%20status.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1084&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Keep messaging command guide concise"](https://github.com/alishahryar1/free-claude-code/commit/b0f0d9d95678cf7523730be00a92c9b9031371b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43695232)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->