### PR TITLE
Make provider reasoning controls explicit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -434,7 +434,7 @@ sequenceDiagram
     Route->>Manager: acquire current generation
     Manager-->>Route: Lease(settings, provider resolver)
     Route->>Handler: create message
-    Handler->>Router: resolve model and thinking
+    Handler->>Router: resolve model and reasoning policy
     Handler->>Handler: server tools or optimizations
     Handler->>Exec: stream routed request
     Exec->>Lease: resolve provider
@@ -465,10 +465,50 @@ If the incoming model is not direct, `ModelRouter` maps it by Claude tier. Names
 containing `fable`, `opus`, `sonnet`, or `haiku` use the matching tier override when set,
 otherwise they fall back to `MODEL`.
 
-The router also resolves thinking. Gateway model IDs can force thinking on or
-off; otherwise `ModelRouter` applies tier-specific thinking overrides or the
-global setting. `ResolvedModel` carries only the selected route and thinking
-decision; provider catalog metadata does not cross the application boundary.
+The router also resolves whether the selected route permits reasoning. Gateway
+model IDs can force reasoning off; otherwise `ModelRouter` applies the
+tier-specific thinking switches or the global setting. `ResolvedModel` carries
+that route-level allowance as `reasoning_allowed`; it is not the final request
+policy, and provider catalog metadata does not cross the application boundary.
+
+### Reasoning Policy Boundary
+
+[application/reasoning.py](src/free_claude_code/application/reasoning.py) owns the
+provider-neutral reasoning decision. After model routing, it combines the route
+allowance with the incoming protocol intent exactly once and produces an
+immutable `ReasoningPolicy`:
+
+- `enabled` is the final on/off decision;
+- `effort` preserves a recognized qualitative level from `output_config`;
+- `budget_tokens` preserves a positive explicit Anthropic thinking budget.
+
+The Anthropic protocol model rejects booleans, strings, zero, and negative
+values for `thinking.budget_tokens`. A request-level disable or a route that
+does not permit reasoning produces `ReasoningPolicy.off()` with no residual
+effort or budget. When both an explicit budget and an effort are present, the
+explicit budget has precedence.
+
+The routed request owns this resolved value. Application execution passes it
+unchanged through the provider port; `ProviderConfig` does not contain a second
+thinking switch, and providers do not inspect settings or re-resolve request
+intent.
+
+Provider adapters own only wire translation:
+
+- native effort APIs receive the closest documented effort, preferring the
+  higher supported level on an equal-distance tie;
+- native numeric APIs receive the explicit budget, or FCC's stable
+  effort-to-budget ladder when only effort was supplied:
+  `minimal=256`, `low=1024`, `medium=2048`, `high=4096`,
+  `xhigh=8192`, and `max=16384`;
+- binary APIs receive their documented enable/disable field;
+- mandatory-reasoning models omit unsupported disable controls;
+- providers with no documented control receive no invented field.
+
+Caller `extra_body` data cannot replace FCC-owned reasoning fields. Provider
+retries preserve the resolved policy. A provider may retry once without an
+optional reasoning field only when that upstream explicitly rejects the field;
+this is a compatibility downgrade, not a global retry with reasoning disabled.
 
 `GET /v1/models` advertises:
 
@@ -536,7 +576,7 @@ compatibility layer.
 [providers/base.py](src/free_claude_code/providers/base.py) defines provider-internal construction and lifecycle contracts:
 
 - `ProviderConfig`: shared provider settings such as API key, base URL, rate
-  limits, timeouts, proxy, thinking, and logging flags. It is a frozen internal
+  limits, timeouts, proxy, and logging flags. It is a frozen internal
   value whose base URL has already been resolved from the catalog.
 - `BaseProvider`: the abstract implementation base for cleanup, model listing,
   explicit preflight, and `stream_response()`.
@@ -545,9 +585,9 @@ There is one upstream provider family:
 [providers/openai_chat/](src/free_claude_code/providers/openai_chat/) implements the concrete
 `OpenAIChatProvider` used by every OpenAI-compatible `/chat/completions`
 upstream. `OpenAIChatProfile` contains immutable request policy, its standard
-streamed-reasoning field, postprocessors, and base-URL normalization for
-ordinary vendors. Configuration differences therefore remain data rather than
-empty subclasses. The package also
+streamed-reasoning field, provider reasoning encoder, postprocessors, and
+base-URL normalization for ordinary vendors. Configuration differences
+therefore remain data rather than empty subclasses. The package also
 owns the exactly typed private per-request runner, recovery operations, tool-call
 assembly, and streamed usage handling. No obsolete generic transport namespace
 or untyped provider backchannel remains.
@@ -559,7 +599,7 @@ LM Studio composes the OpenAI-chat conversion first and its context-budget probe
 second; conversion failure therefore cannot open a stream or run the probe.
 
 Providers call the OpenAI request policy for Anthropic-to-OpenAI conversion,
-thinking replay selection, `extra_body`, and chat-completion field normalization.
+reasoning replay selection, `extra_body`, and chat-completion field normalization.
 Specialized provider packages remain only for true upstream quirks such as
 Gemini thought signatures, NIM tool-schema aliases, retry downgrades, and NVCF
 deployment-failure classification, or DeepSeek attachment/tool/thinking
@@ -579,8 +619,9 @@ account-scoped Workers AI OpenAI-compatible Chat Completions endpoint for
 `@cf/...` model IDs, while account ID composition, model search, and
 Cloudflare-specific reasoning deltas stay in the Cloudflare provider client.
 OpenRouter remains specialized for model filtering and reasoning-detail stream
-events. Wafer, Kimi, MiniMax, Fireworks, and Z.ai use ordinary declarative
-profiles for their thinking, token, and `extra_body` policy. Z.ai is treated as
+events. Wafer, Kimi, MiniMax, Cerebras, Groq, SambaNova, Fireworks, and Z.ai use
+ordinary declarative profiles for their documented reasoning and `extra_body`
+policy. Z.ai is treated as
 the GLM Coding Plan provider and uses Z.ai's Coding Plan OpenAI base.
 Mistral La Plateforme keeps its native `reasoning_effort` and thinking-chunk
 request/stream mapping inside
@@ -755,10 +796,13 @@ tools with a single string `input` field, and restores `custom_tool_call`,
 Responses edge. Text or grammar format metadata is preserved as model guidance;
 FCC does not validate custom-tool grammars.
 
-Responses reasoning is handled as protocol conversion, not provider policy.
-`reasoning.effort = "none"` converts to a disabled Anthropic `thinking`
+Responses reasoning is handled first as protocol conversion, not provider
+policy. `reasoning.effort = "none"` converts to a disabled Anthropic `thinking`
 request; any other explicit Responses reasoning request enables Anthropic
-thinking without translating OpenAI effort names into Anthropic token budgets.
+thinking and preserves its effort in `output_config`. The application reasoning
+boundary then resolves that intent exactly as it does for native Messages
+requests. Only the selected provider adapter may translate the resolved effort
+into a numeric budget.
 Prior Responses `reasoning` input items replay plaintext `reasoning_text`, or
 fallback `summary_text`, into assistant `reasoning_content`. Encrypted reasoning
 input is ignored because the proxy cannot decrypt it.
@@ -792,11 +836,11 @@ request remains ordered and unchanged for provider execution.
 The Messages handler runs these only after model routing and after local server-tool
 handling. Each optimization is controlled by settings flags.
 
-Claude Code auto-mode safety-classifier requests are a message-only routing
-policy, not a short-circuit response. After routing, the Messages handler detects the
-narrow classifier prompt shape and forces thinking off before provider execution
-so Claude Code receives a parser-readable `<block>yes</block>` or
-`<block>no</block>` verdict.
+Claude Code auto-mode safety-classifier requests are a message-only application
+policy, not a short-circuit response. After routing, the Messages handler detects
+the narrow classifier prompt shape and replaces the routed reasoning policy with
+`ReasoningPolicy.off()` before provider execution so Claude Code receives a
+parser-readable `<block>yes</block>` or `<block>no</block>` verdict.
 
 Local `web_search` and `web_fetch` handling lives under
 [api/web_tools/](src/free_claude_code/api/web_tools/). When `ENABLE_WEB_SERVER_TOOLS` is true, the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.7.2"
+version = "4.7.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.7.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/product/test_config_extensibility_product_live.py
+++ b/smoke/product/test_config_extensibility_product_live.py
@@ -81,11 +81,11 @@ def test_per_model_thinking_config_e2e(smoke_config: SmokeConfig, tmp_path) -> N
         "from free_claude_code.config.settings import Settings; "
         "s=Settings(); "
         "r=ModelRouter(s); "
