### PR TITLE
Report output-limit truncation as incomplete Responses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -805,6 +805,11 @@ Post-start Responses failures are assembler-owned: the active
 `ResponsesStreamAssembler` emits `response.failed` so the terminal event keeps
 the same `response.id`, output ledger, and usage state as the earlier
 `response.created`.
+Provider completion reasons remain canonical until that same assembler chooses
+the Responses terminal event. Anthropic `max_tokens` becomes
+`response.incomplete` with `incomplete_details.reason=max_output_tokens` while
+preserving partial output and usage; normal terminal reasons remain
+`response.completed`.
 
 Responses custom tools are also boundary-owned. The adapter accepts native
 Responses `custom` tool declarations, represents them internally as Anthropic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.8.6"
+version = "4.8.7"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/openai_responses/streaming/assembler.py
+++ b/src/free_claude_code/core/openai_responses/streaming/assembler.py
@@ -42,6 +42,7 @@ class ResponsesStreamAssembler:
             on_invalid_function_call=self._fail_invalid_function_call,
         )
         self._started = False
+        self._stop_reason: str | None = None
         self._provisional_error: dict[str, Any] | None = None
         self.terminal = False
         self.final_response: dict[str, Any] | None = None
@@ -58,9 +59,9 @@ class ResponsesStreamAssembler:
         elif event.event == "content_block_stop":
             chunks.extend(self._handle_content_block_stop(event.data))
         elif event.event == "message_delta":
-            self._ledger.record_usage_delta(event.data)
+            self._record_message_delta(event.data)
         elif event.event == "message_stop":
-            chunks.extend(self.complete_response())
+            chunks.extend(self.finish_response())
         elif event.event == "error":
             chunks.extend(self.fail_response(event.data))
         return chunks
@@ -69,11 +70,15 @@ class ResponsesStreamAssembler:
         if self.terminal:
             return []
         chunks = self._ensure_started()
-        chunks.extend(self.complete_response())
+        chunks.extend(self.finish_response())
         return chunks
 
     def response_payload(
-        self, *, status: str, error: dict[str, Any] | None = None
+        self,
+        *,
+        status: str,
+        error: dict[str, Any] | None = None,
+        incomplete_details: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         return {
             "id": self._response_id,
@@ -97,14 +102,18 @@ class ResponsesStreamAssembler:
             "max_output_tokens": self._request.max_output_tokens,
             "usage": self._ledger.usage(),
             "error": error,
+            "incomplete_details": incomplete_details,
         }
 
-    def complete_response(self) -> list[str]:
+    def finish_response(self) -> list[str]:
         chunks = self._flush_active_blocks()
         if self.terminal:
             return chunks
         if self._provisional_error is not None:
             chunks.extend(self._finish_failed_response(self._provisional_error))
+            return chunks
+        if self._stop_reason == "max_tokens":
+            chunks.extend(self._finish_incomplete_response())
             return chunks
         self.final_response = self.response_payload(status="completed")
         chunks.append(events.response_completed(self.final_response))
@@ -132,6 +141,14 @@ class ResponsesStreamAssembler:
         self.final_response = self.response_payload(status="failed", error=error)
         self.terminal = True
         return [events.response_failed(self.final_response)]
+
+    def _finish_incomplete_response(self) -> list[str]:
+        self.final_response = self.response_payload(
+            status="incomplete",
+            incomplete_details={"reason": "max_output_tokens"},
+        )
+        self.terminal = True
+        return [events.response_incomplete(self.final_response)]
 
     def _ensure_started(self) -> list[str]:
         if self._started:
@@ -220,6 +237,15 @@ class ResponsesStreamAssembler:
         if state is None:
             return []
         return self._completer.complete_block(state)
+
+    def _record_message_delta(self, data: Mapping[str, Any]) -> None:
+        self._ledger.record_usage_delta(data)
+        delta = data.get("delta")
+        if not isinstance(delta, Mapping):
+            return
+        stop_reason = delta.get("stop_reason")
+        if isinstance(stop_reason, str):
+            self._stop_reason = stop_reason
 
     def _start_text_block(self, index: int) -> tuple[list[str], TextBlockState | None]:
         chunks = self._complete_existing_block(index)

--- a/src/free_claude_code/core/openai_responses/streaming/event_builders.py
+++ b/src/free_claude_code/core/openai_responses/streaming/event_builders.py
@@ -19,6 +19,13 @@ def response_completed(response: dict[str, Any]) -> str:
     )
 
 
