### PR TITLE
Preserve DeepSeek cache prefixes across tool turns

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -569,7 +569,12 @@ Ollama's standard `reasoning` delta and history field are profile data rather
 than a specialized adapter. DeepSeek intentionally uses its
 OpenAI-compatible Chat Completions endpoint because that is the endpoint that
 reports prompt-cache hit/miss counters; the provider maps those counters back
-into Anthropic usage fields for Claude-compatible clients. Cloudflare uses its
+into Anthropic usage fields for Claude-compatible clients. DeepSeek reasoning
+history is serialized per assistant turn: non-tool reasoning is omitted from
+its first replay, while tool-call reasoning is retained independently of the
+next generation's thinking mode. Append-only conversations therefore keep an
+identical message prefix without violating DeepSeek's tool-call replay contract.
+Cloudflare uses its
 account-scoped Workers AI OpenAI-compatible Chat Completions endpoint for
 `@cf/...` model IDs, while account ID composition, model search, and
 Cloudflare-specific reasoning deltas stay in the Cloudflare provider client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.6.3"
+version = "4.6.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/deepseek/compat.py
+++ b/src/free_claude_code/providers/deepseek/compat.py
@@ -55,7 +55,7 @@ def build_deepseek_request_body(
     _downgrade_forced_tool_choice(data)
 
     has_tool_history = _has_tool_history(data)
-    has_replayable_tool_thinking = _has_replayable_tool_thinking(data)
+    has_replayable_tool_thinking = _all_tool_calls_have_replayable_thinking(data)
     unsafe_tool_followup = has_tool_history and not has_replayable_tool_thinking
     effective_thinking_enabled = thinking_enabled and not unsafe_tool_followup
     if thinking_enabled:
@@ -87,16 +87,14 @@ def build_deepseek_request_body(
 
     if "messages" in data:
         data["messages"] = _normalize_tool_result_content(
-            sanitize_deepseek_messages_for_openai(
-                data["messages"],
-                thinking_enabled=effective_thinking_enabled,
-            )
+            sanitize_deepseek_messages_for_openai(data["messages"])
         )
 
     sanitized_request = MessagesRequest.model_validate(data)
     body = build_openai_chat_request_body(
         sanitized_request,
         thinking_enabled=effective_thinking_enabled,
+        reasoning_history_enabled=True,
         policy=_REQUEST_POLICY,
         postprocessors=(_apply_deepseek_chat_extras,),
     )
@@ -112,10 +110,8 @@ def build_deepseek_request_body(
     return body
 
 
-def sanitize_deepseek_messages_for_openai(
-    messages: Any, *, thinking_enabled: bool
-) -> Any:
-    """Filter assistant content before converting to DeepSeek Chat Completions."""
+def sanitize_deepseek_messages_for_openai(messages: Any) -> Any:
+    """Keep only DeepSeek-required reasoning history on assistant tool calls."""
     if not isinstance(messages, list):
         return messages
 
@@ -127,29 +123,26 @@ def sanitize_deepseek_messages_for_openai(
         if message.get("role") != "assistant":
             sanitized.append(message)
             continue
+        replay_tool_reasoning = _assistant_has_tool_use(message)
+        new_msg = dict(message)
+        if not replay_tool_reasoning:
+            new_msg.pop("reasoning_content", None)
         content = message.get("content")
         if not isinstance(content, list):
-            sanitized.append(message)
+            sanitized.append(new_msg)
             continue
 
-        if not thinking_enabled:
-            filtered = [
-                block
-                for block in content
-                if not (
-                    isinstance(block, dict)
-                    and block.get("type") in ("thinking", "redacted_thinking")
+        filtered = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and (
+                    block.get("type") == "redacted_thinking"
+                    or (block.get("type") == "thinking" and not replay_tool_reasoning)
                 )
-            ]
-        else:
-            filtered = [
-                block
-                for block in content
-                if not (
-                    isinstance(block, dict) and block.get("type") == "redacted_thinking"
-                )
-            ]
-        new_msg = dict(message)
+            )
+        ]
         new_msg["content"] = filtered or ""
         sanitized.append(new_msg)
     return sanitized
@@ -314,6 +307,15 @@ def _has_replayable_thinking_before_tool_use(message: Mapping[str, Any]) -> bool
     return False
 
 
+def _assistant_has_tool_use(message: Mapping[str, Any]) -> bool:
+    if message.get("role") != "assistant":
+        return False
+    content = message.get("content")
+    return isinstance(content, list) and any(
+        isinstance(block, dict) and block.get("type") == "tool_use" for block in content
+    )
+
+
 def _has_tool_history(data: dict[str, Any]) -> bool:
     for message in data.get("messages") or ():
         if isinstance(message, Mapping) and _has_tool_history_blocks(message):
@@ -321,13 +323,15 @@ def _has_tool_history(data: dict[str, Any]) -> bool:
     return False
 
 
-def _has_replayable_tool_thinking(data: dict[str, Any]) -> bool:
+def _all_tool_calls_have_replayable_thinking(data: dict[str, Any]) -> bool:
+    found_tool_call = False
     for message in data.get("messages") or ():
-        if isinstance(message, Mapping) and _has_replayable_thinking_before_tool_use(
-            message
-        ):
-            return True
-    return False
+        if not isinstance(message, Mapping) or not _assistant_has_tool_use(message):
+            continue
+        found_tool_call = True
+        if not _has_replayable_thinking_before_tool_use(message):
+            return False
+    return found_tool_call
 
 
 def _remove_deepseek_thinking_hints(data: dict[str, Any]) -> None:

--- a/src/free_claude_code/providers/openai_chat/request_policy.py
+++ b/src/free_claude_code/providers/openai_chat/request_policy.py
@@ -37,6 +37,7 @@ def build_openai_chat_request_body(
     request_data: MessagesRequest,
     *,
     thinking_enabled: bool,
+    reasoning_history_enabled: bool | None = None,
     policy: OpenAIChatRequestPolicy,
     postprocessors: Iterable[OpenAIChatPostprocessor] = (),
 ) -> dict[str, Any]:
@@ -48,7 +49,9 @@ def build_openai_chat_request_body(
         len(request_data.messages),
     )
     try:
-        if not thinking_enabled:
+        if reasoning_history_enabled is None:
+            reasoning_history_enabled = thinking_enabled
+        if not reasoning_history_enabled:
             reasoning_replay = ReasoningReplayMode.DISABLED
         else:
             reasoning_replay = (

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -1,10 +1,13 @@
 """Tests for DeepSeek OpenAI-compatible Chat Completions provider."""
 
+import json
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
+from openai import AsyncOpenAI
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
@@ -35,6 +38,36 @@ def deepseek_config():
 @pytest.fixture
 def deepseek_provider(deepseek_config):
     return DeepSeekProvider(deepseek_config, rate_limiter=passthrough_rate_limiter())
+
+
+async def _capture_openai_wire_body(body: dict) -> dict:
+    captured: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert isinstance(payload, dict)
+        captured.append(payload)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text="data: [DONE]\n\n",
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = AsyncOpenAI(
+        api_key="test",
+        base_url="https://deepseek.invalid",
+        http_client=http_client,
+        max_retries=0,
+    )
+    try:
+        stream = await client.chat.completions.create(**body, stream=True)
+        await stream.close()
+    finally:
+        await client.close()
+
+    assert len(captured) == 1
+    return captured[0]
 
 
 def test_default_base_url_alias():
@@ -177,7 +210,7 @@ def test_build_request_body_respects_global_thinking_disable():
     assert "stream_options" not in body
 
 
-def test_preserve_unsigned_thinking_when_thinking_on(deepseek_provider):
+def test_non_tool_thinking_is_omitted_from_first_replay(deepseek_provider):
     request = MessagesRequest.model_validate(
         {
             "model": "m",
@@ -197,8 +230,7 @@ def test_preserve_unsigned_thinking_when_thinking_on(deepseek_provider):
         }
     )
     body = deepseek_provider._build_request_body(request)
-    assert body["messages"][0]["content"] == "out"
-    assert body["messages"][0]["reasoning_content"] == "plain"
+    assert body["messages"][0] == {"role": "assistant", "content": "out"}
 
 
 def test_strip_redacted_thinking_when_thinking_on(deepseek_provider):
@@ -484,6 +516,53 @@ def test_thinking_off_strips_thinking_history():
     assert "sec" not in str(body["messages"])
 
 
+def test_thinking_off_still_replays_required_tool_reasoning():
+    provider = DeepSeekProvider(
+        ProviderConfig(
+            api_key="k",
+            base_url=DEEPSEEK_DEFAULT_BASE,
+            rate_limit=1,
+            rate_window=1,
+            enable_thinking=False,
+        ),
+        rate_limiter=passthrough_rate_limiter(),
+    )
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "required"},
+                        {
+                            "type": "tool_use",
+                            "id": "t1",
+                            "name": "Read",
+                            "input": {"file_path": "x"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "t1",
+                            "content": "ok",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    body = provider._build_request_body(request)
+
+    assert "extra_body" not in body
+    assert body["messages"][0]["reasoning_content"] == "required"
+
+
 def test_passthrough_tool_use_and_result(deepseek_provider):
     request = MessagesRequest.model_validate(
         {
@@ -630,7 +709,7 @@ def test_preflight_rejects_server_tool_result_blocks():
         provider.preflight_stream(request)
 
 
-def test_reasoning_content_replayed_to_openai_chat(deepseek_provider):
+def test_non_tool_top_level_reasoning_is_not_replayed(deepseek_provider):
     request = MessagesRequest(
         model="m",
         messages=[
@@ -642,7 +721,131 @@ def test_reasoning_content_replayed_to_openai_chat(deepseek_provider):
         ],
     )
     body = deepseek_provider._build_request_body(request)
-    assert body["messages"][0]["reasoning_content"] == "r"
+    assert body["messages"][0] == {"role": "assistant", "content": "hi"}
+
+
+def test_tool_call_top_level_reasoning_is_replayed(deepseek_provider):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "t1",
+                            "name": "Read",
+                            "input": {"file_path": "x"},
+                        }
+                    ],
+                    "reasoning_content": "required",
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "t1",
+                            "content": "ok",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    body = deepseek_provider._build_request_body(request)
+
+    assert body["messages"][0]["reasoning_content"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_wire_messages_keep_prefix_across_tool_thinking_fallback(
+    deepseek_provider,
+):
+    prefix_messages = [
+        {"role": "user", "content": "first"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "ordinary reasoning"},
+                {"type": "text", "text": "answer"},
+            ],
+        },
+        {"role": "user", "content": "use the first tool"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "required tool reasoning"},
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Read",
+                    "input": {"file_path": "one"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": "one",
+                }
+            ],
+        },
+        {"role": "user", "content": "use the second tool"},
+    ]
+    continued_messages = [
+        *prefix_messages,
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t2",
+                    "name": "Read",
+                    "input": {"file_path": "two"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t2",
+                    "content": "two",
+                }
+            ],
+        },
+    ]
+
+    def build(messages: list[dict]) -> dict:
+        request = MessagesRequest.model_validate(
+            {
+                "model": "deepseek-v4-pro",
+                "messages": messages,
+                "thinking": {"type": "enabled"},
+            }
+        )
+        return deepseek_provider._build_request_body(request)
+
+    first_wire = await _capture_openai_wire_body(build(prefix_messages))
+    continued_wire = await _capture_openai_wire_body(build(continued_messages))
+    first_messages = first_wire["messages"]
+    continued = continued_wire["messages"]
+
+    assert continued[: len(first_messages)] == first_messages
+    assistant_messages = [
+        message for message in first_messages if message["role"] == "assistant"
+    ]
+    assert "reasoning_content" not in assistant_messages[0]
+    assert assistant_messages[1]["reasoning_content"] == "required tool reasoning"
+    assert first_wire["thinking"] == {"type": "enabled"}
+    assert "thinking" not in continued_wire
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.6.3"
+version = "4.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

