### PR TITLE
Fix Pi routing for nested FCC model IDs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -820,7 +820,8 @@ instead of stopping at its login gate.
 is its bundled Pi adapter:
 
 - Session commands load the extension from its absolute installed path and
-  scope Pi to the ephemeral `free-claude-code/*` provider.
+  scope Pi to the ephemeral `free-claude-code/**` provider, whose model IDs
+  retain FCC's nested `provider/model` routing reference.
 - The extension fetches FCC's `/v1/models` catalog before registration, projects
   only routable provider-model IDs, and registers an `anthropic-messages`
   provider targeting the local proxy. Catalog failure is fail-closed so Pi never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "3.6.0"
+version = "4.0.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/pi.py
+++ b/src/free_claude_code/cli/launchers/pi.py
@@ -17,7 +17,7 @@ _BASE_URL_ENV = "FCC_PI_BASE_URL"
 _BINARY_NAME = "pi"
 _DISPLAY_NAME = "Pi"
 _HELP_TIMEOUT_SECONDS = 5.0
-_MODEL_SCOPE = "free-claude-code/*"
+_MODEL_SCOPE = "free-claude-code/**"
 _REQUIRED_HELP_MARKERS = ("--extension", "--models")
 _PASSTHROUGH_COMMANDS = frozenset(
     {"config", "install", "list", "remove", "uninstall", "update"}

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -704,7 +704,7 @@ def test_pi_launcher_builds_scoped_session_command_and_proxy_env(
         "-e",
         str(extension),
         "--models",
-        "free-claude-code/*",
+        "free-claude-code/**",
         "--print",
         "hello",
     ]
@@ -771,7 +771,7 @@ def test_launch_pi_registers_bundled_extension_for_sessions(
         "-e",
         str(extension),
         "--models",
-        "free-claude-code/*",
+        "free-claude-code/**",
         "--print",
         "hello",
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "3.6.0"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Pi registered FCC models but rejected the launcher scope because nested provider/model IDs contain an additional slash. Pi then retained a non-FCC model, so prompts did not reach the local proxy.

## Changes

| Before | After |
| --- | --- |
| `free-claude-code/*` matched only one model-ID path segment. | `free-claude-code/**` matches every nested FCC provider/model ID. |
| The integration architecture described a single-segment scope. | The integration architecture records the nested routing-reference contract. |
| The package version remained 3.6.0. | The package version is released as 4.0.0. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates Pi launcher routing so nested FCC model IDs can be scoped. The main changes are:

- Pi sessions now pass `free-claude-code/**` as the model scope.
- Pi launcher tests now expect the recursive scope string.
- Architecture docs now describe nested FCC provider/model routing.
- Package metadata and lockfile version move from `3.6.0` to `4.0.0`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming Pi accepts the recursive model scope.

The changed launcher passes the new scope as a literal subprocess argument, and no blocking issue was found in the repository-visible changed code.

The only follow-up is external matcher compatibility for `free-claude-code/**`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Pi launcher configuration was updated to enable recursive scope and to target all models under free-claude-code, as shown by the before and after launcher logs.
- The focused Pi tests ran and completed successfully, with 19 passed and 31 deselected, exit code 0.
- The Pi test harness initialization registered extensions, preserved and replaced environment variables, enabled recursive scope, and recorded PACKAGE\_VERSION= 4.0.0.
- The lint step with ruff ran and passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/14193741/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/launchers/pi.py | Changes the Pi model scope from a single-segment pattern to a recursive nested-model pattern. |
| tests/cli/test_entrypoints.py | Updates Pi launcher command assertions to expect the new scope string. |
| ARCHITECTURE.md | Documents the nested FCC routing-reference contract for Pi sessions. |
| pyproject.toml | Bumps the package version to `4.0.0`. |
| uv.lock | Synchronizes the editable package version with the project metadata. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-pi-model-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-pi-model-scope%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffree_claude_code%2Fcli%2Flaunchers%2Fpi.py%3A20%0A**Recursive%20Scope%20Depends%20On%20Pi**%0A%0AWhen%20Pi's%20%60--models%60%20matcher%20does%20not%20support%20recursive%20%60**%60%20patterns%2C%20this%20launcher%20now%20passes%20a%20scope%20that%20can%20match%20no%20FCC%20models%20even%20though%20the%20extension%20registers%20them.%20The%20session%20still%20starts%2C%20but%20the%20FCC%20models%20can%20be%20absent%20from%20Pi's%20picker%20and%20prompts%20can%20continue%20using%20a%20non-FCC%20model.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1090&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix Pi nested model scope"](https://github.com/alishahryar1/free-claude-code/commit/f931b9db4a54801cb82c3d0e1c7674528a6bb5a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43725034)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->