### PR TITLE
Add Ollama Cloud as a first-class provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,10 @@ SAMBANOVA_API_KEY=""
 CEREBRAS_API_KEY=""
 
 
+# Ollama Cloud (direct OpenAI-compatible API at ollama.com/v1)
+OLLAMA_API_KEY=""
+
+
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
@@ -93,7 +97,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "minimax" | "cerebras" | "groq" | "sambanova" | "fireworks" | "cloudflare" | "zai" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "minimax" | "cerebras" | "groq" | "sambanova" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -109,6 +113,7 @@ FCC_SMOKE_MODEL_MISTRAL=
 FCC_SMOKE_MODEL_MISTRAL_REASONING=
 FCC_SMOKE_MODEL_MISTRAL_CODESTRAL=
 FCC_SMOKE_MODEL_DEEPSEEK=
+FCC_SMOKE_MODEL_OLLAMA_CLOUD=
 FCC_SMOKE_MODEL_LMSTUDIO=
 FCC_SMOKE_MODEL_LLAMACPP=
 FCC_SMOKE_MODEL_OLLAMA=
@@ -168,6 +173,7 @@ GEMINI_PROXY=""
 GROQ_PROXY=""
 SAMBANOVA_PROXY=""
 CEREBRAS_PROXY=""
+OLLAMA_CLOUD_PROXY=""
 
 PROVIDER_RATE_LIMIT=1
 PROVIDER_RATE_WINDOW=3

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -544,9 +544,10 @@ compatibility layer.
 There is one upstream provider family:
 [providers/openai_chat/](src/free_claude_code/providers/openai_chat/) implements the concrete
 `OpenAIChatProvider` used by every OpenAI-compatible `/chat/completions`
-upstream. `OpenAIChatProfile` contains immutable request policy,
-postprocessors, and base-URL normalization for ordinary vendors. Configuration
-differences therefore remain data rather than empty subclasses. The package also
+upstream. `OpenAIChatProfile` contains immutable request policy, its standard
+streamed-reasoning field, postprocessors, and base-URL normalization for
+ordinary vendors. Configuration differences therefore remain data rather than
+empty subclasses. The package also
 owns the exactly typed private per-request runner, recovery operations, tool-call
 assembly, and streamed usage handling. No obsolete generic transport namespace
 or untyped provider backchannel remains.
@@ -562,8 +563,10 @@ thinking replay selection, `extra_body`, and chat-completion field normalization
 Specialized provider packages remain only for true upstream quirks such as
 Gemini thought signatures, NIM tool-schema aliases, retry downgrades, and NVCF
 deployment-failure classification, or DeepSeek attachment/tool/thinking
-compatibility. Ollama, llama.cpp, and LM Studio use their OpenAI-compatible Chat
-Completions endpoints like the remote providers. DeepSeek intentionally uses its
+compatibility. Local Ollama, Ollama Cloud, llama.cpp, and LM Studio all use the
+same OpenAI-compatible Chat Completions provider family;
+Ollama's standard `reasoning` delta and history field are profile data rather
+than a specialized adapter. DeepSeek intentionally uses its
 OpenAI-compatible Chat Completions endpoint because that is the endpoint that
 reports prompt-cache hit/miss counters; the provider maps those counters back
 into Anthropic usage fields for Claude-compatible clients. Cloudflare uses its

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 ## What You Get
 
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.
-- Switch among 24 cloud and local providers from the Admin UI.
+- Switch among 25 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
 - Route Fable, Opus, Sonnet, Haiku, and fallback traffic to different models.
 - Keep streaming, tool use, reasoning, and image input across compatible models.
