### PR TITLE
Fix Cerebras reasoning serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.7.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -192,7 +192,9 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             provider_name="CEREBRAS",
             include_extra_body=True,
             max_tokens_field="max_completion_tokens",
-        )
+            reasoning_replay=ReasoningReplayMode.THINK_TAGS,
+        ),
+        reasoning_delta_field="reasoning",
     ),
     "groq": OpenAIChatProfile(
         OpenAIChatRequestPolicy(

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -10,8 +10,40 @@ from tests.providers.request_factory import make_messages_request
 from tests.providers.support import passthrough_rate_limiter, profiled_provider
 
 
-def make_request(**overrides):
-    return make_messages_request("llama3.1-8b", **overrides)
+def make_request(model="llama3.1-8b", **overrides):
+    return make_messages_request(model, **overrides)
+
+
+def make_reasoning_tool_history_request():
+    return make_request(
+        "zai-glm-4.7",
+        messages=[
+            {"role": "user", "content": "Inspect the file."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "I need to read it first."},
+                    {"type": "text", "text": "I will inspect the file."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "read_file",
+                        "input": {"path": "example.py"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "print('hello')",
+                    }
+                ],
+            },
+        ],
+    )
 
 
 @pytest.fixture
@@ -59,6 +91,27 @@ def test_build_request_body_basic(cerebras_provider):
     assert "max_completion_tokens" in body
 
 
+def test_build_request_body_replays_reasoning_as_tagged_content(cerebras_provider):
+    body = cerebras_provider._build_request_body(make_reasoning_tool_history_request())
+
+    assistant = next(
+        message for message in body["messages"] if message["role"] == "assistant"
+    )
+    assert assistant["content"] == (
+        "<think>\nI need to read it first.\n</think>\n\nI will inspect the file."
+    )
+    assert assistant["tool_calls"][0]["id"] == "toolu_1"
+    assert body["messages"][-1] == {
+        "role": "tool",
+        "tool_call_id": "toolu_1",
+        "content": "print('hello')",
+    }
+    assert all(
+        "reasoning_content" not in message and "reasoning" not in message
+        for message in body["messages"]
+    )
+
+
 def test_build_request_body_global_disable_blocks_reasoning_mapping():
     provider = profiled_provider(
         "cerebras",
@@ -71,11 +124,19 @@ def test_build_request_body_global_disable_blocks_reasoning_mapping():
         ),
         rate_limiter=passthrough_rate_limiter(),
     )
-    req = make_request()
-    body = provider._build_request_body(req)
+    body = provider._build_request_body(make_reasoning_tool_history_request())
 
-    roles = [m.get("role") for m in body.get("messages", [])]
-    assert "assistant_reasoning_content" not in roles
+    assistant = next(
+        message for message in body["messages"] if message["role"] == "assistant"
+    )
+    assert assistant["content"] == "I will inspect the file."
+    assert assistant["tool_calls"][0]["id"] == "toolu_1"
+    assert all(
+        "<think>" not in str(message.get("content", ""))
+        and "reasoning_content" not in message
+        and "reasoning" not in message
+        for message in body["messages"]
+    )
 
 
 def test_build_request_body_remaps_max_tokens_preserves_message_name(cerebras_provider):
@@ -156,8 +217,8 @@ async def test_stream_response_text(cerebras_provider):
 
 
 @pytest.mark.asyncio
-async def test_stream_response_reasoning_content(cerebras_provider):
-    """reasoning_content deltas are emitted as thinking blocks."""
+async def test_stream_response_reasoning(cerebras_provider):
+    """Cerebras reasoning deltas are emitted as thinking blocks."""
     req = make_request()
 
     mock_chunk = MagicMock()
@@ -165,7 +226,7 @@ async def test_stream_response_reasoning_content(cerebras_provider):
         MagicMock(
             delta=MagicMock(
                 content=None,
-                reasoning_content="Thinking...",
+                reasoning="Thinking...",
                 tool_calls=None,
             ),
             finish_reason="stop",

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Cerebras rejects multi-turn Claude conversations because FCC serializes prior assistant thinking as the unsupported `reasoning_content` field. Cerebras also streams reasoning through `delta.reasoning`, so FCC can miss reasoning output. Fixes #1136.

## Changes

| Before | After |
| --- | --- |
| Cerebras replayed assistant thinking through `reasoning_content`. | Cerebras replays assistant thinking as `<think>`-tagged assistant content. |
| Cerebras parsed streamed reasoning from `delta.reasoning_content`. | Cerebras parses streamed reasoning from `delta.reasoning`. |
| The disabled-thinking test checked an impossible message role. | Regression tests inspect serialized fields, preserve tool history, and cover disabled thinking. |
| The package version was `4.7.1`. | The package version is `4.7.2`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes reasoning serialization for Cerebras conversations. The main changes are:

- Replays prior assistant reasoning as `<think>`-tagged content.
- Reads streamed reasoning from `delta.reasoning`.
- Adds tests for tool history and disabled thinking.
- Bumps the package version to `4.7.2`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The pre-change run showed HEAD^ failed the tagged-reasoning replay and delta.reasoning streaming tests, with 2 failures and 9 successes.
- The post-change head checkout completed successfully, with 11 tests passing in 0.73s and exit code 0.

<a href="https://app.greptile.com/trex/runs/14672360/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/openai_chat/profiles.py | Updates Cerebras reasoning replay and streaming field configuration. |
| tests/providers/test_cerebras.py | Covers tagged reasoning replay, tool history, disabled thinking, and streamed reasoning. |
| pyproject.toml | Bumps the package patch version to 4.7.2. |
| uv.lock | Synchronizes the locked editable package version. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Cerebras reasoning serialization"](https://github.com/alishahryar1/free-claude-code/commit/bff27ef4de4c968408e6a049bc6cca2068c7c836) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44744399)</sub>

<!-- /greptile_comment -->