### PR TITLE
Keep inline system reminders cache-stable across providers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -699,13 +699,15 @@ usage quirks such as DeepSeek prompt-cache counters.
   stream ledger, Anthropic SSE emitter, continuation-body construction, and tool repair;
 - token counting and Anthropic-owned failure-kind-to-wire mapping.
 
-Anthropic request models validate transcript data without merging, hoisting, or
-reordering semantically meaningful message roles. Top-level `system` content
-stays distinct from inline `system` messages. Target-protocol conversion owns
-their representation: neutral OpenAI Chat conversion preserves inline role and
-order, and rejects unrepresentable blocks instead of dropping them. Any
-provider-specific deviation belongs in an explicit request policy backed by a
-known upstream incompatibility.
+`MessagesRequest` is an ingress model; no current provider sends Anthropic wire
+requests downstream. Anthropic request models validate transcript data without
+merging, hoisting, or reordering semantically meaningful message roles.
+Top-level `system` content stays distinct from inline `system` messages.
+Target-protocol conversion owns their representation: neutral OpenAI Chat
+conversion emits top-level `system` content as the sole leading system message
+and maps inline `system` content to ordered `user` messages. It preserves the
+existing text and position, and rejects unrepresentable blocks instead of
+dropping them. Provider policies do not reinterpret this role mapping.
 
 User image conversion is a pure protocol operation. Core maps Anthropic base64
 and URL image sources to ordered OpenAI `image_url` content parts without

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -705,9 +705,11 @@ merging, hoisting, or reordering semantically meaningful message roles.
 Top-level `system` content stays distinct from inline `system` messages.
 Target-protocol conversion owns their representation: neutral OpenAI Chat
 conversion emits top-level `system` content as the sole leading system message
-and maps inline `system` content to ordered `user` messages. It preserves the
-existing text and position, and rejects unrepresentable blocks instead of
-dropping them. Provider policies do not reinterpret this role mapping.
+and maps inline `system` content into ordered `user` turns. After tool-result
+dependencies are ordered, adjacent user content is coalesced into one turn so
+strict chat templates do not receive consecutive user roles. Conversion
+preserves content order and rejects unrepresentable blocks instead of dropping
+them. Provider policies do not reinterpret this role mapping.
 
 User image conversion is a pure protocol operation. Core maps Anthropic base64
 and URL image sources to ordered OpenAI `image_url` content parts without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.8.0"
+version = "4.8.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -402,7 +402,8 @@ class AnthropicToOpenAIConverter:
                     "OpenAI chat conversion requires an inline Anthropic system "
                     "message to contain text."
                 )
-            return [_PlainSegment([{"role": "system", "content": system_text}])]
+            # Reserve the downstream system role for request.system at index zero.
+            return [_PlainSegment([{"role": "user", "content": system_text}])]
         if role == "assistant" and isinstance(content, list):
             if (first_i := _index_first_tool_use(content)) is not None:
                 for block in content:

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -219,6 +219,55 @@ def _openai_user_image_part(block: Any) -> dict[str, Any]:
     return {"type": "image_url", "image_url": {"url": url}}
 
 
