### PR TITLE
Remove unreliable Star History embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,6 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
   <p><em>Codex native <code>/model</code> picker with the generated FCC catalog.</em></p>
 </div>
 
-## Star History
-
-<div align="center">
-  <a href="https://star-history.com/#Alishahryar1/free-claude-code&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Alishahryar1/free-claude-code&type=Date&theme=dark">
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Alishahryar1/free-claude-code&type=Date">
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Alishahryar1/free-claude-code&type=Date" width="700">
-    </picture>
-  </a>
-</div>
-
 ## What You Get
 
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.


### PR DESCRIPTION
## Problem

GitHub's stargazer access restrictions prevent Star History from reliably rebuilding the repository timeline. The README can therefore display stale or unavailable growth data.

## Changes

| Before | After |
| --- | --- |
| The README embedded a Star History chart backed by restricted stargazer data. | The README omits the unreliable Star History section. |
| The top project badges appeared above the Star History chart. | The top project badges remain unchanged above the usage content. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the unreliable Star History chart from the README.

- Deletes the Star History heading and external embed.
- Leaves the surrounding badges, screenshots, and usage content unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed documentation. The removed block is self-contained, and the surrounding README remains valid.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The general contract validation proof showed that both captures identify the actual source path, clean worktree state, commit, SHA-256, checked patterns, occurrence counts, H2 sequence, and README lines 3–54.
- The proof also confirms that both executions completed with OVERALL=PASS and exit code 0.

<a href="https://app.greptile.com/trex/runs/14746868/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Removes a self-contained external chart block without leaving broken Markdown, HTML, navigation, or repository references. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove broken Star History embed"](https://github.com/alishahryar1/free-claude-code/commit/a266b8cdbb585d4c644aaaf4e4d57ece7669ab17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44896601)</sub>

<!-- /greptile_comment -->