-        "print(r.resolve('claude-fable-5').thinking_enabled); "
-        "print(r.resolve('claude-opus-4-20250514').thinking_enabled); "
-        "print(r.resolve('claude-sonnet-4-20250514').thinking_enabled); "
-        "print(r.resolve('claude-haiku-4-20250514').thinking_enabled); "
-        "print(r.resolve('unknown-model').thinking_enabled)"
+        "print(r.resolve('claude-fable-5').reasoning_allowed); "
+        "print(r.resolve('claude-opus-4-20250514').reasoning_allowed); "
+        "print(r.resolve('claude-sonnet-4-20250514').reasoning_allowed); "
+        "print(r.resolve('claude-haiku-4-20250514').reasoning_allowed); "
+        "print(r.resolve('unknown-model').reasoning_allowed)"
     )
     result = run_captured_text(
         cmd_python_c(script),

--- a/smoke/product/test_provider_product_live.py
+++ b/smoke/product/test_provider_product_live.py
@@ -271,7 +271,7 @@ def _provider_smoke_thinking_enabled(smoke_config: SmokeConfig) -> bool:
     return (
         ModelRouter(smoke_config.settings)
         .resolve("claude-sonnet-4-5-20250929")
-        .thinking_enabled
+        .reasoning_allowed
     )
 
 

--- a/src/free_claude_code/api/handlers/messages.py
+++ b/src/free_claude_code/api/handlers/messages.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncIterator, Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 from fastapi.responses import JSONResponse, Response
 from loguru import logger
@@ -34,6 +34,7 @@ from free_claude_code.api.web_tools.streaming import stream_web_server_tool_resp
 from free_claude_code.application.errors import ApplicationError, InvalidRequestError
 from free_claude_code.application.execution import ProviderExecutor, TokenCounter
 from free_claude_code.application.ports import ProviderResolver
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.application.routing import ModelRouter, RoutedMessagesRequest
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import (
@@ -271,7 +272,7 @@ class MessagesHandler:
     ) -> RoutedMessagesRequest:
         if not is_safety_classifier_request(routed.request):
             return routed
-        changed = routed.resolved.thinking_enabled
+        changed = routed.reasoning.enabled
         trace_event(
             stage="routing",
             event="free_claude_code.api.optimization.safety_classifier_no_thinking",
@@ -283,7 +284,8 @@ class MessagesHandler:
             return routed
         return RoutedMessagesRequest(
             request=routed.request,
-            resolved=replace(routed.resolved, thinking_enabled=False),
+            resolved=routed.resolved,
+            reasoning=ReasoningPolicy.off(),
         )
 
     def _run_message_intercepts(

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -58,7 +58,7 @@ class ProviderExecutor:
         provider = self._provider_resolver(routed.resolved.provider_id)
         provider.preflight_stream(
             routed.request,
-            thinking_enabled=routed.resolved.thinking_enabled,
+            reasoning=routed.reasoning,
         )
 
         route_trace: dict[str, object] = {
@@ -70,7 +70,9 @@ class ProviderExecutor:
             "provider_model": routed.resolved.provider_model,
             "provider_model_ref": routed.resolved.provider_model_ref,
             "gateway_model": routed.request.model,
-            "thinking_enabled": routed.resolved.thinking_enabled,
+            "reasoning_enabled": routed.reasoning.enabled,
+            "reasoning_effort": routed.reasoning.effort,
+            "reasoning_budget_tokens": routed.reasoning.budget_tokens,
         }
         if wire_api == "responses":
             route_trace["wire_api"] = "responses"
@@ -107,7 +109,7 @@ class ProviderExecutor:
                     routed.request,
                     input_tokens=input_tokens,
                     request_id=request_id,
-                    thinking_enabled=routed.resolved.thinking_enabled,
+                    reasoning=routed.reasoning,
                 )
                 async for chunk in provider_stream:
                     yield chunk

--- a/src/free_claude_code/application/ports.py
+++ b/src/free_claude_code/application/ports.py
@@ -8,6 +8,7 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest
 
 from .model_metadata import ProviderModelInfo
+from .reasoning import ReasoningPolicy
 
 
 class ProviderPort(Protocol):
@@ -17,7 +18,7 @@ class ProviderPort(Protocol):
         self,
         request: MessagesRequest,
         *,
-        thinking_enabled: bool,
+        reasoning: ReasoningPolicy,
     ) -> None: ...
 
     def stream_response(
@@ -26,7 +27,7 @@ class ProviderPort(Protocol):
         *,
         input_tokens: int,
         request_id: str,
-        thinking_enabled: bool,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]: ...
 
 

--- a/src/free_claude_code/application/reasoning.py
+++ b/src/free_claude_code/application/reasoning.py
@@ -1,0 +1,100 @@
+"""Canonical reasoning intent resolved at the application boundary."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from free_claude_code.core.anthropic.models import MessagesRequest
+
+
+class ReasoningEffort(StrEnum):
+    """Provider-neutral reasoning effort ordered from least to most compute."""
+
+    MINIMAL = "minimal"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    XHIGH = "xhigh"
+    MAX = "max"
+
+
+@dataclass(frozen=True, slots=True)
+class ReasoningPolicy:
+    """Resolved request intent before provider-specific wire translation."""
+
+    enabled: bool
+    effort: ReasoningEffort | None = None
+    budget_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.enabled and (
+            self.effort is not None or self.budget_tokens is not None
+        ):
+            raise ValueError("Disabled reasoning cannot carry effort or budget.")
+        if self.budget_tokens is not None and (
+            isinstance(self.budget_tokens, bool) or self.budget_tokens <= 0
+        ):
+            raise ValueError("Reasoning budget must be positive.")
+
+    @classmethod
+    def off(cls) -> ReasoningPolicy:
+        """Return a disabled policy."""
+        return cls(enabled=False)
+
+    @classmethod
+    def on(
+        cls,
+        *,
+        effort: ReasoningEffort | None = None,
+        budget_tokens: int | None = None,
+    ) -> ReasoningPolicy:
+        """Return an enabled policy with optional compute intent."""
+        return cls(
+            enabled=True,
+            effort=effort,
+            budget_tokens=budget_tokens,
+        )
+
+
+def resolve_reasoning_policy(
+    request: MessagesRequest,
+    *,
+    route_enabled: bool,
+) -> ReasoningPolicy:
+    """Combine route configuration and protocol request intent exactly once."""
+    if not route_enabled or _request_disables_reasoning(request):
+        return ReasoningPolicy.off()
+
+    return ReasoningPolicy.on(
+        effort=_request_effort(request.output_config),
+        budget_tokens=(
+            request.thinking.budget_tokens if request.thinking is not None else None
+        ),
+    )
+
+
+def _request_disables_reasoning(request: MessagesRequest) -> bool:
+    thinking = request.thinking
+    if thinking is not None:
+        if thinking.type == "disabled":
+            return True
+        if "enabled" in thinking.model_fields_set and thinking.enabled is False:
+            return True
+
+    output_config = request.output_config
+    if not isinstance(output_config, dict):
+        return False
+    effort = output_config.get("effort")
+    return isinstance(effort, str) and effort.strip().lower() == "none"
+
+
+def _request_effort(output_config: Any) -> ReasoningEffort | None:
+    if not isinstance(output_config, dict):
+        return None
+    raw_effort = output_config.get("effort")
+    if not isinstance(raw_effort, str):
+        return None
+    try:
+        return ReasoningEffort(raw_effort.strip().lower())
+    except ValueError:
+        return None

--- a/src/free_claude_code/application/routing.py
+++ b/src/free_claude_code/application/routing.py
@@ -14,6 +14,8 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest, TokenCountRequest
 from free_claude_code.core.gateway_model_ids import decode_gateway_model_id
 
+from .reasoning import ReasoningPolicy, resolve_reasoning_policy
+
 
 @dataclass(frozen=True, slots=True)
 class ResolvedModel:
@@ -21,13 +23,14 @@ class ResolvedModel:
     provider_id: str
     provider_model: str
     provider_model_ref: str
-    thinking_enabled: bool
+    reasoning_allowed: bool
 
 
 @dataclass(frozen=True, slots=True)
 class RoutedMessagesRequest:
     request: MessagesRequest
     resolved: ResolvedModel
+    reasoning: ReasoningPolicy
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,31 +49,31 @@ class ModelRouter:
         (
             direct_provider_id,
             direct_provider_model,
-            force_thinking_enabled,
+            force_reasoning_allowed,
         ) = self._direct_provider_model(claude_model_name)
         if direct_provider_id is not None and direct_provider_model is not None:
-            thinking_enabled = (
-                force_thinking_enabled
-                if force_thinking_enabled is not None
-                else self._resolve_thinking(direct_provider_model)
+            reasoning_allowed = (
+                force_reasoning_allowed
+                if force_reasoning_allowed is not None
+                else self._resolve_reasoning_allowed(direct_provider_model)
             )
             logger.debug(
-                "MODEL DIRECT: '{}' -> provider='{}' model='{}' thinking={}",
+                "MODEL DIRECT: '{}' -> provider='{}' model='{}' reasoning_allowed={}",
                 claude_model_name,
                 direct_provider_id,
                 direct_provider_model,
-                thinking_enabled,
+                reasoning_allowed,
             )
             return ResolvedModel(
                 original_model=claude_model_name,
                 provider_id=direct_provider_id,
                 provider_model=direct_provider_model,
                 provider_model_ref=claude_model_name,
-                thinking_enabled=thinking_enabled,
+                reasoning_allowed=reasoning_allowed,
             )
 
         provider_model_ref = self._resolve_model_ref(claude_model_name)
-        thinking_enabled = self._resolve_thinking(claude_model_name)
+        reasoning_allowed = self._resolve_reasoning_allowed(claude_model_name)
         provider_id = parse_provider_type(provider_model_ref)
         self._validate_provider_id(provider_id)
         provider_model = parse_model_name(provider_model_ref)
@@ -83,7 +86,7 @@ class ModelRouter:
             provider_id=provider_id,
             provider_model=provider_model,
             provider_model_ref=provider_model_ref,
-            thinking_enabled=thinking_enabled,
+            reasoning_allowed=reasoning_allowed,
         )
 
     @staticmethod
@@ -101,7 +104,7 @@ class ModelRouter:
             return (
                 decoded.provider_id,
                 decoded.provider_model,
-                decoded.force_thinking_enabled,
+                decoded.force_reasoning_allowed,
             )
 
         provider_id, separator, provider_model = model_name.partition("/")
@@ -127,8 +130,8 @@ class ModelRouter:
             return self._settings.model_sonnet
         return self._settings.model
 
-    def _resolve_thinking(self, claude_model_name: str) -> bool:
-        """Resolve whether thinking is enabled for an incoming Claude model name."""
+    def _resolve_reasoning_allowed(self, claude_model_name: str) -> bool:
+        """Resolve whether the selected route permits reasoning."""
 
         name_lower = claude_model_name.lower()
         if "fable" in name_lower and self._settings.enable_fable_thinking is not None:
@@ -148,7 +151,14 @@ class ModelRouter:
         resolved = self.resolve(request.model)
         routed = request.model_copy(deep=True)
         routed.model = resolved.provider_model
-        return RoutedMessagesRequest(request=routed, resolved=resolved)
+        return RoutedMessagesRequest(
+            request=routed,
+            resolved=resolved,
+            reasoning=resolve_reasoning_policy(
+                routed,
+                route_enabled=resolved.reasoning_allowed,
+            ),
+        )
 
     def resolve_token_count_request(
         self, request: TokenCountRequest

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -63,7 +63,8 @@ SECTIONS: tuple[ConfigSectionSpec, ...] = (
     ConfigSectionSpec(
         "thinking",
         "Thinking",
-        "Global and tier-specific thinking behavior.",
+        "Effort levels selected in Claude Code, Codex, or Pi are translated "
+        "automatically; these controls only enable or disable reasoning.",
     ),
     ConfigSectionSpec(
         "runtime",

--- a/src/free_claude_code/core/anthropic/models.py
+++ b/src/free_claude_code/core/anthropic/models.py
@@ -108,7 +108,7 @@ class Tool(_AnthropicBlockBase):
 class ThinkingConfig(BaseModel):
     enabled: bool | None = True
     type: str | None = None
-    budget_tokens: int | None = None
+    budget_tokens: int | None = Field(default=None, strict=True, gt=0)
 
 
 class MessagesRequest(BaseModel):

--- a/src/free_claude_code/core/anthropic/request_snapshot.py
+++ b/src/free_claude_code/core/anthropic/request_snapshot.py
@@ -28,7 +28,7 @@ def anthropic_request_snapshot(
             "stop_sequences",
             "metadata",
             "stream",
-            "thinking_enabled",
+            "output_config",
         )
         if key in data and data[key] is not None
     }

--- a/src/free_claude_code/core/gateway_model_ids.py
+++ b/src/free_claude_code/core/gateway_model_ids.py
@@ -14,7 +14,7 @@ NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
 class DecodedGatewayModelId:
     provider_id: str
     provider_model: str
-    force_thinking_enabled: bool | None = None
+    force_reasoning_allowed: bool | None = None
 
 
 def gateway_model_id(provider_model_ref: str) -> str:
@@ -33,11 +33,11 @@ def decode_gateway_model_id(model_name: str) -> DecodedGatewayModelId | None:
     if not separator:
         return None
 
-    force_thinking_enabled: bool | None
+    force_reasoning_allowed: bool | None
     if prefix == GATEWAY_MODEL_ID_PREFIX:
-        force_thinking_enabled = None
+        force_reasoning_allowed = None
     elif prefix == NO_THINKING_GATEWAY_MODEL_ID_PREFIX:
-        force_thinking_enabled = False
+        force_reasoning_allowed = False
     else:
         return None
 
@@ -48,5 +48,5 @@ def decode_gateway_model_id(model_name: str) -> DecodedGatewayModelId | None:
     return DecodedGatewayModelId(
         provider_id=provider_id,
         provider_model=provider_model,
-        force_thinking_enabled=force_thinking_enabled,
+        force_reasoning_allowed=force_reasoning_allowed,
     )

--- a/src/free_claude_code/core/openai_responses/input.py
+++ b/src/free_claude_code/core/openai_responses/input.py
@@ -10,7 +10,7 @@ from .models import OpenAIResponsesRequest
 from .reasoning import (
     combine_reasoning,
     reasoning_text_from_item,
-    responses_reasoning_to_thinking,
+    responses_reasoning_to_anthropic_fields,
 )
 from .tools import (
     call_id_from_item,
@@ -65,8 +65,7 @@ def convert_request_to_anthropic_payload(
     if request.metadata is not None:
         payload["metadata"] = request.metadata
 
-    if thinking := responses_reasoning_to_thinking(request.reasoning):
-        payload["thinking"] = thinking
+    payload.update(responses_reasoning_to_anthropic_fields(request.reasoning))
 
     raw_tool_choice = request.tool_choice
     tools = convert_tools(request.tools)

--- a/src/free_claude_code/core/openai_responses/reasoning.py
+++ b/src/free_claude_code/core/openai_responses/reasoning.py
@@ -32,14 +32,19 @@ def combine_reasoning(existing: str | None, addition: str | None) -> str | None:
     return f"{existing}\n{addition}"
 
 
-def responses_reasoning_to_thinking(value: Any) -> dict[str, Any] | None:
+def responses_reasoning_to_anthropic_fields(value: Any) -> dict[str, Any]:
+    """Preserve Responses reasoning enablement and effort for application routing."""
     if not isinstance(value, Mapping):
-        return None
-    if value.get("effort") == "none":
-        return {"type": "disabled", "enabled": False}
+        return {}
+    effort = value.get("effort")
+    if effort == "none":
+        return {"thinking": {"type": "disabled", "enabled": False}}
+    fields: dict[str, Any] = {}
     if any(item is not None for item in value.values()):
-        return {"type": "enabled", "enabled": True}
-    return None
+        fields["thinking"] = {"type": "adaptive", "enabled": True}
+    if isinstance(effort, str) and effort.strip():
+        fields["output_config"] = {"effort": effort}
+    return fields
 
 
 def _text_parts_from_items(value: Any, *, item_type: str) -> list[str]:

--- a/src/free_claude_code/providers/base.py
+++ b/src/free_claude_code/providers/base.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from loguru import logger
 
 from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.constants import HTTP_CONNECT_TIMEOUT_DEFAULT
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.diagnostics import (
@@ -33,7 +34,6 @@ class ProviderConfig:
     http_read_timeout: float = 300.0
     http_write_timeout: float = 10.0
     http_connect_timeout: float = HTTP_CONNECT_TIMEOUT_DEFAULT
-    enable_thinking: bool = True
     proxy: str = ""
     log_raw_sse_events: bool = False
     log_api_error_tracebacks: bool = False
@@ -45,27 +45,9 @@ class BaseProvider(ABC):
     def __init__(self, config: ProviderConfig):
         self._config = config
 
-    def _is_thinking_enabled(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
-    ) -> bool:
-        """Return whether thinking should be enabled for this request."""
-        thinking = request.thinking
-        config_enabled = (
-            self._config.enable_thinking
-            if thinking_enabled is None
-            else thinking_enabled
-        )
-        request_enabled = True
-        if thinking is not None:
-            if "enabled" in thinking.model_fields_set and thinking.enabled is not None:
-                request_enabled = thinking.enabled
-            if thinking.type == "disabled":
-                request_enabled = False
-        return config_enabled and request_enabled
-
     @abstractmethod
     def preflight_stream(
-        self, request: MessagesRequest, *, thinking_enabled: bool | None = None
+        self, request: MessagesRequest, *, reasoning: ReasoningPolicy
     ) -> None:
         """Validate the upstream request before opening an SSE stream."""
 
@@ -131,6 +113,6 @@ class BaseProvider(ABC):
         input_tokens: int = 0,
         *,
         request_id: str | None = None,
-        thinking_enabled: bool | None = None,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]:
         """Stream response in Anthropic SSE format."""

--- a/src/free_claude_code/providers/cloudflare/client.py
+++ b/src/free_claude_code/providers/cloudflare/client.py
@@ -9,6 +9,7 @@ import httpx
 
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.provider_catalog import CLOUDFLARE_AI_REST_ROOT
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
@@ -119,21 +120,24 @@ class CloudflareProvider(OpenAIChatProvider):
             await maybe_await_aclose(response)
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
         return build_openai_chat_request_body(
             request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            reasoning=reasoning,
             policy=_REQUEST_POLICY,
             postprocessors=(_apply_cloudflare_request_quirks,),
         )
 
     def _handle_extra_reasoning(
-        self, delta: Any, ledger: Any, *, thinking_enabled: bool
+        self, delta: Any, ledger: Any, *, reasoning_enabled: bool
     ) -> Iterator[str]:
         """Map Cloudflare's ``reasoning`` delta field to Anthropic thinking."""
         reasoning = _cloudflare_reasoning(delta)
-        if not thinking_enabled or not reasoning:
+        if not reasoning_enabled or not reasoning:
             return
         yield from ledger.ensure_thinking_block()
         yield ledger.emit_thinking_delta(reasoning)
@@ -143,15 +147,19 @@ class CloudflareProvider(OpenAIChatProvider):
 
 
 def _apply_cloudflare_request_quirks(
-    body: dict[str, Any], _request: MessagesRequest, thinking_enabled: bool
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
 ) -> None:
-    """Attach Cloudflare Workers AI chat-template thinking control."""
+    """Attach Cloudflare's existing chat-template thinking control."""
+    if policy.effort is not None:
+        body["reasoning_effort"] = policy.effort.value
     extra_body = body.setdefault("extra_body", {})
     if not isinstance(extra_body, dict):
         return
     chat_template_kwargs = extra_body.setdefault("chat_template_kwargs", {})
     if isinstance(chat_template_kwargs, dict):
-        chat_template_kwargs.setdefault("thinking", thinking_enabled)
+        chat_template_kwargs["thinking"] = policy.enabled
 
 
 def _cloudflare_reasoning(delta: Any) -> str | None:

--- a/src/free_claude_code/providers/deepseek/client.py
+++ b/src/free_claude_code/providers/deepseek/client.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import (
@@ -28,11 +29,14 @@ class DeepSeekProvider(OpenAIChatProvider):
         )
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
         return build_deepseek_request_body(
             request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            reasoning=reasoning,
         )
 
     def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:

--- a/src/free_claude_code/providers/deepseek/compat.py
+++ b/src/free_claude_code/providers/deepseek/compat.py
@@ -6,6 +6,7 @@ from typing import Any
 from loguru import logger
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 from free_claude_code.core.anthropic import (
     dump_messages_request,
@@ -16,6 +17,7 @@ from free_claude_code.providers.openai_chat import (
     OpenAIChatRequestPolicy,
     build_openai_chat_request_body,
 )
+from free_claude_code.providers.reasoning import reasoning_effort
 
 _REQUEST_POLICY = OpenAIChatRequestPolicy(
     provider_name="DEEPSEEK",
@@ -39,7 +41,9 @@ _OMITTED_ATTACHMENT_BLOCK = {"type": "text", "text": _OMITTED_ATTACHMENT_TEXT}
 
 
 def build_deepseek_request_body(
-    request_data: MessagesRequest, *, thinking_enabled: bool
+    request_data: MessagesRequest,
+    *,
+    reasoning: ReasoningPolicy,
 ) -> dict:
     """Build a DeepSeek Chat Completions body from an Anthropic request."""
     logger.debug(
@@ -57,8 +61,10 @@ def build_deepseek_request_body(
     has_tool_history = _has_tool_history(data)
     has_replayable_tool_thinking = _all_tool_calls_have_replayable_thinking(data)
     unsafe_tool_followup = has_tool_history and not has_replayable_tool_thinking
-    effective_thinking_enabled = thinking_enabled and not unsafe_tool_followup
-    if thinking_enabled:
+    effective_reasoning = (
+        reasoning if not unsafe_tool_followup else ReasoningPolicy.off()
+    )
+    if reasoning.enabled:
         if unsafe_tool_followup:
             logger.debug(
                 "DEEPSEEK_REQUEST: disabling thinking for tool follow-up without "
@@ -93,7 +99,7 @@ def build_deepseek_request_body(
     sanitized_request = MessagesRequest.model_validate(data)
     body = build_openai_chat_request_body(
         sanitized_request,
-        thinking_enabled=effective_thinking_enabled,
+        reasoning=effective_reasoning,
         reasoning_history_enabled=True,
         policy=_REQUEST_POLICY,
         postprocessors=(_apply_deepseek_chat_extras,),
@@ -427,10 +433,21 @@ def _downgrade_forced_tool_choice(data: dict[str, Any]) -> None:
 
 
 def _apply_deepseek_chat_extras(
-    body: dict[str, Any], _request_data: MessagesRequest, thinking_enabled: bool
+    body: dict[str, Any],
+    _request_data: MessagesRequest,
+    policy: ReasoningPolicy,
 ) -> None:
-    if not thinking_enabled or body.get("model") == "deepseek-reasoner":
+    if body.get("model") != "deepseek-reasoner":
+        extra_body = body.setdefault("extra_body", {})
+        if isinstance(extra_body, dict):
+            extra_body["thinking"] = {
+                "type": "enabled" if policy.enabled else "disabled"
+            }
+    if not policy.enabled:
         return
-    extra_body = body.setdefault("extra_body", {})
-    if isinstance(extra_body, dict):
-        extra_body.setdefault("thinking", {"type": "enabled"})
+    effort = reasoning_effort(
+        policy,
+        (ReasoningEffort.HIGH, ReasoningEffort.MAX),
+    )
+    if effort is not None:
+        body["reasoning_effort"] = effort.value

--- a/src/free_claude_code/providers/gemini/client.py
+++ b/src/free_claude_code/providers/gemini/client.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 from typing import Any
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import (
@@ -45,17 +46,20 @@ class GeminiProvider(OpenAIChatProvider):
         self._tool_call_extra_content_by_id[tool_call_id] = deepcopy(extra_content)
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
         return build_openai_chat_request_body(
             request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            reasoning=reasoning,
             policy=_REQUEST_POLICY,
             postprocessors=(
-                lambda body, request_data, enabled: apply_gemini_request_quirks(
+                lambda body, request_data, policy: apply_gemini_request_quirks(
                     body,
                     request_data,
-                    enabled,
+                    policy,
                     tool_call_extra_content_by_id=self._tool_call_extra_content_by_id,
                 ),
             ),

--- a/src/free_claude_code/providers/gemini/quirks.py
+++ b/src/free_claude_code/providers/gemini/quirks.py
@@ -3,7 +3,9 @@
 from copy import deepcopy
 from typing import Any, cast
 
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.providers.reasoning import reasoning_effort
 
 GEMINI_SKIP_THOUGHT_SIGNATURE_VALIDATOR = "skip_thought_signature_validator"
 
@@ -11,7 +13,7 @@ GEMINI_SKIP_THOUGHT_SIGNATURE_VALIDATOR = "skip_thought_signature_validator"
 def apply_gemini_request_quirks(
     body: dict[str, Any],
     request_data: MessagesRequest,
-    thinking_enabled: bool,
+    policy: ReasoningPolicy,
     *,
     tool_call_extra_content_by_id: dict[str, dict[str, Any]] | None = None,
 ) -> None:
@@ -21,9 +23,20 @@ def apply_gemini_request_quirks(
     if isinstance(request_extra, dict):
         extra_body.update(deepcopy(request_extra))
 
-    if thinking_enabled:
+    if policy.enabled:
         _apply_thinking_config(extra_body)
-    else:
+        effort = reasoning_effort(
+            policy,
+            (
+                ReasoningEffort.MINIMAL,
+                ReasoningEffort.LOW,
+                ReasoningEffort.MEDIUM,
+                ReasoningEffort.HIGH,
+            ),
+        )
+        if effort is not None:
+            body["reasoning_effort"] = effort.value
+    elif _gemini_reasoning_can_be_disabled(body.get("model")):
         body["reasoning_effort"] = "none"
 
     if extra_body:
@@ -55,6 +68,11 @@ def _apply_thinking_config(extra_body: dict[str, Any]) -> None:
 
 def _is_gemini_3_model(model: Any) -> bool:
     return "gemini-3" in str(model).lower()
+
+
+def _gemini_reasoning_can_be_disabled(model: Any) -> bool:
+    lowered = str(model).lower()
+    return "gemini-2.5" in lowered and "pro" not in lowered
 
 
 def _thought_signature_from_extra_content(extra_content: Any) -> str | None:

--- a/src/free_claude_code/providers/github_models/client.py
+++ b/src/free_claude_code/providers/github_models/client.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 
 from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.http import maybe_await_aclose
@@ -82,11 +83,14 @@ class GitHubModelsProvider(OpenAIChatProvider):
             await maybe_await_aclose(response)
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
         return build_openai_chat_request_body(
             request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            reasoning=reasoning,
             policy=_REQUEST_POLICY,
         )
 

--- a/src/free_claude_code/providers/lmstudio/client.py
+++ b/src/free_claude_code/providers/lmstudio/client.py
@@ -12,11 +12,13 @@ heuristic recovery on top.
 """
 
 import time
+from typing import Any
 
 import httpx
 from loguru import logger
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.core.anthropic import (
     ReasoningReplayMode,
     build_base_request_body,
@@ -31,6 +33,10 @@ from free_claude_code.providers.openai_chat import (
     OpenAIChatRequestPolicy,
 )
 from free_claude_code.providers.rate_limit import ProviderRateLimiter
+from free_claude_code.providers.reasoning import (
+    reasoning_budget_tokens,
+    reasoning_effort,
+)
 
 _PROFILE = OpenAIChatProfile(OpenAIChatRequestPolicy(provider_name="LMSTUDIO"))
 
@@ -54,7 +60,10 @@ class LMStudioProvider(OpenAIChatProvider):
         self._loaded_context_cache: tuple[float, int | None] = (0.0, None)
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
         """Build an OpenAI chat body from the Anthropic request.
 
@@ -64,17 +73,22 @@ class LMStudioProvider(OpenAIChatProvider):
         back via ``reasoning_content``/``<think>`` parsing in the provider.
         """
         try:
-            return build_base_request_body(
+            body = build_base_request_body(
                 request,
                 reasoning_replay=ReasoningReplayMode.DISABLED,
             )
         except OpenAIConversionError as exc:
             raise InvalidRequestError(str(exc)) from exc
+        _apply_lmstudio_reasoning(body, reasoning)
+        return body
 
     def preflight_stream(
-        self, request: MessagesRequest, *, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> None:
-        super().preflight_stream(request, thinking_enabled=thinking_enabled)
+        super().preflight_stream(request, reasoning=reasoning)
         self._preflight_context_budget(request)
 
     def _preflight_context_budget(self, request: MessagesRequest) -> None:
@@ -125,3 +139,30 @@ class LMStudioProvider(OpenAIChatProvider):
             value = None
         self._loaded_context_cache = (time.monotonic(), value)
         return value
+
+
+def _apply_lmstudio_reasoning(
+    body: dict[str, Any],
+    reasoning: ReasoningPolicy,
+) -> None:
+    """Encode LM Studio's documented effort or explicit token budget."""
+    if not reasoning.enabled:
+        body["reasoning_effort"] = "none"
+        return
+
+    budget = reasoning_budget_tokens(reasoning)
+    if reasoning.budget_tokens is not None and budget is not None:
+        extra_body = body.setdefault("extra_body", {})
+        extra_body["reasoning_tokens"] = budget
+        return
+
+    effort = reasoning_effort(
+        reasoning,
+        (
+            ReasoningEffort.LOW,
+            ReasoningEffort.MEDIUM,
+            ReasoningEffort.HIGH,
+        ),
+    )
+    if effort is not None:
+        body["reasoning_effort"] = effort.value

--- a/src/free_claude_code/providers/mistral/client.py
+++ b/src/free_claude_code/providers/mistral/client.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from loguru import logger
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import (
@@ -36,18 +37,19 @@ class MistralProvider(OpenAIChatProvider):
         )
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
-        effective_thinking_enabled = self._is_thinking_enabled(
-            request, thinking_enabled
-        )
         body = build_openai_chat_request_body(
             request,
-            thinking_enabled=effective_thinking_enabled,
+            reasoning=reasoning,
             policy=_REQUEST_POLICY,
         )
         apply_mistral_reasoning_request_shape(
-            body, thinking_enabled=effective_thinking_enabled
+            body,
+            reasoning=reasoning,
         )
         return body
 

--- a/src/free_claude_code/providers/mistral/reasoning.py
+++ b/src/free_claude_code/providers/mistral/reasoning.py
@@ -8,9 +8,17 @@ from typing import Any
 
 import openai
 
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.http import maybe_await_aclose
+from free_claude_code.providers.reasoning import reasoning_effort
 
-MISTRAL_REASONING_EFFORT = "high"
+_MISTRAL_EFFORTS = (
+    ReasoningEffort.MINIMAL,
+    ReasoningEffort.LOW,
+    ReasoningEffort.MEDIUM,
+    ReasoningEffort.HIGH,
+    ReasoningEffort.XHIGH,
+)
 
 _REASONING_FIELD_NAMES = frozenset(
     {
@@ -23,13 +31,10 @@ _REJECTION_WORDS = ("unsupported", "unknown", "invalid", "forbidden", "extra")
 
 
 def apply_mistral_reasoning_request_shape(
-    body: dict[str, Any], *, thinking_enabled: bool
+    body: dict[str, Any], *, reasoning: ReasoningPolicy
 ) -> None:
     """Apply Mistral's native reasoning request shape in-place."""
-    if thinking_enabled:
-        body["reasoning_effort"] = MISTRAL_REASONING_EFFORT
-    else:
-        body.pop("reasoning_effort", None)
+    body["reasoning_effort"] = _mistral_reasoning_effort(reasoning)
 
     messages = body.get("messages")
     if not isinstance(messages, list):
@@ -38,12 +43,12 @@ def apply_mistral_reasoning_request_shape(
     for message in messages:
         if not isinstance(message, dict) or message.get("role") != "assistant":
             continue
-        reasoning = _clean_text(message.pop("reasoning_content", None))
-        if thinking_enabled and reasoning:
+        reasoning_text = _clean_text(message.pop("reasoning_content", None))
+        if reasoning.enabled and reasoning_text:
             message["content"] = _content_with_prepended_thinking(
-                message.get("content"), reasoning
+                message.get("content"), reasoning_text
             )
-        elif not thinking_enabled:
+        elif not reasoning.enabled:
             message["content"] = _content_without_thinking(message.get("content"))
 
 
@@ -70,6 +75,18 @@ def clone_body_without_mistral_reasoning(
     if not removed:
         return None
     return cloned
+
+
+def _mistral_reasoning_effort(reasoning: ReasoningPolicy) -> str:
+    if not reasoning.enabled:
+        return "none"
+    effort = reasoning_effort(
+        reasoning,
+        _MISTRAL_EFFORTS,
+        default=ReasoningEffort.HIGH,
+    )
+    assert effort is not None
+    return effort.value
 
 
 def is_mistral_reasoning_rejection(error: Exception) -> bool:

--- a/src/free_claude_code/providers/nvidia_nim/client.py
+++ b/src/free_claude_code/providers/nvidia_nim/client.py
@@ -7,6 +7,7 @@ from typing import Any
 import openai
 from loguru import logger
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.failures import ExecutionFailure
@@ -24,7 +25,7 @@ from free_claude_code.providers.rate_limit import ProviderRateLimiter
 from .request_options import build_nim_request_body
 from .retry import (
     clone_body_without_chat_template,
-    clone_body_without_reasoning_budget,
+    clone_body_without_reasoning_budget_controls,
     clone_body_without_reasoning_content,
 )
 from .tool_schema import (
@@ -54,13 +55,16 @@ class NvidiaNimProvider(OpenAIChatProvider):
         self._nim_settings = nim_settings
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
         """Internal helper for tests and shared building."""
         return build_nim_request_body(
             request,
             self._nim_settings,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            reasoning=reasoning,
         )
 
     def _prepare_create_body(self, body: dict[str, Any]) -> dict[str, Any]:
@@ -87,7 +91,7 @@ class NvidiaNimProvider(OpenAIChatProvider):
         if _is_reasoning_budget_rejection(error_text) and (
             bad_request_like or status_code == 500
         ):
-            retry_body = clone_body_without_reasoning_budget(body)
+            retry_body = clone_body_without_reasoning_budget_controls(body)
             if retry_body is None:
                 return None
             logger.warning(
@@ -143,5 +147,7 @@ class NvidiaNimProvider(OpenAIChatProvider):
 def _is_reasoning_budget_rejection(error_text: str) -> bool:
     """Return whether NIM rejected optional thinking budget control."""
     if "reasoning_budget" in error_text:
+        return True
+    if "max_thinking_tokens" in error_text:
         return True
     return "thinking_token_budget" in error_text and "reasoning_config" in error_text

--- a/src/free_claude_code/providers/nvidia_nim/request_options.py
+++ b/src/free_claude_code/providers/nvidia_nim/request_options.py
@@ -1,7 +1,9 @@
 """NVIDIA NIM request option injection."""
 
+from copy import deepcopy
 from typing import Any
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.core.anthropic import set_if_not_none
 from free_claude_code.core.anthropic.models import MessagesRequest
@@ -9,6 +11,7 @@ from free_claude_code.providers.openai_chat import (
     OpenAIChatRequestPolicy,
     build_openai_chat_request_body,
 )
+from free_claude_code.providers.reasoning import reasoning_budget_tokens
 
 from .tool_schema import sanitize_nim_tool_schemas
 
@@ -16,18 +19,21 @@ _REQUEST_POLICY = OpenAIChatRequestPolicy(provider_name="NIM")
 
 
 def build_nim_request_body(
-    request_data: MessagesRequest, nim: NimSettings, *, thinking_enabled: bool
+    request_data: MessagesRequest,
+    nim: NimSettings,
+    *,
+    reasoning: ReasoningPolicy,
 ) -> dict[str, Any]:
     """Build OpenAI-format request body from Anthropic request plus NIM settings."""
     return build_openai_chat_request_body(
         request_data,
-        thinking_enabled=thinking_enabled,
+        reasoning=reasoning,
         policy=_REQUEST_POLICY,
         postprocessors=(
-            lambda body, request, enabled: apply_nim_request_options(
+            lambda body, request, policy: apply_nim_request_options(
                 body,
                 request,
-                enabled,
+                policy,
                 nim=nim,
             ),
         ),
@@ -37,7 +43,7 @@ def build_nim_request_body(
 def apply_nim_request_options(
     body: dict[str, Any],
     request_data: MessagesRequest,
-    thinking_enabled: bool,
+    reasoning: ReasoningPolicy,
     *,
     nim: NimSettings,
 ) -> None:
@@ -71,14 +77,9 @@ def apply_nim_request_options(
     extra_body: dict[str, Any] = {}
     request_extra = request_data.extra_body
     if request_extra:
-        extra_body.update(request_extra)
+        extra_body.update(deepcopy(request_extra))
 
-    if thinking_enabled:
-        chat_template_kwargs = extra_body.setdefault(
-            "chat_template_kwargs", {"thinking": True, "enable_thinking": True}
-        )
-        if isinstance(chat_template_kwargs, dict):
-            chat_template_kwargs.setdefault("reasoning_budget", max_tokens)
+    _apply_nim_reasoning(extra_body, request_data.model, reasoning)
 
     req_top_k = request_data.top_k
     top_k = req_top_k if req_top_k is not None else nim.top_k
@@ -94,6 +95,38 @@ def apply_nim_request_options(
 
     if extra_body:
         body["extra_body"] = extra_body
+
+
+def _apply_nim_reasoning(
+    extra_body: dict[str, Any],
+    model: str,
+    reasoning: ReasoningPolicy,
+) -> None:
+    """Encode NIM's toggle plus optional model-specific numeric budget."""
+    chat_template_kwargs = extra_body.setdefault("chat_template_kwargs", {})
+    if not isinstance(chat_template_kwargs, dict):
+        return
+
+    chat_template_kwargs["thinking"] = reasoning.enabled
+    chat_template_kwargs["enable_thinking"] = reasoning.enabled
+    chat_template_kwargs.pop("reasoning_budget", None)
+    chat_template_kwargs.pop("low_effort", None)
+
+    nvext = extra_body.get("nvext")
+    if isinstance(nvext, dict):
+        nvext.pop("max_thinking_tokens", None)
+        if not nvext:
+            extra_body.pop("nvext", None)
+
+    budget = reasoning_budget_tokens(reasoning)
+    if budget is None:
+        return
+    if "nvidia-nemotron-nano-9b-v2" in model.lower():
+        nvext = extra_body.setdefault("nvext", {})
+        if isinstance(nvext, dict):
+            nvext["max_thinking_tokens"] = budget
+        return
+    chat_template_kwargs["reasoning_budget"] = budget
 
 
 def _set_extra(

--- a/src/free_claude_code/providers/nvidia_nim/retry.py
+++ b/src/free_claude_code/providers/nvidia_nim/retry.py
@@ -5,8 +5,10 @@ from copy import deepcopy
 from typing import Any
 
 
-def clone_body_without_reasoning_budget(body: dict[str, Any]) -> dict[str, Any] | None:
-    """Clone a request body and strip only reasoning_budget fields."""
+def clone_body_without_reasoning_budget_controls(
+    body: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Clone a request body and strip optional NIM reasoning-budget controls."""
     return _clone_strip_extra_body(body, _strip_reasoning_budget_fields)
 
 
@@ -42,12 +44,18 @@ def _clone_strip_extra_body(
 
 def _strip_reasoning_budget_fields(extra_body: dict[str, Any]) -> bool:
     removed = extra_body.pop("reasoning_budget", None) is not None
-    chat_template_kwargs = extra_body.get("chat_template_kwargs")
-    if (
-        isinstance(chat_template_kwargs, dict)
-        and chat_template_kwargs.pop("reasoning_budget", None) is not None
-    ):
+    if extra_body.pop("thinking_token_budget", None) is not None:
         removed = True
+    chat_template_kwargs = extra_body.get("chat_template_kwargs")
+    if isinstance(chat_template_kwargs, dict):
+        for key in ("reasoning_budget", "thinking_token_budget", "low_effort"):
+            if chat_template_kwargs.pop(key, None) is not None:
+                removed = True
+    nvext = extra_body.get("nvext")
+    if isinstance(nvext, dict) and nvext.pop("max_thinking_tokens", None) is not None:
+        removed = True
+        if not nvext:
+            extra_body.pop("nvext", None)
     return removed
 
 

--- a/src/free_claude_code/providers/open_router/client.py
+++ b/src/free_claude_code/providers/open_router/client.py
@@ -5,8 +5,9 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import Any
 
 from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
-from free_claude_code.core.anthropic.models import MessagesRequest, ThinkingConfig
+from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.model_listing import (
@@ -42,14 +43,14 @@ class OpenRouterProvider(OpenAIChatProvider):
         )
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
-        effective_thinking_enabled = self._is_thinking_enabled(
-            request, thinking_enabled
-        )
         return build_openai_chat_request_body(
             request,
-            thinking_enabled=effective_thinking_enabled,
+            reasoning=reasoning,
             policy=_REQUEST_POLICY,
             postprocessors=(
                 _apply_openrouter_reasoning_policy,
@@ -72,35 +73,37 @@ class OpenRouterProvider(OpenAIChatProvider):
         )
 
     def _handle_extra_reasoning(
-        self, delta: Any, ledger: AnthropicStreamLedger, *, thinking_enabled: bool
+        self, delta: Any, ledger: AnthropicStreamLedger, *, reasoning_enabled: bool
     ) -> Iterator[str]:
         """Map OpenRouter reasoning details onto Anthropic thinking blocks."""
-        if not thinking_enabled:
+        if not reasoning_enabled:
             return iter(())
         return _iter_openrouter_reasoning_detail_events(delta, ledger)
 
 
 def _apply_openrouter_reasoning_policy(
-    body: dict[str, Any], request: MessagesRequest, thinking_enabled: bool
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
 ) -> None:
-    if not thinking_enabled:
-        return
     extra_body = body.setdefault("extra_body", {})
     if not isinstance(extra_body, dict):
         return
-    reasoning = extra_body.setdefault("reasoning", {"enabled": True})
-    if not isinstance(reasoning, dict):
-        return
-    reasoning.setdefault("enabled", True)
-    budget_tokens = _thinking_budget_tokens(request.thinking)
-    if isinstance(budget_tokens, int):
-        reasoning.setdefault("max_tokens", budget_tokens)
+    reasoning: dict[str, Any] = {"enabled": policy.enabled}
+    if policy.enabled:
+        if policy.budget_tokens is not None:
+            reasoning["max_tokens"] = policy.budget_tokens
+        elif policy.effort is not None:
+            reasoning["effort"] = policy.effort.value
+    extra_body["reasoning"] = reasoning
 
 
 def _apply_openrouter_reasoning_details_replay(
-    body: dict[str, Any], request: MessagesRequest, thinking_enabled: bool
+    body: dict[str, Any],
+    request: MessagesRequest,
+    policy: ReasoningPolicy,
 ) -> None:
-    if not thinking_enabled:
+    if not policy.enabled:
         return
     assistant_details = _assistant_reasoning_details(request.messages)
     if not assistant_details:
@@ -155,11 +158,6 @@ def _redacted_reasoning_details(content: Any) -> list[dict[str, Any]]:
         else:
             details.append({"type": "reasoning.encrypted", "data": data})
     return details
-
-
-def _thinking_budget_tokens(thinking: ThinkingConfig | None) -> int | None:
-    value = thinking.budget_tokens if thinking is not None else None
-    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _iter_openrouter_reasoning_detail_events(

--- a/src/free_claude_code/providers/openai_chat/extra_body.py
+++ b/src/free_claude_code/providers/openai_chat/extra_body.py
@@ -17,6 +17,12 @@ CANONICAL_OPENAI_CHAT_BODY_KEYS = frozenset(
         "stop",
         "stop_sequences",
         "stream_options",
+        "reasoning",
+        "reasoning_effort",
+        "reasoning_tokens",
+        "thinking",
+        "thinking_budget_tokens",
+        "chat_template_kwargs",
     }
 )
 

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -6,12 +6,28 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 from free_claude_code.core.anthropic import ReasoningReplayMode
 from free_claude_code.core.anthropic.models import MessagesRequest
 
 from .base_url import openai_v1_base_url
 from .extra_body import validate_extra_body_does_not_override_canonical_fields
+from .reasoning import (
+    encode_cerebras_reasoning,
+    encode_cohere_reasoning,
+    encode_fireworks_reasoning,
+    encode_groq_reasoning,
+    encode_huggingface_reasoning,
+    encode_kimi_reasoning,
+    encode_llamacpp_reasoning,
+    encode_minimax_reasoning,
+    encode_ollama_reasoning,
+    encode_sambanova_reasoning,
+    encode_vercel_reasoning,
+    encode_wafer_reasoning,
+    encode_zai_reasoning,
+)
 from .request_policy import OpenAIChatPostprocessor, OpenAIChatRequestPolicy
 
 
@@ -21,6 +37,7 @@ class OpenAIChatProfile:
 
     request_policy: OpenAIChatRequestPolicy
     postprocessors: tuple[OpenAIChatPostprocessor, ...] = ()
+    reasoning_encoder: OpenAIChatPostprocessor | None = None
     normalize_base_url: bool = False
     reasoning_delta_field: Literal["reasoning_content", "reasoning"] = (
         "reasoning_content"
@@ -37,12 +54,20 @@ class OpenAIChatProfile:
         value = getattr(delta, self.reasoning_delta_field, None)
         return value if isinstance(value, str) else None
 
+    @property
+    def request_postprocessors(self) -> tuple[OpenAIChatPostprocessor, ...]:
+        """Return generic transforms followed by the provider reasoning encoder."""
+        if self.reasoning_encoder is None:
+            return self.postprocessors
+        return (*self.postprocessors, self.reasoning_encoder)
+
 
 def _apply_cohere_request_quirks(
-    body: dict[str, Any], request: MessagesRequest, thinking_enabled: bool
+    body: dict[str, Any],
+    request: MessagesRequest,
+    _policy: ReasoningPolicy,
 ) -> None:
     _merge_allowed_cohere_extra_body(body, request.extra_body)
-    body["reasoning_effort"] = "high" if thinking_enabled else "none"
 
 
 _COHERE_EXTRA_BODY_KEYS = frozenset(
@@ -72,57 +97,6 @@ def _merge_allowed_cohere_extra_body(body: dict[str, Any], extra_body: Any) -> N
     body.update({str(key): deepcopy(value) for key, value in extra_body.items()})
 
 
-def _apply_kimi_thinking_policy(
-    body: dict[str, Any], _request: MessagesRequest, thinking_enabled: bool
-) -> None:
-    if thinking_enabled:
-        return
-    extra_body = body.setdefault("extra_body", {})
-    if isinstance(extra_body, dict):
-        extra_body["thinking"] = {"type": "disabled"}
-
-
-def _apply_minimax_thinking_policy(
-    body: dict[str, Any], _request: MessagesRequest, thinking_enabled: bool
-) -> None:
-    extra_body = body.setdefault("extra_body", {})
-    if not isinstance(extra_body, dict):
-        return
-    extra_body["reasoning_split"] = True
-    extra_body["thinking"] = (
-        {"type": "adaptive"} if thinking_enabled else {"type": "disabled"}
-    )
-
-
-def _apply_ollama_thinking_policy(
-    body: dict[str, Any], _request: MessagesRequest, thinking_enabled: bool
-) -> None:
-    body["reasoning_effort"] = "high" if thinking_enabled else "none"
-
-
-def _apply_wafer_thinking_policy(
-    body: dict[str, Any], _request: MessagesRequest, thinking_enabled: bool
-) -> None:
-    extra_body = body.setdefault("extra_body", {})
-    if isinstance(extra_body, dict):
-        extra_body["thinking"] = (
-            {"type": "enabled"} if thinking_enabled else {"type": "disabled"}
-        )
-
-
-def _apply_zai_thinking_policy(
-    body: dict[str, Any], _request: MessagesRequest, thinking_enabled: bool
-) -> None:
-    extra_body = body.setdefault("extra_body", {})
-    if not isinstance(extra_body, dict):
-        return
-    extra_body["thinking"] = (
-        {"type": "enabled", "clear_thinking": False}
-        if thinking_enabled
-        else {"type": "disabled"}
-    )
-
-
 OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
     "mistral_codestral": OpenAIChatProfile(
         OpenAIChatRequestPolicy(provider_name="CODESTRAL")
@@ -132,14 +106,16 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         OpenAIChatRequestPolicy(provider_name="OPENCODE_GO")
     ),
     "vercel": OpenAIChatProfile(
-        OpenAIChatRequestPolicy(provider_name="VERCEL", include_extra_body=True)
+        OpenAIChatRequestPolicy(provider_name="VERCEL", include_extra_body=True),
+        reasoning_encoder=encode_vercel_reasoning,
     ),
     "huggingface": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
             provider_name="HUGGINGFACE",
             include_extra_body=True,
             reasoning_replay=ReasoningReplayMode.DISABLED,
-        )
+        ),
+        reasoning_encoder=encode_huggingface_reasoning,
     ),
     "cohere": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
@@ -161,13 +137,14 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             ),
         ),
         postprocessors=(_apply_cohere_request_quirks,),
+        reasoning_encoder=encode_cohere_reasoning,
     ),
     "wafer": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
             provider_name="WAFER",
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
-        postprocessors=(_apply_wafer_thinking_policy,),
+        reasoning_encoder=encode_wafer_reasoning,
     ),
     "kimi": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
@@ -177,7 +154,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             ),
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
-        postprocessors=(_apply_kimi_thinking_policy,),
+        reasoning_encoder=encode_kimi_reasoning,
     ),
     "minimax": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
@@ -185,14 +162,15 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
             max_tokens_field="max_completion_tokens",
         ),
-        postprocessors=(_apply_minimax_thinking_policy,),
+        reasoning_encoder=encode_minimax_reasoning,
     ),
     "cerebras": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
             provider_name="CEREBRAS",
             include_extra_body=True,
             max_tokens_field="max_completion_tokens",
-        )
+        ),
+        reasoning_encoder=encode_cerebras_reasoning,
     ),
     "groq": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
@@ -202,10 +180,12 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             strip_message_names=True,
             unsupported_body_keys=frozenset({"logprobs", "logit_bias", "top_logprobs"}),
             normalize_n_to_one=True,
-        )
+        ),
+        reasoning_encoder=encode_groq_reasoning,
     ),
     "sambanova": OpenAIChatProfile(
-        OpenAIChatRequestPolicy(provider_name="SAMBANOVA", include_extra_body=True)
+        OpenAIChatRequestPolicy(provider_name="SAMBANOVA", include_extra_body=True),
+        reasoning_encoder=encode_sambanova_reasoning,
     ),
     "fireworks": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
@@ -213,7 +193,8 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             include_extra_body=True,
             extra_body_validator=validate_extra_body_does_not_override_canonical_fields,
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
-        )
+        ),
+        reasoning_encoder=encode_fireworks_reasoning,
     ),
     "zai": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
@@ -223,7 +204,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             ),
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
-        postprocessors=(_apply_zai_thinking_policy,),
+        reasoning_encoder=encode_zai_reasoning,
     ),
     "ollama_cloud": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
@@ -231,7 +212,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
             reasoning_replay=ReasoningReplayMode.REASONING,
         ),
-        postprocessors=(_apply_ollama_thinking_policy,),
+        reasoning_encoder=encode_ollama_reasoning,
         reasoning_delta_field="reasoning",
     ),
     "llamacpp": OpenAIChatProfile(
@@ -239,13 +220,17 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             provider_name="LLAMACPP",
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
+        reasoning_encoder=encode_llamacpp_reasoning,
         normalize_base_url=True,
     ),
     "ollama": OpenAIChatProfile(
         OpenAIChatRequestPolicy(
             provider_name="OLLAMA",
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+            reasoning_replay=ReasoningReplayMode.REASONING,
         ),
+        reasoning_encoder=encode_ollama_reasoning,
         normalize_base_url=True,
+        reasoning_delta_field="reasoning",
     ),
 }

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -10,6 +10,7 @@ import httpx
 from loguru import logger
 from openai import AsyncOpenAI
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic import (
     ContentType,
     HeuristicToolParser,
@@ -120,24 +121,30 @@ class OpenAIChatProvider(BaseProvider):
         return extract_openai_model_ids(payload, provider_name=self._provider_name)
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict[str, Any]:
         """Build a provider request from the immutable profile."""
         return build_openai_chat_request_body(
             request,
-            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+            reasoning=reasoning,
             policy=self._profile.request_policy,
-            postprocessors=self._profile.postprocessors,
+            postprocessors=self._profile.request_postprocessors,
         )
 
     def preflight_stream(
-        self, request: MessagesRequest, *, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> None:
         """Validate OpenAI-chat request conversion before streaming."""
-        self._build_request_body(request, thinking_enabled=thinking_enabled)
+        self._build_request_body(request, reasoning=reasoning)
 
     def _handle_extra_reasoning(
-        self, delta: Any, ledger: AnthropicStreamLedger, *, thinking_enabled: bool
+        self, delta: Any, ledger: AnthropicStreamLedger, *, reasoning_enabled: bool
     ) -> Iterator[str]:
         """Hook for provider-specific reasoning."""
         return iter(())
@@ -254,7 +261,7 @@ class OpenAIChatProvider(BaseProvider):
         input_tokens: int = 0,
         *,
         request_id: str | None = None,
-        thinking_enabled: bool | None = None,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]:
         """Stream response in Anthropic SSE format."""
         runner = _OpenAIChatStreamRunner(
@@ -262,7 +269,7 @@ class OpenAIChatProvider(BaseProvider):
             request=request,
             input_tokens=input_tokens,
             request_id=request_id,
-            thinking_enabled=thinking_enabled,
+            reasoning=reasoning,
         )
         return runner.run()
 
@@ -277,13 +284,13 @@ class _OpenAIChatStreamRunner:
         request: MessagesRequest,
         input_tokens: int,
         request_id: str | None,
-        thinking_enabled: bool | None,
+        reasoning: ReasoningPolicy,
     ) -> None:
         self._provider = provider
         self._request = request
         self._input_tokens = input_tokens
         self._request_id = request_id
-        self._thinking_enabled = thinking_enabled
+        self._reasoning = reasoning
         self._message_id = f"msg_{uuid.uuid4()}"
         self._tool_calls = OpenAIToolCallAssembler(
             record_extra_content=provider._record_tool_call_extra_content
@@ -307,12 +314,11 @@ class _OpenAIChatStreamRunner:
                 yield from hold_event(event)
 
         body = self._provider._build_request_body(
-            self._request, thinking_enabled=self._thinking_enabled
+            self._request,
+            reasoning=self._reasoning,
         )
         request_stream_usage(body)
-        thinking_enabled = self._provider._is_thinking_enabled(
-            self._request, self._thinking_enabled
-        )
+        reasoning_enabled = self._reasoning.enabled
         trace_event(
             stage="provider",
             event="provider.request.sent",
@@ -362,7 +368,7 @@ class _OpenAIChatStreamRunner:
                             logger.debug("{} finish_reason: {}", tag, finish_reason)
 
                         reasoning = self._provider._profile.reasoning_delta(delta)
-                        if thinking_enabled and reasoning is not None:
+                        if reasoning_enabled and reasoning is not None:
                             for event in hold_events(ledger.ensure_thinking_block()):
                                 yield event
                             if reasoning:
@@ -374,7 +380,7 @@ class _OpenAIChatStreamRunner:
                         for event in self._provider._handle_extra_reasoning(
                             delta,
                             ledger,
-                            thinking_enabled=thinking_enabled,
+                            reasoning_enabled=reasoning_enabled,
                         ):
                             for out_event in hold_event(event):
                                 yield out_event
@@ -382,7 +388,7 @@ class _OpenAIChatStreamRunner:
                         if delta.content:
                             for part in think_parser.feed(delta.content):
                                 if part.type == ContentType.THINKING:
-                                    if not thinking_enabled:
+                                    if not reasoning_enabled:
                                         continue
                                     for event in hold_events(
                                         ledger.ensure_thinking_block()
@@ -477,7 +483,7 @@ class _OpenAIChatStreamRunner:
                                 ledger=ledger,
                                 error=error,
                                 tool_argument_alias_buffers=tool_argument_alias_buffers,
-                                thinking_enabled=thinking_enabled,
+                                reasoning_enabled=reasoning_enabled,
                             )
                         except Exception as recovery_error:
                             trace_event(
@@ -550,7 +556,7 @@ class _OpenAIChatStreamRunner:
         remaining = think_parser.flush()
         if remaining:
             if remaining.type == ContentType.THINKING:
-                if not thinking_enabled:
+                if not reasoning_enabled:
                     remaining = None
                 else:
                     for event in hold_events(ledger.ensure_thinking_block()):
@@ -701,7 +707,7 @@ class _OpenAIChatStreamRunner:
         ledger: AnthropicStreamLedger,
         error: Exception,
         tool_argument_alias_buffers: dict[int, str],
-        thinking_enabled: bool,
+        reasoning_enabled: bool,
     ) -> list[str] | None:
         """Build terminal recovery events when the interrupted stream permits it."""
         if not is_retryable_stream_error(error):
@@ -743,7 +749,7 @@ class _OpenAIChatStreamRunner:
 
         recovery_body = make_text_recovery_body(body, partial_text, partial_thinking)
         text, thinking = await self._collect_recovery_text(
-            recovery_body, include_reasoning=thinking_enabled
+            recovery_body, include_reasoning=reasoning_enabled
         )
         text_suffix = continuation_suffix(partial_text, text)
         thinking_suffix = continuation_suffix(partial_thinking, thinking)

--- a/src/free_claude_code/providers/openai_chat/reasoning.py
+++ b/src/free_claude_code/providers/openai_chat/reasoning.py
@@ -1,0 +1,309 @@
+"""Provider-specific reasoning encoders for OpenAI-compatible chat APIs."""
+
+from typing import Any
+
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.providers.reasoning import (
+    reasoning_budget_tokens,
+    reasoning_effort,
+)
+
+_LOW_MEDIUM_HIGH = (
+    ReasoningEffort.LOW,
+    ReasoningEffort.MEDIUM,
+    ReasoningEffort.HIGH,
+)
+_MINIMAL_TO_XHIGH = (
+    ReasoningEffort.MINIMAL,
+    ReasoningEffort.LOW,
+    ReasoningEffort.MEDIUM,
+    ReasoningEffort.HIGH,
+    ReasoningEffort.XHIGH,
+)
+_LOW_TO_MAX = (
+    ReasoningEffort.LOW,
+    ReasoningEffort.MEDIUM,
+    ReasoningEffort.HIGH,
+    ReasoningEffort.MAX,
+)
+_FIREWORKS_V4_EFFORTS = (
+    ReasoningEffort.LOW,
+    ReasoningEffort.MEDIUM,
+    ReasoningEffort.HIGH,
+    ReasoningEffort.XHIGH,
+    ReasoningEffort.MAX,
+)
+
+
+def encode_vercel_reasoning(
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Use Vercel AI Gateway's OpenAI-compatible effort control."""
+    _encode_optional_effort(body, policy, _MINIMAL_TO_XHIGH, disabled="none")
+
+
+def encode_huggingface_reasoning(
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Use Hugging Face Inference Providers' normalized effort control."""
+    _encode_optional_effort(body, policy, _MINIMAL_TO_XHIGH, disabled="none")
+
+
+def encode_cohere_reasoning(
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Map Cohere's binary none/high compatibility contract."""
+    body["reasoning_effort"] = "high" if policy.enabled else "none"
+
+
+def encode_wafer_reasoning(
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Map Wafer's documented thinking toggle."""
+    _extra_body(body)["thinking"] = {
+        "type": "enabled" if policy.enabled else "disabled"
+    }
+
+
+def encode_kimi_reasoning(
+    body: dict[str, Any],
+    request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Disable configurable Kimi thinking while leaving mandatory models alone."""
+    model = request.model.lower()
+    if "kimi-k2.7" in model and "code" in model:
+        return
+    if not policy.enabled:
+        _extra_body(body)["thinking"] = {"type": "disabled"}
+
+
+def encode_minimax_reasoning(
+    body: dict[str, Any],
+    request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Use MiniMax M3 adaptive/disabled control; M2 reasoning is mandatory."""
+    extra = _extra_body(body)
+    extra["reasoning_split"] = True
+    if "minimax-m3" not in request.model.lower():
+        return
+    extra["thinking"] = {"type": "adaptive" if policy.enabled else "disabled"}
+
+
+def encode_cerebras_reasoning(
+    body: dict[str, Any],
+    request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Apply only the model-family controls documented by Cerebras."""
+    model = request.model.lower()
+    if "gpt-oss" in model:
+        if not policy.enabled:
+            return
+        effort = reasoning_effort(
+            policy,
+            _LOW_MEDIUM_HIGH,
+            default=ReasoningEffort.MEDIUM,
+        )
+        assert effort is not None
+        body["reasoning_effort"] = effort.value
+        return
+    if "zai-glm" in model and not policy.enabled:
+        body["reasoning_effort"] = "none"
+        return
+    if "gemma-4" in model:
+        if not policy.enabled:
+            body["reasoning_effort"] = "none"
+            return
+        effort = reasoning_effort(
+            policy,
+            _LOW_MEDIUM_HIGH,
+            default=ReasoningEffort.MEDIUM,
+        )
+        assert effort is not None
+        body["reasoning_effort"] = effort.value
+
+
+def encode_groq_reasoning(
+    body: dict[str, Any],
+    request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Apply Groq's distinct Qwen and GPT-OSS reasoning contracts."""
+    model = request.model.lower()
+    if "gpt-oss" in model:
+        if not policy.enabled:
+            return
+        effort = reasoning_effort(
+            policy,
+            _LOW_MEDIUM_HIGH,
+            default=ReasoningEffort.MEDIUM,
+        )
+        assert effort is not None
+        body["reasoning_effort"] = effort.value
+        return
+    if "qwen" in model and "3" in model:
+        body["reasoning_effort"] = "default" if policy.enabled else "none"
+
+
+def encode_sambanova_reasoning(
+    body: dict[str, Any],
+    request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Use SambaNova's documented model-family thinking toggle."""
+    model = request.model.lower()
+    if not (
+        ("deepseek" in model and _has_version(model, "v3.2", "v3p2"))
+        or "gemma-4" in model
+    ):
+        return
+    chat_template = _nested_dict(_extra_body(body), "chat_template_kwargs")
+    chat_template["enable_thinking"] = policy.enabled
+
+
+def encode_fireworks_reasoning(
+    body: dict[str, Any],
+    request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Apply Fireworks' documented model-specific reasoning validation."""
+    model = request.model.lower()
+    if "gpt-oss" in model or "harmony" in model or "minimax-m2" in model:
+        if not policy.enabled:
+            return
+        effort = reasoning_effort(
+            policy,
+            _LOW_MEDIUM_HIGH,
+            default=ReasoningEffort.MEDIUM,
+        )
+        assert effort is not None
+        body["reasoning_effort"] = effort.value
+        return
+    if "deepseek" in model and "v4" in model:
+        if not policy.enabled:
+            body["reasoning_effort"] = "none"
+            return
+        effort = reasoning_effort(
+            policy,
+            _FIREWORKS_V4_EFFORTS,
+            default=ReasoningEffort.HIGH,
+        )
+        assert effort is not None
+        body["reasoning_effort"] = effort.value
+        return
+    if "qwen3" in model:
+        if not policy.enabled:
+            body["reasoning_effort"] = "none"
+            return
+        if policy.budget_tokens is not None:
+            _extra_body(body)["reasoning_effort"] = policy.budget_tokens
+            return
+        effort = reasoning_effort(policy, _LOW_MEDIUM_HIGH)
+        if effort is not None:
+            body["reasoning_effort"] = effort.value
+        return
+    if "glm-5.2" in model or "glm-5p2" in model:
+        if not policy.enabled:
+            body["reasoning_effort"] = "none"
+            return
+        effort = reasoning_effort(
+            policy,
+            (ReasoningEffort.HIGH, ReasoningEffort.MAX),
+            default=ReasoningEffort.MAX,
+        )
+        assert effort is not None
+        body["reasoning_effort"] = effort.value
+        return
+    if (
+        "deepseek" in model and _has_version(model, "v3.1", "v3p1", "v3.2", "v3p2")
+    ) or ("glm-" in model or "glm_" in model):
+        body["reasoning_effort"] = policy.enabled
+
+
+def encode_zai_reasoning(
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Use Z.ai's thinking object and preserve agent reasoning history."""
+    _extra_body(body)["thinking"] = (
+        {"type": "enabled", "clear_thinking": False}
+        if policy.enabled
+        else {"type": "disabled"}
+    )
+
+
+def encode_ollama_reasoning(
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Map Ollama's none/low/medium/high effort contract."""
+    if not policy.enabled:
+        body["reasoning_effort"] = "none"
+        return
+    effort = reasoning_effort(
+        policy,
+        _LOW_TO_MAX,
+        default=ReasoningEffort.HIGH,
+    )
+    assert effort is not None
+    body["reasoning_effort"] = effort.value
+
+
+def encode_llamacpp_reasoning(
+    body: dict[str, Any],
+    _request: MessagesRequest,
+    policy: ReasoningPolicy,
+) -> None:
+    """Use llama.cpp's per-request numeric thinking budget."""
+    if not policy.enabled:
+        _extra_body(body)["thinking_budget_tokens"] = 0
+        return
+    budget = reasoning_budget_tokens(policy)
+    if budget is not None:
+        _extra_body(body)["thinking_budget_tokens"] = budget
+
+
+def _encode_optional_effort(
+    body: dict[str, Any],
+    policy: ReasoningPolicy,
+    supported: tuple[ReasoningEffort, ...],
+    *,
+    disabled: str,
+) -> None:
+    if not policy.enabled:
+        body["reasoning_effort"] = disabled
+        return
+    effort = reasoning_effort(policy, supported)
+    if effort is not None:
+        body["reasoning_effort"] = effort.value
+
+
+def _extra_body(body: dict[str, Any]) -> dict[str, Any]:
+    extra = body.setdefault("extra_body", {})
+    if not isinstance(extra, dict):
+        raise TypeError("OpenAI extra_body must be an object.")
+    return extra
+
+
+def _nested_dict(container: dict[str, Any], key: str) -> dict[str, Any]:
+    value = container.setdefault(key, {})
+    if not isinstance(value, dict):
+        raise TypeError(f"{key} must be an object.")
+    return value
+
+
+def _has_version(model: str, *versions: str) -> bool:
+    return any(version in model for version in versions)

--- a/src/free_claude_code/providers/openai_chat/request_policy.py
+++ b/src/free_claude_code/providers/openai_chat/request_policy.py
@@ -8,12 +8,15 @@ from typing import Any, Literal
 from loguru import logger
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic import ReasoningReplayMode, build_base_request_body
 from free_claude_code.core.anthropic.conversion import OpenAIConversionError
 from free_claude_code.core.anthropic.models import MessagesRequest
 
 MaxTokensField = Literal["max_tokens", "max_completion_tokens"]
-OpenAIChatPostprocessor = Callable[[dict[str, Any], MessagesRequest, bool], None]
+OpenAIChatPostprocessor = Callable[
+    [dict[str, Any], MessagesRequest, ReasoningPolicy], None
+]
 ExtraBodyValidator = Callable[[dict[str, Any]], None]
 
 
@@ -36,7 +39,7 @@ class OpenAIChatRequestPolicy:
 def build_openai_chat_request_body(
     request_data: MessagesRequest,
     *,
-    thinking_enabled: bool,
+    reasoning: ReasoningPolicy,
     reasoning_history_enabled: bool | None = None,
     policy: OpenAIChatRequestPolicy,
     postprocessors: Iterable[OpenAIChatPostprocessor] = (),
@@ -50,7 +53,7 @@ def build_openai_chat_request_body(
     )
     try:
         if reasoning_history_enabled is None:
-            reasoning_history_enabled = thinking_enabled
+            reasoning_history_enabled = reasoning.enabled
         if not reasoning_history_enabled:
             reasoning_replay = ReasoningReplayMode.DISABLED
         else:
@@ -81,7 +84,7 @@ def build_openai_chat_request_body(
     _apply_common_openai_chat_policy(body, policy)
 
     for postprocess in postprocessors:
-        postprocess(body, request_data, thinking_enabled)
+        postprocess(body, request_data, reasoning)
 
     logger.debug(
         "{}_REQUEST: conversion done model={} msgs={} tools={}",

--- a/src/free_claude_code/providers/reasoning.py
+++ b/src/free_claude_code/providers/reasoning.py
@@ -1,0 +1,68 @@
+"""Shared conversion primitives for provider-owned reasoning encoders."""
+
+from collections.abc import Sequence
+
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
+
+_EFFORT_ORDER = tuple(ReasoningEffort)
+_EFFORT_BUDGET_TOKENS = {
+    ReasoningEffort.MINIMAL: 256,
+    ReasoningEffort.LOW: 1_024,
+    ReasoningEffort.MEDIUM: 2_048,
+    ReasoningEffort.HIGH: 4_096,
+    ReasoningEffort.XHIGH: 8_192,
+    ReasoningEffort.MAX: 16_384,
+}
+
+
+def reasoning_budget_tokens(policy: ReasoningPolicy) -> int | None:
+    """Return an explicit budget or FCC's documented effort-to-budget mapping."""
+    if not policy.enabled:
+        return None
+    if policy.budget_tokens is not None:
+        return policy.budget_tokens
+    if policy.effort is None:
+        return None
+    return _EFFORT_BUDGET_TOKENS[policy.effort]
+
+
+def reasoning_effort(
+    policy: ReasoningPolicy,
+    supported: Sequence[ReasoningEffort],
+    *,
+    default: ReasoningEffort | None = None,
+) -> ReasoningEffort | None:
+    """Return the closest supported effort, preferring the higher tier on ties."""
+    if not policy.enabled:
+        return None
+    requested: ReasoningEffort | None = None
+    if policy.budget_tokens is not None:
+        requested = _effort_for_budget(policy.budget_tokens)
+    elif policy.effort is not None:
+        requested = policy.effort
+    if requested is None:
+        return default
+    return _closest_supported_effort(requested, supported)
+
+
+def _effort_for_budget(budget_tokens: int) -> ReasoningEffort:
+    for effort in _EFFORT_ORDER:
+        if budget_tokens <= _EFFORT_BUDGET_TOKENS[effort]:
+            return effort
+    return ReasoningEffort.MAX
+
+
+def _closest_supported_effort(
+    requested: ReasoningEffort,
+    supported: Sequence[ReasoningEffort],
+) -> ReasoningEffort:
+    if not supported:
+        raise ValueError("At least one supported reasoning effort is required.")
+    target = _EFFORT_ORDER.index(requested)
+    return min(
+        supported,
+        key=lambda effort: (
+            abs(_EFFORT_ORDER.index(effort) - target),
+            -_EFFORT_ORDER.index(effort),
+        ),
+    )

--- a/src/free_claude_code/providers/runtime/config.py
+++ b/src/free_claude_code/providers/runtime/config.py
@@ -61,7 +61,6 @@ def build_provider_config(
         http_read_timeout=settings.http_read_timeout,
         http_write_timeout=settings.http_write_timeout,
         http_connect_timeout=settings.http_connect_timeout,
-        enable_thinking=settings.enable_model_thinking,
         proxy=proxy,
         log_raw_sse_events=settings.log_raw_sse_events,
         log_api_error_tracebacks=settings.log_api_error_tracebacks,

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -177,6 +177,13 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
     assert "CLAUDE_WORKSPACE" not in keys
     assert "CLAUDE_CLI_BIN" not in keys
     assert "LOG_FILE" not in keys
+    thinking_section = next(
+        section for section in body["sections"] if section["id"] == "thinking"
+    )
+    assert thinking_section["description"] == (
+        "Effort levels selected in Claude Code, Codex, or Pi are translated "
+        "automatically; these controls only enable or disable reasoning."
+    )
     auth_field = next(
         field for field in body["fields"] if field["key"] == "ANTHROPIC_AUTH_TOKEN"
     )

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -155,7 +155,7 @@ def test_auto_mode_classifier_without_stream_returns_json(client: TestClient):
     assert body["usage"] == {"input_tokens": 0, "output_tokens": 0}
     routed_request = _stream_response_calls[0][0][0]
     assert routed_request.stream is False
-    assert _stream_response_calls[0][1]["thinking_enabled"] is False
+    assert _stream_response_calls[0][1]["reasoning"].enabled is False
 
 
 def test_create_message_ingress_error_has_request_id_without_terminal_header(
@@ -277,7 +277,7 @@ def test_model_mapping(client: TestClient):
     args = _stream_response_calls[0][0]
     kwargs = _stream_response_calls[0][1]
     assert args[0].model != "claude-3-haiku-20240307"
-    assert kwargs["thinking_enabled"] is True
+    assert kwargs["reasoning"].enabled is True
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_api_handlers.py
+++ b/tests/api/test_api_handlers.py
@@ -12,6 +12,7 @@ from free_claude_code.api.handlers import (
     TokenCountHandler,
 )
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic.models import (
     Message,
@@ -33,7 +34,7 @@ _CLASSIFIER_USER = (
 
 class FakeProvider:
     def __init__(self, events: list[str] | None = None) -> None:
-        self.preflight_calls: list[tuple[MessagesRequest, bool | None]] = []
+        self.preflight_calls: list[tuple[MessagesRequest, ReasoningPolicy]] = []
         self.requests: list[MessagesRequest] = []
         self.stream_kwargs: list[dict[str, Any]] = []
         self.events = events or [
@@ -42,9 +43,12 @@ class FakeProvider:
         ]
 
     def preflight_stream(
-        self, request: MessagesRequest, *, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> None:
-        self.preflight_calls.append((request, thinking_enabled))
+        self.preflight_calls.append((request, reasoning))
 
     async def cleanup(self) -> None:
         return None
@@ -58,14 +62,14 @@ class FakeProvider:
         input_tokens: int = 0,
         *,
         request_id: str | None = None,
-        thinking_enabled: bool | None = None,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]:
         self.requests.append(request)
         self.stream_kwargs.append(
             {
                 "input_tokens": input_tokens,
                 "request_id": request_id,
-                "thinking_enabled": thinking_enabled,
+                "reasoning": reasoning,
             }
         )
         for event in self.events:
@@ -115,7 +119,7 @@ async def test_messages_handler_passes_routed_request_and_stream_metadata() -> N
     assert provider.requests[0].model == "test-model"
     assert provider.stream_kwargs[0]["input_tokens"] > 0
     assert provider.stream_kwargs[0]["request_id"].startswith("req_")
-    assert provider.stream_kwargs[0]["thinking_enabled"] is True
+    assert provider.stream_kwargs[0]["reasoning"].enabled is True
     assert len(provider.preflight_calls) == 1
 
 
@@ -129,7 +133,7 @@ async def test_messages_handler_preflight_invalid_request_stays_http_error(
             self,
             request: MessagesRequest,
             *,
-            thinking_enabled: bool | None = None,
+            reasoning: ReasoningPolicy,
         ) -> None:
             raise InvalidRequestError("bad tool shape")
 
@@ -328,14 +332,14 @@ async def test_messages_handler_stream_false_provider_exception_keeps_status() -
             input_tokens: int = 0,
             *,
             request_id: str | None = None,
-            thinking_enabled: bool | None = None,
+            reasoning: ReasoningPolicy,
         ) -> AsyncIterator[str]:
             self.requests.append(request)
             self.stream_kwargs.append(
                 {
                     "input_tokens": input_tokens,
                     "request_id": request_id,
-                    "thinking_enabled": thinking_enabled,
+                    "reasoning": reasoning,
                 }
             )
             raise ExecutionFailure(
@@ -384,8 +388,8 @@ async def test_messages_handler_forces_no_thinking_for_safety_classifier() -> No
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] is False
-    assert provider.stream_kwargs[0]["thinking_enabled"] is False
+    assert provider.preflight_calls[0][1].enabled is False
+    assert provider.stream_kwargs[0]["reasoning"].enabled is False
     assert provider.requests[0].model == "test-model"
     assert provider.requests[0].system == _CLASSIFIER_SYSTEM
     assert _trace_events(
@@ -426,8 +430,8 @@ async def test_messages_handler_preserves_thinking_for_non_classifier() -> None:
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] is True
-    assert provider.stream_kwargs[0]["thinking_enabled"] is True
+    assert provider.preflight_calls[0][1].enabled is True
+    assert provider.stream_kwargs[0]["reasoning"].enabled is True
     assert (
         _trace_events(
             trace_mock,
@@ -454,8 +458,8 @@ async def test_messages_handler_keeps_existing_no_thinking_for_classifier() -> N
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] is False
-    assert provider.stream_kwargs[0]["thinking_enabled"] is False
+    assert provider.preflight_calls[0][1].enabled is False
+    assert provider.stream_kwargs[0]["reasoning"].enabled is False
     assert _trace_events(
         trace_mock, "free_claude_code.api.optimization.safety_classifier_no_thinking"
     ) == [
@@ -530,8 +534,8 @@ async def test_responses_handler_does_not_apply_safety_classifier_policy() -> No
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] is True
-    assert provider.stream_kwargs[0]["thinking_enabled"] is True
+    assert provider.preflight_calls[0][1].enabled is True
+    assert provider.stream_kwargs[0]["reasoning"].enabled is True
     assert (
         _trace_events(
             trace_mock,

--- a/tests/api/test_openai_responses.py
+++ b/tests/api/test_openai_responses.py
@@ -593,7 +593,7 @@ def test_create_response_quarantines_malformed_prior_function_call() -> None:
     ("reasoning", "expected_type", "expected_enabled"),
     [
         ({"effort": "none"}, "disabled", False),
-        ({"effort": "low"}, "enabled", True),
+        ({"effort": "low"}, "adaptive", True),
     ],
 )
 def test_create_response_maps_reasoning_effort_to_thinking_request(
@@ -621,6 +621,16 @@ def test_create_response_maps_reasoning_effort_to_thinking_request(
     thinking = provider.requests[0].thinking
     assert thinking.type == expected_type
     assert thinking.enabled is expected_enabled
+    expected_effort = reasoning["effort"]
+    if expected_effort == "none":
+        assert provider.requests[0].output_config is None
+    else:
+        assert provider.requests[0].output_config == {"effort": expected_effort}
+    policy = provider.stream_kwargs[0]["reasoning"]
+    assert policy.enabled is expected_enabled
+    assert (policy.effort.value if policy.effort is not None else None) == (
+        None if expected_effort == "none" else expected_effort
+    )
 
 
 def test_create_response_maps_redacted_thinking_to_encrypted_reasoning() -> None:

--- a/tests/api/test_web_server_tools.py
+++ b/tests/api/test_web_server_tools.py
@@ -22,6 +22,7 @@ from free_claude_code.api.web_tools.outbound import (
 from free_claude_code.api.web_tools.request import is_web_server_tool_request
 from free_claude_code.api.web_tools.streaming import stream_web_server_tool_response
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.application.routing import (
     ModelRouter,
     ResolvedModel,
@@ -66,11 +67,15 @@ class FixedProviderModelRouter(ModelRouter):
             provider_id=self._fixed_provider_id,
             provider_model=request.model,
             provider_model_ref=f"{self._fixed_provider_id}/{request.model}",
-            thinking_enabled=False,
+            reasoning_allowed=False,
         )
         routed = request.model_copy(deep=True)
         routed.model = resolved.provider_model
-        return RoutedMessagesRequest(request=routed, resolved=resolved)
+        return RoutedMessagesRequest(
+            request=routed,
+            resolved=resolved,
+            reasoning=ReasoningPolicy.off(),
+        )
 
 
 def test_web_server_tool_not_detected_when_tool_only_listed():

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from free_claude_code.application.execution import ProviderExecutor
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.application.routing import ResolvedModel, RoutedMessagesRequest
 from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.core.async_iterators import AsyncCloseable
@@ -13,7 +14,7 @@ from free_claude_code.core.async_iterators import AsyncCloseable
 
 class FakeProvider:
     def __init__(self) -> None:
-        self.preflight_calls: list[tuple[MessagesRequest, bool]] = []
+        self.preflight_calls: list[tuple[MessagesRequest, ReasoningPolicy]] = []
         self.stream_calls: list[dict[str, object]] = []
         self.stream_close_calls = 0
 
@@ -21,9 +22,9 @@ class FakeProvider:
         self,
         request: MessagesRequest,
         *,
-        thinking_enabled: bool,
+        reasoning: ReasoningPolicy,
     ) -> None:
-        self.preflight_calls.append((request, thinking_enabled))
+        self.preflight_calls.append((request, reasoning))
 
     async def stream_response(
         self,
@@ -31,14 +32,14 @@ class FakeProvider:
         input_tokens: int = 0,
         *,
         request_id: str | None = None,
-        thinking_enabled: bool | None = None,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]:
         self.stream_calls.append(
             {
                 "request": request,
                 "input_tokens": input_tokens,
                 "request_id": request_id,
-                "thinking_enabled": thinking_enabled,
+                "reasoning": reasoning,
             }
         )
         try:
@@ -52,7 +53,7 @@ class FailingPreflightProvider(FakeProvider):
         self,
         request: MessagesRequest,
         *,
-        thinking_enabled: bool,
+        reasoning: ReasoningPolicy,
     ) -> None:
         raise ValueError("invalid provider request")
 
@@ -64,7 +65,7 @@ class FailingStreamConstructionProvider(FakeProvider):
         input_tokens: int = 0,
         *,
         request_id: str | None = None,
-        thinking_enabled: bool | None = None,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]:
         raise RuntimeError("stream construction failed")
 
@@ -81,8 +82,9 @@ def _routed_request() -> RoutedMessagesRequest:
             provider_id="provider",
             provider_model="provider-model",
             provider_model_ref="provider/provider-model",
-            thinking_enabled=True,
+            reasoning_allowed=True,
         ),
+        reasoning=ReasoningPolicy.on(),
     )
 
 
@@ -104,14 +106,14 @@ async def test_executor_uses_structural_provider_port_and_preflights_eagerly() -
         request_id="req_application",
     )
 
-    assert provider.preflight_calls == [(request, True)]
+    assert provider.preflight_calls == [(request, ReasoningPolicy.on())]
     assert [chunk async for chunk in stream] == ["event: message_stop\ndata: {}\n\n"]
     assert provider.stream_calls == [
         {
             "request": request,
             "input_tokens": 17,
             "request_id": "req_application",
-            "thinking_enabled": True,
+            "reasoning": ReasoningPolicy.on(),
         }
     ]
     assert provider.stream_close_calls == 1

--- a/tests/application/test_reasoning.py
+++ b/tests/application/test_reasoning.py
@@ -1,0 +1,96 @@
+import pytest
+
+from free_claude_code.application.reasoning import (
+    ReasoningEffort,
+    ReasoningPolicy,
+    resolve_reasoning_policy,
+)
+from free_claude_code.core.anthropic.models import Message, MessagesRequest
+
+
+def _request(**overrides: object) -> MessagesRequest:
+    data: dict[str, object] = {
+        "model": "provider/model",
+        "messages": [Message(role="user", content="hello")],
+    }
+    data.update(overrides)
+    return MessagesRequest.model_validate(data)
+
+
+@pytest.mark.parametrize(
+    "message_request",
+    [
+        _request(thinking={"type": "disabled"}),
+        _request(thinking={"type": "adaptive", "enabled": False}),
+        _request(output_config={"effort": "none"}),
+    ],
+)
+def test_request_can_disable_reasoning(message_request: MessagesRequest) -> None:
+    assert (
+        resolve_reasoning_policy(message_request, route_enabled=True)
+        == ReasoningPolicy.off()
+    )
+
+
+def test_route_gate_overrides_request_compute_intent() -> None:
+    request = _request(
+        thinking={"type": "enabled", "budget_tokens": 8192},
+        output_config={"effort": "max"},
+    )
+
+    assert (
+        resolve_reasoning_policy(request, route_enabled=False) == ReasoningPolicy.off()
+    )
+
+
+def test_resolver_preserves_explicit_effort_and_budget() -> None:
+    request = _request(
+        thinking={"type": "enabled", "budget_tokens": 4096},
+        output_config={"effort": "xhigh"},
+    )
+
+    assert resolve_reasoning_policy(request, route_enabled=True) == ReasoningPolicy.on(
+        effort=ReasoningEffort.XHIGH,
+        budget_tokens=4096,
+    )
+
+
+@pytest.mark.parametrize(
+    ("output_config", "expected"),
+    [
+        ({"effort": " HIGH "}, ReasoningEffort.HIGH),
+        ({"effort": "ultracode"}, None),
+        ({"effort": 3}, None),
+        (None, None),
+    ],
+)
+def test_resolver_accepts_only_canonical_efforts(
+    output_config: object,
+    expected: ReasoningEffort | None,
+) -> None:
+    policy = resolve_reasoning_policy(
+        _request(output_config=output_config),
+        route_enabled=True,
+    )
+
+    assert policy == ReasoningPolicy.on(effort=expected)
+
+
+def test_resolver_allows_enabled_reasoning_without_a_budget() -> None:
+    policy = resolve_reasoning_policy(
+        _request(thinking={"type": "enabled"}),
+        route_enabled=True,
+    )
+
+    assert policy == ReasoningPolicy.on()
+
+
+def test_disabled_policy_rejects_compute_controls() -> None:
+    with pytest.raises(ValueError, match="Disabled reasoning"):
+        ReasoningPolicy(enabled=False, effort=ReasoningEffort.LOW)
+
+
+@pytest.mark.parametrize("budget", [0, -1, True])
+def test_enabled_policy_rejects_invalid_budgets(budget: int) -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        ReasoningPolicy.on(budget_tokens=budget)

--- a/tests/application/test_routing.py
+++ b/tests/application/test_routing.py
@@ -36,7 +36,7 @@ def test_model_router_resolves_default_model(settings):
     assert resolved.provider_id == "nvidia_nim"
     assert resolved.provider_model == "fallback-model"
     assert resolved.provider_model_ref == "nvidia_nim/fallback-model"
-    assert resolved.thinking_enabled is True
+    assert resolved.reasoning_allowed is True
 
 
 def test_model_router_applies_opus_override(settings):
@@ -52,7 +52,8 @@ def test_model_router_applies_opus_override(settings):
     assert routed.request.model == "deepseek/deepseek-r1"
     assert routed.resolved.provider_model_ref == "open_router/deepseek/deepseek-r1"
     assert routed.resolved.original_model == "claude-opus-4-20250514"
-    assert routed.resolved.thinking_enabled is True
+    assert routed.resolved.reasoning_allowed is True
+    assert routed.reasoning.enabled is True
     assert request.model == "claude-opus-4-20250514"
 
 
@@ -80,11 +81,11 @@ def test_model_router_resolves_per_model_thinking(settings):
 
     router = ModelRouter(settings)
 
-    assert router.resolve("claude-fable-5").thinking_enabled is True
-    assert router.resolve("claude-opus-4-20250514").thinking_enabled is True
-    assert router.resolve("claude-sonnet-4-20250514").thinking_enabled is False
-    assert router.resolve("claude-3-haiku-20240307").thinking_enabled is False
-    assert router.resolve("claude-2.1").thinking_enabled is False
+    assert router.resolve("claude-fable-5").reasoning_allowed is True
+    assert router.resolve("claude-opus-4-20250514").reasoning_allowed is True
+    assert router.resolve("claude-sonnet-4-20250514").reasoning_allowed is False
+    assert router.resolve("claude-3-haiku-20240307").reasoning_allowed is False
+    assert router.resolve("claude-2.1").reasoning_allowed is False
 
 
 def test_model_router_applies_haiku_override(settings):
@@ -205,7 +206,8 @@ def test_model_router_routes_no_thinking_gateway_model_directly(settings):
     )
     assert routed.resolved.provider_id == "nvidia_nim"
     assert routed.resolved.provider_model == "deepseek-ai/deepseek-v4-pro"
-    assert routed.resolved.thinking_enabled is False
+    assert routed.resolved.reasoning_allowed is False
+    assert routed.reasoning.enabled is False
 
 
 def test_model_router_direct_prefixed_model_uses_provider_model_for_thinking(settings):
@@ -216,7 +218,7 @@ def test_model_router_direct_prefixed_model_uses_provider_model_for_thinking(set
 
     assert resolved.provider_id == "open_router"
     assert resolved.provider_model == "anthropic/claude-opus-4"
-    assert resolved.thinking_enabled is True
+    assert resolved.reasoning_allowed is True
 
 
 def test_model_router_routes_token_count_request(settings):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -409,7 +409,7 @@ class TestSettings:
         settings = Settings()
         assert settings.enable_opus_thinking is None
         assert (
-            ModelRouter(settings).resolve("claude-opus-4-20250514").thinking_enabled
+            ModelRouter(settings).resolve("claude-opus-4-20250514").reasoning_allowed
             is False
         )
 
@@ -424,11 +424,11 @@ class TestSettings:
         monkeypatch.setenv("ENABLE_HAIKU_THINKING", "false")
         settings = Settings()
         router = ModelRouter(settings)
-        assert router.resolve("claude-fable-5").thinking_enabled is True
-        assert router.resolve("claude-opus-4-20250514").thinking_enabled is True
-        assert router.resolve("claude-sonnet-4-20250514").thinking_enabled is False
-        assert router.resolve("claude-haiku-4-20250514").thinking_enabled is False
-        assert router.resolve("unknown-model").thinking_enabled is False
+        assert router.resolve("claude-fable-5").reasoning_allowed is True
+        assert router.resolve("claude-opus-4-20250514").reasoning_allowed is True
+        assert router.resolve("claude-sonnet-4-20250514").reasoning_allowed is False
+        assert router.resolve("claude-haiku-4-20250514").reasoning_allowed is False
+        assert router.resolve("unknown-model").reasoning_allowed is False
 
     def test_anthropic_auth_token_from_env_without_dotenv_key(self, monkeypatch):
         """ANTHROPIC_AUTH_TOKEN env var is loaded when dotenv does not define it."""

--- a/tests/core/anthropic/test_models.py
+++ b/tests/core/anthropic/test_models.py
@@ -199,6 +199,23 @@ def test_messages_request_preserves_native_thinking_budget():
     assert dumped["thinking"]["budget_tokens"] == 4096
 
 
+@pytest.mark.parametrize("budget_tokens", [0, -1, True, "4096"])
+def test_messages_request_rejects_invalid_thinking_budget(
+    budget_tokens: object,
+) -> None:
+    with pytest.raises(ValidationError):
+        MessagesRequest.model_validate(
+            {
+                "model": "claude-3-opus",
+                "messages": [{"role": "user", "content": "think"}],
+                "thinking": {
+                    "type": "enabled",
+                    "budget_tokens": budget_tokens,
+                },
+            }
+        )
+
+
 def test_messages_request_accepts_adaptive_thinking_type():
     request = MessagesRequest.model_validate(
         {

--- a/tests/providers/support.py
+++ b/tests/providers/support.py
@@ -3,12 +3,20 @@
 from collections.abc import Callable
 from typing import Any
 
+from free_claude_code.application.reasoning import (
+    ReasoningPolicy,
+    resolve_reasoning_policy,
+)
+from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import (
     OpenAIChatProvider,
     create_openai_chat_provider,
 )
 from free_claude_code.providers.rate_limit import ProviderRateLimiter
+
+REASONING_ON = ReasoningPolicy.on()
+REASONING_OFF = ReasoningPolicy.off()
 
 
 class PassthroughProviderRateLimiter(ProviderRateLimiter):
@@ -74,3 +82,12 @@ def retrying_rate_limiter() -> ProviderRateLimiter:
         rate_window=1.0,
         max_concurrency=1_000,
     )
+
+
+def reasoning_for(
+    request: MessagesRequest,
+    *,
+    route_enabled: bool = True,
+) -> ReasoningPolicy:
+    """Resolve provider-test reasoning through the production boundary function."""
+    return resolve_reasoning_policy(request, route_enabled=route_enabled)

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -7,7 +7,11 @@ import pytest
 from free_claude_code.config.provider_catalog import CEREBRAS_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def make_request(**overrides):
@@ -21,7 +25,6 @@ def cerebras_config():
         base_url=CEREBRAS_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -52,7 +55,7 @@ def test_default_base_url_constant():
 def test_build_request_body_basic(cerebras_provider):
     """Basic request body conversion attaches system message from Claude request."""
     req = make_request()
-    body = cerebras_provider._build_request_body(req)
+    body = cerebras_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["model"] == "llama3.1-8b"
     assert body["messages"][0]["role"] == "system"
@@ -67,12 +70,11 @@ def test_build_request_body_global_disable_blocks_reasoning_mapping():
             base_url=CEREBRAS_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
     req = make_request()
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=REASONING_ON)
 
     roles = [m.get("role") for m in body.get("messages", [])]
     assert "assistant_reasoning_content" not in roles
@@ -89,7 +91,7 @@ def test_build_request_body_remaps_max_tokens_preserves_message_name(cerebras_pr
             "max_tokens": 42,
         }
         req = make_request()
-        body = cerebras_provider._build_request_body(req)
+        body = cerebras_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["messages"][0].get("name") == "alice"
     assert body.get("max_tokens") is None
@@ -106,7 +108,9 @@ def test_build_request_body_prefers_existing_max_completion_tokens(cerebras_prov
             "max_completion_tokens": 77,
             "max_tokens": 999,
         }
-        body = cerebras_provider._build_request_body(make_request())
+        body = cerebras_provider._build_request_body(
+            make_request(), reasoning=REASONING_ON
+        )
 
     assert body["max_completion_tokens"] == 77
     assert "max_tokens" not in body
@@ -115,7 +119,7 @@ def test_build_request_body_prefers_existing_max_completion_tokens(cerebras_prov
 def test_build_request_body_preserves_caller_extra_body(cerebras_provider):
     req = make_request(extra_body={"clear_thinking": False})
 
-    body = cerebras_provider._build_request_body(req)
+    body = cerebras_provider._build_request_body(req, reasoning=REASONING_ON)
 
     eb = body.get("extra_body")
     assert isinstance(eb, dict)
@@ -148,7 +152,12 @@ async def test_stream_response_text(cerebras_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in cerebras_provider.stream_response(req)]
+        events = [
+            event
+            async for event in cerebras_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"text_delta"' in event and "Hello back!" in event for event in events
@@ -181,7 +190,12 @@ async def test_stream_response_reasoning_content(cerebras_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in cerebras_provider.stream_response(req)]
+        events = [
+            event
+            async for event in cerebras_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"thinking_delta"' in event and "Thinking..." in event for event in events

--- a/tests/providers/test_cloudflare.py
+++ b/tests/providers/test_cloudflare.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from free_claude_code.application.errors import ApplicationUnavailableError
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.config.provider_catalog import CLOUDFLARE_AI_REST_ROOT
 from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
@@ -16,7 +17,11 @@ from free_claude_code.providers.cloudflare import (
     CloudflareProvider,
     cloudflare_ai_base_url,
 )
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+)
 
 _ACCOUNT_ID = "account-123"
 _BASE_URL = f"{CLOUDFLARE_AI_REST_ROOT}/accounts/{_ACCOUNT_ID}/ai/v1"
@@ -30,7 +35,6 @@ def cloudflare_config() -> ProviderConfig:
         base_url=CLOUDFLARE_AI_REST_ROOT,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -122,7 +126,7 @@ def test_build_request_body_preserves_literal_cf_model_id_and_controls_thinking(
         }
     )
 
-    body = cloudflare_provider._build_request_body(request, thinking_enabled=True)
+    body = cloudflare_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["model"] == "@cf/moonshotai/kimi-k2.6"
     assert body["max_completion_tokens"] == 100
@@ -141,12 +145,36 @@ def test_build_request_body_disabled_thinking_sets_cloudflare_template_flag(
         }
     )
 
-    body = cloudflare_provider._build_request_body(request, thinking_enabled=True)
+    body = cloudflare_provider._build_request_body(request, reasoning=REASONING_OFF)
 
     assert body["extra_body"]["chat_template_kwargs"]["thinking"] is False
 
 
-def test_build_request_body_preserves_user_extra_body_without_overriding_thinking(
+def test_build_request_body_sends_explicit_cloudflare_effort(
+    cloudflare_provider: CloudflareProvider,
+) -> None:
+    body = cloudflare_provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.LOW),
+    )
+
+    assert body["reasoning_effort"] == "low"
+    assert body["extra_body"]["chat_template_kwargs"]["thinking"] is True
+
+
+def test_build_request_body_does_not_invent_cloudflare_budget_mapping(
+    cloudflare_provider: CloudflareProvider,
+) -> None:
+    body = cloudflare_provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(budget_tokens=2048),
+    )
+
+    assert "reasoning_effort" not in body
+    assert body["extra_body"]["chat_template_kwargs"]["thinking"] is True
+
+
+def test_build_request_body_canonical_policy_overrides_user_thinking_extra(
     cloudflare_provider: CloudflareProvider,
 ) -> None:
     request = MessagesRequest.model_validate(
@@ -157,9 +185,9 @@ def test_build_request_body_preserves_user_extra_body_without_overriding_thinkin
         }
     )
 
-    body = cloudflare_provider._build_request_body(request, thinking_enabled=True)
+    body = cloudflare_provider._build_request_body(request, reasoning=REASONING_ON)
 
-    assert body["extra_body"]["chat_template_kwargs"]["thinking"] is False
+    assert body["extra_body"]["chat_template_kwargs"]["thinking"] is True
 
 
 @pytest.mark.asyncio
@@ -215,7 +243,10 @@ async def test_stream_uses_openai_chat_completions(
         return_value=_stream(_chunk(delta)),
     ) as mock_create:
         events = [
-            event async for event in cloudflare_provider.stream_response(_request())
+            event
+            async for event in cloudflare_provider.stream_response(
+                _request(), reasoning=REASONING_ON
+            )
         ]
 
     parsed = parse_sse_text("".join(events))
@@ -246,7 +277,10 @@ async def test_stream_maps_cloudflare_reasoning_delta_to_thinking(
         return_value=_stream(_chunk(delta)),
     ):
         events = [
-            event async for event in cloudflare_provider.stream_response(_request())
+            event
+            async for event in cloudflare_provider.stream_response(
+                _request(), reasoning=REASONING_ON
+            )
         ]
 
     parsed = parse_sse_text("".join(events))
@@ -296,7 +330,12 @@ async def test_stream_maps_openai_tool_calls_to_tool_use(
         new_callable=AsyncMock,
         return_value=_stream(_chunk(delta, finish_reason="tool_calls")),
     ):
-        events = [event async for event in cloudflare_provider.stream_response(request)]
+        events = [
+            event
+            async for event in cloudflare_provider.stream_response(
+                request, reasoning=REASONING_ON
+            )
+        ]
 
     parsed = parse_sse_text("".join(events))
     assert any(

--- a/tests/providers/test_codestral.py
+++ b/tests/providers/test_codestral.py
@@ -7,7 +7,11 @@ import pytest
 from free_claude_code.config.provider_catalog import CODESTRAL_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def make_request(**overrides):
@@ -21,7 +25,6 @@ def codestral_config():
         base_url=CODESTRAL_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -54,7 +57,7 @@ def test_default_base_url():
 def test_build_request_body_basic(codestral_provider):
     """Basic request body conversion works for Codestral."""
     req = make_request()
-    body = codestral_provider._build_request_body(req)
+    body = codestral_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["model"] == "devstral-small-latest"
     assert body["messages"][0]["role"] == "system"
@@ -69,12 +72,11 @@ def test_build_request_body_global_disable_blocks_reasoning_mapping():
             base_url=CODESTRAL_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
     req = make_request()
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=REASONING_ON)
 
     roles = [m.get("role") for m in body.get("messages", [])]
     assert "assistant_reasoning_content" not in roles
@@ -106,7 +108,12 @@ async def test_stream_response_text(codestral_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in codestral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in codestral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"text_delta"' in event and "Hello back!" in event for event in events
@@ -139,7 +146,12 @@ async def test_stream_response_reasoning_content(codestral_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in codestral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in codestral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"thinking_delta"' in event and "Thinking..." in event for event in events

--- a/tests/providers/test_cohere.py
+++ b/tests/providers/test_cohere.py
@@ -9,7 +9,12 @@ from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.config.provider_catalog import COHERE_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def make_request(**overrides):
@@ -23,7 +28,6 @@ def cohere_config():
         base_url=COHERE_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -82,7 +86,9 @@ def test_build_request_body_sanitizes_documented_unsupported_fields(cohere_provi
             "parallel_tool_calls": True,
         }
 
-        body = cohere_provider._build_request_body(make_request())
+        body = cohere_provider._build_request_body(
+            make_request(), reasoning=REASONING_ON
+        )
 
     assert body["messages"][0].get("name") is None
     assert body["max_tokens"] == 42
@@ -103,7 +109,7 @@ def test_build_request_body_sanitizes_documented_unsupported_fields(cohere_provi
 
 
 def test_build_request_body_maps_thinking_enabled_to_reasoning_high(cohere_provider):
-    body = cohere_provider._build_request_body(make_request())
+    body = cohere_provider._build_request_body(make_request(), reasoning=REASONING_ON)
 
     assert body["reasoning_effort"] == "high"
 
@@ -123,7 +129,9 @@ def test_build_request_body_preserves_replayed_reasoning_content(cohere_provider
             ],
         }
 
-        body = cohere_provider._build_request_body(make_request())
+        body = cohere_provider._build_request_body(
+            make_request(), reasoning=REASONING_ON
+        )
 
     assert body["messages"] == [
         {
@@ -143,12 +151,11 @@ def test_build_request_body_maps_thinking_disabled_to_reasoning_none():
             base_url=COHERE_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
 
-    body = provider._build_request_body(make_request())
+    body = provider._build_request_body(make_request(), reasoning=REASONING_OFF)
 
     assert body["reasoning_effort"] == "none"
 
@@ -163,7 +170,7 @@ def test_build_request_body_promotes_allowed_extra_body(cohere_provider):
         }
     )
 
-    body = cohere_provider._build_request_body(req)
+    body = cohere_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["frequency_penalty"] == 0.1
     assert body["presence_penalty"] == 0.2
@@ -176,7 +183,7 @@ def test_build_request_body_rejects_unsupported_extra_body(cohere_provider):
     req = make_request(extra_body={"documents": [{"text": "x"}]})
 
     with pytest.raises(InvalidRequestError, match="Unsupported"):
-        cohere_provider._build_request_body(req)
+        cohere_provider._build_request_body(req, reasoning=REASONING_ON)
 
 
 @pytest.mark.asyncio
@@ -203,7 +210,10 @@ async def test_stream_response_text(cohere_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in cohere_provider.stream_response(make_request())
+            event
+            async for event in cohere_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(
@@ -238,7 +248,10 @@ async def test_stream_response_tool_call(cohere_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in cohere_provider.stream_response(make_request())
+            event
+            async for event in cohere_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(
@@ -273,7 +286,10 @@ async def test_stream_response_reasoning_content(cohere_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in cohere_provider.stream_response(make_request())
+            event
+            async for event in cohere_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -10,6 +10,7 @@ import pytest
 from openai import AsyncOpenAI
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 from free_claude_code.config.provider_catalog import DEEPSEEK_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import (
@@ -21,7 +22,11 @@ from free_claude_code.core.anthropic.models import (
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.deepseek import DeepSeekProvider
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+)
 
 
 @pytest.fixture
@@ -31,7 +36,6 @@ def deepseek_config():
         base_url=DEEPSEEK_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -93,7 +97,7 @@ def test_build_request_body_openai_chat_shape(deepseek_provider):
         messages=[Message(role="user", content="Hello")],
         system="S",
     )
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
     assert body["model"] == "deepseek-v4-pro"
     assert "stream" not in body
     assert body["messages"][0] == {"role": "system", "content": "S"}
@@ -108,7 +112,7 @@ def test_build_request_body_default_max_tokens(deepseek_provider):
         model="m",
         messages=[Message(role="user", content="x")],
     )
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
     assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 
 
@@ -120,8 +124,25 @@ def test_build_request_body_thinking_enabled(deepseek_provider):
             "thinking": {"type": "enabled", "budget_tokens": 2000},
         }
     )
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+def test_reasoner_alias_omits_toggle_but_preserves_supported_effort(
+    deepseek_provider,
+):
+    request = MessagesRequest(
+        model="deepseek-reasoner",
+        messages=[Message(role="user", content="x")],
+    )
+
+    body = deepseek_provider._build_request_body(
+        request,
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.XHIGH),
+    )
+
+    assert "extra_body" not in body
+    assert body["reasoning_effort"] == "max"
 
 
 def test_build_request_body_tool_list_keeps_thinking(deepseek_provider):
@@ -140,7 +161,7 @@ def test_build_request_body_tool_list_keeps_thinking(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
     assert body["tools"][0]["function"]["name"] == "Read"
@@ -156,7 +177,7 @@ def test_build_request_body_tool_choice_keeps_thinking(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
     assert body["tool_choice"] == "auto"
@@ -181,7 +202,7 @@ def test_build_request_body_forced_tool_choice_downgrades_to_auto(
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
     assert body["tool_choice"] == "auto"
@@ -194,7 +215,6 @@ def test_build_request_body_respects_global_thinking_disable():
             base_url=DEEPSEEK_DEFAULT_BASE,
             rate_limit=1,
             rate_window=1,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -205,8 +225,8 @@ def test_build_request_body_respects_global_thinking_disable():
             "thinking": {"type": "enabled", "budget_tokens": 1},
         }
     )
-    body = provider._build_request_body(request)
-    assert "extra_body" not in body
+    body = provider._build_request_body(request, reasoning=REASONING_OFF)
+    assert body["extra_body"]["thinking"] == {"type": "disabled"}
     assert "stream_options" not in body
 
 
@@ -229,7 +249,7 @@ def test_non_tool_thinking_is_omitted_from_first_replay(deepseek_provider):
             ],
         }
     )
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
     assert body["messages"][0] == {"role": "assistant", "content": "out"}
 
 
@@ -248,7 +268,7 @@ def test_strip_redacted_thinking_when_thinking_on(deepseek_provider):
             ],
         }
     )
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
     assert body["messages"][0] == {"role": "assistant", "content": "out"}
 
 
@@ -293,7 +313,7 @@ def test_tool_history_with_replayable_thinking_preserves_thinking(deepseek_provi
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
     assert "context_management" not in body
@@ -342,7 +362,7 @@ def test_tool_history_with_unsigned_thinking_preserves_thinking(deepseek_provide
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
     assert body["messages"][0]["reasoning_content"] == "plain"
@@ -395,9 +415,9 @@ def test_tool_history_without_thinking_disables_thinking_and_hints(deepseek_prov
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
-    assert "extra_body" not in body
+    assert body["extra_body"]["thinking"] == {"type": "disabled"}
     assert "context_management" not in body
     assert "output_config" not in body
     assert body["tools"][0]["function"]["name"] == "Read"
@@ -438,7 +458,7 @@ def test_tool_history_with_empty_thinking_preserves_reasoning_state(deepseek_pro
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
     assert body["messages"][0]["reasoning_content"] == ""
@@ -479,7 +499,7 @@ def test_tool_history_with_empty_top_level_reasoning_preserves_reasoning_state(
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"]["thinking"] == {"type": "enabled"}
     assert body["messages"][0]["reasoning_content"] == ""
@@ -493,7 +513,6 @@ def test_thinking_off_strips_thinking_history():
             base_url=DEEPSEEK_DEFAULT_BASE,
             rate_limit=1,
             rate_window=1,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -511,7 +530,7 @@ def test_thinking_off_strips_thinking_history():
             ],
         }
     )
-    body = provider._build_request_body(request)
+    body = provider._build_request_body(request, reasoning=REASONING_OFF)
     assert "reasoning_content" not in body["messages"][0]
     assert "sec" not in str(body["messages"])
 
@@ -523,7 +542,6 @@ def test_thinking_off_still_replays_required_tool_reasoning():
             base_url=DEEPSEEK_DEFAULT_BASE,
             rate_limit=1,
             rate_window=1,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -557,9 +575,9 @@ def test_thinking_off_still_replays_required_tool_reasoning():
         }
     )
 
-    body = provider._build_request_body(request)
+    body = provider._build_request_body(request, reasoning=REASONING_OFF)
 
-    assert "extra_body" not in body
+    assert body["extra_body"]["thinking"] == {"type": "disabled"}
     assert body["messages"][0]["reasoning_content"] == "required"
 
 
@@ -592,7 +610,7 @@ def test_passthrough_tool_use_and_result(deepseek_provider):
             ],
         }
     )
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
     assert body["messages"][0]["tool_calls"][0]["function"]["name"] == "n"
     assert body["messages"][1]["role"] == "tool"
 
@@ -627,8 +645,8 @@ def test_preflight_strips_user_image():
         rate_limiter=passthrough_rate_limiter(),
     )
     # Should not raise; image is stripped.
-    provider.preflight_stream(request, thinking_enabled=True)
-    body = provider._build_request_body(request)
+    provider.preflight_stream(request, reasoning=REASONING_ON)
+    body = provider._build_request_body(request, reasoning=REASONING_ON)
     content = body["messages"][0]["content"]
     assert "attachment omitted" in content.lower()
     assert "image or document inputs" in content.lower()
@@ -650,7 +668,7 @@ def test_preflight_rejects_mcp_servers():
         rate_limiter=passthrough_rate_limiter(),
     )
     with pytest.raises(InvalidRequestError, match="mcp_servers"):
-        provider.preflight_stream(request)
+        provider.preflight_stream(request, reasoning=REASONING_ON)
 
 
 def test_preflight_rejects_listed_server_tools_in_tools_list():
@@ -669,7 +687,7 @@ def test_preflight_rejects_listed_server_tools_in_tools_list():
         rate_limiter=passthrough_rate_limiter(),
     )
     with pytest.raises(InvalidRequestError, match="web_search"):
-        provider.preflight_stream(request)
+        provider.preflight_stream(request, reasoning=REASONING_ON)
 
 
 def test_preflight_rejects_server_tool_result_blocks():
@@ -706,7 +724,7 @@ def test_preflight_rejects_server_tool_result_blocks():
         rate_limiter=passthrough_rate_limiter(),
     )
     with pytest.raises(InvalidRequestError, match=r"web_search_tool_result|server"):
-        provider.preflight_stream(request)
+        provider.preflight_stream(request, reasoning=REASONING_ON)
 
 
 def test_non_tool_top_level_reasoning_is_not_replayed(deepseek_provider):
@@ -720,7 +738,7 @@ def test_non_tool_top_level_reasoning_is_not_replayed(deepseek_provider):
             )
         ],
     )
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
     assert body["messages"][0] == {"role": "assistant", "content": "hi"}
 
 
@@ -755,7 +773,7 @@ def test_tool_call_top_level_reasoning_is_replayed(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["messages"][0]["reasoning_content"] == "required"
 
@@ -831,7 +849,7 @@ async def test_wire_messages_keep_prefix_across_tool_thinking_fallback(
                 "thinking": {"type": "enabled"},
             }
         )
-        return deepseek_provider._build_request_body(request)
+        return deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     first_wire = await _capture_openai_wire_body(build(prefix_messages))
     continued_wire = await _capture_openai_wire_body(build(continued_messages))
@@ -845,7 +863,7 @@ async def test_wire_messages_keep_prefix_across_tool_thinking_fallback(
     assert "reasoning_content" not in assistant_messages[0]
     assert assistant_messages[1]["reasoning_content"] == "required tool reasoning"
     assert first_wire["thinking"] == {"type": "enabled"}
-    assert "thinking" not in continued_wire
+    assert continued_wire["thinking"] == {"type": "disabled"}
 
 
 @pytest.mark.asyncio
@@ -893,7 +911,7 @@ async def test_stream_uses_chat_completions_and_maps_cache_usage(deepseek_provid
         chunks = [
             chunk
             async for chunk in deepseek_provider.stream_response(
-                request, input_tokens=7, request_id="r1"
+                request, input_tokens=7, request_id="r1", reasoning=REASONING_ON
             )
         ]
 
@@ -923,7 +941,7 @@ def test_preserves_extra_body_for_openai_chat_request(deepseek_provider):
         "extra_body": {"note": 1},
     }
     r = MessagesRequest.model_validate(raw)
-    body = deepseek_provider._build_request_body(r)
+    body = deepseek_provider._build_request_body(r, reasoning=REASONING_ON)
     assert body["extra_body"] == {"note": 1, "thinking": {"type": "enabled"}}
 
 
@@ -961,7 +979,7 @@ def test_normalizes_tool_result_content_array_to_string(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     tool_result = body["messages"][1]
     assert tool_result["role"] == "tool"
@@ -995,7 +1013,7 @@ def test_strips_document_blocks_for_deepseek(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["messages"][0] == {
         "role": "tool",
@@ -1028,7 +1046,7 @@ def test_strips_image_blocks_for_deepseek(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["messages"][0] == {"role": "user", "content": "describe this"}
 
@@ -1064,7 +1082,7 @@ def test_normalizes_tool_result_content_dict_to_string(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     tool_result = body["messages"][1]
     assert tool_result["role"] == "tool"
@@ -1114,7 +1132,7 @@ def test_strips_image_block_inside_tool_result(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     tool_result = body["messages"][1]
     assert tool_result["role"] == "tool"
@@ -1165,7 +1183,7 @@ def test_image_only_tool_result_replaced_with_placeholder(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     tool_result = body["messages"][1]
     assert tool_result["role"] == "tool"
@@ -1216,7 +1234,7 @@ def test_document_only_tool_result_replaced_with_generic_placeholder(
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     tool_result = body["messages"][1]
     assert tool_result["role"] == "tool"
@@ -1249,7 +1267,7 @@ def test_image_only_message_replaced_with_placeholder(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     content = body["messages"][0]["content"]
     assert "attachment omitted" in content.lower()
@@ -1275,7 +1293,7 @@ def test_document_only_message_replaced_with_placeholder(deepseek_provider):
         }
     )
 
-    body = deepseek_provider._build_request_body(request)
+    body = deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     content = body["messages"][0]["content"]
     assert "attachment omitted" in content.lower()
@@ -1337,7 +1355,7 @@ def test_warns_when_stripping_attachment_blocks(deepseek_provider, caplog):
     )
 
     with caplog.at_level(logging.WARNING):
-        deepseek_provider._build_request_body(request)
+        deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert any("stripped unsupported attachment blocks" in r.message for r in warnings)
@@ -1353,7 +1371,7 @@ def test_no_warning_when_no_attachments(deepseek_provider, caplog):
     )
 
     with caplog.at_level(logging.WARNING):
-        deepseek_provider._build_request_body(request)
+        deepseek_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert not any(
         "stripped unsupported attachment blocks" in r.message

--- a/tests/providers/test_execution_failure_boundary.py
+++ b/tests/providers/test_execution_failure_boundary.py
@@ -14,7 +14,7 @@ from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.http import close_provider_stream
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import REASONING_ON, passthrough_rate_limiter
 
 
 class _FailingStream:
@@ -94,6 +94,7 @@ async def test_committed_provider_failure_closes_block_then_raises_canonical_val
         async for event in provider.stream_response(
             request,
             request_id="req_committed_failure",
+            reasoning=REASONING_ON,
         ):
             emitted.append(event)
 
@@ -136,6 +137,7 @@ async def test_openai_stream_close_failure_cannot_mask_execution_failure() -> No
             async for event in provider.stream_response(
                 request,
                 request_id="req_close_failure",
+                reasoning=REASONING_ON,
             )
         ]
 
@@ -214,6 +216,7 @@ async def test_completed_stream_close_failure_preserves_success_lifecycle() -> N
             async for event in provider.stream_response(
                 request,
                 request_id="req_successful_close_failure",
+                reasoning=REASONING_ON,
             )
         ]
 
@@ -256,7 +259,9 @@ async def test_closing_public_openai_stream_closes_raw_stream_once() -> None:
         new_callable=AsyncMock,
         return_value=raw_stream,
     ):
-        stream = provider.stream_response(request, request_id="req_early_close")
+        stream = provider.stream_response(
+            request, request_id="req_early_close", reasoning=REASONING_ON
+        )
         await anext(stream)
         assert isinstance(stream, AsyncCloseable)
         await stream.aclose()

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -10,7 +10,12 @@ from free_claude_code.config.provider_catalog import FIREWORKS_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 @pytest.fixture
@@ -22,7 +27,6 @@ def fireworks_provider():
             base_url=FIREWORKS_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=True,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -46,7 +50,7 @@ def test_build_request_body_openai_chat_shape(fireworks_provider):
         system="System prompt",
     )
 
-    body = fireworks_provider._build_request_body(request)
+    body = fireworks_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["model"] == "accounts/fireworks/models/glm-5p1"
     assert body["max_tokens"] == 100
@@ -62,7 +66,7 @@ def test_build_request_body_default_max_tokens(fireworks_provider):
         messages=[Message(role="user", content="x")],
     )
 
-    body = fireworks_provider._build_request_body(request)
+    body = fireworks_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 
@@ -75,7 +79,6 @@ def test_build_request_body_global_disable_blocks_thinking():
             base_url=FIREWORKS_DEFAULT_BASE,
             rate_limit=1,
             rate_window=1,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -91,7 +94,7 @@ def test_build_request_body_global_disable_blocks_thinking():
         }
     )
 
-    body = provider._build_request_body(request)
+    body = provider._build_request_body(request, reasoning=REASONING_OFF)
 
     assert "reasoning_content" not in body["messages"][0]
 
@@ -105,7 +108,7 @@ def test_build_request_body_preserves_validated_extra_body(fireworks_provider):
         }
     )
 
-    body = fireworks_provider._build_request_body(request)
+    body = fireworks_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["extra_body"] == {"custom_param": "value"}
 
@@ -120,7 +123,7 @@ def test_build_request_body_rejects_reserved_extra_body_keys(fireworks_provider)
     )
 
     with pytest.raises(InvalidRequestError, match="extra_body must not override"):
-        fireworks_provider._build_request_body(request)
+        fireworks_provider._build_request_body(request, reasoning=REASONING_ON)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_gemini.py
+++ b/tests/providers/test_gemini.py
@@ -11,11 +11,16 @@ from free_claude_code.providers.gemini.quirks import (
     GEMINI_SKIP_THOUGHT_SIGNATURE_VALIDATOR,
 )
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+)
 
 
 def make_request(**overrides):
-    return make_messages_request("models/gemini-3.1-flash-lite", **overrides)
+    model = overrides.pop("model", "models/gemini-3.1-flash-lite")
+    return make_messages_request(model, **overrides)
 
 
 def _simulate_openai_sdk_wire_json(body: dict) -> dict:
@@ -33,7 +38,6 @@ def gemini_config():
         base_url=GEMINI_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -67,7 +71,7 @@ def test_default_base_url_constant():
 def test_build_request_body_basic(gemini_provider):
     """Basic body conversion attaches Gemini thinking fields when thinking is on."""
     req = make_request()
-    body = gemini_provider._build_request_body(req)
+    body = gemini_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["model"] == "models/gemini-3.1-flash-lite"
     assert body["messages"][0]["role"] == "system"
@@ -88,7 +92,7 @@ def test_build_request_body_sdk_wire_json_has_literal_extra_body(gemini_provider
     """Regression for issue #542: SDK merge must not send top-level google."""
     req = make_request()
 
-    body = gemini_provider._build_request_body(req)
+    body = gemini_provider._build_request_body(req, reasoning=REASONING_ON)
     wire_json = _simulate_openai_sdk_wire_json(body)
 
     assert "reasoning_effort" not in wire_json
@@ -110,12 +114,11 @@ def test_build_request_body_global_disable_sets_reasoning_none():
             base_url=GEMINI_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
-    req = make_request()
-    body = provider._build_request_body(req)
+    req = make_request(model="models/gemini-2.5-flash")
+    body = provider._build_request_body(req, reasoning=REASONING_OFF)
 
     assert body["reasoning_effort"] == "none"
     roles = [m.get("role") for m in body.get("messages", [])]
@@ -125,7 +128,7 @@ def test_build_request_body_global_disable_sets_reasoning_none():
 def test_build_request_body_preserves_caller_extra_body(gemini_provider):
     req = make_request(extra_body={"metadata": {"user": "u1"}})
 
-    body = gemini_provider._build_request_body(req)
+    body = gemini_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert "reasoning_effort" not in body
     eb = body.get("extra_body")
@@ -150,7 +153,7 @@ def test_build_request_body_merges_caller_nested_google(gemini_provider):
         }
     )
 
-    body = gemini_provider._build_request_body(req)
+    body = gemini_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert "reasoning_effort" not in body
     eb = body.get("extra_body")
@@ -199,7 +202,7 @@ def test_build_request_body_preserves_tool_call_extra_content(gemini_provider):
         ],
     )
 
-    body = gemini_provider._build_request_body(req)
+    body = gemini_provider._build_request_body(req, reasoning=REASONING_ON)
 
     tool_call = body["messages"][1]["tool_calls"][0]
     assert tool_call["extra_content"] == {
@@ -239,7 +242,7 @@ def test_build_request_body_uses_cached_tool_call_signature(gemini_provider):
         ],
     )
 
-    body = gemini_provider._build_request_body(req)
+    body = gemini_provider._build_request_body(req, reasoning=REASONING_ON)
 
     tool_call = body["messages"][1]["tool_calls"][0]
     assert tool_call["extra_content"] == {
@@ -289,7 +292,7 @@ def test_build_request_body_adds_gemini3_current_turn_fallback_signature(
         ],
     )
 
-    body = gemini_provider._build_request_body(req)
+    body = gemini_provider._build_request_body(req, reasoning=REASONING_ON)
 
     tool_calls = body["messages"][1]["tool_calls"]
     assert tool_calls[0]["extra_content"] == {
@@ -323,7 +326,12 @@ async def test_stream_response_text(gemini_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in gemini_provider.stream_response(req)]
+        events = [
+            event
+            async for event in gemini_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"text_delta"' in event and "Hello back!" in event for event in events
@@ -374,7 +382,12 @@ async def test_stream_response_preserves_tool_call_extra_content(gemini_provider
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in gemini_provider.stream_response(req)]
+        events = [
+            event
+            async for event in gemini_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
     tool_starts = [
         event
@@ -414,7 +427,12 @@ async def test_stream_response_reasoning_content(gemini_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in gemini_provider.stream_response(req)]
+        events = [
+            event
+            async for event in gemini_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"thinking_delta"' in event and "Thinking..." in event for event in events

--- a/tests/providers/test_github_models.py
+++ b/tests/providers/test_github_models.py
@@ -15,7 +15,7 @@ from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.github_models import GitHubModelsProvider
 from free_claude_code.providers.github_models.client import GITHUB_MODELS_CATALOG_URL
 from free_claude_code.providers.model_listing import ModelListResponseError
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import REASONING_ON, passthrough_rate_limiter
 
 
 @pytest.fixture
@@ -25,7 +25,6 @@ def github_models_config() -> ProviderConfig:
         base_url=GITHUB_MODELS_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -118,7 +117,7 @@ def test_build_request_body_uses_shared_openai_chat_policy(
 ) -> None:
     request = _request()
 
-    body = github_models_provider._build_request_body(request, thinking_enabled=True)
+    body = github_models_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["model"] == "openai/gpt-4.1"
     assert body["max_tokens"] == 100
@@ -215,7 +214,10 @@ async def test_stream_response_text(
         return_value=_stream(_chunk(delta)),
     ) as mock_create:
         events = [
-            event async for event in github_models_provider.stream_response(_request())
+            event
+            async for event in github_models_provider.stream_response(
+                _request(), reasoning=REASONING_ON
+            )
         ]
 
     parsed = parse_sse_text("".join(events))
@@ -265,7 +267,10 @@ async def test_stream_response_tool_call(
         return_value=_stream(_chunk(delta, finish_reason="tool_calls")),
     ):
         events = [
-            event async for event in github_models_provider.stream_response(request)
+            event
+            async for event in github_models_provider.stream_response(
+                request, reasoning=REASONING_ON
+            )
         ]
 
     parsed = parse_sse_text("".join(events))
@@ -299,7 +304,10 @@ async def test_stream_response_reasoning_content(
         return_value=_stream(_chunk(delta)),
     ):
         events = [
-            event async for event in github_models_provider.stream_response(_request())
+            event
+            async for event in github_models_provider.stream_response(
+                _request(), reasoning=REASONING_ON
+            )
         ]
 
     parsed = parse_sse_text("".join(events))

--- a/tests/providers/test_groq.py
+++ b/tests/providers/test_groq.py
@@ -7,7 +7,11 @@ import pytest
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def make_request(**overrides):
@@ -21,7 +25,6 @@ def groq_config():
         base_url=GROQ_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -52,7 +55,7 @@ def test_default_base_url_constant():
 def test_build_request_body_basic(groq_provider):
     """Basic request body conversion attaches system message from Claude request."""
     req = make_request()
-    body = groq_provider._build_request_body(req)
+    body = groq_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["model"] == "llama-3.3-70b-versatile"
     assert body["messages"][0]["role"] == "system"
@@ -67,12 +70,11 @@ def test_build_request_body_global_disable_blocks_reasoning_mapping():
             base_url=GROQ_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
     req = make_request()
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=REASONING_ON)
 
     roles = [m.get("role") for m in body.get("messages", [])]
     assert "assistant_reasoning_content" not in roles
@@ -100,7 +102,7 @@ def test_build_request_body_sanitizes_and_remaps_via_mock_converter(groq_provide
             "n": 4,
         }
         req = make_request()
-        body = groq_provider._build_request_body(req)
+        body = groq_provider._build_request_body(req, reasoning=REASONING_ON)
 
     msgs = body["messages"]
     assert msgs[0].get("name") is None and msgs[1].get("name") is None
@@ -121,7 +123,7 @@ def test_build_request_body_prefers_existing_max_completion_tokens(groq_provider
             "max_completion_tokens": 77,
             "max_tokens": 999,
         }
-        body = groq_provider._build_request_body(make_request())
+        body = groq_provider._build_request_body(make_request(), reasoning=REASONING_ON)
 
     assert body["max_completion_tokens"] == 77
     assert "max_tokens" not in body
@@ -130,7 +132,7 @@ def test_build_request_body_prefers_existing_max_completion_tokens(groq_provider
 def test_build_request_body_preserves_caller_extra_body(groq_provider):
     req = make_request(extra_body={"metadata": {"user": "u1"}})
 
-    body = groq_provider._build_request_body(req)
+    body = groq_provider._build_request_body(req, reasoning=REASONING_ON)
 
     eb = body.get("extra_body")
     assert isinstance(eb, dict)
@@ -163,7 +165,12 @@ async def test_stream_response_text(groq_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in groq_provider.stream_response(req)]
+        events = [
+            event
+            async for event in groq_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"text_delta"' in event and "Hello back!" in event for event in events
@@ -196,7 +203,12 @@ async def test_stream_response_reasoning_content(groq_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in groq_provider.stream_response(req)]
+        events = [
+            event
+            async for event in groq_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"thinking_delta"' in event and "Thinking..." in event for event in events

--- a/tests/providers/test_huggingface.py
+++ b/tests/providers/test_huggingface.py
@@ -9,7 +9,11 @@ from free_claude_code.config.provider_catalog import HUGGINGFACE_DEFAULT_BASE
 from free_claude_code.core.anthropic import ReasoningReplayMode
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def make_request(**overrides):
@@ -23,7 +27,6 @@ def huggingface_config():
         base_url=HUGGINGFACE_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -72,7 +75,9 @@ def test_build_request_body_keeps_max_tokens(huggingface_provider):
             "max_tokens": 42,
         }
 
-        body = huggingface_provider._build_request_body(make_request())
+        body = huggingface_provider._build_request_body(
+            make_request(), reasoning=REASONING_ON
+        )
 
     mock_convert.assert_called_once()
     assert (
@@ -88,7 +93,7 @@ def test_build_request_body_preserves_caller_extra_body(huggingface_provider):
     extra_body = {"provider": "auto", "routing": {"bill_to": "my-org"}}
     req = make_request(extra_body=extra_body)
 
-    body = huggingface_provider._build_request_body(req)
+    body = huggingface_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["extra_body"] == extra_body
     assert body["extra_body"] is not extra_body
@@ -111,7 +116,7 @@ def test_build_request_body_does_not_replay_prior_thinking_blocks(
         ],
     )
 
-    body = huggingface_provider._build_request_body(req)
+    body = huggingface_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["messages"] == [{"role": "assistant", "content": "visible answer"}]
     assert "reasoning_content" not in body["messages"][0]
@@ -132,7 +137,7 @@ def test_build_request_body_does_not_replay_top_level_reasoning_content(
         ],
     )
 
-    body = huggingface_provider._build_request_body(req)
+    body = huggingface_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["messages"] == [{"role": "assistant", "content": "visible answer"}]
     assert "hidden prior reasoning" not in str(body)
@@ -163,7 +168,9 @@ async def test_stream_response_text(huggingface_provider):
 
         events = [
             event
-            async for event in huggingface_provider.stream_response(make_request())
+            async for event in huggingface_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(
@@ -197,7 +204,9 @@ async def test_stream_response_reasoning_content(huggingface_provider):
 
         events = [
             event
-            async for event in huggingface_provider.stream_response(make_request())
+            async for event in huggingface_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(

--- a/tests/providers/test_kimi.py
+++ b/tests/providers/test_kimi.py
@@ -11,7 +11,12 @@ from free_claude_code.config.provider_catalog import KIMI_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 @pytest.fixture
@@ -23,7 +28,6 @@ def kimi_provider():
             base_url=KIMI_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=True,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -42,7 +46,7 @@ def test_build_request_body_openai_chat(kimi_provider):
         messages=[Message(role="user", content="hi")],
     )
 
-    body = kimi_provider._build_request_body(request)
+    body = kimi_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["model"] == "kimi-k2.5"
     assert body["max_tokens"] == 50
@@ -56,7 +60,7 @@ def test_build_request_body_default_max_tokens(kimi_provider):
         messages=[Message(role="user", content="x")],
     )
 
-    body = kimi_provider._build_request_body(request)
+    body = kimi_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 
@@ -71,7 +75,7 @@ def test_build_request_body_rejects_caller_extra_body(kimi_provider):
     )
 
     with pytest.raises(InvalidRequestError, match="Kimi Chat Completions"):
-        kimi_provider._build_request_body(request)
+        kimi_provider._build_request_body(request, reasoning=REASONING_ON)
 
 
 def test_build_request_body_disables_kimi_thinking(kimi_provider):
@@ -83,7 +87,7 @@ def test_build_request_body_disables_kimi_thinking(kimi_provider):
         }
     )
 
-    body = kimi_provider._build_request_body(request)
+    body = kimi_provider._build_request_body(request, reasoning=REASONING_OFF)
 
     assert body["extra_body"]["thinking"] == {"type": "disabled"}
 

--- a/tests/providers/test_llamacpp.py
+++ b/tests/providers/test_llamacpp.py
@@ -9,7 +9,12 @@ from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 LLAMACPP_MODEL = "llamacpp-community/qwen2.5-7b-instruct"
 
@@ -73,7 +78,7 @@ def test_build_request_body_uses_openai_chat_shape(
 ) -> None:
     request = make_messages_request(LLAMACPP_MODEL, max_tokens=None)
 
-    body = provider._build_request_body(request)
+    body = provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["model"] == LLAMACPP_MODEL
     assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
@@ -99,7 +104,7 @@ def test_disabled_thinking_does_not_replay_assistant_reasoning(
         ],
     )
 
-    body = provider._build_request_body(request, thinking_enabled=False)
+    body = provider._build_request_body(request, reasoning=REASONING_OFF)
 
     assert "private" not in str(body)
     assert "visible" in str(body)
@@ -135,7 +140,7 @@ async def test_stream_response_uses_shared_openai_chat_provider(
             [
                 event
                 async for event in provider.stream_response(
-                    make_messages_request(LLAMACPP_MODEL)
+                    make_messages_request(LLAMACPP_MODEL), reasoning=REASONING_ON
                 )
             ]
         )

--- a/tests/providers/test_lmstudio.py
+++ b/tests/providers/test_lmstudio.py
@@ -10,7 +10,11 @@ from free_claude_code.config.provider_catalog import LMSTUDIO_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.lmstudio import LMStudioProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+)
 
 
 def make_request(**overrides):
@@ -52,7 +56,7 @@ def test_default_base_url_constant():
 
 def test_build_request_body_basic(lmstudio_provider):
     req = make_request()
-    body = lmstudio_provider._build_request_body(req)
+    body = lmstudio_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["model"] == "lmstudio-community/qwen2.5-7b-instruct"
     assert body["messages"][0]["role"] == "system"
@@ -76,7 +80,7 @@ def test_build_request_body_never_replays_prior_thinking(lmstudio_provider):
             },
         ]
     )
-    body = lmstudio_provider._build_request_body(req)
+    body = lmstudio_provider._build_request_body(req, reasoning=REASONING_ON)
 
     roles = [m.get("role") for m in body.get("messages", [])]
     assert "assistant_reasoning_content" not in roles
@@ -89,9 +93,9 @@ def test_preflight_builds_before_context_budget_and_preserves_false(
     request = make_request()
     calls: list[tuple[str, object]] = []
 
-    def build(request_arg, thinking_enabled=None):
+    def build(request_arg, *, reasoning):
         assert request_arg is request
-        calls.append(("build", thinking_enabled))
+        calls.append(("build", reasoning))
         return {}
 
     def check_context(request_arg):
@@ -106,9 +110,9 @@ def test_preflight_builds_before_context_budget_and_preserves_false(
             side_effect=check_context,
         ),
     ):
-        lmstudio_provider.preflight_stream(request, thinking_enabled=False)
+        lmstudio_provider.preflight_stream(request, reasoning=REASONING_OFF)
 
-    assert calls == [("build", False), ("context", request)]
+    assert calls == [("build", REASONING_OFF), ("context", request)]
 
 
 def test_preflight_conversion_failure_skips_context_budget(lmstudio_provider):
@@ -124,7 +128,7 @@ def test_preflight_conversion_failure_skips_context_budget(lmstudio_provider):
         patch.object(lmstudio_provider, "_preflight_context_budget") as context,
         pytest.raises(InvalidRequestError, match="invalid request conversion"),
     ):
-        lmstudio_provider.preflight_stream(request, thinking_enabled=True)
+        lmstudio_provider.preflight_stream(request, reasoning=REASONING_ON)
 
     context.assert_not_called()
 
@@ -153,7 +157,12 @@ async def test_stream_response_text(lmstudio_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in lmstudio_provider.stream_response(req)]
+        events = [
+            event
+            async for event in lmstudio_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"text_delta"' in event and "Hello back!" in event for event in events

--- a/tests/providers/test_minimax.py
+++ b/tests/providers/test_minimax.py
@@ -15,7 +15,12 @@ from free_claude_code.core.anthropic.stream_contracts import (
 )
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 class AsyncStream:
@@ -43,7 +48,6 @@ def minimax_provider():
             base_url=MINIMAX_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=True,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -95,7 +99,7 @@ def test_build_request_body_uses_adaptive_thinking_and_max_completion_tokens(
         }
     )
 
-    body = minimax_provider._build_request_body(request)
+    body = minimax_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["model"] == "MiniMax-M3"
     assert body["tools"][0]["function"]["name"] == "echo"
@@ -111,7 +115,7 @@ def test_build_request_body_honors_no_thinking(minimax_provider):
         messages=[Message(role="user", content="Hello")],
     )
 
-    body = minimax_provider._build_request_body(request, thinking_enabled=False)
+    body = minimax_provider._build_request_body(request, reasoning=REASONING_OFF)
 
     assert body["extra_body"]["thinking"] == {"type": "disabled"}
 
@@ -148,7 +152,12 @@ async def test_stream_preserves_reasoning_content(minimax_provider):
         new_callable=AsyncMock,
         return_value=stream,
     ) as create:
-        events = [event async for event in minimax_provider.stream_response(request)]
+        events = [
+            event
+            async for event in minimax_provider.stream_response(
+                request, reasoning=REASONING_ON
+            )
+        ]
 
     parsed = parse_sse_text("".join(events))
     assert thinking_content(parsed) == "plan"

--- a/tests/providers/test_mistral.py
+++ b/tests/providers/test_mistral.py
@@ -12,7 +12,11 @@ from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.mistral import MistralProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+)
 
 
 def make_request(**overrides):
@@ -26,7 +30,6 @@ def mistral_config():
         base_url=MISTRAL_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -55,7 +58,7 @@ def test_default_base_url():
 def test_build_request_body_basic(mistral_provider):
     """Basic request body conversion works for Mistral."""
     req = make_request()
-    body = mistral_provider._build_request_body(req)
+    body = mistral_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["model"] == "devstral-small-latest"
     assert body["messages"][0]["role"] == "system"
@@ -94,7 +97,7 @@ def test_build_request_body_replays_prior_thinking_as_mistral_chunks(
         ],
     )
 
-    body = mistral_provider._build_request_body(req)
+    body = mistral_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assistant = body["messages"][0]
     assert "reasoning_content" not in assistant
@@ -125,7 +128,7 @@ def test_build_request_body_preserves_tools_tool_choice_and_params(mistral_provi
         stop_sequences=["STOP"],
     )
 
-    body = mistral_provider._build_request_body(req)
+    body = mistral_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["max_tokens"] == 100
     assert body["temperature"] == 0.5
@@ -143,14 +146,13 @@ def test_build_request_body_global_disable_blocks_reasoning_mapping():
             base_url=MISTRAL_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
     req = make_request()
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=REASONING_OFF)
 
-    assert "reasoning_effort" not in body
+    assert body["reasoning_effort"] == "none"
     assert all("reasoning_content" not in m for m in body.get("messages", []))
 
 
@@ -161,7 +163,6 @@ def test_build_request_body_thinking_disabled_strips_prior_mistral_thinking():
             base_url=MISTRAL_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -178,9 +179,9 @@ def test_build_request_body_thinking_disabled_strips_prior_mistral_thinking():
         ],
     )
 
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=REASONING_OFF)
 
-    assert "reasoning_effort" not in body
+    assert body["reasoning_effort"] == "none"
     assert body["messages"][0]["content"] == "Visible."
 
 
@@ -210,7 +211,12 @@ async def test_stream_response_text(mistral_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in mistral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in mistral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"text_delta"' in event and "Hello back!" in event for event in events
@@ -243,7 +249,12 @@ async def test_stream_response_reasoning_content(mistral_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in mistral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in mistral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
         assert any(
             '"thinking_delta"' in event and "Thinking..." in event for event in events
@@ -280,7 +291,12 @@ async def test_stream_response_native_mistral_thinking_chunk(mistral_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in mistral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in mistral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
     assert any(
         '"thinking_delta"' in event and "Native thought." in event for event in events
@@ -312,7 +328,12 @@ async def test_stream_response_native_mistral_text_chunk(mistral_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in mistral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in mistral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
     assert any('"text_delta"' in event and "Native text." in event for event in events)
 
@@ -346,7 +367,12 @@ async def test_stream_response_preserves_native_thinking_and_string_text(
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in mistral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in mistral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
     event_text = "\n".join(events)
     assert '"thinking_delta"' in event_text
@@ -384,7 +410,12 @@ async def test_stream_response_preserves_native_reasoning_and_string_text(
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in mistral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in mistral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
     event_text = "\n".join(events)
     assert "Native reasoning." in event_text
@@ -424,7 +455,12 @@ async def test_stream_response_preserves_mixed_native_content_array(
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [event async for event in mistral_provider.stream_response(req)]
+        events = [
+            event
+            async for event in mistral_provider.stream_response(
+                req, reasoning=REASONING_ON
+            )
+        ]
 
     event_text = "\n".join(events)
     assert "Native thought." in event_text
@@ -467,7 +503,7 @@ async def test_stream_response_suppresses_native_mistral_thinking_when_disabled(
         events = [
             event
             async for event in mistral_provider.stream_response(
-                req, thinking_enabled=False
+                req, reasoning=REASONING_OFF
             )
         ]
 
@@ -529,7 +565,10 @@ async def test_stream_response_retries_without_mistral_reasoning_on_rejection(
     ) as mock_create:
         mock_create.side_effect = [error, mock_stream()]
 
-        events = [e async for e in mistral_provider.stream_response(req)]
+        events = [
+            e
+            async for e in mistral_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     assert mock_create.await_count == 2
     first_call = mock_create.await_args_list[0].kwargs
@@ -595,7 +634,10 @@ async def test_stream_response_reasoning_retry_preserves_visible_text_and_tools(
     ) as mock_create:
         mock_create.side_effect = [error, mock_stream()]
 
-        events = [e async for e in mistral_provider.stream_response(req)]
+        events = [
+            e
+            async for e in mistral_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     second_call = mock_create.await_args_list[1].kwargs
     assert second_call["messages"][0]["content"] == "Visible history."
@@ -632,7 +674,10 @@ async def test_stream_response_retries_on_mistral_422_reasoning_rejection(
     ) as mock_create:
         mock_create.side_effect = [error, mock_stream()]
 
-        events = [e async for e in mistral_provider.stream_response(req)]
+        events = [
+            e
+            async for e in mistral_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     assert mock_create.await_count == 2
     assert "reasoning_effort" not in mock_create.await_args_list[1].kwargs
@@ -684,7 +729,10 @@ async def test_stream_response_retries_when_model_disables_reasoning_input(
     ) as mock_create:
         mock_create.side_effect = [error, mock_stream()]
 
-        events = [e async for e in mistral_provider.stream_response(req)]
+        events = [
+            e
+            async for e in mistral_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     assert mock_create.await_count == 2
     second_call = mock_create.await_args_list[1].kwargs
@@ -704,7 +752,12 @@ async def test_stream_response_unrelated_bad_request_does_not_retry(mistral_prov
         mock_create.side_effect = error
 
         with pytest.raises(ExecutionFailure) as exc_info:
-            [e async for e in mistral_provider.stream_response(req)]
+            [
+                e
+                async for e in mistral_provider.stream_response(
+                    req, reasoning=REASONING_ON
+                )
+            ]
 
     assert mock_create.await_count == 1
     assert "Invalid request sent to provider" in exc_info.value.message
@@ -723,7 +776,12 @@ async def test_stream_response_generic_thinking_error_does_not_retry(
         mock_create.side_effect = error
 
         with pytest.raises(ExecutionFailure) as exc_info:
-            [e async for e in mistral_provider.stream_response(req)]
+            [
+                e
+                async for e in mistral_provider.stream_response(
+                    req, reasoning=REASONING_ON
+                )
+            ]
 
     assert mock_create.await_count == 1
     assert "Invalid request sent to provider" in exc_info.value.message

--- a/tests/providers/test_model_validation.py
+++ b/tests/providers/test_model_validation.py
@@ -8,6 +8,7 @@ import pytest
 
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.config.provider_catalog import (
     DEEPSEEK_DEFAULT_BASE,
@@ -325,9 +326,7 @@ class FakeProvider(BaseProvider):
         self._peer_started = peer_started
         self.cleaned = False
 
-    def preflight_stream(
-        self, request: Any, *, thinking_enabled: bool | None = None
-    ) -> None:
+    def preflight_stream(self, request: Any, *, reasoning: ReasoningPolicy) -> None:
         return None
 
     async def cleanup(self) -> None:
@@ -359,7 +358,7 @@ class FakeProvider(BaseProvider):
         input_tokens: int = 0,
         *,
         request_id: str | None = None,
-        thinking_enabled: bool | None = None,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]:
         if False:
             yield ""

--- a/tests/providers/test_nim_request_clone.py
+++ b/tests/providers/test_nim_request_clone.py
@@ -3,40 +3,49 @@
 from copy import deepcopy
 
 from free_claude_code.providers.nvidia_nim.retry import (
-    clone_body_without_reasoning_budget,
+    clone_body_without_reasoning_budget_controls,
 )
 
 
-def test_clone_body_without_reasoning_budget_strips_top_level_and_nested():
+def test_clone_body_without_reasoning_budget_controls_strips_all_supported_forms():
     body: dict = {
         "model": "x",
         "extra_body": {
             "reasoning_budget": 99,
-            "chat_template_kwargs": {"reasoning_budget": 42, "thinking": True},
+            "thinking_token_budget": 98,
+            "chat_template_kwargs": {
+                "reasoning_budget": 42,
+                "thinking_token_budget": 41,
+                "low_effort": True,
+                "thinking": True,
+            },
+            "nvext": {"max_thinking_tokens": 40},
             "top_k": 1,
         },
     }
     original_extra = deepcopy(body["extra_body"])
-    out = clone_body_without_reasoning_budget(body)
+    out = clone_body_without_reasoning_budget_controls(body)
 
     assert out is not None
     assert out["extra_body"]["chat_template_kwargs"] == {"thinking": True}
     assert "reasoning_budget" not in out["extra_body"]
+    assert "thinking_token_budget" not in out["extra_body"]
+    assert "nvext" not in out["extra_body"]
     assert body["extra_body"] == original_extra
 
 
-def test_clone_body_without_reasoning_budget_returns_none_when_unchanged():
+def test_clone_body_without_reasoning_budget_controls_returns_none_when_unchanged():
     body = {"model": "x", "extra_body": {"top_k": 3}}
-    assert clone_body_without_reasoning_budget(body) is None
+    assert clone_body_without_reasoning_budget_controls(body) is None
 
 
-def test_clone_body_without_reasoning_budget_returns_none_without_extra_body():
-    assert clone_body_without_reasoning_budget({"model": "y"}) is None
+def test_clone_body_without_reasoning_budget_controls_returns_none_without_extra_body():
+    assert clone_body_without_reasoning_budget_controls({"model": "y"}) is None
 
 
 def test_clone_body_drops_empty_extra_body_after_strip():
     body = {"model": "z", "extra_body": {"reasoning_budget": 7}}
-    out = clone_body_without_reasoning_budget(body)
+    out = clone_body_without_reasoning_budget_controls(body)
     assert out is not None
     assert "extra_body" not in out
     assert "extra_body" in body

--- a/tests/providers/test_nvidia_nim.py
+++ b/tests/providers/test_nvidia_nim.py
@@ -1,11 +1,11 @@
 import json
-from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import openai
 import pytest
 from httpx import Request, Response
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.config.provider_catalog import NVIDIA_NIM_DEFAULT_BASE
 from free_claude_code.core.failures import ExecutionFailure
@@ -14,7 +14,12 @@ from free_claude_code.providers.nvidia_nim.tool_schema import (
     NIM_TOOL_ARGUMENT_ALIASES_KEY,
 )
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    reasoning_for,
+)
 
 
 def message(role, content):
@@ -149,7 +154,7 @@ async def test_build_request_body(provider_config):
         rate_limiter=passthrough_rate_limiter(),
     )
     req = make_request()
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["model"] == "test-model"
     assert body["temperature"] == 0.5
@@ -161,25 +166,26 @@ async def test_build_request_body(provider_config):
     ctk = body["extra_body"]["chat_template_kwargs"]
     assert ctk["thinking"] is True
     assert ctk["enable_thinking"] is True
-    assert ctk["reasoning_budget"] == body["max_tokens"]
+    assert "reasoning_budget" not in ctk
     assert "reasoning_budget" not in body["extra_body"]
 
 
 @pytest.mark.asyncio
-async def test_build_request_body_omits_reasoning_when_globally_disabled(
+async def test_build_request_body_disables_reasoning_when_route_is_disabled(
     provider_config,
 ):
     provider = NvidiaNimProvider(
-        replace(provider_config, enable_thinking=False),
+        provider_config,
         nim_settings=NimSettings(),
         rate_limiter=passthrough_rate_limiter(),
     )
     req = make_request()
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=REASONING_OFF)
 
-    extra = body.get("extra_body", {})
-    assert "chat_template_kwargs" not in extra
-    assert "reasoning_budget" not in extra
+    ctk = body["extra_body"]["chat_template_kwargs"]
+    assert ctk["thinking"] is False
+    assert ctk["enable_thinking"] is False
+    assert "reasoning_budget" not in ctk
 
 
 @pytest.mark.asyncio
@@ -193,11 +199,12 @@ async def test_build_request_body_omits_reasoning_when_request_disables_thinking
     )
     req = make_request()
     req.thinking.enabled = False
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(req, reasoning=reasoning_for(req))
 
-    extra = body.get("extra_body", {})
-    assert "chat_template_kwargs" not in extra
-    assert "reasoning_budget" not in extra
+    ctk = body["extra_body"]["chat_template_kwargs"]
+    assert ctk["thinking"] is False
+    assert ctk["enable_thinking"] is False
+    assert "reasoning_budget" not in ctk
 
 
 def test_preflight_and_build_request_issue_206_post_tool_text(nim_provider):
@@ -230,8 +237,8 @@ def test_preflight_and_build_request_issue_206_post_tool_text(nim_provider):
             ),
         ],
     )
-    nim_provider.preflight_stream(req, thinking_enabled=False)
-    body = nim_provider._build_request_body(req, thinking_enabled=False)
+    nim_provider.preflight_stream(req, reasoning=REASONING_OFF)
+    body = nim_provider._build_request_body(req, reasoning=REASONING_OFF)
     assert "messages" in body
     assert any(m.get("role") == "tool" for m in body["messages"])
 
@@ -268,7 +275,9 @@ async def test_stream_response_text(nim_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
         assert len(events) > 0
         assert "event: message_start" in events[0]
@@ -316,7 +325,9 @@ async def test_stream_response_thinking_reasoning_content(nim_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
         # Check for thinking_delta
         found_thinking = False
@@ -333,7 +344,7 @@ async def test_stream_response_thinking_reasoning_content(nim_provider):
 @pytest.mark.asyncio
 async def test_stream_response_suppresses_thinking_when_disabled(provider_config):
     provider = NvidiaNimProvider(
-        replace(provider_config, enable_thinking=False),
+        provider_config,
         nim_settings=NimSettings(),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -358,7 +369,9 @@ async def test_stream_response_suppresses_thinking_when_disabled(provider_config
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in provider.stream_response(req)]
+        events = [
+            e async for e in provider.stream_response(req, reasoning=REASONING_OFF)
+        ]
 
     event_text = "".join(events)
     assert "thinking_delta" not in event_text
@@ -403,7 +416,13 @@ async def test_stream_response_retries_without_chat_template(provider_config):
     ) as mock_create:
         mock_create.side_effect = [first_error, mock_stream()]
 
-        events = [e async for e in provider.stream_response(req)]
+        events = [
+            e
+            async for e in provider.stream_response(
+                req,
+                reasoning=ReasoningPolicy.on(budget_tokens=100),
+            )
+        ]
 
     assert mock_create.await_count == 2
 
@@ -459,7 +478,13 @@ async def test_stream_response_retries_without_chat_template_kwargs_issue_993(
     ) as mock_create:
         mock_create.side_effect = [first_error, mock_stream()]
 
-        events = [e async for e in provider.stream_response(req)]
+        events = [
+            e
+            async for e in provider.stream_response(
+                req,
+                reasoning=ReasoningPolicy.on(budget_tokens=100),
+            )
+        ]
 
     assert mock_create.await_count == 2
 
@@ -496,7 +521,13 @@ async def test_stream_response_does_not_retry_unrelated_bad_request(provider_con
         mock_create.side_effect = _make_bad_request_error("unrelated bad request")
 
         with pytest.raises(ExecutionFailure) as exc_info:
-            [e async for e in provider.stream_response(req)]
+            [
+                e
+                async for e in provider.stream_response(
+                    req,
+                    reasoning=REASONING_ON,
+                )
+            ]
 
     assert mock_create.await_count == 1
     assert "Invalid request sent to provider" in exc_info.value.message
@@ -531,7 +562,9 @@ async def test_tool_call_stream(nim_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
         starts = [
             e for e in events if "event: content_block_start" in e and '"tool_use"' in e
@@ -573,7 +606,9 @@ async def test_stream_response_restores_aliased_tool_arguments(nim_provider):
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     await_args = mock_create.await_args
     assert await_args is not None
@@ -630,7 +665,9 @@ async def test_stream_response_buffers_chunked_aliased_tool_arguments(nim_provid
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     deltas = _input_json_deltas(events)
     assert len(deltas) == 1
@@ -676,7 +713,9 @@ async def test_stream_response_restores_nested_aliased_tool_arguments(nim_provid
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     deltas = _input_json_deltas(events)
     assert len(deltas) == 1
@@ -722,7 +761,9 @@ async def test_stream_response_task_tool_still_forces_background_false(nim_provi
     ) as mock_create:
         mock_create.return_value = mock_stream()
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     deltas = _input_json_deltas(events)
     assert len(deltas) == 1
@@ -752,15 +793,18 @@ async def test_stream_response_retries_without_reasoning_budget(nim_provider):
     ) as mock_create:
         mock_create.side_effect = [error, mock_stream()]
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e
+            async for e in nim_provider.stream_response(
+                req,
+                reasoning=ReasoningPolicy.on(budget_tokens=100),
+            )
+        ]
 
     assert mock_create.await_count == 2
     first_call = mock_create.await_args_list[0].kwargs
     second_call = mock_create.await_args_list[1].kwargs
-    assert (
-        first_call["extra_body"]["chat_template_kwargs"]["reasoning_budget"]
-        == first_call["max_tokens"]
-    )
+    assert first_call["extra_body"]["chat_template_kwargs"]["reasoning_budget"] == 100
     assert "reasoning_budget" not in second_call["extra_body"]
     assert "reasoning_budget" not in second_call["extra_body"]["chat_template_kwargs"]
     assert second_call["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
@@ -796,15 +840,18 @@ async def test_stream_response_retries_without_budget_for_thinking_token_error(
     ) as mock_create:
         mock_create.side_effect = [error, mock_stream()]
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e
+            async for e in nim_provider.stream_response(
+                req,
+                reasoning=ReasoningPolicy.on(budget_tokens=100),
+            )
+        ]
 
     assert mock_create.await_count == 2
     first_call = mock_create.await_args_list[0].kwargs
     second_call = mock_create.await_args_list[1].kwargs
-    assert (
-        first_call["extra_body"]["chat_template_kwargs"]["reasoning_budget"]
-        == first_call["max_tokens"]
-    )
+    assert first_call["extra_body"]["chat_template_kwargs"]["reasoning_budget"] == 100
     assert "reasoning_budget" not in second_call["extra_body"]
     assert "reasoning_budget" not in second_call["extra_body"]["chat_template_kwargs"]
     assert second_call["extra_body"]["chat_template_kwargs"]["thinking"] is True
@@ -862,7 +909,9 @@ async def test_stream_response_retries_without_reasoning_content(nim_provider):
     ) as mock_create:
         mock_create.side_effect = [error, mock_stream()]
 
-        events = [e async for e in nim_provider.stream_response(req)]
+        events = [
+            e async for e in nim_provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     assert mock_create.await_count == 2
     first_call = mock_create.await_args_list[0].kwargs
@@ -887,7 +936,13 @@ async def test_stream_response_bad_request_without_reasoning_budget_does_not_ret
         mock_create.side_effect = error
 
         with pytest.raises(ExecutionFailure) as exc_info:
-            [e async for e in nim_provider.stream_response(req)]
+            [
+                e
+                async for e in nim_provider.stream_response(
+                    req,
+                    reasoning=REASONING_ON,
+                )
+            ]
 
     assert mock_create.await_count == 1
     assert "Invalid request sent to provider" in exc_info.value.message
@@ -906,7 +961,13 @@ async def test_stream_response_unrelated_internal_error_does_not_downgrade(
         mock_create.side_effect = error
 
         with pytest.raises(ExecutionFailure) as exc_info:
-            [e async for e in nim_provider.stream_response(req)]
+            [
+                e
+                async for e in nim_provider.stream_response(
+                    req,
+                    reasoning=REASONING_ON,
+                )
+            ]
 
     assert mock_create.await_count == 1
     assert "Provider API request failed" in exc_info.value.message
@@ -927,7 +988,13 @@ async def test_stream_response_internal_reasoning_content_error_does_not_downgra
         mock_create.side_effect = error
 
         with pytest.raises(ExecutionFailure) as exc_info:
-            [e async for e in nim_provider.stream_response(req)]
+            [
+                e
+                async for e in nim_provider.stream_response(
+                    req,
+                    reasoning=REASONING_ON,
+                )
+            ]
 
     assert mock_create.await_count == 1
     assert "Provider API request failed" in exc_info.value.message

--- a/tests/providers/test_nvidia_nim_degraded_retry.py
+++ b/tests/providers/test_nvidia_nim_degraded_retry.py
@@ -21,6 +21,7 @@ from free_claude_code.providers.rate_limit import (
     ProviderRateLimiter,
 )
 from tests.providers.request_factory import make_messages_request
+from tests.providers.support import REASONING_ON
 
 _FUNCTION_ID = "87ea0ddc-cff1-4bca-bf8b-3bd98a35ddd0"
 _DEGRADED_DETAIL = f"Function id '{_FUNCTION_ID}': DEGRADED function cannot be invoked"
@@ -111,7 +112,9 @@ async def test_degraded_function_retries_unchanged_request_then_succeeds() -> No
         events = [
             event
             async for event in provider.stream_response(
-                make_messages_request(), request_id="req_recovered"
+                make_messages_request(),
+                request_id="req_recovered",
+                reasoning=REASONING_ON,
             )
         ]
 
@@ -154,7 +157,9 @@ async def test_degraded_function_exhaustion_is_detailed_redacted_overload() -> N
         [
             event
             async for event in provider.stream_response(
-                make_messages_request(), request_id="req_degraded"
+                make_messages_request(),
+                request_id="req_degraded",
+                reasoning=REASONING_ON,
             )
         ]
 
@@ -212,7 +217,12 @@ async def test_unrelated_nim_bad_request_is_not_retried(detail: str) -> None:
         ) as sleep,
         pytest.raises(ExecutionFailure) as exc_info,
     ):
-        [event async for event in provider.stream_response(make_messages_request())]
+        [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), reasoning=REASONING_ON
+            )
+        ]
 
     assert create.await_count == 1
     extend_block.assert_not_called()
@@ -246,7 +256,12 @@ async def test_degraded_wording_remains_non_retryable_for_other_providers() -> N
         ) as sleep,
         pytest.raises(ExecutionFailure) as exc_info,
     ):
-        [event async for event in provider.stream_response(make_messages_request())]
+        [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), reasoning=REASONING_ON
+            )
+        ]
 
     assert create.await_count == 1
     extend_block.assert_not_called()

--- a/tests/providers/test_nvidia_nim_request.py
+++ b/tests/providers/test_nvidia_nim_request.py
@@ -24,6 +24,7 @@ from free_claude_code.providers.nvidia_nim.tool_schema import (
     nim_tool_argument_aliases_from_body,
 )
 from tests.providers.request_factory import make_messages_request
+from tests.providers.support import reasoning_for
 
 GREP_SCHEMA_FROM_SERVER_LOG: dict[str, Any] = {
     "type": "object",
@@ -102,21 +103,25 @@ class TestBuildRequestBody:
     def test_max_tokens_capped_by_nim(self, req):
         req.max_tokens = 100000
         nim = NimSettings(max_tokens=4096)
-        body = build_request_body(req, nim, thinking_enabled=True)
+        body = build_request_body(req, nim, reasoning=reasoning_for(req))
         assert body["max_tokens"] == 4096
 
     def test_presence_penalty_included_when_nonzero(self, req):
         nim = NimSettings(presence_penalty=0.5)
-        body = build_request_body(req, nim, thinking_enabled=True)
+        body = build_request_body(req, nim, reasoning=reasoning_for(req))
         assert body["presence_penalty"] == 0.5
 
     def test_include_stop_str_in_output_not_sent(self, req):
-        body = build_request_body(req, NimSettings(), thinking_enabled=True)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req),
+        )
         assert "include_stop_str_in_output" not in body.get("extra_body", {})
 
     def test_parallel_tool_calls_included(self, req):
         nim = NimSettings(parallel_tool_calls=False)
-        body = build_request_body(req, nim, thinking_enabled=True)
+        body = build_request_body(req, nim, reasoning=reasoning_for(req))
         assert body["parallel_tool_calls"] is False
 
     def test_tool_schema_boolean_subschemas_are_removed_without_mutating_request(
@@ -141,7 +146,11 @@ class TestBuildRequestBody:
             )
         ]
 
-        body = build_request_body(req, NimSettings(), thinking_enabled=False)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req, route_enabled=False),
+        )
 
         parameters = body["tools"][0]["function"]["parameters"]
         properties = parameters["properties"]
@@ -169,7 +178,11 @@ class TestBuildRequestBody:
             )
         ]
 
-        body = build_request_body(req, NimSettings(), thinking_enabled=False)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req, route_enabled=False),
+        )
 
         parameters = body["tools"][0]["function"]["parameters"]
         properties = parameters["properties"]
@@ -215,7 +228,11 @@ class TestBuildRequestBody:
             )
         ]
 
-        body = build_request_body(req, NimSettings(), thinking_enabled=False)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req, route_enabled=False),
+        )
 
         assert NIM_TOOL_ARGUMENT_ALIASES_KEY not in body
         parameters = body["tools"][0]["function"]["parameters"]
@@ -248,7 +265,11 @@ class TestBuildRequestBody:
             )
         ]
 
