### PR TITLE
Update docstring for clarity in ProviderExecutor

### DIFF
--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -30,7 +30,7 @@ WireApi = Literal["messages", "responses"]
 
 
 class ProviderExecutor:
-    """Resolve a provider and execute one routed Anthropic Messages stream."""
+    """Resolve a provider & execute one routed Anthropic Messages stream."""
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the wording of the `ProviderExecutor` class docstring.

- Replaces “and” with “&” in the executor description.
- Leaves runtime logic, imports, configuration, and API behavior unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Saved a proof log that captures commands, working directory, timestamps, outputs, and exit codes to support verification.
- Ran Pytest to exercise the application's execution behavior, focusing on provider preflight, stream construction, token counting order, and stream closing.
- Performed static validation and confirmed the updated execution module remains lint- and type-clean.

<a href="https://app.greptile.com/trex/runs/14361516/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/application/execution.py | Only the `ProviderExecutor` docstring text changed; no behavior changed. |

<sub>Reviews (1): Last reviewed commit: ["Update docstring for clarity in Provider..."](https://github.com/alishahryar1/free-claude-code/commit/45ae6c7edeef0821abcfd450a53aab3235c952f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44079667)</sub>

<!-- /greptile_comment -->