### PR TITLE
Refactor client reasoning policy refactor: extract reasoning policy construction into helperand helper functions

### DIFF
--- a/src/free_claude_code/application/reasoning.py
+++ b/src/free_claude_code/application/reasoning.py
@@ -1,4 +1,4 @@
-"""Resolve client reasoning input and FCC configuration exactly once."""
+""" Extract the client's requested reasoning configuration without applying user preference overrides. """
 
 from collections.abc import Mapping
 from typing import Any
@@ -27,6 +27,32 @@ def resolve_reasoning_policy(
     return client_reasoning_policy(request)
 
 
+
+def _build_reasoning_policy(
+    thinking_control: ReasoningControl,
+    effort: ReasoningEffort | None,
+    budget_tokens: int | None,
+) -> ReasoningPolicy:
+    """Create the final reasoning policy from resolved client settings."""
+
+    if thinking_control is ReasoningControl.OFF:
+        return ReasoningPolicy(
+            control=ReasoningControl.OFF,
+            effort=effort,
+        )
+
+    if thinking_control is ReasoningControl.ON:
+        return ReasoningPolicy.on(
+            effort=effort,
+            budget_tokens=budget_tokens,
+        )
+
+    return ReasoningPolicy(
+        control=ReasoningControl.DEFAULT,
+        effort=effort,
+    )
+
+
 def client_reasoning_policy(request: MessagesRequest) -> ReasoningPolicy:
     """Return the lossless reasoning intent expressed by one client request."""
 
@@ -39,27 +65,18 @@ def client_reasoning_policy(request: MessagesRequest) -> ReasoningPolicy:
 
     if effort_disables:
         return ReasoningPolicy.off()
-    if thinking_control is ReasoningControl.OFF:
-        return ReasoningPolicy(
-            control=ReasoningControl.OFF,
-            effort=effort,
-        )
-    if thinking_control is ReasoningControl.ON or budget_tokens is not None:
-        return ReasoningPolicy.on(
-            effort=effort,
-            budget_tokens=budget_tokens,
-        )
-    return ReasoningPolicy(
-        control=ReasoningControl.DEFAULT,
-        effort=effort,
-    )
 
+    return _build_reasoning_policy(
+        thinking_control,
+        effort,
+        budget_tokens,
+    )
 
 def _thinking_control(
     thinking: ThinkingConfig | None,
     *,
     budget_tokens: int | None,
-) -> ReasoningControl:
+    ) -> ReasoningControl:
     if thinking is None:
         return ReasoningControl.DEFAULT
     if thinking.type == "disabled" or (
@@ -75,14 +92,15 @@ def _thinking_control(
     return ReasoningControl.DEFAULT
 
 
-def _output_effort(value: Any) -> tuple[ReasoningEffort | None, bool]:
+def _output_effort(...) -> OutputEffort:
+    OutputEffort = tuple[ReasoningEffort | None, bool] # to increase the readability
     if not isinstance(value, Mapping):
         return None, False
-    raw = value.get("effort")
-    if not isinstance(raw, str):
+    raw_effort = value.get("effort")
+    if not isinstance(raw_effort, str):
         return None, False
-    normalized = raw.strip().lower()
-    if normalized == "none":
+    normalized_effort = raw_effort.strip().lower()
+    if normalized_effort == "none":
         return None, True
     try:
         return ReasoningEffort(normalized), False


### PR DESCRIPTION
Refactor reasoning policy functi## Summary

This PR refactors the reasoning policy construction by extracting it into a dedicated helper function.

## Changes

- Extracted reasoning policy creation into `_build_reasoning_policy()`
- Simplified `client_reasoning_policy()`
- No intended behavioral changesons for clarity and modularity.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts reasoning-policy construction into a dedicated helper. The main changes are:

- Moves final policy construction into `_build_reasoning_policy()`.
- Simplifies `client_reasoning_policy()` to resolve inputs and delegate.
- Renames variables in output-effort parsing.
- Updates the module description.

<h3>Confidence Score: 2/5</h3>

The reasoning module cannot import, and valid named-effort requests remain broken after the signature is repaired.

`_output_effort(...)` has an invalid parameter list that prevents module loading. Named efforts such as `high` reach an undefined variable and raise an exception. The required package version and lockfile updates are missing.

src/free_claude_code/application/reasoning.py, pyproject.toml, and uv.lock

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced an import failure for the reasoning module when importing free\_claude\_code.application.reasoning under Python 3.14.6, due to an invalid function parameter list.
- Validated a runtime-only repair harness that changes the parse-blocking function in memory, which caused a NameError for the \_output\_effort path instead of delivering a reasoning policy.
- Verified production version bump is missing: base/head validation shows reasoning.py changed while pyproject.toml and uv.lock remained at version 4.8.7, and the built head wheel reports 4.8.7.
- Observed a blocker in the test harness: /bin/sh: 5: /home/user/repo/.venv/bin/pytest: not found.

<a href="https://app.greptile.com/trex/runs/14935221/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/application/reasoning.py | Extracts policy construction, but introduces an invalid function signature and an undefined variable in effort parsing. |

<sub>Reviews (1): Last reviewed commit: ["Refactor client reasoning policy and hel..."](https://github.com/alishahryar1/free-claude-code/commit/14627be63f0a379d266fd6efe184d0b1e802ceab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45284880)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/alishahryar1/github/Alishahryar1/free-claude-code/-/custom-context?memory=d2fd24d8-0dec-4faf-8ee4-e085e215a2f8))

<!-- /greptile_comment -->