-        body = build_request_body(req, NimSettings(), thinking_enabled=False)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req, route_enabled=False),
+        )
 
         aliases = body[NIM_TOOL_ARGUMENT_ALIASES_KEY]["NotionLike"]
         parent = body["tools"][0]["function"]["parameters"]["properties"]["parent"]
@@ -276,7 +297,7 @@ class TestBuildRequestBody:
             "Grep": {"_fcc_arg_A": "-A"}
         }
 
-    def test_reasoning_params_in_extra_body(self):
+    def test_explicit_reasoning_budget_is_sent_without_using_max_tokens(self):
         req = make_messages_request(
             model="test",
             messages=[{"role": "user", "content": "hi"}],
@@ -289,16 +310,16 @@ class TestBuildRequestBody:
             tool_choice=None,
             extra_body=None,
             top_k=None,
-            thinking=None,
+            thinking={"type": "enabled", "budget_tokens": 4096},
         )
 
         nim = NimSettings()
-        body = build_request_body(req, nim, thinking_enabled=True)
+        body = build_request_body(req, nim, reasoning=reasoning_for(req))
         extra = body["extra_body"]
         assert extra["chat_template_kwargs"] == {
             "thinking": True,
             "enable_thinking": True,
-            "reasoning_budget": body["max_tokens"],
+            "reasoning_budget": 4096,
         }
         assert "reasoning_budget" not in extra
 
