### PR TITLE
Capture selected models in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,6 +23,13 @@ body:
         - Codex (fcc-codex)
         - Pi (fcc-pi)
 
+  - type: input
+    id: selected-models
+    attributes:
+      label: Selected model(s)
+      description: If relevant, enter each model exactly as shown in the selector or configuration.
+      placeholder: nvidia_nim/nvidia/nemotron-3-super-120b-a12b
+
   - type: textarea
     id: model-mappings
     attributes:


### PR DESCRIPTION
## Problem

Bug reports can include tier mappings and providers but not the model selected directly through a client picker.

## Changes

| Before | After |
| --- | --- |
| Bug reports captured optional model mappings and providers. | Bug reports also capture optional selected model values exactly as shown by the client. |
| The minimum bug report required FCC version and issue details. | The minimum bug report still requires only FCC version and issue details. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a selected-model field to the bug report issue form. The main changes are:

- New optional `Selected model(s)` input in `.github/ISSUE_TEMPLATE/bug-report.yml`.
- Existing FCC version and issue details requirements left unchanged.
- Model-related optional fields kept together in the form.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the issue-template validation script and confirmed the run completed with exit code 0, with the key findings that selected\_models.required is false, label is "Selected model(s)", and placeholder is "nvidia\_nim/nvidia/nemotron-3-super-120b-a12b", and that required\_ids is exactly \["fcc-version", "issue"\].

<a href="https://app.greptile.com/trex/runs/14363612/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug-report.yml | Adds a valid optional selected-models input without changing existing required fields. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add selected model field to bug reports"](https://github.com/alishahryar1/free-claude-code/commit/8723f106dce92e7ae316916faee658a5a254417b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44083525)</sub>

<!-- /greptile_comment -->