### PR TITLE
fix : remove env variable for claude code models to display

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,7 @@ Install the [Claude Code extension](https://marketplace.visualstudio.com/items?i
   { "name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082" },
   { "name": "ANTHROPIC_AUTH_TOKEN", "value": "freecc" },
   { "name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1" },
-  { "name": "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "value": "190000" },
-  { "name": "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "value": "1" }
+  { "name": "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "value": "190000" }
 ]
 ```
 
@@ -274,8 +273,7 @@ Set the environment for `acp.registry.claude-acp`:
   "ANTHROPIC_BASE_URL": "http://localhost:8082",
   "ANTHROPIC_AUTH_TOKEN": "freecc",
   "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
-  "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000",
-  "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000"
 }
 ```
 

--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 from free_claude_code.cli.proxy_auth import proxy_auth_token
 
 CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"
-CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1"
 CLAUDE_BINARY_NAME = "claude"
 
 
@@ -26,7 +25,4 @@ def build_claude_proxy_env(
     env["ANTHROPIC_AUTH_TOKEN"] = proxy_auth_token(auth_token)
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = CLAUDE_CODE_AUTO_COMPACT_WINDOW
-    env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = (
-        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
-    )
     return env

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -468,7 +468,6 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
             "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
             "ANTHROPIC_AUTH_TOKEN": "old-token",
             "ANTHROPIC_API_KEY": "official-key",
-            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "0",
         },
     )
 
@@ -477,7 +476,6 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
-    assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
     assert "ANTHROPIC_API_URL" not in env
     assert "ANTHROPIC_API_KEY" not in env
 
@@ -537,7 +535,6 @@ def test_launch_claude_passes_args_and_child_env(
     assert child_env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert child_env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert child_env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
-    assert child_env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
     assert child_env["KEEP_ME"] == "yes"
     register_pid.assert_called_once_with(12345)
     unregister_pid.assert_called_once_with(12345)

--- a/tests/cli/test_managed_claude.py
+++ b/tests/cli/test_managed_claude.py
@@ -68,7 +68,6 @@ def test_managed_claude_builds_new_task_command_and_env() -> None:
     assert invocation.env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert invocation.env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert invocation.env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
-    assert invocation.env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
     assert "ANTHROPIC_API_URL" not in invocation.env
     assert "ANTHROPIC_API_KEY" not in invocation.env
     assert invocation.trace_metadata["client_cli_id"] == "claude"
@@ -136,7 +135,6 @@ def test_managed_claude_env_only_adds_noninteractive_process_settings() -> None:
         "PATH": "keep",
         "ANTHROPIC_API_URL": "https://api.anthropic.com/v1",
         "ANTHROPIC_API_KEY": "official-key",
-        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "0",
     }
     proxy_env = build_claude_proxy_env(
         proxy_root_url="http://localhost:8082",


### PR DESCRIPTION
Fixes #1112

# Problem

Models are not displayed in claude code.

# Fix

Remove env variable CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the Claude Code traffic-disable flag so model discovery can work. The main changes are:

- Removed `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` from the Claude Code child environment.
- Updated README setup examples to omit the removed flag.
- Updated CLI and managed-Claude tests to match the new environment shape.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran verbose pytest for claude-env CLI tests and confirmed all 61 tests passed.
- Generated a runtime inspection harness named inspect\_claude\_env\_absence.py to validate direct environment construction.
- Validated absence-related behavior by reviewing the harness output in claude-env-absence-02-after.log, which shows proxy\_has\_disable\_nonessential=False and managed\_has\_disable\_nonessential=False and preserves the remaining environment behavior.
- Documented the harness and test results for reviewer review.

<a href="https://app.greptile.com/trex/runs/14458022/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/claude_env.py | Removes the hardcoded Claude Code traffic-disable flag from the proxy environment builder. |
| README.md | Updates Claude Code setup examples to stop documenting the removed flag. |
| tests/cli/test_entrypoints.py | Updates CLI environment tests for the new child environment shape. |
| tests/cli/test_managed_claude.py | Updates managed-Claude environment tests for the new child environment shape. |

<sub>Reviews (2): Last reviewed commit: ["fix: delete all CLAUDE\_CODE\_DISABLE\_NONE..."](https://github.com/alishahryar1/free-claude-code/commit/9cbba932565abca0de56b4f152b8b88f034c2d12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44132261)</sub>

<!-- /greptile_comment -->