### PR TITLE
Accept copied FCC version output in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,8 +8,8 @@ body:
     id: fcc-version
     attributes:
       label: FCC version
-      description: Run `fcc-server --version` and enter only the version number, such as `4.6.1`. If FCC did not install, enter `None`.
-      placeholder: "4.6.1 or None"
+      description: Paste the output of `fcc-server --version`, such as `free-claude-code 4.6.1`. A bare version number or `None` is also accepted.
+      placeholder: "free-claude-code 4.6.1, 4.6.1, or None"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,8 +8,8 @@ body:
     id: fcc-version
     attributes:
       label: FCC version
-      description: Paste the output of `fcc-server --version`, such as `free-claude-code 4.6.1`. A bare version number or `None` is also accepted.
-      placeholder: "free-claude-code 4.6.1, 4.6.1, or None"
+      description: Run `fcc-server --version` and enter only the version number, such as `4.6.1`. If FCC did not install, enter `None`.
+      placeholder: "4.6.1 or None"
     validations:
       required: true
 

--- a/.github/workflows/validate-bug-report-version.yml
+++ b/.github/workflows/validate-bug-report-version.yml
@@ -54,7 +54,7 @@ jobs:
                     ...repo,
                     name: labelName,
                     color: "d4c5f9",
-                    description: "FCC version output, number.number.number, or None required",
+                    description: "FCC version must be number.number.number or None",
                   });
                 } catch (createError) {
                   if (createError.status !== 422) throw createError;
@@ -75,6 +75,6 @@ jobs:
               await github.rest.issues.createComment({
                 ...repo,
                 issue_number,
-                body: `${marker}\nPlease edit **FCC version** and paste the output of \`fcc-server --version\`, such as \`free-claude-code 4.6.1\`. A bare version like \`4.6.1\` or \`None\` is also accepted.`,
+                body: `${marker}\nPlease edit **FCC version** to contain only an exact \`number.number.number\` value, such as \`4.6.1\`, or \`None\`. Run \`fcc-server --version\` to find the installed version.`,
               });
             }

--- a/.github/workflows/validate-bug-report-version.yml
+++ b/.github/workflows/validate-bug-report-version.yml
@@ -23,7 +23,7 @@ jobs:
           script: |
             const issue = context.payload.issue;
             const fieldPattern = "^### FCC version\\r?\\n+\\s*([^\\r\\n]+)";
-            const versionPattern = "^(?:\\d+\\.\\d+\\.\\d+|None)$";
+            const versionPattern = "^(?:(?:free-claude-code )?\\d+\\.\\d+\\.\\d+|None)$";
             const match = (issue.body || "").match(new RegExp(fieldPattern, "m"));
             const version = match?.[1]?.trim() || "";
             const valid = new RegExp(versionPattern).test(version);
@@ -54,7 +54,7 @@ jobs:
                     ...repo,
                     name: labelName,
                     color: "d4c5f9",
-                    description: "FCC version must be number.number.number or None",
+                    description: "FCC version output, number.number.number, or None required",
                   });
                 } catch (createError) {
                   if (createError.status !== 422) throw createError;
@@ -75,6 +75,6 @@ jobs:
               await github.rest.issues.createComment({
                 ...repo,
                 issue_number,
-                body: `${marker}\nPlease edit **FCC version** to contain only an exact \`number.number.number\` value, such as \`4.6.1\`, or \`None\`. Run \`fcc-server --version\` to find the installed version.`,
+                body: `${marker}\nPlease edit **FCC version** and paste the output of \`fcc-server --version\`, such as \`free-claude-code 4.6.1\`. A bare version like \`4.6.1\` or \`None\` is also accepted.`,
               });
             }

--- a/tests/contracts/test_issue_form_version_validation.py
+++ b/tests/contracts/test_issue_form_version_validation.py
@@ -15,13 +15,15 @@ def _workflow_pattern(name: str) -> str:
     return json.loads(match.group(1))
 
 
-def test_bug_form_accepts_the_version_command_output_or_none() -> None:
+def test_bug_form_requests_an_exact_version_or_none() -> None:
     form = BUG_FORM.read_text(encoding="utf-8")
 