DeepSeek cache accounting was restored, but a later tool turn could still make FCC rewrite older assistant history. That prevented FCC from guaranteeing the identical serialized prefix required for cache reuse and left the remaining behavior in #904 unresolved.

## Changes

| Before | After |
| --- | --- |
| Non-tool reasoning was replayed until a later tool fallback removed it. | Non-tool reasoning is omitted consistently from its first history serialization. |
| Current-generation thinking controlled all historical reasoning replay. | Required tool-call reasoning is replayed independently of current-generation thinking. |
| One replayable tool turn made the entire tool history appear safe. | Every tool-call turn must have replayable reasoning before thinking remains enabled. |
| Prefix behavior was not verified after SDK request serialization. | DeepSeek tests capture final SDK JSON and require an exact append-only message prefix. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves DeepSeek cache prefixes while retaining required tool-call reasoning. The main changes are:

- Omits non-tool reasoning from its first history serialization.
- Replays tool-call reasoning independently of current thinking mode.
- Disables thinking unless every historical tool call has replayable reasoning.
- Tests the final SDK-serialized message prefix.
- Bumps the package patch version and updates the lockfile.
</details>

<h3>Confidence Score: 4/5</h3>

The reasoning-only assistant path needs a fix before merging.

The main prefix-preservation flow is covered at the SDK wire boundary. Filtering a `redacted_thinking`-only turn emits empty assistant content instead of the converter's non-empty sentinel. Other request-policy callers retain their previous behavior.

