### PR TITLE
Add Fable as a first-class Claude routing tier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
 # Valid providers: "nvidia_nim" | "open_router" | "gemini" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "minimax" | "cerebras" | "groq" | "sambanova" | "fireworks" | "cloudflare" | "zai" | "lmstudio" | "llamacpp" | "ollama"
+MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=
@@ -136,6 +137,7 @@ FCC_SMOKE_OPENROUTER_FREE_EXTRA_MODELS=
 # Thinking output
 # Per-Claude-model switches for provider reasoning requests and Claude thinking blocks.
 # Blank per-model switches inherit ENABLE_MODEL_THINKING.
+ENABLE_FABLE_THINKING=
 ENABLE_OPUS_THINKING=
 ENABLE_SONNET_THINKING=
 ENABLE_HAIKU_THINKING=

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -311,9 +311,9 @@ source detection for startup warnings also belongs to `src/free_claude_code/conf
 Model routing configuration is tiered:
 
 - `MODEL` is the fallback provider-prefixed model ref.
-- `MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU` override Claude model tiers.
+- `MODEL_FABLE`, `MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU` override Claude model tiers.
 - `ENABLE_MODEL_THINKING` is the global thinking switch.
-- `ENABLE_OPUS_THINKING`, `ENABLE_SONNET_THINKING`, and
+- `ENABLE_FABLE_THINKING`, `ENABLE_OPUS_THINKING`, `ENABLE_SONNET_THINKING`, and
   `ENABLE_HAIKU_THINKING` optionally override thinking by tier.
 
 [config/model_refs.py](src/free_claude_code/config/model_refs.py) owns provider-prefixed model ref
@@ -462,7 +462,7 @@ It supports two forms:
 - Gateway model IDs decoded by [core/gateway_model_ids.py](src/free_claude_code/core/gateway_model_ids.py).
 
 If the incoming model is not direct, `ModelRouter` maps it by Claude tier. Names
-containing `opus`, `sonnet`, or `haiku` use the matching tier override when set,
+containing `fable`, `opus`, `sonnet`, or `haiku` use the matching tier override when set,
 otherwise they fall back to `MODEL`.
 
 The router also resolves thinking. Gateway model IDs can force thinking on or

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.
 - Switch among 24 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
-- Route Opus, Sonnet, Haiku, and fallback traffic to different models.
+- Route Fable, Opus, Sonnet, Haiku, and fallback traffic to different models.
 - Keep streaming, tool use, reasoning, and image input across compatible models.
 - Connect Claude Code and Codex in VS Code or Claude Code through JetBrains ACP.
 - Optionally run Claude Code sessions through Discord or Telegram with voice-note transcription.
@@ -205,7 +205,7 @@ Use the tag shown by `ollama list` with the `ollama/` prefix. `OLLAMA_BASE_URL` 
 
 ### Optional Model-Tier Routing
 
-`MODEL` is the fallback for every request. Set `MODEL_OPUS`, `MODEL_SONNET`, or `MODEL_HAIKU` to override individual Claude Code tiers; leave a tier blank to inherit `MODEL`.
+`MODEL` is the fallback for every request. Set `MODEL_FABLE`, `MODEL_OPUS`, `MODEL_SONNET`, or `MODEL_HAIKU` to override individual Claude Code tiers; leave a tier blank to inherit `MODEL`.
 
 For example, route Opus to `nvidia_nim/moonshotai/kimi-k2.6`, Sonnet to `open_router/openrouter/free`, Haiku to `lmstudio/qwen3.5-coder`, and keep `MODEL` on `zai/glm-5.2`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.3.1"
+version = "4.4.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -41,7 +41,7 @@ uv run pytest smoke -n auto --dist=loadgroup -s --tb=short
 ```
 
 Provider product E2E runs once per configured provider, independent of `MODEL`,
