### PR TITLE
Default messaging sessions to Fable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -848,9 +848,9 @@ is its bundled Pi adapter:
 [cli/managed/](src/free_claude_code/cli/managed/) owns managed Claude Code subprocesses used by
 Discord and Telegram messaging. Managed task invocations extend the same proxy
 environment only with non-interactive terminal settings, optional `--resume`,
-optional `--fork-session`, `--model opus`, and `--output-format stream-json`.
+optional `--fork-session`, `--model fable`, and `--output-format stream-json`.
 Messaging pins this Claude tier alias so phone sessions route through
-`MODEL_OPUS` or the `MODEL` fallback instead of inheriting a user's interactive
+`MODEL_FABLE` or the `MODEL` fallback instead of inheriting a user's interactive
 `/model` picker state. Managed execution does not override Claude's
 `plansDirectory`; plan files use Claude's native user-level location so the
 project workspace may reside on any filesystem volume. The managed session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.4.0"
+version = "4.4.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/managed/claude.py
+++ b/src/free_claude_code/cli/managed/claude.py
@@ -12,7 +12,7 @@ from free_claude_code.cli.claude_env import (
     build_claude_proxy_env,
 )
 
-MANAGED_CLAUDE_MODEL_TIER = "opus"
+MANAGED_CLAUDE_MODEL_TIER = "fable"
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/cli/test_managed_claude.py
+++ b/tests/cli/test_managed_claude.py
@@ -40,6 +40,10 @@ def _config(**overrides: object) -> ManagedClaudeConfig:
     )
 
 
+def test_managed_claude_defaults_to_fable() -> None:
+    assert MANAGED_CLAUDE_MODEL_TIER == "fable"
+
+
 def test_managed_claude_builds_new_task_command_and_env() -> None:
     invocation = build_managed_claude_invocation(
         config=_config(allowed_dirs=[os.path.normpath("/tmp/extra")]),

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.4.0"
+version = "4.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Discord and Telegram sessions remained pinned to Opus after Fable became a first-class routing tier.

## Changes

| Before | After |
| --- | --- |
| Managed messaging launched Claude Code with `--model opus`. | Managed messaging launches Claude Code with `--model fable`. |
| Phone sessions selected `MODEL_OPUS` or the `MODEL` fallback. | Phone sessions select `MODEL_FABLE` or the `MODEL` fallback. |
| The architecture documented the Opus pin. | The architecture documents the Fable pin. |
| FCC reported version `4.4.0`. | FCC reports version `4.4.1`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes managed messaging sessions to use the Fable tier by default. The main changes are:

- Managed Claude Code invocations now pass `--model fable`.
- Managed messaging documentation now points to `MODEL_FABLE` and the `MODEL` fallback.
- Tests now assert the managed tier default is `fable`.
- The package version is bumped from `4.4.0` to `4.4.1` in both project metadata and the lockfile.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the focused PyTest run for Claude Fable version completed with EXIT\_CODE: 0, confirming the validation command produced a successful result.
- Verified that the pytest node collection for the same validation scope finished with EXIT\_CODE: 0, confirming all intended tests were discovered.

<a href="https://app.greptile.com/trex/runs/14345687/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/managed/claude.py | Changes the managed Claude model tier constant from `opus` to `fable`. |
| tests/cli/test_managed_claude.py | Adds coverage for the new managed tier default. |
| ARCHITECTURE.md | Updates the managed messaging architecture notes for Fable routing. |
| pyproject.toml | Bumps the package version to `4.4.1`. |
| uv.lock | Updates the locked editable package version to `4.4.1`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Default messaging sessions to Fable"](https://github.com/alishahryar1/free-claude-code/commit/08772b5c9a8f2bba91eddb1f9599eef043bb4557) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44041521)</sub>

<!-- /greptile_comment -->