### PR TITLE
fix: send reasoning_effort to local Ollama so thinking stays off when disabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.7.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -246,6 +246,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             provider_name="OLLAMA",
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
+        postprocessors=(_apply_ollama_thinking_policy,),
         normalize_base_url=True,
     ),
 }

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -78,7 +78,7 @@ def test_build_request_body_uses_openai_chat_shape() -> None:
 
     assert body["model"] == OLLAMA_MODEL
     assert body["messages"][0]["role"] == "system"
-    assert "reasoning_effort" not in body
+    assert body["reasoning_effort"] == "high"
     assert "thinking" not in body
     assert "extra_body" not in body
 
@@ -132,7 +132,7 @@ def test_cloud_build_request_body_replays_thinking_in_ollama_reasoning_field() -
 
 @pytest.mark.parametrize(
     ("provider", "expected_effort"),
-    [(_provider, None), (_cloud_provider, "none")],
+    [(_provider, "none"), (_cloud_provider, "none")],
 )
 def test_disabled_thinking_is_not_replayed_and_disables_ollama_reasoning(
     provider, expected_effort

--- a/uv.lock
+++ b/uv.lock
@@ -350,34 +350,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.7.1"
+version = "4.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Local Ollama was missing the thinking postprocessor that `ollama_cloud` already had. When "Enable Thinking" was disabled in settings, the proxy never sent `reasoning_effort: "none"` to local Ollama. With tools attached to the request, Ollama defaulted to thinking mode anyway, overflowing output token limits.

## Fix

Add `postprocessors=(_apply_ollama_thinking_policy,)` to the local `ollama` profile — one line change, reusing the same postprocessor already used by `ollama_cloud`.

Also updated two test assertions to match the new behavior (thinking enabled → `reasoning_effort: "high"`, thinking disabled → `reasoning_effort: "none"`).

Fixes #898

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes local Ollama honor the configured thinking mode. The main changes are:

- Apply the existing Ollama thinking policy to local requests.
- Send `reasoning_effort` as `high` or `none` based on the setting.
- Update tests for enabled and disabled thinking.
- Bump the package version to 4.7.2 and refresh the lockfile.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The local Ollama policy now matches the intended thinking setting. Tests cover both enabled and disabled request values. Package and lockfile versions are synchronized.

No blocking issues were found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the pre-change policy requests and exit status are captured in ollama-local-thinking-policy-01-before.log.
- Validated that the post-change policy requests and exit status are captured in ollama-local-thinking-policy-02-after.log.
- Verified that the targeted pytest run completed with exit code 0 and all 11 tests passing, as documented in ollama-targeted-pytest.log.
- Collected and linked the artifacts (pre-change log, post-change log, pytest log, and the Python test artifact) to support review of the verification steps.

<a href="https://app.greptile.com/trex/runs/14781697/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/openai_chat/profiles.py | Adds the Ollama thinking-policy postprocessor to the local profile. |
| tests/providers/test_ollama.py | Updates request-body expectations for enabled and disabled thinking. |
| pyproject.toml | Bumps the package version from 4.7.1 to 4.7.2. |
| uv.lock | Synchronizes the package version and refreshed platform markers. |

<sub>Reviews (2): Last reviewed commit: ["chore: bump version to 4.7.2"](https://github.com/alishahryar1/free-claude-code/commit/5da87ea21710acf2fb01b09abfc2ad3332ebc27a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44879319)</sub>

<!-- /greptile_comment -->