@@ -354,7 +375,7 @@ class TestBuildRequestBody:
 
         assert clone_body_without_chat_template(body) is None
 
-    def test_no_chat_template_kwargs_when_thinking_disabled(self):
+    def test_chat_template_explicitly_disables_thinking(self):
         req = make_messages_request(
             model="test",
             messages=[{"role": "user", "content": "hi"}],
@@ -371,12 +392,19 @@ class TestBuildRequestBody:
         )
 
         nim = NimSettings()
-        body = build_request_body(req, nim, thinking_enabled=False)
+        body = build_request_body(
+            req,
+            nim,
+            reasoning=reasoning_for(req, route_enabled=False),
+        )
         extra = body.get("extra_body", {})
-        assert "chat_template_kwargs" not in extra
+        assert extra["chat_template_kwargs"] == {
+            "thinking": False,
+            "enable_thinking": False,
+        }
         assert "reasoning_budget" not in extra
 
-    def test_reasoning_budget_respects_existing_chat_template_kwargs(self):
+    def test_canonical_reasoning_overrides_conflicting_chat_template_toggle(self):
         req = make_messages_request(
             model="test",
             messages=[{"role": "user", "content": "hi"}],
@@ -397,11 +425,15 @@ class TestBuildRequestBody:
             thinking=None,
         )
 
