### PR TITLE
Validate FCC versions in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,8 +8,8 @@ body:
     id: fcc-version
     attributes:
       label: FCC version
-      description: Run `fcc-server --version` and enter the reported version. If FCC did not install, enter `not installed`.
-      placeholder: "4.4.1 or not installed"
+      description: Run `fcc-server --version` and enter only the version number, such as `4.6.1`. If FCC did not install, enter `None`.
+      placeholder: "4.6.1 or None"
     validations:
       required: true
 

--- a/.github/workflows/validate-bug-report-version.yml
+++ b/.github/workflows/validate-bug-report-version.yml
@@ -1,0 +1,80 @@
+name: Validate bug report version
+
+on:
+  issues:
+    types: [opened, edited]
+
+concurrency:
+  group: bug-report-version-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+
+jobs:
+  validate:
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate FCC version
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const fieldPattern = "^### FCC version\\r?\\n+\\s*([^\\r\\n]+)";
+            const versionPattern = "^(?:\\d+\\.\\d+\\.\\d+|None)$";
+            const match = (issue.body || "").match(new RegExp(fieldPattern, "m"));
+            const version = match?.[1]?.trim() || "";
+            const valid = new RegExp(versionPattern).test(version);
+            const labelName = "needs-fcc-version";
+            const marker = "<!-- fcc-version-validator -->";
+            const labels = new Set(issue.labels.map((label) => label.name));
+            const repo = context.repo;
+            const issue_number = issue.number;
+
+            if (valid) {
+              if (labels.has(labelName)) {
+                await github.rest.issues.removeLabel({
+                  ...repo,
+                  issue_number,
+                  name: labelName,
+                });
+              }
+              return;
+            }
+
+            if (!labels.has(labelName)) {
+              try {
+                await github.rest.issues.getLabel({ ...repo, name: labelName });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                try {
+                  await github.rest.issues.createLabel({
+                    ...repo,
+                    name: labelName,
+                    color: "d4c5f9",
+                    description: "FCC version must be number.number.number or None",
+                  });
+                } catch (createError) {
+                  if (createError.status !== 422) throw createError;
+                }
+              }
+              await github.rest.issues.addLabels({
+                ...repo,
+                issue_number,
+                labels: [labelName],
+              });
+            }
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { ...repo, issue_number, per_page: 100 },
+            );
+            if (!comments.some((comment) => comment.body?.includes(marker))) {
+              await github.rest.issues.createComment({
+                ...repo,
+                issue_number,
+                body: `${marker}\nPlease edit **FCC version** to contain only an exact \`number.number.number\` value, such as \`4.6.1\`, or \`None\`. Run \`fcc-server --version\` to find the installed version.`,
+              });
+            }

--- a/tests/contracts/test_issue_form_version_validation.py
+++ b/tests/contracts/test_issue_form_version_validation.py
@@ -1,0 +1,76 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+BUG_FORM = Path(".github/ISSUE_TEMPLATE/bug-report.yml")
+WORKFLOW = Path(".github/workflows/validate-bug-report-version.yml")
+
+
+def _workflow_pattern(name: str) -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(rf"const {name} = (\"[^\"]+\");", workflow)
+    assert match is not None
+    return json.loads(match.group(1))
+
+
+def test_bug_form_requires_an_exact_version_or_none() -> None:
+    form = BUG_FORM.read_text(encoding="utf-8")
+
+    assert "Run `fcc-server --version`" in form
+    assert "enter only the version number" in form
+    assert "enter `None`" in form
+    assert 'placeholder: "4.6.1 or None"' in form
+    assert "not installed" not in form
+
+
+@pytest.mark.parametrize("value", ["0.0.0", "4.6.1", "123.45.678", "None"])
+def test_version_pattern_accepts_supported_values(value: str) -> None:
+    assert re.fullmatch(_workflow_pattern("versionPattern"), value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "latest",
+        "4.6",
+        "4.6.1.2",
+        "v4.6.1",
+        "4.6.x",
+        "none",
+        "free-claude-code 4.6.1",
+    ],
+)
+def test_version_pattern_rejects_ambiguous_values(value: str) -> None:
+    assert re.fullmatch(_workflow_pattern("versionPattern"), value) is None
+
+
+def test_field_pattern_extracts_the_issue_form_value() -> None:
+    body = """### FCC version
+
+4.6.1
+
+### CLI
+
+Claude Code (fcc-claude)
+"""
+
+    match = re.search(_workflow_pattern("fieldPattern"), body, flags=re.MULTILINE)
+
+    assert match is not None
+    assert match.group(1) == "4.6.1"
+
+
+def test_workflow_owns_one_idempotent_triage_state() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "types: [opened, edited]" in workflow
+    assert "issues: write" in workflow
+    assert "needs-fcc-version" in workflow
+    assert "<!-- fcc-version-validator -->" in workflow
+    assert "github.rest.issues.createLabel" in workflow
+    assert "github.rest.issues.addLabels" in workflow
+    assert "github.rest.issues.removeLabel" in workflow
+    assert "comments.some" in workflow


### PR DESCRIPTION
## Problem

Bug reports can satisfy the required FCC version field with ambiguous values such as `latest`, preventing reliable reproduction and regression analysis.

## Changes

| Before | After |
| --- | --- |
| The form accepted any non-empty FCC version text. | The form requests only an `x.y.z` version or `None`. |
| Invalid values required manual maintainer follow-up. | A dedicated workflow labels invalid reports and posts one correction prompt. |
| Corrected reports retained manual triage state. | Editing the issue reruns validation and removes the workflow-owned label when valid. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR validates FCC versions supplied through the bug-report form. The main changes are:

- Requests an exact `x.y.z` version or `None`.
- Validates bug reports when opened or edited.
- Adds and removes workflow-owned triage state.
- Adds contract tests for parsing and workflow behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the initial state showing there was no version triage before capture.
- After capture, the latest state showed a needs-fcc-version label added and one marked comment.
- Repeat delivery then listed only comments.
- In the 4.6.1 case, the needs-fcc-version label was removed.
- With the None input, no API calls were made.

<a href="https://app.greptile.com/trex/runs/14521311/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug-report.yml | Updates the FCC version instructions and placeholder to require an exact version or `None`. |
| .github/workflows/validate-bug-report-version.yml | Adds exact version validation with per-issue concurrency, idempotent comments, and label reconciliation after edits. |
| tests/contracts/test_issue_form_version_validation.py | Adds contract coverage for form text, accepted and rejected values, field extraction, and triage operations. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Validate FCC versions in bug reports"](https://github.com/alishahryar1/free-claude-code/commit/388fe8515d61bdd47bc6ee9e1c9034222940c3bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44414967)</sub>

<!-- /greptile_comment -->