### PR TITLE
Fix messaging task launch on uvloop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.5.0"
+version = "4.5.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/messaging/trees/processor.py
+++ b/src/free_claude_code/messaging/trees/processor.py
@@ -81,8 +81,10 @@ class TreeQueueProcessor:
         slot = _TaskSlot(tree=tree, claim=claim)
         self._tasks[key] = slot
         self._idle.clear()
+        ownership_ready = asyncio.Event()
         claim_runner = self._run_claim(
             slot,
+            ownership_ready=ownership_ready,
             announce_started=announce_started,
             queue=queue,
         )
@@ -90,7 +92,6 @@ class TreeQueueProcessor:
             task = asyncio.create_task(
                 claim_runner,
                 name=(f"messaging-claim-{claim.identity.root_id}-{claim.claim_id[:8]}"),
-                eager_start=False,
             )
         except BaseException:
             claim_runner.close()
@@ -101,6 +102,7 @@ class TreeQueueProcessor:
             raise
         slot.task = task
         task.add_done_callback(lambda _task, claim_key=key: self._task_done(claim_key))
+        ownership_ready.set()
 
     def _task_done(self, key: str) -> None:
         """Recover a claim if its task was cancelled before entering its body."""
@@ -156,9 +158,11 @@ class TreeQueueProcessor:
         self,
         slot: _TaskSlot,
         *,
+        ownership_ready: asyncio.Event,
         announce_started: bool,
         queue: tuple[QueueEntry, ...],
     ) -> None:
+        await ownership_ready.wait()
         claim = slot.claim
         try:
             if announce_started:

--- a/tests/messaging/test_tree_ownership_concurrency.py
+++ b/tests/messaging/test_tree_ownership_concurrency.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import importlib
 import sys
 
 import pytest
@@ -482,7 +481,7 @@ async def test_claim_launch_uses_portable_event_loop_task_contract(
     reason="uvloop is not installed on this Python platform",
 )
 def test_claim_launch_runs_on_uvloop() -> None:
-    uvloop = importlib.import_module("uvloop")
+    uvloop = pytest.importorskip("uvloop")
 
     async def scenario() -> None:
         processed = asyncio.Event()

--- a/tests/messaging/test_tree_ownership_concurrency.py
+++ b/tests/messaging/test_tree_ownership_concurrency.py
@@ -1,5 +1,7 @@
 import asyncio
 import contextlib
+import importlib
+import sys
 
 import pytest
 
@@ -448,6 +450,54 @@ async def test_eager_task_factory_cannot_run_claim_before_admission_returns() ->
     finally:
         release.set()
         await _wait_for_no_tasks(manager)
+
+
+@pytest.mark.asyncio
+async def test_claim_launch_uses_portable_event_loop_task_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processed = asyncio.Event()
+
+    async def process(_claim: NodeClaim) -> None:
+        processed.set()
+
+    loop = asyncio.get_running_loop()
+    original_create_task = loop.create_task
+
+    def portable_create_task(coro, *, name=None, context=None):
+        return original_create_task(coro, name=name, context=context)
+
+    monkeypatch.setattr(loop, "create_task", portable_create_task)
+    manager = TreeQueueManager(process)
+
+    decision = await manager.admit(_incoming("root"), "status-root")
+    await asyncio.wait_for(manager.wait_idle(), timeout=1)
+
+    assert decision.accepted is True
+    assert processed.is_set()
+
+
+@pytest.mark.skipif(
+    sys.platform in {"cygwin", "win32"} or sys.implementation.name == "pypy",
+    reason="uvloop is not installed on this Python platform",
+)
+def test_claim_launch_runs_on_uvloop() -> None:
+    uvloop = importlib.import_module("uvloop")
+
+    async def scenario() -> None:
+        processed = asyncio.Event()
+
+        async def process(_claim: NodeClaim) -> None:
+            processed.set()
+
+        manager = TreeQueueManager(process)
+        decision = await manager.admit(_incoming("root"), "status-root")
+        await asyncio.wait_for(manager.wait_idle(), timeout=1)
+
+        assert decision.accepted is True
+        assert processed.is_set()
+
+    uvloop.run(scenario())
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.5.0"
+version = "4.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

uvloop 0.22.1 rejects the Python 3.14-only `eager_start` task keyword, so every Telegram and Discord message fails on Unix. Removing the keyword alone would let eager task factories execute claims before FCC publishes task ownership. Fixes #1108 and fixes #1115.

## Changes

| Before | After |
| --- | --- |
| Claim tasks depend on `eager_start=False`, which uvloop does not accept. | Claim tasks use the portable event-loop contract behind an explicit ownership gate. |
| Task execution ordering depends on event-loop keyword support. | Task execution begins only after FCC attaches the task and completion callback. |
| Regression coverage exercises native asyncio only. | Regression coverage exercises a restricted task contract, eager task factories, and real uvloop. |
| The package version is 4.5.0. | The package version is 4.5.1 with a refreshed lockfile. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes messaging task startup so it works with uvloop. The main changes are:

- Replaces the `eager_start` task keyword with an explicit ownership gate.
- Starts claim processing only after the task and callback are attached.
- Adds tests for the portable task contract, eager task factories, and uvloop.
- Bumps the package metadata to `4.5.1`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The environment details were captured showing Python 3.14.0, pytest 9.1.1, and uvloop 0.22.1 from the project's virtual environment.
- The full focused test suite was executed and reported 17 passed in 0.14s.
- The targeted uvloop test was run with 1 selected, and the test\_claim\_launch\_runs\_on\_uvloop passed while 16 tests were deselected.

<a href="https://app.greptile.com/trex/runs/14466985/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/messaging/trees/processor.py | Adds an ownership readiness event before claim task execution. |
| tests/messaging/test_tree_ownership_concurrency.py | Adds task startup tests, including guarded uvloop coverage. |
| pyproject.toml | Bumps the project version to `4.5.1`. |
| uv.lock | Updates the locked editable package version to `4.5.1`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Skip uvloop regression when unavailable"](https://github.com/alishahryar1/free-claude-code/commit/918119f367a8c04dedf189fdc766229b968ad627) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44296382)</sub>

<!-- /greptile_comment -->