-        body = build_request_body(req, NimSettings(), thinking_enabled=True)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req),
+        )
         assert body["extra_body"]["chat_template_kwargs"] == {
-            "enable_thinking": False,
+            "thinking": True,
+            "enable_thinking": True,
             "custom": "value",
-            "reasoning_budget": body["max_tokens"],
         }
 
     def test_chat_template_fields_present_for_mistral_model(self):
@@ -421,14 +453,43 @@ class TestBuildRequestBody:
         )
 
         nim = NimSettings(chat_template="custom_template")
-        body = build_request_body(req, nim, thinking_enabled=True)
+        body = build_request_body(req, nim, reasoning=reasoning_for(req))
         extra = body.get("extra_body", {})
         assert extra["chat_template_kwargs"] == {
             "thinking": True,
             "enable_thinking": True,
-            "reasoning_budget": body["max_tokens"],
         }
         assert extra["chat_template"] == "custom_template"
+
+    def test_effort_is_converted_to_documented_numeric_budget(self):
+        req = make_messages_request(
+            model="nvidia/nemotron-3-super-120b-a12b",
+            thinking={"type": "adaptive"},
+            output_config={"effort": "high"},
+        )
+
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req),
+        )
+
+        assert body["extra_body"]["chat_template_kwargs"]["reasoning_budget"] == 4096
+
+    def test_nemotron_nano_uses_nvext_budget_field(self):
+        req = make_messages_request(
+            model="nvidia/nvidia-nemotron-nano-9b-v2",
+            thinking={"type": "enabled", "budget_tokens": 2048},
+        )
+
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req),
+        )
+
+        assert body["extra_body"]["nvext"] == {"max_thinking_tokens": 2048}
+        assert "reasoning_budget" not in body["extra_body"]["chat_template_kwargs"]
 
     def test_no_reasoning_params_in_extra_body(self):
         req = make_messages_request(
@@ -447,7 +508,11 @@ class TestBuildRequestBody:
         )
 
         nim = NimSettings()
