### PR TITLE
Fix Codex VS Code proxy authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,19 +247,11 @@ model = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 [model_providers.fcc]
 name = "Free Claude Code"
 base_url = "http://127.0.0.1:8082/v1"
-env_key = "FCC_CODEX_API_KEY"
+http_headers = { "X-API-Key" = "freecc" }
 wire_api = "responses"
 ```
 
-Store the Admin UI authentication token in `~/.codex/auth.json` or its Windows equivalent:
-
-```json
-{
-  "FCC_CODEX_API_KEY": "freecc"
-}
-```
-
-Match `model`, the port, and the token to the Admin UI, then restart VS Code. For WSL-backed Codex, edit the files inside WSL.
+Match `model`, the port, and `X-API-Key` to the Admin UI, then restart VS Code. For WSL-backed Codex, edit the file inside WSL.
 
 </details>
 


### PR DESCRIPTION
## Problem

The Codex VS Code guide configured `FCC_CODEX_API_KEY` as an environment variable but stored it in `auth.json`, which Codex does not use for custom-provider environment keys. IDE sessions therefore failed with a missing-variable error. Fixes #905.

## Changes

| Before | After |
| --- | --- |
| The guide split FCC authentication across `env_key` and an unsupported custom `auth.json` entry. | The guide sends the proxy token through Codex's supported static `X-API-Key` provider header. |
| VS Code had to inherit `FCC_CODEX_API_KEY` from its launcher environment. | VS Code reads the complete FCC provider configuration from `config.toml`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Codex VS Code setup guide for proxy authentication. The main changes are:

- Replaces the unsupported `auth.json` token step with a provider header in `config.toml`.
- Uses `X-API-Key` with the default `freecc` token for the local proxy.
- Updates the restart note to point users at the single WSL config file.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed documentation. The documented header matches the proxy authentication path already used by the service.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the repository README by executing codex\_readme\_validate.py on README.md; the run exited with code 0 and logged the extracted README section, a TOML snippet, and assertions.
- Collected installer and client related tests with pytest --collect-only for tests/scripts/test\_installers.py, and the collection run exited with code 0.
- Confirmed that no live Codex, VS Code, or provider credential calls were attempted during this validation run.

<a href="https://app.greptile.com/trex/runs/14221927/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates the Codex VS Code authentication instructions to use a static `X-API-Key` provider header instead of an unsupported `auth.json` entry. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Codex VS Code proxy authentication"](https://github.com/alishahryar1/free-claude-code/commit/6ed20f370fe7beb69445496b05976cb54f4e55cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43784097)</sub>

<!-- /greptile_comment -->