### PR TITLE
Add structured bug and feature issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report something that is not working in Free Claude Code.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: input
+    id: fcc-version
+    attributes:
+      label: FCC version
+      description: Run `fcc-server --version` and enter the reported version.
+      placeholder: "4.4.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cli
+    attributes:
+      label: CLI
+      description: If the problem occurred while using a coding CLI, select it.
+      options:
+        - Claude Code (fcc-claude)
+        - Codex (fcc-codex)
+        - Pi (fcc-pi)
+
+  - type: textarea
+    id: model-mappings
+    attributes:
+      label: Model mappings
+      description: If relevant, enter the model mappings used when the problem occurred.
+      placeholder: |
+        MODEL_FABLE=
+        MODEL_OPUS=
+        MODEL_SONNET=
+        MODEL_HAIKU=
+
+  - type: input
+    id: providers
+    attributes:
+      label: Provider(s)
+      description: If relevant, enter the provider or providers involved.
+      placeholder: NVIDIA NIM, OpenRouter
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: Issue
+      description: Describe what happened and include any useful reproduction details. Remove API keys and tokens from logs or screenshots.
+      placeholder: Tell us what went wrong.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,8 +8,8 @@ body:
     id: fcc-version
     attributes:
       label: FCC version
-      description: Run `fcc-server --version` and enter the reported version.
-      placeholder: "4.4.1"
+      description: Run `fcc-server --version` and enter the reported version. If FCC did not install, enter `not installed`.
+      placeholder: "4.4.1 or not installed"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Alishahryar1/free-claude-code/security/advisories/new
+    about: Report credential leaks and security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an improvement to Free Claude Code.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What?
+      description: What would you like Free Claude Code to do?
+      placeholder: Describe the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: Why would this be useful?
+      placeholder: Describe the problem or use case this would address.
+    validations:
+      required: true


### PR DESCRIPTION
## Problem

New issues currently open as unstructured blank reports, so maintainers may not receive the FCC version or relevant runtime context. Sensitive vulnerability reports also lacked a private route.

## Changes

| Before | After |
| --- | --- |
| Contributors opened blank issues. | Contributors choose a bug report or feature request form. |
| Bug reports had no required diagnostic fields. | Bug reports require the FCC version and issue description, with optional CLI, model mapping, and provider context. |
| Failed installations could not report an FCC version. | Failed installations can enter `not installed` while keeping the version field required. |
| Feature requests had no focused structure. | Feature requests ask only what should change and why. |
| Security reports had no private route. | The chooser links to enabled GitHub private vulnerability reporting. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds structured GitHub issue reporting for the repository. The main changes are:

- A bug report form with required FCC version and issue fields.
- Optional bug context for CLI, model mappings, and providers.
- A feature request form with required what and why fields.
- Issue chooser configuration that disables blank issues and adds a security contact link.
</details>

<h3>Confidence Score: 4/5</h3>

The security reporting path can still be unavailable when the repository setting for private vulnerability reports is off.

The bug and feature forms are valid issue forms, and the installer reporting case now has a clear `not installed` value. The security link needs a reachable fallback or a repository setting guarantee.

.github/ISSUE_TEMPLATE/config.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the advisory link verification against the issue template config and reproduced that the advisory URL requires authentication, blocking unauthenticated reporters.
- Captured a verbose HTTP trace showing a 302 redirect from the advisory URL to the login page and a 200 response for the login page, confirming unauthenticated access is blocked.
- The executable validation script trex-artifacts/issue\_template\_validation.py was generated and is ready to run.
- The validation run log trex-artifacts/issue\_template\_validation\_after.log was captured, showing parsed field summaries and that VALIDATION RESULT: PASS with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14362318/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug-report.yml | Adds a bug report form with required version and issue fields plus optional runtime context. |
| .github/ISSUE_TEMPLATE/config.yml | Disables blank issues and adds a security advisory contact link. |
| .github/ISSUE_TEMPLATE/feature-request.yml | Adds a feature request form with required what and why prompts. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fadd-issue-forms%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fadd-issue-forms%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2FISSUE_TEMPLATE%2Fconfig.yml%3A4%0A**Advisory%20Link%20Can%20404**%0A%0AWhen%20private%20vulnerability%20reporting%20is%20not%20enabled%20for%20the%20repository%2C%20this%20advisory%20URL%20returns%20a%20404.%20With%20blank%20issues%20disabled%20and%20no%20fallback%20disclosure%20path%20in%20the%20repo%2C%20a%20credential%20leak%20or%20auth%20report%20can%20still%20be%20abandoned%20or%20filed%20through%20a%20public%20issue%20form.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Add private security reporting route"](https://github.com/alishahryar1/free-claude-code/commit/e59304262c452279e51118a14007f1a5e144b052) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44079735)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->