-        body = build_request_body(req, nim, thinking_enabled=False)
+        body = build_request_body(
+            req,
+            nim,
+            reasoning=reasoning_for(req, route_enabled=False),
+        )
         extra = body.get("extra_body", {})
         for param in (
             "thinking",
@@ -482,7 +547,11 @@ class TestBuildRequestBody:
             thinking=None,
         )
 
-        body = build_request_body(req, NimSettings(), thinking_enabled=False)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req, route_enabled=False),
+        )
         assert "<think>" not in body["messages"][0]["content"]
         assert "answer" in body["messages"][0]["content"]
 
@@ -510,7 +579,11 @@ class TestBuildRequestBody:
             thinking=None,
         )
 
-        body = build_request_body(req, NimSettings(), thinking_enabled=True)
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=reasoning_for(req),
+        )
         assistant = body["messages"][0]
         assert assistant["reasoning_content"] == "secret"
         assert assistant["content"] == "answer"

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -15,7 +15,12 @@ from free_claude_code.core.anthropic.stream_contracts import (
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 OLLAMA_MODEL = "llama3.1:8b"
 OLLAMA_CLOUD_MODEL = "qwen3-coder:480b"
@@ -74,18 +79,20 @@ def test_cloud_init_uses_fixed_openai_endpoint_and_api_key() -> None:
 
 
 def test_build_request_body_uses_openai_chat_shape() -> None:
-    body = _provider()._build_request_body(make_messages_request(OLLAMA_MODEL))
+    body = _provider()._build_request_body(
+        make_messages_request(OLLAMA_MODEL), reasoning=REASONING_ON
+    )
 
     assert body["model"] == OLLAMA_MODEL
     assert body["messages"][0]["role"] == "system"
-    assert "reasoning_effort" not in body
+    assert body["reasoning_effort"] == "high"
     assert "thinking" not in body
     assert "extra_body" not in body
 
 
 def test_cloud_build_request_body_enables_ollama_reasoning() -> None:
     body = _cloud_provider()._build_request_body(
-        make_messages_request(OLLAMA_CLOUD_MODEL)
+        make_messages_request(OLLAMA_CLOUD_MODEL), reasoning=REASONING_ON
     )
 
     assert body["model"] == OLLAMA_CLOUD_MODEL
@@ -121,7 +128,7 @@ def test_cloud_build_request_body_replays_thinking_in_ollama_reasoning_field() -
         ],
     )
 
