### PR TITLE
Fail safely when FCC is running during installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.8.7"
+version = "4.8.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -20,6 +20,14 @@ $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"
 $UvInstallUrl = "https://astral.sh/uv/install.ps1"
+$FccCommands = @(
+    "fcc-server",
+    "fcc-claude",
+    "fcc-codex",
+    "fcc-pi",
+    "fcc-init",
+    "free-claude-code"
+)
 
 function Show-Usage {
     @"
@@ -183,6 +191,20 @@ function Add-PiBinDirectories {
     }
     if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($prefix)) {
         Add-PathEntry $prefix
+    }
+}
+
+function Assert-NoFccProcessesRunning {
+    $running = @()
+    foreach ($commandName in $FccCommands) {
+        $processes = @(Get-Process -Name $commandName -ErrorAction SilentlyContinue)
+        foreach ($process in $processes) {
+            $running += "$commandName (PID $($process.Id))"
+        }
+    }
+
+    if ($running.Count -gt 0) {
+        throw "Free Claude Code is still running ($($running -join ', ')). Stop those processes, then rerun the installer."
     }
 }
 
@@ -448,6 +470,7 @@ function Get-PackageSpec {
 }
 
 function Install-FreeClaudeCode {
+    Assert-NoFccProcessesRunning
     $packageSpec = Get-PackageSpec
     $arguments = @(
         "tool",
@@ -532,6 +555,9 @@ if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not ($VoiceLocal -
 }
 
 Add-KnownBinDirectories
+
+Write-Step "Checking for running Free Claude Code processes"
+Assert-NoFccProcessesRunning
 
 Write-Step "Ensuring Claude Code is installed"
 Ensure-ClaudeCode

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@ CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
 CODEX_INSTALL_URL="https://chatgpt.com/codex/install.sh"
 PI_INSTALL_URL="https://pi.dev/install.sh"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
+FCC_COMMANDS="fcc-server fcc-claude fcc-codex fcc-pi fcc-init free-claude-code"
 
 dry_run=0
 voice_nim=0
@@ -120,6 +121,53 @@ add_pi_bin_directories() {
             export PATH
             hash -r 2>/dev/null || true
         fi
+    fi
+}
+
+fcc_process_ids() {
+    command_name=$1
+
+    if command -v pgrep >/dev/null 2>&1; then
+        {
+            pgrep -x "$command_name" 2>/dev/null || true
+            pgrep -f "(^|/)${command_name}([[:space:]]|$)" 2>/dev/null || true
+        } | sort -nu
+        return 0
+    fi
+
+    ps -A -o pid= -o args= 2>/dev/null |
+        awk -v command_name="$command_name" '
+            BEGIN {
+                pattern = "(^|/)" command_name "([[:space:]]|$)"
+            }
+            {
+                process_id = $1
+                sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "")
+                if ($0 ~ pattern) {
+                    print process_id
+                }
+            }
+        ' || true
+}
+
+assert_no_fcc_processes_running() {
+    running=""
+    for command_name in $FCC_COMMANDS; do
+        process_ids=$(fcc_process_ids "$command_name")
+        [ -n "$process_ids" ] || continue
+
+        for process_id in $process_ids; do
+            process="$command_name (PID $process_id)"
+            if [ -n "$running" ]; then
+                running="$running, $process"
+            else
+                running=$process
+            fi
+        done
+    done
+
+    if [ -n "$running" ]; then
+        fail "Free Claude Code is still running ($running). Stop those processes, then rerun the installer."
     fi
 }
 
@@ -426,6 +474,7 @@ package_spec() {
 }
 
 install_free_claude_code() {
+    assert_no_fcc_processes_running
     spec=$(package_spec)
 
     if [ -n "$torch_backend" ]; then
@@ -468,6 +517,9 @@ configure_and_verify_free_claude_code() {
 parse_args "$@"
 validate_args
 add_known_bin_directories
+
+step "Checking for running Free Claude Code processes"
+assert_no_fcc_processes_running
 
 step "Checking installation prerequisites"
 require_command curl

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -91,20 +91,34 @@ add_known_uv_paths() {
     hash -r 2>/dev/null || true
 }
 
-is_fcc_command_running() {
+fcc_process_ids() {
     command_name=$1
 
     if command -v pgrep >/dev/null 2>&1; then
-        if pgrep -x "$command_name" >/dev/null 2>&1; then
-            return 0
-        fi
-        if pgrep -f "(^|/)${command_name}( |$)" >/dev/null 2>&1; then
-            return 0
-        fi
-        return 1
+        {
+            pgrep -x "$command_name" 2>/dev/null || true
+            pgrep -f "(^|/)${command_name}([[:space:]]|$)" 2>/dev/null || true
+        } | sort -nu
+        return 0
     fi
 
-    ps -A -o comm= 2>/dev/null | grep -qx "$command_name"
+    ps -A -o pid= -o args= 2>/dev/null |
+        awk -v command_name="$command_name" '
+            BEGIN {
+                pattern = "(^|/)" command_name "([[:space:]]|$)"
+            }
+            {
+                process_id = $1
+                sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "")
+                if ($0 ~ pattern) {
+                    print process_id
+                }
+            }
+        ' || true
+}
+
+is_fcc_command_running() {
+    [ -n "$(fcc_process_ids "$1")" ]
 }
 
 assert_no_fcc_processes_running() {

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -6,6 +6,15 @@ from pathlib import Path
 
 import pytest
 
+FCC_COMMANDS = (
+    "fcc-server",
+    "fcc-claude",
+    "fcc-codex",
+    "fcc-pi",
+    "fcc-init",
+    "free-claude-code",
+)
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
@@ -71,6 +80,9 @@ def _posix_uv_command(version: str) -> str:
     return f"""#!/bin/sh
 echo "uv:$*" >> "$CALL_LOG"
 if [ "${{1:-}}" = "--version" ]; then
+    if [ "${{FCC_RUNNING_PHASE:-}}" = "late" ]; then
+        : > "$FCC_PROCESS_MARKER"
+    fi
     if [ "$FAIL_STEP" = "uv-verify" ]; then
         exit 32
     fi
@@ -128,6 +140,22 @@ class PosixHarness:
     def add_uv(self, version: str) -> None:
         _write_executable(self.bin_dir / "uv", _posix_uv_command(version))
 
+    def use_process_list_fallback(self, process_line: str) -> None:
+        fallback_bin = self.root / "fallback-bin"
+        fallback_bin.mkdir()
+        _write_executable(
+            fallback_bin / "ps",
+            """#!/bin/sh
+printf '%s\n' "$FCC_PS_OUTPUT"
+""",
+        )
+        awk = shutil.which("awk", path=self.env["PATH"])
+        if awk is None:
+            pytest.skip("awk is required for the POSIX process fallback scenario")
+        shutil.copy2(awk, fallback_bin / "awk")
+        self.env["FCC_PS_OUTPUT"] = process_line
+        self.env["PATH"] = str(fallback_bin)
+
     def run(self, *args: str, fail_step: str = "") -> subprocess.CompletedProcess[str]:
         env = self.env | {"FAIL_STEP": fail_step}
         return subprocess.run(
@@ -157,6 +185,19 @@ def posix_harness(tmp_path: Path) -> PosixHarness:
     for path in (bin_dir, fixtures, tool_bin, home):
         path.mkdir(parents=True)
 
+    _write_executable(
+        bin_dir / "pgrep",
+        """#!/bin/sh
+[ -n "${FCC_RUNNING_COMMAND:-}" ] || exit 1
+if [ "${FCC_RUNNING_PHASE:-early}" = "late" ] && [ ! -e "$FCC_PROCESS_MARKER" ]; then
+    exit 1
+fi
+case "$*" in
+    *"$FCC_RUNNING_COMMAND"*) printf '4242\n'; exit 0 ;;
+    *) exit 1 ;;
+esac
+""",
+    )
     _write_executable(
         bin_dir / "curl",
         """#!/bin/sh
@@ -261,6 +302,9 @@ fi
             "CALL_LOG": str(log),
             "FAKE_FIXTURES": str(fixtures),
             "FAKE_TOOL_BIN": str(tool_bin),
+            "FCC_PROCESS_MARKER": str(tmp_path / "fcc-process-ready"),
+            "FCC_RUNNING_COMMAND": "",
+            "FCC_RUNNING_PHASE": "early",
             "FAIL_STEP": "",
         }
     )
