### PR TITLE
Fix: remove invalid eager_start kwarg from create_task() call

### DIFF
--- a/src/free_claude_code/messaging/trees/processor.py
+++ b/src/free_claude_code/messaging/trees/processor.py
@@ -90,7 +90,6 @@ class TreeQueueProcessor:
             task = asyncio.create_task(
                 claim_runner,
                 name=(f"messaging-claim-{claim.identity.root_id}-{claim.claim_id[:8]}"),
-                eager_start=False,
             )
         except BaseException:
             claim_runner.close()

--- a/src/free_claude_code/messaging/trees/processor.py
+++ b/src/free_claude_code/messaging/trees/processor.py
@@ -87,10 +87,18 @@ class TreeQueueProcessor:
             queue=queue,
         )
         try:
-            task = asyncio.create_task(
-                claim_runner,
-                name=(f"messaging-claim-{claim.identity.root_id}-{claim.claim_id[:8]}"),
-            )
+	       try:
+               task = asyncio.create_task(
+                  claim_runner,
+                  name=(f"messaging-claim-{claim.identity.root_id}-{claim.claim_id[:8]}"),
+                  eager_start=False,
+               )
+           except TypeError:
+               task = asyncio.create_task(
+                   claim_runner,
+                   name=(f"messaging-claim-{claim.identity.root_id}-{claim.claim_id[:8]}"),
+              )
+
         except BaseException:
             claim_runner.close()
             if self._tasks.get(key) is slot:


### PR DESCRIPTION
Fixes #1108

## Problem
`free_claude_code/messaging/trees/processor.py` calls:

    task = asyncio.create_task(
        claim_runner,
        name=(f"messaging-claim-{claim.identity.root_id}-{claim.claim_id[:8]}"),
        eager_start=False,
    )

`asyncio.create_task()` has never accepted an `eager_start` keyword argument.
That parameter only exists on the `asyncio.Task` class constructor, not the
`create_task()` convenience function. This causes:

    TypeError: create_task() got an unexpected keyword argument 'eager_start'

...on every incoming Telegram message, breaking the bot entirely.

## Fix
Removed the invalid `eager_start=False` argument. Since `False` is also the
implicit default behavior of `create_task()`, this is a no-op behavior
change — just removes the crash.

## Testing
- Reproduced the crash on Python 3.14.0
- Applied the fix locally, restarted `fcc-server`, sent a Telegram message
- Bot now responds normally with no error

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the messaging claim task launch path. The main changes are:

- Adds a fallback around `asyncio.create_task()` when `eager_start` is rejected.
- Keeps the task name unchanged for both task creation paths.
- Leaves the existing outer cleanup path in place for launch failures.

<h3>Confidence Score: 2/5</h3>

The changed messaging processor can fail during import.

The nested `try:` uses a tab in a space-indented block, so Python can raise `TabError` before the bot reaches the task launch code.

src/free_claude_code/messaging/trees/processor.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reproduced a TabError when compiling processor.py with py\_compile, confirming the indentation issue is reproducible.
- T-Rex collected and inspected logs and a source excerpt, including the Python version, the compile gate failure, and the relevant code region, to document the failing indentation block.
- T-Rex noted that no new bug was filed for the TabError because it is an accepted existing blocker.

<a href="https://app.greptile.com/trex/runs/14388536/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/messaging/trees/processor.py | Updates task creation fallback logic, but the changed indentation can block module import. |

<sub>Reviews (2): Last reviewed commit: ["fix: gracefully fallback when event loop..."](https://github.com/alishahryar1/free-claude-code/commit/7765f54982873bcf9cefed7b8a740b6b28db0eaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44124322)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->