-    body = _cloud_provider()._build_request_body(request)
+    body = _cloud_provider()._build_request_body(request, reasoning=REASONING_ON)
 
     assistant = next(
         message for message in body["messages"] if message["role"] == "assistant"
@@ -132,7 +139,7 @@ def test_cloud_build_request_body_replays_thinking_in_ollama_reasoning_field() -
 
 @pytest.mark.parametrize(
     ("provider", "expected_effort"),
-    [(_provider, None), (_cloud_provider, "none")],
+    [(_provider, "none"), (_cloud_provider, "none")],
 )
 def test_disabled_thinking_is_not_replayed_and_disables_ollama_reasoning(
     provider, expected_effort
@@ -151,15 +158,12 @@ def test_disabled_thinking_is_not_replayed_and_disables_ollama_reasoning(
         ],
     )
 
-    body = provider()._build_request_body(request, thinking_enabled=False)
+    body = provider()._build_request_body(request, reasoning=REASONING_OFF)
     assistant = next(
         message for message in body["messages"] if message["role"] == "assistant"
     )
 
-    if expected_effort is None:
-        assert "reasoning_effort" not in body
-    else:
-        assert body["reasoning_effort"] == expected_effort
+    assert body["reasoning_effort"] == expected_effort
     assert "reasoning" not in assistant
     assert "reasoning_content" not in assistant
     assert assistant["content"] == "Visible answer."
@@ -194,7 +198,7 @@ async def test_stream_response_uses_shared_openai_chat_provider() -> None:
             [
                 event
                 async for event in provider.stream_response(
-                    make_messages_request(OLLAMA_MODEL)
+                    make_messages_request(OLLAMA_MODEL), reasoning=REASONING_ON
                 )
             ]
         )
@@ -234,7 +238,7 @@ async def test_cloud_stream_maps_ollama_reasoning_delta_to_anthropic_thinking() 
             [
                 event
                 async for event in client.stream_response(
-                    make_messages_request(OLLAMA_CLOUD_MODEL)
+                    make_messages_request(OLLAMA_CLOUD_MODEL), reasoning=REASONING_ON
                 )
             ]
         )

--- a/tests/providers/test_open_router.py
+++ b/tests/providers/test_open_router.py
@@ -16,7 +16,7 @@ from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.open_router import OpenRouterProvider
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import passthrough_rate_limiter, reasoning_for
 
 
 class AsyncStream:
@@ -77,7 +77,11 @@ def test_init_uses_openai_chat_provider(open_router_provider):
 
 
 def test_build_request_body_uses_openai_chat_shape(open_router_provider):
-    body = open_router_provider._build_request_body(make_request())
+    request = make_request()
+    body = open_router_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
 
     assert body["model"] == "moonshotai/kimi-k2.6:free"
     assert body["temperature"] == 0.5
@@ -90,7 +94,11 @@ def test_build_request_body_uses_openai_chat_shape(open_router_provider):
 
 
 def test_build_request_body_default_max_tokens(open_router_provider):
-    body = open_router_provider._build_request_body(make_request(max_tokens=None))
+    request = make_request(max_tokens=None)
+    body = open_router_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
 
     assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 
@@ -99,35 +107,46 @@ def test_openrouter_extra_body_rejects_overriding_reserved_fields(
     open_router_provider,
 ):
     with pytest.raises(InvalidRequestError, match="model"):
+        request = make_request(extra_body={"model": "hijack"})
         open_router_provider._build_request_body(
-            make_request(extra_body={"model": "hijack"})
+            request,
+            reasoning=reasoning_for(request),
         )
 
 
 def test_openrouter_extra_body_allows_provider_keys(open_router_provider):
+    request = make_request(extra_body={"transforms": ["no-web"], "plugins": []})
     body = open_router_provider._build_request_body(
-        make_request(extra_body={"transforms": ["no-web"], "plugins": []}),
-        thinking_enabled=False,
+        request,
+        reasoning=reasoning_for(request, route_enabled=False),
     )
 
-    assert body["extra_body"] == {"transforms": ["no-web"], "plugins": []}
+    assert body["extra_body"] == {
+        "transforms": ["no-web"],
+        "plugins": [],
+        "reasoning": {"enabled": False},
+    }
 
 
 def test_build_request_body_omits_reasoning_when_thinking_disabled(
     open_router_provider,
 ):
+    request = make_request(thinking={"type": "disabled"})
     body = open_router_provider._build_request_body(
-        make_request(thinking={"type": "disabled"})
+        request,
+        reasoning=reasoning_for(request),
     )
 
-    assert "extra_body" not in body
+    assert body["extra_body"]["reasoning"] == {"enabled": False}
 
 
 def test_build_request_body_maps_thinking_budget_to_reasoning_max_tokens(
     open_router_provider,
 ):
+    request = make_request(thinking={"type": "enabled", "budget_tokens": 4096})
     body = open_router_provider._build_request_body(
-        make_request(thinking={"type": "enabled", "budget_tokens": 4096})
+        request,
+        reasoning=reasoning_for(request),
     )
 
     assert body["extra_body"]["reasoning"] == {"enabled": True, "max_tokens": 4096}
@@ -156,7 +175,10 @@ def test_build_request_body_replays_openrouter_reasoning_details(
         }
     )
 
-    body = open_router_provider._build_request_body(request)
+    body = open_router_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
 
     assistant = next(msg for msg in body["messages"] if msg["role"] == "assistant")
     assert assistant["reasoning_details"] == [detail]
@@ -165,6 +187,7 @@ def test_build_request_body_replays_openrouter_reasoning_details(
 @pytest.mark.asyncio
 async def test_stream_maps_reasoning_content_and_details(open_router_provider):
     redacted = {"type": "reasoning.encrypted", "data": "opaque"}
+    request = make_request()
     stream = AsyncStream(
         [
             _chunk(reasoning_content="plan "),
@@ -180,7 +203,10 @@ async def test_stream_maps_reasoning_content_and_details(open_router_provider):
     ):
         events = [
             event
-            async for event in open_router_provider.stream_response(make_request())
+            async for event in open_router_provider.stream_response(
+                request,
+                reasoning=reasoning_for(request),
+            )
         ]
 
     event_text = "".join(events)

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -16,7 +16,11 @@ from free_claude_code.providers.openai_chat.output_cap import (
     parse_output_token_cap,
 )
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 class _BadRequest(Exception):
@@ -119,7 +123,6 @@ def groq_provider():
             base_url=GROQ_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=False,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -132,7 +135,8 @@ async def test_create_stream_clamps_and_learns_on_cap_rejection(groq_provider):
             "llama-3.3-70b-versatile",
             max_tokens=64000,
             thinking={"enabled": False},
-        )
+        ),
+        reasoning=REASONING_ON,
     )
     assert body["max_completion_tokens"] == 64000
     model = body["model"]
@@ -156,7 +160,8 @@ async def test_learned_cap_clamps_next_request_without_a_400(groq_provider):
             "llama-3.3-70b-versatile",
             max_tokens=64000,
             thinking={"enabled": False},
-        )
+        ),
+        reasoning=REASONING_ON,
     )
     model = body["model"]
     groq_provider._model_output_caps[model] = 40960
@@ -177,7 +182,8 @@ async def test_unrelated_400_is_not_clamped_and_propagates(groq_provider):
             "llama-3.3-70b-versatile",
             max_tokens=100,
             thinking={"enabled": False},
-        )
+        ),
+        reasoning=REASONING_ON,
     )
     create = AsyncMock(side_effect=_BadRequest("messages: invalid role 'wizard'"))
 

--- a/tests/providers/test_openai_chat_reasoning.py
+++ b/tests/providers/test_openai_chat_reasoning.py
@@ -1,0 +1,227 @@
+import pytest
+
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.core.anthropic.models import Message, MessagesRequest
+from free_claude_code.providers.openai_chat.reasoning import (
+    encode_cerebras_reasoning,
+    encode_fireworks_reasoning,
+    encode_minimax_reasoning,
+    encode_ollama_reasoning,
+    encode_sambanova_reasoning,
+)
+
+
+def _request(model: str) -> MessagesRequest:
+    return MessagesRequest(
+        model=model,
+        messages=[Message(role="user", content="hello")],
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "policy", "expected"),
+    [
+        (
+            "MiniMax-M3",
+            ReasoningPolicy.on(),
+            {
+                "reasoning_split": True,
+                "thinking": {"type": "adaptive"},
+            },
+        ),
+        (
+            "MiniMax-M3",
+            ReasoningPolicy.off(),
+            {
+                "reasoning_split": True,
+                "thinking": {"type": "disabled"},
+            },
+        ),
+        (
+            "MiniMax-M2.7",
+            ReasoningPolicy.off(),
+            {"reasoning_split": True},
+        ),
+    ],
+)
+def test_minimax_reasoning_contract(
+    model: str,
+    policy: ReasoningPolicy,
+    expected: dict[str, object],
+) -> None:
+    body: dict[str, object] = {}
+
+    encode_minimax_reasoning(body, _request(model), policy)
+
+    assert body == {"extra_body": expected}
+
+
+@pytest.mark.parametrize(
+    ("model", "policy", "expected"),
+    [
+        (
+            "gpt-oss-120b",
+            ReasoningPolicy.on(),
+            {"reasoning_effort": "medium"},
+        ),
+        ("gpt-oss-120b", ReasoningPolicy.off(), {}),
+        ("zai-glm-4.7", ReasoningPolicy.on(), {}),
+        (
+            "zai-glm-4.7",
+            ReasoningPolicy.off(),
+            {"reasoning_effort": "none"},
+        ),
+        (
+            "gemma-4-31b",
+            ReasoningPolicy.on(),
+            {"reasoning_effort": "medium"},
+        ),
+        (
+            "gemma-4-31b",
+            ReasoningPolicy.off(),
+            {"reasoning_effort": "none"},
+        ),
+        ("llama-3.3-70b", ReasoningPolicy.on(), {}),
+    ],
+)
+def test_cerebras_reasoning_contract(
+    model: str,
+    policy: ReasoningPolicy,
+    expected: dict[str, object],
+) -> None:
+    body: dict[str, object] = {}
+
+    encode_cerebras_reasoning(body, _request(model), policy)
+
+    assert body == expected
+
+
+@pytest.mark.parametrize(
+    ("model", "policy", "expected"),
+    [
+        (
+            "DeepSeek-V3.2",
+            ReasoningPolicy.on(),
+            {"chat_template_kwargs": {"enable_thinking": True}},
+        ),
+        (
+            "deepseek-v3p2",
+            ReasoningPolicy.off(),
+            {"chat_template_kwargs": {"enable_thinking": False}},
+        ),
+        (
+            "gemma-4-31B-it",
+            ReasoningPolicy.on(),
+            {"chat_template_kwargs": {"enable_thinking": True}},
+        ),
+        ("gpt-oss-120b", ReasoningPolicy.on(), None),
+    ],
+)
+def test_sambanova_reasoning_contract(
+    model: str,
+    policy: ReasoningPolicy,
+    expected: dict[str, object] | None,
+) -> None:
+    body: dict[str, object] = {}
+
+    encode_sambanova_reasoning(body, _request(model), policy)
+
+    assert body == ({"extra_body": expected} if expected is not None else {})
+
+
+@pytest.mark.parametrize(
+    ("model", "policy", "expected"),
+    [
+        (
+            "accounts/fireworks/models/gpt-oss-120b",
+            ReasoningPolicy.on(),
+            {"reasoning_effort": "medium"},
+        ),
+        (
+            "accounts/fireworks/models/gpt-oss-120b",
+            ReasoningPolicy.off(),
+            {},
+        ),
+        (
+            "accounts/fireworks/models/deepseek-v3p1",
+            ReasoningPolicy.on(),
+            {"reasoning_effort": True},
+        ),
+        (
+            "accounts/fireworks/models/deepseek-v3p2",
+            ReasoningPolicy.off(),
+            {"reasoning_effort": False},
+        ),
+        (
+            "accounts/fireworks/models/deepseek-v4",
+            ReasoningPolicy.on(effort=ReasoningEffort.XHIGH),
+            {"reasoning_effort": "xhigh"},
+        ),
+        (
+            "accounts/fireworks/models/deepseek-v4",
+            ReasoningPolicy.off(),
+            {"reasoning_effort": "none"},
+        ),
+        (
+            "accounts/fireworks/models/qwen3-235b",
+            ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+            {"reasoning_effort": "high"},
+        ),
+        (
+            "accounts/fireworks/models/qwen3-235b",
+            ReasoningPolicy.on(budget_tokens=3072),
+            {"extra_body": {"reasoning_effort": 3072}},
+        ),
+        (
+            "accounts/fireworks/models/qwen3-235b",
+            ReasoningPolicy.off(),
+            {"reasoning_effort": "none"},
+        ),
+        (
+            "accounts/fireworks/models/glm-5p1",
+            ReasoningPolicy.on(),
+            {"reasoning_effort": True},
+        ),
+        (
+            "accounts/fireworks/models/glm-5p2",
+            ReasoningPolicy.on(),
+            {"reasoning_effort": "max"},
+        ),
+        (
+            "accounts/fireworks/models/glm-5p2",
+            ReasoningPolicy.off(),
+            {"reasoning_effort": "none"},
+        ),
+        ("accounts/fireworks/models/llama-v4", ReasoningPolicy.on(), {}),
+    ],
+)
+def test_fireworks_reasoning_contract(
+    model: str,
+    policy: ReasoningPolicy,
+    expected: dict[str, object],
+) -> None:
+    body: dict[str, object] = {}
+
+    encode_fireworks_reasoning(body, _request(model), policy)
+
+    assert body == expected
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected"),
+    [
+        (ReasoningPolicy.on(), "high"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.MAX), "max"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.XHIGH), "max"),
+        (ReasoningPolicy.off(), "none"),
+    ],
+)
+def test_ollama_reasoning_contract(
+    policy: ReasoningPolicy,
+    expected: str,
+) -> None:
+    body: dict[str, object] = {}
+
+    encode_ollama_reasoning(body, _request("gpt-oss:20b"), policy)
+
+    assert body == {"reasoning_effort": expected}

--- a/tests/providers/test_openai_chat_usage.py
+++ b/tests/providers/test_openai_chat_usage.py
@@ -8,6 +8,7 @@ import openai
 import pytest
 from httpx import Request, Response
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.providers.base import ProviderConfig
@@ -23,7 +24,7 @@ from free_claude_code.providers.openai_chat.usage import (
     usage_int,
 )
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import REASONING_ON, passthrough_rate_limiter
 
 
 class _UsageTestProvider(OpenAIChatProvider):
@@ -42,7 +43,10 @@ class _UsageTestProvider(OpenAIChatProvider):
         )
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
         return {"model": request.model, "messages": [{"role": "user", "content": "x"}]}
 
@@ -170,7 +174,10 @@ async def test_openai_chat_stream_requests_usage_and_uses_provider_prompt_tokens
 
     with patch.object(provider._client.chat.completions, "create", create):
         events = [
-            event async for event in provider.stream_response(request, input_tokens=7)
+            event
+            async for event in provider.stream_response(
+                request, input_tokens=7, reasoning=REASONING_ON
+            )
         ]
 
     create.assert_awaited_once()

--- a/tests/providers/test_openai_compat_5xx_retry.py
+++ b/tests/providers/test_openai_compat_5xx_retry.py
@@ -12,7 +12,7 @@ from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import retrying_rate_limiter
+from tests.providers.support import REASONING_ON, retrying_rate_limiter
 
 
 def _internal_5xx(code: int) -> openai.InternalServerError:
@@ -70,7 +70,9 @@ async def test_nim_stream_retries_on_openai_5xx_then_streams(status_code):
         ) as mock_create,
     ):
         mock_create.side_effect = [_internal_5xx(status_code), mock_stream()]
-        events = [e async for e in provider.stream_response(req)]
+        events = [
+            e async for e in provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     assert mock_create.await_count == 2
     assert any("Hi" in e for e in events)
@@ -114,7 +116,9 @@ async def test_nim_stream_retries_on_pre_stream_connection_error_then_streams():
         ) as mock_create,
     ):
         mock_create.side_effect = [_connection_error(), mock_stream()]
-        events = [e async for e in provider.stream_response(req)]
+        events = [
+            e async for e in provider.stream_response(req, reasoning=REASONING_ON)
+        ]
 
     assert mock_create.await_count == 2
     assert any("Recovered" in e for e in events)
@@ -149,7 +153,12 @@ async def test_nim_stream_connection_error_exhausted_emits_cause_chain():
         patch("free_claude_code.providers.openai_chat.provider.trace_event") as trace,
         pytest.raises(ExecutionFailure) as exc_info,
     ):
-        [e async for e in provider.stream_response(req, request_id="req_conn")]
+        [
+            e
+            async for e in provider.stream_response(
+                req, request_id="req_conn", reasoning=REASONING_ON
+            )
+        ]
 
     assert mock_create.await_count == 5
     error_traces = [
@@ -202,7 +211,7 @@ async def test_nim_stream_openai_5xx_exhausted_emits_user_message(
     ):
         mock_create.side_effect = _internal_5xx(status_code)
         with pytest.raises(ExecutionFailure) as exc_info:
-            [e async for e in provider.stream_response(req)]
+            [e async for e in provider.stream_response(req, reasoning=REASONING_ON)]
 
     assert mock_create.await_count == 5
     assert expect_substr in exc_info.value.message.lower()

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -2,7 +2,11 @@
 
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def test_build_request_body_preserves_empty_reasoning_content() -> None:
@@ -13,7 +17,6 @@ def test_build_request_body_preserves_empty_reasoning_content() -> None:
             base_url="https://example.invalid/v1",
             rate_limit=1,
             rate_window=1,
-            enable_thinking=True,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -31,7 +34,7 @@ def test_build_request_body_preserves_empty_reasoning_content() -> None:
         }
     )
 
-    body = provider._build_request_body(request)
+    body = provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["messages"][0] == {
         "role": "assistant",

--- a/tests/providers/test_preflight_contract.py
+++ b/tests/providers/test_preflight_contract.py
@@ -4,19 +4,24 @@ from collections.abc import AsyncIterator
 
 import pytest
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.providers.base import BaseProvider, ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import REASONING_OFF
 
 
 class RecordingOpenAIProvider(OpenAIChatProvider):
     def __init__(self) -> None:
-        self.build_calls: list[tuple[MessagesRequest, bool | None]] = []
+        self.build_calls: list[tuple[MessagesRequest, ReasoningPolicy]] = []
 
     def _build_request_body(
-        self, request: MessagesRequest, thinking_enabled: bool | None = None
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
     ) -> dict:
-        self.build_calls.append((request, thinking_enabled))
+        self.build_calls.append((request, reasoning))
         return {}
 
 
@@ -33,7 +38,7 @@ class ProviderWithoutPreflight(BaseProvider):
         input_tokens: int = 0,
         *,
         request_id: str | None = None,
-        thinking_enabled: bool | None = None,
+        reasoning: ReasoningPolicy,
     ) -> AsyncIterator[str]:
         if False:
             yield ""
