### PR TITLE
Restore Claude model discovery without enabling telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,10 @@ Install the [Claude Code extension](https://marketplace.visualstudio.com/items?i
   { "name": "ANTHROPIC_AUTH_TOKEN", "value": "freecc" },
   { "name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1" },
   { "name": "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "value": "190000" },
-  { "name": "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "value": "1" }
+  { "name": "DISABLE_AUTOUPDATER", "value": "1" },
+  { "name": "DISABLE_FEEDBACK_COMMAND", "value": "1" },
+  { "name": "DISABLE_ERROR_REPORTING", "value": "1" },
+  { "name": "DISABLE_TELEMETRY", "value": "1" }
 ]
 ```
 
@@ -275,7 +278,10 @@ Set the environment for `acp.registry.claude-acp`:
   "ANTHROPIC_AUTH_TOKEN": "freecc",
   "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
   "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000",
-  "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  "DISABLE_AUTOUPDATER": "1",
+  "DISABLE_FEEDBACK_COMMAND": "1",
+  "DISABLE_ERROR_REPORTING": "1",
+  "DISABLE_TELEMETRY": "1"
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.5.1"
+version = "4.5.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/prereq/test_cli_prereq_live.py
+++ b/smoke/prereq/test_cli_prereq_live.py
@@ -73,6 +73,9 @@ def test_claude_cli_prompt_when_available(
         )
         server_log = server.log_path.read_text(encoding="utf-8", errors="replace")
     assert result.returncode == 0, result.stderr or result.stdout
+    assert "GET /v1/models" in server_log, (
+        "Claude CLI did not discover models from the local gateway"
+    )
     assert "POST /v1/messages" in server_log, (
         "Claude CLI did not call the local Anthropic-compatible endpoint"
     )

--- a/smoke/product/test_client_product_live.py
+++ b/smoke/product/test_client_product_live.py
@@ -192,8 +192,8 @@ def test_claude_cli_provider_error_e2e(
 
     combined = f"{result.stdout}\n{result.stderr}"
     lower = combined.lower()
-    downstream_requests = sum(
-        "POST /v1/messages" in line and "HTTP/1.1" in line
+    failed_downstream_requests = sum(
+        "POST /v1/messages" in line and "400 Bad Request" in line
         for line in server_log.splitlines()
     )
 
@@ -202,7 +202,7 @@ def test_claude_cli_provider_error_e2e(
     assert "proxy or gateway intercepting" not in lower
     assert "api error" in lower or "selected model" in lower
     assert "fcc smoke provider rejected the request deliberately" in lower
-    assert downstream_requests == 1, server_log
+    assert failed_downstream_requests == 1, server_log
     assert provider_requests == ["/v1/chat/completions"]
 
 

--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 from free_claude_code.cli.proxy_auth import proxy_auth_token
 
 CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"
-CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1"
 CLAUDE_BINARY_NAME = "claude"
 
 
@@ -17,16 +16,19 @@ def build_claude_proxy_env(
 ) -> dict[str, str]:
     """Return the canonical environment for Claude Code proxy sessions."""
 
+    # Claude's aggregate traffic flag also suppresses gateway model discovery.
     env = {
         key: value
         for key, value in base_env.items()
         if not key.startswith("ANTHROPIC_")
+        and key != "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"
     }
     env["ANTHROPIC_BASE_URL"] = proxy_root_url
     env["ANTHROPIC_AUTH_TOKEN"] = proxy_auth_token(auth_token)
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = CLAUDE_CODE_AUTO_COMPACT_WINDOW
-    env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = (
-        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
-    )
+    env["DISABLE_AUTOUPDATER"] = "1"
+    env["DISABLE_FEEDBACK_COMMAND"] = "1"
+    env["DISABLE_ERROR_REPORTING"] = "1"
+    env["DISABLE_TELEMETRY"] = "1"
     return env

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -621,7 +621,9 @@ class TestManagedClaudeSession:
             assert env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
             assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
             assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+            assert env["DISABLE_TELEMETRY"] == "1"
             assert "ANTHROPIC_API_KEY" not in env
+            assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in env
 
     @pytest.mark.asyncio
     async def test_start_task_uses_sentinel_when_proxy_auth_blank(self):

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -468,7 +468,12 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
             "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
             "ANTHROPIC_AUTH_TOKEN": "old-token",
             "ANTHROPIC_API_KEY": "official-key",
-            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "0",
+            "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "0",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "DISABLE_AUTOUPDATER": "0",
+            "DISABLE_FEEDBACK_COMMAND": "0",
+            "DISABLE_ERROR_REPORTING": "0",
+            "DISABLE_TELEMETRY": "0",
         },
     )
 
@@ -477,9 +482,13 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
-    assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert env["DISABLE_AUTOUPDATER"] == "1"
+    assert env["DISABLE_FEEDBACK_COMMAND"] == "1"
+    assert env["DISABLE_ERROR_REPORTING"] == "1"
+    assert env["DISABLE_TELEMETRY"] == "1"
     assert "ANTHROPIC_API_URL" not in env
     assert "ANTHROPIC_API_KEY" not in env
+    assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in env
 
 
 def test_claude_child_env_uses_sentinel_for_blank_configured_auth_token() -> None:
@@ -537,7 +546,11 @@ def test_launch_claude_passes_args_and_child_env(
     assert child_env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert child_env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert child_env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
-    assert child_env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert child_env["DISABLE_AUTOUPDATER"] == "1"
+    assert child_env["DISABLE_FEEDBACK_COMMAND"] == "1"
+    assert child_env["DISABLE_ERROR_REPORTING"] == "1"
+    assert child_env["DISABLE_TELEMETRY"] == "1"
+    assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in child_env
     assert child_env["KEEP_ME"] == "yes"
     register_pid.assert_called_once_with(12345)
     unregister_pid.assert_called_once_with(12345)

--- a/tests/cli/test_managed_claude.py
+++ b/tests/cli/test_managed_claude.py
@@ -68,7 +68,11 @@ def test_managed_claude_builds_new_task_command_and_env() -> None:
     assert invocation.env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"
     assert invocation.env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert invocation.env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
-    assert invocation.env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+    assert invocation.env["DISABLE_AUTOUPDATER"] == "1"
+    assert invocation.env["DISABLE_FEEDBACK_COMMAND"] == "1"
+    assert invocation.env["DISABLE_ERROR_REPORTING"] == "1"
+    assert invocation.env["DISABLE_TELEMETRY"] == "1"
+    assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in invocation.env
     assert "ANTHROPIC_API_URL" not in invocation.env
     assert "ANTHROPIC_API_KEY" not in invocation.env
     assert invocation.trace_metadata["client_cli_id"] == "claude"
@@ -136,7 +140,8 @@ def test_managed_claude_env_only_adds_noninteractive_process_settings() -> None:
         "PATH": "keep",
         "ANTHROPIC_API_URL": "https://api.anthropic.com/v1",
         "ANTHROPIC_API_KEY": "official-key",
-        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "0",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "DISABLE_TELEMETRY": "0",
     }
     proxy_env = build_claude_proxy_env(
         proxy_root_url="http://localhost:8082",

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.5.1"
+version = "4.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Claude Code's aggregate nonessential-traffic flag overrides gateway discovery, so `fcc-claude` never requests `/v1/models` and `/model` omits FCC models. Deleting the flag alone also re-enables updater, feedback, error-reporting, and telemetry traffic. Fixes #1112.

## Changes

| Before | After |
| --- | --- |
| FCC forced the aggregate traffic flag, which suppressed gateway model discovery. | The shared Claude environment removes inherited aggregate flags and enables gateway discovery. |
| Removing the aggregate flag would restore every optional traffic category. | Four granular opt-outs preserve the existing updater, feedback, error-reporting, and telemetry policy. |
| VS Code and JetBrains examples documented the discovery-blocking flag. | Both IDE examples use the same granular environment policy as `fcc-claude`. |
| The retry smoke counted locally short-circuited auxiliary requests as provider retries. | The retry smoke counts terminal failures and still requires exactly one upstream provider attempt. |
| Package metadata reported version 4.5.1. | Package metadata and the lockfile report version 4.5.2. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores Claude gateway model discovery while keeping most optional Claude traffic disabled. The main changes are:

- Replaces the aggregate Claude traffic flag with granular opt-out environment variables.
- Updates VS Code and JetBrains setup examples to match the new environment policy.
- Adds smoke coverage for `/v1/models` discovery through the local gateway.
- Adjusts the provider-error smoke retry count.
- Bumps package metadata and the lockfile to 4.5.2.
</details>

<h3>Confidence Score: 4/5</h3>

The Claude environment policy has one contained traffic-control regression.

Gateway discovery is enabled through the changed launch environment, and package version sources are consistent.

src/free_claude_code/cli/claude_env.py and README.md need the granular opt-out set checked because it does not cover feedback-survey traffic that the removed aggregate flag previously blocked.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the Feedback Survey Traffic Reenabled scenario by running a focused Python repro harness that imports build\_claude\_proxy\_env with CLAUDE\_CODE\_DISABLE\_NONESSENTIAL\_TRAFFIC in the base environment.
- Used the repro harness to verify that CLAUDE\_CODE\_ENABLE\_GATEWAY\_MODEL\_DISCOVERY is set to '1' and the four granular opt-outs are '1', while CLAUDE\_CODE\_DISABLE\_NONESSENTIAL\_TRAFFIC is removed and CLAUDE\_CODE\_DISABLE\_FEEDBACK\_SURVEY is absent.
- Observed in the repro command output that the aggregate traffic flag was stripped and the feedback-survey opt-out was absent, confirming the expected environment state.
- Performed broader contract validation: the env policy harness shows the expected proxy/managed env state with aggregate flag absent and gateway model discovery enabled, the targeted CLI tests total 96 with exit code 0, and the CLAUDE CLI is unavailable in this environment (exit code 127).

<a href="https://app.greptile.com/trex/runs/14470129/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/claude_env.py | Builds the Claude child environment with gateway discovery and granular traffic opt-outs, but misses the feedback-survey opt-out. |
| README.md | Updates IDE examples to use the same granular Claude environment policy as the runtime helper. |
| smoke/prereq/test_cli_prereq_live.py | Adds a live assertion that Claude discovers models through the local gateway. |
| smoke/product/test_client_product_live.py | Counts terminal failed downstream message requests while preserving the provider-attempt assertion. |
| pyproject.toml | Bumps the project version to 4.5.2. |
| uv.lock | Updates the locked editable package version to 4.5.2. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Frestore-claude-model-discovery%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Frestore-claude-model-discovery%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffree_claude_code%2Fcli%2Fclaude_env.py%3A30-33%0A**Feedback%20Survey%20Traffic%20Reenabled**%0A%0AWhen%20%60fcc-claude%60%20or%20a%20managed%20Claude%20task%20is%20launched%20through%20this%20helper%2C%20the%20old%20aggregate%20opt-out%20no%20longer%20suppresses%20Claude's%20session%20feedback%20survey%20path.%20The%20replacement%20only%20disables%20updater%2C%20feedback%20command%2C%20error%20reporting%2C%20and%20telemetry%2C%20so%20restricted-network%20or%20privacy-controlled%20runs%20can%20still%20show%20or%20send%20nonessential%20feedback-survey%20traffic%20that%20was%20previously%20blocked.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Restore Claude gateway model discovery"](https://github.com/alishahryar1/free-claude-code/commit/03e915adfb6f49d96e492e4659c3e00a3f7b12dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44306473)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/alishahryar1/github/Alishahryar1/free-claude-code/-/custom-context?memory=d2fd24d8-0dec-4faf-8ee4-e085e215a2f8))

<!-- /greptile_comment -->