### PR TITLE
Add an explicit searchable model dropdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.6.4"
+version = "4.7.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -50,6 +50,7 @@
   --radius-md: 10px;
   --radius-lg: 14px;
   --radius-full: 9999px;
+  --dropdown-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
   
   /* Typography */
   --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -487,11 +488,101 @@ textarea:focus-visible,
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
+  background-image: var(--dropdown-chevron);
   background-repeat: no-repeat;
   background-position: right 14px center;
   background-size: 14px;
   padding-right: 36px;
+}
+
+.model-combobox {
+  position: relative;
+  width: 100%;
+}
+
+.model-combobox.open {
+  z-index: 110;
+}
+
+.field .model-combobox input[type="text"] {
+  padding-right: 44px;
+}
+
+.model-combobox-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: grid;
+  width: 42px;
+  height: 40px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.model-combobox-toggle::before {
+  width: 14px;
+  height: 14px;
+  background-image: var(--dropdown-chevron);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 14px;
+  content: "";
+  transition: transform var(--transition-fast);
+}
+
+.model-combobox-toggle[aria-expanded="true"]::before {
+  transform: rotate(180deg);
+}
+
+.model-combobox-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.model-combobox-list {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  left: 0;
+  z-index: 120;
+  max-height: 280px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-md);
+  background: var(--panel-strong);
+  box-shadow: var(--shadow);
+  padding: 6px;
+}
+
+.model-combobox-list[hidden] {
+  display: none;
+}
+
+.model-combobox-option {
+  border-radius: var(--radius-sm);
+  padding: 9px 10px;
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+}
+
+.model-combobox-option:hover,
+.model-combobox-option.active {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+
+.model-combobox-empty {
+  padding: 10px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .field input:focus,

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -509,7 +509,14 @@ class ModelCombobox {
   handleKeydown(event) {
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       event.preventDefault();
-      this.isOpen ? this.move(event.key === "ArrowDown" ? 1 : -1) : this.open();
+      if (this.isOpen) {
+        this.move(event.key === "ArrowDown" ? 1 : -1);
+      } else {
+        this.open();
+        if (event.key === "ArrowUp") {
+          this.setActive(this.visibleOptions.length - 1);
+        }
+      }
     } else if (this.isOpen && (event.key === "Home" || event.key === "End")) {
       event.preventDefault();
       this.setActive(event.key === "Home" ? 0 : this.visibleOptions.length - 1);

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -3,6 +3,7 @@ const state = {
   fields: new Map(),
   localStatus: new Map(),
   modelOptions: [],
+  modelComboboxes: new Set(),
   activeView: "providers",
 };
 
@@ -185,6 +186,7 @@ function updateProviderCard(providerId, status, label, metaText) {
 }
 
 function renderSections(sections, fields) {
+  state.modelComboboxes.clear();
   VIEW_GROUPS.forEach((view) => {
     byId(view.containerId).innerHTML = "";
   });
@@ -283,7 +285,11 @@ function renderField(field) {
     });
   }
 
-  wrapper.append(label, input);
+  const control =
+    field.type === "model" || field.type === "optional_model"
+      ? new ModelCombobox(input, field).element
+      : input;
+  wrapper.append(label, control);
   if (field.description) {
     const description = document.createElement("div");
     description.className = "field-description";
@@ -330,10 +336,6 @@ function inputForField(field) {
     const input = document.createElement("input");
     input.type = "text";
     input.value = field.value || (field.type === "optional_model" ? "None" : "");
-    input.setAttribute(
-      "list",
-      field.type === "optional_model" ? "optional-model-options" : "model-options",
-    );
     input.autocomplete = "off";
     return input;
   }
@@ -351,6 +353,179 @@ function inputForField(field) {
     input.value = field.value || "";
   }
   return input;
+}
+
+class ModelCombobox {
+  constructor(input, field) {
+    this.input = input;
+    this.fieldType = field.type;
+    this.activeIndex = -1;
+    this.query = "";
+
+    this.element = document.createElement("div");
+    this.element.className = "model-combobox";
+    this.listbox = document.createElement("div");
+    this.listbox.className = "model-combobox-list";
+    this.listbox.id = `model-options-${field.key}`;
+    this.listbox.setAttribute("role", "listbox");
+    this.listbox.hidden = true;
+    this.toggle = document.createElement("button");
+    this.toggle.type = "button";
+    this.toggle.className = "model-combobox-toggle";
+    this.toggle.disabled = input.disabled;
+    this.toggle.setAttribute("aria-label", `Show ${field.label} options`);
+
+    input.setAttribute("role", "combobox");
+    input.setAttribute("aria-autocomplete", "list");
+    input.setAttribute("aria-haspopup", "listbox");
+    for (const control of [input, this.toggle]) {
+      control.setAttribute("aria-controls", this.listbox.id);
+      control.setAttribute("aria-expanded", "false");
+    }
+
+    input.addEventListener("click", () => this.open());
+    input.addEventListener("input", () => this.open(input.value));
+    input.addEventListener("keydown", (event) => this.handleKeydown(event));
+    this.toggle.addEventListener("mousedown", (event) => event.preventDefault());
+    this.toggle.addEventListener("click", () => {
+      if (this.isOpen) this.close();
+      else this.open();
+      input.focus();
+    });
+    this.listbox.addEventListener("mousedown", (event) => event.preventDefault());
+    this.listbox.addEventListener("mousemove", (event) => {
+      const optionEl = event.target.closest('[role="option"]');
+      if (optionEl) this.setActive(this.visibleOptions.indexOf(optionEl));
+    });
+    this.listbox.addEventListener("click", (event) => {
+      const optionEl = event.target.closest('[role="option"]');
+      if (optionEl) this.select(optionEl.dataset.value);
+    });
+
+    this.element.append(input, this.toggle, this.listbox);
+    state.modelComboboxes.add(this);
+  }
+
+  get isOpen() {
+    return this.element.classList.contains("open");
+  }
+
+  get values() {
+    return this.fieldType === "optional_model"
+      ? ["None", ...state.modelOptions]
+      : state.modelOptions;
+  }
+
+  get visibleOptions() {
+    return Array.from(this.listbox.querySelectorAll('[role="option"]'));
+  }
+
+  open(query = "") {
+    if (this.input.disabled) return;
+    state.modelComboboxes.forEach((combobox) => {
+      if (combobox !== this) combobox.close();
+    });
+    this.render(query);
+    this.element.classList.add("open");
+    this.listbox.hidden = false;
+    this.setExpanded(true);
+  }
+
+  close() {
+    this.element.classList.remove("open");
+    this.listbox.hidden = true;
+    this.activeIndex = -1;
+    this.input.removeAttribute("aria-activedescendant");
+    this.setExpanded(false);
+  }
+
+  setExpanded(expanded) {
+    for (const control of [this.input, this.toggle]) {
+      control.setAttribute("aria-expanded", String(expanded));
+    }
+  }
+
+  render(query) {
+    this.query = query;
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+    const values = normalizedQuery
+      ? this.values.filter((value) =>
+          value.toLocaleLowerCase().includes(normalizedQuery),
+        )
+      : this.values;
+    this.listbox.innerHTML = "";
+
+    if (values.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "model-combobox-empty";
+      empty.textContent = state.modelOptions.length
+        ? "No matching models. You can still enter a custom slug."
+        : "No discovered models. Refresh models or enter a custom slug.";
+      this.listbox.appendChild(empty);
+      this.activeIndex = -1;
+      this.input.removeAttribute("aria-activedescendant");
+      return;
+    }
+
+    values.forEach((value, index) => {
+      const optionEl = document.createElement("div");
+      optionEl.className = "model-combobox-option";
+      optionEl.id = `${this.listbox.id}-option-${index}`;
+      optionEl.dataset.value = value;
+      optionEl.setAttribute("role", "option");
+      optionEl.textContent = value;
+      this.listbox.appendChild(optionEl);
+    });
+    const selectedIndex = values.indexOf(this.input.value);
+    this.setActive(selectedIndex >= 0 ? selectedIndex : 0, false);
+  }
+
+  setActive(index, scroll = true) {
+    const options = this.visibleOptions;
+    if (options.length === 0) return;
+    this.activeIndex = Math.max(0, Math.min(index, options.length - 1));
+    options.forEach((optionEl, optionIndex) => {
+      const active = optionIndex === this.activeIndex;
+      optionEl.classList.toggle("active", active);
+      optionEl.setAttribute("aria-selected", String(active));
+    });
+    const activeOption = options[this.activeIndex];
+    this.input.setAttribute("aria-activedescendant", activeOption.id);
+    if (scroll) activeOption.scrollIntoView({ block: "nearest" });
+  }
+
+  move(offset) {
+    const count = this.visibleOptions.length;
+    if (count) this.setActive((this.activeIndex + offset + count) % count);
+  }
+
+  select(value) {
+    this.input.value = value;
+    this.input.dispatchEvent(new Event("change", { bubbles: true }));
+    this.close();
+    this.input.focus();
+  }
+
+  handleKeydown(event) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      this.isOpen ? this.move(event.key === "ArrowDown" ? 1 : -1) : this.open();
+    } else if (this.isOpen && (event.key === "Home" || event.key === "End")) {
+      event.preventDefault();
+      this.setActive(event.key === "Home" ? 0 : this.visibleOptions.length - 1);
+    } else if (this.isOpen && event.key === "Enter") {
+      const active = this.visibleOptions[this.activeIndex];
+      if (active) {
+        event.preventDefault();
+        this.select(active.dataset.value);
+      }
+    } else if (this.isOpen && event.key === "Escape") {
+      event.preventDefault();
+      this.close();
+    } else if (this.isOpen && event.key === "Tab") {
+      this.close();
+    }
+  }
 }
 
 function option(value, label) {
@@ -531,23 +706,9 @@ function setModelOptions(models) {
   state.modelOptions = Array.from(
     new Set(models.filter((model) => typeof model === "string" && model.trim())),
   ).sort((left, right) => left.localeCompare(right));
-  syncModelDatalists();
-}
-
-function syncModelDatalist(id, values) {
-  let datalist = byId(id);
-  if (!datalist) {
-    datalist = document.createElement("datalist");
-    datalist.id = id;
-    document.body.appendChild(datalist);
-  }
-  datalist.innerHTML = "";
-  values.forEach((model) => datalist.appendChild(option(model, model)));
-}
-
-function syncModelDatalists() {
-  syncModelDatalist("model-options", state.modelOptions);
-  syncModelDatalist("optional-model-options", ["None", ...state.modelOptions]);
+  state.modelComboboxes.forEach((combobox) => {
+    if (combobox.isOpen) combobox.render(combobox.query);
+  });
 }
 
 function showMessage(message, kind = "") {
@@ -558,6 +719,11 @@ function showMessage(message, kind = "") {
 
 byId("validateButton").addEventListener("click", () => validate(true));
 byId("applyButton").addEventListener("click", apply);
+document.addEventListener("pointerdown", (event) => {
+  state.modelComboboxes.forEach((combobox) => {
+    if (combobox.isOpen && !combobox.element.contains(event.target)) combobox.close();
+  });
+});
 
 load().catch((error) => {
   showMessage(error.message, "error");

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -124,6 +124,7 @@ def test_admin_static_model_combobox_owns_dropdown_and_search_behavior():
     assert 'input.addEventListener("click", () => this.open())' in script
     assert "value.toLocaleLowerCase().includes(normalizedQuery)" in script
     assert 'event.key === "ArrowDown" || event.key === "ArrowUp"' in script
+    assert "this.setActive(this.visibleOptions.length - 1)" in script
     assert 'event.key === "Enter"' in script
     assert 'event.key === "Escape"' in script
     assert 'document.createElement("datalist")' not in script

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -107,14 +107,38 @@ def test_admin_static_hides_managed_source_label():
     assert "sourceEl.textContent = source" in script
 
 
-def test_admin_static_loads_searchable_model_options_and_maps_none_to_unset():
+def test_admin_static_model_combobox_owns_dropdown_and_search_behavior():
     script = Path("src/free_claude_code/api/admin_static/admin.js").read_text(
+        encoding="utf-8"
+    )
+    styles = Path("src/free_claude_code/api/admin_static/admin.css").read_text(
         encoding="utf-8"
     )
 
     assert 'api("/admin/api/models" + (refresh ? "/refresh" : "")' in script
     assert 'field.type === "model" || field.type === "optional_model"' in script
-    assert '"optional-model-options", ["None", ...state.modelOptions]' in script
+    assert 'input.setAttribute("role", "combobox")' in script
+    assert 'listbox.setAttribute("role", "listbox")' in script
+    assert 'toggle.className = "model-combobox-toggle"' in script
+    assert "class ModelCombobox" in script
+    assert 'input.addEventListener("click", () => this.open())' in script
+    assert "value.toLocaleLowerCase().includes(normalizedQuery)" in script
+    assert 'event.key === "ArrowDown" || event.key === "ArrowUp"' in script
+    assert 'event.key === "Enter"' in script
+    assert 'event.key === "Escape"' in script
+    assert 'document.createElement("datalist")' not in script
+    assert ".model-combobox-list" in styles
+    assert ".model-combobox-option.active" in styles
+    assert styles.count("background-image: var(--dropdown-chevron)") == 2
+
+
+def test_admin_static_model_combobox_preserves_custom_slugs_and_none_semantics():
+    script = Path("src/free_claude_code/api/admin_static/admin.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert '? ["None", ...state.modelOptions]' in script
+    assert "You can still enter a custom slug." in script
     assert 'input.dataset.fieldType === "optional_model"' in script
     assert 'return "";' in script
     assert "await hydrateModelOptions();" in script

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.6.4"
+version = "4.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Admin model fields depended on the browser's native datalist. Filtering worked, but browsers did not consistently expose a visible dropdown for browsing the full model catalog.

## Changes

| Before | After |
| --- | --- |
| Model fields relied on browser-native datalist behavior. | Model fields use one FCC-owned searchable combobox with a visible chevron. |
| Suggestions became discoverable only through browser-specific interactions. | Clicking the field or chevron opens the full catalog, while typing filters it. |
| Keyboard navigation and empty results depended on native picker behavior. | Arrow keys, Enter, Escape, empty-state guidance, custom slugs, and None are handled explicitly. |
| Selects and model fields rendered separate dropdown indicators. | Both controls use the same shared chevron asset. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces native model datalists with an explicit searchable combobox. The main changes are:

- Adds a visible model dropdown with filtering and empty-state guidance.
- Supports keyboard navigation, custom model slugs, and optional `None` values.
- Shares one chevron style across model fields and selects.
- Updates admin tests and bumps the package version to 4.7.0.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Closed Arrow-Up activates the last available option. Empty model lists and optional `None` values remain valid. No blocking issues were found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Completed end-to-end validation of the FCC listbox model selection flow, including the discovery of models, opus-based filtering, keyboard selection, preservation of a custom slug, serializing None as empty, final activation with Arrow Up, and display of no-match guidance when needed.
- Verified that corresponding admin requests returned HTTP 200 during the interaction, confirming contract-level success.

<a href="https://app.greptile.com/trex/runs/14651225/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/api/admin_static/admin.js | Adds the searchable model combobox and correctly activates the last option when Arrow-Up opens a closed list. |
| src/free_claude_code/api/admin_static/admin.css | Adds combobox layout, option states, dropdown stacking, and shared chevron styling. |
| tests/api/test_admin.py | Updates admin static assertions for combobox behavior, custom slugs, and optional model values. |
| pyproject.toml | Bumps the project version from 4.6.4 to 4.7.0. |
| uv.lock | Synchronizes the editable package version with the project metadata. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix closed ArrowUp model navigation"](https://github.com/alishahryar1/free-claude-code/commit/846c3423c8734c1b69cc340a3ff0c2031ff8bc48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44698382)</sub>

<!-- /greptile_comment -->