@@ -57,6 +62,6 @@ def test_provider_preflight_calls_builder_and_preserves_false() -> None:
         messages=[Message(role="user", content="hello")],
     )
 
-    provider.preflight_stream(request, thinking_enabled=False)
+    provider.preflight_stream(request, reasoning=REASONING_OFF)
 
-    assert provider.build_calls == [(request, False)]
+    assert provider.build_calls == [(request, REASONING_OFF)]

--- a/tests/providers/test_provider_transport_logging.py
+++ b/tests/providers/test_provider_transport_logging.py
@@ -13,7 +13,7 @@ from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import REASONING_ON, passthrough_rate_limiter
 
 
 def _provider(*, verbose: bool = False) -> NvidiaNimProvider:
@@ -47,7 +47,12 @@ async def test_stream_failure_default_logs_exclude_exception_text(caplog) -> Non
         caplog.at_level(logging.ERROR),
         pytest.raises(ExecutionFailure),
     ):
-        [event async for event in provider.stream_response(make_messages_request())]
+        [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), reasoning=REASONING_ON
+            )
+        ]
 
     messages = " | ".join(record.getMessage() for record in caplog.records)
     assert "SECRET_OPENAI_COMPAT" not in messages
@@ -72,7 +77,12 @@ async def test_stream_failure_default_logs_cause_types_only(caplog) -> None:
         caplog.at_level(logging.ERROR),
         pytest.raises(ExecutionFailure),
     ):
-        [event async for event in provider.stream_response(make_messages_request())]
+        [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), reasoning=REASONING_ON
+            )
+        ]
 
     messages = " | ".join(record.getMessage() for record in caplog.records)
     assert "SECRET_CAUSE_DETAIL" not in messages
@@ -96,7 +106,12 @@ async def test_stream_failure_verbose_traceback_redacts_credentials(caplog) -> N
         caplog.at_level(logging.ERROR),
         pytest.raises(ExecutionFailure),
     ):
-        [event async for event in provider.stream_response(make_messages_request())]
+        [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), reasoning=REASONING_ON
+            )
+        ]
 
     messages = " | ".join(record.getMessage() for record in caplog.records)
     assert "api_key=<redacted>" in messages

--- a/tests/providers/test_reasoning_policy.py
+++ b/tests/providers/test_reasoning_policy.py
@@ -1,0 +1,89 @@
+import pytest
+
+from free_claude_code.application.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.reasoning import (
+    reasoning_budget_tokens,
+    reasoning_effort,
+)
+
+
+@pytest.mark.parametrize(
+    ("effort", "budget"),
+    [
+        (ReasoningEffort.MINIMAL, 256),
+        (ReasoningEffort.LOW, 1024),
+        (ReasoningEffort.MEDIUM, 2048),
+        (ReasoningEffort.HIGH, 4096),
+        (ReasoningEffort.XHIGH, 8192),
+        (ReasoningEffort.MAX, 16384),
+    ],
+)
+def test_fcc_effort_budget_ladder(
+    effort: ReasoningEffort,
+    budget: int,
+) -> None:
+    assert reasoning_budget_tokens(ReasoningPolicy.on(effort=effort)) == budget
+
+
+def test_explicit_budget_wins_over_effort_for_budget_provider() -> None:
+    policy = ReasoningPolicy.on(
+        effort=ReasoningEffort.MAX,
+        budget_tokens=777,
+    )
+
+    assert reasoning_budget_tokens(policy) == 777
+
+
+def test_explicit_budget_wins_over_effort_for_effort_provider() -> None:
+    policy = ReasoningPolicy.on(
+        effort=ReasoningEffort.MINIMAL,
+        budget_tokens=5000,
+    )
+
+    assert (
+        reasoning_effort(
+            policy,
+            (
+                ReasoningEffort.LOW,
+                ReasoningEffort.MEDIUM,
+                ReasoningEffort.HIGH,
+            ),
+        )
+        == ReasoningEffort.HIGH
+    )
+
+
+def test_effort_mapping_prefers_higher_level_on_tie() -> None:
+    assert (
+        reasoning_effort(
+            ReasoningPolicy.on(effort=ReasoningEffort.MEDIUM),
+            (ReasoningEffort.LOW, ReasoningEffort.HIGH),
+        )
+        == ReasoningEffort.HIGH
+    )
+
+
+def test_effort_mapping_uses_provider_default_only_without_compute_hint() -> None:
+    assert (
+        reasoning_effort(
+            ReasoningPolicy.on(),
+            (ReasoningEffort.LOW, ReasoningEffort.HIGH),
+            default=ReasoningEffort.LOW,
+        )
+        == ReasoningEffort.LOW
+    )
+
+
+def test_disabled_policy_has_no_budget_or_effort() -> None:
+    policy = ReasoningPolicy.off()
+
+    assert reasoning_budget_tokens(policy) is None
+    assert reasoning_effort(policy, (ReasoningEffort.HIGH,)) is None
+
+
+def test_effort_mapping_requires_supported_levels() -> None:
+    with pytest.raises(ValueError, match="At least one"):
+        reasoning_effort(
+            ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+            (),
+        )

--- a/tests/providers/test_sambanova.py
+++ b/tests/providers/test_sambanova.py
@@ -8,7 +8,11 @@ import pytest
 from free_claude_code.config.provider_catalog import SAMBANOVA_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def make_request(**overrides):
@@ -22,7 +26,6 @@ def sambanova_config():
         base_url=SAMBANOVA_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -63,7 +66,9 @@ def test_init_strips_trailing_slash(sambanova_config):
 
 def test_build_request_body_basic(sambanova_provider):
     """Basic request body conversion attaches system message and keeps max_tokens."""
-    body = sambanova_provider._build_request_body(make_request())
+    body = sambanova_provider._build_request_body(
+        make_request(), reasoning=REASONING_ON
+    )
 
     assert body["model"] == "Meta-Llama-3.3-70B-Instruct"
     assert body["messages"][0]["role"] == "system"
@@ -74,7 +79,7 @@ def test_build_request_body_basic(sambanova_provider):
 def test_build_request_body_preserves_caller_extra_body(sambanova_provider):
     req = make_request(extra_body={"metadata": {"user": "u1"}})
 
-    body = sambanova_provider._build_request_body(req)
+    body = sambanova_provider._build_request_body(req, reasoning=REASONING_ON)
 
     eb = body.get("extra_body")
     assert isinstance(eb, dict)
@@ -106,7 +111,10 @@ async def test_stream_response_text(sambanova_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in sambanova_provider.stream_response(make_request())
+            event
+            async for event in sambanova_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(
@@ -141,7 +149,10 @@ async def test_stream_response_tool_call(sambanova_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in sambanova_provider.stream_response(make_request())
+            event
+            async for event in sambanova_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(
@@ -177,7 +188,10 @@ async def test_stream_response_reasoning_content(sambanova_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in sambanova_provider.stream_response(make_request())
+            event
+            async for event in sambanova_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -8,6 +8,7 @@ import httpx
 import openai
 import pytest
 
+from free_claude_code.application.reasoning import ReasoningPolicy
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.core.anthropic.stream_contracts import (
     parse_sse_text,
@@ -32,7 +33,11 @@ from free_claude_code.providers.stream_recovery import (
     TruncatedProviderStreamError,
 )
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+)
 
 
 class AsyncStreamMock:
@@ -84,22 +89,6 @@ def _make_tool_assembler(provider: NvidiaNimProvider) -> OpenAIToolCallAssembler
     )
 
 
-def _make_provider_with_thinking_enabled(enabled: bool):
-    """Create a provider instance with thinking explicitly enabled or disabled."""
-    config = ProviderConfig(
-        api_key="test_key",
-        base_url="https://test.api.nvidia.com/v1",
-        rate_limit=10,
-        rate_window=60,
-        enable_thinking=enabled,
-    )
-    return NvidiaNimProvider(
-        config,
-        nim_settings=NimSettings(),
-        rate_limiter=passthrough_rate_limiter(),
-    )
-
-
 def _make_request(model: str = "test-model", stream: bool = True, **overrides: object):
     """Create a concrete request matching the original streaming-test defaults."""
     request_overrides: dict[str, object] = {
@@ -122,13 +111,14 @@ def _make_stream_runner(
     *,
     request=None,
     request_id: str | None = None,
+    reasoning: ReasoningPolicy = REASONING_ON,
 ) -> _OpenAIChatStreamRunner:
     return _OpenAIChatStreamRunner(
         provider,
         request=request or _make_request(),
         input_tokens=0,
         request_id=request_id,
-        thinking_enabled=None,
+        reasoning=reasoning,
     )
 
 
@@ -163,23 +153,49 @@ def _make_tool_calls_chunk(*, name: str, arguments: str, tool_id: str, index: in
     return _make_chunk(tool_calls=[tc])
 
 
-async def _collect_stream(provider, request):
+async def _collect_stream(
+    provider,
+    request,
+    *,
+    reasoning: ReasoningPolicy = REASONING_ON,
+):
     """Collect all SSE events from a stream."""
-    return [e async for e in provider.stream_response(request)]
+    return [e async for e in provider.stream_response(request, reasoning=reasoning)]
 
 
-async def _collect_stream_error(provider, request, **kwargs) -> ExecutionFailure:
+async def _collect_stream_error(
+    provider,
+    request,
+    *,
+    reasoning: ReasoningPolicy = REASONING_ON,
+    **kwargs,
+) -> ExecutionFailure:
     with pytest.raises(ExecutionFailure) as exc_info:
-        [e async for e in provider.stream_response(request, **kwargs)]
+        [
+            e
+            async for e in provider.stream_response(
+                request,
+                **kwargs,
+                reasoning=reasoning,
+            )
+        ]
     return exc_info.value
 
 
 async def _collect_stream_and_error(
-    provider, request, **kwargs
+    provider,
+    request,
+    *,
+    reasoning: ReasoningPolicy = REASONING_ON,
+    **kwargs,
 ) -> tuple[list[str], ExecutionFailure]:
     events: list[str] = []
     with pytest.raises(ExecutionFailure) as exc_info:
-        async for event in provider.stream_response(request, **kwargs):
+        async for event in provider.stream_response(
+            request,
+            **kwargs,
+            reasoning=reasoning,
+        ):
             events.extend((event,))
     return events, exc_info.value
 
@@ -422,7 +438,7 @@ class TestStreamingExceptionHandling:
         NIM / some templates may emit no main ``content``; a minimal text block matches
         the empty-body placeholder and helps clients that expect a text segment.
         """
-        provider = _make_provider_with_thinking_enabled(True)
+        provider = _make_provider()
         request = _make_request()
         chunk1 = _make_chunk(reasoning_content="reasoning only from provider")
         chunk2 = _make_chunk(finish_reason="stop")
@@ -556,7 +572,7 @@ class TestStreamingExceptionHandling:
     @pytest.mark.asyncio
     async def test_stream_with_reasoning_content_suppressed_when_disabled(self):
         """reasoning deltas are stripped while normal text still streams."""
-        provider = _make_provider_with_thinking_enabled(False)
+        provider = _make_provider()
         request = _make_request()
 
         chunk1 = _make_chunk(reasoning_content="I think...")
@@ -578,7 +594,11 @@ class TestStreamingExceptionHandling:
                 return_value=False,
             ),
         ):
-            events = await _collect_stream(provider, request)
+            events = await _collect_stream(
+                provider,
+                request,
+                reasoning=REASONING_OFF,
+            )
 
         event_text = "".join(events)
         assert "thinking_delta" not in event_text
@@ -843,7 +863,7 @@ class TestStreamingExceptionHandling:
 
     @pytest.mark.asyncio
     async def test_disabled_thinking_recovery_discards_reasoning(self):
-        provider = _make_provider_with_thinking_enabled(False)
+        provider = _make_provider()
         request = _make_request()
         initial_stream = AsyncStreamMock([_make_chunk(content="hello")])
         recovery_stream = AsyncStreamMock(
@@ -860,7 +880,11 @@ class TestStreamingExceptionHandling:
             new_callable=AsyncMock,
             side_effect=[initial_stream, recovery_stream],
         ):
-            events = await _collect_stream(provider, request)
+            events = await _collect_stream(
+                provider,
+                request,
+                reasoning=REASONING_OFF,
+            )
 
         parsed = parse_sse_text("".join(events))
         text = "".join(
@@ -996,7 +1020,7 @@ class TestStreamingExceptionHandling:
                 ledger=ledger,
                 error=TimeoutError("cutoff"),
                 tool_argument_alias_buffers={},
-                thinking_enabled=True,
+                reasoning_enabled=True,
             )
 
         assert events is not None

--- a/tests/providers/test_vercel.py
+++ b/tests/providers/test_vercel.py
@@ -8,7 +8,11 @@ import pytest
 from free_claude_code.config.provider_catalog import VERCEL_AI_GATEWAY_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 def make_request(**overrides):
@@ -22,7 +26,6 @@ def vercel_config():
         base_url=VERCEL_AI_GATEWAY_DEFAULT_BASE,
         rate_limit=10,
         rate_window=60,
-        enable_thinking=True,
     )
 
 
@@ -77,7 +80,9 @@ def test_build_request_body_keeps_max_tokens(vercel_provider):
             "max_tokens": 42,
         }
 
-        body = vercel_provider._build_request_body(make_request())
+        body = vercel_provider._build_request_body(
+            make_request(), reasoning=REASONING_ON
+        )
 
     assert body["messages"][0].get("name") == "alice"
     assert body["max_tokens"] == 42
@@ -87,7 +92,7 @@ def test_build_request_body_keeps_max_tokens(vercel_provider):
 def test_build_request_body_preserves_caller_extra_body(vercel_provider):
     req = make_request(extra_body={"providerOptions": {"openai": {"reasoning": "low"}}})
 
-    body = vercel_provider._build_request_body(req)
+    body = vercel_provider._build_request_body(req, reasoning=REASONING_ON)
 
     assert body["extra_body"] == {"providerOptions": {"openai": {"reasoning": "low"}}}
 
@@ -116,7 +121,10 @@ async def test_stream_response_text(vercel_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in vercel_provider.stream_response(make_request())
+            event
+            async for event in vercel_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(
@@ -148,7 +156,10 @@ async def test_stream_response_reasoning_content(vercel_provider):
         mock_create.return_value = mock_stream()
 
         events = [
-            event async for event in vercel_provider.stream_response(make_request())
+            event
+            async for event in vercel_provider.stream_response(
+                make_request(), reasoning=REASONING_ON
+            )
         ]
 
     assert any(

--- a/tests/providers/test_wafer.py
+++ b/tests/providers/test_wafer.py
@@ -1,6 +1,5 @@
 """Tests for the Wafer OpenAI-chat provider."""
 
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,28 +8,14 @@ from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKEN
 from free_claude_code.config.provider_catalog import WAFER_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import Message, MessagesRequest, Tool
 from free_claude_code.providers.base import ProviderConfig
-from free_claude_code.providers.openai_chat import (
-    OPENAI_CHAT_PROFILES,
-    OpenAIChatProvider,
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+    reasoning_for,
 )
-from free_claude_code.providers.rate_limit import ProviderRateLimiter
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
-
-
-class CountingWaferProvider(OpenAIChatProvider):
-    def __init__(self, config: ProviderConfig, *, rate_limiter: ProviderRateLimiter):
-        super().__init__(
-            config,
-            profile=OPENAI_CHAT_PROFILES["wafer"],
-            rate_limiter=rate_limiter,
-        )
-        self.thinking_checks = 0
-
-    def _is_thinking_enabled(
-        self, request: Any, thinking_enabled: bool | None = None
-    ) -> bool:
-        self.thinking_checks += 1
-        return super()._is_thinking_enabled(request, thinking_enabled)
 
 
 @pytest.fixture
@@ -79,7 +64,10 @@ def test_build_request_body_openai_shape_and_defaults(wafer_provider):
         }
     )
 
-    body = wafer_provider._build_request_body(request)
+    body = wafer_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
 
     assert body["model"] == "DeepSeek-V4-Pro"
     assert body["messages"][0] == {"role": "user", "content": "Hello"}
@@ -96,7 +84,7 @@ def test_build_request_body_honors_effective_no_thinking(wafer_provider):
         }
     )
 
-    body = wafer_provider._build_request_body(request, thinking_enabled=False)
+    body = wafer_provider._build_request_body(request, reasoning=REASONING_OFF)
 
     assert body["extra_body"]["thinking"] == {"type": "disabled"}
 
@@ -110,27 +98,28 @@ def test_build_request_body_preserves_request_disabled_thinking(wafer_provider):
         }
     )
 
-    body = wafer_provider._build_request_body(request, thinking_enabled=True)
+    body = wafer_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
 
     assert body["extra_body"]["thinking"] == {"type": "disabled"}
 
 
-def test_build_request_body_resolves_thinking_once(wafer_config):
-    provider = CountingWaferProvider(
-        wafer_config,
-        rate_limiter=passthrough_rate_limiter(),
-    )
+def test_build_request_body_uses_canonical_policy_without_rechecking_request(
+    wafer_provider,
+):
     request = MessagesRequest.model_validate(
         {
             "model": "DeepSeek-V4-Pro",
             "messages": [{"role": "user", "content": "Explore the codebase."}],
+            "thinking": {"type": "disabled"},
         }
     )
 
-    body = provider._build_request_body(request, thinking_enabled=False)
+    body = wafer_provider._build_request_body(request, reasoning=REASONING_ON)
 
-    assert body["extra_body"]["thinking"] == {"type": "disabled"}
-    assert provider.thinking_checks == 1
+    assert body["extra_body"]["thinking"] == {"type": "enabled"}
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_zai.py
+++ b/tests/providers/test_zai.py
@@ -10,7 +10,12 @@ from free_claude_code.config.provider_catalog import ZAI_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
-from tests.providers.support import passthrough_rate_limiter, profiled_provider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    passthrough_rate_limiter,
+    profiled_provider,
+)
 
 
 @pytest.fixture
@@ -22,7 +27,6 @@ def zai_provider():
             base_url=ZAI_DEFAULT_BASE,
             rate_limit=10,
             rate_window=60,
-            enable_thinking=True,
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
@@ -41,7 +45,7 @@ def test_build_request_body_openai_chat(zai_provider):
         messages=[Message(role="user", content="Hello")],
     )
 
-    body = zai_provider._build_request_body(request)
+    body = zai_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["model"] == "glm-5.2"
     assert body["max_tokens"] == 100
@@ -58,7 +62,7 @@ def test_build_request_body_default_max_tokens(zai_provider):
         messages=[Message(role="user", content="x")],
     )
 
-    body = zai_provider._build_request_body(request)
+    body = zai_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 
@@ -73,7 +77,7 @@ def test_build_request_body_rejects_caller_extra_body(zai_provider):
     )
 
     with pytest.raises(InvalidRequestError, match=r"Z\.ai Chat Completions"):
-        zai_provider._build_request_body(request)
+        zai_provider._build_request_body(request, reasoning=REASONING_ON)
 
 
 def test_build_request_body_disables_zai_thinking(zai_provider):
@@ -85,7 +89,7 @@ def test_build_request_body_disables_zai_thinking(zai_provider):
         }
     )
 
-    body = zai_provider._build_request_body(request)
+    body = zai_provider._build_request_body(request, reasoning=REASONING_OFF)
 
     assert body["extra_body"]["thinking"] == {"type": "disabled"}
 
@@ -104,7 +108,7 @@ def test_build_request_body_replays_prior_reasoning_content(zai_provider):
         }
     )
 
-    body = zai_provider._build_request_body(request)
+    body = zai_provider._build_request_body(request, reasoning=REASONING_ON)
 
     assert body["messages"][0]["reasoning_content"] == "prior"
     assert body["extra_body"]["thinking"] == {

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.7.2"
+version = "4.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Reasoning intent was re-resolved across routing and providers, sometimes conflated with output limits, and translated inconsistently. This caused unsupported fields and oversized budgets, including the NIM failure reported in #1134, while the Admin UI did not explain that CLI effort selections remain authoritative.

## Changes

| Before | After |
| --- | --- |
| Route settings, request fields, and provider config each participated in the final decision. | The application boundary resolves one immutable `ReasoningPolicy` with enablement, recognized effort, and an optional positive budget. |
| Claude Code, Codex, and Pi effort selections could appear unrelated to the Admin thinking controls. | The Admin UI states that CLI effort is translated automatically and its existing controls only enable or disable reasoning. |
| OpenAI Responses effort became only enabled or disabled. | Responses preserves effort through `output_config`; `none` disables reasoning and other recognized levels reach the shared policy. |
| NVIDIA NIM reused the output-token ceiling as `reasoning_budget`. | NIM receives a distinct budget, and Nemotron Nano v2 uses `nvext.max_thinking_tokens`; rejected optional budgets alone are removed on retry. [NVIDIA documentation](https://docs.nvidia.com/nim/large-language-models/1.15.0/thinking-budget-control.html) |
| OpenRouter received a partial ad hoc reasoning object. | OpenRouter receives its unified `reasoning` object with enablement plus native effort or an explicit maximum. [OpenRouter documentation](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens) |
| Gemini reasoning was effectively boolean. | Compatible Gemini models receive native effort, while unsupported models omit the field and only documented models receive `none`. [Gemini documentation](https://ai.google.dev/gemini-api/docs/openai) |
| DeepSeek only received a thinking toggle. | DeepSeek receives its documented enabled/disabled object plus supported high or max effort; mandatory reasoning aliases omit the toggle. [DeepSeek documentation](https://api-docs.deepseek.com/guides/thinking_mode) |
| Mistral forced high whenever reasoning was enabled. | Mistral receives the closest documented level from minimal through xhigh, or none when disabled. [Mistral documentation](https://docs.mistral.ai/studio-api/conversations/reasoning) |
| Codestral inherited assumptions from other Mistral surfaces. | Codestral omits invented reasoning fields because its coding-model contract does not define one. [Mistral model guide](https://docs.mistral.ai/models/model-selection-guide) |
| OpenCode Zen and Go could inherit generic reasoning guesses. | OpenCode profiles omit a universal field because controls are documented as model- and provider-specific. [OpenCode models](https://opencode.ai/docs/models) |
| Vercel AI Gateway had no explicit reasoning adapter. | Vercel receives native OpenAI-compatible effort when supplied and `none` for disablement. [Vercel documentation](https://vercel.com/changelog/ai-gateway-supports-openais-responses-api) |
| Hugging Face had no explicit reasoning adapter. | Hugging Face receives normalized `reasoning_effort`, with model validation left to the upstream provider. [Hugging Face documentation](https://huggingface.co/docs/inference-providers/main/en/tasks/chat-completion) |
| Cohere hard-coded high or none inside an unrelated quirk. | Cohere's dedicated encoder emits its documented binary high-or-none contract. [Cohere documentation](https://docs.cohere.com/docs/compatibility-api) |
| GitHub Models could inherit unsupported generic controls. | GitHub Models omits reasoning fields because its request schema does not define one. [GitHub documentation](https://docs.github.com/en/rest/models/inference) |
| Wafer's toggle lived as an inline profile quirk. | Wafer has an explicit enabled/disabled thinking-object encoder. [Wafer documentation](https://app.wafer.ai/models) |
| Kimi treated every model as optionally disableable. | Configurable Kimi models receive `disabled`; mandatory-reasoning K2.7 Code omits the unsupported switch. [Kimi documentation](https://platform.kimi.com/docs/guide/use-kimi-k2-thinking-model) |
| MiniMax applied adaptive/disabled controls to every model. | M3 receives adaptive/disabled, M2 keeps mandatory reasoning, and `reasoning_split` remains output separation. [MiniMax documentation](https://platform.minimax.io/docs/api-reference/text-openai-api) |
| Cerebras had no model-family policy. | Documented model families receive their supported effort vocabulary; unrelated models receive no field. [Cerebras documentation](https://inference-docs.cerebras.ai/capabilities/reasoning) |
| Groq had no model-family policy. | GPT-OSS receives low/medium/high, Qwen 3.6 receives default/none, and unrelated models receive no field. [Groq documentation](https://console.groq.com/docs/reasoning) |
| SambaNova had no model-family policy. | Only exact documented DeepSeek V3.2 and Gemma 4 families receive `chat_template_kwargs.enable_thinking`. [SambaNova documentation](https://docs.sambanova.ai/docs/en/features/text-generation) |
| Fireworks had one generic profile for incompatible model contracts. | Exact documented model families select boolean, native effort, integer Qwen budget, mandatory omission, or no field. [Fireworks documentation](https://docs.fireworks.ai/api-reference/post-chatcompletions) |
| Cloudflare always reduced reasoning to a boolean. | Cloudflare preserves its chat-template toggle, forwards explicit native effort, and invents no numeric-budget translation. [Cloudflare documentation](https://developers.cloudflare.com/workers-ai/models/glm-5.2/) |
| Z.ai's toggle was an inline profile quirk. | Z.ai has a dedicated enabled/disabled thinking object and preserves agent reasoning history with `clear_thinking=false`. [Z.ai documentation](https://docs.z.ai/guides/capabilities/thinking-mode) |
| Ollama and Ollama Cloud forced high or none. | Both use the documented low/medium/high/max/none contract and map explicit budgets to the nearest supported effort. [Ollama documentation](https://docs.ollama.com/api/openai-compatibility) |
| LM Studio had no request-side control. | LM Studio uses native effort or an explicit `reasoning_tokens` budget, never both. [LM Studio documentation](https://lmstudio.ai/changelog/lmstudio-v0.4.8) |
| llama.cpp had no request-side control. | llama.cpp receives `thinking_budget_tokens`; zero disables reasoning and positive values cap it. [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md) |
| Provider retries could lose policy or caller fields could override FCC-owned controls. | Retries preserve the policy, caller `extra_body` cannot override owned reasoning fields, and downgrade retries remove only rejected optional controls. |
| Reasoning behavior was covered through scattered expectations. | Provider-contract, routing, Responses, validation, retry, streaming, and Admin manifest regressions cover the ownership boundary. |
| The package version was 4.7.1. | The complete backward-compatible fix ships as 4.7.3 with the lockfile updated. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes reasoning policy explicit across routing and provider adapters. The main changes are:

- Resolves enablement, effort, and token budgets at the application boundary.
- Passes an immutable reasoning policy through provider execution and retries.
- Adds provider-specific reasoning encoders and model-family controls.
- Prevents caller fields from overriding application-owned reasoning settings.
- Adds validation, provider contract tests, and a package version bump.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a focused PyTest command to validate reasoning and provider code for the PR.
- The test run completed with 94 tests passing in 1.14 seconds and exit code 0.
- Generated a verbose contract validation log and uploaded it for review.
- No before-run comparison was produced because the change was already committed and reverting the broad 82-file commit was outside the requested focused validation scope.

<a href="https://app.greptile.com/trex/runs/14669377/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/application/reasoning.py | Adds the immutable provider-neutral reasoning policy and its validation rules. |
| src/free_claude_code/application/routing.py | Resolves reasoning intent after model routing and carries it with each routed request. |
| src/free_claude_code/providers/gemini/quirks.py | Adds model-aware Gemini reasoning effort and disablement translation. |
| src/free_claude_code/providers/openai_chat/reasoning.py | Defines model-family-specific reasoning encoders for OpenAI-compatible providers. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Clarify reasoning effort ownership in ad..."](https://github.com/alishahryar1/free-claude-code/commit/3ee2ea888b9e383b8c8289c4c6cf53a7e9cb8441) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44735536)</sub>

<!-- /greptile_comment -->