-`MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU`. Defaults come from the provider
+`MODEL_FABLE`, `MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU`. Defaults come from the provider
 catalog/docs and can be overridden with `FCC_SMOKE_MODEL_<PROVIDER>`, for example
 `FCC_SMOKE_MODEL_DEEPSEEK=deepseek-v4-pro` (or `deepseek-v4-flash`). If no provider smoke model is
 configured, live product smoke fails as `missing_env` unless you explicitly set

--- a/smoke/capabilities.py
+++ b/smoke/capabilities.py
@@ -138,7 +138,7 @@ CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
         "mixed_provider_resolution",
         "mixed_provider_mapping",
         "free_claude_code.application.routing.ModelRouter",
-        "Opus/Sonnet/Haiku/fallback model config",
+        "Fable/Opus/Sonnet/Haiku/fallback model config",
         "distinct provider selections per request",
         "skip live execution when providers are not configured",
         ("tests/application/test_routing.py", "tests/config/test_config.py"),

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -123,13 +123,13 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
     ),
     FeatureCoverage(
         "per_model_mapping",
-        "Opus, Sonnet, Haiku, and fallback mappings route explicitly",
+        "Fable, Opus, Sonnet, Haiku, and fallback mappings route explicitly",
         "readme",
         ("tests/application/test_routing.py", "tests/config/test_config.py"),
         ("test_model_mapping_configuration_is_consistent",),
         ("test_model_mapping_matrix_e2e",),
         ("providers",),
-        ("MODEL", "MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"),
+        ("MODEL", "MODEL_FABLE", "MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"),
         "skip only when live smoke is intentionally allowed to run with no provider",
     ),
     FeatureCoverage(
@@ -140,7 +140,7 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
         ("test_mixed_provider_model_mapping_when_configured",),
         ("test_model_mapping_matrix_e2e",),
         ("providers",),
-        ("MODEL", "MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"),
+        ("MODEL", "MODEL_FABLE", "MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"),
         "configured mixed-provider mappings must resolve consistently",
     ),
     FeatureCoverage(

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -169,6 +169,7 @@ class SmokeConfig:
     def provider_models(self) -> list[ProviderModel]:
         candidates = (
             ("MODEL", self.settings.model),
+            ("MODEL_FABLE", self.settings.model_fable),
             ("MODEL_OPUS", self.settings.model_opus),
             ("MODEL_SONNET", self.settings.model_sonnet),
             ("MODEL_HAIKU", self.settings.model_haiku),

--- a/smoke/prereq/test_provider_prereq_live.py
+++ b/smoke/prereq/test_provider_prereq_live.py
@@ -38,7 +38,13 @@ def test_mixed_provider_model_mapping_when_configured(
         pytest.skip("configure MODEL_* with at least two provider prefixes")
 
     sources = {provider_model.source for provider_model in models}
-    assert sources <= {"MODEL", "MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"}
+    assert sources <= {
+        "MODEL",
+        "MODEL_FABLE",
+        "MODEL_OPUS",
+        "MODEL_SONNET",
+        "MODEL_HAIKU",
+    }
     assert len(providers) >= 2
 
 

--- a/smoke/product/test_client_product_live.py
+++ b/smoke/product/test_client_product_live.py
@@ -171,6 +171,7 @@ def test_claude_cli_provider_error_e2e(
             name="product-claude-cli-provider-error",
             env_overrides={
                 "MODEL": broken_model,
+                "MODEL_FABLE": broken_model,
                 "MODEL_OPUS": broken_model,
                 "MODEL_SONNET": broken_model,
                 "MODEL_HAIKU": broken_model,

--- a/smoke/product/test_config_extensibility_product_live.py
+++ b/smoke/product/test_config_extensibility_product_live.py
@@ -68,6 +68,7 @@ def test_per_model_thinking_config_e2e(smoke_config: SmokeConfig, tmp_path) -> N
     env_file = tmp_path / "thinking.env"
     env_file.write_text(
         'ENABLE_MODEL_THINKING="false"\n'
+        'ENABLE_FABLE_THINKING="true"\n'
         'ENABLE_OPUS_THINKING="true"\n'
         "ENABLE_SONNET_THINKING=\n"
         'ENABLE_HAIKU_THINKING="false"\n',
@@ -80,6 +81,7 @@ def test_per_model_thinking_config_e2e(smoke_config: SmokeConfig, tmp_path) -> N
         "from free_claude_code.config.settings import Settings; "
         "s=Settings(); "
         "r=ModelRouter(s); "
+        "print(r.resolve('claude-fable-5').thinking_enabled); "
         "print(r.resolve('claude-opus-4-20250514').thinking_enabled); "
         "print(r.resolve('claude-sonnet-4-20250514').thinking_enabled); "
         "print(r.resolve('claude-haiku-4-20250514').thinking_enabled); "
@@ -93,7 +95,13 @@ def test_per_model_thinking_config_e2e(smoke_config: SmokeConfig, tmp_path) -> N
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    assert result.stdout.splitlines() == ["True", "False", "False", "False"]
+    assert result.stdout.splitlines() == [
+        "True",
+        "True",
+        "False",
+        "False",
+        "False",
+    ]
 
 
 @pytest.mark.smoke_target("config")

--- a/smoke/product/test_provider_product_live.py
+++ b/smoke/product/test_provider_product_live.py
@@ -33,7 +33,13 @@ def test_provider_matrix_presence_e2e(smoke_config: SmokeConfig) -> None:
 def test_model_mapping_matrix_e2e(smoke_config: SmokeConfig) -> None:
     models = ProviderMatrixDriver(smoke_config).configured_models()
     sources = {model.source for model in models}
-    assert sources <= {"MODEL", "MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"}
+    assert sources <= {
+        "MODEL",
+        "MODEL_FABLE",
+        "MODEL_OPUS",
+        "MODEL_SONNET",
+        "MODEL_HAIKU",
+    }
     for model in models:
         assert model.provider
         assert model.model_name

--- a/smoke/product/test_runtime_ownership_product_live.py
+++ b/smoke/product/test_runtime_ownership_product_live.py
@@ -179,6 +179,7 @@ def _write_initial_managed_config(home: Path, upstream: FakeOpenAIUpstream) -> N
         + "\n".join(
             [
                 "MODEL=lmstudio/model-a",
+                "MODEL_FABLE=",
                 "MODEL_OPUS=",
                 "MODEL_SONNET=",
                 "MODEL_HAIKU=",
@@ -240,6 +241,7 @@ def test_provider_hot_swap_preserves_inflight_stream_e2e(
                     "FCC_ENV_FILE",
                     "LM_STUDIO_BASE_URL",
                     "MODEL",
+                    "MODEL_FABLE",
                     "MODEL_HAIKU",
                     "MODEL_OPUS",
                     "MODEL_SONNET",

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -35,6 +35,11 @@ class ModelsListResponse(BaseModel):
 
 SUPPORTED_CLAUDE_MODELS = [
     ModelResponse(
+        id="claude-fable-5",
+        display_name="Claude Fable 5",
+        created_at="2026-06-09T00:00:00Z",
+    ),
+    ModelResponse(
         id="claude-opus-4-20250514",
         display_name="Claude Opus 4",
         created_at="2025-05-14T00:00:00Z",

--- a/src/free_claude_code/application/routing.py
+++ b/src/free_claude_code/application/routing.py
@@ -117,6 +117,8 @@ class ModelRouter:
         """Resolve a Claude model name to the configured provider/model ref."""
 
         name_lower = claude_model_name.lower()
+        if "fable" in name_lower and self._settings.model_fable is not None:
+            return self._settings.model_fable
         if "opus" in name_lower and self._settings.model_opus is not None:
             return self._settings.model_opus
         if "haiku" in name_lower and self._settings.model_haiku is not None:
@@ -129,6 +131,8 @@ class ModelRouter:
         """Resolve whether thinking is enabled for an incoming Claude model name."""
 
         name_lower = claude_model_name.lower()
+        if "fable" in name_lower and self._settings.enable_fable_thinking is not None:
+            return self._settings.enable_fable_thinking
         if "opus" in name_lower and self._settings.enable_opus_thinking is not None:
             return self._settings.enable_opus_thinking
         if "haiku" in name_lower and self._settings.enable_haiku_thinking is not None:

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -108,6 +108,13 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         description="Fallback provider/model route for all Claude model names.",
     ),
     ConfigFieldSpec(
+        "MODEL_FABLE",
+        "Fable Override",
+        "models",
+        settings_attr="model_fable",
+        description="Optional provider/model route for Fable requests.",
+    ),
+    ConfigFieldSpec(
         "MODEL_OPUS",
         "Opus Override",
         "models",
@@ -135,6 +142,14 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         "boolean",
         settings_attr="enable_model_thinking",
         default="true",
+    ),
+    ConfigFieldSpec(
+        "ENABLE_FABLE_THINKING",
+        "Fable Thinking",
+        "thinking",
+        "tri_boolean",
+        settings_attr="enable_fable_thinking",
+        description="Blank inherits Enable Thinking.",
     ),
     ConfigFieldSpec(
         "ENABLE_OPUS_THINKING",

--- a/src/free_claude_code/config/model_refs.py
+++ b/src/free_claude_code/config/model_refs.py
@@ -16,6 +16,7 @@ class ConfiguredChatModelRef:
 
 class ChatModelConfig(Protocol):
     model: str
+    model_fable: str | None
     model_opus: str | None
     model_sonnet: str | None
     model_haiku: str | None
@@ -40,6 +41,7 @@ def configured_chat_model_refs(
 
     candidates = (
         ("MODEL", settings.model),
+        ("MODEL_FABLE", settings.model_fable),
         ("MODEL_OPUS", settings.model_opus),
         ("MODEL_SONNET", settings.model_sonnet),
         ("MODEL_HAIKU", settings.model_haiku),

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -124,6 +124,7 @@ class Settings(BaseSettings):
 
     # Per-model overrides (optional, falls back to MODEL)
     # Each can use a different provider
+    model_fable: str | None = Field(default=None, validation_alias="MODEL_FABLE")
     model_opus: str | None = Field(default=None, validation_alias="MODEL_OPUS")
     model_sonnet: str | None = Field(default=None, validation_alias="MODEL_SONNET")
     model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
@@ -164,6 +165,9 @@ class Settings(BaseSettings):
     )
     enable_model_thinking: bool = Field(
         default=True, validation_alias="ENABLE_MODEL_THINKING"
+    )
+    enable_fable_thinking: bool | None = Field(
+        default=None, validation_alias="ENABLE_FABLE_THINKING"
     )
     enable_opus_thinking: bool | None = Field(
         default=None, validation_alias="ENABLE_OPUS_THINKING"
@@ -287,9 +291,11 @@ class Settings(BaseSettings):
         "allowed_telegram_user_id",
         "discord_bot_token",
         "allowed_discord_channels",
+        "model_fable",
         "model_opus",
         "model_sonnet",
         "model_haiku",
+        "enable_fable_thinking",
         "enable_opus_thinking",
         "enable_sonnet_thinking",
         "enable_haiku_thinking",
@@ -353,7 +359,9 @@ class Settings(BaseSettings):
                 )
         return ",".join(schemes)
 
-    @field_validator("model", "model_opus", "model_sonnet", "model_haiku")
+    @field_validator(
+        "model", "model_fable", "model_opus", "model_sonnet", "model_haiku"
+    )
     @classmethod
     def validate_model_format(cls, v: str | None) -> str | None:
         if v is None:

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -112,6 +112,8 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
     assert response.status_code == 200
     body = response.json()
     keys = {field["key"] for field in body["fields"]}
+    assert "MODEL_FABLE" in keys
+    assert "ENABLE_FABLE_THINKING" in keys
     assert "ANTHROPIC_AUTH_TOKEN" in keys
     assert "OPENROUTER_API_KEY" in keys
     assert "FIREWORKS_API_KEY" in keys

--- a/tests/api/test_model_listing.py
+++ b/tests/api/test_model_listing.py
@@ -8,11 +8,13 @@ from tests.api.support import create_test_app, provider_manager_for_app
 def _settings(
     *,
     model: str = "deepseek/deepseek-chat",
+    model_fable: str | None = None,
     model_opus: str | None = "open_router/anthropic/claude-opus",
     model_haiku: str | None = "deepseek/deepseek-chat",
 ) -> Settings:
     return Settings.model_construct(
         model=model,
+        model_fable=model_fable,
         model_opus=model_opus,
         model_sonnet=None,
         model_haiku=model_haiku,
@@ -62,6 +64,7 @@ def test_models_list_includes_configured_refs_cached_provider_models_and_aliases
         == "open_router/meta/llama-3.3 (no thinking)"
     )
     assert "claude-sonnet-4-20250514" in ids
+    assert "claude-fable-5" in ids
     assert data["first_id"] == ids[0]
     assert data["last_id"] == ids[-1]
     assert data["has_more"] is False

--- a/tests/application/test_routing.py
+++ b/tests/application/test_routing.py
@@ -17,10 +17,12 @@ from free_claude_code.core.anthropic.models import (
 def settings():
     settings = Settings()
     settings.model = "nvidia_nim/fallback-model"
+    settings.model_fable = None
     settings.model_opus = None
     settings.model_sonnet = None
     settings.model_haiku = None
     settings.enable_model_thinking = True
+    settings.enable_fable_thinking = None
     settings.enable_opus_thinking = None
     settings.enable_sonnet_thinking = None
     settings.enable_haiku_thinking = None
@@ -54,13 +56,31 @@ def test_model_router_applies_opus_override(settings):
     assert request.model == "claude-opus-4-20250514"
 
 
+def test_model_router_applies_fable_override(settings):
+    settings.model_fable = "open_router/anthropic/claude-fable-5"
+
+    routed = ModelRouter(settings).resolve_messages_request(
+        MessagesRequest(
+            model="claude-fable-5",
+            max_tokens=100,
+            messages=[Message(role="user", content="hello")],
+        )
+    )
+
+    assert routed.request.model == "anthropic/claude-fable-5"
+    assert routed.resolved.provider_model_ref == "open_router/anthropic/claude-fable-5"
+    assert routed.resolved.original_model == "claude-fable-5"
+
+
 def test_model_router_resolves_per_model_thinking(settings):
     settings.enable_model_thinking = False
+    settings.enable_fable_thinking = True
     settings.enable_opus_thinking = True
     settings.enable_haiku_thinking = False
 
     router = ModelRouter(settings)
 
+    assert router.resolve("claude-fable-5").thinking_enabled is True
     assert router.resolve("claude-opus-4-20250514").thinking_enabled is True
     assert router.resolve("claude-sonnet-4-20250514").thinking_enabled is False
     assert router.resolve("claude-3-haiku-20240307").thinking_enabled is False

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -382,10 +382,12 @@ class TestSettings:
         """Per-model thinking env vars are loaded into settings."""
         from free_claude_code.config.settings import Settings
 
+        monkeypatch.setenv("ENABLE_FABLE_THINKING", "true")
         monkeypatch.setenv("ENABLE_OPUS_THINKING", "true")
         monkeypatch.setenv("ENABLE_SONNET_THINKING", "false")
         monkeypatch.setenv("ENABLE_HAIKU_THINKING", "false")
         settings = Settings()
+        assert settings.enable_fable_thinking is True
         assert settings.enable_opus_thinking is True
         assert settings.enable_sonnet_thinking is False
         assert settings.enable_haiku_thinking is False
@@ -410,10 +412,12 @@ class TestSettings:
         from free_claude_code.config.settings import Settings
 
         monkeypatch.setenv("ENABLE_MODEL_THINKING", "false")
+        monkeypatch.setenv("ENABLE_FABLE_THINKING", "true")
         monkeypatch.setenv("ENABLE_OPUS_THINKING", "true")
         monkeypatch.setenv("ENABLE_HAIKU_THINKING", "false")
         settings = Settings()
         router = ModelRouter(settings)
+        assert router.resolve("claude-fable-5").thinking_enabled is True
         assert router.resolve("claude-opus-4-20250514").thinking_enabled is True
         assert router.resolve("claude-sonnet-4-20250514").thinking_enabled is False
         assert router.resolve("claude-haiku-4-20250514").thinking_enabled is False
@@ -719,6 +723,7 @@ class TestPerModelMapping:
         from free_claude_code.config.settings import Settings
 
         s = Settings()
+        assert s.model_fable is None
         assert s.model_opus is None
         assert s.model_sonnet is None
         assert s.model_haiku is None
@@ -731,7 +736,17 @@ class TestPerModelMapping:
         s = Settings()
         assert s.model_opus == "open_router/deepseek/deepseek-r1"
 
-    @pytest.mark.parametrize("env_var", ["MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"])
+    def test_model_fable_from_env(self, monkeypatch):
+        """MODEL_FABLE env var is loaded."""
+        from free_claude_code.config.settings import Settings
+
+        monkeypatch.setenv("MODEL_FABLE", "open_router/anthropic/claude-fable-5")
+        s = Settings()
+        assert s.model_fable == "open_router/anthropic/claude-fable-5"
+
+    @pytest.mark.parametrize(
+        "env_var", ["MODEL_FABLE", "MODEL_OPUS", "MODEL_SONNET", "MODEL_HAIKU"]
+    )
     def test_empty_model_override_env_is_unset(self, monkeypatch, env_var):
         """Empty per-model override env vars are treated as unset."""
         from free_claude_code.application.routing import ModelRouter
@@ -838,6 +853,26 @@ class TestPerModelMapping:
         with pytest.raises(ValidationError, match="Invalid provider"):
             Settings()
 
+    def test_model_fable_invalid_provider_raises(self, monkeypatch):
+        """MODEL_FABLE with invalid provider prefix raises ValidationError."""
+        from free_claude_code.config.settings import Settings
+
+        monkeypatch.setenv("MODEL_FABLE", "invalid/model")
+        with pytest.raises(ValidationError, match="Invalid provider"):
+            Settings()
+
+    def test_resolve_model_fable_override(self):
+        """ModelRouter returns model_fable for Fable model names."""
+        from free_claude_code.application.routing import ModelRouter
+        from free_claude_code.config.settings import Settings
+
+        s = Settings()
+        s.model_fable = "open_router/anthropic/claude-fable-5"
+        assert (
+            ModelRouter(s).resolve("claude-fable-5").provider_model_ref
+            == "open_router/anthropic/claude-fable-5"
+        )
+
     def test_resolve_model_opus_override(self):
         """ModelRouter returns model_opus for opus model names."""
         from free_claude_code.application.routing import ModelRouter
@@ -905,6 +940,10 @@ class TestPerModelMapping:
         s = Settings()
         s.model = "nvidia_nim/fallback-model"
         router = ModelRouter(s)
+        assert (
+            router.resolve("claude-fable-5").provider_model_ref
+            == "nvidia_nim/fallback-model"
+        )
         assert (
             router.resolve("claude-opus-4-20250514").provider_model_ref
             == "nvidia_nim/fallback-model"
@@ -1032,6 +1071,7 @@ class TestPerModelMapping:
         monkeypatch.setenv("WHISPER_MODEL", "openai/whisper-large-v3")
         s = Settings()
         s.model = "nvidia_nim/fallback"
+        s.model_fable = "open_router/anthropic/claude-fable-5"
         s.model_opus = "open_router/anthropic/claude-opus"
         s.model_sonnet = "nvidia_nim/fallback"
         s.model_haiku = None
@@ -1040,11 +1080,15 @@ class TestPerModelMapping:
 
         assert [ref.model_ref for ref in refs] == [
             "nvidia_nim/fallback",
+            "open_router/anthropic/claude-fable-5",
             "open_router/anthropic/claude-opus",
         ]
         assert refs[0].provider_id == "nvidia_nim"
         assert refs[0].model_id == "fallback"
         assert refs[0].sources == ("MODEL", "MODEL_SONNET")
         assert refs[1].provider_id == "open_router"
-        assert refs[1].model_id == "anthropic/claude-opus"
-        assert refs[1].sources == ("MODEL_OPUS",)
+        assert refs[1].model_id == "anthropic/claude-fable-5"
+        assert refs[1].sources == ("MODEL_FABLE",)
+        assert refs[2].provider_id == "open_router"
+        assert refs[2].model_id == "anthropic/claude-opus"
+        assert refs[2].sources == ("MODEL_OPUS",)

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -24,6 +24,7 @@ from smoke.lib.config import (
 def _settings(**overrides):
     values = {
         "model": "ollama/llama3.1",
+        "model_fable": None,
         "model_opus": None,
         "model_sonnet": None,
         "model_haiku": None,

--- a/tests/providers/test_model_validation.py
+++ b/tests/providers/test_model_validation.py
@@ -31,6 +31,7 @@ from tests.providers.support import passthrough_rate_limiter, profiled_provider
 def _settings(
     *,
     model: str = "nvidia_nim/nim-model",
+    model_fable: str | None = None,
     model_opus: str | None = None,
     model_sonnet: str | None = None,
     model_haiku: str | None = None,
@@ -43,6 +44,7 @@ def _settings(
 ) -> Settings:
     return Settings.model_construct(
         model=model,
+        model_fable=model_fable,
         model_opus=model_opus,
         model_sonnet=model_sonnet,
         model_haiku=model_haiku,

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -40,6 +40,7 @@ from free_claude_code.providers.runtime import (
 def _make_settings(**overrides):
     mock = MagicMock()
     mock.model = "nvidia_nim/meta/llama3"
+    mock.model_fable = None
     mock.model_opus = None
     mock.model_sonnet = None
     mock.model_haiku = None

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.3.1"
+version = "4.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Claude Code now sends `claude-fable-5` for the Fable alias, but FCC treated it as an unrecognized model and collapsed it into the global fallback route. Users could not map Fable traffic or reasoning behavior independently. Fixes #1097.

## Changes

| Before | After |
| --- | --- |
| Fable requests inherited `MODEL` and `ENABLE_MODEL_THINKING`. | Fable requests use `MODEL_FABLE` and `ENABLE_FABLE_THINKING` when configured, otherwise inherit the existing defaults. |
| `/v1/models` omitted Claude Fable 5. | `/v1/models` advertises the canonical `claude-fable-5` identifier. |
| Admin, documentation, validation, and smoke contracts described three Claude tiers. | Admin, documentation, validation, and smoke contracts describe Fable alongside Opus, Sonnet, and Haiku. |
| The package version was `4.3.1`. | The package version is `4.4.0`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Fable as a Claude routing tier. The main changes are:

- `MODEL_FABLE` and `ENABLE_FABLE_THINKING` settings.
- Fable routing and thinking resolution in `ModelRouter`.
- `claude-fable-5` in the model catalog.
- Admin, docs, smoke, and test coverage updates.
- Package version bump to `4.4.0`.
</details>

<h3>Confidence Score: 4/5</h3>

The changed routing path needs a fix for direct provider model ids containing `fable`.

Fable settings, validation, admin fields, and model listing are consistent with the existing tier patterns. Blank Fable settings inherit the existing defaults. Direct provider model ids can receive the Fable thinking override when their model name contains `fable`.

src/free_claude_code/application/routing.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the Fable thinking overmatch by running a focused Python repro that disables global thinking and enables Fable thinking, then resolves sambanova/my-fable-ensemble-v2.
- The repro confirmed direct routing preserved provider\_id=sambanova, provider\_model=my-fable-ensemble-v2, and provider\_model\_ref=sambanova/my-fable-ensemble-v2, with resolved\_thinking\_enabled and thinking\_enabled both true.
- Ran the fable-tier validation pytest, which finished with exit code 0 and 177 tests passed.
- Ran the runtime probe to exercise the API model list, Settings env parsing, and ModelRouter paths, and observed a 200 OK on GET /v1/models, with the catalog item id claude-fable-5 and the expected Fable vs global-default routing behavior.
- Generated the probe source file used to exercise the API and Settings paths, enabling repeatable validation without real provider credentials.

<a href="https://app.greptile.com/trex/runs/14275379/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/application/routing.py | Adds Fable model and thinking branches; the thinking branch can also match unrelated direct provider model ids containing `fable`. |
| src/free_claude_code/config/settings.py | Adds optional Fable model and thinking settings with blank-env inheritance and provider/model validation. |
| src/free_claude_code/config/model_refs.py | Includes Fable in configured chat model reference collection and dedupe. |
| src/free_claude_code/config/admin/manifest.py | Adds Fable model and thinking controls to the admin manifest. |
| src/free_claude_code/api/model_catalog.py | Adds `claude-fable-5` to the advertised Claude model aliases. |
| pyproject.toml | Bumps the package version to `4.4.0`. |
| uv.lock | Updates the editable package version to match `pyproject.toml`. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Incoming model name] --> B{Direct provider or gateway id?}
  B -- yes --> C[Use provider/model directly]
  C --> D[Resolve thinking from provider model string]
  B -- no --> E{Claude tier match}
  E -- Fable --> F[MODEL_FABLE or MODEL]
  E -- Opus/Sonnet/Haiku --> G[Tier override or MODEL]
  E -- None --> H[MODEL]
  D --> I[Provider request]
  F --> I
  G --> I
  H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Incoming model name] --> B{Direct provider or gateway id?}
  B -- yes --> C[Use provider/model directly]
  C --> D[Resolve thinking from provider model string]
  B -- no --> E{Claude tier match}
  E -- Fable --> F[MODEL_FABLE or MODEL]
  E -- Opus/Sonnet/Haiku --> G[Tier override or MODEL]
  E -- None --> H[MODEL]
  D --> I[Provider request]
  F --> I
  G --> I
  H --> I
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fadd-fable-routing-tier%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fadd-fable-routing-tier%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffree_claude_code%2Fapplication%2Frouting.py%3A134-135%0A**Fable%20Thinking%20Overmatches%20Models**%0A%0AWhen%20a%20direct%20provider%20request%20uses%20a%20model%20id%20like%20%60sambanova%2Fmy-fable-ensemble-v2%60%2C%20the%20direct%20route%20bypasses%20tier%20remapping%20but%20still%20calls%20%60_resolve_thinking%28%29%60%20with%20the%20provider%20model%20string.%20With%20%60ENABLE_FABLE_THINKING%60%20set%2C%20this%20substring%20check%20applies%20Fable%20thinking%20behavior%20to%20an%20unrelated%20provider%20model%2C%20changing%20the%20outgoing%20request%20shape%20just%20because%20the%20model%20id%20contains%20%60fable%60.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1099&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add Fable as a first-class routing tier"](https://github.com/alishahryar1/free-claude-code/commit/0705840c65511fd85c74fd2c62ba8ea97afe7c12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43892323)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->