### PR TITLE
Honor reasoning tiers on numeric-budget providers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -611,14 +611,18 @@ provider-neutral `ReasoningPolicy`. It represents three distinct facts:
 
 - `control`: provider default, explicitly off, or explicitly on;
 - `effort`: the client's named effort when one was supplied;
-- `budget_tokens`: an exact positive client budget, never a derived value.
+- `budget_tokens`: an exact positive client budget when one was supplied.
+
+When a numeric-budget provider needs a budget, `ReasoningPolicy` expresses named
+effort through FCC's single product scale: `minimal`/`low=512`, `medium=1024`,
+`high=2048`, `xhigh=4096`, and `max=8192`. Exact client budgets take precedence.
 
 The application layer resolves configuration and client input into this value;
 the API layer may replace it for a product policy such as the safety classifier;
 providers receive it unchanged. Provider adapters alone translate the subset
 their documented wire API can represent. The shared OpenAI-chat implementation
 uses small encoder objects for named effort, reasoning objects, thinking
-objects, chat-template booleans, exact llama.cpp budgets, and split reasoning
+objects, chat-template booleans, numeric llama.cpp budgets, and split reasoning
 output. Specialized providers keep only translations that cannot be expressed
 by those encoders.
 
@@ -631,11 +635,11 @@ for a valid continuation.
 The boundary has four hard rules:
 
 1. Never inspect an upstream model name or version to select reasoning behavior.
