### PR TITLE
Install FCC without requiring Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ Run Claude Code or Codex with free, paid, or local models. Choose and validate p
 
 ### 1. Install Or Update
 
-The installer uses the official native installers for missing Claude Code, Codex, and uv, then installs Free Claude Code with uv-managed Python 3.14. Install [Git](https://git-scm.com/downloads) first because FCC is installed directly from this repository. Every step is verified, and the installer stops immediately if one fails.
-
 macOS/Linux:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.5.18"
+version = "3.5.19"
 description = "Local proxy connecting Claude Code and Codex to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -13,7 +13,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-$RepoGitUrl = "git+https://github.com/Alishahryar1/free-claude-code.git"
+$RepoArchiveUrl = "https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
 $PythonVersion = "3.14.0"
 $MinUvVersion = "0.11.0"
 $ClaudeInstallUrl = "https://claude.ai/install.ps1"
@@ -159,19 +159,6 @@ function Add-KnownBinDirectories {
     if (-not [string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
         Add-PathEntry (Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin")
     }
-}
-
-function Assert-Prerequisites {
-    if ($DryRun) {
-        Write-Host "+ git --version"
-        return
-    }
-
-    $gitCommand = Get-ApplicationCommand "git"
-    if (-not $gitCommand) {
-        throw "git is required to install Free Claude Code from GitHub. Install Git, then rerun this installer."
-    }
-    Invoke-NativeCommand -FilePath $gitCommand.Source -Arguments @("--version")
 }
 
 function Invoke-DownloadedPowerShellInstaller {
@@ -369,20 +356,28 @@ function Get-PackageSpec {
     }
 
     if ($includeNim -and $includeLocal) {
-        return "free-claude-code[voice,voice_local] @ $RepoGitUrl"
+        return "free-claude-code[voice,voice_local] @ $RepoArchiveUrl"
     }
     if ($includeNim) {
-        return "free-claude-code[voice] @ $RepoGitUrl"
+        return "free-claude-code[voice] @ $RepoArchiveUrl"
     }
     if ($includeLocal) {
-        return "free-claude-code[voice_local] @ $RepoGitUrl"
+        return "free-claude-code[voice_local] @ $RepoArchiveUrl"
     }
-    return $RepoGitUrl
+    return "free-claude-code @ $RepoArchiveUrl"
 }
 
 function Install-FreeClaudeCode {
     $packageSpec = Get-PackageSpec
-    $arguments = @("tool", "install", "--force", "--python", $PythonVersion)
+    $arguments = @(
+        "tool",
+        "install",
+        "--force",
+        "--refresh-package",
+        "free-claude-code",
+        "--python",
+        $PythonVersion
+    )
     if (-not [string]::IsNullOrWhiteSpace($TorchBackend)) {
         $arguments += @("--torch-backend", $TorchBackend)
     }
@@ -457,9 +452,6 @@ if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not ($VoiceLocal -
 }
 
 Add-KnownBinDirectories
-
-Write-Step "Checking installation prerequisites"
-Assert-Prerequisites
 
 Write-Step "Ensuring Claude Code is installed"
 Ensure-ClaudeCode

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-REPO_GIT_URL="git+https://github.com/Alishahryar1/free-claude-code.git"
+REPO_ARCHIVE_URL="https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
 PYTHON_VERSION="3.14.0"
 MIN_UV_VERSION="0.11.0"
 CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
@@ -355,13 +355,13 @@ package_spec() {
     fi
 
     if [ "$include_nim" -eq 1 ] && [ "$include_local" -eq 1 ]; then
-        printf 'free-claude-code[voice,voice_local] @ %s' "$REPO_GIT_URL"
+        printf 'free-claude-code[voice,voice_local] @ %s' "$REPO_ARCHIVE_URL"
     elif [ "$include_nim" -eq 1 ]; then
-        printf 'free-claude-code[voice] @ %s' "$REPO_GIT_URL"
+        printf 'free-claude-code[voice] @ %s' "$REPO_ARCHIVE_URL"
     elif [ "$include_local" -eq 1 ]; then
-        printf 'free-claude-code[voice_local] @ %s' "$REPO_GIT_URL"
+        printf 'free-claude-code[voice_local] @ %s' "$REPO_ARCHIVE_URL"
     else
-        printf '%s' "$REPO_GIT_URL"
+        printf 'free-claude-code @ %s' "$REPO_ARCHIVE_URL"
     fi
 }
 
@@ -369,9 +369,9 @@ install_free_claude_code() {
     spec=$(package_spec)
 
     if [ -n "$torch_backend" ]; then
-        run uv tool install --force --python "$PYTHON_VERSION" --torch-backend "$torch_backend" "$spec"
+        run uv tool install --force --refresh-package free-claude-code --python "$PYTHON_VERSION" --torch-backend "$torch_backend" "$spec"
     else
-        run uv tool install --force --python "$PYTHON_VERSION" "$spec"
+        run uv tool install --force --refresh-package free-claude-code --python "$PYTHON_VERSION" "$spec"
     fi
 }
 
@@ -414,8 +414,6 @@ require_command curl
 require_command bash
 require_command sh
 require_command mktemp
-require_command git
-run git --version
 
 step "Ensuring Claude Code is installed"
 ensure_claude

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -125,10 +125,6 @@ def posix_harness(tmp_path: Path) -> PosixHarness:
         path.mkdir(parents=True)
 
     _write_executable(
-        bin_dir / "git",
-        '#!/bin/sh\necho "git:$*" >> "$CALL_LOG"\necho "git version 2.0.0"\n',
-    )
-    _write_executable(
         bin_dir / "curl",
         """#!/bin/sh
 url=""
@@ -232,9 +228,14 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
     assert calls.index("codex-install:1") < calls.index("codex:--version")
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
-        call.startswith("uv:tool install --force --python 3.14.0 git+")
+        call.startswith(
+            "uv:tool install --force --refresh-package free-claude-code "
+            "--python 3.14.0 free-claude-code @ "
+            "https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
+        )
         for call in calls
     )
+    assert not any(call.startswith("git:") for call in calls)
     assert calls[-3:] == [
         "uv:tool update-shell",
         "uv:tool dir --bin",
@@ -354,7 +355,9 @@ def test_install_sh_voice_flags_only_change_fcc_spec(
 
     assert result.returncode == 0, result.stderr
     assert any(
-        "--torch-backend cu130 free-claude-code[voice,voice_local] @ git+" in call
+        "--torch-backend cu130 free-claude-code[voice,voice_local] @ "
+        "https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
+        in call
         for call in posix_harness.calls()
     )
 
@@ -427,7 +430,7 @@ class PowerShellHarness:
     def add_uv(self, version: str) -> None:
         _write_executable(self.bin_dir / "uv.cmd", _batch_uv(version))
 
-    def run(self, fail_step: str = "") -> subprocess.CompletedProcess[str]:
+    def run(self, *args: str, fail_step: str = "") -> subprocess.CompletedProcess[str]:
         env = self.env | {"FAIL_STEP": fail_step}
         return subprocess.run(
             [
@@ -437,6 +440,7 @@ class PowerShellHarness:
                 "Bypass",
                 "-File",
                 str(self.wrapper),
+                *args,
             ],
             check=False,
             capture_output=True,
@@ -471,10 +475,6 @@ def powershell_harness(
     for path in (bin_dir, fixtures, tool_bin, home, local_app_data):
         path.mkdir(parents=True)
 
-    _write_executable(
-        bin_dir / "git.cmd",
-        '@echo off\necho git:%*>>"%CALL_LOG%"\necho git version 2.0.0\n',
-    )
     (fixtures / "claude-command.cmd").write_text(
         _batch_client("claude"), encoding="utf-8"
     )
@@ -551,7 +551,7 @@ function Invoke-RestMethod {
     Copy-Item -LiteralPath $source -Destination $OutFile -Force
 }
 $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
-& $installer
+& $installer @args
 """,
         encoding="utf-8",
     )
@@ -590,9 +590,14 @@ def test_install_ps1_fresh_install_is_verified(
     assert calls.index("codex-install:1") < calls.index("codex:--version")
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
-        call.startswith("uv:tool install --force --python 3.14.0 git+")
+        call.startswith(
+            "uv:tool install --force --refresh-package free-claude-code "
+            '--python 3.14.0 "free-claude-code @ '
+            'https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"'
+        )
         for call in calls
     )
+    assert not any(call.startswith("git:") for call in calls)
     assert calls[-3:] == [
         "uv:tool update-shell",
         "uv:tool dir --bin",
@@ -721,16 +726,18 @@ def test_install_ps1_rejects_unparseable_existing_uv(
     assert not any("astral.sh" in call for call in powershell_harness.calls())
 
 
-def test_install_ps1_requires_git_before_mutation(
+def test_install_ps1_voice_flags_only_change_fcc_spec(
     powershell_harness: PowerShellHarness,
 ) -> None:
-    (powershell_harness.bin_dir / "git.cmd").unlink()
+    result = powershell_harness.run("-VoiceAll", "-TorchBackend", "cu130")
 
-    result = powershell_harness.run()
-
-    assert result.returncode != 0
-    assert powershell_harness.calls() == []
-    assert "git is required" in result.stderr
+    assert result.returncode == 0, result.stderr
+    assert any(
+        '--torch-backend cu130 "free-claude-code[voice,voice_local] @ '
+        'https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"'
+        in call
+        for call in powershell_harness.calls()
+    )
 
 
 def test_installers_use_native_clients_and_single_python_selection() -> None:
@@ -740,9 +747,26 @@ def test_installers_use_native_clients_and_single_python_selection() -> None:
     for text in (shell, powershell):
         assert "@anthropic-ai/claude-code" not in text
         assert "@openai/codex" not in text
+        assert "git+" not in text
+        assert "git --version" not in text
+        assert (
+            "https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
+            in text
+        )
         assert "python install" not in text
+        assert "--refresh-package" in text
         assert "tool update-shell" in text
         assert "--python" in text
+
+
+def test_readme_install_section_has_no_manual_git_prerequisite() -> None:
+    readme = (_repo_root() / "README.md").read_text(encoding="utf-8")
+    install_section = readme.split("### 1. Install Or Update", 1)[1].split(
+        "### 2. Start The Server", 1
+    )[0]
+
+    assert "Install Git" not in install_section
+    assert "official native installers" not in install_section
 
 
 @pytest.mark.parametrize("powershell", _powershells())

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.5.18"
+version = "3.5.19"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC required Git solely to fetch its source from GitHub. Customers had to install an unrelated prerequisite before running an otherwise self-contained installer.

## Changes

| Before | After |
| --- | --- |
| Installers fetched FCC through a mutable `git+` repository URL. | Installers fetch the same visible `main` source through GitHub's generated ZIP archive. |
| Git had to exist before either installer could continue. | FCC installation has no Git dependency or Git-specific branch. |
| The unnamed source requirement relied on Git metadata. | Every base and voice variant uses a named direct-archive requirement. |
| Reinstallation relied on Git to discover the current branch head. | `--refresh-package free-claude-code` fetches the current archive on every rerun. |
| Installer tests provisioned a fake Git executable. | Windows and Linux scenarios pass with no Git executable and verify archive and voice specifications. |
| The README described installer internals and a manual Git prerequisite. | The install section presents the platform commands directly. |
| The package version was 3.5.18. | The package version is 3.5.19 with a synchronized lockfile. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the Git requirement from the FCC installers. The main changes are:

- Installer package specs now use GitHub's generated `main.zip` archive.
- POSIX and PowerShell installers no longer check for `git`.
- `uv tool install` now refreshes FCC during tool install.
- Installer tests now assert archive URLs, voice extras, and no Git calls.
- The package version and lockfile move to `3.5.19`.
- The README no longer lists Git as a manual prerequisite.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. The installer changes are consistent across POSIX and PowerShell. The package metadata uses plain Hatchling configuration and does not rely on Git-derived versioning.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the installer tests and observed a test run summary of 23 passed and 21 skipped with EXIT\_CODE 0.
- Executed a dry-run installer test with git intentionally unavailable, which reported an archive URL, a refresh flag, and EXIT\_CODE 0.
- Saved the no\_git\_installer\_harness.sh script to simulate a missing git on PATH while keeping UV, Python, and core utilities available.
- Ran a grep-based validation that confirmed the test pass summary, identified the no-git condition, captured the archive URL, and verified exit codes.

<a href="https://app.greptile.com/trex/runs/14184929/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/install.sh | Uses archive-based package specs, removes the Git prerequisite, and refreshes FCC during tool install. |
| scripts/install.ps1 | Mirrors the archive install flow and Git removal for Windows. |
| tests/scripts/test_installers.py | Updates installer tests for archive URLs, no Git calls, and voice/torch argument handling. |
| pyproject.toml | Bumps the project version to `3.5.19`. |
| uv.lock | Synchronizes the locked local package version. |
| README.md | Removes the obsolete manual Git prerequisite from install instructions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Install FCC without requiring Git"](https://github.com/alishahryar1/free-claude-code/commit/9b1af99f89658867a5b2e8a1f7150fde297c0420) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43708108)</sub>

<!-- /greptile_comment -->