### PR TITLE
Make installers native, fail-fast, and verifiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Re-run the matching command from [Install Or Update](#install).
 
 ### Uninstall
 
-Stop every running FCC command first. The uninstall script removes the FCC uv tool and always deletes `~/.fcc/`; it does not remove uv, Python, Claude Code, or Codex.
+Stop every running FCC command first. The uninstaller removes the FCC uv tool, verifies every FCC command is gone, and then deletes `~/.fcc/`. It leaves uv, Python, Claude Code, Codex, and shared PATH entries intact.
 
 macOS/Linux:
 
@@ -411,7 +411,7 @@ curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main
 Windows PowerShell:
 
 ```powershell
-irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/uninstall.ps1" | iex
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/uninstall.ps1")))
 ```
 
 ## Project Links

--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ Run Claude Code or Codex with free, paid, or local models. Choose and validate p
 
 ### 1. Install Or Update
 
-The installer provisions Free Claude Code, uv, and Python 3.14. It also installs Claude Code and Codex when they are missing; install [Node.js](https://nodejs.org/) first so `npm` is available for those agents.
+The installer uses the official native installers for missing Claude Code, Codex, and uv, then installs Free Claude Code with uv-managed Python 3.14. Install [Git](https://git-scm.com/downloads) first because FCC is installed directly from this repository. Every step is verified, and the installer stops immediately if one fails.
 
 macOS/Linux:
 
 ```bash
-curl -fsSL "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh?raw=1" | sh
+curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.sh" | sh
 ```
 
 Windows PowerShell:
 
 ```powershell
-irm "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.ps1?raw=1" | iex
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1")))
 ```
 
 Re-run the same command whenever you want to update. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
@@ -360,32 +360,32 @@ macOS/Linux:
 
 ```bash
 # NVIDIA NIM transcription
-curl -fsSL "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh?raw=1" | sh -s -- --voice-nim
+curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.sh" | sh -s -- --voice-nim
 
 # Local Whisper on CPU or CUDA
-curl -fsSL "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh?raw=1" | sh -s -- --voice-local
+curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.sh" | sh -s -- --voice-local
 
 # Both backends
-curl -fsSL "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh?raw=1" | sh -s -- --voice-all
+curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.sh" | sh -s -- --voice-all
 
 # Local Whisper with the CUDA 13.0 PyTorch backend
-curl -fsSL "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.sh?raw=1" | sh -s -- --voice-local --torch-backend cu130
+curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.sh" | sh -s -- --voice-local --torch-backend cu130
 ```
 
 Windows PowerShell:
 
 ```powershell
 # NVIDIA NIM transcription
-& ([scriptblock]::Create((irm "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.ps1?raw=1"))) -VoiceNim
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1"))) -VoiceNim
 
 # Local Whisper on CPU or CUDA
-& ([scriptblock]::Create((irm "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.ps1?raw=1"))) -VoiceLocal
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1"))) -VoiceLocal
 
 # Both backends
-& ([scriptblock]::Create((irm "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.ps1?raw=1"))) -VoiceAll
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1"))) -VoiceAll
 
 # Local Whisper with the CUDA 13.0 PyTorch backend
-& ([scriptblock]::Create((irm "https://github.com/Alishahryar1/free-claude-code/blob/main/scripts/install.ps1?raw=1"))) -VoiceLocal -TorchBackend cu130
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1"))) -VoiceLocal -TorchBackend cu130
 ```
 
 Restart `fcc-server`. In **Admin UI → Messaging → Voice**, enable voice notes, select `cpu`, `cuda`, or `nvidia_nim`, and choose the Whisper model. Local gated models need `HUGGINGFACE_API_KEY`; NVIDIA NIM transcription needs `NVIDIA_NIM_API_KEY`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.17"
+version = "3.5.18"
 description = "Local proxy connecting Claude Code and Codex to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -112,6 +112,28 @@ function Get-ApplicationCommand {
     return $commands[0]
 }
 
+function Get-PowerShellExecutable {
+    param([string] $PowerShellHome = $PSHOME)
+
+    $executableName = if ($PSVersionTable.PSEdition -eq "Core") {
+        "pwsh.exe"
+    }
+    else {
+        "powershell.exe"
+    }
+    $bundledExecutable = Join-Path $PowerShellHome $executableName
+    if (Test-Path -LiteralPath $bundledExecutable -PathType Leaf) {
+        return $bundledExecutable
+    }
+
+    $pathCommand = Get-ApplicationCommand ([IO.Path]::GetFileNameWithoutExtension($executableName))
+    if ($pathCommand) {
+        return $pathCommand.Source
+    }
+
+    throw "Unable to locate a PowerShell executable for the downloaded installer."
+}
+
 function Add-PathEntry {
     param([string] $PathEntry)
 
@@ -174,10 +196,7 @@ function Invoke-DownloadedPowerShellInstaller {
             throw "The downloaded $Name installer was empty."
         }
 
-        $powerShellPath = (Get-Process -Id $PID).Path
-        if ([string]::IsNullOrWhiteSpace($powerShellPath)) {
-            throw "Unable to locate the current PowerShell executable."
-        }
+        $powerShellPath = Get-PowerShellExecutable
 
         $hadNonInteractive = Test-Path Env:CODEX_NON_INTERACTIVE
         $previousNonInteractive = $env:CODEX_NON_INTERACTIVE

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,17 +11,20 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
 $RepoGitUrl = "git+https://github.com/Alishahryar1/free-claude-code.git"
 $PythonVersion = "3.14.0"
 $MinUvVersion = "0.11.0"
+$ClaudeInstallUrl = "https://claude.ai/install.ps1"
+$CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $UvInstallUrl = "https://astral.sh/uv/install.ps1"
 
 function Show-Usage {
     @"
 Usage: install.ps1 [options]
 
-Installs Claude Code and Codex if missing, installs or updates uv, Python 3.14.0, and Free Claude Code.
+Installs Claude Code and Codex if missing, ensures a compatible uv, and installs or updates Free Claude Code.
 
 Options:
   -VoiceNim              Install NVIDIA NIM voice transcription support.
@@ -43,34 +46,70 @@ function Write-Step {
 function Format-Argument {
     param([string] $Value)
 
-    if ($Value -match '^[A-Za-z0-9_./:@%+=,\[\]-]+$') {
+    if ($Value -match '^[A-Za-z0-9_./:@%+=,\[\]\\-]+$') {
         return $Value
     }
 
     return "'" + ($Value -replace "'", "''") + "'"
 }
 
-function Invoke-InstallCommand {
+function Format-Command {
     param(
         [string] $FilePath,
         [string[]] $Arguments = @()
     )
 
     $parts = @($FilePath) + $Arguments
-    $commandText = ($parts | ForEach-Object { Format-Argument ([string] $_) }) -join " "
-    Write-Host "+ $commandText"
+    return ($parts | ForEach-Object { Format-Argument ([string] $_) }) -join " "
+}
 
-    if (-not $DryRun) {
-        & $FilePath @Arguments
+function Invoke-NativeCommand {
+    param(
+        [string] $FilePath,
+        [string[]] $Arguments = @()
+    )
+
+    $commandText = Format-Command -FilePath $FilePath -Arguments $Arguments
+    Write-Host "+ $commandText"
+    if ($DryRun) {
+        return
+    }
+
+    $global:LASTEXITCODE = 0
+    & $FilePath @Arguments
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "Command failed with exit code ${exitCode}: $commandText"
     }
 }
 
-function Invoke-UvInstaller {
-    Write-Host "+ irm $UvInstallUrl | iex"
+function Invoke-NativeCapture {
+    param(
+        [string] $FilePath,
+        [string[]] $Arguments = @()
+    )
 
-    if (-not $DryRun) {
-        Invoke-RestMethod $UvInstallUrl | Invoke-Expression
+    $commandText = Format-Command -FilePath $FilePath -Arguments $Arguments
+    Write-Host "+ $commandText"
+    $global:LASTEXITCODE = 0
+    $output = & $FilePath @Arguments
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "Command failed with exit code ${exitCode}: $commandText"
     }
+
+    return ($output | Out-String).Trim()
+}
+
+function Get-ApplicationCommand {
+    param([string] $Name)
+
+    $commands = @(Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue)
+    if ($commands.Count -eq 0) {
+        return $null
+    }
+
+    return $commands[0]
 }
 
 function Add-PathEntry {
@@ -91,44 +130,123 @@ function Add-PathEntry {
     }
 }
 
-function Add-UvToPath {
-    Add-PathEntry (Join-Path $HOME ".local\bin")
-    Add-PathEntry (Join-Path $HOME ".cargo\bin")
-}
-
-function Assert-CommandAvailable {
-    param([string] $Name)
-
-    if ((-not $DryRun) -and (-not (Get-Command $Name -ErrorAction SilentlyContinue))) {
-        throw "$Name is required. Install it first, then rerun this installer."
+function Add-KnownBinDirectories {
+    if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        Add-PathEntry (Join-Path $env:USERPROFILE ".local\bin")
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        Add-PathEntry (Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin")
     }
 }
 
-function Invoke-ProbeCommand {
+function Assert-Prerequisites {
+    if ($DryRun) {
+        Write-Host "+ git --version"
+        return
+    }
+
+    $gitCommand = Get-ApplicationCommand "git"
+    if (-not $gitCommand) {
+        throw "git is required to install Free Claude Code from GitHub. Install Git, then rerun this installer."
+    }
+    Invoke-NativeCommand -FilePath $gitCommand.Source -Arguments @("--version")
+}
+
+function Invoke-DownloadedPowerShellInstaller {
     param(
-        [string] $FilePath,
-        [string[]] $Arguments = @()
+        [string] $Url,
+        [string] $Name,
+        [switch] $NonInteractive
     )
 
-    $previousErrorActionPreference = $ErrorActionPreference
-    $ErrorActionPreference = "Continue"
-
-    try {
-        $output = & $FilePath @Arguments 2>$null
-        return [pscustomobject] @{
-            ExitCode = $LASTEXITCODE
-            Output = ($output | Out-String)
-        }
+    if ($DryRun) {
+        Write-Host "+ irm $Url -OutFile <temporary-script>"
+        $prefix = if ($NonInteractive) { "CODEX_NON_INTERACTIVE=1 " } else { "" }
+        Write-Host "+ ${prefix}powershell -NoProfile -ExecutionPolicy Bypass -File <temporary-script>"
+        return
     }
-    catch {
-        return [pscustomobject] @{
-            ExitCode = 1
-            Output = ""
+
+    $temporaryScript = Join-Path ([IO.Path]::GetTempPath()) ("fcc-install-" + [guid]::NewGuid().ToString("N") + ".ps1")
+    try {
+        Write-Host "+ irm $Url -OutFile $(Format-Argument $temporaryScript)"
+        Invoke-RestMethod -Uri $Url -OutFile $temporaryScript -ErrorAction Stop
+        if ((-not (Test-Path -LiteralPath $temporaryScript)) -or ((Get-Item -LiteralPath $temporaryScript).Length -eq 0)) {
+            throw "The downloaded $Name installer was empty."
+        }
+
+        $powerShellPath = (Get-Process -Id $PID).Path
+        if ([string]::IsNullOrWhiteSpace($powerShellPath)) {
+            throw "Unable to locate the current PowerShell executable."
+        }
+
+        $hadNonInteractive = Test-Path Env:CODEX_NON_INTERACTIVE
+        $previousNonInteractive = $env:CODEX_NON_INTERACTIVE
+        try {
+            if ($NonInteractive) {
+                $env:CODEX_NON_INTERACTIVE = "1"
+            }
+            Invoke-NativeCommand -FilePath $powerShellPath -Arguments @(
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                $temporaryScript
+            )
+        }
+        finally {
+            if ($hadNonInteractive) {
+                $env:CODEX_NON_INTERACTIVE = $previousNonInteractive
+            }
+            else {
+                Remove-Item Env:CODEX_NON_INTERACTIVE -ErrorAction SilentlyContinue
+            }
         }
     }
     finally {
-        $ErrorActionPreference = $previousErrorActionPreference
+        Remove-Item -LiteralPath $temporaryScript -Force -ErrorAction SilentlyContinue
     }
+}
+
+function Confirm-Application {
+    param(
+        [string] $CommandName,
+        [string] $DisplayName
+    )
+
+    if ($DryRun) {
+        Write-Host "+ $CommandName --version"
+        return
+    }
+
+    $command = Get-ApplicationCommand $CommandName
+    if (-not $command) {
+        throw "$DisplayName was installed, but '$CommandName' is not available on PATH."
+    }
+    Invoke-NativeCommand -FilePath $command.Source -Arguments @("--version")
+}
+
+function Ensure-ClaudeCode {
+    if (Get-ApplicationCommand "claude") {
+        Write-Host "Claude Code already found on PATH; verifying it."
+    }
+    else {
+        Invoke-DownloadedPowerShellInstaller -Url $ClaudeInstallUrl -Name "Claude Code"
+        Add-KnownBinDirectories
+    }
+
+    Confirm-Application -CommandName "claude" -DisplayName "Claude Code"
+}
+
+function Ensure-Codex {
+    if (Get-ApplicationCommand "codex") {
+        Write-Host "Codex already found on PATH; verifying it."
+    }
+    else {
+        Invoke-DownloadedPowerShellInstaller -Url $CodexInstallUrl -Name "Codex" -NonInteractive
+        Add-KnownBinDirectories
+    }
+
+    Confirm-Application -CommandName "codex" -DisplayName "Codex"
 }
 
 function Convert-UvVersionOutput {
@@ -145,23 +263,13 @@ function Convert-UvVersionOutput {
     return ""
 }
 
-function Get-InstalledUvVersion {
-    $version = ""
+function Get-UvVersion {
+    param([string] $UvPath)
 
-    $selfVersionProbe = Invoke-ProbeCommand -FilePath "uv" -Arguments @("self", "version", "--short")
-    if ($selfVersionProbe.ExitCode -eq 0) {
-        $version = Convert-UvVersionOutput $selfVersionProbe.Output
-    }
-
+    $output = Invoke-NativeCapture -FilePath $UvPath -Arguments @("--version")
+    $version = Convert-UvVersionOutput $output
     if ([string]::IsNullOrWhiteSpace($version)) {
-        $versionProbe = Invoke-ProbeCommand -FilePath "uv" -Arguments @("--version")
-        if ($versionProbe.ExitCode -eq 0) {
-            $version = Convert-UvVersionOutput $versionProbe.Output
-        }
-    }
-
-    if ([string]::IsNullOrWhiteSpace($version)) {
-        throw "Unable to determine uv version."
+        throw "uv is present, but 'uv --version' did not return a valid version."
     }
 
     return $version
@@ -173,172 +281,63 @@ function Test-UvVersionAtLeast {
         [string] $Minimum
     )
 
-    $normalizedVersion = Convert-UvVersionOutput $Version
-    $normalizedMinimum = Convert-UvVersionOutput $Minimum
+    $normalizedVersion = (Convert-UvVersionOutput $Version) -replace '[-+].*$', ''
+    $normalizedMinimum = (Convert-UvVersionOutput $Minimum) -replace '[-+].*$', ''
     if ([string]::IsNullOrWhiteSpace($normalizedVersion) -or [string]::IsNullOrWhiteSpace($normalizedMinimum)) {
         throw "Unable to compare uv versions."
     }
 
-    $normalizedVersion = $normalizedVersion -replace '[-+].*$', ''
-    $normalizedMinimum = $normalizedMinimum -replace '[-+].*$', ''
     return ([version] $normalizedVersion) -ge ([version] $normalizedMinimum)
 }
 
-function Test-UvVersionSatisfiesMinimum {
-    $version = Get-InstalledUvVersion
-    return Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion
-}
-
-function Assert-MinUvVersion {
+function Confirm-Uv {
     if ($DryRun) {
+        Write-Host "+ uv --version"
         return
     }
 
-    $version = Get-InstalledUvVersion
-    if (-not (Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion)) {
-        throw "uv $MinUvVersion or newer is required; found uv $version. Upgrade uv with its installer or package manager, then rerun this installer."
-    }
-}
-
-function Test-UvSelfUpdateSupported {
-    $probe = Invoke-ProbeCommand -FilePath "uv" -Arguments @("self", "update", "--dry-run")
-    return $probe.ExitCode -eq 0
-}
-
-function Test-UvInstalledByScoop {
-    if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
-        return $false
-    }
-
-    $probe = Invoke-ProbeCommand -FilePath "scoop" -Arguments @("list", "uv")
-    return ($probe.ExitCode -eq 0) -and ($probe.Output -match '(^|\s)uv(\s|$)')
-}
-
-function Test-UvInstalledByWinget {
-    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-        return $false
-    }
-
-    $probe = Invoke-ProbeCommand -FilePath "winget" -Arguments @("list", "--id", "astral-sh.uv", "-e")
-    return ($probe.ExitCode -eq 0) -and ($probe.Output -match 'astral-sh\.uv')
-}
-
-function Test-UvInstalledByPipx {
-    if (-not (Get-Command pipx -ErrorAction SilentlyContinue)) {
-        return $false
-    }
-
-    $probe = Invoke-ProbeCommand -FilePath "pipx" -Arguments @("list")
-    return ($probe.ExitCode -eq 0) -and ($probe.Output -match '(?m)\bpackage uv\b')
-}
-
-function Test-UvInstalledInActiveVirtualenv {
-    if ([string]::IsNullOrWhiteSpace($env:VIRTUAL_ENV)) {
-        return $false
-    }
-
-    $uvCommand = Get-Command uv -ErrorAction SilentlyContinue
+    $uvCommand = Get-ApplicationCommand "uv"
     if (-not $uvCommand) {
-        return $false
+        throw "uv was installed, but it is not available on PATH."
     }
 
-    $uvPath = [IO.Path]::GetFullPath($uvCommand.Source)
-    $venvPath = ([IO.Path]::GetFullPath($env:VIRTUAL_ENV)).TrimEnd(
-        [IO.Path]::DirectorySeparatorChar,
-        [IO.Path]::AltDirectorySeparatorChar
-    )
-    $nativePrefix = "$venvPath$([IO.Path]::DirectorySeparatorChar)"
-    $alternatePrefix = "$venvPath$([IO.Path]::AltDirectorySeparatorChar)"
-
-    return $uvPath.StartsWith($nativePrefix, [StringComparison]::OrdinalIgnoreCase) -or
-        $uvPath.StartsWith($alternatePrefix, [StringComparison]::OrdinalIgnoreCase)
+    $version = Get-UvVersion $uvCommand.Source
+    if (-not (Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion)) {
+        throw "uv $MinUvVersion or newer is required; found uv $version after installation."
+    }
+    Write-Host "Verified uv $version."
 }
 
-function Update-ExistingUv {
-    if (Test-UvSelfUpdateSupported) {
-        Invoke-InstallCommand -FilePath "uv" -Arguments @("self", "update")
+function Ensure-Uv {
+    if ($DryRun) {
+        if (Get-ApplicationCommand "uv") {
+            Write-Host "+ uv --version"
+            Write-Host "A compatible existing uv will be left unchanged; an obsolete one will be replaced by the standalone installer."
+        }
+        else {
+            Write-Host "uv is not installed; the current standalone uv would be installed."
+            Invoke-DownloadedPowerShellInstaller -Url $UvInstallUrl -Name "uv"
+            Confirm-Uv
+        }
         return
     }
 
-    if (Test-UvInstalledByScoop) {
-        Invoke-InstallCommand -FilePath "scoop" -Arguments @("update", "uv")
-        return
+    $uvCommand = Get-ApplicationCommand "uv"
+    if ($uvCommand) {
+        $version = Get-UvVersion $uvCommand.Source
+        if (Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion) {
+            Write-Host "uv $version already satisfies >=$MinUvVersion; leaving it unchanged."
+            return
+        }
+        Write-Host "uv $version is below $MinUvVersion; installing the current standalone uv."
+    }
+    else {
+        Write-Host "uv is not installed; installing the current standalone uv."
     }
 
-    if (Test-UvInstalledByWinget) {
-        Invoke-InstallCommand -FilePath "winget" -Arguments @(
-            "upgrade",
-            "--id",
-            "astral-sh.uv",
-            "-e",
-            "--accept-package-agreements",
-            "--accept-source-agreements"
-        )
-        return
-    }
-
-    if (Test-UvInstalledByPipx) {
-        Invoke-InstallCommand -FilePath "pipx" -Arguments @("upgrade", "uv")
-        return
-    }
-
-    if (Test-UvInstalledInActiveVirtualenv) {
-        Invoke-InstallCommand -FilePath "python" -Arguments @("-m", "pip", "install", "--upgrade", "uv")
-        return
-    }
-
-    if (Test-UvVersionSatisfiesMinimum) {
-        Write-Host "uv is already installed and satisfies >=$MinUvVersion; skipping automatic uv update because the install source was not detected."
-        return
-    }
-
-    $version = "unknown"
-    try {
-        $version = Get-InstalledUvVersion
-    }
-    catch {
-        $version = "unknown"
-    }
-    throw "uv $MinUvVersion or newer is required; found uv $version. The existing uv install source was not detected. Upgrade uv manually with the package manager that installed it, then rerun this installer."
-}
-
-function Install-ClaudeIfMissing {
-    if (Get-Command claude -ErrorAction SilentlyContinue) {
-        Write-Host "Claude Code already found on PATH; skipping install."
-        return
-    }
-
-    Assert-CommandAvailable "npm"
-    Invoke-InstallCommand -FilePath "npm" -Arguments @("install", "-g", "@anthropic-ai/claude-code")
-}
-
-function Install-CodexIfMissing {
-    if (Get-Command codex -ErrorAction SilentlyContinue) {
-        Write-Host "Codex already found on PATH; skipping install."
-        return
-    }
-
-    Assert-CommandAvailable "npm"
-    Invoke-InstallCommand -FilePath "npm" -Arguments @("install", "-g", "@openai/codex")
-}
-
-function Install-OrUpdateUv {
-    Add-UvToPath
-
-    if (Get-Command uv -ErrorAction SilentlyContinue) {
-        Update-ExistingUv
-        Assert-MinUvVersion
-        return
-    }
-
-    Invoke-UvInstaller
-    Add-UvToPath
-
-    if ((-not $DryRun) -and (-not (Get-Command uv -ErrorAction SilentlyContinue))) {
-        throw "uv was installed, but it is not available on PATH. Open a new terminal or add uv's bin directory to PATH."
-    }
-
-    Assert-MinUvVersion
+    Invoke-DownloadedPowerShellInstaller -Url $UvInstallUrl -Name "uv"
+    Add-KnownBinDirectories
+    Confirm-Uv
 }
 
 function Get-PackageSpec {
@@ -350,35 +349,78 @@ function Get-PackageSpec {
         $includeLocal = $true
     }
 
-    if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not $includeLocal)) {
-        throw "-TorchBackend requires -VoiceLocal or -VoiceAll."
-    }
-
     if ($includeNim -and $includeLocal) {
         return "free-claude-code[voice,voice_local] @ $RepoGitUrl"
     }
-
     if ($includeNim) {
         return "free-claude-code[voice] @ $RepoGitUrl"
     }
-
     if ($includeLocal) {
         return "free-claude-code[voice_local] @ $RepoGitUrl"
     }
-
     return $RepoGitUrl
 }
 
 function Install-FreeClaudeCode {
     $packageSpec = Get-PackageSpec
-    $toolArgs = @("tool", "install", "--force")
-
+    $arguments = @("tool", "install", "--force", "--python", $PythonVersion)
     if (-not [string]::IsNullOrWhiteSpace($TorchBackend)) {
-        $toolArgs += @("--torch-backend", $TorchBackend)
+        $arguments += @("--torch-backend", $TorchBackend)
+    }
+    $arguments += $packageSpec
+
+    $uvPath = "uv"
+    if (-not $DryRun) {
+        $uvCommand = Get-ApplicationCommand "uv"
+        if (-not $uvCommand) {
+            throw "uv is not available for the Free Claude Code installation."
+        }
+        $uvPath = $uvCommand.Source
+    }
+    Invoke-NativeCommand -FilePath $uvPath -Arguments $arguments
+}
+
+function Configure-AndConfirmFreeClaudeCode {
+    if ($DryRun) {
+        Write-Host "+ uv tool update-shell"
+        Write-Host "+ uv tool dir --bin"
+        Write-Host "+ verify fcc-server, fcc-claude, and fcc-codex in the uv tool bin directory"
+        Write-Host "+ fcc-server --version"
+        return
     }
 
-    $toolArgs += $packageSpec
-    Invoke-InstallCommand -FilePath "uv" -Arguments $toolArgs
+    $uvCommand = Get-ApplicationCommand "uv"
+    if (-not $uvCommand) {
+        throw "uv is not available for PATH configuration."
+    }
+    Invoke-NativeCommand -FilePath $uvCommand.Source -Arguments @("tool", "update-shell")
+    $toolBin = Invoke-NativeCapture -FilePath $uvCommand.Source -Arguments @("tool", "dir", "--bin")
+    if ([string]::IsNullOrWhiteSpace($toolBin)) {
+        throw "uv returned an empty tool bin directory."
+    }
+
+    Add-PathEntry $toolBin
+    $toolBinPath = ([IO.Path]::GetFullPath($toolBin)).TrimEnd(
+        [IO.Path]::DirectorySeparatorChar,
+        [IO.Path]::AltDirectorySeparatorChar
+    )
+    $installedCommands = @{}
+    foreach ($commandName in @("fcc-server", "fcc-claude", "fcc-codex")) {
+        $command = Get-ApplicationCommand $commandName
+        if (-not $command) {
+            throw "Free Claude Code installation did not create '$commandName'."
+        }
+        $commandDirectory = ([IO.Path]::GetFullPath((Split-Path -Parent $command.Source))).TrimEnd(
+            [IO.Path]::DirectorySeparatorChar,
+            [IO.Path]::AltDirectorySeparatorChar
+        )
+        if (-not $commandDirectory.Equals($toolBinPath, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "'$commandName' resolved outside the uv tool bin directory: $($command.Source)"
+        }
+        $installedCommands[$commandName] = $command.Source
+    }
+
+    Invoke-NativeCommand -FilePath $installedCommands["fcc-server"] -Arguments @("--version")
 }
 
 if ($Help) {
@@ -395,22 +437,32 @@ if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not ($VoiceLocal -
     throw "-TorchBackend requires -VoiceLocal or -VoiceAll."
 }
 
-Write-Step "Installing Claude Code if missing"
-Install-ClaudeIfMissing
+Add-KnownBinDirectories
 
-Write-Step "Installing Codex if missing"
-Install-CodexIfMissing
+Write-Step "Checking installation prerequisites"
+Assert-Prerequisites
 
-Write-Step "Installing uv if missing, updating if present"
-Install-OrUpdateUv
+Write-Step "Ensuring Claude Code is installed"
+Ensure-ClaudeCode
 
-Write-Step "Installing Python $PythonVersion"
-Invoke-InstallCommand -FilePath "uv" -Arguments @("python", "install", $PythonVersion)
+Write-Step "Ensuring Codex is installed"
+Ensure-Codex
+
+Write-Step "Ensuring uv $MinUvVersion or newer is installed"
+Ensure-Uv
 
 Write-Step "Installing or updating Free Claude Code"
 Install-FreeClaudeCode
 
+Write-Step "Configuring PATH and verifying Free Claude Code"
+Configure-AndConfirmFreeClaudeCode
+
 Write-Host ""
-Write-Host "Free Claude Code is installed. Start the proxy with: fcc-server"
-Write-Host "Run Claude Code with: fcc-claude"
-Write-Host "Run Codex with: fcc-codex"
+if ($DryRun) {
+    Write-Host "Dry run complete. No changes were made."
+}
+else {
+    Write-Host "Free Claude Code is installed and verified. Start the proxy with: fcc-server"
+    Write-Host "Run Claude Code with: fcc-claude"
+    Write-Host "Run Codex with: fcc-codex"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,8 @@ set -eu
 REPO_GIT_URL="git+https://github.com/Alishahryar1/free-claude-code.git"
 PYTHON_VERSION="3.14.0"
 MIN_UV_VERSION="0.11.0"
+CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
+CODEX_INSTALL_URL="https://chatgpt.com/codex/install.sh"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 
 dry_run=0
@@ -11,12 +13,13 @@ voice_nim=0
 voice_local=0
 voice_all=0
 torch_backend=""
+temporary_script=""
 
 show_usage() {
     cat <<'USAGE'
 Usage: install.sh [options]
 
-Installs Claude Code and Codex if missing, installs or updates uv, Python 3.14.0, and Free Claude Code.
+Installs Claude Code and Codex if missing, ensures a compatible uv, and installs or updates Free Claude Code.
 
 Options:
   --voice-nim              Install NVIDIA NIM voice transcription support.
@@ -60,18 +63,28 @@ print_command() {
 
 run() {
     print_command "$@"
-    if [ "$dry_run" -eq 0 ]; then
-        "$@"
+    if [ "$dry_run" -eq 1 ]; then
+        return 0
+    fi
+
+    if "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+
+    fail "Command failed with exit code $status: $1"
+}
+
+cleanup() {
+    if [ -n "$temporary_script" ] && [ -e "$temporary_script" ]; then
+        rm -f "$temporary_script"
     fi
 }
 
-run_uv_installer() {
-    printf '+ curl -LsSf %s | sh\n' "$UV_INSTALL_URL"
-    if [ "$dry_run" -eq 0 ]; then
-        command -v curl >/dev/null 2>&1 || fail "curl is required to install uv."
-        curl -LsSf "$UV_INSTALL_URL" | sh
-    fi
-}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' HUP TERM
 
 add_path_entry() {
     [ -n "$1" ] || return 0
@@ -81,7 +94,7 @@ add_path_entry() {
     esac
 }
 
-add_uv_to_path() {
+add_known_bin_directories() {
     if [ -n "${XDG_BIN_HOME:-}" ]; then
         add_path_entry "$XDG_BIN_HOME"
     fi
@@ -92,6 +105,7 @@ add_uv_to_path() {
     fi
 
     export PATH
+    hash -r 2>/dev/null || true
 }
 
 require_command() {
@@ -100,14 +114,115 @@ require_command() {
     fi
 }
 
-current_uv_version() {
-    version=$(uv self version --short 2>/dev/null || true)
-    if [ -z "$version" ]; then
-        version=$(uv --version 2>/dev/null | sed 's/^uv //; s/ .*//' || true)
+download_and_run() {
+    url=$1
+    interpreter=$2
+    label=$3
+    non_interactive=${4:-0}
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command curl -fsSL "$url" -o "<temporary-script>"
+        if [ "$non_interactive" -eq 1 ]; then
+            printf '+ CODEX_NON_INTERACTIVE=1 '
+            quote_arg "$interpreter"
+            printf ' <temporary-script>\n'
+        else
+            print_command "$interpreter" "<temporary-script>"
+        fi
+        return 0
     fi
 
-    [ -n "$version" ] || return 1
-    printf '%s\n' "$version"
+    temporary_script=$(mktemp "${TMPDIR:-/tmp}/fcc-install.XXXXXX") || fail "Unable to create a temporary file for $label."
+    print_command curl -fsSL "$url" -o "$temporary_script"
+    if curl -fsSL "$url" -o "$temporary_script"; then
+        :
+    else
+        status=$?
+        fail "Could not download the $label installer (curl exit code $status)."
+    fi
+
+    if [ ! -s "$temporary_script" ]; then
+        fail "The downloaded $label installer was empty."
+    fi
+
+    if [ "$non_interactive" -eq 1 ]; then
+        printf '+ CODEX_NON_INTERACTIVE=1 '
+        quote_arg "$interpreter"
+        printf ' '
+        quote_arg "$temporary_script"
+        printf '\n'
+        if CODEX_NON_INTERACTIVE=1 "$interpreter" "$temporary_script"; then
+            :
+        else
+            status=$?
+            fail "$label installation failed with exit code $status."
+        fi
+    else
+        print_command "$interpreter" "$temporary_script"
+        if "$interpreter" "$temporary_script"; then
+            :
+        else
+            status=$?
+            fail "$label installation failed with exit code $status."
+        fi
+    fi
+
+    rm -f "$temporary_script"
+    temporary_script=""
+}
+
+verify_command() {
+    command_name=$1
+    display_name=$2
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command "$command_name" --version
+        return 0
+    fi
+
+    command_path=$(command -v "$command_name" 2>/dev/null) || fail "$display_name was installed, but '$command_name' is not available on PATH."
+    run "$command_path" --version
+}
+
+ensure_claude() {
+    if command -v claude >/dev/null 2>&1; then
+        printf 'Claude Code already found on PATH; verifying it.\n'
+    else
+        download_and_run "$CLAUDE_INSTALL_URL" bash "Claude Code"
+        add_known_bin_directories
+    fi
+
+    verify_command claude "Claude Code"
+}
+
+ensure_codex() {
+    if command -v codex >/dev/null 2>&1; then
+        printf 'Codex already found on PATH; verifying it.\n'
+    else
+        download_and_run "$CODEX_INSTALL_URL" sh "Codex" 1
+        add_known_bin_directories
+    fi
+
+    verify_command codex "Codex"
+}
+
+current_uv_version() {
+    if output=$(uv --version); then
+        :
+    else
+        return 1
+    fi
+
+    case "$output" in
+        uv\ *) version=${output#uv } ;;
+        *) version=$output ;;
+    esac
+    version=${version%% *}
+
+    case "$version" in
+        [0-9]*.[0-9]*.[0-9]*) printf '%s\n' "$version" ;;
+        *) return 1 ;;
+    esac
 }
 
 version_ge() {
@@ -126,6 +241,10 @@ version_ge() {
     minimum_patch=${3:-0}
     IFS=$old_ifs
 
+    case "$current_major$current_minor$current_patch$minimum_major$minimum_minor$minimum_patch" in
+        *[!0-9]*) return 1 ;;
+    esac
+
     [ "$current_major" -gt "$minimum_major" ] && return 0
     [ "$current_major" -lt "$minimum_major" ] && return 1
     [ "$current_minor" -gt "$minimum_minor" ] && return 0
@@ -133,109 +252,48 @@ version_ge() {
     [ "$current_patch" -ge "$minimum_patch" ]
 }
 
-uv_version_satisfies_minimum() {
-    version=$(current_uv_version) || return 1
-    version_ge "$version" "$MIN_UV_VERSION"
-}
+verify_uv() {
+    if [ "$dry_run" -eq 1 ]; then
+        print_command uv --version
+        return 0
+    fi
 
-validate_uv_version() {
-    [ "$dry_run" -eq 1 ] && return 0
-
-    version=$(current_uv_version) || fail "Unable to determine uv version."
+    command -v uv >/dev/null 2>&1 || fail "uv was installed, but it is not available on PATH."
+    version=$(current_uv_version) || fail "uv is present, but 'uv --version' did not return a valid version."
     if ! version_ge "$version" "$MIN_UV_VERSION"; then
-        fail "uv $MIN_UV_VERSION or newer is required; found uv $version. Upgrade uv with its installer or package manager, then rerun this installer."
+        fail "uv $MIN_UV_VERSION or newer is required; found uv $version after installation."
     fi
+
+    printf 'Verified uv %s.\n' "$version"
 }
 
-uv_self_update_supported() {
-    uv self update --dry-run >/dev/null 2>&1
-}
-
-uv_installed_by_homebrew() {
-    command -v brew >/dev/null 2>&1 && brew list --versions uv >/dev/null 2>&1
-}
-
-uv_installed_by_pipx() {
-    command -v pipx >/dev/null 2>&1 && pipx list 2>/dev/null | grep -Eq '(^|[[:space:]])package uv([[:space:]]|$)'
-}
-
-uv_installed_in_active_virtualenv() {
-    [ -n "${VIRTUAL_ENV:-}" ] || return 1
-
-    uv_path=$(command -v uv)
-    case "$uv_path" in
-        "$VIRTUAL_ENV"/*) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-update_existing_uv() {
-    if uv_self_update_supported; then
-        run uv self update
+ensure_uv() {
+    if [ "$dry_run" -eq 1 ]; then
+        if command -v uv >/dev/null 2>&1; then
+            print_command uv --version
+            printf 'A compatible existing uv will be left unchanged; an obsolete one will be replaced by the standalone installer.\n'
+        else
+            printf 'uv is not installed; the current standalone uv would be installed.\n'
+            download_and_run "$UV_INSTALL_URL" sh "uv"
+            verify_uv
+        fi
         return 0
     fi
-
-    if uv_installed_by_homebrew; then
-        run brew upgrade uv
-        return 0
-    fi
-
-    if uv_installed_by_pipx; then
-        run pipx upgrade uv
-        return 0
-    fi
-
-    if uv_installed_in_active_virtualenv; then
-        run python -m pip install --upgrade uv
-        return 0
-    fi
-
-    if uv_version_satisfies_minimum; then
-        printf 'uv is already installed and satisfies >=%s; skipping automatic uv update because the install source was not detected.\n' "$MIN_UV_VERSION"
-        return 0
-    fi
-
-    version=$(current_uv_version 2>/dev/null || printf 'unknown')
-    fail "uv $MIN_UV_VERSION or newer is required; found uv $version. The existing uv install source was not detected. Upgrade uv manually with the package manager that installed it, then rerun this installer."
-}
-
-install_claude_if_missing() {
-    if command -v claude >/dev/null 2>&1; then
-        printf 'Claude Code already found on PATH; skipping install.\n'
-        return 0
-    fi
-
-    require_command npm
-    run npm install -g @anthropic-ai/claude-code
-}
-
-install_codex_if_missing() {
-    if command -v codex >/dev/null 2>&1; then
-        printf 'Codex already found on PATH; skipping install.\n'
-        return 0
-    fi
-
-    require_command npm
-    run npm install -g @openai/codex
-}
-
-install_or_update_uv() {
-    add_uv_to_path
 
     if command -v uv >/dev/null 2>&1; then
-        update_existing_uv
-        validate_uv_version
-        return 0
+        version=$(current_uv_version) || fail "uv is present, but 'uv --version' did not return a valid version."
+        if version_ge "$version" "$MIN_UV_VERSION"; then
+            printf 'uv %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_UV_VERSION"
+            return 0
+        fi
+        printf 'uv %s is below %s; installing the current standalone uv.\n' "$version" "$MIN_UV_VERSION"
+    else
+        printf 'uv is not installed; installing the current standalone uv.\n'
     fi
 
-    run_uv_installer
-    add_uv_to_path
-
-    if [ "$dry_run" -eq 0 ] && ! command -v uv >/dev/null 2>&1; then
-        fail "uv was installed, but it is not available on PATH. Open a new terminal or add uv's bin directory to PATH."
-    fi
-
-    validate_uv_version
+    download_and_run "$UV_INSTALL_URL" sh "uv"
+    add_known_bin_directories
+    verify_uv
 }
 
 parse_args() {
@@ -253,11 +311,11 @@ parse_args() {
             --torch-backend)
                 shift
                 [ "$#" -gt 0 ] || fail "--torch-backend requires a value."
-                torch_backend="$1"
+                torch_backend=$1
                 [ -n "$torch_backend" ] || fail "--torch-backend requires a non-empty value."
                 ;;
             --torch-backend=*)
-                torch_backend="${1#*=}"
+                torch_backend=${1#*=}
                 [ -n "$torch_backend" ] || fail "--torch-backend requires a non-empty value."
                 ;;
             --dry-run)
@@ -278,7 +336,6 @@ parse_args() {
 
 validate_args() {
     include_local=$voice_local
-
     if [ "$voice_all" -eq 1 ]; then
         include_local=1
     fi
@@ -297,10 +354,6 @@ package_spec() {
         include_local=1
     fi
 
-    if [ -n "$torch_backend" ] && [ "$include_local" -ne 1 ]; then
-        fail "--torch-backend requires --voice-local or --voice-all."
-    fi
-
     if [ "$include_nim" -eq 1 ] && [ "$include_local" -eq 1 ]; then
         printf 'free-claude-code[voice,voice_local] @ %s' "$REPO_GIT_URL"
     elif [ "$include_nim" -eq 1 ]; then
@@ -316,30 +369,73 @@ install_free_claude_code() {
     spec=$(package_spec)
 
     if [ -n "$torch_backend" ]; then
-        run uv tool install --force --torch-backend "$torch_backend" "$spec"
+        run uv tool install --force --python "$PYTHON_VERSION" --torch-backend "$torch_backend" "$spec"
     else
-        run uv tool install --force "$spec"
+        run uv tool install --force --python "$PYTHON_VERSION" "$spec"
     fi
+}
+
+configure_and_verify_free_claude_code() {
+    run uv tool update-shell
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command uv tool dir --bin
+        printf '+ verify fcc-server, fcc-claude, and fcc-codex in the uv tool bin directory\n'
+        print_command fcc-server --version
+        return 0
+    fi
+
+    print_command uv tool dir --bin
+    if tool_bin=$(uv tool dir --bin); then
+        :
+    else
+        status=$?
+        fail "Could not determine the uv tool bin directory (exit code $status)."
+    fi
+    [ -n "$tool_bin" ] || fail "uv returned an empty tool bin directory."
+
+    add_path_entry "$tool_bin"
+    export PATH
+    hash -r 2>/dev/null || true
+
+    for command_name in fcc-server fcc-claude fcc-codex; do
+        [ -x "$tool_bin/$command_name" ] || fail "Free Claude Code installation did not create $tool_bin/$command_name."
+    done
+
+    run "$tool_bin/fcc-server" --version
 }
 
 parse_args "$@"
 validate_args
+add_known_bin_directories
 
-step "Installing Claude Code if missing"
-install_claude_if_missing
+step "Checking installation prerequisites"
+require_command curl
+require_command bash
+require_command sh
+require_command mktemp
+require_command git
+run git --version
 
-step "Installing Codex if missing"
-install_codex_if_missing
+step "Ensuring Claude Code is installed"
+ensure_claude
 
-step "Installing uv if missing, updating if present"
-install_or_update_uv
+step "Ensuring Codex is installed"
+ensure_codex
 
-step "Installing Python $PYTHON_VERSION"
-run uv python install "$PYTHON_VERSION"
+step "Ensuring uv $MIN_UV_VERSION or newer is installed"
+ensure_uv
 
 step "Installing or updating Free Claude Code"
 install_free_claude_code
 
-printf '\nFree Claude Code is installed. Start the proxy with: fcc-server\n'
-printf 'Run Claude Code with: fcc-claude\n'
-printf 'Run Codex with: fcc-codex\n'
+step "Configuring PATH and verifying Free Claude Code"
+configure_and_verify_free_claude_code
+
+if [ "$dry_run" -eq 1 ]; then
+    printf '\nDry run complete. No changes were made.\n'
+else
+    printf '\nFree Claude Code is installed and verified. Start the proxy with: fcc-server\n'
+    printf 'Run Claude Code with: fcc-claude\n'
+    printf 'Run Codex with: fcc-codex\n'
+fi

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -17,13 +17,15 @@ $FccCommands = @(
     "fcc-init",
     "free-claude-code"
 )
+$script:UvPath = ""
+$script:UvToolBin = ""
 
 function Show-Usage {
     @"
 Usage: uninstall.ps1 [options]
 
-Removes the Free Claude Code uv tool and deletes ~/.fcc/.
-Does not remove uv, Claude Code, Codex, or the uv-managed Python runtime.
+Removes the Free Claude Code uv tool and deletes ~/.fcc/ after removal is verified.
+Does not remove uv, Claude Code, Codex, the uv-managed Python runtime, or shared PATH entries.
 
 Options:
   -DryRun                Print commands without running them.
@@ -41,22 +43,58 @@ function Write-Step {
 function Format-Argument {
     param([string] $Value)
 
-    if ($Value -match '^[A-Za-z0-9_./:@%+=,\[\]-]+$') {
+    if ($Value -match '^[A-Za-z0-9_./:@%+=,\[\]\\-]+$') {
         return $Value
     }
-
     return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function Format-Command {
+    param(
+        [string] $FilePath,
+        [string[]] $Arguments = @()
+    )
+
+    $parts = @($FilePath) + $Arguments
+    return ($parts | ForEach-Object { Format-Argument ([string] $_) }) -join " "
+}
+
+function Get-ApplicationCommand {
+    param([string] $Name)
+
+    $commands = @(Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue)
+    if ($commands.Count -eq 0) {
+        return $null
+    }
+    return $commands[0]
+}
+
+function Invoke-NativeResult {
+    param(
+        [string] $FilePath,
+        [string[]] $Arguments
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $global:LASTEXITCODE = 0
+        $output = (& $FilePath @Arguments 2>&1 | Out-String).Trim()
+        return [pscustomobject] @{
+            ExitCode = $LASTEXITCODE
+            Output = $output
+        }
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
 }
 
 function Test-MissingUvToolError {
     param([string] $Output)
 
     $normalized = $Output.ToLowerInvariant()
-    return (
-        $normalized.Contains("not installed") -or
-        $normalized.Contains("no tool") -or
-        $normalized.Contains("nothing to uninstall")
-    )
+    return $normalized.Contains($PackageName) -and $normalized.Contains("is not installed")
 }
 
 function Add-PathEntry {
@@ -65,73 +103,113 @@ function Add-PathEntry {
     if ([string]::IsNullOrWhiteSpace($PathEntry)) {
         return
     }
-
     $separator = [IO.Path]::PathSeparator
     $entries = @()
     if (-not [string]::IsNullOrEmpty($env:Path)) {
         $entries = $env:Path -split [regex]::Escape([string] $separator)
     }
-
     if ($entries -notcontains $PathEntry) {
         $env:Path = "$PathEntry$separator$env:Path"
     }
 }
 
-function Add-UvToPath {
-    Add-PathEntry (Join-Path $HOME ".local\bin")
-    Add-PathEntry (Join-Path $HOME ".cargo\bin")
+function Add-KnownUvPaths {
+    Add-PathEntry (Join-Path $env:USERPROFILE ".local\bin")
+    Add-PathEntry (Join-Path $env:USERPROFILE ".cargo\bin")
 }
 
 function Assert-NoFccProcessesRunning {
     $running = @()
-
     foreach ($commandName in $FccCommands) {
         $processes = @(Get-Process -Name $commandName -ErrorAction SilentlyContinue)
         if ($processes.Count -gt 0) {
             $running += $commandName
         }
     }
-
     if ($running.Count -gt 0) {
         throw "Free Claude Code is still running ($($running -join ', ')). Stop those processes, then rerun uninstall."
     }
 }
 
-function Uninstall-FreeClaudeCode {
-    Add-UvToPath
+function Initialize-UvContext {
+    Add-KnownUvPaths
 
-    if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-        Write-Host "uv not found on PATH; skipping uv tool uninstall."
+    if ($DryRun) {
+        Write-Host "+ uv tool dir --bin"
         return
     }
 
+    $uvCommand = Get-ApplicationCommand "uv"
+    if (-not $uvCommand) {
+        throw "uv is required to remove the Free Claude Code tool. Install uv, then rerun this uninstaller; ~/.fcc was not deleted."
+    }
+    $script:UvPath = $uvCommand.Source
+
+    $commandText = Format-Command -FilePath $script:UvPath -Arguments @("tool", "dir", "--bin")
+    Write-Host "+ $commandText"
+    $result = Invoke-NativeResult -FilePath $script:UvPath -Arguments @("tool", "dir", "--bin")
+    if ($result.ExitCode -ne 0) {
+        if (-not [string]::IsNullOrWhiteSpace($result.Output)) {
+            [Console]::Error.WriteLine($result.Output)
+        }
+        throw "Could not determine the uv tool bin directory (exit code $($result.ExitCode)); ~/.fcc was not deleted."
+    }
+    $script:UvToolBin = $result.Output.Trim()
+    if ([string]::IsNullOrWhiteSpace($script:UvToolBin)) {
+        throw "uv returned an empty tool bin directory; ~/.fcc was not deleted."
+    }
+}
+
+function Uninstall-FreeClaudeCode {
     Write-Host "+ uv tool uninstall $PackageName"
-    if (-not $DryRun) {
-        $previousErrorActionPreference = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        try {
-            $output = (& uv tool uninstall $PackageName 2>&1 | Out-String).Trim()
-            $exitCode = $LASTEXITCODE
-            if ($exitCode -eq 0) {
-                return
-            }
-            if (Test-MissingUvToolError -Output $output) {
-                Write-Host "Free Claude Code uv tool not installed or already removed; skipping uv tool uninstall."
-                return
-            }
-            if (-not [string]::IsNullOrWhiteSpace($output)) {
-                [Console]::Error.WriteLine($output)
-            }
-            throw "uv tool uninstall $PackageName failed with exit code $exitCode; aborting before deleting ~/.fcc."
+    if ($DryRun) {
+        return
+    }
+
+    $result = Invoke-NativeResult -FilePath $script:UvPath -Arguments @(
+        "tool",
+        "uninstall",
+        $PackageName
+    )
+    if ($result.ExitCode -eq 0) {
+        if (-not [string]::IsNullOrWhiteSpace($result.Output)) {
+            Write-Host $result.Output
         }
-        finally {
-            $ErrorActionPreference = $previousErrorActionPreference
+        return
+    }
+    if (Test-MissingUvToolError -Output $result.Output) {
+        Write-Host "Free Claude Code uv tool is already absent; verifying its entry points."
+        return
+    }
+    if (-not [string]::IsNullOrWhiteSpace($result.Output)) {
+        [Console]::Error.WriteLine($result.Output)
+    }
+    throw "uv tool uninstall $PackageName failed with exit code $($result.ExitCode); ~/.fcc was not deleted."
+}
+
+function Confirm-FccCommandsRemoved {
+    if ($DryRun) {
+        Write-Host "+ verify all Free Claude Code entry points are absent from the uv tool bin directory"
+        return
+    }
+
+    $remaining = @()
+    $extensions = @("", ".exe", ".cmd", ".bat", ".ps1")
+    foreach ($commandName in $FccCommands) {
+        foreach ($extension in $extensions) {
+            $commandPath = Join-Path $script:UvToolBin "$commandName$extension"
+            if (Test-Path -LiteralPath $commandPath) {
+                $remaining += $commandPath
+            }
         }
+    }
+    if ($remaining.Count -gt 0) {
+        throw "Free Claude Code entry points remain after uv uninstall: $($remaining -join ', '); ~/.fcc was not deleted."
     }
 }
 
 function Purge-FccHome {
-    $fccHome = Join-Path $HOME $FccHomeDirname
+    $fccHome = Join-Path $env:USERPROFILE $FccHomeDirname
     if (-not (Test-Path -LiteralPath $fccHome)) {
         Write-Host "No FCC config directory at $fccHome; skipping purge."
         return
@@ -145,9 +223,13 @@ function Purge-FccHome {
         "-Force"
     ) -join " "
     Write-Host "+ $commandText"
+    if ($DryRun) {
+        return
+    }
 
-    if (-not $DryRun) {
-        Remove-Item -LiteralPath $fccHome -Recurse -Force
+    Remove-Item -LiteralPath $fccHome -Recurse -Force
+    if (Test-Path -LiteralPath $fccHome) {
+        throw "FCC config directory still exists after deletion: $fccHome"
     }
 }
 
@@ -155,21 +237,34 @@ if ($Help) {
     Show-Usage
     return
 }
-
 if ($RemainingArgs.Count -gt 0) {
     Show-Usage
     throw "Unknown option: $($RemainingArgs -join ' ')"
+}
+if ([string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+    throw "USERPROFILE is not set; cannot locate Free Claude Code data."
 }
 
 Write-Step "Checking for running Free Claude Code processes"
 Assert-NoFccProcessesRunning
 
-Write-Step "Removing Free Claude Code uv tool"
+Write-Step "Locating the uv-managed Free Claude Code installation"
+Initialize-UvContext
+
+Write-Step "Removing the Free Claude Code uv tool"
 Uninstall-FreeClaudeCode
+
+Write-Step "Verifying Free Claude Code entry points were removed"
+Confirm-FccCommandsRemoved
 
 Write-Step "Purging FCC config and data from ~/.fcc"
 Purge-FccHome
 
 Write-Host ""
-Write-Host "Free Claude Code has been removed."
-Write-Host "uv, Claude Code, Codex, and the uv-managed Python runtime were left installed."
+if ($DryRun) {
+    Write-Host "Dry run complete. No changes were made."
+}
+else {
+    Write-Host "Free Claude Code has been removed and verified."
+    Write-Host "uv, Claude Code, Codex, the uv-managed Python runtime, and shared PATH entries were left installed."
+}

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,13 +6,14 @@ FCC_HOME_DIRNAME=".fcc"
 FCC_COMMANDS="fcc-server fcc-claude fcc-codex fcc-init free-claude-code"
 
 dry_run=0
+uv_tool_bin=""
 
 show_usage() {
     cat <<'USAGE'
 Usage: uninstall.sh [options]
 
-Removes the Free Claude Code uv tool and deletes ~/.fcc/.
-Does not remove uv, Claude Code, Codex, or the uv-managed Python runtime.
+Removes the Free Claude Code uv tool and deletes ~/.fcc/ after removal is verified.
+Does not remove uv, Claude Code, Codex, the uv-managed Python runtime, or shared PATH entries.
 
 Options:
   --dry-run                Print commands without running them.
@@ -52,15 +53,22 @@ print_command() {
 
 run() {
     print_command "$@"
-    if [ "$dry_run" -eq 0 ]; then
-        "$@"
+    if [ "$dry_run" -eq 1 ]; then
+        return 0
     fi
+
+    if "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+    fail "Command failed with exit code $status: $1"
 }
 
 is_missing_uv_tool_error() {
     normalized=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
     case "$normalized" in
-        *"not installed"* | *"no tool"* | *"nothing to uninstall"*) return 0 ;;
+        *"$PACKAGE_NAME"*"is not installed"*) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -73,17 +81,14 @@ add_path_entry() {
     esac
 }
 
-add_uv_to_path() {
+add_known_uv_paths() {
     if [ -n "${XDG_BIN_HOME:-}" ]; then
         add_path_entry "$XDG_BIN_HOME"
     fi
-
-    if [ -n "${HOME:-}" ]; then
-        add_path_entry "$HOME/.local/bin"
-        add_path_entry "$HOME/.cargo/bin"
-    fi
-
+    add_path_entry "$HOME/.local/bin"
+    add_path_entry "$HOME/.cargo/bin"
     export PATH
+    hash -r 2>/dev/null || true
 }
 
 is_fcc_command_running() {
@@ -99,16 +104,11 @@ is_fcc_command_running() {
         return 1
     fi
 
-    if ps -A -o comm= 2>/dev/null | grep -qx "$command_name"; then
-        return 0
-    fi
-
-    return 1
+    ps -A -o comm= 2>/dev/null | grep -qx "$command_name"
 }
 
 assert_no_fcc_processes_running() {
     running=""
-
     for command_name in $FCC_COMMANDS; do
         if is_fcc_command_running "$command_name"; then
             running="${running} ${command_name}"
@@ -120,35 +120,72 @@ assert_no_fcc_processes_running() {
     fi
 }
 
-uninstall_free_claude_code() {
-    add_uv_to_path
+initialize_uv_context() {
+    add_known_uv_paths
 
-    if ! command -v uv >/dev/null 2>&1; then
-        printf 'uv not found on PATH; skipping uv tool uninstall.\n'
+    if [ "$dry_run" -eq 1 ]; then
+        print_command uv tool dir --bin
         return 0
     fi
 
+    if ! command -v uv >/dev/null 2>&1; then
+        fail "uv is required to remove the Free Claude Code tool. Install uv, then rerun this uninstaller; ~/.fcc was not deleted."
+    fi
+
+    print_command uv tool dir --bin
+    if uv_tool_bin=$(uv tool dir --bin); then
+        :
+    else
+        status=$?
+        fail "Could not determine the uv tool bin directory (exit code $status); ~/.fcc was not deleted."
+    fi
+    [ -n "$uv_tool_bin" ] || fail "uv returned an empty tool bin directory; ~/.fcc was not deleted."
+}
+
+uninstall_free_claude_code() {
     print_command uv tool uninstall "$PACKAGE_NAME"
-    if [ "$dry_run" -eq 0 ]; then
-        if output=$(uv tool uninstall "$PACKAGE_NAME" 2>&1); then
-            return 0
-        else
-            status=$?
-        fi
-        if is_missing_uv_tool_error "$output"; then
-            printf 'Free Claude Code uv tool not installed or already removed; skipping uv tool uninstall.\n'
-            return 0
-        fi
+    if [ "$dry_run" -eq 1 ]; then
+        return 0
+    fi
+
+    if output=$(uv tool uninstall "$PACKAGE_NAME" 2>&1); then
         if [ -n "$output" ]; then
-            printf '%s\n' "$output" >&2
+            printf '%s\n' "$output"
         fi
-        fail "uv tool uninstall $PACKAGE_NAME failed with exit code $status; aborting before deleting ~/.fcc."
+        return 0
+    else
+        status=$?
+    fi
+
+    if is_missing_uv_tool_error "$output"; then
+        printf 'Free Claude Code uv tool is already absent; verifying its entry points.\n'
+        return 0
+    fi
+    if [ -n "$output" ]; then
+        printf '%s\n' "$output" >&2
+    fi
+    fail "uv tool uninstall $PACKAGE_NAME failed with exit code $status; ~/.fcc was not deleted."
+}
+
+verify_fcc_commands_removed() {
+    if [ "$dry_run" -eq 1 ]; then
+        printf '+ verify all Free Claude Code entry points are absent from the uv tool bin directory\n'
+        return 0
+    fi
+
+    remaining=""
+    for command_name in $FCC_COMMANDS; do
+        command_path="$uv_tool_bin/$command_name"
+        if [ -e "$command_path" ] || [ -L "$command_path" ]; then
+            remaining="${remaining} ${command_path}"
+        fi
+    done
+    if [ -n "$remaining" ]; then
+        fail "Free Claude Code entry points remain after uv uninstall:${remaining}; ~/.fcc was not deleted."
     fi
 }
 
 purge_fcc_home() {
-    [ -n "${HOME:-}" ] || fail "HOME is not set; cannot locate ~/.fcc."
-
     fcc_home="$HOME/$FCC_HOME_DIRNAME"
     if [ ! -e "$fcc_home" ]; then
         printf 'No FCC config directory at %s; skipping purge.\n' "$fcc_home"
@@ -156,6 +193,9 @@ purge_fcc_home() {
     fi
 
     run rm -rf "$fcc_home"
+    if [ "$dry_run" -eq 0 ] && [ -e "$fcc_home" ]; then
+        fail "FCC config directory still exists after deletion: $fcc_home"
+    fi
 }
 
 parse_args() {
@@ -178,15 +218,26 @@ parse_args() {
 }
 
 parse_args "$@"
+[ -n "${HOME:-}" ] || fail "HOME is not set; cannot locate Free Claude Code data."
 
 step "Checking for running Free Claude Code processes"
 assert_no_fcc_processes_running
 
-step "Removing Free Claude Code uv tool"
+step "Locating the uv-managed Free Claude Code installation"
+initialize_uv_context
+
+step "Removing the Free Claude Code uv tool"
 uninstall_free_claude_code
+
+step "Verifying Free Claude Code entry points were removed"
+verify_fcc_commands_removed
 
 step "Purging FCC config and data from ~/.fcc"
 purge_fcc_home
 
-printf '\nFree Claude Code has been removed.\n'
-printf 'uv, Claude Code, Codex, and the uv-managed Python runtime were left installed.\n'
+if [ "$dry_run" -eq 1 ]; then
+    printf '\nDry run complete. No changes were made.\n'
+else
+    printf '\nFree Claude Code has been removed and verified.\n'
+    printf 'uv, Claude Code, Codex, the uv-managed Python runtime, and shared PATH entries were left installed.\n'
+fi

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1,5 +1,7 @@
+import os
 import shutil
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -9,283 +11,721 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _script_text(name: str) -> str:
-    return (_repo_root() / "scripts" / name).read_text(encoding="utf-8")
+def _write_executable(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
 
 
-def _braced_body(text: str, declaration: str) -> str:
-    start = text.index(declaration)
-    brace_start = text.index("{", start)
-    depth = 0
-
-    for index, char in enumerate(text[brace_start:], start=brace_start):
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return text[brace_start + 1 : index]
-
-    raise AssertionError(f"Unclosed function body for {declaration}")
-
-
-def test_install_sh_installs_claude_only_when_missing() -> None:
-    text = _script_text("install.sh")
-    body = _braced_body(text, "install_claude_if_missing()")
-    main = text[text.index('parse_args "$@"') :]
-
-    assert "Installs Claude Code and Codex if missing" in text
-    assert "if command -v claude >/dev/null 2>&1; then" in body
-    assert "Claude Code already found on PATH; skipping install." in body
-    assert "require_command npm" in body
-    assert "run npm install -g @anthropic-ai/claude-code" in body
-    assert body.index("command -v claude") < body.index("run npm install")
-    assert body.index("return 0") < body.index("run npm install")
-    assert 'step "Installing Claude Code if missing"\ninstall_claude_if_missing' in main
-    assert "npm install -g @anthropic-ai/claude-code" not in main
-
-
-def test_install_sh_installs_codex_only_when_missing() -> None:
-    text = _script_text("install.sh")
-    body = _braced_body(text, "install_codex_if_missing()")
-    main = text[text.index('parse_args "$@"') :]
-
-    assert "if command -v codex >/dev/null 2>&1; then" in body
-    assert "Codex already found on PATH; skipping install." in body
-    assert "require_command npm" in body
-    assert "run npm install -g @openai/codex" in body
-    assert body.index("command -v codex") < body.index("run npm install")
-    assert body.index("return 0") < body.index("run npm install")
-    assert 'step "Installing Codex if missing"\ninstall_codex_if_missing' in main
-    assert "npm install -g @openai/codex" not in main
-    assert "fcc-claude" in text
-    assert "fcc-codex" in text
-
-
-def test_install_sh_installs_missing_uv_without_self_update() -> None:
-    text = _script_text("install.sh")
-    body = _braced_body(text, "install_or_update_uv()")
-
-    assert "if command -v uv >/dev/null 2>&1; then" in body
-    assert "update_existing_uv" in body
-    assert "run uv self update" not in body
-
-    update_index = body.index("update_existing_uv")
-    validate_existing_index = body.index("validate_uv_version", update_index)
-    installer_index = body.index("run_uv_installer")
-    validate_installed_index = body.index("validate_uv_version", installer_index)
-    verification_index = body.index('if [ "$dry_run" -eq 0 ] && ! command -v uv')
-
-    assert update_index < validate_existing_index < installer_index
-    assert installer_index < verification_index < validate_installed_index
-
-
-def test_install_sh_updates_uv_with_detected_source() -> None:
-    text = _script_text("install.sh")
-    update_body = _braced_body(text, "update_existing_uv()")
-
-    assert "uv self update --dry-run" in text
-    assert update_body.count("run uv self update") == 1
-    assert update_body.index("uv_self_update_supported") < update_body.index(
-        "run uv self update"
-    )
-
-    assert "brew list --versions uv" in text
-    assert "run brew upgrade uv" in update_body
-    assert "pipx list" in text
-    assert "run pipx upgrade uv" in update_body
-    assert "VIRTUAL_ENV" in text
-    assert "run python -m pip install --upgrade uv" in update_body
-    assert "uv_version_satisfies_minimum" in update_body
-    assert "install source was not detected" in update_body
-
-
-def test_install_sh_validates_minimum_uv_version() -> None:
-    text = _script_text("install.sh")
-    validate_body = _braced_body(text, "validate_uv_version()")
-
-    assert 'MIN_UV_VERSION="0.11.0"' in text
-    assert "uv self version --short" in text
-    assert "version_ge" in validate_body
-    assert "uv $MIN_UV_VERSION or newer is required" in validate_body
-
-
-def test_install_ps1_installs_claude_only_when_missing() -> None:
-    text = _script_text("install.ps1")
-    body = _braced_body(text, "function Install-ClaudeIfMissing")
-
-    assert "Installs Claude Code and Codex if missing" in text
-    assert "if (Get-Command claude -ErrorAction SilentlyContinue)" in body
-    assert "Claude Code already found on PATH; skipping install." in body
-    assert 'Assert-CommandAvailable "npm"' in body
-    assert (
-        'Invoke-InstallCommand -FilePath "npm" '
-        '-Arguments @("install", "-g", "@anthropic-ai/claude-code")'
-    ) in body
-    assert body.index("Get-Command claude") < body.index("Invoke-InstallCommand")
-    assert body.index("return") < body.index("Invoke-InstallCommand")
-    assert (
-        'Write-Step "Installing Claude Code if missing"\nInstall-ClaudeIfMissing'
-        in text
-    )
-
-
-def test_install_ps1_installs_codex_only_when_missing() -> None:
-    text = _script_text("install.ps1")
-    body = _braced_body(text, "function Install-CodexIfMissing")
-
-    assert "if (Get-Command codex -ErrorAction SilentlyContinue)" in body
-    assert "Codex already found on PATH; skipping install." in body
-    assert 'Assert-CommandAvailable "npm"' in body
-    assert (
-        'Invoke-InstallCommand -FilePath "npm" '
-        '-Arguments @("install", "-g", "@openai/codex")'
-    ) in body
-    assert body.index("Get-Command codex") < body.index("Invoke-InstallCommand")
-    assert body.index("return") < body.index("Invoke-InstallCommand")
-    assert 'Write-Step "Installing Codex if missing"\nInstall-CodexIfMissing' in text
-    assert "fcc-claude" in text
-    assert "fcc-codex" in text
-
-
-def test_install_ps1_installs_missing_uv_without_self_update() -> None:
-    text = _script_text("install.ps1")
-    body = _braced_body(text, "function Install-OrUpdateUv")
-    self_update = 'Invoke-InstallCommand -FilePath "uv" -Arguments @("self", "update")'
-
-    assert "if (Get-Command uv -ErrorAction SilentlyContinue)" in body
-    assert "Update-ExistingUv" in body
-    assert self_update not in body
-
-    update_index = body.index("Update-ExistingUv")
-    validate_existing_index = body.index("Assert-MinUvVersion", update_index)
-    installer_index = body.index("Invoke-UvInstaller")
-    verification_index = body.index("if ((-not $DryRun)")
-    validate_installed_index = body.index("Assert-MinUvVersion", installer_index)
-
-    assert update_index < validate_existing_index < installer_index
-    assert installer_index < verification_index < validate_installed_index
-
-
-def test_install_ps1_updates_uv_with_detected_source() -> None:
-    text = _script_text("install.ps1")
-    update_body = _braced_body(text, "function Update-ExistingUv")
-    self_update = 'Invoke-InstallCommand -FilePath "uv" -Arguments @("self", "update")'
-
-    assert '"self", "update", "--dry-run"' in text
-    assert update_body.count(self_update) == 1
-    assert update_body.index("Test-UvSelfUpdateSupported") < update_body.index(
-        self_update
-    )
-
-    assert (
-        'Invoke-InstallCommand -FilePath "scoop" -Arguments @("update", "uv")'
-        in update_body
-    )
-    assert '"winget"' in update_body
-    assert '"astral-sh.uv"' in update_body
-    assert '"--accept-package-agreements"' in update_body
-    assert (
-        'Invoke-InstallCommand -FilePath "pipx" -Arguments @("upgrade", "uv")'
-        in update_body
-    )
-    assert (
-        'Invoke-InstallCommand -FilePath "python" -Arguments @("-m", "pip", "install", "--upgrade", "uv")'
-        in update_body
-    )
-    assert "Test-UvVersionSatisfiesMinimum" in update_body
-    assert "install source was not detected" in update_body
-
-
-def test_install_ps1_validates_minimum_uv_version() -> None:
-    text = _script_text("install.ps1")
-    validate_body = _braced_body(text, "function Assert-MinUvVersion")
-    get_version_body = _braced_body(text, "function Get-InstalledUvVersion")
-
-    assert '$MinUvVersion = "0.11.0"' in text
-    assert '"self", "version", "--short"' in text
-    assert "Convert-UvVersionOutput $selfVersionProbe.Output" in get_version_body
-    assert "Convert-UvVersionOutput $versionProbe.Output" in get_version_body
-    assert ".Output.Trim()" not in get_version_body
-    assert "[version]" in text
-    assert "uv $MinUvVersion or newer is required" in validate_body
-
-
-def test_install_ps1_parses_uv_version_probe_outputs(tmp_path: Path) -> None:
-    powershell = shutil.which("pwsh") or shutil.which("powershell")
-    if powershell is None:
-        pytest.skip("PowerShell is not available")
-
-    text = _script_text("install.ps1")
-    convert_body = _braced_body(text, "function Convert-UvVersionOutput")
-    get_version_body = _braced_body(text, "function Get-InstalledUvVersion")
-    compare_body = _braced_body(text, "function Test-UvVersionAtLeast")
-    script = f"""
-Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
-function Convert-UvVersionOutput {{
-{convert_body}
-}}
-function Get-InstalledUvVersion {{
-{get_version_body}
-}}
-function Test-UvVersionAtLeast {{
-{compare_body}
-}}
-
-$script:Mode = "self-long"
-function Invoke-ProbeCommand {{
-    param(
-        [string] $FilePath,
-        [string[]] $Arguments = @()
-    )
-
-    $joined = $Arguments -join " "
-    if ($script:Mode -eq "self-long" -and $joined -eq "self version --short") {{
-        return [pscustomobject] @{{ ExitCode = 0; Output = "0.11.7 (9d177269e 2026-06-05 x86_64-pc-windows-msvc)" }}
-    }}
-    if ($script:Mode -eq "fallback-long" -and $joined -eq "self version --short") {{
-        return [pscustomobject] @{{ ExitCode = 1; Output = "" }}
-    }}
-    if ($script:Mode -eq "fallback-long" -and $joined -eq "--version") {{
-        return [pscustomobject] @{{ ExitCode = 0; Output = "uv 0.11.7 (9d177269e 2026-06-05 x86_64-pc-windows-msvc)" }}
-    }}
-    if ($script:Mode -eq "bad") {{
-        return [pscustomobject] @{{ ExitCode = 0; Output = "not a uv version" }}
-    }}
-    throw "Unexpected probe: $joined"
-}}
-
-if ((Convert-UvVersionOutput "0.11.7") -ne "0.11.7") {{ throw "clean version parse failed" }}
-if ((Convert-UvVersionOutput "uv 0.11.7 (9d177269e 2026)") -ne "0.11.7") {{ throw "uv --version parse failed" }}
-if ((Convert-UvVersionOutput "0.11.7 (9d177269e 2026)") -ne "0.11.7") {{ throw "self version parse failed" }}
-if ((Convert-UvVersionOutput "not a uv version") -ne "") {{ throw "bad output should not parse" }}
-
-$script:Mode = "self-long"
-if ((Get-InstalledUvVersion) -ne "0.11.7") {{ throw "self version normalization failed" }}
-$script:Mode = "fallback-long"
-if ((Get-InstalledUvVersion) -ne "0.11.7") {{ throw "fallback version normalization failed" }}
-if (-not (Test-UvVersionAtLeast -Version "0.11.7 (9d177269e 2026)" -Minimum "0.11.0")) {{ throw "version comparison failed" }}
-
-$script:Mode = "bad"
-try {{
-    Get-InstalledUvVersion | Out-Null
-    throw "bad version did not fail"
-}}
-catch {{
-    if ($_.Exception.Message -ne "Unable to determine uv version.") {{
-        throw
-    }}
-}}
+def _posix_command(name: str) -> str:
+    return f"""#!/bin/sh
+echo "{name}:$*" >> "$CALL_LOG"
+if [ "$FAIL_STEP" = "{name}-verify" ]; then
+    exit 31
+fi
+if [ "${{1:-}}" = "--version" ]; then
+    echo "{name} 1.0.0"
+fi
 """
-    script_path = tmp_path / "test-install-uv-version.ps1"
-    script_path.write_text(script, encoding="utf-8")
 
+
+def _posix_uv_command(version: str) -> str:
+    return f"""#!/bin/sh
+echo "uv:$*" >> "$CALL_LOG"
+if [ "${{1:-}}" = "--version" ]; then
+    if [ "$FAIL_STEP" = "uv-verify" ]; then
+        exit 32
+    fi
+    echo "uv {version}"
+    exit 0
+fi
+if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "install" ]; then
+    if [ "$FAIL_STEP" = "fcc-install" ]; then
+        exit 33
+    fi
+    mkdir -p "$FAKE_TOOL_BIN"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-server"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-claude"
+    if [ "$FAIL_STEP" != "fcc-missing" ]; then
+        cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-codex"
+    fi
+    chmod +x "$FAKE_TOOL_BIN"/fcc-*
+    exit 0
+fi
+if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "update-shell" ]; then
+    if [ "$FAIL_STEP" = "path-update" ]; then
+        exit 34
+    fi
+    exit 0
+fi
+if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "dir" ] && [ "${{3:-}}" = "--bin" ]; then
+    printf '%s\n' "$FAKE_TOOL_BIN"
+    exit 0
+fi
+exit 35
+"""
+
+
+@dataclass
+class PosixHarness:
+    root: Path
+    bin_dir: Path
+    fixtures: Path
+    tool_bin: Path
+    log: Path
+    env: dict[str, str]
+
+    def add_client(self, name: str) -> None:
+        _write_executable(self.bin_dir / name, _posix_command(name))
+
+    def add_uv(self, version: str) -> None:
+        _write_executable(self.bin_dir / "uv", _posix_uv_command(version))
+
+    def run(self, *args: str, fail_step: str = "") -> subprocess.CompletedProcess[str]:
+        env = self.env | {"FAIL_STEP": fail_step}
+        return subprocess.run(
+            ["/bin/sh", str(_repo_root() / "scripts" / "install.sh"), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def calls(self) -> list[str]:
+        if not self.log.exists():
+            return []
+        return self.log.read_text(encoding="utf-8").splitlines()
+
+
+@pytest.fixture
+def posix_harness(tmp_path: Path) -> PosixHarness:
+    if os.name == "nt":
+        pytest.skip("POSIX installer scenarios run on POSIX hosts")
+
+    bin_dir = tmp_path / "bin"
+    fixtures = tmp_path / "fixtures"
+    tool_bin = tmp_path / "tool-bin"
+    home = tmp_path / "home"
+    log = tmp_path / "calls.log"
+    for path in (bin_dir, fixtures, tool_bin, home):
+        path.mkdir(parents=True)
+
+    _write_executable(
+        bin_dir / "git",
+        '#!/bin/sh\necho "git:$*" >> "$CALL_LOG"\necho "git version 2.0.0"\n',
+    )
+    _write_executable(
+        bin_dir / "curl",
+        """#!/bin/sh
+url=""
+output=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            shift
+            output=$1
+            ;;
+        http*)
+            url=$1
+            ;;
+    esac
+    shift
+done
+echo "download:$url" >> "$CALL_LOG"
+case "$url:$FAIL_STEP" in
+    *claude.ai*:claude-download|*chatgpt.com*:codex-download|*astral.sh*:uv-download)
+        exit 41
+        ;;
+esac
+case "$url" in
+    *claude.ai*) source="$FAKE_FIXTURES/claude-installer.sh" ;;
+    *chatgpt.com*) source="$FAKE_FIXTURES/codex-installer.sh" ;;
+    *astral.sh*) source="$FAKE_FIXTURES/uv-installer.sh" ;;
+    *) exit 42 ;;
+esac
+cp "$source" "$output"
+""",
+    )
+    _write_executable(
+        fixtures / "claude-installer.sh",
+        """#!/bin/sh
+echo "claude-install" >> "$CALL_LOG"
+[ "$FAIL_STEP" = "claude-install" ] && exit 21
+mkdir -p "$HOME/.local/bin"
+cp "$FAKE_FIXTURES/claude-command.sh" "$HOME/.local/bin/claude"
+chmod +x "$HOME/.local/bin/claude"
+""",
+    )
+    _write_executable(
+        fixtures / "codex-installer.sh",
+        """#!/bin/sh
+echo "codex-install:$CODEX_NON_INTERACTIVE" >> "$CALL_LOG"
+[ "$FAIL_STEP" = "codex-install" ] && exit 22
+mkdir -p "$HOME/.local/bin"
+cp "$FAKE_FIXTURES/codex-command.sh" "$HOME/.local/bin/codex"
+chmod +x "$HOME/.local/bin/codex"
+""",
+    )
+    _write_executable(
+        fixtures / "uv-installer.sh",
+        """#!/bin/sh
+echo "uv-install" >> "$CALL_LOG"
+[ "$FAIL_STEP" = "uv-install" ] && exit 23
+mkdir -p "$HOME/.local/bin"
+cp "$FAKE_FIXTURES/uv-command.sh" "$HOME/.local/bin/uv"
+chmod +x "$HOME/.local/bin/uv"
+""",
+    )
+    _write_executable(fixtures / "claude-command.sh", _posix_command("claude"))
+    _write_executable(fixtures / "codex-command.sh", _posix_command("codex"))
+    _write_executable(fixtures / "uv-command.sh", _posix_uv_command("0.11.28"))
+    _write_executable(
+        fixtures / "fcc-command.sh",
+        """#!/bin/sh
+name=${0##*/}
+echo "$name:$*" >> "$CALL_LOG"
+if [ "$FAIL_STEP" = "fcc-verify" ]; then
+    exit 36
+fi
+if [ "$name" = "fcc-server" ] && [ "${1:-}" = "--version" ]; then
+    echo "free-claude-code 3.5.18"
+fi
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(home),
+            "CALL_LOG": str(log),
+            "FAKE_FIXTURES": str(fixtures),
+            "FAKE_TOOL_BIN": str(tool_bin),
+            "FAIL_STEP": "",
+        }
+    )
+    env.pop("XDG_BIN_HOME", None)
+    return PosixHarness(tmp_path, bin_dir, fixtures, tool_bin, log, env)
+
+
+def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> None:
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Free Claude Code is installed and verified." in result.stdout
+    calls = posix_harness.calls()
+    assert calls.index("claude-install") < calls.index("claude:--version")
+    assert calls.index("codex-install:1") < calls.index("codex:--version")
+    assert calls.index("uv-install") < calls.index("uv:--version")
+    assert any(
+        call.startswith("uv:tool install --force --python 3.14.0 git+")
+        for call in calls
+    )
+    assert calls[-3:] == [
+        "uv:tool update-shell",
+        "uv:tool dir --bin",
+        "fcc-server:--version",
+    ]
+
+
+def test_install_sh_preserves_valid_existing_tools(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_client("claude")
+    posix_harness.add_client("codex")
+    posix_harness.add_uv("0.11.7")
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert not any(call.startswith("download:") for call in posix_harness.calls())
+    assert "leaving it unchanged" in result.stdout
+
+
+def test_install_sh_replaces_obsolete_uv(posix_harness: PosixHarness) -> None:
+    posix_harness.add_client("claude")
+    posix_harness.add_client("codex")
+    posix_harness.add_uv("0.5.9")
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "uv 0.5.9 is below 0.11.0" in result.stdout
+    assert "uv-install" in posix_harness.calls()
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "claude-download",
+        "claude-install",
+        "claude-verify",
+        "codex-download",
+        "codex-install",
+        "codex-verify",
+        "uv-download",
+        "uv-install",
+        "uv-verify",
+        "fcc-install",
+        "path-update",
+        "fcc-missing",
+        "fcc-verify",
+    ],
+)
+def test_install_sh_stops_without_success_on_each_failure(
+    posix_harness: PosixHarness,
+    failure: str,
+) -> None:
+    result = posix_harness.run(fail_step=failure)
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    forbidden = {
+        "claude-download": "claude-install",
+        "claude-install": "claude:--version",
+        "claude-verify": "chatgpt.com",
+        "codex-download": "codex-install",
+        "codex-install": "codex:--version",
+        "codex-verify": "astral.sh",
+        "uv-download": "uv-install",
+        "uv-install": "uv:--version",
+        "uv-verify": "uv:tool install",
+        "fcc-install": "uv:tool update-shell",
+        "path-update": "uv:tool dir --bin",
+        "fcc-missing": "fcc-server:--version",
+    }.get(failure)
+    if forbidden is not None:
+        assert not any(forbidden in call for call in posix_harness.calls())
+
+
+def test_install_sh_dry_run_never_executes_commands(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run("--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert posix_harness.calls() == []
+    assert "Dry run complete. No changes were made." in result.stdout
+    assert "Free Claude Code is installed and verified." not in result.stdout
+
+
+def test_install_sh_rejects_broken_existing_client_without_replacing_it(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_client("claude")
+
+    result = posix_harness.run(fail_step="claude-verify")
+
+    assert result.returncode != 0
+    assert not any(call.startswith("download:") for call in posix_harness.calls())
+
+
+def test_install_sh_rejects_unparseable_existing_uv(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_client("claude")
+    posix_harness.add_client("codex")
+    posix_harness.add_uv("not-a-version")
+
+    result = posix_harness.run()
+
+    assert result.returncode != 0
+    assert not any("astral.sh" in call for call in posix_harness.calls())
+
+
+def test_install_sh_voice_flags_only_change_fcc_spec(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run("--voice-all", "--torch-backend", "cu130")
+
+    assert result.returncode == 0, result.stderr
+    assert any(
+        "--torch-backend cu130 free-claude-code[voice,voice_local] @ git+" in call
+        for call in posix_harness.calls()
+    )
+
+
+def test_install_sh_rejects_invalid_options_before_mutation(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run("--torch-backend", "cu130")
+
+    assert result.returncode != 0
+    assert posix_harness.calls() == []
+
+
+def _powershells() -> tuple[str, ...]:
+    candidates = (shutil.which("pwsh"), shutil.which("powershell"))
+    return tuple(dict.fromkeys(path for path in candidates if path is not None))
+
+
+def _batch_client(name: str) -> str:
+    return f"""@echo off
+echo {name}:%*>>"%CALL_LOG%"
+if "%FAIL_STEP%"=="{name}-verify" exit /b 51
+if "%1"=="--version" echo {name} 1.0.0
+exit /b 0
+"""
+
+
+def _batch_uv(version: str) -> str:
+    return rf"""@echo off
+echo uv:%*>>"%CALL_LOG%"
+if "%1"=="--version" goto version
+if "%1"=="tool" if "%2"=="install" goto install
+if "%1"=="tool" if "%2"=="update-shell" goto update_shell
+if "%1"=="tool" if "%2"=="dir" if "%3"=="--bin" goto tool_bin
+exit /b 59
+:version
+if "%FAIL_STEP%"=="uv-verify" exit /b 52
+echo uv {version}
+exit /b 0
+:install
+if "%FAIL_STEP%"=="fcc-install" exit /b 53
+if not exist "%FAKE_TOOL_BIN%" mkdir "%FAKE_TOOL_BIN%"
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-server.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-claude.cmd" >nul
+if not "%FAIL_STEP%"=="fcc-missing" copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-codex.cmd" >nul
+exit /b 0
+:update_shell
+if "%FAIL_STEP%"=="path-update" exit /b 54
+exit /b 0
+:tool_bin
+echo %FAKE_TOOL_BIN%
+exit /b 0
+"""
+
+
+@dataclass
+class PowerShellHarness:
+    root: Path
+    bin_dir: Path
+    fixtures: Path
+    tool_bin: Path
+    log: Path
+    env: dict[str, str]
+    powershell: str
+    wrapper: Path
+
+    def add_client(self, name: str) -> None:
+        _write_executable(self.bin_dir / f"{name}.cmd", _batch_client(name))
+
+    def add_uv(self, version: str) -> None:
+        _write_executable(self.bin_dir / "uv.cmd", _batch_uv(version))
+
+    def run(self, fail_step: str = "") -> subprocess.CompletedProcess[str]:
+        env = self.env | {"FAIL_STEP": fail_step}
+        return subprocess.run(
+            [
+                self.powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(self.wrapper),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def calls(self) -> list[str]:
+        if not self.log.exists():
+            return []
+        return self.log.read_text(encoding="utf-8").splitlines()
+
+
+@pytest.fixture(
+    params=_powershells() or (None,),
+    ids=lambda path: Path(path).name if path is not None else "unavailable",
+)
+def powershell_harness(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> PowerShellHarness:
+    powershell = request.param
+    if powershell is None or os.name != "nt":
+        pytest.skip("PowerShell installer scenarios run on Windows hosts")
+
+    bin_dir = tmp_path / "bin"
+    fixtures = tmp_path / "fixtures"
+    tool_bin = tmp_path / "tool-bin"
+    home = tmp_path / "home"
+    local_app_data = tmp_path / "local-app-data"
+    log = tmp_path / "calls.log"
+    for path in (bin_dir, fixtures, tool_bin, home, local_app_data):
+        path.mkdir(parents=True)
+
+    _write_executable(
+        bin_dir / "git.cmd",
+        '@echo off\necho git:%*>>"%CALL_LOG%"\necho git version 2.0.0\n',
+    )
+    (fixtures / "claude-command.cmd").write_text(
+        _batch_client("claude"), encoding="utf-8"
+    )
+    (fixtures / "codex-command.cmd").write_text(
+        _batch_client("codex"), encoding="utf-8"
+    )
+    (fixtures / "uv-command.cmd").write_text(_batch_uv("0.11.28"), encoding="utf-8")
+    (fixtures / "fcc-command.cmd").write_text(
+        """@echo off
+for %%I in ("%~f0") do set "FCC_NAME=%%~nI"
+echo %FCC_NAME%:%*>>"%CALL_LOG%"
+if "%FAIL_STEP%"=="fcc-verify" exit /b 55
+if "%FCC_NAME%"=="fcc-server" if "%1"=="--version" echo free-claude-code 3.5.18
+exit /b 0
+""",
+        encoding="utf-8",
+    )
+    (fixtures / "claude-installer.ps1").write_text(
+        r"""if ($env:FAIL_STEP -eq "claude-install") { exit 61 }
+$bin = Join-Path $env:USERPROFILE ".local\bin"
+New-Item -ItemType Directory -Force -Path $bin | Out-Null
+Copy-Item (Join-Path $env:FAKE_FIXTURES "claude-command.cmd") (Join-Path $bin "claude.cmd") -Force
+Add-Content -LiteralPath $env:CALL_LOG -Value "claude-install"
+""",
+        encoding="utf-8",
+    )
+    (fixtures / "codex-installer.ps1").write_text(
+        r"""if ($env:FAIL_STEP -eq "codex-install") { exit 62 }
+$bin = Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin"
+New-Item -ItemType Directory -Force -Path $bin | Out-Null
+Copy-Item (Join-Path $env:FAKE_FIXTURES "codex-command.cmd") (Join-Path $bin "codex.cmd") -Force
+Add-Content -LiteralPath $env:CALL_LOG -Value "codex-install:$env:CODEX_NON_INTERACTIVE"
+""",
+        encoding="utf-8",
+    )
+    (fixtures / "uv-installer.ps1").write_text(
+        r"""if ($env:FAIL_STEP -eq "uv-install") { exit 63 }
+$bin = Join-Path $env:USERPROFILE ".local\bin"
+New-Item -ItemType Directory -Force -Path $bin | Out-Null
+Copy-Item (Join-Path $env:FAKE_FIXTURES "uv-command.cmd") (Join-Path $bin "uv.cmd") -Force
+Add-Content -LiteralPath $env:CALL_LOG -Value "uv-install"
+""",
+        encoding="utf-8",
+    )
+
+    wrapper = tmp_path / "run-installer.ps1"
+    wrapper.write_text(
+        """Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+function Invoke-RestMethod {
+    [CmdletBinding()]
+    param([string] $Uri, [string] $OutFile)
+
+    Add-Content -LiteralPath $env:CALL_LOG -Value "download:$Uri"
+    if (
+        ($env:FAIL_STEP -eq "claude-download" -and $Uri.Contains("claude.ai")) -or
+        ($env:FAIL_STEP -eq "codex-download" -and $Uri.Contains("chatgpt.com")) -or
+        ($env:FAIL_STEP -eq "uv-download" -and $Uri.Contains("astral.sh"))
+    ) {
+        throw "simulated download failure"
+    }
+    if ($Uri.Contains("claude.ai")) {
+        $source = Join-Path $env:FAKE_FIXTURES "claude-installer.ps1"
+    }
+    elseif ($Uri.Contains("chatgpt.com")) {
+        $source = Join-Path $env:FAKE_FIXTURES "codex-installer.ps1"
+    }
+    elseif ($Uri.Contains("astral.sh")) {
+        $source = Join-Path $env:FAKE_FIXTURES "uv-installer.ps1"
+    }
+    else {
+        throw "unexpected installer URL: $Uri"
+    }
+    Copy-Item -LiteralPath $source -Destination $OutFile -Force
+}
+$installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
+& $installer
+""",
+        encoding="utf-8",
+    )
+
+    system_root = os.environ["SYSTEMROOT"]
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": os.pathsep.join(
+                [str(bin_dir), str(Path(system_root) / "System32"), system_root]
+            ),
+            "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+            "USERPROFILE": str(home),
+            "LOCALAPPDATA": str(local_app_data),
+            "CALL_LOG": str(log),
+            "FAKE_FIXTURES": str(fixtures),
+            "FAKE_TOOL_BIN": str(tool_bin),
+            "FCC_INSTALLER": str(_repo_root() / "scripts" / "install.ps1"),
+            "FAIL_STEP": "",
+        }
+    )
+    return PowerShellHarness(
+        tmp_path, bin_dir, fixtures, tool_bin, log, env, powershell, wrapper
+    )
+
+
+def test_install_ps1_fresh_install_is_verified(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Free Claude Code is installed and verified." in result.stdout
+    calls = powershell_harness.calls()
+    assert calls.index("claude-install") < calls.index("claude:--version")
+    assert calls.index("codex-install:1") < calls.index("codex:--version")
+    assert calls.index("uv-install") < calls.index("uv:--version")
+    assert any(
+        call.startswith("uv:tool install --force --python 3.14.0 git+")
+        for call in calls
+    )
+    assert calls[-3:] == [
+        "uv:tool update-shell",
+        "uv:tool dir --bin",
+        "fcc-server:--version",
+    ]
+
+
+def test_install_ps1_preserves_valid_existing_tools(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("claude")
+    powershell_harness.add_client("codex")
+    powershell_harness.add_uv("0.11.7")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert not any(call.startswith("download:") for call in powershell_harness.calls())
+    assert "leaving it unchanged" in result.stdout
+
+
+def test_install_ps1_replaces_obsolete_uv(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("claude")
+    powershell_harness.add_client("codex")
+    powershell_harness.add_uv("0.5.9")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "uv 0.5.9 is below 0.11.0" in result.stdout
+    assert "uv-install" in powershell_harness.calls()
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "claude-download",
+        "claude-install",
+        "claude-verify",
+        "codex-download",
+        "codex-install",
+        "codex-verify",
+        "uv-download",
+        "uv-install",
+        "uv-verify",
+        "fcc-install",
+        "path-update",
+        "fcc-missing",
+        "fcc-verify",
+    ],
+)
+def test_install_ps1_stops_without_success_on_each_failure(
+    powershell_harness: PowerShellHarness,
+    failure: str,
+) -> None:
+    result = powershell_harness.run(fail_step=failure)
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    forbidden = {
+        "claude-download": "claude-install",
+        "claude-install": "claude:--version",
+        "claude-verify": "chatgpt.com",
+        "codex-download": "codex-install",
+        "codex-install": "codex:--version",
+        "codex-verify": "astral.sh",
+        "uv-download": "uv-install",
+        "uv-install": "uv:--version",
+        "uv-verify": "uv:tool install",
+        "fcc-install": "uv:tool update-shell",
+        "path-update": "uv:tool dir --bin",
+        "fcc-missing": "fcc-server:--version",
+    }.get(failure)
+    if forbidden is not None:
+        assert not any(forbidden in call for call in powershell_harness.calls())
+
+
+def test_install_ps1_dry_run_never_executes_commands(
+    powershell_harness: PowerShellHarness,
+) -> None:
     result = subprocess.run(
-        [powershell, "-NoProfile", "-File", str(script_path)],
+        [
+            powershell_harness.powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(_repo_root() / "scripts" / "install.ps1"),
+            "-DryRun",
+        ],
         check=False,
         capture_output=True,
         text=True,
+        env=powershell_harness.env,
     )
 
     assert result.returncode == 0, result.stderr
+    assert powershell_harness.calls() == []
+    assert "Dry run complete. No changes were made." in result.stdout
+    assert "Free Claude Code is installed and verified." not in result.stdout
+
+
+def test_install_ps1_rejects_broken_existing_client_without_replacing_it(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("claude")
+
+    result = powershell_harness.run(fail_step="claude-verify")
+
+    assert result.returncode != 0
+    assert not any(call.startswith("download:") for call in powershell_harness.calls())
+
+
+def test_install_ps1_rejects_unparseable_existing_uv(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("claude")
+    powershell_harness.add_client("codex")
+    powershell_harness.add_uv("not-a-version")
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert not any("astral.sh" in call for call in powershell_harness.calls())
+
+
+def test_install_ps1_requires_git_before_mutation(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    (powershell_harness.bin_dir / "git.cmd").unlink()
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert powershell_harness.calls() == []
+    assert "git is required" in result.stderr
+
+
+def test_installers_use_native_clients_and_single_python_selection() -> None:
+    shell = (_repo_root() / "scripts" / "install.sh").read_text(encoding="utf-8")
+    powershell = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+
+    for text in (shell, powershell):
+        assert "@anthropic-ai/claude-code" not in text
+        assert "@openai/codex" not in text
+        assert "python install" not in text
+        assert "tool update-shell" in text
+        assert "--python" in text

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -17,6 +17,20 @@ def _write_executable(path: Path, text: str) -> None:
     path.chmod(0o755)
 
 
+def _braced_body(text: str, declaration: str) -> str:
+    start = text.index(declaration)
+    brace_start = text.index("{", start)
+    depth = 0
+    for index, char in enumerate(text[brace_start:], start=brace_start):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace_start + 1 : index]
+    raise AssertionError(f"Unclosed function body for {declaration}")
+
+
 def _posix_command(name: str) -> str:
     return f"""#!/bin/sh
 echo "{name}:$*" >> "$CALL_LOG"
@@ -729,3 +743,39 @@ def test_installers_use_native_clients_and_single_python_selection() -> None:
         assert "python install" not in text
         assert "tool update-shell" in text
         assert "--python" in text
+
+
+@pytest.mark.parametrize("powershell", _powershells())
+def test_install_ps1_falls_back_when_pshome_executable_is_unavailable(
+    tmp_path: Path,
+    powershell: str,
+) -> None:
+    text = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    body = _braced_body(text, "function Get-PowerShellExecutable")
+    fallback = tmp_path / "fallback" / "powershell.exe"
+    script = tmp_path / "test-powershell-resolution.ps1"
+    script.write_text(
+        f"""Set-StrictMode -Version Latest
+function Get-ApplicationCommand {{
+    param([string] $Name)
+    return [pscustomobject] @{{ Source = {str(fallback)!r} }}
+}}
+function Get-PowerShellExecutable {{
+{body}
+}}
+$resolved = Get-PowerShellExecutable -PowerShellHome {str(tmp_path / "missing")!r}
+if ($resolved -ne {str(fallback)!r}) {{
+    throw "Unexpected fallback: $resolved"
+}}
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-File", str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -1,21 +1,497 @@
 import os
 import shutil
-import stat
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+
+FCC_COMMANDS = (
+    "fcc-server",
+    "fcc-claude",
+    "fcc-codex",
+    "fcc-init",
+    "free-claude-code",
+)
 
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _script_text(name: str) -> str:
-    return (_repo_root() / "scripts" / name).read_text(encoding="utf-8")
+def _write_executable(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
 
 
-def test_readme_uninstall_one_liners_use_raw_github_urls() -> None:
+def _powershells() -> tuple[str, ...]:
+    candidates = (shutil.which("pwsh"), shutil.which("powershell"))
+    return tuple(dict.fromkeys(path for path in candidates if path is not None))
+
+
+@dataclass
+class PosixUninstallHarness:
+    home: Path
+    bin_dir: Path
+    tool_bin: Path
+    fcc_home: Path
+    log: Path
+    env: dict[str, str]
+
+    def run(
+        self,
+        *args: str,
+        fail_step: str = "",
+        include_uv: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        uv = self.bin_dir / "uv"
+        if not include_uv and uv.exists():
+            uv.unlink()
+        return subprocess.run(
+            ["/bin/sh", str(_repo_root() / "scripts" / "uninstall.sh"), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=self.env | {"FAIL_STEP": fail_step},
+        )
+
+    def calls(self) -> list[str]:
+        if not self.log.exists():
+            return []
+        return self.log.read_text(encoding="utf-8").splitlines()
+
+    def remove_entry_points(self) -> None:
+        for name in FCC_COMMANDS:
+            (self.tool_bin / name).unlink(missing_ok=True)
+
+
+@pytest.fixture
+def posix_uninstall_harness(tmp_path: Path) -> PosixUninstallHarness:
+    if os.name == "nt":
+        pytest.skip("POSIX uninstaller scenarios run on POSIX hosts")
+
+    home = tmp_path / "home"
+    bin_dir = home / ".local" / "bin"
+    tool_bin = tmp_path / "tool-bin"
+    fcc_home = home / ".fcc"
+    log = tmp_path / "calls.log"
+    for path in (bin_dir, tool_bin, fcc_home):
+        path.mkdir(parents=True)
+    (fcc_home / "config.json").write_text("{}", encoding="utf-8")
+    for name in FCC_COMMANDS:
+        _write_executable(tool_bin / name, "#!/bin/sh\nexit 0\n")
+
+    _write_executable(bin_dir / "claude", "#!/bin/sh\nexit 0\n")
+    _write_executable(bin_dir / "codex", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        bin_dir / "uv",
+        """#!/bin/sh
+echo "uv:$*" >> "$CALL_LOG"
+if [ "${1:-}" = "tool" ] && [ "${2:-}" = "dir" ] && [ "${3:-}" = "--bin" ]; then
+    if [ "$FAIL_STEP" = "tool-dir" ]; then
+        echo "tool directory unavailable" >&2
+        exit 41
+    fi
+    printf '%s\n' "$FAKE_TOOL_BIN"
+    exit 0
+fi
+if [ "${1:-}" = "tool" ] && [ "${2:-}" = "uninstall" ]; then
+    if [ "$FAIL_STEP" = "uninstall" ]; then
+        echo "permission denied while removing tool" >&2
+        exit 42
+    fi
+    if [ "$FAIL_STEP" = "missing" ] || [ "$FAIL_STEP" = "stale-entrypoint" ]; then
+        echo 'Tool `free-claude-code` is not installed' >&2
+        exit 2
+    fi
+    for name in fcc-server fcc-claude fcc-codex fcc-init free-claude-code; do
+        /bin/rm -f "$FAKE_TOOL_BIN/$name"
+    done
+    echo "Uninstalled free-claude-code"
+    exit 0
+fi
+exit 43
+""",
+    )
+    _write_executable(
+        bin_dir / "rm",
+        """#!/bin/sh
+echo "rm:$*" >> "$CALL_LOG"
+if [ "$FAIL_STEP" = "purge" ]; then
+    echo "simulated purge failure" >&2
+    exit 44
+fi
+exec /bin/rm "$@"
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "CALL_LOG": str(log),
+            "FAKE_TOOL_BIN": str(tool_bin),
+            "FAIL_STEP": "",
+        }
+    )
+    env.pop("XDG_BIN_HOME", None)
+    return PosixUninstallHarness(home, bin_dir, tool_bin, fcc_home, log, env)
+
+
+def test_uninstall_sh_removes_and_verifies_only_fcc(
+    posix_uninstall_harness: PosixUninstallHarness,
+) -> None:
+    result = posix_uninstall_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Free Claude Code has been removed and verified." in result.stdout
+    assert not posix_uninstall_harness.fcc_home.exists()
+    assert all(
+        not (posix_uninstall_harness.tool_bin / name).exists() for name in FCC_COMMANDS
+    )
+    assert (posix_uninstall_harness.bin_dir / "uv").exists()
+    assert (posix_uninstall_harness.bin_dir / "claude").exists()
+    assert (posix_uninstall_harness.bin_dir / "codex").exists()
+    assert posix_uninstall_harness.calls() == [
+        "uv:tool dir --bin",
+        "uv:tool uninstall free-claude-code",
+        f"rm:-rf {posix_uninstall_harness.fcc_home}",
+    ]
+
+
+def test_uninstall_sh_is_idempotent_when_tool_is_already_absent(
+    posix_uninstall_harness: PosixUninstallHarness,
+) -> None:
+    posix_uninstall_harness.remove_entry_points()
+
+    result = posix_uninstall_harness.run(fail_step="missing")
+
+    assert result.returncode == 0, result.stderr
+    assert not posix_uninstall_harness.fcc_home.exists()
+    assert "already absent" in result.stdout
+
+
+@pytest.mark.parametrize("failure", ["tool-dir", "uninstall", "stale-entrypoint"])
+def test_uninstall_sh_preserves_config_when_tool_removal_is_unconfirmed(
+    posix_uninstall_harness: PosixUninstallHarness,
+    failure: str,
+) -> None:
+    result = posix_uninstall_harness.run(fail_step=failure)
+
+    assert result.returncode != 0
+    assert posix_uninstall_harness.fcc_home.exists()
+    assert "Free Claude Code has been removed and verified." not in result.stdout
+    assert not any(call.startswith("rm:") for call in posix_uninstall_harness.calls())
+
+
+def test_uninstall_sh_requires_uv_before_deleting_config(
+    posix_uninstall_harness: PosixUninstallHarness,
+) -> None:
+    result = posix_uninstall_harness.run(include_uv=False)
+
+    assert result.returncode != 0
+    assert posix_uninstall_harness.fcc_home.exists()
+    assert "uv is required" in result.stderr
+    assert posix_uninstall_harness.calls() == []
+
+
+def test_uninstall_sh_reports_purge_failure_after_verified_tool_removal(
+    posix_uninstall_harness: PosixUninstallHarness,
+) -> None:
+    result = posix_uninstall_harness.run(fail_step="purge")
+
+    assert result.returncode != 0
+    assert posix_uninstall_harness.fcc_home.exists()
+    assert all(
+        not (posix_uninstall_harness.tool_bin / name).exists() for name in FCC_COMMANDS
+    )
+    assert "Free Claude Code has been removed and verified." not in result.stdout
+
+
+def test_uninstall_sh_dry_run_is_non_mutating(
+    posix_uninstall_harness: PosixUninstallHarness,
+) -> None:
+    result = posix_uninstall_harness.run("--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert posix_uninstall_harness.fcc_home.exists()
+    assert all(
+        (posix_uninstall_harness.tool_bin / name).exists() for name in FCC_COMMANDS
+    )
+    assert posix_uninstall_harness.calls() == []
+    assert "Dry run complete. No changes were made." in result.stdout
+
+
+def test_uninstall_sh_rejects_invalid_options_before_mutation(
+    posix_uninstall_harness: PosixUninstallHarness,
+) -> None:
+    result = posix_uninstall_harness.run("--unknown")
+
+    assert result.returncode != 0
+    assert posix_uninstall_harness.fcc_home.exists()
+    assert posix_uninstall_harness.calls() == []
+
+
+@dataclass
+class PowerShellUninstallHarness:
+    home: Path
+    bin_dir: Path
+    tool_bin: Path
+    fcc_home: Path
+    log: Path
+    env: dict[str, str]
+    powershell: str
+    wrapper: Path
+
+    def run(
+        self,
+        *,
+        fail_step: str = "",
+        include_uv: bool = True,
+        dry_run: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        uv = self.bin_dir / "uv.cmd"
+        if not include_uv and uv.exists():
+            uv.unlink()
+        return subprocess.run(
+            [
+                self.powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(self.wrapper),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=self.env
+            | {
+                "FAIL_STEP": fail_step,
+                "UNINSTALL_DRY_RUN": "1" if dry_run else "0",
+            },
+        )
+
+    def calls(self) -> list[str]:
+        if not self.log.exists():
+            return []
+        return self.log.read_text(encoding="utf-8").splitlines()
+
+    def remove_entry_points(self) -> None:
+        for name in FCC_COMMANDS:
+            (self.tool_bin / f"{name}.cmd").unlink(missing_ok=True)
+
+
+@pytest.fixture(
+    params=_powershells() or (None,),
+    ids=lambda path: Path(path).name if path is not None else "unavailable",
+)
+def powershell_uninstall_harness(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> PowerShellUninstallHarness:
+    powershell = request.param
+    if powershell is None or os.name != "nt":
+        pytest.skip("PowerShell uninstaller scenarios run on Windows hosts")
+
+    home = tmp_path / "home"
+    bin_dir = home / ".local" / "bin"
+    tool_bin = tmp_path / "tool-bin"
+    fcc_home = home / ".fcc"
+    log = tmp_path / "calls.log"
+    for path in (bin_dir, tool_bin, fcc_home):
+        path.mkdir(parents=True)
+    (fcc_home / "config.json").write_text("{}", encoding="utf-8")
+    for name in FCC_COMMANDS:
+        (tool_bin / f"{name}.cmd").write_text(
+            "@echo off\nexit /b 0\n", encoding="utf-8"
+        )
+    for name in ("claude", "codex"):
+        (bin_dir / f"{name}.cmd").write_text("@echo off\nexit /b 0\n", encoding="utf-8")
+
+    uv_commands = " ".join(FCC_COMMANDS)
+    (bin_dir / "uv.cmd").write_text(
+        rf"""@echo off
+echo uv:%*>>"%CALL_LOG%"
+if "%1"=="tool" if "%2"=="dir" if "%3"=="--bin" goto tool_bin
+if "%1"=="tool" if "%2"=="uninstall" goto uninstall
+exit /b 53
+:tool_bin
+if "%FAIL_STEP%"=="tool-dir" echo tool directory unavailable 1>&2 & exit /b 51
+echo %FAKE_TOOL_BIN%
+exit /b 0
+:uninstall
+if "%FAIL_STEP%"=="uninstall" echo permission denied while removing tool 1>&2 & exit /b 52
+if "%FAIL_STEP%"=="missing" echo Tool `free-claude-code` is not installed 1>&2 & exit /b 2
+if "%FAIL_STEP%"=="stale-entrypoint" echo Tool `free-claude-code` is not installed 1>&2 & exit /b 2
+for %%C in ({uv_commands}) do del /q "%FAKE_TOOL_BIN%\%%C.cmd" 2>nul
+echo Uninstalled free-claude-code
+exit /b 0
+""",
+        encoding="utf-8",
+    )
+
+    wrapper = tmp_path / "run-uninstaller.ps1"
+    wrapper.write_text(
+        r"""Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+function Remove-Item {
+    [CmdletBinding()]
+    param(
+        [string] $LiteralPath,
+        [switch] $Recurse,
+        [switch] $Force
+    )
+    Add-Content -LiteralPath $env:CALL_LOG -Value "remove:$LiteralPath"
+    if ($env:FAIL_STEP -eq "purge") {
+        throw "simulated purge failure"
+    }
+    Microsoft.PowerShell.Management\Remove-Item @PSBoundParameters
+}
+$installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_UNINSTALLER))
+if ($env:UNINSTALL_DRY_RUN -eq "1") {
+    & $installer -DryRun
+}
+else {
+    & $installer
+}
+""",
+        encoding="utf-8",
+    )
+
+    system_root = os.environ["SYSTEMROOT"]
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": os.pathsep.join(
+                [str(bin_dir), str(Path(system_root) / "System32"), system_root]
+            ),
+            "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "CALL_LOG": str(log),
+            "FAKE_TOOL_BIN": str(tool_bin),
+            "FCC_UNINSTALLER": str(_repo_root() / "scripts" / "uninstall.ps1"),
+            "FAIL_STEP": "",
+            "UNINSTALL_DRY_RUN": "0",
+        }
+    )
+    return PowerShellUninstallHarness(
+        home, bin_dir, tool_bin, fcc_home, log, env, powershell, wrapper
+    )
+
+
+def test_uninstall_ps1_removes_and_verifies_only_fcc(
+    powershell_uninstall_harness: PowerShellUninstallHarness,
+) -> None:
+    result = powershell_uninstall_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Free Claude Code has been removed and verified." in result.stdout
+    assert not powershell_uninstall_harness.fcc_home.exists()
+    assert all(
+        not (powershell_uninstall_harness.tool_bin / f"{name}.cmd").exists()
+        for name in FCC_COMMANDS
+    )
+    assert (powershell_uninstall_harness.bin_dir / "uv.cmd").exists()
+    assert (powershell_uninstall_harness.bin_dir / "claude.cmd").exists()
+    assert (powershell_uninstall_harness.bin_dir / "codex.cmd").exists()
+    assert powershell_uninstall_harness.calls() == [
+        "uv:tool dir --bin",
+        "uv:tool uninstall free-claude-code",
+        f"remove:{powershell_uninstall_harness.fcc_home}",
+    ]
+
+
+def test_uninstall_ps1_is_idempotent_when_tool_is_already_absent(
+    powershell_uninstall_harness: PowerShellUninstallHarness,
+) -> None:
+    powershell_uninstall_harness.remove_entry_points()
+
+    result = powershell_uninstall_harness.run(fail_step="missing")
+
+    assert result.returncode == 0, result.stderr
+    assert not powershell_uninstall_harness.fcc_home.exists()
+    assert "already absent" in result.stdout
+
+
+@pytest.mark.parametrize("failure", ["tool-dir", "uninstall", "stale-entrypoint"])
+def test_uninstall_ps1_preserves_config_when_tool_removal_is_unconfirmed(
+    powershell_uninstall_harness: PowerShellUninstallHarness,
+    failure: str,
+) -> None:
+    result = powershell_uninstall_harness.run(fail_step=failure)
+
+    assert result.returncode != 0
+    assert powershell_uninstall_harness.fcc_home.exists()
+    assert "Free Claude Code has been removed and verified." not in result.stdout
+    assert not any(
+        call.startswith("remove:") for call in powershell_uninstall_harness.calls()
+    )
+
+
+def test_uninstall_ps1_requires_uv_before_deleting_config(
+    powershell_uninstall_harness: PowerShellUninstallHarness,
+) -> None:
+    result = powershell_uninstall_harness.run(include_uv=False)
+
+    assert result.returncode != 0
+    assert powershell_uninstall_harness.fcc_home.exists()
+    assert "uv is required" in result.stderr
+    assert powershell_uninstall_harness.calls() == []
+
+
+def test_uninstall_ps1_reports_purge_failure_after_verified_tool_removal(
+    powershell_uninstall_harness: PowerShellUninstallHarness,
+) -> None:
+    result = powershell_uninstall_harness.run(fail_step="purge")
+
+    assert result.returncode != 0
+    assert powershell_uninstall_harness.fcc_home.exists()
+    assert all(
+        not (powershell_uninstall_harness.tool_bin / f"{name}.cmd").exists()
+        for name in FCC_COMMANDS
+    )
+    assert "Free Claude Code has been removed and verified." not in result.stdout
+
+
+def test_uninstall_ps1_dry_run_is_non_mutating(
+    powershell_uninstall_harness: PowerShellUninstallHarness,
+) -> None:
+    result = powershell_uninstall_harness.run(dry_run=True)
+
+    assert result.returncode == 0, result.stderr
+    assert powershell_uninstall_harness.fcc_home.exists()
+    assert all(
+        (powershell_uninstall_harness.tool_bin / f"{name}.cmd").exists()
+        for name in FCC_COMMANDS
+    )
+    assert powershell_uninstall_harness.calls() == []
+    assert "Dry run complete. No changes were made." in result.stdout
+
+
+def test_uninstallers_guard_running_commands_and_preserve_shared_owners() -> None:
+    shell = (_repo_root() / "scripts" / "uninstall.sh").read_text(encoding="utf-8")
+    powershell = (_repo_root() / "scripts" / "uninstall.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert "pgrep" in shell
+    assert "Get-Process" in powershell
+    for text in (shell, powershell):
+        for command in FCC_COMMANDS:
+            assert command in text
+        assert "npm uninstall" not in text
+        assert "uv self uninstall" not in text
+        assert "uv python uninstall" not in text
+        assert "is not installed" in text
+        assert "no tool" not in text
+        assert "nothing to uninstall" not in text
+
+
+def test_readme_uninstall_uses_raw_urls_and_verification_contract() -> None:
     text = (_repo_root() / "README.md").read_text(encoding="utf-8")
 
     assert (
@@ -23,365 +499,7 @@ def test_readme_uninstall_one_liners_use_raw_github_urls() -> None:
         'Alishahryar1/free-claude-code/main/scripts/uninstall.sh" | sh'
     ) in text
     assert (
-        'irm "https://raw.githubusercontent.com/'
-        'Alishahryar1/free-claude-code/main/scripts/uninstall.ps1" | iex'
+        '& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/'
+        'Alishahryar1/free-claude-code/main/scripts/uninstall.ps1")))'
     ) in text
-    assert "blob/main/scripts/uninstall.sh?raw=1" not in text
-    assert "blob/main/scripts/uninstall.ps1?raw=1" not in text
-
-
-def _braced_body(text: str, declaration: str) -> str:
-    start = text.index(declaration)
-    brace_start = text.index("{", start)
-    depth = 0
-
-    for index, char in enumerate(text[brace_start:], start=brace_start):
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return text[brace_start + 1 : index]
-
-    raise AssertionError(f"Unclosed function body for {declaration}")
-
-
-def _shell_path_with_mock(bin_dir: Path) -> str:
-    return f"{bin_dir}:/usr/bin:/bin"
-
-
-def _path_prepending(path: Path) -> str:
-    return os.pathsep.join((str(path), os.environ.get("PATH", "")))
-
-
-def _path_without_uv(prefix: Path) -> str:
-    uv_names = ("uv", "uv.exe", "uv.cmd", "uv.bat")
-    entries = [str(prefix)]
-    for raw_entry in os.environ.get("PATH", "").split(os.pathsep):
-        if not raw_entry:
-            continue
-        entry = Path(raw_entry)
-        if any((entry / name).exists() for name in uv_names):
-            continue
-        entries.append(raw_entry)
-    return os.pathsep.join(entries)
-
-
-def _write_mock_uv(bin_dir: Path, *, message: str, exit_code: int) -> None:
-    if os.name == "nt":
-        uv = bin_dir / "uv.cmd"
-        uv.write_text(
-            f"@echo off\necho {message} 1>&2\nexit /b {exit_code}\n",
-            encoding="utf-8",
-        )
-        return
-
-    uv = bin_dir / "uv"
-    uv.write_text(
-        f"#!/bin/sh\nprintf '%s\\n' '{message}' >&2\nexit {exit_code}\n",
-        encoding="utf-8",
-    )
-    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
-
-
-def test_uninstall_sh_removes_uv_tool_and_purges_fcc_home() -> None:
-    text = _script_text("uninstall.sh")
-    tool_body = _braced_body(text, "uninstall_free_claude_code()")
-    purge_body = _braced_body(text, "purge_fcc_home()")
-
-    assert "Does not remove uv, Claude Code, Codex" in text
-    assert "uv tool uninstall" in tool_body
-    assert 'PACKAGE_NAME="free-claude-code"' in text
-    assert "uv not found on PATH; skipping uv tool uninstall." in tool_body
-    assert "is_missing_uv_tool_error" in tool_body
-    assert "aborting before deleting ~/.fcc." in tool_body
-    assert "rm -rf" in purge_body
-    assert ".fcc" in purge_body
-    assert "npm uninstall" not in text
-    assert "uv self uninstall" not in text
-    assert "uv python uninstall" not in text
-
-
-def test_uninstall_sh_fails_when_fcc_commands_are_running() -> None:
-    text = _script_text("uninstall.sh")
-    guard_body = _braced_body(text, "assert_no_fcc_processes_running()")
-    main = text[text.index('parse_args "$@"') :]
-
-    for command in (
-        "fcc-server",
-        "fcc-claude",
-        "fcc-codex",
-        "fcc-init",
-        "free-claude-code",
-    ):
-        assert command in text
-
-    assert "FCC_COMMANDS" in text
-
-    assert "Free Claude Code is still running" in guard_body
-    assert (
-        'step "Checking for running Free Claude Code processes"\nassert_no_fcc_processes_running'
-        in main
-    )
-
-
-def test_uninstall_ps1_removes_uv_tool_and_purges_fcc_home() -> None:
-    text = _script_text("uninstall.ps1")
-    tool_body = _braced_body(text, "function Uninstall-FreeClaudeCode")
-    purge_body = _braced_body(text, "function Purge-FccHome")
-
-    assert "Does not remove uv, Claude Code, Codex" in text
-    assert "uv tool uninstall" in tool_body
-    assert '$PackageName = "free-claude-code"' in text
-    assert "uv not found on PATH; skipping uv tool uninstall." in tool_body
-    assert "Test-MissingUvToolError" in tool_body
-    assert "aborting before deleting ~/.fcc." in tool_body
-    assert "Remove-Item" in purge_body
-    assert purge_body.count("Remove-Item -LiteralPath") == 1
-    assert '$FccHomeDirname = ".fcc"' in text
-    assert "npm uninstall" not in text
-    assert "uv self uninstall" not in text
-    assert "uv python uninstall" not in text
-
-
-def test_uninstall_ps1_fails_when_fcc_commands_are_running() -> None:
-    text = _script_text("uninstall.ps1")
-    guard_body = _braced_body(text, "function Assert-NoFccProcessesRunning")
-
-    for command in (
-        "fcc-server",
-        "fcc-claude",
-        "fcc-codex",
-        "fcc-init",
-        "free-claude-code",
-    ):
-        assert command in text
-
-    assert "FccCommands" in text
-
-    assert "Free Claude Code is still running" in guard_body
-    assert (
-        'Write-Step "Checking for running Free Claude Code processes"\n'
-        "Assert-NoFccProcessesRunning" in text
-    )
-
-
-def test_uninstall_sh_missing_tool_detection_is_narrow() -> None:
-    text = _script_text("uninstall.sh")
-    detector_body = _braced_body(text, "is_missing_uv_tool_error()")
-
-    assert "not installed" in detector_body
-    assert "no tool" in detector_body
-    assert "nothing to uninstall" in detector_body
-    assert "permission denied" not in detector_body
-    assert "locked" not in detector_body
-
-
-def test_uninstall_ps1_missing_tool_detection_is_narrow() -> None:
-    text = _script_text("uninstall.ps1")
-    detector_body = _braced_body(text, "function Test-MissingUvToolError")
-
-    assert "not installed" in detector_body
-    assert "no tool" in detector_body
-    assert "nothing to uninstall" in detector_body
-    assert "permission denied" not in detector_body
-    assert "locked" not in detector_body
-
-
-def test_uninstall_sh_generic_uv_failure_does_not_delete_fcc_home(
-    tmp_path: Path,
-) -> None:
-    sh = shutil.which("sh")
-    if sh is None:
-        pytest.skip("sh is not available on this platform")
-
-    home = tmp_path / "home"
-    fcc_home = home / ".fcc"
-    bin_dir = home / ".local" / "bin"
-    fcc_home.mkdir(parents=True)
-    bin_dir.mkdir(parents=True)
-    uv = bin_dir / "uv"
-    uv.write_text(
-        "#!/bin/sh\n"
-        "printf '%s\\n' 'permission denied while removing tool' >&2\n"
-        "exit 42\n",
-        encoding="utf-8",
-    )
-    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
-
-    result = subprocess.run(
-        [sh, str(_repo_root() / "scripts" / "uninstall.sh")],
-        cwd=_repo_root(),
-        env={**os.environ, "HOME": str(home), "PATH": _shell_path_with_mock(bin_dir)},
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    assert fcc_home.exists()
-    assert "failed with exit code 42" in result.stderr
-    assert "before deleting ~/.fcc" in result.stderr
-
-
-def test_uninstall_sh_missing_tool_still_deletes_fcc_home(tmp_path: Path) -> None:
-    sh = shutil.which("sh")
-    if sh is None:
-        pytest.skip("sh is not available on this platform")
-
-    home = tmp_path / "home"
-    fcc_home = home / ".fcc"
-    bin_dir = home / ".local" / "bin"
-    fcc_home.mkdir(parents=True)
-    bin_dir.mkdir(parents=True)
-    uv = bin_dir / "uv"
-    uv.write_text(
-        "#!/bin/sh\n"
-        "printf '%s\\n' 'tool free-claude-code is not installed' >&2\n"
-        "exit 2\n",
-        encoding="utf-8",
-    )
-    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
-
-    result = subprocess.run(
-        [sh, str(_repo_root() / "scripts" / "uninstall.sh")],
-        cwd=_repo_root(),
-        env={**os.environ, "HOME": str(home), "PATH": _shell_path_with_mock(bin_dir)},
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0
-    assert not fcc_home.exists()
-
-
-def test_uninstall_sh_missing_uv_still_deletes_fcc_home(tmp_path: Path) -> None:
-    sh = shutil.which("sh")
-    if sh is None:
-        pytest.skip("sh is not available on this platform")
-
-    home = tmp_path / "home"
-    fcc_home = home / ".fcc"
-    empty_bin = tmp_path / "empty-bin"
-    fcc_home.mkdir(parents=True)
-    empty_bin.mkdir()
-
-    result = subprocess.run(
-        [sh, str(_repo_root() / "scripts" / "uninstall.sh")],
-        cwd=_repo_root(),
-        env={
-            **os.environ,
-            "HOME": str(home),
-            "PATH": f"{empty_bin}:/usr/bin:/bin",
-        },
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0
-    assert not fcc_home.exists()
-    assert "uv not found on PATH; skipping uv tool uninstall." in result.stdout
-
-
-def test_uninstall_ps1_generic_uv_failure_does_not_delete_fcc_home(
-    tmp_path: Path,
-) -> None:
-    pwsh = shutil.which("pwsh") or shutil.which("powershell")
-    if pwsh is None:
-        pytest.skip("PowerShell is not available on this platform")
-
-    home = tmp_path / "home"
-    fcc_home = home / ".fcc"
-    bin_dir = home / ".local" / "bin"
-    fcc_home.mkdir(parents=True)
-    bin_dir.mkdir(parents=True)
-    _write_mock_uv(
-        bin_dir,
-        message="permission denied while removing tool",
-        exit_code=42,
-    )
-
-    result = subprocess.run(
-        [pwsh, "-NoProfile", "-File", str(_repo_root() / "scripts" / "uninstall.ps1")],
-        cwd=_repo_root(),
-        env={
-            **os.environ,
-            "HOME": str(home),
-            "USERPROFILE": str(home),
-            "PATH": _path_prepending(bin_dir),
-        },
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    assert fcc_home.exists()
-    assert "failed with exit code 42" in result.stderr
-    assert "before deleting ~/.fcc" in result.stderr
-
-
-def test_uninstall_ps1_missing_tool_still_deletes_fcc_home(tmp_path: Path) -> None:
-    pwsh = shutil.which("pwsh") or shutil.which("powershell")
-    if pwsh is None:
-        pytest.skip("PowerShell is not available on this platform")
-
-    home = tmp_path / "home"
-    fcc_home = home / ".fcc"
-    bin_dir = home / ".local" / "bin"
-    fcc_home.mkdir(parents=True)
-    bin_dir.mkdir(parents=True)
-    _write_mock_uv(
-        bin_dir,
-        message="tool free-claude-code is not installed",
-        exit_code=2,
-    )
-
-    result = subprocess.run(
-        [pwsh, "-NoProfile", "-File", str(_repo_root() / "scripts" / "uninstall.ps1")],
-        cwd=_repo_root(),
-        env={
-            **os.environ,
-            "HOME": str(home),
-            "USERPROFILE": str(home),
-            "PATH": _path_prepending(bin_dir),
-        },
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0
-    assert not fcc_home.exists()
-
-
-def test_uninstall_ps1_missing_uv_still_deletes_fcc_home(tmp_path: Path) -> None:
-    pwsh = shutil.which("pwsh") or shutil.which("powershell")
-    if pwsh is None:
-        pytest.skip("PowerShell is not available on this platform")
-
-    home = tmp_path / "home"
-    fcc_home = home / ".fcc"
-    empty_bin = tmp_path / "empty-bin"
-    fcc_home.mkdir(parents=True)
-    empty_bin.mkdir()
-
-    result = subprocess.run(
-        [pwsh, "-NoProfile", "-File", str(_repo_root() / "scripts" / "uninstall.ps1")],
-        cwd=_repo_root(),
-        env={
-            **os.environ,
-            "HOME": str(home),
-            "USERPROFILE": str(home),
-            "PATH": _path_without_uv(empty_bin),
-        },
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0
-    assert not fcc_home.exists()
-    assert "uv not found on PATH; skipping uv tool uninstall." in result.stdout
+    assert "verifies every FCC command is gone" in text

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.17"
+version = "3.5.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The install and uninstall scripts mixed tool ownership, relied on npm and package-manager detection, and could report success after native commands or FCC removal failed. Users could be left without runnable FCC commands or lose `~/.fcc` while the FCC tool remained. Fixes #547, #753, #908, #942, #952, #1078, and #1080.

## Changes

| Before | After |
| --- | --- |
| Missing Claude Code and Codex were installed through global npm. | Missing clients use their official native installers without requiring Node.js or npm. |
| Existing uv installations were updated through package-manager detection. | Compatible uv installations are preserved; missing or obsolete uv uses Astral's standalone installer. |
| Python 3.14 was installed as a separate step. | `uv tool install --python 3.14.0` owns Python selection and FCC installation together. |
| PowerShell relied on `$ErrorActionPreference` and process metadata. | Native exits are checked explicitly and the PowerShell host resolves through `$PSHOME` with a PATH fallback. |
| Missing Git surfaced late during `uv tool install`. | Git is verified before any installation mutation. |
| PATH setup and FCC entry points were trusted after installation. | Persistent PATH setup, FCC entry points, and `fcc-server --version` must verify before success. |
| Missing uv caused uninstall to skip FCC removal and still delete `~/.fcc`. | Missing uv stops uninstall before configuration is touched. |
| FCC removal trusted `uv tool uninstall` without checking commands. | All five FCC entry points must be absent before `~/.fcc` is deleted. |
| Dry runs printed successful installation or removal messages. | Dry runs execute no mutations and report that no changes were made. |
| Installer tests inspected source strings. | Hermetic POSIX, PowerShell 5.1, and PowerShell 7 scenarios execute success and failure branches. |
| README commands used GitHub HTML redirects or direct `iex` pipelines. | README commands use raw URLs and parameter-safe PowerShell script blocks. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the installer and uninstaller flows native, fail-fast, and verified. The main changes are:

- Native Claude Code, Codex, and uv installer paths.
- Git and command-exit checks before install mutations continue.
- FCC installation through `uv tool install --python 3.14.0`.
- PATH persistence and FCC entrypoint verification before install success.
- Verified uv-tool removal before deleting `~/.fcc/`.
- Raw GitHub README commands and expanded installer tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reviewed the general-contract-validation-proof and confirmed the installer validation log records the exact commands, working directory, PowerShell availability checks, pytest summary, skip indicators, and exit code.
- T-Rex verified from the log that there were no installer/uninstaller failures observed in the hermetic POSIX test path.
- T-Rex identified the installer-validation.log as the primary artifact supporting this validation and noted it as the key evidence for reviewers to inspect.

<a href="https://app.greptile.com/trex/runs/14183505/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/install.ps1 | Adds native installer execution, PowerShell executable fallback, fail-fast command handling, uv checks, and FCC verification. |
| scripts/install.sh | Adds native installer downloads, prerequisite checks, uv handling, Python selection, and FCC entrypoint verification. |
| scripts/uninstall.ps1 | Verifies uv tool removal and FCC entrypoint absence before purging Windows user data. |
| scripts/uninstall.sh | Verifies uv tool removal and FCC entrypoint absence before purging POSIX user data. |
| tests/scripts/test_installers.py | Replaces source-string checks with hermetic installer success and failure scenarios. |
| tests/scripts/test_uninstallers.py | Adds hermetic uninstaller scenarios for verified removal, idempotency, dry runs, and failed cleanup. |
| README.md | Updates install and uninstall commands to raw script URLs and scriptblock PowerShell invocation. |
| pyproject.toml | Bumps the package patch version for the installer changes. |
| uv.lock | Reflects the updated package version. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Make FCC uninstall fail-fast and verifia..."](https://github.com/alishahryar1/free-claude-code/commit/031e79fa4990606c4eb04dcc3980458e560167e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43701775)</sub>

<!-- /greptile_comment -->