src/free_claude_code/providers/deepseek/compat.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the requested verification of the code base.
- T-Rex ran the focused test wire\_messages\_keep\_prefix\_across\_tool\_thinking\_fallback with pytest; the exact command and harness are captured in the log, and the test completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/14533439/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/deepseek/compat.py | Separates historical tool reasoning from current thinking, but can serialize an empty assistant message after filtering. |
| src/free_claude_code/providers/openai_chat/request_policy.py | Adds an optional reasoning-history switch while preserving existing defaults for other callers. |
| tests/providers/test_deepseek.py | Adds SDK wire-format tests for stable prefixes and independent tool-reasoning replay. |
| pyproject.toml | Bumps the package patch version to 4.6.4. |
| uv.lock | Synchronizes the editable package version with the project metadata. |
| ARCHITECTURE.md | Documents DeepSeek's per-turn reasoning replay and append-only prefix behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
A[Anthropic history] --> B[Classify tool-call reasoning]
B --> C[Sanitize assistant history]
C --> D[Convert to OpenAI messages]
D --> E[Serialize through SDK]
E --> F[DeepSeek request]
B -->|Every tool call replayable| G[Keep current thinking]
B -->|Any tool call not replayable| H[Disable current thinking]
C -->|Tool-call turn| I[Retain reasoning]
C -->|Non-tool turn| J[Omit reasoning]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
A[Anthropic history] --> B[Classify tool-call reasoning]
B --> C[Sanitize assistant history]
C --> D[Convert to OpenAI messages]
D --> E[Serialize through SDK]
E --> F[DeepSeek request]
B -->|Every tool call replayable| G[Keep current thinking]
B -->|Any tool call not replayable| H[Disable current thinking]
C -->|Tool-call turn| I[Retain reasoning]
C -->|Non-tool turn| J[Omit reasoning]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fdeepseek-cache-stable-history%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fdeepseek-cache-stable-history%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Ffree_claude_code%2Fproviders%2Fdeepseek%2Fcompat.py%3A146%0A**Empty%20Assistant%20Content%20Reaches%20Wire**%0A%0AWhen%20an%20assistant%20turn%20contains%20only%20%60redacted_thinking%60%2C%20filtering%20removes%20every%20block%20and%20replaces%20the%20list%20with%20%60%22%22%60.%20Revalidation%20then%20takes%20the%20string-content%20path%20and%20bypasses%20the%20converter's%20existing%20%60%22%20%22%60%20fallback%2C%20so%20DeepSeek%20can%20reject%20the%20continued%20conversation%20as%20an%20empty%20assistant%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20new_msg%5B%22content%22%5D%20%3D%20filtered%20or%20%22%20%22%0A%60%60%60%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1126&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Preserve DeepSeek prompt cache prefixes"](https://github.com/alishahryar1/free-claude-code/commit/b07ecf28a193e9cff1624e4ef75f38344a146d49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44440120)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->