@@ -482,6 +526,68 @@ def test_install_sh_rejects_invalid_options_before_mutation(
     assert posix_harness.calls() == []
 
 
+@pytest.mark.parametrize("command_name", FCC_COMMANDS)
+def test_install_sh_rejects_running_fcc_before_mutation(
+    posix_harness: PosixHarness,
+    command_name: str,
+) -> None:
+    posix_harness.env["FCC_RUNNING_COMMAND"] = command_name
+
+    result = posix_harness.run()
+
+    assert result.returncode != 0
+    assert posix_harness.calls() == []
+    assert f"{command_name} (PID 4242)" in result.stderr
+
+
+def test_install_sh_rechecks_for_fcc_process_before_tool_replacement(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_client("claude")
+    posix_harness.add_client("codex")
+    posix_harness.add_client("pi")
+    posix_harness.add_uv("0.11.16")
+    posix_harness.env["FCC_RUNNING_COMMAND"] = "fcc-server"
+    posix_harness.env["FCC_RUNNING_PHASE"] = "late"
+
+    result = posix_harness.run()
+
+    assert result.returncode != 0
+    assert "fcc-server (PID 4242)" in result.stderr
+    assert not any(call.startswith("uv:tool install") for call in posix_harness.calls())
+
+
+def test_install_sh_ignores_similarly_named_process(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.env["FCC_RUNNING_COMMAND"] = "fcc-server-helper"
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("command_name", "process_args"),
+    (
+        ("free-claude-code", "/home/user/.local/bin/free-claude-code"),
+        ("fcc-server", "/usr/bin/python3 /home/user/.local/bin/fcc-server"),
+    ),
+)
+def test_install_sh_process_fallback_reads_full_command_line(
+    posix_harness: PosixHarness,
+    command_name: str,
+    process_args: str,
+) -> None:
+    posix_harness.use_process_list_fallback(f"4242 {process_args}")
+
+    result = posix_harness.run()
+
+    assert result.returncode != 0
+    assert posix_harness.calls() == []
+    assert f"{command_name} (PID 4242)" in result.stderr
+
+
 def _powershells() -> tuple[str, ...]:
     candidates = (shutil.which("pwsh"), shutil.which("powershell"))
     return tuple(dict.fromkeys(path for path in candidates if path is not None))
@@ -523,6 +629,7 @@ if "%1"=="tool" if "%2"=="update-shell" goto update_shell
 if "%1"=="tool" if "%2"=="dir" if "%3"=="--bin" goto tool_bin
 exit /b 59
 :version
+if "%FCC_RUNNING_PHASE%"=="late" type nul > "%FCC_PROCESS_MARKER%"
 if "%FAIL_STEP%"=="uv-verify" exit /b 52
 echo uv {version}
 exit /b 0
@@ -703,6 +810,25 @@ function Invoke-RestMethod {
     }
     Copy-Item -LiteralPath $source -Destination $OutFile -Force
 }
+function Get-Process {
+    [CmdletBinding()]
+    param([string[]] $Name)
+
+    if ([string]::IsNullOrWhiteSpace($env:FCC_RUNNING_COMMAND)) {
+        return
+    }
+    if (
+        $env:FCC_RUNNING_PHASE -eq "late" -and
+        -not (Test-Path -LiteralPath $env:FCC_PROCESS_MARKER)
+    ) {
+        return
+    }
+    foreach ($requestedName in $Name) {
+        if ($requestedName -eq $env:FCC_RUNNING_COMMAND) {
+            [pscustomobject] @{ Id = 4242; ProcessName = $requestedName }
+        }
+    }
+}
 $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
 & $installer @args
 """,
@@ -724,6 +850,9 @@ $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
             "FAKE_FIXTURES": str(fixtures),
             "FAKE_TOOL_BIN": str(tool_bin),
             "FCC_INSTALLER": str(_repo_root() / "scripts" / "install.ps1"),
+            "FCC_PROCESS_MARKER": str(tmp_path / "fcc-process-ready"),
+            "FCC_RUNNING_COMMAND": "",
+            "FCC_RUNNING_PHASE": "early",
             "FAIL_STEP": "",
         }
     )
@@ -955,11 +1084,56 @@ def test_install_ps1_voice_flags_only_change_fcc_spec(
     )
 
 
+@pytest.mark.parametrize("command_name", FCC_COMMANDS)
+def test_install_ps1_rejects_running_fcc_before_mutation(
+    powershell_harness: PowerShellHarness,
+    command_name: str,
+) -> None:
+    powershell_harness.env["FCC_RUNNING_COMMAND"] = command_name
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert powershell_harness.calls() == []
+    assert f"{command_name} (PID 4242)" in result.stderr
+
+
+def test_install_ps1_rechecks_for_fcc_process_before_tool_replacement(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("claude")
+    powershell_harness.add_client("codex")
+    powershell_harness.add_client("pi")
+    powershell_harness.add_uv("0.11.16")
+    powershell_harness.env["FCC_RUNNING_COMMAND"] = "fcc-server"
+    powershell_harness.env["FCC_RUNNING_PHASE"] = "late"
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert "fcc-server (PID 4242)" in result.stderr
+    assert not any(
+        call.startswith("uv:tool install") for call in powershell_harness.calls()
+    )
+
+
+def test_install_ps1_ignores_similarly_named_process(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.env["FCC_RUNNING_COMMAND"] = "fcc-server-helper"
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_installers_use_native_clients_and_single_python_selection() -> None:
     shell = (_repo_root() / "scripts" / "install.sh").read_text(encoding="utf-8")
     powershell = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
 
     for text in (shell, powershell):
+        for command_name in FCC_COMMANDS:
+            assert command_name in text
         assert "@anthropic-ai/claude-code" not in text
         assert "@openai/codex" not in text
         assert "@earendil-works/pi-coding-agent" not in text

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -66,6 +66,22 @@ class PosixUninstallHarness:
         for name in FCC_COMMANDS:
             (self.tool_bin / name).unlink(missing_ok=True)
 
+    def use_process_list_fallback(self, process_line: str) -> None:
+        fallback_bin = self.home.parent / "fallback-bin"
+        fallback_bin.mkdir()
+        _write_executable(
+            fallback_bin / "ps",
+            """#!/bin/sh
+printf '%s\n' "$FCC_PS_OUTPUT"
+""",
+        )
+        awk = shutil.which("awk", path=self.env["PATH"])
+        if awk is None:
+            pytest.skip("awk is required for the POSIX process fallback scenario")
+        shutil.copy2(awk, fallback_bin / "awk")
+        self.env["FCC_PS_OUTPUT"] = process_line
+        self.env["PATH"] = str(fallback_bin)
+
 
 @pytest.fixture
 def posix_uninstall_harness(tmp_path: Path) -> PosixUninstallHarness:
@@ -235,6 +251,28 @@ def test_uninstall_sh_rejects_invalid_options_before_mutation(
     assert result.returncode != 0
     assert posix_uninstall_harness.fcc_home.exists()
     assert posix_uninstall_harness.calls() == []
+
+
+@pytest.mark.parametrize(
+    ("command_name", "process_args"),
+    (
+        ("free-claude-code", "/home/user/.local/bin/free-claude-code"),
+        ("fcc-server", "/usr/bin/python3 /home/user/.local/bin/fcc-server"),
+    ),
+)
+def test_uninstall_sh_process_fallback_reads_full_command_line(
+    posix_uninstall_harness: PosixUninstallHarness,
+    command_name: str,
+    process_args: str,
+) -> None:
+    posix_uninstall_harness.use_process_list_fallback(f"4242 {process_args}")
+
+    result = posix_uninstall_harness.run()
+
+    assert result.returncode != 0
+    assert posix_uninstall_harness.fcc_home.exists()
+    assert posix_uninstall_harness.calls() == []
+    assert command_name in result.stderr
 
 
 @dataclass

--- a/uv.lock
+++ b/uv.lock
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.8.7"
+version = "4.8.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

A running Free Claude Code command can make `uv tool install --force` fail after partially deleting the installed tool environment. The installers did not detect this precondition, and the POSIX fallback relied on truncated process names.

## Changes

| Before | After |
| --- | --- |
| Installers entered tool replacement while FCC commands were running. | Installers report matching FCC commands and PIDs, then exit before mutation. |
| A process starting during client or uv setup could reach tool replacement. | Installers recheck immediately before `uv tool install`. |
| The no-`pgrep` fallback compared truncated `comm` names. | Install and uninstall fallbacks match full command lines. |
| Running-process coverage existed only for uninstallers. | Cross-platform tests cover every FCC entry point, late starts, similar names, and fallback detection. |
| The package version was 4.8.7. | The package version is 4.8.8. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents tool replacement while Free Claude Code commands are running. The main changes are:

- Adds early and pre-install process checks to both installers.
- Uses full process arguments in the POSIX fallback.
- Adds tests for all FCC commands, late process starts, and similarly named processes.
- Bumps the package version to 4.8.8.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The updated fallback checks full process arguments instead of the truncated process name. Tests cover direct and interpreter-launched command lines. No blocking issues were found in the updated code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the changes, the parent installer failed all six active-entry-point checks and the late-start check (7 failed, 1 passed).
- After applying the changes, the installer passed all eight targeted tests (8 passed, 70 deselected, exit code 0).
- The harness assertions verified that blocking cases do not mutate state and the late-start case never invokes the uv tool install.

<a href="https://app.greptile.com/trex/runs/14936764/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/install.sh | Adds early and late process guards with full-command-line fallback matching. |
| scripts/uninstall.sh | Replaces truncated process-name matching with PID and argument inspection. |
| scripts/install.ps1 | Adds running-process checks before setup and tool replacement. |
| tests/scripts/test_installers.py | Covers all FCC commands, late process starts, similar names, and POSIX fallback matching. |
| tests/scripts/test_uninstallers.py | Covers full-command-line matching in the POSIX uninstaller fallback. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fail safely when FCC is running during i..."](https://github.com/alishahryar1/free-claude-code/commit/589d983bc936ae28c914b7cb713c6b0775ab8a39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45286907)</sub>

<!-- /greptile_comment -->