+def response_incomplete(response: dict[str, Any]) -> str:
+    return format_response_sse_event(
+        "response.incomplete",
+        {"type": "response.incomplete", "response": response},
+    )
+
+
 def response_failed(response: dict[str, Any]) -> str:
     return format_response_sse_event(
         "response.failed",

--- a/tests/api/test_openai_responses.py
+++ b/tests/api/test_openai_responses.py
@@ -110,6 +110,34 @@ def test_create_response_stream_routes_through_provider(
     assert provider.stream_kwargs[0]["request_id"] == response.headers["request-id"]
 
 
+def test_create_response_stream_preserves_output_limit_as_incomplete() -> None:
+    provider = FakeProvider(
+        _anthropic_text_stream("partial output", stop_reason="max_tokens")
+    )
+    app = create_test_app()
+    with (
+        patch("free_claude_code.api.routes.resolve_provider", return_value=provider),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "nvidia_nim/test-model",
+                "input": "Keep working",
+                "max_output_tokens": 32,
+            },
+        )
+
+    assert response.status_code == 200
+    events = parse_sse_text(response.text)
+    assert events[-1].event == "response.incomplete"
+    incomplete = events[-1].data["response"]
+    assert incomplete["id"] == events[0].data["response"]["id"]
+    assert incomplete["status"] == "incomplete"
+    assert incomplete["incomplete_details"] == {"reason": "max_output_tokens"}
+    assert incomplete["output"][0]["content"][0]["text"] == "partial output"
+
+
 def test_create_response_preflight_rejection_stays_an_ordinary_http_error() -> None:
     provider = FakeProvider(_anthropic_text_stream("unused"))
     provider.preflight_stream.side_effect = InvalidRequestError("bad tool shape")
@@ -685,7 +713,7 @@ def test_create_response_unsupported_tool_returns_openai_error(
     assert "Unsupported Responses tool type" in payload["error"]["message"]
 
 
-def _anthropic_text_stream(text: str) -> list[str]:
+def _anthropic_text_stream(text: str, *, stop_reason: str = "end_turn") -> list[str]:
     return [
         format_sse_event("message_start", {"type": "message_start", "message": {}}),
         format_sse_event(
@@ -712,7 +740,7 @@ def _anthropic_text_stream(text: str) -> list[str]:
             "message_delta",
             {
                 "type": "message_delta",
-                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
                 "usage": {"input_tokens": 3, "output_tokens": 4},
             },
         ),

--- a/tests/core/openai_responses/test_sse.py
+++ b/tests/core/openai_responses/test_sse.py
@@ -187,6 +187,63 @@ async def test_anthropic_text_stream_converts_to_responses_sse() -> None:
 
 
 @pytest.mark.asyncio
+async def test_max_tokens_stop_reason_converts_to_response_incomplete() -> None:
+    text = await _collect_sse(
+        _responses_sse(
+            _aiter(_anthropic_text_stream("partial output", stop_reason="max_tokens")),
+            {"model": "nvidia_nim/test-model", "stream": True},
+        )
+    )
+
+    events = parse_sse_text(text)
+    assert events[-1].event == "response.incomplete"
+    assert "response.completed" not in [event.event for event in events]
+    incomplete = events[-1].data["response"]
+    assert incomplete["id"] == events[0].data["response"]["id"]
+    assert incomplete["status"] == "incomplete"
+    assert incomplete["incomplete_details"] == {"reason": "max_output_tokens"}
+    assert incomplete["error"] is None
+    assert incomplete["output"][0]["content"][0]["text"] == "partial output"
+    assert incomplete["usage"] == {
+        "input_tokens": 3,
+        "output_tokens": 4,
+        "total_tokens": 7,
+    }
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_without_visible_output_is_still_incomplete() -> None:
+    text = await _collect_sse(
+        _responses_sse(
+            _aiter(
+                [
+                    format_sse_event(
+                        "message_start", {"type": "message_start", "message": {}}
+                    ),
+                    format_sse_event(
+                        "message_delta",
+                        {
+                            "type": "message_delta",
+                            "delta": {"stop_reason": "max_tokens"},
+                            "usage": {"input_tokens": 3, "output_tokens": 64},
+                        },
+                    ),
+                    format_sse_event("message_stop", {"type": "message_stop"}),
+                ]
+            ),
+            {"model": "nvidia_nim/test-model", "stream": True},
+        )
+    )
+
+    incomplete = parse_sse_text(text)[-1]
+    assert incomplete.event == "response.incomplete"
+    assert incomplete.data["response"]["output"] == []
+    assert incomplete.data["response"]["incomplete_details"] == {
+        "reason": "max_output_tokens"
+    }
+
+
+@pytest.mark.asyncio
 async def test_response_payload_preserves_explicit_request_options() -> None:
     response = await _completed_response_from_sse(
         _aiter(_anthropic_text_stream("done")),
@@ -710,7 +767,7 @@ async def _aiter_then_raise(
     raise failure
 
 
-def _anthropic_text_stream(text: str) -> list[str]:
+def _anthropic_text_stream(text: str, *, stop_reason: str = "end_turn") -> list[str]:
     return [
         format_sse_event("message_start", {"type": "message_start", "message": {}}),
         format_sse_event(
@@ -737,7 +794,7 @@ def _anthropic_text_stream(text: str) -> list[str]:
             "message_delta",
             {
                 "type": "message_delta",
-                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
                 "usage": {"input_tokens": 3, "output_tokens": 4},
             },
         ),

--- a/uv.lock
+++ b/uv.lock
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.8.6"
+version = "4.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Responses streams discarded the canonical Anthropic `max_tokens` stop reason and emitted `response.completed`. Codex therefore treated truncated provider output as a successful end and could stop midway without explaining why. Fixes #1178.

## Changes

| Before | After |
| --- | --- |
| The Responses boundary discarded `message_delta.stop_reason`. | The Responses assembler retains the canonical terminal stop reason. |
| Output-limit streams ended with `response.completed`. | Output-limit streams end with `response.incomplete` and `incomplete_details.reason=max_output_tokens`. |
| Truncated output had no dedicated Responses contract coverage. | Core and API tests cover partial-output and zero-visible-output truncation while preserving response ID and usage. |
| The package version was `4.8.6`. | The patch release is `4.8.7`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reports Anthropic output-limit termination as an incomplete Responses result. The main changes are:

- Retains the canonical `message_delta.stop_reason` until stream finalization.
- Emits `response.incomplete` with `max_output_tokens` details for `max_tokens` termination.
- Preserves partial output, usage, and response identity.
- Adds core and API tests for visible and empty truncated output.
- Updates the package and lockfile version to 4.8.7.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. Terminal failure handling still takes precedence over incomplete completion. Tests cover both partial-output and zero-visible-output truncation.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that after the change, both requests end with response.incomplete instead of response.completed.
- Observed that partial output remains as 3/4/7 and zero-visible output remains as 3/64/67, confirming the output retention behavior after the change.
- Confirmed that created and terminal response IDs match in every after-change case.
- Reviewed the Python contract-validation artifact to support the conclusions.

<a href="https://app.greptile.com/trex/runs/14931704/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/openai_responses/streaming/assembler.py | Retains the provider stop reason and emits an incomplete terminal response when output reaches the token limit. |
| src/free_claude_code/core/openai_responses/streaming/event_builders.py | Adds the Responses SSE envelope for `response.incomplete`. |
| tests/core/openai_responses/test_sse.py | Covers truncated streams with partial output and no visible output. |
| tests/api/test_openai_responses.py | Covers output-limit reporting through the public Responses API route. |
| pyproject.toml | Bumps the package patch version to 4.8.7. |
| uv.lock | Synchronizes the locked editable package version. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Responses output-limit terminal stat..."](https://github.com/alishahryar1/free-claude-code/commit/d41767572b0820481e3e7555c5b361b184c139c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45277818)</sub>

<!-- /greptile_comment -->