### PR TITLE
Fix Auto Mode classifier responses when stream is omitted

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -396,7 +396,8 @@ response. Once FCC has finalized the failure, the response includes
 without causing a second client retry loop. After the first chunk has escaped,
 HTTP status is committed; Messages emits an Anthropic `event: error` and closes
 without a synthetic `message_stop`; Responses emits `response.failed` with the
-original response ID. Non-streaming Messages aggregate internally and return
+original response ID. Messages are non-streaming unless the client explicitly
+sets `stream: true`. Non-streaming Messages aggregate internally and return
 non-2xx JSON for any terminal stream error, discarding incomplete content rather
 than presenting a partial success.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.3.0"
+version = "4.3.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/handlers/messages.py
+++ b/src/free_claude_code/api/handlers/messages.py
@@ -135,12 +135,12 @@ class MessagesHandler:
         self,
         result: _MessagesResult,
         *,
-        stream: bool | None,
+        stream: bool,
         request_id: str,
     ) -> object:
         if isinstance(result, _MessagesCompleteResult):
             return result.response
-        if stream is False:
+        if not stream:
             # Non-streaming clients (e.g. Claude Code utility calls) need a
             # complete JSON Message; the internal pipeline is always SSE, so
             # serving that raw here breaks the client SDK's response parse.

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -109,7 +109,7 @@ async def create_message(
     services: ApiServices = Depends(get_services),
     _auth=Depends(require_proxy_auth),
 ):