-2. Never convert a named effort into a fabricated token budget, or use the
-   output-token limit as a reasoning budget.
-3. Forward an exact token budget only where the provider documents one; otherwise
-   translate a supported named or boolean control and leave unsupported precision
-   to the provider.
+2. Prefer a provider's named effort vocabulary; use FCC's documented numeric
+   scale only when the provider exposes a numeric budget rather than named effort.
+3. Never use the output-token limit as a reasoning budget. Forward exact or
+   FCC-mapped budgets only through documented numeric fields; otherwise translate
+   a supported named or boolean control and leave unsupported precision upstream.
 4. Provider-default intent emits no compute-control field. Explicit off requests
    an upstream disable where supported and always suppresses reasoning output at
    the FCC protocol boundary.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ For example, route Opus to `nvidia_nim/moonshotai/kimi-k2.6`, Sonnet to `open_ro
 
 Open **Admin UI → Model Config → Reasoning** to choose how FCC handles client reasoning controls. The default **From client** option preserves reasoning effort sent by Claude Code, Codex, or Pi; when the client sends no control, the provider keeps its own default.
 
-You can instead select **Off**, **Low**, **Medium**, **High**, **X-High**, or **Max**. Fable, Opus, Sonnet, and Haiku each have the same choices plus **Inherit**, which uses the root policy. FCC translates each choice only into controls documented by that provider, so unsupported precision safely remains provider-defined.
+You can instead select **Off**, **Low**, **Medium**, **High**, **X-High**, or **Max**. Fable, Opus, Sonnet, and Haiku each have the same choices plus **Inherit**, which uses the root policy. Providers with named effort receive those names; numeric-budget providers map **Low=512**, **Medium=1,024**, **High=2,048**, **X-High=4,096**, and **Max=8,192** reasoning tokens; boolean providers receive on or off. Unsupported controls safely remain provider-defined.
 
 <a id="connect-your-client"></a>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.8.1"
+version = "4.8.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/reasoning.py
+++ b/src/free_claude_code/core/reasoning.py
@@ -22,6 +22,22 @@ class ReasoningEffort(StrEnum):
     XHIGH = "xhigh"
     MAX = "max"
 
+    @property
+    def budget_tokens(self) -> int:
+        """Return FCC's numeric token budget for this effort."""
+
+        return _EFFORT_BUDGET_TOKENS[self]
+
+
+_EFFORT_BUDGET_TOKENS = {
+    ReasoningEffort.MINIMAL: 512,
+    ReasoningEffort.LOW: 512,
+    ReasoningEffort.MEDIUM: 1_024,
+    ReasoningEffort.HIGH: 2_048,
+    ReasoningEffort.XHIGH: 4_096,
+    ReasoningEffort.MAX: 8_192,
+}
+
 
 @dataclass(frozen=True, slots=True)
 class ReasoningPolicy:
@@ -88,6 +104,18 @@ class ReasoningPolicy:
             or self.effort is not None
             or self.budget_tokens is not None
         )
+
+    @property
+    def numeric_budget_tokens(self) -> int | None:
+        """Express this intent as an exact or FCC-mapped numeric budget."""
+
+        if self.control is ReasoningControl.OFF:
+            return None
+        if self.budget_tokens is not None:
+            return self.budget_tokens
+        if self.effort is None:
+            return None
+        return self.effort.budget_tokens
 
 
 DEFAULT_REASONING_POLICY = ReasoningPolicy.provider_default()

--- a/src/free_claude_code/providers/nvidia_nim/request_options.py
+++ b/src/free_claude_code/providers/nvidia_nim/request_options.py
@@ -98,8 +98,8 @@ def apply_nim_request_options(
             enabled = reasoning.control is not ReasoningControl.OFF
             chat_template_kwargs["thinking"] = enabled
             chat_template_kwargs["enable_thinking"] = enabled
-            if enabled and reasoning.budget_tokens is not None:
-                chat_template_kwargs["reasoning_budget"] = reasoning.budget_tokens
+            if enabled and (budget := reasoning.numeric_budget_tokens) is not None:
+                chat_template_kwargs["reasoning_budget"] = budget
 
     req_top_k = request_data.top_k
     top_k = req_top_k if req_top_k is not None else nim.top_k

--- a/src/free_claude_code/providers/nvidia_nim/request_options.py
+++ b/src/free_claude_code/providers/nvidia_nim/request_options.py
@@ -79,6 +79,7 @@ def apply_nim_request_options(
         extra_body.update(deepcopy(request_extra))
     for key in (
         "reasoning",
+        "reasoning_budget",
         "reasoning_effort",
         "reasoning_tokens",
         "thinking",

--- a/src/free_claude_code/providers/openai_chat/reasoning.py
+++ b/src/free_claude_code/providers/openai_chat/reasoning.py
@@ -110,13 +110,13 @@ class ChatTemplateReasoning:
 
 @dataclass(frozen=True, slots=True)
 class LlamaCppReasoning:
-    """Encode llama.cpp's exact per-request numeric thinking budget."""
+    """Encode llama.cpp's per-request numeric thinking budget."""
 
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         if policy.control is ReasoningControl.OFF:
             _extra_body(body)["thinking_budget_tokens"] = 0
-        elif policy.budget_tokens is not None:
-            _extra_body(body)["thinking_budget_tokens"] = policy.budget_tokens
+        elif (budget := policy.numeric_budget_tokens) is not None:
+            _extra_body(body)["thinking_budget_tokens"] = budget
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/application/test_reasoning.py
+++ b/tests/application/test_reasoning.py
@@ -40,7 +40,7 @@ def test_client_reasoning_preserves_effort_and_exact_budget() -> None:
     )
 
 
-def test_named_effort_does_not_invent_a_token_budget() -> None:
+def test_named_effort_preserves_intent_without_exact_client_budget() -> None:
     policy = client_reasoning_policy(_request(output_config={"effort": "high"}))
 
     assert policy == ReasoningPolicy(
@@ -127,3 +127,43 @@ def test_reasoning_budget_requires_a_positive_integer(budget: int) -> None:
 def test_reasoning_budget_requires_explicit_on_control() -> None:
     with pytest.raises(ValueError, match="control to be on"):
         ReasoningPolicy(budget_tokens=100)
+
+
+@pytest.mark.parametrize(
+    ("effort", "expected"),
+    (
+        (ReasoningEffort.MINIMAL, 512),
+        (ReasoningEffort.LOW, 512),
+        (ReasoningEffort.MEDIUM, 1_024),
+        (ReasoningEffort.HIGH, 2_048),
+        (ReasoningEffort.XHIGH, 4_096),
+        (ReasoningEffort.MAX, 8_192),
+    ),
+)
+def test_reasoning_effort_has_one_fcc_numeric_budget(
+    effort: ReasoningEffort, expected: int
+) -> None:
+    assert ReasoningPolicy.on(effort=effort).numeric_budget_tokens == expected
+
+
+def test_exact_reasoning_budget_takes_precedence_over_effort_mapping() -> None:
+    policy = ReasoningPolicy.on(
+        effort=ReasoningEffort.XHIGH,
+        budget_tokens=777,
+    )
+
+    assert policy.numeric_budget_tokens == 777
+
+
+@pytest.mark.parametrize(
+    "policy",
+    (
+        ReasoningPolicy.provider_default(),
+        ReasoningPolicy.off(),
+        ReasoningPolicy.on(),
+    ),
+)
+def test_reasoning_without_numeric_intensity_has_no_budget(
+    policy: ReasoningPolicy,
+) -> None:
+    assert policy.numeric_budget_tokens is None

--- a/tests/providers/test_nvidia_nim.py
+++ b/tests/providers/test_nvidia_nim.py
@@ -8,7 +8,7 @@ from httpx import Request, Response
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.config.provider_catalog import NVIDIA_NIM_DEFAULT_BASE
 from free_claude_code.core.failures import ExecutionFailure
-from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from free_claude_code.providers.nvidia_nim.tool_schema import (
     NIM_TOOL_ARGUMENT_ALIASES_KEY,
@@ -767,14 +767,15 @@ async def test_stream_response_retries_without_reasoning_budget(nim_provider):
         events = [
             e
             async for e in nim_provider.stream_response(
-                req, reasoning=ReasoningPolicy.on(budget_tokens=77)
+                req,
+                reasoning=ReasoningPolicy.on(effort=ReasoningEffort.XHIGH),
             )
         ]
 
     assert mock_create.await_count == 2
     first_call = mock_create.await_args_list[0].kwargs
     second_call = mock_create.await_args_list[1].kwargs
-    assert first_call["extra_body"]["chat_template_kwargs"]["reasoning_budget"] == 77
+    assert first_call["extra_body"]["chat_template_kwargs"]["reasoning_budget"] == 4096
     assert "reasoning_budget" not in second_call["extra_body"]
     assert "reasoning_budget" not in second_call["extra_body"]["chat_template_kwargs"]
     assert second_call["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True

--- a/tests/providers/test_nvidia_nim_request.py
+++ b/tests/providers/test_nvidia_nim_request.py
@@ -101,14 +101,31 @@ class TestSetExtra:
 
 
 class TestBuildRequestBody:
-    def test_named_effort_enables_boolean_chat_template_control(self, req):
-        policy = ReasoningPolicy(effort=ReasoningEffort.HIGH)
+    @pytest.mark.parametrize(
+        ("effort", "expected_budget"),
+        (
+            (ReasoningEffort.MINIMAL, 512),
+            (ReasoningEffort.LOW, 512),
+            (ReasoningEffort.MEDIUM, 1_024),
+            (ReasoningEffort.HIGH, 2_048),
+            (ReasoningEffort.XHIGH, 4_096),
+            (ReasoningEffort.MAX, 8_192),
+        ),
+    )
+    def test_named_effort_enables_thinking_with_numeric_budget(
+        self,
+        req,
+        effort: ReasoningEffort,
+        expected_budget: int,
+    ):
+        policy = ReasoningPolicy(effort=effort)
 
         body = build_request_body(req, NimSettings(), reasoning=policy)
 
         assert body["extra_body"]["chat_template_kwargs"] == {
             "thinking": True,
             "enable_thinking": True,
+            "reasoning_budget": expected_budget,
         }
 
     def test_max_tokens_capped_by_nim(self, req):

--- a/tests/providers/test_nvidia_nim_request.py
+++ b/tests/providers/test_nvidia_nim_request.py
@@ -128,6 +128,34 @@ class TestBuildRequestBody:
             "reasoning_budget": expected_budget,
         }
 
+    def test_named_effort_replaces_client_reasoning_budgets(self):
+        req = make_messages_request(
+            model="test",
+            thinking=None,
+            extra_body={
+                "reasoning_budget": 99,
+                "chat_template_kwargs": {
+                    "reasoning_budget": 100,
+                    "custom": "value",
+                },
+            },
+        )
+
+        body = build_request_body(
+            req,
+            NimSettings(),
+            reasoning=ReasoningPolicy(effort=ReasoningEffort.HIGH),
+        )
+
+        extra_body = body["extra_body"]
+        assert "reasoning_budget" not in extra_body
+        assert extra_body["chat_template_kwargs"] == {
+            "custom": "value",
+            "thinking": True,
+            "enable_thinking": True,
+            "reasoning_budget": 2048,
+        }
+
     def test_max_tokens_capped_by_nim(self, req):
         req.max_tokens = 100000
         nim = NimSettings(max_tokens=4096)

--- a/tests/providers/test_openai_chat_reasoning.py
+++ b/tests/providers/test_openai_chat_reasoning.py
@@ -88,17 +88,17 @@ def test_chat_template_encoder_maps_named_effort_to_boolean_capability() -> None
     assert body == {"extra_body": {"chat_template_kwargs": {"thinking": True}}}
 
 
-def test_llamacpp_encoder_forwards_only_exact_budget_or_off() -> None:
-    default_body: dict = {}
+def test_llamacpp_encoder_maps_effort_preserves_exact_budget_and_disables() -> None:
+    effort_body: dict = {}
     budget_body: dict = {}
     off_body: dict = {}
     encoder = LlamaCppReasoning()
 
-    encoder.encode(default_body, ReasoningPolicy.on(effort=ReasoningEffort.HIGH))
+    encoder.encode(effort_body, ReasoningPolicy.on(effort=ReasoningEffort.HIGH))
     encoder.encode(budget_body, ReasoningPolicy.on(budget_tokens=256))
     encoder.encode(off_body, ReasoningPolicy.off())
 
-    assert default_body == {}
+    assert effort_body == {"extra_body": {"thinking_budget_tokens": 2048}}
     assert budget_body == {"extra_body": {"thinking_budget_tokens": 256}}
     assert off_body == {"extra_body": {"thinking_budget_tokens": 0}}
 

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.8.1"
+version = "4.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC preserved named reasoning effort but numeric-budget providers received no intensity unless a client supplied an exact token budget. NIM and llama.cpp therefore treated Low through Max like the same provider default.

## Changes

| Before | After |
| --- | --- |
| Named effort had no FCC-owned numeric meaning. | FCC maps Low, Medium, High, X-High, and Max to 512, 1,024, 2,048, 4,096, and 8,192 tokens. |
| NIM received only thinking booleans for named effort. | [NIM](https://docs.nvidia.com/nim/large-language-models/1.15.0/thinking-budget-control.html) receives thinking booleans plus the mapped `reasoning_budget`, retaining its existing retry without rejected budget control. |
| llama.cpp forwarded only exact client budgets. | [llama.cpp](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md) receives the mapped `thinking_budget_tokens` value. |
| Named, boolean, and provider-default adapters shared no explicit numeric contract. | Named adapters keep words, boolean adapters keep on/off, and only numeric-budget adapters consume the FCC scale. |
| Documentation prohibited every named-effort budget conversion. | Documentation defines the product scale, exact-budget precedence, and model-independent ownership boundary. |
| Version 4.8.0 exposed tiers that collapsed on numeric providers. | Version 4.8.1 completes the tiers; all five local CI checks pass with 2,383 tests passed and 40 skipped. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gives named reasoning tiers numeric budgets on providers that use token-based controls. The main changes are:

- Adds one shared effort-to-token scale with exact-budget precedence.
- Sends mapped budgets to NVIDIA NIM and llama.cpp.
- Removes conflicting client-supplied NIM budget fields.
- Retains NIM retry behavior when budget control is rejected.
- Updates tests, documentation, and the package version.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The NIM fix removes conflicting top-level and nested client budgets. The retry path strips the canonical budget when NIM rejects budget control. No distinct blocking issue remains in the latest fixes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We examined the pre-change state and found that NIM flags were booleans and no numeric NIM or llama.cpp budget was emitted, while 321 remained supported.
- We confirmed after the change that numeric request bodies are properly mapped for both provider paths.
- We ran the focused pytest and it completed with exit code 0 and 18 tests passed in 0.77s.
- We reviewed the uploaded artifacts, which include three URL-backed logs and a Python source artifact to inspect the mapping and test results.

<a href="https://app.greptile.com/trex/runs/14803745/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/reasoning.py | Adds the shared effort-to-token mapping while preserving exact budgets and provider-default behavior. |
| src/free_claude_code/providers/nvidia_nim/request_options.py | Removes competing budget fields before writing one canonical NIM reasoning budget. |
| src/free_claude_code/providers/openai_chat/reasoning.py | Extends llama.cpp encoding to send mapped budgets for named effort. |
| tests/providers/test_nvidia_nim_request.py | Covers all named tiers and conflicting top-level and nested NIM budget inputs. |
| tests/providers/test_nvidia_nim.py | Confirms NIM retries without rejected mapped budget control. |
| tests/providers/test_openai_chat_reasoning.py | Covers mapped effort, exact budget, and disabled llama.cpp reasoning. |

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: bump version to 4.8.2"](https://github.com/alishahryar1/free-claude-code/commit/a3f474d8a80a8ff8f3b883ad525949d140fd5570) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44998377)</sub>

<!-- /greptile_comment -->