### PR TITLE
Prevent the admin UI from being served from cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.8.2"
+version = "4.8.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_cache.py
+++ b/src/free_claude_code/api/admin_cache.py
@@ -1,0 +1,49 @@
+"""Admin response cache policy."""
+
+from fastapi import Response
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_ADMIN_CACHE_CONTROL = "no-store"
+
+
+class AdminNoStoreMiddleware:
+    """Prevent browsers from retaining responses from the admin surface."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        path = scope.get("path", "")
+        if scope["type"] != "http" or not _is_admin_path(path):
+            await self._app(scope, receive, send)
+            return
+
+        async def send_without_cache(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message = dict(message)
+                raw_headers = list(message.get("headers", ()))
+                _set_no_store(MutableHeaders(raw=raw_headers))
+                message["headers"] = raw_headers
+            await send(message)
+
+        await self._app(scope, receive, send_without_cache)
+
+
+def attach_admin_no_store(response: Response, *, path: str) -> None:
+    """Attach the policy when an outer server-error boundary bypasses middleware."""
+    if _is_admin_path(path):
+        _set_no_store(response.headers)
+
+
+def _is_admin_path(path: str) -> bool:
+    return path == "/admin" or path.startswith("/admin/")
+
+
+def _set_no_store(headers: MutableHeaders) -> None:
+    headers["Cache-Control"] = _ADMIN_CACHE_CONTROL

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -1,13 +1,15 @@
 """Local admin UI routes and APIs."""
 
 import ipaddress
+from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
+from fastapi.routing import APIRoute
 from pydantic import BaseModel, Field
 
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
@@ -19,7 +21,26 @@ from free_claude_code.config.model_refs import configured_chat_model_refs
 from .dependencies import get_services
 from .ports import ApiServices
 
-router = APIRouter()
+_ADMIN_CACHE_CONTROL = "no-store"
+
+
+class _AdminNoStoreRoute(APIRoute):
+    """Prevent browsers from retaining any local admin response."""
+
+    def get_route_handler(
+        self,
+    ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        route_handler = super().get_route_handler()
+
+        async def no_store_handler(request: Request) -> Response:
+            response = await route_handler(request)
+            response.headers["Cache-Control"] = _ADMIN_CACHE_CONTROL
+            return response
+
+        return no_store_handler
+
+
+router = APIRouter(route_class=_AdminNoStoreRoute)
 
 STATIC_DIR = Path(__file__).resolve().parent / "admin_static"
 LOCAL_PROVIDER_PATHS = {

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -1,15 +1,13 @@
 """Local admin UI routes and APIs."""
 
 import ipaddress
-from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from fastapi.responses import FileResponse, Response
-from fastapi.routing import APIRoute
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
@@ -21,26 +19,7 @@ from free_claude_code.config.model_refs import configured_chat_model_refs
 from .dependencies import get_services
 from .ports import ApiServices
 
-_ADMIN_CACHE_CONTROL = "no-store"
-
-
-class _AdminNoStoreRoute(APIRoute):
-    """Prevent browsers from retaining any local admin response."""
-
-    def get_route_handler(
-        self,
-    ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-        route_handler = super().get_route_handler()
-
-        async def no_store_handler(request: Request) -> Response:
-            response = await route_handler(request)
-            response.headers["Cache-Control"] = _ADMIN_CACHE_CONTROL
-            return response
-
-        return no_store_handler
-
-
-router = APIRouter(route_class=_AdminNoStoreRoute)
+router = APIRouter()
 
 STATIC_DIR = Path(__file__).resolve().parent / "admin_static"
 LOCAL_PROVIDER_PATHS = {

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -69,6 +69,7 @@ async function api(path, options = {}) {
   const response = await fetch(path, {
     headers: { "Content-Type": "application/json", ...(options.headers || {}) },
     ...options,
+    cache: "no-store",
   });
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);

--- a/src/free_claude_code/api/app.py
+++ b/src/free_claude_code/api/app.py
@@ -21,6 +21,7 @@ from free_claude_code.core.trace import (
 )
 from free_claude_code.core.version import package_version
 
+from .admin_cache import AdminNoStoreMiddleware, attach_admin_no_store
 from .admin_routes import router as admin_router
 from .ports import ApiServices
 from .request_errors import ordinary_application_error_response
@@ -38,6 +39,7 @@ def create_app(services: ApiServices) -> FastAPI:
     app = FastAPI(title="Claude Code Proxy", version=package_version())
     app.state.services = services
     app.add_middleware(RequestCorrelationMiddleware)
+    app.add_middleware(AdminNoStoreMiddleware)
 
     app.include_router(admin_router)
     app.include_router(router)
@@ -108,6 +110,7 @@ def create_app(services: ApiServices) -> FastAPI:
                     request_id=request_id,
                 )
             response = JSONResponse(status_code=500, content=content)
+        attach_admin_no_store(response, path=request.url.path)
         attach_request_id_headers(
             response,
             request_id=request_id,

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -78,6 +78,69 @@ def test_admin_responses_are_never_cached(monkeypatch, tmp_path, path):
     assert response.headers["cache-control"] == "no-store"
 
 
+@pytest.mark.parametrize(
+    ("path", "client_host", "expected_status"),
+    (
+        ("/admin", "203.0.113.10", 403),
+        ("/admin/assets/missing.js", "127.0.0.1", 404),
+    ),
+)
+def test_admin_http_errors_are_never_cached(
+    monkeypatch,
+    tmp_path,
+    path,
+    client_host,
+    expected_status,
+):
+    _set_home(monkeypatch, tmp_path)
+    client = TestClient(create_test_app(), client=(client_host, 50000))
+
+    response = client.get(path)
+
+    assert response.status_code == expected_status
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_admin_validation_errors_are_never_cached(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+
+    response = _local_client(create_test_app()).post(
+        "/admin/api/config/validate",
+        content="{",
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_admin_unexpected_errors_are_never_cached(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    client = TestClient(
+        create_test_app(),
+        client=("127.0.0.1", 50000),
+        raise_server_exceptions=False,
+    )
+
+    with patch(
+        "free_claude_code.api.admin_routes.load_config_response",
+        side_effect=RuntimeError("test error"),
+    ):
+        response = client.get("/admin/api/config")
+
+    assert response.status_code == 500
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_admin_cache_policy_does_not_match_similar_public_paths(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+
+    response = _local_client(create_test_app()).get("/administrator")
+
+    assert response.status_code == 404
+    assert "cache-control" not in response.headers
+
+
 def test_admin_api_fetches_bypass_browser_cache():
     script = Path("src/free_claude_code/api/admin_static/admin.js").read_text(
         encoding="utf-8"

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -61,6 +61,31 @@ def test_admin_page_is_loopback_only(monkeypatch, tmp_path):
     assert remote_client.get("/admin").status_code == 403
 
 
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/admin",
+        "/admin/assets/admin.css",
+        "/admin/assets/admin.js",
+        "/admin/api/config",
+    ),
+)
+def test_admin_responses_are_never_cached(monkeypatch, tmp_path, path):
+    _set_home(monkeypatch, tmp_path)
+    response = _local_client(create_test_app()).get(path)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_admin_api_fetches_bypass_browser_cache():
+    script = Path("src/free_claude_code/api/admin_static/admin.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'cache: "no-store"' in script
+
+
 def test_admin_page_no_longer_renders_generated_env_panel(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     app = create_test_app()

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.8.2"
+version = "4.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Browsers could retain the local admin page, assets, or error responses, leaving users on stale UI state after an FCC update.

## Changes

| Before | After |
| --- | --- |
| Admin responses had no complete cache policy, and route-level handling missed exception responses. | A dedicated admin response boundary sends `Cache-Control: no-store` for every `/admin` response, including 403, 404, validation, and unexpected errors. |
| Admin API fetches used the browser's default cache mode. | Admin API fetches explicitly use `cache: "no-store"`. |
| Cache behavior was untested. | Tests cover HTML, assets, JSON, failure responses, and path scoping. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents browsers from retaining stale admin UI responses. The main changes are:

- Adds `Cache-Control: no-store` to successful and error responses under `/admin`.
- Sets admin API fetches to use the browser's `no-store` cache mode.
- Adds tests for HTML, assets, API responses, errors, and path matching.
- Bumps the package patch version and updates the lockfile.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The middleware covers normal and handled error responses under the admin path. The explicit fallback covers general admin error responses. Tests cover successful responses and the relevant 403, 404, 422, and 500 paths.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The runtime probe script admin-cache-runtime-probe.py was executed to exercise the repository's create\_test\_app() application.
- The admin-cache-http-01-before.log log captured three endpoint responses without Cache-Control before the change.
- The admin-cache-http-02-after.log log captured the same endpoints after applying Cache-Control: no-store.
- The focused test evidence in admin-cache-02-after.log recorded the exact command, working directory, exit code, and verbose results.

<a href="https://app.greptile.com/trex/runs/14828301/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/api/admin_cache.py | Adds middleware and an error-response fallback that apply `Cache-Control: no-store` to the admin surface. |
| src/free_claude_code/api/app.py | Registers the cache middleware and applies the policy to general admin error responses. |
| src/free_claude_code/api/admin_static/admin.js | Configures admin API fetches to bypass the browser cache. |
| tests/api/test_admin.py | Covers cache headers on successful, missing, denied, invalid, and failed admin requests. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Cover admin error responses with no-stor..."](https://github.com/alishahryar1/free-claude-code/commit/06c92fc4325ee7bcd96641051d19d5b83462322b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45057666)</sub>

<!-- /greptile_comment -->