@@ -170,6 +170,7 @@ Enter the listed setting in the Admin UI, set `MODEL` to a provider-prefixed mod
 | [Fireworks AI](https://fireworks.ai/account/api-keys) | `FIREWORKS_API_KEY` | `fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct` |
 | [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` | `cloudflare/@cf/moonshotai/kimi-k2.6` |
 | [Z.ai](https://z.ai/manage-apikey/apikey-list) | `ZAI_API_KEY` | `zai/glm-5.2` |
+| [Ollama Cloud](https://ollama.com/settings/keys) | `OLLAMA_API_KEY` | `ollama_cloud/qwen3-coder:480b` |
 | [LM Studio](https://lmstudio.ai/) | `LM_STUDIO_BASE_URL` | `lmstudio/<model-id>` |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | `LLAMACPP_BASE_URL` | `llamacpp/<model-id>` |
 | [Ollama](https://ollama.com/) | `OLLAMA_BASE_URL` | `ollama/<model-tag>` |
@@ -179,6 +180,9 @@ Important provider notes:
 - Mistral Codestral uses a separate key from Mistral La Plateforme.
 - OpenCode Zen and OpenCode Go share `OPENCODE_API_KEY` but use different model prefixes.
 - Cloudflare requires both its API token and account ID.
+- Ollama Cloud connects directly to `ollama.com`; use the exact model IDs shown
+  by FCC's model picker. Local Ollama remains available through the separate
+  `ollama/` prefix.
 - Prefer tool-capable models for coding agents. Local models also need enough context for the agent's system prompt and tool definitions.
 
 <details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.4.1"
+version = "4.5.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -134,7 +134,7 @@ uv run pytest smoke/product -n 0 -s --tb=short
   `FCC_SMOKE_MODEL_OPENCODE`, `FCC_SMOKE_MODEL_OPENCODE_GO`,
   `FCC_SMOKE_MODEL_ZAI`, `FCC_SMOKE_MODEL_FIREWORKS`, `FCC_SMOKE_MODEL_CLOUDFLARE`,
   `FCC_SMOKE_MODEL_GEMINI`, `FCC_SMOKE_MODEL_GROQ`, `FCC_SMOKE_MODEL_CEREBRAS`,
-  `FCC_SMOKE_MODEL_LMSTUDIO`,
+  `FCC_SMOKE_MODEL_OLLAMA_CLOUD`, `FCC_SMOKE_MODEL_LMSTUDIO`,
   `FCC_SMOKE_MODEL_LLAMACPP`, `FCC_SMOKE_MODEL_OLLAMA`: optional per-provider
   smoke model overrides. Values may include the provider prefix or just the model
   name for that provider.

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -49,6 +49,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "mistral": "mistral/devstral-small-latest",
     "mistral_codestral": "mistral_codestral/codestral-latest",
     "deepseek": "deepseek/deepseek-v4-pro",
+    "ollama_cloud": "ollama_cloud/qwen3-coder:480b",
     "lmstudio": "lmstudio/local-model",
     "llamacpp": "llamacpp/local-model",
     "ollama": "ollama/llama3.1",
@@ -259,6 +260,8 @@ class SmokeConfig:
             return bool(self.settings.codestral_api_key.strip())
         if provider == "deepseek":
             return bool(self.settings.deepseek_api_key.strip())
+        if provider == "ollama_cloud":
+            return bool(self.settings.ollama_api_key.strip())
         if provider == "kimi":
             return bool(self.settings.kimi_api_key.strip())
         if provider == "lmstudio":

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -569,6 +569,12 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         advanced=True,
     ),
     ConfigFieldSpec(
+        "FCC_SMOKE_MODEL_OLLAMA_CLOUD",
+        "Smoke Ollama Cloud Model",
+        "smoke",
+        advanced=True,
+    ),
+    ConfigFieldSpec(
         "FCC_SMOKE_MODEL_KIMI",
         "Smoke Kimi Model",
         "smoke",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -109,6 +109,11 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "[OpenAI compatibility](https://inference-docs.cerebras.ai/resources/openai)."
         ),
     },
+    "OLLAMA_API_KEY": {
+        "description": (
+            "Ollama API key for direct OpenAI-compatible Cloud access at ollama.com/v1."
+        ),
+    },
 }
 
 

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -24,6 +24,7 @@ CODESTRAL_DEFAULT_BASE = "https://codestral.mistral.ai/v1"
 LMSTUDIO_DEFAULT_BASE = "http://localhost:1234/v1"
 LLAMACPP_DEFAULT_BASE = "http://localhost:8080/v1"
 OLLAMA_DEFAULT_BASE = "http://localhost:11434"
+OLLAMA_CLOUD_DEFAULT_BASE = "https://ollama.com/v1"
 OPENCODE_DEFAULT_BASE = "https://opencode.ai/zen/v1"
 OPENCODE_GO_DEFAULT_BASE = "https://opencode.ai/zen/go/v1"
 VERCEL_AI_GATEWAY_DEFAULT_BASE = "https://ai-gateway.vercel.sh/v1"
@@ -243,6 +244,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=ZAI_DEFAULT_BASE,
         proxy_attr="zai_proxy",
     ),
+    "ollama_cloud": ProviderDescriptor(
+        provider_id="ollama_cloud",
+        display_name="Ollama Cloud",
+        credential_env="OLLAMA_API_KEY",
+        credential_url="https://ollama.com/settings/keys",
+        credential_attr="ollama_api_key",
+        default_base_url=OLLAMA_CLOUD_DEFAULT_BASE,
+        proxy_attr="ollama_cloud_proxy",
+    ),
     "lmstudio": ProviderDescriptor(
         provider_id="lmstudio",
         display_name="LM Studio",
@@ -274,7 +284,7 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
 # Key order:
 # NVIDIA NIM first (README default), DeepSeek fourth, OpenCode gateways adjacent,
 # Vercel / Hugging Face / Cohere / GitHub Models follow gateway-style remotes,
-# then cloud gateways and local providers per project plan
+# then cloud gateways, Ollama Cloud, and local providers per project plan
 # (github.com/cheahjs/free-llm-api-resources Free Providers TOC as rough guide
 # beyond fixed slots).
 # ``SUPPORTED_PROVIDER_IDS`` inherits this insertion order for UI and error-message listing.

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -84,6 +84,9 @@ class Settings(BaseSettings):
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
 
+    # ==================== Ollama Cloud ====================
+    ollama_api_key: str = Field(default="", validation_alias="OLLAMA_API_KEY")
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord" | "none"
     messaging_platform: str = Field(
@@ -154,6 +157,7 @@ class Settings(BaseSettings):
     gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")
     groq_proxy: str = Field(default="", validation_alias="GROQ_PROXY")
     cerebras_proxy: str = Field(default="", validation_alias="CEREBRAS_PROXY")
+    ollama_cloud_proxy: str = Field(default="", validation_alias="OLLAMA_CLOUD_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -22,6 +22,24 @@ class ReasoningReplayMode(StrEnum):
     DISABLED = "disabled"
     THINK_TAGS = "think_tags"
     REASONING_CONTENT = "reasoning_content"
+    REASONING = "reasoning"
+
+
+def _reasoning_replay_field(mode: ReasoningReplayMode) -> str | None:
+    if mode in (
+        ReasoningReplayMode.REASONING_CONTENT,
+        ReasoningReplayMode.REASONING,
+    ):
+        return mode.value
+    return None
+
+
+def _set_replayed_reasoning(
+    message: dict[str, Any], reasoning: str, mode: ReasoningReplayMode
+) -> None:
+    field_name = _reasoning_replay_field(mode)
+    if field_name is not None:
+        message[field_name] = reasoning
 
 
 def _openai_reject_native_only_top_level_fields(
@@ -378,8 +396,10 @@ class AnthropicToOpenAIConverter:
         if isinstance(content, str):
             converted = {"role": role, "content": content}
             if role == "assistant" and reasoning_content is not None:
-                if reasoning_replay == ReasoningReplayMode.REASONING_CONTENT:
-                    converted["reasoning_content"] = reasoning_content
+                if _reasoning_replay_field(reasoning_replay) is not None:
+                    _set_replayed_reasoning(
+                        converted, reasoning_content, reasoning_replay
+                    )
                 elif (
                     reasoning_replay == ReasoningReplayMode.THINK_TAGS
                     and reasoning_content
@@ -422,10 +442,8 @@ class AnthropicToOpenAIConverter:
                 "role": "assistant",
                 "content": "",
             }
-            if reasoning_replay == ReasoningReplayMode.REASONING_CONTENT:
-                replay = reasoning_content
-                if replay is not None:
-                    pre_msg["reasoning_content"] = replay
+            if reasoning_content is not None:
+                _set_replayed_reasoning(pre_msg, reasoning_content, reasoning_replay)
         else:
             pre_msg = AnthropicToOpenAIConverter._convert_assistant_message(
                 pre,
@@ -469,7 +487,7 @@ class AnthropicToOpenAIConverter:
                     thinking_parts.append(thinking)
             elif block_type == "redacted_thinking":
                 # Opaque provider continuation data; do not materialize as model-visible text
-                # or reasoning_content for OpenAI chat upstreams.
+                # or native reasoning fields for OpenAI chat upstreams.
                 continue
             elif block_type == "tool_use":
                 tool_calls.append(_tool_call_from_tool_use(block))
@@ -486,11 +504,13 @@ class AnthropicToOpenAIConverter:
         }
         if tool_calls:
             msg["tool_calls"] = tool_calls
-        if reasoning_replay == ReasoningReplayMode.REASONING_CONTENT:
+        if _reasoning_replay_field(reasoning_replay) is not None:
             if reasoning_content is not None:
-                msg["reasoning_content"] = reasoning_content
+                _set_replayed_reasoning(msg, reasoning_content, reasoning_replay)
             elif thinking_seen:
-                msg["reasoning_content"] = "\n".join(thinking_parts)
+                _set_replayed_reasoning(
+                    msg, "\n".join(thinking_parts), reasoning_replay
+                )
 
         return [msg]
 

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -245,9 +245,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         OpenAIChatRequestPolicy(
             provider_name="OLLAMA",
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
-            reasoning_replay=ReasoningReplayMode.REASONING,
         ),
         normalize_base_url=True,
-        reasoning_delta_field="reasoning",
     ),
 }

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
@@ -22,6 +22,9 @@ class OpenAIChatProfile:
     request_policy: OpenAIChatRequestPolicy
     postprocessors: tuple[OpenAIChatPostprocessor, ...] = ()
     normalize_base_url: bool = False
+    reasoning_delta_field: Literal["reasoning_content", "reasoning"] = (
+        "reasoning_content"
+    )
 
     @property
     def provider_name(self) -> str:
@@ -29,6 +32,10 @@ class OpenAIChatProfile:
 
     def base_url(self, configured: str) -> str:
         return openai_v1_base_url(configured) if self.normalize_base_url else configured
+
+    def reasoning_delta(self, delta: Any) -> str | None:
+        value = getattr(delta, self.reasoning_delta_field, None)
+        return value if isinstance(value, str) else None
 
 
 def _apply_cohere_request_quirks(
@@ -85,6 +92,12 @@ def _apply_minimax_thinking_policy(
     extra_body["thinking"] = (
         {"type": "adaptive"} if thinking_enabled else {"type": "disabled"}
     )
+
+
+def _apply_ollama_thinking_policy(
+    body: dict[str, Any], _request: MessagesRequest, thinking_enabled: bool
+) -> None:
+    body["reasoning_effort"] = "high" if thinking_enabled else "none"
 
 
 def _apply_wafer_thinking_policy(
@@ -212,6 +225,15 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         ),
         postprocessors=(_apply_zai_thinking_policy,),
     ),
+    "ollama_cloud": OpenAIChatProfile(
+        OpenAIChatRequestPolicy(
+            provider_name="OLLAMA_CLOUD",
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+            reasoning_replay=ReasoningReplayMode.REASONING,
+        ),
+        postprocessors=(_apply_ollama_thinking_policy,),
+        reasoning_delta_field="reasoning",
+    ),
     "llamacpp": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
             provider_name="LLAMACPP",
@@ -223,7 +245,10 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         OpenAIChatRequestPolicy(
             provider_name="OLLAMA",
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+            reasoning_replay=ReasoningReplayMode.REASONING,
         ),
+        postprocessors=(_apply_ollama_thinking_policy,),
         normalize_base_url=True,
+        reasoning_delta_field="reasoning",
     ),
 }

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -247,7 +247,6 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
             reasoning_replay=ReasoningReplayMode.REASONING,
         ),
-        postprocessors=(_apply_ollama_thinking_policy,),
         normalize_base_url=True,
         reasoning_delta_field="reasoning",
     ),

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -361,8 +361,8 @@ class _OpenAIChatStreamRunner:
                             finish_reason = choice.finish_reason
                             logger.debug("{} finish_reason: {}", tag, finish_reason)
 
-                        reasoning = getattr(delta, "reasoning_content", None)
-                        if thinking_enabled and isinstance(reasoning, str):
+                        reasoning = self._provider._profile.reasoning_delta(delta)
+                        if thinking_enabled and reasoning is not None:
                             for event in hold_events(ledger.ensure_thinking_block()):
                                 yield event
                             if reasoning:
@@ -658,8 +658,8 @@ class _OpenAIChatStreamRunner:
                     delta = choice.delta
                     if delta is None:
                         continue
-                    reasoning = getattr(delta, "reasoning_content", None)
-                    if isinstance(reasoning, str) and reasoning:
+                    reasoning = self._provider._profile.reasoning_delta(delta)
+                    if reasoning:
                         thinking_parts.append(reasoning)
                     content = getattr(delta, "content", None)
                     if isinstance(content, str) and content:

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -477,6 +477,7 @@ class _OpenAIChatStreamRunner:
                                 ledger=ledger,
                                 error=error,
                                 tool_argument_alias_buffers=tool_argument_alias_buffers,
+                                thinking_enabled=thinking_enabled,
                             )
                         except Exception as recovery_error:
                             trace_event(
@@ -639,7 +640,9 @@ class _OpenAIChatStreamRunner:
         for event in recovery.flush():
             yield event
 
-    async def _collect_recovery_text(self, body: dict[str, Any]) -> tuple[str, str]:
+    async def _collect_recovery_text(
+        self, body: dict[str, Any], *, include_reasoning: bool
+    ) -> tuple[str, str]:
         """Collect a complete text/reasoning continuation stream."""
         last_error: Exception | None = None
         for attempt in range(MIDSTREAM_RECOVERY_ATTEMPTS):
@@ -658,9 +661,10 @@ class _OpenAIChatStreamRunner:
                     delta = choice.delta
                     if delta is None:
                         continue
-                    reasoning = self._provider._profile.reasoning_delta(delta)
-                    if reasoning:
-                        thinking_parts.append(reasoning)
+                    if include_reasoning:
+                        reasoning = self._provider._profile.reasoning_delta(delta)
+                        if reasoning:
+                            thinking_parts.append(reasoning)
                     content = getattr(delta, "content", None)
                     if isinstance(content, str) and content:
                         text_parts.append(content)
@@ -697,6 +701,7 @@ class _OpenAIChatStreamRunner:
         ledger: AnthropicStreamLedger,
         error: Exception,
         tool_argument_alias_buffers: dict[int, str],
+        thinking_enabled: bool,
     ) -> list[str] | None:
         """Build terminal recovery events when the interrupted stream permits it."""
         if not is_retryable_stream_error(error):
@@ -737,7 +742,9 @@ class _OpenAIChatStreamRunner:
             return None
 
         recovery_body = make_text_recovery_body(body, partial_text, partial_thinking)
-        text, thinking = await self._collect_recovery_text(recovery_body)
+        text, thinking = await self._collect_recovery_text(
+            recovery_body, include_reasoning=thinking_enabled
+        )
         text_suffix = continuation_suffix(partial_text, text)
         thinking_suffix = continuation_suffix(partial_thinking, thinking)
         events: list[str] = []
@@ -799,7 +806,9 @@ class _OpenAIChatStreamRunner:
             )
             accepted_suffix: str | None = None
             for attempt in range(MIDSTREAM_RECOVERY_ATTEMPTS):
-                text, _ = await self._collect_recovery_text(recovery_body)
+                text, _ = await self._collect_recovery_text(
+                    recovery_body, include_reasoning=False
+                )
                 repair = accept_tool_json_repair(
                     repair_prefix,
                     text,

--- a/src/free_claude_code/providers/openai_chat/request_policy.py
+++ b/src/free_claude_code/providers/openai_chat/request_policy.py
@@ -48,12 +48,11 @@ def build_openai_chat_request_body(
         len(request_data.messages),
     )
     try:
-        reasoning_replay = policy.reasoning_replay
-        if reasoning_replay is None:
+        if not thinking_enabled:
+            reasoning_replay = ReasoningReplayMode.DISABLED
+        else:
             reasoning_replay = (
-                ReasoningReplayMode.REASONING_CONTENT
-                if thinking_enabled
-                else ReasoningReplayMode.DISABLED
+                policy.reasoning_replay or ReasoningReplayMode.REASONING_CONTENT
             )
         body = build_base_request_body(
             request_data,

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -27,6 +27,7 @@ def _clear_process_config(monkeypatch) -> None:
         "NVIDIA_NIM_API_KEY",
         "HUGGINGFACE_API_KEY",
         "OPENROUTER_API_KEY",
+        "OLLAMA_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
         "TELEGRAM_PROXY_URL",
         "FCC_ENV_FILE",
@@ -125,6 +126,7 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
     assert "SAMBANOVA_API_KEY" in keys
     assert "TELEGRAM_PROXY_URL" in keys
     assert "CEREBRAS_API_KEY" in keys
+    assert "OLLAMA_API_KEY" in keys
     assert "FCC_OPEN_BROWSER" in keys
     assert "ZAI_BASE_URL" not in keys
     assert "CLAUDE_WORKSPACE" not in keys

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -227,6 +227,13 @@ class TestSettings:
         monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
         assert Settings().ollama_base_url == "http://localhost:11434/v1"
 
+    def test_ollama_cloud_api_key_from_env(self, monkeypatch):
+        from free_claude_code.config.settings import Settings
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama-cloud-key")
+
+        assert Settings().ollama_api_key == "ollama-cloud-key"
+
     def test_provider_rate_limit_from_env(self, monkeypatch):
         """PROVIDER_RATE_LIMIT env var is loaded into settings."""
         from free_claude_code.config.settings import Settings
@@ -798,6 +805,11 @@ class TestPerModelMapping:
             ({"MODEL": "lmstudio/qwen2.5-7b"}, "lmstudio/qwen2.5-7b", None),
             ({"MODEL": "llamacpp/local-model"}, "llamacpp/local-model", None),
             ({"MODEL": "ollama/llama3.1"}, "ollama/llama3.1", None),
+            (
+                {"MODEL": "ollama_cloud/qwen3-coder:480b"},
+                "ollama_cloud/qwen3-coder:480b",
+                None,
+            ),
         ],
     )
     def test_settings_models_from_env(
@@ -999,6 +1011,7 @@ class TestPerModelMapping:
         assert parse_provider_type("lmstudio/qwen") == "lmstudio"
         assert parse_provider_type("llamacpp/model") == "llamacpp"
         assert parse_provider_type("ollama/llama3.1") == "ollama"
+        assert parse_provider_type("ollama_cloud/qwen3-coder:480b") == "ollama_cloud"
         assert parse_provider_type("wafer/DeepSeek-V4-Pro") == "wafer"
         assert parse_provider_type("minimax/MiniMax-M3") == "minimax"
         assert (
@@ -1032,6 +1045,7 @@ class TestPerModelMapping:
         assert parse_model_name("lmstudio/qwen") == "qwen"
         assert parse_model_name("llamacpp/model") == "model"
         assert parse_model_name("ollama/llama3.1") == "llama3.1"
+        assert parse_model_name("ollama_cloud/qwen3-coder:480b") == "qwen3-coder:480b"
         assert parse_model_name("wafer/DeepSeek-V4-Pro") == "DeepSeek-V4-Pro"
         assert parse_model_name("minimax/MiniMax-M3") == "MiniMax-M3"
         assert (

--- a/tests/config/test_provider_catalog.py
+++ b/tests/config/test_provider_catalog.py
@@ -32,3 +32,13 @@ def test_catalog_local_assignments_are_exact() -> None:
         for provider_id, descriptor in PROVIDER_CATALOG.items()
         if descriptor.local
     } == {"lmstudio", "llamacpp", "ollama"}
+
+
+def test_ollama_cloud_is_remote_and_distinct_from_local_ollama() -> None:
+    cloud = PROVIDER_CATALOG["ollama_cloud"]
+    local = PROVIDER_CATALOG["ollama"]
+
+    assert cloud.local is False
+    assert cloud.credential_env == "OLLAMA_API_KEY"
+    assert local.local is True
+    assert local.credential_env is None

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -27,6 +27,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "fireworks",
     "cloudflare",
     "zai",
+    "ollama_cloud",
     "lmstudio",
     "llamacpp",
     "ollama",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -46,6 +46,7 @@ def _settings(**overrides):
         "groq_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
+        "ollama_api_key": "",
         "fireworks_api_key": "",
         "cloudflare_api_token": "",
         "cloudflare_account_id": "",
@@ -102,6 +103,23 @@ def test_ollama_provider_matrix_filters_models() -> None:
     config = _smoke_config(provider_matrix=frozenset({"ollama"}))
 
     assert [model.provider for model in config.provider_models()] == ["ollama"]
+
+
+def test_ollama_cloud_provider_configuration_uses_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_OLLAMA_CLOUD", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            ollama_api_key="ollama-cloud-key",
+        )
+    )
+
+    assert config.has_provider_configuration("ollama_cloud")
+    models = config.provider_smoke_models()
+    assert [model.provider for model in models] == ["ollama_cloud"]
+    assert models[0].full_model == "ollama_cloud/qwen3-coder:480b"
+    assert models[0].source == "provider_default"
 
 
 def test_provider_smoke_models_cover_configured_providers_independent_of_model_mapping(

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -245,6 +245,26 @@ def test_convert_assistant_message_thinking_replays_reasoning_content():
     assert "<think>" not in result[0]["content"]
 
 
+def test_convert_assistant_message_thinking_replays_reasoning():
+    content = [
+        MockBlock(type="thinking", thinking="I need to calculate this."),
+        MockBlock(type="text", text="The answer is 4."),
+    ]
+    messages = [MockMessage("assistant", content)]
+
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages, reasoning_replay=ReasoningReplayMode.REASONING
+    )
+
+    assert result == [
+        {
+            "role": "assistant",
+            "content": "The answer is 4.",
+            "reasoning": "I need to calculate this.",
+        }
+    ]
+
+
 def test_convert_assistant_top_level_reasoning_content_is_preserved():
     messages = [
         MockMessage(
@@ -314,6 +334,30 @@ def test_convert_assistant_thinking_tool_use_replays_top_level_reasoning():
     assert result[0]["reasoning_content"] == "I should call the tool."
     assert "<think>" not in result[0]["content"]
     assert result[0]["tool_calls"][0]["id"] == "call_reasoning"
+
+
+def test_convert_assistant_tool_use_replays_ollama_reasoning_field():
+    messages = [
+        MockMessage(
+            "assistant",
+            [
+                MockBlock(type="thinking", thinking="Call the tool."),
+                MockBlock(type="tool_use", id="call_1", name="Read", input={}),
+            ],
+        ),
+        MockMessage(
+            "user",
+            [MockBlock(type="tool_result", tool_use_id="call_1", content="done")],
+        ),
+    ]
+
+    result = AnthropicToOpenAIConverter.convert_messages(
+        messages, reasoning_replay=ReasoningReplayMode.REASONING
+    )
+
+    assert result[0]["reasoning"] == "Call the tool."
+    assert "reasoning_content" not in result[0]
+    assert result[0]["tool_calls"][0]["id"] == "call_1"
 
 
 def test_convert_assistant_empty_thinking_replays_empty_reasoning_content():

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -1,23 +1,41 @@
-"""Tests for the Ollama OpenAI-compatible provider."""
+"""Tests for the local and Cloud Ollama OpenAI-compatible providers."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from free_claude_code.config.provider_catalog import OLLAMA_DEFAULT_BASE
-from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.config.provider_catalog import (
+    OLLAMA_CLOUD_DEFAULT_BASE,
+    OLLAMA_DEFAULT_BASE,
+)
+from free_claude_code.core.anthropic.stream_contracts import (
+    parse_sse_text,
+    thinking_content,
+)
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from tests.providers.request_factory import make_messages_request
 from tests.providers.support import passthrough_rate_limiter, profiled_provider
 
 OLLAMA_MODEL = "llama3.1:8b"
+OLLAMA_CLOUD_MODEL = "qwen3-coder:480b"
 
 
 def _provider(base_url: str = OLLAMA_DEFAULT_BASE) -> OpenAIChatProvider:
     return profiled_provider(
         "ollama",
         ProviderConfig(api_key="ollama", base_url=base_url),
+        rate_limiter=passthrough_rate_limiter(),
+    )
+
+
+def _cloud_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "ollama_cloud",
+        ProviderConfig(
+            api_key="ollama-cloud-key",
+            base_url=OLLAMA_CLOUD_DEFAULT_BASE,
+        ),
         rate_limiter=passthrough_rate_limiter(),
     )
 
@@ -42,13 +60,97 @@ def test_init_normalizes_openai_base_url(configured: str, expected: str) -> None
     assert openai_client.call_args.kwargs["base_url"] == expected
 
 
+def test_cloud_init_uses_fixed_openai_endpoint_and_api_key() -> None:
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI"
+    ) as openai_client:
+        provider = _cloud_provider()
+
+    assert provider._provider_name == "OLLAMA_CLOUD"
+    assert provider._base_url == OLLAMA_CLOUD_DEFAULT_BASE
+    assert provider._api_key == "ollama-cloud-key"
+    assert openai_client.call_args.kwargs["base_url"] == OLLAMA_CLOUD_DEFAULT_BASE
+    assert openai_client.call_args.kwargs["api_key"] == "ollama-cloud-key"
+
+
 def test_build_request_body_uses_openai_chat_shape() -> None:
     body = _provider()._build_request_body(make_messages_request(OLLAMA_MODEL))
 
     assert body["model"] == OLLAMA_MODEL
     assert body["messages"][0]["role"] == "system"
+    assert body["reasoning_effort"] == "high"
     assert "thinking" not in body
     assert "extra_body" not in body
+
+
+@pytest.mark.parametrize("provider", [_provider, _cloud_provider])
+def test_build_request_body_replays_thinking_in_ollama_reasoning_field(
+    provider,
+) -> None:
+    request = make_messages_request(
+        OLLAMA_CLOUD_MODEL,
+        messages=[
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Inspect the repository."},
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "read_file",
+                        "input": {"path": "README.md"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "contents",
+                    }
+                ],
+            },
+        ],
+    )
+
+    body = provider()._build_request_body(request)
+
+    assistant = next(
+        message for message in body["messages"] if message["role"] == "assistant"
+    )
+    assert assistant["reasoning"] == "Inspect the repository."
+    assert "reasoning_content" not in assistant
+
+
+@pytest.mark.parametrize("provider", [_provider, _cloud_provider])
+def test_disabled_thinking_is_not_replayed_and_disables_ollama_reasoning(
+    provider,
+) -> None:
+    request = make_messages_request(
+        OLLAMA_CLOUD_MODEL,
+        messages=[
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Hidden plan."},
+                    {"type": "text", "text": "Visible answer."},
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ],
+    )
+
+    body = provider()._build_request_body(request, thinking_enabled=False)
+    assistant = next(
+        message for message in body["messages"] if message["role"] == "assistant"
+    )
+
+    assert body["reasoning_effort"] == "none"
+    assert "reasoning" not in assistant
+    assert "reasoning_content" not in assistant
+    assert assistant["content"] == "Visible answer."
 
 
 @pytest.mark.asyncio
@@ -59,7 +161,7 @@ async def test_stream_response_uses_shared_openai_chat_provider() -> None:
         MagicMock(
             delta=MagicMock(
                 content="Hello from Ollama",
-                reasoning_content=None,
+                reasoning=None,
                 tool_calls=None,
             ),
             finish_reason="stop",
@@ -89,3 +191,46 @@ async def test_stream_response_uses_shared_openai_chat_provider() -> None:
     assert create.call_args.kwargs["model"] == OLLAMA_MODEL
     assert "Hello from Ollama" in output
     assert parse_sse_text(output)[-1].event == "message_stop"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", [_provider, _cloud_provider])
+async def test_stream_maps_ollama_reasoning_delta_to_anthropic_thinking(
+    provider,
+) -> None:
+    client = provider()
+    chunk = MagicMock()
+    chunk.choices = [
+        MagicMock(
+            delta=MagicMock(
+                content="Final answer",
+                reasoning="Working it out",
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    chunk.usage = MagicMock(prompt_tokens=8, completion_tokens=4)
+
+    async def stream():
+        yield chunk
+
+    with patch.object(
+        client._client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=stream(),
+    ):
+        output = "".join(
+            [
+                event
+                async for event in client.stream_response(
+                    make_messages_request(OLLAMA_CLOUD_MODEL)
+                )
+            ]
+        )
+
+    events = parse_sse_text(output)
+    assert thinking_content(events) == "Working it out"
+    assert "Final answer" in output
+    assert events[-1].event == "message_stop"

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -92,10 +92,7 @@ def test_cloud_build_request_body_enables_ollama_reasoning() -> None:
     assert body["reasoning_effort"] == "high"
 
 
-@pytest.mark.parametrize("provider", [_provider, _cloud_provider])
-def test_build_request_body_replays_thinking_in_ollama_reasoning_field(
-    provider,
-) -> None:
+def test_cloud_build_request_body_replays_thinking_in_ollama_reasoning_field() -> None:
     request = make_messages_request(
         OLLAMA_CLOUD_MODEL,
         messages=[
@@ -124,7 +121,7 @@ def test_build_request_body_replays_thinking_in_ollama_reasoning_field(
         ],
     )
 
-    body = provider()._build_request_body(request)
+    body = _cloud_provider()._build_request_body(request)
 
     assistant = next(
         message for message in body["messages"] if message["role"] == "assistant"
@@ -176,7 +173,7 @@ async def test_stream_response_uses_shared_openai_chat_provider() -> None:
         MagicMock(
             delta=MagicMock(
                 content="Hello from Ollama",
-                reasoning=None,
+                reasoning_content=None,
                 tool_calls=None,
             ),
             finish_reason="stop",
@@ -209,11 +206,8 @@ async def test_stream_response_uses_shared_openai_chat_provider() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider", [_provider, _cloud_provider])
-async def test_stream_maps_ollama_reasoning_delta_to_anthropic_thinking(
-    provider,
-) -> None:
-    client = provider()
+async def test_cloud_stream_maps_ollama_reasoning_delta_to_anthropic_thinking() -> None:
+    client = _cloud_provider()
     chunk = MagicMock()
     chunk.choices = [
         MagicMock(

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -78,9 +78,18 @@ def test_build_request_body_uses_openai_chat_shape() -> None:
 
     assert body["model"] == OLLAMA_MODEL
     assert body["messages"][0]["role"] == "system"
-    assert body["reasoning_effort"] == "high"
+    assert "reasoning_effort" not in body
     assert "thinking" not in body
     assert "extra_body" not in body
+
+
+def test_cloud_build_request_body_enables_ollama_reasoning() -> None:
+    body = _cloud_provider()._build_request_body(
+        make_messages_request(OLLAMA_CLOUD_MODEL)
+    )
+
+    assert body["model"] == OLLAMA_CLOUD_MODEL
+    assert body["reasoning_effort"] == "high"
 
 
 @pytest.mark.parametrize("provider", [_provider, _cloud_provider])
@@ -124,9 +133,12 @@ def test_build_request_body_replays_thinking_in_ollama_reasoning_field(
     assert "reasoning_content" not in assistant
 
 
-@pytest.mark.parametrize("provider", [_provider, _cloud_provider])
+@pytest.mark.parametrize(
+    ("provider", "expected_effort"),
+    [(_provider, None), (_cloud_provider, "none")],
+)
 def test_disabled_thinking_is_not_replayed_and_disables_ollama_reasoning(
-    provider,
+    provider, expected_effort
 ) -> None:
     request = make_messages_request(
         OLLAMA_CLOUD_MODEL,
@@ -147,7 +159,10 @@ def test_disabled_thinking_is_not_replayed_and_disables_ollama_reasoning(
         message for message in body["messages"] if message["role"] == "assistant"
     )
 
-    assert body["reasoning_effort"] == "none"
+    if expected_effort is None:
+        assert "reasoning_effort" not in body
+    else:
+        assert body["reasoning_effort"] == expected_effort
     assert "reasoning" not in assistant
     assert "reasoning_content" not in assistant
     assert assistant["content"] == "Visible answer."

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -12,6 +12,7 @@ from free_claude_code.config.provider_catalog import (
     GITHUB_MODELS_DEFAULT_BASE,
     HUGGINGFACE_DEFAULT_BASE,
     MINIMAX_DEFAULT_BASE,
+    OLLAMA_CLOUD_DEFAULT_BASE,
     PROVIDER_CATALOG,
     SUPPORTED_PROVIDER_IDS,
     VERCEL_AI_GATEWAY_DEFAULT_BASE,
@@ -60,6 +61,7 @@ def _make_settings(**overrides):
     mock.lm_studio_base_url = "http://localhost:1234/v1"
     mock.llamacpp_base_url = "http://localhost:8080/v1"
     mock.ollama_base_url = "http://localhost:11434"
+    mock.ollama_api_key = "test_ollama_cloud_key"
     mock.nvidia_nim_proxy = ""
     mock.open_router_proxy = ""
     mock.lmstudio_proxy = ""
@@ -88,6 +90,7 @@ def _make_settings(**overrides):
     mock.groq_proxy = ""
     mock.cerebras_api_key = ""
     mock.cerebras_proxy = ""
+    mock.ollama_cloud_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
     mock.provider_max_concurrency = 5
@@ -131,6 +134,30 @@ def test_ollama_descriptor_uses_local_openai_endpoint_semantics():
 
     assert descriptor.default_base_url == "http://localhost:11434"
     assert descriptor.local is True
+
+
+def test_ollama_cloud_descriptor_uses_direct_authenticated_endpoint():
+    descriptor = PROVIDER_CATALOG["ollama_cloud"]
+
+    assert descriptor.default_base_url == OLLAMA_CLOUD_DEFAULT_BASE
+    assert descriptor.credential_env == "OLLAMA_API_KEY"
+    assert descriptor.credential_attr == "ollama_api_key"
+    assert descriptor.base_url_attr is None
+    assert descriptor.local is False
+
+
+def test_ollama_cloud_provider_config_uses_key_and_proxy():
+    descriptor = PROVIDER_CATALOG["ollama_cloud"]
+    settings = _make_settings(
+        ollama_api_key="ollama-cloud-token",
+        ollama_cloud_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+
+    assert config.api_key == "ollama-cloud-token"
+    assert config.base_url == OLLAMA_CLOUD_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
 
 
 @pytest.mark.parametrize(
@@ -352,6 +379,7 @@ def test_create_provider_instantiates_each_builtin():
         "lmstudio": LMStudioProvider,
         "llamacpp": OpenAIChatProvider,
         "ollama": OpenAIChatProvider,
+        "ollama_cloud": OpenAIChatProvider,
         "wafer": OpenAIChatProvider,
         "opencode": OpenAIChatProvider,
         "opencode_go": OpenAIChatProvider,

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -842,6 +842,40 @@ class TestStreamingExceptionHandling:
         assert not any(event.event == "error" for event in parsed)
 
     @pytest.mark.asyncio
+    async def test_disabled_thinking_recovery_discards_reasoning(self):
+        provider = _make_provider_with_thinking_enabled(False)
+        request = _make_request()
+        initial_stream = AsyncStreamMock([_make_chunk(content="hello")])
+        recovery_stream = AsyncStreamMock(
+            [
+                _make_chunk(reasoning_content="hidden reasoning"),
+                _make_chunk(content="hello world"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[initial_stream, recovery_stream],
+        ):
+            events = await _collect_stream(provider, request)
+
+        parsed = parse_sse_text("".join(events))
+        text = "".join(
+            event.data.get("delta", {}).get("text", "")
+            for event in parsed
+            if event.event == "content_block_delta"
+        )
+        assert text == "hello world"
+        assert "hidden reasoning" not in "".join(events)
+        assert not any(
+            event.data.get("delta", {}).get("type") == "thinking_delta"
+            for event in parsed
+        )
+
+    @pytest.mark.asyncio
     async def test_recovery_collect_text_requires_finish_reason(self):
         """Recovery collectors reject truncated OpenAI-chat continuation streams."""
         streams = [
@@ -856,7 +890,9 @@ class TestStreamingExceptionHandling:
             patch.object(provider, "_create_stream", create_stream),
             pytest.raises(TruncatedProviderStreamError),
         ):
-            await runner._collect_recovery_text({"messages": []})
+            await runner._collect_recovery_text(
+                {"messages": []}, include_reasoning=True
+            )
 
         assert create_stream.await_count == MIDSTREAM_RECOVERY_ATTEMPTS
         assert all(stream.closed for stream in streams)
@@ -879,7 +915,9 @@ class TestStreamingExceptionHandling:
             patch.object(provider, "_create_stream", create_stream),
             pytest.raises(TimeoutError),
         ):
-            await runner._collect_recovery_text({"messages": []})
+            await runner._collect_recovery_text(
+                {"messages": []}, include_reasoning=True
+            )
 
         assert create_stream.await_count == MIDSTREAM_RECOVERY_ATTEMPTS
         assert all(stream.closed for stream in streams)
@@ -903,7 +941,9 @@ class TestStreamingExceptionHandling:
         runner = _make_stream_runner(provider)
 
         with patch.object(provider, "_create_stream", create_stream):
-            result = await runner._collect_recovery_text({"messages": []})
+            result = await runner._collect_recovery_text(
+                {"messages": []}, include_reasoning=True
+            )
 
         assert result == ("world", "")
         assert stream.closed is True
@@ -956,12 +996,14 @@ class TestStreamingExceptionHandling:
                 ledger=ledger,
                 error=TimeoutError("cutoff"),
                 tool_argument_alias_buffers={},
+                thinking_enabled=True,
             )
 
         assert events is not None
         assert mock_collect.await_args is not None
         recovery_body = mock_collect.await_args.args[0]
         assert "hidden reasoning" in recovery_body["messages"][-1]["content"]
+        assert mock_collect.await_args.kwargs["include_reasoning"] is True
 
     @pytest.mark.asyncio
     async def test_primary_stream_closes_when_iteration_fails(self):

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.4.1"
+version = "4.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC supports Ollama only through a local daemon, so users cannot authenticate directly to Ollama Cloud or discover its hosted models from the Admin UI. Ollama's OpenAI-compatible API also uses the standard `reasoning` field instead of `reasoning_content`, which would otherwise drop thinking output and tool-history reasoning.

## Changes

| Before | After |
| --- | --- |
| `ollama/...` requires a local Ollama server. | `ollama_cloud/...` connects directly to `https://ollama.com/v1` with `OLLAMA_API_KEY`, while local Ollama remains unchanged. |
| OpenAI-chat reasoning was hard-coded to `reasoning_content`. | Provider profiles declare their reasoning field, so Ollama streams and replays `reasoning` without a specialized transport. |
| Ollama Cloud was absent from configuration, model discovery, docs, and smoke coverage. | The catalog, Admin UI, proxy setting, model picker, README, smoke matrix, and `4.5.0` release metadata expose the provider consistently. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Ollama Cloud as a separate OpenAI-compatible provider. The main changes are:

- New `ollama_cloud` catalog entry, settings, admin fields, proxy setting, and smoke configuration.
- Provider profiles now choose the streamed and replayed reasoning field per provider.
- Ollama Cloud uses `reasoning` and `reasoning_effort`, while local Ollama stays on its separate local configuration.
- Streaming recovery now respects the resolved thinking setting when collecting reasoning.
- Tests, docs, environment examples, and release metadata were updated for the new provider.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the provider/runtime/converter/streaming tests with full verbose pytest output and confirmed EXIT\_CODE: 0.
- Ran the config/catalog/contracts/admin tests with full verbose pytest output and confirmed EXIT\_CODE: 0.
- Generated and ran an introspection script to verify catalog, profile, settings, and admin manifest values without external API calls, and recorded the local execution output.

<a href="https://app.greptile.com/trex/runs/14367965/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/openai_chat/profiles.py | Adds provider-level reasoning field selection and the Ollama Cloud profile. |
| src/free_claude_code/providers/openai_chat/provider.py | Uses the profile reasoning field for streaming and passes the thinking setting into recovery. |
| src/free_claude_code/providers/openai_chat/request_policy.py | Selects reasoning replay mode from the provider policy only when thinking is enabled. |
| src/free_claude_code/core/anthropic/conversion.py | Supports replaying assistant reasoning through either `reasoning_content` or `reasoning`. |
| src/free_claude_code/config/provider_catalog.py | Registers Ollama Cloud as a remote provider distinct from local Ollama. |
| src/free_claude_code/config/settings.py | Adds the Ollama Cloud API key and proxy settings. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Keep local Ollama wire behavior unchange..."](https://github.com/alishahryar1/free-claude-code/commit/d6f97cdb0074a4cbda140d484fb6dd679a1406df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44089262)</sub>

<!-- /greptile_comment -->