-    assert "`fcc-server --version`" in form
-    assert "Paste the output" in form
-    assert "bare version number" in form
-    assert 'placeholder: "free-claude-code 4.6.1, 4.6.1, or None"' in form
+    assert "Run `fcc-server --version`" in form
+    assert "enter only the version number" in form
+    assert "enter `None`" in form
+    assert 'placeholder: "4.6.1 or None"' in form
+    assert "not installed" not in form
+    assert "free-claude-code" not in form
 
 
 @pytest.mark.parametrize(

--- a/tests/contracts/test_issue_form_version_validation.py
+++ b/tests/contracts/test_issue_form_version_validation.py
@@ -15,17 +15,27 @@ def _workflow_pattern(name: str) -> str:
     return json.loads(match.group(1))
 
 
-def test_bug_form_requires_an_exact_version_or_none() -> None:
+def test_bug_form_accepts_the_version_command_output_or_none() -> None:
     form = BUG_FORM.read_text(encoding="utf-8")
 
-    assert "Run `fcc-server --version`" in form
-    assert "enter only the version number" in form
-    assert "enter `None`" in form
-    assert 'placeholder: "4.6.1 or None"' in form
-    assert "not installed" not in form
+    assert "`fcc-server --version`" in form
+    assert "Paste the output" in form
+    assert "bare version number" in form
+    assert 'placeholder: "free-claude-code 4.6.1, 4.6.1, or None"' in form
 
 
-@pytest.mark.parametrize("value", ["0.0.0", "4.6.1", "123.45.678", "None"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "0.0.0",
+        "4.6.1",
+        "123.45.678",
+        "free-claude-code 0.0.0",
+        "free-claude-code 4.6.1",
+        "free-claude-code 123.45.678",
+        "None",
+    ],
+)
 def test_version_pattern_accepts_supported_values(value: str) -> None:
     assert re.fullmatch(_workflow_pattern("versionPattern"), value)
 
@@ -40,7 +50,10 @@ def test_version_pattern_accepts_supported_values(value: str) -> None:
         "v4.6.1",
         "4.6.x",
         "none",
-        "free-claude-code 4.6.1",
+        "free-claude-code",
+        "free-claude-code v4.6.1",
+        "free-claude-code 4.6",
+        "free-claude-code 4.6.1 extra",
     ],
 )
 def test_version_pattern_rejects_ambiguous_values(value: str) -> None:


### PR DESCRIPTION
## Problem

Bug-report validation rejected the literal output of `fcc-server --version`, leaving reports labeled even when they contained an unambiguous FCC version.

## Changes

| Before | After |
| --- | --- |
| The validator rejected `free-claude-code x.y.z` copied from the command output. | The validator silently accepts copied command output. |
| The form requested a bare `x.y.z` value or `None`. | The form continues requesting a bare `x.y.z` value or `None`. |
| Prefixed version input had no accepted exact shape. | Prefixed version input must exactly match `free-claude-code x.y.z`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands bug-report version validation to accept copied FCC command output. The main changes are:

- Accept bare semantic versions and `free-claude-code X.Y.Z` values.
- Add contract cases for supported prefixed output.
- Add rejection cases for malformed prefixed values.
</details>

<h3>Confidence Score: 4/5</h3>

The version validator works, but the paste-directly form contract needs to be corrected before merging.

- The workflow accepts the normal `free-claude-code X.Y.Z` output.
- The changed test preserves instructions to enter only the numeric version.
- The form and its contract test need to request copied command output consistently.

tests/contracts/test_issue_form_version_validation.py and .github/ISSUE_TEMPLATE/bug-report.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the paste-directly guidance check against the checked-in form, workflow, and contract test, showing numeric-only form guidance while the workflow accepted free-claude-code 4.6.1.
- Validated that the narrow Python 3.14 contract run passed all 21 tests, including the numeric-only form assertion and literal-prefix validator acceptance.
- Compared pre-change and post-change version regex behavior and confirmed pre-change rejection and post-change acceptance, using the version pattern artifacts and the generated validation harness.

<a href="https://app.greptile.com/trex/runs/14584187/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validate-bug-report-version.yml | The version regex now accepts the normal prefixed CLI output while retaining bare versions and `None`. |
| tests/contracts/test_issue_form_version_validation.py | The regex coverage is expanded, but the form contract still enforces instructions that exclude the copied-output prefix. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Faccept-fcc-version-output%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Faccept-fcc-version-output%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fcontracts%2Ftest_issue_form_version_validation.py%3A26%0A**Paste-Directly%20Guidance%20Remains%20Blocked**%0A%0AThe%20issue%20form%20still%20tells%20users%20to%20enter%20only%20the%20version%20number%2C%20and%20this%20new%20assertion%20prevents%20it%20from%20mentioning%20the%20%60free-claude-code%60%20prefix.%20Users%20are%20therefore%20still%20instructed%20to%20strip%20the%20prefix%20instead%20of%20pasting%20the%20literal%20%60fcc-server%20--version%60%20output%2C%20so%20the%20advertised%20form%20behavior%20is%20not%20delivered.%0A%0A&repo=alishahryar1%2Ffree-claude-code&pr=1131&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Keep FCC version guidance concise"](https://github.com/alishahryar1/free-claude-code/commit/465e517a9da6c0cbd8eb18c31cd6b6ffad2dedb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44550101)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->