+def _openai_user_content_parts(content: Any) -> list[dict[str, Any]]:
+    """Return an owned content-part list for one converted user message."""
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    if isinstance(content, list) and all(isinstance(part, dict) for part in content):
+        return deepcopy(content)
+    raise OpenAIConversionError(
+        "OpenAI chat conversion produced unsupported user message content."
+    )
+
+
+def _merge_openai_user_content(first: Any, second: Any) -> str | list[dict[str, Any]]:
+    """Combine adjacent user content while preserving multimodal part order."""
+    if isinstance(first, str) and isinstance(second, str):
+        return f"{first}\n\n{second}"
+
+    first_parts = _openai_user_content_parts(first)
+    second_parts = _openai_user_content_parts(second)
+    first_ends_in_text = bool(first_parts) and first_parts[-1].get("type") == "text"
+    second_starts_with_text = (
+        bool(second_parts) and second_parts[0].get("type") == "text"
+    )
+    if first_ends_in_text and second_starts_with_text:
+        first_text = first_parts[-1].get("text", "")
+        second_text = second_parts.pop(0).get("text", "")
+        first_parts[-1]["text"] = f"{first_text}\n\n{second_text}"
+    return [*first_parts, *second_parts]
+
+
+def _coalesce_openai_user_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Combine adjacent user messages after transcript ordering is complete."""
+    result: list[dict[str, Any]] = []
+    for message in messages:
+        if (
+            message.get("role") == "user"
+            and result
+            and result[-1].get("role") == "user"
+        ):
+            previous = result[-1]
+            previous["content"] = _merge_openai_user_content(
+                previous.get("content"), message.get("content")
+            )
+            continue
+        result.append(message)
+    return result
+
+
 class _OpenAIChatHistoryLedger:
     """Assemble OpenAI chat history while respecting tool-result dependencies."""
 
@@ -382,7 +431,7 @@ class AnthropicToOpenAIConverter:
                 else:
                     ledger.add_tool_turn(segment)
 
-        return ledger.finish()
+        return _coalesce_openai_user_messages(ledger.finish())
 
     @staticmethod
     def _convert_message_to_segments(

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -59,7 +59,7 @@ def test_convert_system_prompt_none():
     assert AnthropicToOpenAIConverter.convert_system_prompt(None) is None
 
 
-def test_openai_build_preserves_top_level_and_inline_system_message_order() -> None:
+def test_openai_build_uses_only_top_level_system_role() -> None:
     request = MessagesRequest.model_validate(
         {
             "model": "model",
@@ -69,6 +69,7 @@ def test_openai_build_preserves_top_level_and_inline_system_message_order() -> N
                 {"role": "assistant", "content": "First answer"},
                 {"role": "system", "content": "Instructions from this point"},
                 {"role": "user", "content": "Second question"},
+                {"role": "system", "content": "A second reminder"},
             ],
         }
     )
@@ -79,12 +80,13 @@ def test_openai_build_preserves_top_level_and_inline_system_message_order() -> N
         {"role": "system", "content": "Conversation-wide instructions"},
         {"role": "user", "content": "First question"},
         {"role": "assistant", "content": "First answer"},
-        {"role": "system", "content": "Instructions from this point"},
+        {"role": "user", "content": "Instructions from this point"},
         {"role": "user", "content": "Second question"},
+        {"role": "user", "content": "A second reminder"},
     ]
 
 
-def test_openai_build_joins_inline_system_text_blocks_without_repositioning() -> None:
+def test_openai_build_demotes_inline_system_text_blocks_without_repositioning() -> None:
     request = MessagesRequest.model_validate(
         {
             "model": "model",
@@ -104,10 +106,14 @@ def test_openai_build_joins_inline_system_text_blocks_without_repositioning() ->
 
     body = build_base_request_body(request)
 
-    assert body["messages"][1] == {
-        "role": "system",
-        "content": "First instruction\n\nSecond instruction",
-    }
+    assert body["messages"] == [
+        {"role": "user", "content": "Before"},
+        {
+            "role": "user",
+            "content": "First instruction\n\nSecond instruction",
+        },
+        {"role": "user", "content": "After"},
+    ]
 
 
 def test_inline_system_message_preserves_existing_openai_cache_prefix() -> None:
@@ -128,7 +134,13 @@ def test_inline_system_message_preserves_existing_openai_cache_prefix() -> None:
             "messages": [
                 {"role": "user", "content": "First question"},
                 {"role": "assistant", "content": "First answer"},
-                {"role": "system", "content": "Instructions from this point"},
+                {
+                    "role": "system",
+                    "content": (
+                        "<system-reminder>Instructions from this point"
+                        "</system-reminder>"
+                    ),
+                },
                 {"role": "user", "content": "Second question"},
             ],
         }
@@ -139,7 +151,12 @@ def test_inline_system_message_preserves_existing_openai_cache_prefix() -> None:
 
     assert continued[: len(prefix)] == prefix
     assert continued[len(prefix) :] == [
-        {"role": "system", "content": "Instructions from this point"},
+        {
+            "role": "user",
+            "content": (
+                "<system-reminder>Instructions from this point</system-reminder>"
+            ),
+        },
         {"role": "user", "content": "Second question"},
     ]
 
@@ -180,7 +197,7 @@ def test_inline_system_message_follows_completed_tool_result() -> None:
     assert [message["role"] for message in body["messages"]] == [
         "assistant",
         "tool",
-        "system",
+        "user",
     ]
 
 

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -66,10 +66,11 @@ def test_openai_build_uses_only_top_level_system_role() -> None:
             "system": "Conversation-wide instructions",
             "messages": [
                 {"role": "user", "content": "First question"},
-                {"role": "assistant", "content": "First answer"},
                 {"role": "system", "content": "Instructions from this point"},
-                {"role": "user", "content": "Second question"},
                 {"role": "system", "content": "A second reminder"},
+                {"role": "assistant", "content": "First answer"},
+                {"role": "user", "content": "Second question"},
+                {"role": "system", "content": "A final reminder"},
             ],
         }
     )
@@ -78,11 +79,14 @@ def test_openai_build_uses_only_top_level_system_role() -> None:
 
     assert body["messages"] == [
         {"role": "system", "content": "Conversation-wide instructions"},
-        {"role": "user", "content": "First question"},
+        {
+            "role": "user",
+            "content": (
+                "First question\n\nInstructions from this point\n\nA second reminder"
+            ),
+        },
         {"role": "assistant", "content": "First answer"},
-        {"role": "user", "content": "Instructions from this point"},
-        {"role": "user", "content": "Second question"},
-        {"role": "user", "content": "A second reminder"},
+        {"role": "user", "content": "Second question\n\nA final reminder"},
     ]
 
 
@@ -99,7 +103,6 @@ def test_openai_build_demotes_inline_system_text_blocks_without_repositioning() 
                         {"type": "text", "text": "Second instruction"},
                     ],
                 },
-                {"role": "user", "content": "After"},
             ],
         }
     )
@@ -107,12 +110,10 @@ def test_openai_build_demotes_inline_system_text_blocks_without_repositioning() 
     body = build_base_request_body(request)
 
     assert body["messages"] == [
-        {"role": "user", "content": "Before"},
         {
             "role": "user",
-            "content": "First instruction\n\nSecond instruction",
-        },
-        {"role": "user", "content": "After"},
+            "content": "Before\n\nFirst instruction\n\nSecond instruction",
+        }
     ]
 
 
@@ -134,6 +135,7 @@ def test_inline_system_message_preserves_existing_openai_cache_prefix() -> None:
             "messages": [
                 {"role": "user", "content": "First question"},
                 {"role": "assistant", "content": "First answer"},
+                {"role": "user", "content": "Second question"},
                 {
                     "role": "system",
                     "content": (
@@ -141,7 +143,6 @@ def test_inline_system_message_preserves_existing_openai_cache_prefix() -> None:
                         "</system-reminder>"
                     ),
                 },
-                {"role": "user", "content": "Second question"},
             ],
         }
     )
@@ -154,10 +155,54 @@ def test_inline_system_message_preserves_existing_openai_cache_prefix() -> None:
         {
             "role": "user",
             "content": (
-                "<system-reminder>Instructions from this point</system-reminder>"
+                "Second question\n\n<system-reminder>Instructions from this point"
+                "</system-reminder>"
             ),
-        },
-        {"role": "user", "content": "Second question"},
+        }
+    ]
+
+
+def test_inline_system_message_coalesces_with_multimodal_user_content() -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "model",
+            "messages": [
+                {"role": "user", "content": "Existing context."},
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "url",
+                                "url": "https://example.com/image.png",
+                            },
+                        },
+                        {"type": "text", "text": "Inspect this image."},
+                    ],
+                },
+                {"role": "system", "content": "Focus on correctness."},
+            ],
+        }
+    )
+
+    body = build_base_request_body(request)
+
+    assert body["messages"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Existing context."},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                },
+                {
+                    "type": "text",
+                    "text": "Inspect this image.\n\nFocus on correctness.",
+                },
+            ],
+        }
     ]
 
 
@@ -166,6 +211,7 @@ def test_inline_system_message_follows_completed_tool_result() -> None:
         {
             "model": "model",
             "messages": [
+                {"role": "user", "content": "Use the tool"},
                 {
                     "role": "assistant",
                     "content": [
@@ -195,10 +241,12 @@ def test_inline_system_message_follows_completed_tool_result() -> None:
     body = build_base_request_body(request)
 
     assert [message["role"] for message in body["messages"]] == [
+        "user",
         "assistant",
         "tool",
         "user",
     ]
+    assert body["messages"][-1]["content"] == "New instructions"
 
 
 def test_openai_build_rejects_non_text_inline_system_blocks() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.8.0"
+version = "4.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Inline Anthropic system reminders were forwarded as mid-conversation OpenAI system roles. Compatible provider chat templates could reposition those roles, changing prior prompt tokens and causing periodic full cache misses. Fixes #1152.

## Changes

| Before | After |
| --- | --- |
| Top-level and inline system content both used downstream system roles. | Only top-level system content uses the leading downstream system role. |
| Inline system reminders could trigger provider-side prompt retemplating. | Inline system reminders keep their text and position as downstream user messages. |
| Provider policies could reinterpret the shared role mapping. | Shared conversion owns one provider-independent role mapping. |
| Cache-prefix coverage allowed mid-conversation system roles. | Cache-prefix coverage requires append-only user-encoded reminders. |
| The package version was 4.8.0. | The package version is 4.8.1. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps inline system reminders stable across OpenAI-compatible providers. The main changes are:

- Maps only the top-level system prompt to the downstream system role.
- Encodes inline system reminders as ordered user content.
- Coalesces adjacent user messages after transcript ordering.
- Adds tests for text, multimodal content, cache-prefix stability, and tool-result ordering.
- Updates the architecture notes and bumps the package to 4.8.1.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Adjacent user messages are combined after assistant and tool dependencies are ordered. Multimodal content keeps its part order. No blocking issues were found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before capture, the converted prefix roles were shown as system, user, and assistant.
- After capture, the same prefix appeared, followed by a user continuation containing a second question and a system-reminder tag; all runtime assertions passed.
- The preserved harness documents and reproduces the public-builder validation.

<a href="https://app.greptile.com/trex/runs/14803290/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/anthropic/conversion.py | Maps inline system reminders to user content and coalesces adjacent user messages after transcript ordering. |
| tests/providers/test_converter.py | Adds tests for inline reminders, multimodal content, cache-prefix stability, and tool-result ordering. |
| ARCHITECTURE.md | Documents the shared role-mapping and adjacent-user coalescing rules. |
| pyproject.toml | Bumps the package version to 4.8.1. |
| uv.lock | Synchronizes the locked editable package version with 4.8.1. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: coalesce adjacent provider user tur..."](https://github.com/alishahryar1/free-claude-code/commit/7af6327c79fa15c0f4922bad8864f1c6656b2814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45005803)</sub>

<!-- /greptile_comment -->