-    """Create a message (streaming by default; stream=false gets aggregated JSON)."""
+    """Create a message (JSON by default; stream=true returns Anthropic SSE)."""
     return await _create_messages_response(
         services,
         request_data,

--- a/src/free_claude_code/core/anthropic/models.py
+++ b/src/free_claude_code/core/anthropic/models.py
@@ -183,7 +183,7 @@ class MessagesRequest(BaseModel):
     messages: list[Message]
     system: str | list[SystemContent] | None = None
     stop_sequences: list[str] | None = None
-    stream: bool | None = True
+    stream: bool = False
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None

--- a/src/free_claude_code/core/anthropic/sse_aggregation.py
+++ b/src/free_claude_code/core/anthropic/sse_aggregation.py
@@ -1,10 +1,10 @@
 """Fold an Anthropic Messages SSE stream into a single JSON Message body.
 
-Used to honor client requests with ``stream: false``. The internal pipeline
-is always SSE (provider execution always yields a stream), so
-callers that need a non-streaming response consume the stream here and get
-back the same shape the real Anthropic API returns for a non-streaming
-``messages.create()`` call.
+Used when client requests omit ``stream`` or set ``stream: false``. The internal
+pipeline is always SSE (provider execution always yields a stream), so callers
+that need a non-streaming response consume the stream here and get back the same
+shape the real Anthropic API returns for a non-streaming ``messages.create()``
+call.
 """
 
 import json

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -128,6 +128,36 @@ def test_create_message_stream(client: TestClient):
     assert _stream_response_calls[0][1]["request_id"] == response.headers["request-id"]
 
 
+def test_auto_mode_classifier_without_stream_returns_json(client: TestClient):
+    """Claude side queries omit stream and require one complete Message object."""
+    _stream_response_calls.clear()
+    payload = {
+        "model": "claude-opus-4-8",
+        "max_tokens": 64,
+        "system": (
+            "You are a security monitor. Respond with <block>yes</block> "
+            "or <block>no</block>."
+        ),
+        "messages": [
+            {
+                "role": "user",
+                "content": "<transcript>\nBash curl example.com\n</transcript>",
+            }
+        ],
+    }
+
+    response = client.post("/v1/messages?beta=true", json=payload)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert body["type"] == "message"
+    assert body["usage"] == {"input_tokens": 0, "output_tokens": 0}
+    routed_request = _stream_response_calls[0][0][0]
+    assert routed_request.stream is False
+    assert _stream_response_calls[0][1]["thinking_enabled"] is False
+
+
 def test_create_message_ingress_error_has_request_id_without_terminal_header(
     client: TestClient,
 ):

--- a/tests/api/test_api_handlers.py
+++ b/tests/api/test_api_handlers.py
@@ -103,6 +103,7 @@ async def test_messages_handler_passes_routed_request_and_stream_metadata() -> N
     request = MessagesRequest(
         model="nvidia_nim/test-model",
         max_tokens=100,
+        stream=True,
         messages=[Message(role="user", content="hi")],
     )
 
@@ -373,6 +374,7 @@ async def test_messages_handler_forces_no_thinking_for_safety_classifier() -> No
     request = MessagesRequest(
         model="nvidia_nim/test-model",
         max_tokens=100,
+        stream=True,
         system=_CLASSIFIER_SYSTEM,
         messages=[Message(role="user", content=_CLASSIFIER_USER)],
     )
@@ -406,6 +408,7 @@ async def test_messages_handler_preserves_thinking_for_non_classifier() -> None:
     request = MessagesRequest(
         model="nvidia_nim/test-model",
         max_tokens=100,
+        stream=True,
         system="Explain XML formats.",
         messages=[
             Message(
@@ -441,6 +444,7 @@ async def test_messages_handler_keeps_existing_no_thinking_for_classifier() -> N
     request = MessagesRequest(
         model="claude-3-freecc-no-thinking/nvidia_nim/test-model",
         max_tokens=100,
+        stream=True,
         system=_CLASSIFIER_SYSTEM,
         messages=[Message(role="user", content=_CLASSIFIER_USER)],
     )

--- a/tests/api/test_web_server_tools.py
+++ b/tests/api/test_web_server_tools.py
@@ -424,6 +424,7 @@ async def test_service_streams_forced_web_search_by_default(monkeypatch):
     request = MessagesRequest(
         model="claude-haiku-4-5-20251001",
         max_tokens=100,
+        stream=True,
         messages=[Message(role="user", content="Search for DeepSeek V4")],
         tools=[Tool(name="web_search", type="web_search_20250305")],
         tool_choice={"type": "tool", "name": "web_search"},

--- a/tests/core/anthropic/test_models.py
+++ b/tests/core/anthropic/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from free_claude_code.core.anthropic.conversion import (
     OpenAIConversionError,
@@ -21,6 +22,19 @@ def test_messages_request_parses_without_model_mapping_side_effects():
     )
 
     assert request.model == "claude-3-opus"
+    assert request.stream is False
+
+
+def test_messages_request_rejects_null_stream() -> None:
+    with pytest.raises(ValidationError):
+        MessagesRequest.model_validate(
+            {
+                "model": "claude-3-opus",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": None,
+            }
+        )
 
 
 def test_messages_request_normalizes_system_role_messages():
@@ -292,7 +306,7 @@ def test_messages_request_dump_preserves_public_defaults_and_excludes_internal_f
     assert dumped == {
         "model": "model",
         "messages": [{"role": "user", "content": "hello"}],
-        "stream": True,
+        "stream": False,
         "thinking": {"enabled": True, "type": "adaptive"},
         "client_extension": {"enabled": True},
     }

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.3.0"
+version = "4.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Claude Code Auto Mode classifier requests omit `stream`, which means they expect a non-streaming Messages response. FCC treated omission as streaming, returned SSE, and caused Claude to report the classifier model as temporarily unavailable. Fixes #1094.

## Changes

| Before | After |
| --- | --- |
| Omitted `stream` defaulted to streaming SSE. | Omitted `stream` defaults to a complete JSON Message; only `stream: true` selects SSE. |
| Classifier side queries received a body without top-level `usage`. | Classifier side queries receive a JSON Message with top-level `usage` while thinking remains disabled. |
| Tests encoded FCC's nonstandard streaming default. | Model and HTTP-boundary tests enforce Anthropic's response-mode contract. |
| The package version was 4.3.0. | The package version is 4.3.1. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Messages response mode handling when clients omit `stream`. The main changes are:

- Defaulted Anthropic Messages requests to non-streaming JSON.
- Returned SSE only when `stream: true` is set.
- Updated classifier, handler, web-tool, and model tests for the new contract.
- Documented the default response mode and bumped the package version.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after deciding whether `stream: null` should remain accepted.

The JSON-by-default Messages path is covered in the model, handler, and API tests. Explicit streaming still flows through the SSE path.

Clients that send `stream: null` can now get a validation error instead of a response.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the full test suite for the code under test; pytest completed with 132 tests passed in 2.96s and exited with code 0.
- Validated the testclient probe non-stream request returned 200 OK with a JSON message.
- Validated the testclient probe stream request returned 200 OK with a text/event-stream SSE and routing/behaviors as expected (routed\_stream true, thinking\_enabled\_kwarg false).

<a href="https://app.greptile.com/trex/runs/14257681/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/anthropic/models.py | Changes `MessagesRequest.stream` to default to non-streaming JSON and reject null values. |
| src/free_claude_code/api/handlers/messages.py | Aggregates internal SSE into JSON unless streaming was explicitly requested. |
| src/free_claude_code/api/routes.py | Updates the Messages route description to match the new JSON-by-default behavior. |
| src/free_claude_code/core/anthropic/sse_aggregation.py | Updates aggregation documentation for omitted and false stream requests. |
| tests/api/test_api.py | Adds coverage for classifier-style requests that omit `stream` and expect JSON. |
| tests/api/test_api_handlers.py | Marks streaming handler tests with explicit `stream=True`. |
| tests/api/test_web_server_tools.py | Marks the forced web-search streaming test with explicit `stream=True`. |
| tests/core/anthropic/test_models.py | Updates model expectations for the new default and adds null-stream rejection coverage. |
| pyproject.toml | Bumps the package version to `4.3.1`. |
| uv.lock | Keeps the editable package version in sync with `pyproject.toml`. |
| ARCHITECTURE.md | Documents that Messages responses are non-streaming unless `stream: true` is provided. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-auto-mode-omitted-stream%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-auto-mode-omitted-stream%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffree_claude_code%2Fcore%2Fanthropic%2Fmodels.py%3A186%0A**Null%20Stream%20Now%20Fails%20Validation**%0A%0AWhen%20a%20client%20serializes%20an%20unspecified%20optional%20stream%20flag%20as%20%60%22stream%22%3A%20null%60%2C%20this%20narrowed%20field%20rejects%20the%20request%20before%20the%20handler%20can%20return%20the%20new%20non-streaming%20JSON%20response.%20The%20old%20model%20accepted%20that%20input%2C%20so%20these%20clients%20now%20receive%20a%20validation%20error%20instead%20of%20a%20Message%20object.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1098&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix omitted Messages stream default"](https://github.com/alishahryar1/free-claude-code/commit/ca61e5ad4adf085d5cef1e0e5f3a8ae26d189853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43859149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->