### PR TITLE
Enable uv malware checks on every CI runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@
 
 name: CI
 
+env:
+  UV_MALWARE_CHECK: "1"
+  UV_PREVIEW_FEATURES: "malware-check"
+
 on:
   push:
     branches: [main, master]
@@ -66,7 +70,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
-          version: "0.11.15"
+          version: "0.11.16"
           enable-cache: true
           cache-python: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.8.5"
+version = "4.8.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -53,7 +53,7 @@ packages = ["src/free_claude_code"]
 ".env.example" = "free_claude_code/config/env.example"
 
 [tool.uv]
-required-version = ">=0.11.0"
+required-version = ">=0.11.16"
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu130" }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -355,17 +355,23 @@ function Get-UvVersion {
     return $version
 }
 
-function Test-UvVersionAtLeast {
+function Test-SupportedUvVersion {
     param(
         [string] $Version,
         [string] $Minimum
     )
 
-    $normalizedVersion = (Convert-UvVersionOutput $Version) -replace '[-+].*$', ''
-    $normalizedMinimum = (Convert-UvVersionOutput $Minimum) -replace '[-+].*$', ''
-    if ([string]::IsNullOrWhiteSpace($normalizedVersion) -or [string]::IsNullOrWhiteSpace($normalizedMinimum)) {
+    $parsedVersion = Convert-UvVersionOutput $Version
+    $parsedMinimum = Convert-UvVersionOutput $Minimum
+    if ([string]::IsNullOrWhiteSpace($parsedVersion) -or [string]::IsNullOrWhiteSpace($parsedMinimum)) {
         throw "Unable to compare uv versions."
     }
+    if ($parsedVersion.Contains("-")) {
+        return $false
+    }
+
+    $normalizedVersion = $parsedVersion -replace '\+.*$', ''
+    $normalizedMinimum = $parsedMinimum -replace '\+.*$', ''
 
     return ([version] $normalizedVersion) -ge ([version] $normalizedMinimum)
 }
@@ -382,8 +388,8 @@ function Confirm-Uv {
     }
 
     $version = Get-UvVersion $uvCommand.Source
-    if (-not (Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion)) {
-        throw "uv $MinUvVersion or newer is required; found uv $version after installation."
+    if (-not (Test-SupportedUvVersion -Version $version -Minimum $MinUvVersion)) {
+        throw "Stable uv $MinUvVersion or newer is required; found uv $version after installation."
     }
     Write-Host "Verified uv $version."
 }
@@ -405,11 +411,11 @@ function Ensure-Uv {
     $uvCommand = Get-ApplicationCommand "uv"
     if ($uvCommand) {
         $version = Get-UvVersion $uvCommand.Source
-        if (Test-UvVersionAtLeast -Version $version -Minimum $MinUvVersion) {
+        if (Test-SupportedUvVersion -Version $version -Minimum $MinUvVersion) {
             Write-Host "uv $version already satisfies >=$MinUvVersion; leaving it unchanged."
             return
         }
-        Write-Host "uv $version is below $MinUvVersion; installing the current standalone uv."
+        Write-Host "uv $version does not satisfy stable >=$MinUvVersion; installing the current standalone uv."
     }
     else {
         Write-Host "uv is not installed; installing the current standalone uv."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,7 +15,7 @@ $ProgressPreference = "SilentlyContinue"
 
 $RepoArchiveUrl = "https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
 $PythonVersion = "3.14.0"
-$MinUvVersion = "0.11.0"
+$MinUvVersion = "0.11.16"
 $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 REPO_ARCHIVE_URL="https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
 PYTHON_VERSION="3.14.0"
-MIN_UV_VERSION="0.11.0"
+MIN_UV_VERSION="0.11.16"
 CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
 CODEX_INSTALL_URL="https://chatgpt.com/codex/install.sh"
 PI_INSTALL_URL="https://pi.dev/install.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -281,9 +281,13 @@ current_uv_version() {
     esac
 }
 
-version_ge() {
-    current=${1%%[-+]*}
-    minimum=${2%%[-+]*}
+uv_version_is_supported() {
+    case "$1" in
+        *-*) return 1 ;;
+    esac
+
+    current=${1%%+*}
+    minimum=${2%%+*}
 
     old_ifs=$IFS
     IFS=.
@@ -316,8 +320,8 @@ verify_uv() {
 
     command -v uv >/dev/null 2>&1 || fail "uv was installed, but it is not available on PATH."
     version=$(current_uv_version) || fail "uv is present, but 'uv --version' did not return a valid version."
-    if ! version_ge "$version" "$MIN_UV_VERSION"; then
-        fail "uv $MIN_UV_VERSION or newer is required; found uv $version after installation."
+    if ! uv_version_is_supported "$version" "$MIN_UV_VERSION"; then
+        fail "Stable uv $MIN_UV_VERSION or newer is required; found uv $version after installation."
     fi
 
     printf 'Verified uv %s.\n' "$version"
@@ -338,11 +342,11 @@ ensure_uv() {
 
     if command -v uv >/dev/null 2>&1; then
         version=$(current_uv_version) || fail "uv is present, but 'uv --version' did not return a valid version."
-        if version_ge "$version" "$MIN_UV_VERSION"; then
+        if uv_version_is_supported "$version" "$MIN_UV_VERSION"; then
             printf 'uv %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_UV_VERSION"
             return 0
         fi
-        printf 'uv %s is below %s; installing the current standalone uv.\n' "$version" "$MIN_UV_VERSION"
+        printf 'uv %s does not satisfy stable >=%s; installing the current standalone uv.\n' "$version" "$MIN_UV_VERSION"
     else
         printf 'uv is not installed; installing the current standalone uv.\n'
     fi

--- a/tests/contracts/test_uv_policy.py
+++ b/tests/contracts/test_uv_policy.py
@@ -1,0 +1,26 @@
+import tomllib
+from pathlib import Path
+
+UV_MINIMUM = "0.11.16"
+
+
+def test_supported_uv_minimum_is_consistent() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    install_sh = Path("scripts/install.sh").read_text(encoding="utf-8")
+    install_ps1 = Path("scripts/install.ps1").read_text(encoding="utf-8")
+    workflow = Path(".github/workflows/tests.yml").read_text(encoding="utf-8")
+
+    assert pyproject["tool"]["uv"]["required-version"] == f">={UV_MINIMUM}"
+    assert f'MIN_UV_VERSION="{UV_MINIMUM}"' in install_sh
+    assert f'$MinUvVersion = "{UV_MINIMUM}"' in install_ps1
+    assert f'version: "{UV_MINIMUM}"' in workflow
+
+
+def test_every_ci_job_inherits_uv_malware_check() -> None:
+    workflow = Path(".github/workflows/tests.yml").read_text(encoding="utf-8")
+    workflow_env = (
+        'env:\n  UV_MALWARE_CHECK: "1"\n  UV_PREVIEW_FEATURES: "malware-check"\n'
+    )
+
+    assert workflow.count(workflow_env) == 1
+    assert workflow.index(workflow_env) < workflow.index("jobs:\n")

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -300,7 +300,7 @@ def test_install_sh_preserves_valid_existing_tools(
     posix_harness.add_client("claude")
     posix_harness.add_client("codex")
     posix_harness.add_client("pi")
-    posix_harness.add_uv("0.11.7")
+    posix_harness.add_uv("0.11.16")
 
     result = posix_harness.run()
 
@@ -315,7 +315,7 @@ def test_install_sh_replaces_unrelated_pi_command(
     posix_harness.add_client("claude")
     posix_harness.add_client("codex")
     posix_harness.add_unrelated_pi()
-    posix_harness.add_uv("0.11.7")
+    posix_harness.add_uv("0.11.16")
 
     result = posix_harness.run()
 
@@ -330,7 +330,7 @@ def test_install_sh_discovers_custom_pi_npm_prefix(
     posix_harness.add_client("claude")
     posix_harness.add_client("codex")
     posix_harness.add_npm_prefix(posix_harness.root / "custom-npm")
-    posix_harness.add_uv("0.11.7")
+    posix_harness.add_uv("0.11.16")
 
     result = posix_harness.run()
 
@@ -350,7 +350,7 @@ def test_install_sh_replaces_obsolete_uv(posix_harness: PosixHarness) -> None:
     result = posix_harness.run()
 
     assert result.returncode == 0, result.stderr
-    assert "uv 0.5.9 is below 0.11.0" in result.stdout
+    assert "uv 0.5.9 is below 0.11.16" in result.stdout
     assert "uv-install" in posix_harness.calls()
 
 
@@ -747,7 +747,7 @@ def test_install_ps1_preserves_valid_existing_tools(
     powershell_harness.add_client("claude")
     powershell_harness.add_client("codex")
     powershell_harness.add_client("pi")
-    powershell_harness.add_uv("0.11.7")
+    powershell_harness.add_uv("0.11.16")
 
     result = powershell_harness.run()
 
@@ -762,7 +762,7 @@ def test_install_ps1_replaces_unrelated_pi_command(
     powershell_harness.add_client("claude")
     powershell_harness.add_client("codex")
     powershell_harness.add_unrelated_pi()
-    powershell_harness.add_uv("0.11.7")
+    powershell_harness.add_uv("0.11.16")
 
     result = powershell_harness.run()
 
@@ -777,7 +777,7 @@ def test_install_ps1_discovers_custom_pi_npm_prefix(
     powershell_harness.add_client("claude")
     powershell_harness.add_client("codex")
     powershell_harness.add_npm_prefix(powershell_harness.root / "custom-npm")
-    powershell_harness.add_uv("0.11.7")
+    powershell_harness.add_uv("0.11.16")
 
     result = powershell_harness.run()
 
@@ -799,7 +799,7 @@ def test_install_ps1_replaces_obsolete_uv(
     result = powershell_harness.run()
 
     assert result.returncode == 0, result.stderr
-    assert "uv 0.5.9 is below 0.11.0" in result.stdout
+    assert "uv 0.5.9 is below 0.11.16" in result.stdout
     assert "uv-install" in powershell_harness.calls()
 
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -294,13 +294,15 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
     ]
 
 
+@pytest.mark.parametrize("uv_version", ("0.11.16", "0.11.16+build.1"))
 def test_install_sh_preserves_valid_existing_tools(
     posix_harness: PosixHarness,
+    uv_version: str,
 ) -> None:
     posix_harness.add_client("claude")
     posix_harness.add_client("codex")
     posix_harness.add_client("pi")
-    posix_harness.add_uv("0.11.16")
+    posix_harness.add_uv(uv_version)
 
     result = posix_harness.run()
 
@@ -350,7 +352,24 @@ def test_install_sh_replaces_obsolete_uv(posix_harness: PosixHarness) -> None:
     result = posix_harness.run()
 
     assert result.returncode == 0, result.stderr
-    assert "uv 0.5.9 is below 0.11.16" in result.stdout
+    assert "uv 0.5.9 does not satisfy stable >=0.11.16" in result.stdout
+    assert "uv-install" in posix_harness.calls()
+
+
+@pytest.mark.parametrize("version", ("0.11.16-alpha.1", "0.12.0-rc.1"))
+def test_install_sh_replaces_prerelease_uv(
+    posix_harness: PosixHarness,
+    version: str,
+) -> None:
+    posix_harness.add_client("claude")
+    posix_harness.add_client("codex")
+    posix_harness.add_client("pi")
+    posix_harness.add_uv(version)
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert f"uv {version} does not satisfy stable >=0.11.16" in result.stdout
     assert "uv-install" in posix_harness.calls()
 
 
@@ -741,13 +760,15 @@ def test_install_ps1_fresh_install_is_verified(
     ]
 
 
+@pytest.mark.parametrize("uv_version", ("0.11.16", "0.11.16+build.1"))
 def test_install_ps1_preserves_valid_existing_tools(
     powershell_harness: PowerShellHarness,
+    uv_version: str,
 ) -> None:
     powershell_harness.add_client("claude")
     powershell_harness.add_client("codex")
     powershell_harness.add_client("pi")
-    powershell_harness.add_uv("0.11.16")
+    powershell_harness.add_uv(uv_version)
 
     result = powershell_harness.run()
 
@@ -799,7 +820,24 @@ def test_install_ps1_replaces_obsolete_uv(
     result = powershell_harness.run()
 
     assert result.returncode == 0, result.stderr
-    assert "uv 0.5.9 is below 0.11.16" in result.stdout
+    assert "uv 0.5.9 does not satisfy stable >=0.11.16" in result.stdout
+    assert "uv-install" in powershell_harness.calls()
+
+
+@pytest.mark.parametrize("version", ("0.11.16-alpha.1", "0.12.0-rc.1"))
+def test_install_ps1_replaces_prerelease_uv(
+    powershell_harness: PowerShellHarness,
+    version: str,
+) -> None:
+    powershell_harness.add_client("claude")
+    powershell_harness.add_client("codex")
+    powershell_harness.add_client("pi")
+    powershell_harness.add_uv(version)
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert f"uv {version} does not satisfy stable >=0.11.16" in result.stdout
     assert "uv-install" in powershell_harness.calls()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.8.5"
+version = "4.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Dependabot updates passed CI without uv checking their locked packages against known malware advisories. The supported uv minimum also predated this capability.

## Changes

| Before | After |
| --- | --- |
| Project, installers, and CI allowed uv versions without malware checking. | All supported surfaces require uv `0.11.16` or newer. |
| Parallel CI runners synchronized dependencies without an OSV malware check. | Workflow-wide uv environment settings enable the check independently on every runner. |
| Installers treated prerelease builds as their equivalent stable version. | Installers accept stable uv releases only while preserving valid build metadata. |
| uv security-policy values and edge behavior could drift between maintained surfaces. | Contract and installer tests enforce the shared policy. |
| FCC reported version `4.8.5`. | FCC reports patch version `4.8.6`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables uv malware checks across CI and raises the supported uv baseline. The main changes are:

- Requires uv `0.11.16` across project, installer, and CI configuration.
- Enables the malware-check preview policy at workflow scope.
- Rejects prerelease uv versions in both installers.
- Adds policy and installer tests for the updated behavior.
- Bumps the package and lockfile version to `4.8.6`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The installer fix preserves prerelease suffixes and rejects them before numeric comparison. Both installer variants cover stable releases, build metadata, and prerelease versions. No blocking issues remain in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Policy declarations were verified to include uv 0.11.16 in the pyproject, in both installers, and in CI setup, along with workflow-level malware variables.
- The installer dry run printed all planned stages and ended with the message "Dry run complete. No changes were made.".
- PowerShell execution was intentionally not attempted on Linux as part of the contract validation.
- A set of 10 log artifacts was collected to support inspection of policy coverage, dry-run results, and environment constraints.

<a href="https://app.greptile.com/trex/runs/14927224/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/tests.yml | Enables the uv malware-check policy at workflow scope and installs uv 0.11.16. |
| pyproject.toml | Raises the required uv version and bumps the package patch version. |
| scripts/install.sh | Rejects prerelease uv versions while accepting stable versions with build metadata. |
| scripts/install.ps1 | Applies the same stable-version requirement to the PowerShell installer. |
| tests/contracts/test_uv_policy.py | Checks uv minimum consistency and workflow-wide malware policy placement. |
| tests/scripts/test_installers.py | Adds stable, build-metadata, and prerelease cases for both installers. |
| uv.lock | Synchronizes the locked project version with the package version bump. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Reject prerelease uv in installers"](https://github.com/alishahryar1/free-claude-code/commit/d35d9d44d68d78ab2f00af0cb7297ffd7b7c4c3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45238978)</sub>

<!-- /greptile_comment -->