### PR TITLE
Add LOG_LEVEL env var to control log verbosity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,6 +248,10 @@ WEB_FETCH_ALLOW_PRIVATE_NETWORKS=false
 # like ``api_key`` / ``authorization`` are redacted. Raw transport payloads still require
 # the LOG_RAW_* toggles below.
 #
+# Minimum log level for the JSON file sink: DEBUG, INFO, WARNING, ERROR, CRITICAL.
+# Defaults to DEBUG. Set to INFO or WARNING to reduce log volume.
+LOG_LEVEL=DEBUG
+#
 # Verbose diagnostics (avoid logging raw prompts / SSE bodies in production)
 DEBUG_PLATFORM_EDITS=false
 DEBUG_SUBAGENT_STACK=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.8.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/logging_config.py
+++ b/src/free_claude_code/config/logging_config.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from loguru import logger
 
 _configured = False
+_current_level = "DEBUG"
+_sink_id: int | None = None
 
 # Loguru ``logger.bind()`` key used by structured TRACE payloads; ``core/trace.py``
 # uses the identical string constant ``TRACE_PAYLOAD_BINDING``.
@@ -104,35 +106,10 @@ class InterceptHandler(logging.Handler):
             self._local.active = False
 
 
-def configure_logging(
-    log_file: str | Path, *, force: bool = False, verbose_third_party: bool = False
-) -> None:
-    """Configure loguru with JSON output to log_file and intercept stdlib logging.
-
-    Idempotent: skips if already configured (e.g. hot reload).
-    Use force=True to reconfigure (e.g. in tests with a different log path).
-
-    When ``verbose_third_party`` is false, noisy HTTP and Telegram loggers are capped
-    at WARNING unless explicitly configured otherwise.
-    """
-    global _configured
-    if _configured and not force:
-        return
-    _configured = True
-
-    # Remove default loguru handler (writes to stderr)
-    logger.remove()
-
-    log_path = Path(log_file)
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Truncate log file on fresh start for clean debugging
-    log_path.write_text("")
-
-    # Add file sink: JSON lines, DEBUG level, context vars at top level
-    logger.add(
+def _add_file_sink(log_file: str | Path, level: str) -> int:
+    return logger.add(
         log_file,
-        level="DEBUG",
+        level=level,
         format=_serialize_with_context,
         encoding="utf-8",
         mode="a",
@@ -140,20 +117,61 @@ def configure_logging(
         enqueue=True,
     )
 
-    # Intercept stdlib logging: route all root logger output to loguru
-    intercept = InterceptHandler()
-    logging.root.handlers = [intercept]
-    logging.root.setLevel(logging.DEBUG)
 
-    third_party = (
-        "httpx",
-        "httpcore",
-        "httpcore.http11",
-        "httpcore.connection",
-        "telegram",
-        "telegram.ext",
-    )
-    for name in third_party:
-        logging.getLogger(name).setLevel(
-            logging.WARNING if not verbose_third_party else logging.NOTSET
+def configure_logging(
+    log_file: str | Path,
+    *,
+    force: bool = False,
+    verbose_third_party: bool = False,
+    level: str = "DEBUG",
+) -> None:
+    """Configure loguru with JSON output to log_file and intercept stdlib logging.
+
+    Idempotent: skips if already configured with the same level (e.g. hot reload).
+    On level change, replaces only the file sink without truncating the log.
+    Use force=True to reconfigure from scratch (e.g. in tests with a different log path).
+
+    When ``verbose_third_party`` is false, noisy HTTP and Telegram loggers are capped
+    at WARNING unless explicitly configured otherwise.
+    """
+    global _configured, _current_level, _sink_id
+
+    if _configured and not force and level == _current_level:
+        return
+
+    if not _configured or force:
+        # First-time configuration: full setup with stdlib interception
+        _configured = True
+
+        logger.remove()
+
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("")
+
+        _sink_id = _add_file_sink(log_file, level)
+
+        intercept = InterceptHandler()
+        logging.root.handlers = [intercept]
+        logging.root.setLevel(logging.DEBUG)
+
+        third_party = (
+            "httpx",
+            "httpcore",
+            "httpcore.http11",
+            "httpcore.connection",
+            "telegram",
+            "telegram.ext",
         )
+        for name in third_party:
+            logging.getLogger(name).setLevel(
+                logging.WARNING if not verbose_third_party else logging.NOTSET
+            )
+    else:
+        # Level changed during supervised restart: replace only the file sink.
+        # Don't truncate the log file and don't reconfigure stdlib interception.
+        if _sink_id is not None:
+            logger.remove(_sink_id)
+        _sink_id = _add_file_sink(log_file, level)
+
+    _current_level = level

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -219,6 +219,8 @@ class Settings(BaseSettings):
     )
 
     # ==================== Debug / diagnostic logging (avoid sensitive content) ====================
+    # Minimum log level for the JSON file sink (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+    log_level: str = Field(default="DEBUG", validation_alias="LOG_LEVEL")
     # When false (default), API and SSE helpers log only metadata (counts, lengths, ids).
     log_raw_api_payloads: bool = Field(
         default=False, validation_alias="LOG_RAW_API_PAYLOADS"
@@ -317,6 +319,15 @@ class Settings(BaseSettings):
         if v == "" or v is None:
             return None
         return v
+
+    @field_validator("log_level")
+    @classmethod
+    def validate_log_level(cls, v: str) -> str:
+        valid = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        upper = v.upper()
+        if upper not in valid:
+            raise ValueError(f"LOG_LEVEL must be one of {sorted(valid)}, got {v!r}")
+        return upper
 
     @field_validator("whisper_device")
     @classmethod

--- a/src/free_claude_code/runtime/bootstrap.py
+++ b/src/free_claude_code/runtime/bootstrap.py
@@ -23,7 +23,11 @@ def build_asgi_app(
 ) -> RuntimeASGIApp:
     """Construct the complete server application and its resource owner."""
     log_path = Path(os.getenv("LOG_FILE", server_log_path()))
-    configure_logging(log_path, verbose_third_party=settings.log_raw_api_payloads)
+    configure_logging(
+        log_path,
+        level=settings.log_level,
+        verbose_third_party=settings.log_raw_api_payloads,
+    )
     provider_manager = ProviderRuntimeManager(settings)
     runtime = ApplicationRuntime(
         provider_manager,

--- a/tests/api/test_app_lifespan_and_errors.py
+++ b/tests/api/test_app_lifespan_and_errors.py
@@ -308,6 +308,7 @@ def test_bootstrap_configures_default_log_and_publishes_only_services(tmp_path):
 
     configure.assert_called_once_with(
         Path(log_path),
+        level=settings.log_level,
         verbose_third_party=settings.log_raw_api_payloads,
     )
     api_app = cast(FastAPI, asgi_app.app)

--- a/tests/config/test_logging_config.py
+++ b/tests/config/test_logging_config.py
@@ -101,3 +101,72 @@ def test_httpx_resets_to_notset_when_verbose_third_party(tmp_path) -> None:
     log_file = str(tmp_path / "verbose.log")
     configure_logging(log_file, force=True, verbose_third_party=True)
     assert logging.getLogger("httpx").level == logging.NOTSET
+
+
+def test_configure_logging_respects_level(tmp_path) -> None:
+    """INFO level suppresses DEBUG messages from the file sink."""
+    log_file = str(tmp_path / "level.log")
+    configure_logging(log_file, force=True, level="INFO")
+
+    logger.debug("should not appear")
+    logger.info("should appear")
+    logger.complete()
+
+    text = Path(log_file).read_text(encoding="utf-8")
+    assert "should appear" in text
+    assert "should not appear" not in text
+
+
+def test_configure_logging_defaults_to_debug(tmp_path) -> None:
+    """Backward compat: default level is DEBUG so all messages appear."""
+    log_file = str(tmp_path / "default.log")
+    configure_logging(log_file, force=True)
+
+    logger.debug("debug message")
+    logger.info("info message")
+    logger.complete()
+
+    text = Path(log_file).read_text(encoding="utf-8")
+    assert "debug message" in text
+    assert "info message" in text
+
+
+def test_configure_logging_handles_level_change_on_restart(tmp_path) -> None:
+    """Restart with a different level replaces the sink without truncating."""
+    log_file = str(tmp_path / "restart.log")
+
+    # First call: DEBUG level
+    configure_logging(log_file, force=True, level="DEBUG")
+    logger.debug("first debug")
+    logger.complete()
+
+    # Second call: change to INFO (simulates supervised restart)
+    configure_logging(log_file, level="INFO")
+    logger.debug("second debug")
+    logger.info("second info")
+    logger.complete()
+
+    text = Path(log_file).read_text(encoding="utf-8")
+    # First DEBUG message was written before the level change
+    assert "first debug" in text
+    # Second DEBUG is suppressed by the new INFO level
+    assert "second debug" not in text
+    # INFO messages appear regardless
+    assert "second info" in text
+
+
+def test_configure_logging_skips_when_level_unchanged(tmp_path) -> None:
+    """When level hasn't changed, the existing sink is reused."""
+    log_file = str(tmp_path / "same.log")
+    configure_logging(log_file, force=True, level="WARNING")
+    logger.warning("first warning")
+    logger.complete()
+
+    # Second call with same level — should be a no-op for the sink
+    configure_logging(log_file, level="WARNING")
+    logger.warning("second warning")
+    logger.complete()
+
+    text = Path(log_file).read_text(encoding="utf-8")
+    assert "first warning" in text
+    assert "second warning" in text

--- a/uv.lock
+++ b/uv.lock
@@ -350,34 +350,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Adds `LOG_LEVEL` env var (default `DEBUG`) with validator for Python log level names
- `configure_logging()` accepts `level` parameter; on supervised restart with a changed level, only the file sink is replaced — no truncation, no stdlib reconfiguration
- Backward compatible: default stays `DEBUG`

## Test plan
- [x] `LOG_LEVEL=INFO` suppresses DEBUG messages from the file sink
- [x] Default level is `DEBUG` (backward compat)
- [x] Supervised restart with changed level replaces sink without truncating
- [x] Same-level restart is a no-op
- [x] ruff format / ruff check / ty check pass
- [x] All existing logging config + API lifespan tests pass

Fixes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds configurable file-log verbosity through `LOG_LEVEL`. The main changes are:

- A validated `LOG_LEVEL` setting with a `DEBUG` default.
- Level-aware Loguru sink replacement during supervised restarts.
- Bootstrap propagation and tests for filtering and restart behavior.
- A package version bump and refreshed lockfile.

<h3>Confidence Score: 4/5</h3>

The same-level restart path needs to apply changed third-party verbosity before merging.

File-sink filtering and level replacement follow the intended flow.

A restart can silently retain stale third-party logger levels when only `LOG_RAW_API_PAYLOADS` changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the same-level logging scenario by running two configure\_logging calls at DEBUG, toggling verbose\_third\_party from false to true on the second call; the first call set six loggers to WARNING, and the second call did not reset them to NOTSET.
- The focused repro exited with code 1 after confirming that all affected loggers remained at the same WARNING level instead of returning to NOTSET.
- I captured a focused logging harness artifact and its execution log to document the unchanged logger levels.
- I validated the broader lifecycle behavior with a focused pytest run and related lifecycle artifacts, which reported 30 tests passed and demonstrated the before/after state assertions for INFO filtering and DEBUG defaults.

<a href="https://app.greptile.com/trex/runs/14728504/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/config/logging_config.py | Adds level-aware sink tracking, but the same-level return also suppresses updates to third-party logger verbosity. |
| src/free_claude_code/config/settings.py | Adds and validates the `LOG_LEVEL` environment setting. |
| src/free_claude_code/runtime/bootstrap.py | Passes the validated level into logging configuration. |
| tests/config/test_logging_config.py | Covers file-sink level changes but not a same-level restart with changed third-party verbosity. |
| uv.lock | Updates the project version and records platform markers for transitive CUDA extras. |

<sub>Reviews (1): Last reviewed commit: ["Add LOG\_LEVEL env var to control log ver..."](https://github.com/alishahryar1/free-claude-code/commit/c0cd7899541ce19a42eae02a88edb3ff70f9e518) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44859099)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/alishahryar1/github/Alishahryar1/free-claude-code/-/custom-context?memory=d2fd24d8-0dec-4faf-8ee4-e085e215a2f8))

<!-- /greptile_comment -->