### PR TITLE
Add ChatGPT/Codex OAuth provider (experimental)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,14 @@ KIMI_API_KEY=""
 KIMI_CODE_API_KEY=""
 
 
+# ChatGPT OAuth Config (experimental/unsanctioned; posts directly to chatgpt.com/backend-api/codex/responses)
+# Leave CHATGPT_OAUTH_ACCESS_TOKEN empty to auto-load from ~/.codex/auth.json after `codex login`.
+CHATGPT_OAUTH_ACCESS_TOKEN=""
+CHATGPT_OAUTH_ACCOUNT_ID=""
+CHATGPT_OAUTH_BASE_URL=""
+CHATGPT_OAUTH_PROXY=""
+
+
 # Wafer Config (OpenAI-compatible Chat Completions at pass.wafer.ai/v1)
 WAFER_API_KEY=""
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Enter the listed setting in the Admin UI, open **Model Config**, then search the
 | [Wafer](https://wafer.ai/) | `WAFER_API_KEY` | `wafer/DeepSeek-V4-Pro` |
 | [Kimi API](https://platform.moonshot.ai/console/api-keys) | `KIMI_API_KEY` | `kimi/kimi-k2.5` |
 | [Kimi Code](https://www.kimi.com/code/console) | `KIMI_CODE_API_KEY` | `kimi_code/k3` |
+| [ChatGPT OAuth](https://github.com/openai/codex) (experimental) | `CHATGPT_OAUTH_ACCESS_TOKEN` + `CHATGPT_OAUTH_BASE_URL` | `chatgpt_oauth/gpt-5` |
 | [MiniMax](https://platform.minimax.io/user-center/basic-information/interface-key) | `MINIMAX_API_KEY` | `minimax/MiniMax-M3` |
 | [Cerebras Inference](https://cloud.cerebras.ai/) | `CEREBRAS_API_KEY` | `cerebras/gpt-oss-120b` |
 | [Groq](https://console.groq.com/keys) | `GROQ_API_KEY` | `groq/llama-3.3-70b-versatile` |
@@ -172,6 +173,7 @@ Important provider notes:
   [Kimi's community guidelines](https://www.kimi.com/code/docs/en/kimi-code/community-guidelines.html).
 - OpenCode Zen and OpenCode Go share `OPENCODE_API_KEY` but use different model prefixes.
 - Cloudflare requires both its API token and account ID.
+- **ChatGPT OAuth is experimental and unsanctioned.** It is not an official OpenAI API product. The provider posts directly to `chatgpt.com/backend-api/codex/responses` using an OAuth access token. You can log in from the admin dashboard (Providers → ChatGPT OAuth Login), run `fcc-chatgpt-oauth-login` (headless device flow), or run `codex login`; leave `CHATGPT_OAUTH_ACCESS_TOKEN` empty so FCC reads `~/.codex/auth.json`. Supported models include `chatgpt_oauth/gpt-5.5`, `chatgpt_oauth/gpt-5.4`, `chatgpt_oauth/gpt-5.4-mini`, and `chatgpt_oauth/gpt-5.3-codex-spark`. The ChatGPT/Codex backend only exposes a limited set of built-in tools, so custom FCC tools may be rejected; use it at your own risk.
 - Ollama Cloud connects directly to `ollama.com`; use the exact model IDs shown
   by FCC's model picker. Local Ollama remains available through the separate
   `ollama/` prefix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ fcc-init = "free_claude_code.cli.entrypoints:init"
 fcc-claude = "free_claude_code.cli.launchers.claude:launch"
 fcc-codex = "free_claude_code.cli.launchers.codex:launch"
 fcc-pi = "free_claude_code.cli.launchers.pi:launch"
+fcc-chatgpt-oauth-login = "free_claude_code.cli.entrypoints:chatgpt_oauth_login"
 
 [project.optional-dependencies]
 voice = [

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -20,6 +20,11 @@ from free_claude_code.providers.chatgpt_oauth.credentials import (
     ChatGPTOAuthError,
     import_codex_cli_tokens,
 )
+from free_claude_code.providers.chatgpt_oauth.browser_login import (
+    ChatGPTOAuthBrowserUnavailableError,
+    browser_login_status,
+    start_browser_login,
+)
 from free_claude_code.providers.chatgpt_oauth.oauth_login import (
     CHATGPT_OAUTH_DEVICE_VERIFICATION_URL,
     _initiate_device_auth,
@@ -250,6 +255,29 @@ class _ChatGPTOAuthInitiateResponse(BaseModel):
     device_auth_id: str
     user_code: str
     verification_url: str
+
+
+class _ChatGPTOAuthBrowserInitiateResponse(BaseModel):
+    authorize_url: str
+    expires_in: str
+
+
+@router.post("/admin/api/chatgpt-oauth/browser/initiate")
+async def chatgpt_oauth_browser_initiate(request: Request):
+    """Start a browser-based ChatGPT OAuth login (PKCE + local callback)."""
+    require_loopback_admin(request)
+    try:
+        payload = await asyncio.to_thread(start_browser_login)
+    except ChatGPTOAuthBrowserUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return _ChatGPTOAuthBrowserInitiateResponse(**payload)
+
+
+@router.post("/admin/api/chatgpt-oauth/browser/status")
+async def chatgpt_oauth_browser_status(request: Request):
+    """Poll the status of the in-flight browser OAuth login."""
+    require_loopback_admin(request)
+    return await asyncio.to_thread(browser_login_status)
 
 
 class _ChatGPTOAuthExchangeRequest(BaseModel):

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -1,5 +1,6 @@
 """Local admin UI routes and APIs."""
 
+import asyncio
 import ipaddress
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,18 @@ from free_claude_code.config.admin.manifest import FIELD_BY_KEY
 from free_claude_code.config.admin.persistence import validate_updates
 from free_claude_code.config.admin.values import load_config_response
 from free_claude_code.config.model_refs import configured_chat_model_refs
+from free_claude_code.providers.chatgpt_oauth.credentials import (
+    ChatGPTOAuthError,
+    import_codex_cli_tokens,
+)
+from free_claude_code.providers.chatgpt_oauth.oauth_login import (
+    CHATGPT_OAUTH_DEVICE_VERIFICATION_URL,
+    _initiate_device_auth,
+    exchange_device_auth_for_tokens,
+)
+from free_claude_code.providers.chatgpt_oauth.oauth_login import (
+    ChatGPTOAuthLoginError as ChatGPTOAuthLoginFlowError,
+)
 
 from .dependencies import get_services
 from .ports import ApiServices
@@ -231,3 +244,92 @@ async def _check_local_provider(
             "base_url": base_url,
             "error_type": type(exc).__name__,
         }
+
+
+class _ChatGPTOAuthInitiateResponse(BaseModel):
+    device_auth_id: str
+    user_code: str
+    verification_url: str
+
+
+class _ChatGPTOAuthExchangeRequest(BaseModel):
+    device_auth_id: str
+    user_code: str
+
+
+class _ChatGPTOAuthExchangeResponse(BaseModel):
+    status: str
+    access_token: str = ""
+    account_id: str = ""
+    message: str = ""
+
+
+@router.post("/admin/api/chatgpt-oauth/initiate")
+async def chatgpt_oauth_initiate(request: Request):
+    """Start a ChatGPT/Codex OAuth device-auth flow from the admin UI."""
+    require_loopback_admin(request)
+    try:
+        device_auth_id, user_code, _interval_ms = await asyncio.to_thread(
+            _initiate_device_auth
+        )
+    except ChatGPTOAuthLoginFlowError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _ChatGPTOAuthInitiateResponse(
+        device_auth_id=device_auth_id,
+        user_code=user_code,
+        verification_url=CHATGPT_OAUTH_DEVICE_VERIFICATION_URL,
+    )
+
+
+@router.post("/admin/api/chatgpt-oauth/exchange")
+async def chatgpt_oauth_exchange(
+    payload: _ChatGPTOAuthExchangeRequest,
+    request: Request,
+):
+    """Poll for ChatGPT/Codex OAuth completion and return tokens."""
+    require_loopback_admin(request)
+    try:
+        tokens = await asyncio.to_thread(
+            exchange_device_auth_for_tokens,
+            payload.device_auth_id,
+            payload.user_code,
+            timeout_seconds=8.0,
+        )
+    except ChatGPTOAuthLoginFlowError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if tokens is None:
+        return _ChatGPTOAuthExchangeResponse(
+            status="pending",
+            message="Waiting for authorization. Open the verification URL and enter the code.",
+        )
+    return _ChatGPTOAuthExchangeResponse(
+        status="complete",
+        access_token=tokens.get("access_token", ""),
+        account_id=tokens.get("account_id", ""),
+        message="Login successful. Tokens saved to ~/.codex/auth.json.",
+    )
+
+
+class _ChatGPTOAuthImportCodexResponse(BaseModel):
+    status: str
+    access_token: str = ""
+    account_id: str = ""
+    message: str = ""
+
+
+@router.post("/admin/api/chatgpt-oauth/import-codex")
+async def chatgpt_oauth_import_codex(request: Request):
+    """Import ChatGPT/Codex OAuth tokens from an existing Codex CLI install."""
+    require_loopback_admin(request)
+    try:
+        credentials = await asyncio.to_thread(import_codex_cli_tokens)
+    except ChatGPTOAuthError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return _ChatGPTOAuthImportCodexResponse(
+        status="complete",
+        access_token=credentials.access_token,
+        account_id=credentials.account_id,
+        message="Imported existing Codex CLI tokens.",
+    )

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -403,6 +403,16 @@ textarea:focus-visible,
   color: var(--muted);
 }
 
+.oauth-login-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  background: var(--accent-muted);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-md);
+}
+
 .ghost-button {
   background: transparent;
   color: var(--muted);

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -275,15 +275,17 @@ function renderField(field) {
   input.dataset.configured = field.configured ? "true" : "false";
   input.dataset.fieldType = field.type;
   input.disabled = field.locked;
-  input.addEventListener("input", updateDirtyState);
-  input.addEventListener("change", updateDirtyState);
-  if (field.type === "optional_model") {
-    input.addEventListener("blur", () => {
-      if (!input.value.trim() || input.value.trim().toLowerCase() === "none") {
-        input.value = "None";
-        updateDirtyState();
-      }
-    });
+  if (field.type !== "oauth_login") {
+    input.addEventListener("input", updateDirtyState);
+    input.addEventListener("change", updateDirtyState);
+    if (field.type === "optional_model") {
+      input.addEventListener("blur", () => {
+        if (!input.value.trim() || input.value.trim().toLowerCase() === "none") {
+          input.value = "None";
+          updateDirtyState();
+        }
+      });
+    }
   }
 
   const control =
@@ -307,6 +309,30 @@ function inputForField(field) {
     input.checked = String(field.value).toLowerCase() === "true";
     input.dataset.original = input.checked ? "true" : "false";
     return input;
+  }
+
+  if (field.type === "oauth_login") {
+    const wrapper = document.createElement("div");
+    wrapper.className = "oauth-login-control";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className =
+      field.key === "CHATGPT_OAUTH_IMPORT_CODEX"
+        ? "secondary-button"
+        : "primary-button";
+    button.textContent =
+      field.key === "CHATGPT_OAUTH_IMPORT_CODEX"
+        ? "Import existing Codex login"
+        : "Log in with ChatGPT";
+    button.addEventListener("click", () => {
+      if (field.key === "CHATGPT_OAUTH_IMPORT_CODEX") {
+        importChatGPTOAuthCodexTokens(button);
+      } else {
+        startChatGPTOAuthLogin(button);
+      }
+    });
+    wrapper.appendChild(button);
+    return wrapper;
   }
 
   if (field.type === "select") {
@@ -691,6 +717,100 @@ async function refreshModelOptions(button) {
   } finally {
     button.disabled = false;
     button.textContent = original;
+  }
+}
+
+async function importChatGPTOAuthCodexTokens(button) {
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = "Importing...";
+  try {
+    const result = await api("/admin/api/chatgpt-oauth/import-codex", {
+      method: "POST",
+      body: "{}",
+    });
+    if (result.status === "complete") {
+      const tokenField = document.querySelector('[data-key="CHATGPT_OAUTH_ACCESS_TOKEN"] input');
+      const accountField = document.querySelector('[data-key="CHATGPT_OAUTH_ACCOUNT_ID"] input');
+      if (tokenField) {
+        tokenField.value = result.access_token;
+        tokenField.dispatchEvent(new Event("input"));
+      }
+      if (accountField && result.account_id) {
+        accountField.value = result.account_id;
+        accountField.dispatchEvent(new Event("input"));
+      }
+      showMessage("Imported existing Codex CLI tokens. Apply settings to save.", "ok");
+    }
+  } catch (error) {
+    showMessage(`Could not import Codex tokens: ${error.message}`, "error");
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+}
+
+async function startChatGPTOAuthLogin(button) {
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = "Starting login...";
+  let pollHandle = null;
+
+  try {
+    const initiate = await api("/admin/api/chatgpt-oauth/initiate", {
+      method: "POST",
+      body: "{}",
+    });
+    const verificationUrl = initiate.verification_url;
+    const userCode = initiate.user_code;
+
+    showMessage(
+      `ChatGPT OAuth: open ${verificationUrl} and enter code ${userCode}`,
+      "warn",
+    );
+
+    const tokenField = document.querySelector('[data-key="CHATGPT_OAUTH_ACCESS_TOKEN"] input');
+    const accountField = document.querySelector('[data-key="CHATGPT_OAUTH_ACCOUNT_ID"] input');
+
+    const stopPolling = () => {
+      if (pollHandle) {
+        clearInterval(pollHandle);
+        pollHandle = null;
+      }
+      button.disabled = false;
+      button.textContent = original;
+    };
+
+    pollHandle = setInterval(async () => {
+      try {
+        const result = await api("/admin/api/chatgpt-oauth/exchange", {
+          method: "POST",
+          body: JSON.stringify({
+            device_auth_id: initiate.device_auth_id,
+            user_code: userCode,
+          }),
+        });
+        if (result.status === "complete") {
+          stopPolling();
+          if (tokenField) {
+            tokenField.value = result.access_token;
+            tokenField.dispatchEvent(new Event("input"));
+          }
+          if (accountField && result.account_id) {
+            accountField.value = result.account_id;
+            accountField.dispatchEvent(new Event("input"));
+          }
+          showMessage("ChatGPT OAuth login complete. Apply settings to save.", "ok");
+        }
+      } catch (error) {
+        stopPolling();
+        showMessage(`ChatGPT OAuth login failed: ${error.message}`, "error");
+      }
+    }, 8000);
+  } catch (error) {
+    button.disabled = false;
+    button.textContent = original;
+    showMessage(`ChatGPT OAuth login failed: ${error.message}`, "error");
   }
 }
 

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -754,64 +754,110 @@ async function startChatGPTOAuthLogin(button) {
   const original = button.textContent;
   button.disabled = true;
   button.textContent = "Starting login...";
-  let pollHandle = null;
 
   try {
-    const initiate = await api("/admin/api/chatgpt-oauth/initiate", {
-      method: "POST",
-      body: "{}",
-    });
-    const verificationUrl = initiate.verification_url;
-    const userCode = initiate.user_code;
-
-    showMessage(
-      `ChatGPT OAuth: open ${verificationUrl} and enter code ${userCode}`,
-      "warn",
-    );
-
-    const tokenField = document.querySelector('[data-key="CHATGPT_OAUTH_ACCESS_TOKEN"] input');
-    const accountField = document.querySelector('[data-key="CHATGPT_OAUTH_ACCOUNT_ID"] input');
-
-    const stopPolling = () => {
-      if (pollHandle) {
-        clearInterval(pollHandle);
-        pollHandle = null;
-      }
+    // Primary: browser PKCE flow — the login page opens automatically and the
+    // local callback completes the flow; no code to copy or paste.
+    try {
+      const initiate = await api("/admin/api/chatgpt-oauth/browser/initiate", {
+        method: "POST",
+        body: "{}",
+      });
+      window.open(initiate.authorize_url, "_blank", "noopener");
+      showMessage(
+        "ChatGPT OAuth: complete the login in the browser tab that just opened.",
+        "warn",
+      );
+      await pollBrowserOAuthLogin();
       button.disabled = false;
       button.textContent = original;
-    };
+      return;
+    } catch (browserError) {
+      showMessage(
+        `Browser login unavailable (${browserError.message}); trying device-code login...`,
+        "warn",
+      );
+    }
 
-    pollHandle = setInterval(async () => {
-      try {
-        const result = await api("/admin/api/chatgpt-oauth/exchange", {
-          method: "POST",
-          body: JSON.stringify({
-            device_auth_id: initiate.device_auth_id,
-            user_code: userCode,
-          }),
-        });
-        if (result.status === "complete") {
-          stopPolling();
-          if (tokenField) {
-            tokenField.value = result.access_token;
-            tokenField.dispatchEvent(new Event("input"));
-          }
-          if (accountField && result.account_id) {
-            accountField.value = result.account_id;
-            accountField.dispatchEvent(new Event("input"));
-          }
-          showMessage("ChatGPT OAuth login complete. Apply settings to save.", "ok");
-        }
-      } catch (error) {
-        stopPolling();
-        showMessage(`ChatGPT OAuth login failed: ${error.message}`, "error");
-      }
-    }, 8000);
+    await startDeviceOAuthLogin(button);
+    button.disabled = false;
+    button.textContent = original;
   } catch (error) {
     button.disabled = false;
     button.textContent = original;
     showMessage(`ChatGPT OAuth login failed: ${error.message}`, "error");
   }
+}
+
+async function pollBrowserOAuthLogin() {
+  const deadline = Date.now() + 5 * 60 * 1000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    const result = await api("/admin/api/chatgpt-oauth/browser/status", {
+      method: "POST",
+      body: "{}",
+    });
+    if (result.status === "complete") {
+      fillChatGPTOAuthFields(result.access_token, result.account_id);
+      showMessage("ChatGPT OAuth login complete. Apply settings to save.", "ok");
+      return;
+    }
+    if (result.status === "error") {
+      throw new Error(result.message || "Browser login failed");
+    }
+  }
+  throw new Error("Timed out waiting for the browser login to complete");
+}
+
+function fillChatGPTOAuthFields(accessToken, accountId) {
+  const tokenField = document.querySelector(
+    '[data-key="CHATGPT_OAUTH_ACCESS_TOKEN"] input',
+  );
+  const accountField = document.querySelector(
+    '[data-key="CHATGPT_OAUTH_ACCOUNT_ID"] input',
+  );
+  if (tokenField) {
+    tokenField.value = accessToken;
+    tokenField.dispatchEvent(new Event("input"));
+  }
+  if (accountField && accountId) {
+    accountField.value = accountId;
+    accountField.dispatchEvent(new Event("input"));
+  }
+}
+
+async function startDeviceOAuthLogin(button) {
+  const initiate = await api("/admin/api/chatgpt-oauth/initiate", {
+    method: "POST",
+    body: "{}",
+  });
+  const verificationUrl = initiate.verification_url;
+  const userCode = initiate.user_code;
+
+  // Open the verification page automatically; the user only enters the code.
+  window.open(verificationUrl, "_blank", "noopener");
+  showMessage(
+    `ChatGPT OAuth: a browser tab was opened for ${verificationUrl} - enter code ${userCode}`,
+    "warn",
+  );
+
+  const deadline = Date.now() + 10 * 60 * 1000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 8000));
+    const result = await api("/admin/api/chatgpt-oauth/exchange", {
+      method: "POST",
+      body: JSON.stringify({
+        device_auth_id: initiate.device_auth_id,
+        user_code: userCode,
+      }),
+    });
+    if (result.status === "complete") {
+      fillChatGPTOAuthFields(result.access_token, result.account_id);
+      showMessage("ChatGPT OAuth login complete. Apply settings to save.", "ok");
+      return;
+    }
+  }
+  throw new Error("Timed out waiting for device authorization");
 }
 
 function providerDisplayName(providerId) {

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -151,3 +151,10 @@ def _migrate_config_env_keys() -> tuple[Path, ...]:
     if warning := explicit_env_file_migration_warning(os.environ):
         print(warning, file=sys.stderr)
     return migrated
+
+
+def chatgpt_oauth_login() -> None:
+    """Run the ChatGPT/Codex OAuth device-flow login."""
+    from free_claude_code.providers.chatgpt_oauth import chatgpt_oauth_login_command
+
+    chatgpt_oauth_login_command()

--- a/src/free_claude_code/cli/entrypoints.py
+++ b/src/free_claude_code/cli/entrypoints.py
@@ -28,6 +28,16 @@ def init(argv: Sequence[str] | None = None) -> None:
     initialize_config()
 
 
+def chatgpt_oauth_login(argv: Sequence[str] | None = None) -> None:
+    """Log in to ChatGPT/Codex via OAuth device flow (``fcc-chatgpt-oauth-login``)."""
+    if _print_version_if_requested(argv):
+        return
+
+    from free_claude_code.cli.commands import chatgpt_oauth_login as run_login
+
+    run_login()
+
+
 def _print_version_if_requested(argv: Sequence[str] | None) -> bool:
     args = sys.argv[1:] if argv is None else argv
     if "--version" not in args:

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -22,6 +22,7 @@ FieldType = Literal[
     "optional_model",
     "select",
     "textarea",
+    "oauth_login",
 ]
 
 

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -63,6 +63,29 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
         "label": "Fireworks API Key",
         "description": "Fireworks AI inference API key.",
     },
+    "CHATGPT_OAUTH_ACCESS_TOKEN": {
+        "label": "ChatGPT OAuth Access Token",
+        "description": (
+            "Experimental/unsanctioned: OAuth access token for ChatGPT/Codex. "
+            "Leave empty to auto-load from ~/.codex/auth.json after running "
+            "'fcc-chatgpt-oauth-login' or 'codex login'. "
+            "Use at your own risk; this flow is not an official OpenAI API product."
+        ),
+    },
+    "CHATGPT_OAUTH_BASE_URL": {
+        "label": "ChatGPT OAuth Base URL",
+        "description": (
+            "Experimental/unsanctioned: ChatGPT/Codex backend root. Defaults to "
+            "https://chatgpt.com/backend-api. Only change this if you need to "
+            "route through a proxy or mirror."
+        ),
+    },
+    "CHATGPT_OAUTH_PROXY": {
+        "label": "ChatGPT OAuth Proxy",
+        "description": (
+            "Experimental/unsanctioned: optional HTTP proxy for ChatGPT/Codex requests."
+        ),
+    },
     "MINIMAX_API_KEY": {
         "label": "MiniMax API Key",
         "description": (
@@ -129,6 +152,8 @@ def provider_field_specs() -> tuple[dict[str, Any], ...]:
 
     return (
         *_credential_field_specs(),
+        *_chatgpt_oauth_login_field_specs(),
+        *_chatgpt_oauth_account_field_specs(),
         *_cloudflare_account_field_specs(),
         *_local_base_url_field_specs(),
         *_proxy_field_specs(),
@@ -172,6 +197,48 @@ def _local_base_url_field_specs() -> tuple[dict[str, Any], ...]:
             }
         )
     return tuple(specs)
+
+
+def _chatgpt_oauth_account_field_specs() -> tuple[dict[str, Any], ...]:
+    return (
+        {
+            "key": "CHATGPT_OAUTH_ACCOUNT_ID",
+            "label": "ChatGPT OAuth Account ID",
+            "section_id": "providers",
+            "settings_attr": "chatgpt_oauth_account_id",
+            "description": (
+                "Experimental/unsanctioned: ChatGPT account ID used for the "
+                "ChatGPT-Account-ID header. Optional when using a bridge; "
+                "auto-extracted from the access token JWT when empty."
+            ),
+        },
+    )
+
+
+def _chatgpt_oauth_login_field_specs() -> tuple[dict[str, Any], ...]:
+    return (
+        {
+            "key": "CHATGPT_OAUTH_LOGIN",
+            "label": "ChatGPT OAuth Login",
+            "section_id": "providers",
+            "field_type": "oauth_login",
+            "description": (
+                "Experimental/unsanctioned: click the button to log in to ChatGPT/Codex "
+                "via OAuth. Tokens are saved to ~/.codex/auth.json. "
+                "Use at your own risk; this is not an official OpenAI API product."
+            ),
+        },
+        {
+            "key": "CHATGPT_OAUTH_IMPORT_CODEX",
+            "label": "Import Codex CLI Tokens",
+            "section_id": "providers",
+            "field_type": "oauth_login",
+            "description": (
+                "Experimental/unsanctioned: if you have already run 'codex login', "
+                "click the button to import the existing tokens from ~/.codex/auth.json."
+            ),
+        },
+    )
 
 
 def _cloudflare_account_field_specs() -> tuple[dict[str, Any], ...]:

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -12,6 +12,9 @@ NVIDIA_NIM_DEFAULT_BASE = "https://integrate.api.nvidia.com/v1"
 KIMI_DEFAULT_BASE = "https://api.moonshot.ai/v1"
 # Kimi Code subscription OpenAI-compatible Chat Completions API.
 KIMI_CODE_DEFAULT_BASE = "https://api.kimi.com/coding/v1"
+# ChatGPT OAuth (Codex) backend root. The provider posts to
+# /codex/responses using an OAuth access token.
+CHATGPT_OAUTH_DEFAULT_BASE = "https://chatgpt.com/backend-api"
 WAFER_DEFAULT_BASE = "https://pass.wafer.ai/v1"
 MINIMAX_DEFAULT_BASE = "https://api.minimax.io/v1"
 # DeepSeek Chat Completions API; cache usage is reported on this endpoint.
@@ -192,6 +195,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="kimi_code_api_key",
         default_base_url=KIMI_CODE_DEFAULT_BASE,
         proxy_attr="kimi_code_proxy",
+    ),
+    "chatgpt_oauth": ProviderDescriptor(
+        provider_id="chatgpt_oauth",
+        display_name="ChatGPT OAuth (experimental)",
+        credential_env="CHATGPT_OAUTH_ACCESS_TOKEN",
+        credential_attr="chatgpt_oauth_access_token",
+        default_base_url=CHATGPT_OAUTH_DEFAULT_BASE,
+        base_url_attr="chatgpt_oauth_base_url",
+        proxy_attr="chatgpt_oauth_proxy",
     ),
     "minimax": ProviderDescriptor(
         provider_id="minimax",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -1,5 +1,7 @@
 """Flat application settings schema loaded by Pydantic Settings."""
 
+import json
+import os
 from functools import lru_cache
 from typing import Any
 
@@ -37,6 +39,17 @@ class Settings(BaseSettings):
 
     # ==================== Kimi Code Subscription ====================
     kimi_code_api_key: str = Field(default="", validation_alias="KIMI_CODE_API_KEY")
+
+    # ==================== ChatGPT OAuth (experimental) Config ====================
+    chatgpt_oauth_access_token: str = Field(
+        default="", validation_alias="CHATGPT_OAUTH_ACCESS_TOKEN"
+    )
+    chatgpt_oauth_account_id: str = Field(
+        default="", validation_alias="CHATGPT_OAUTH_ACCOUNT_ID"
+    )
+    chatgpt_oauth_base_url: str = Field(
+        default="", validation_alias="CHATGPT_OAUTH_BASE_URL"
+    )
 
     # ==================== Wafer Config ====================
     wafer_api_key: str = Field(default="", validation_alias="WAFER_API_KEY")
@@ -145,6 +158,9 @@ class Settings(BaseSettings):
     llamacpp_proxy: str = Field(default="", validation_alias="LLAMACPP_PROXY")
     kimi_proxy: str = Field(default="", validation_alias="KIMI_PROXY")
     kimi_code_proxy: str = Field(default="", validation_alias="KIMI_CODE_PROXY")
+    chatgpt_oauth_proxy: str = Field(
+        default="", validation_alias="CHATGPT_OAUTH_PROXY"
+    )
     wafer_proxy: str = Field(default="", validation_alias="WAFER_PROXY")
     minimax_proxy: str = Field(default="", validation_alias="MINIMAX_PROXY")
     opencode_proxy: str = Field(default="", validation_alias="OPENCODE_PROXY")
@@ -407,6 +423,27 @@ class Settings(BaseSettings):
             supported = ", ".join(f"'{p}'" for p in SUPPORTED_PROVIDER_IDS)
             raise ValueError(f"Invalid provider: '{provider}'. Supported: {supported}")
         return v
+
+    @model_validator(mode="after")
+    def load_chatgpt_oauth_token_from_codex_cli(self) -> Settings:
+        """Backfill CHATGPT_OAUTH_ACCESS_TOKEN from Codex CLI auth file."""
+        if self.chatgpt_oauth_access_token.strip():
+            return self
+        try:
+            from pathlib import Path
+
+            codex_home = Path(os.environ.get("CODEX_HOME", "")).expanduser()
+            if not str(codex_home).strip() or str(codex_home) == ".":
+                codex_home = Path.home() / ".codex"
+            auth_path = codex_home / "auth.json"
+            data = json.loads(auth_path.read_text(encoding="utf-8"))
+            tokens = data.get("tokens") or {}
+            access_token = tokens.get("access_token")
+            if isinstance(access_token, str) and access_token.strip():
+                self.chatgpt_oauth_access_token = access_token
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            pass
+        return self
 
     @model_validator(mode="after")
     def check_nvidia_nim_api_key(self) -> Settings:

--- a/src/free_claude_code/providers/chatgpt_oauth/__init__.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/__init__.py
@@ -1,0 +1,6 @@
+"""Direct ChatGPT/Codex OAuth provider using the Responses API."""
+
+from .oauth_login import chatgpt_oauth_login_command
+from .provider import ChatGPTOAuthProvider
+
+__all__ = ["ChatGPTOAuthProvider", "chatgpt_oauth_login_command"]

--- a/src/free_claude_code/providers/chatgpt_oauth/browser_login.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/browser_login.py
@@ -1,0 +1,396 @@
+"""Browser-based ChatGPT/Codex OAuth login with PKCE and a local callback.
+
+This mirrors OpenCode's primary "ChatGPT Pro/Plus (browser)" method: a local
+HTTP server on ``127.0.0.1:1455`` receives the ``/auth/callback`` redirect,
+and the authorization code is exchanged for tokens using PKCE (S256). The
+user never copies a URL or code — the browser opens automatically and the
+callback completes the flow.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import string
+import threading
+import time
+import webbrowser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from .credentials import (
+    CODEX_OAUTH_CLIENT_ID,
+    CODEX_OAUTH_TOKEN_URL,
+    extract_account_id_from_tokens,
+)
+from .oauth_login import (
+    ChatGPTOAuthLoginError,
+    ChatGPTOAuthLoginTimeoutError,
+    _write_codex_auth_file,
+)
+
+CHATGPT_OAUTH_ISSUER = "https://auth.openai.com"
+CHATGPT_OAUTH_AUTHORIZE_URL = f"{CHATGPT_OAUTH_ISSUER}/oauth/authorize"
+OAUTH_CALLBACK_HOST = "127.0.0.1"
+OAUTH_CALLBACK_PORT = 1455
+OAUTH_CALLBACK_PATH = "/auth/callback"
+OAUTH_CANCEL_PATH = "/cancel"
+OAUTH_SCOPE = "openid profile email offline_access"
+OAUTH_ORIGINATOR = "free-claude-code"
+BROWSER_LOGIN_TIMEOUT_SECONDS = 300.0
+
+
+class ChatGPTOAuthBrowserLoginError(ChatGPTOAuthLoginError):
+    """Raised when the browser-based OAuth login fails."""
+
+
+class ChatGPTOAuthBrowserUnavailableError(ChatGPTOAuthBrowserLoginError):
+    """Raised when the browser flow cannot start (no browser or busy port)."""
+
+
+def _generate_pkce() -> tuple[str, str]:
+    """Return a (verifier, S256 challenge) pair shaped like OpenCode's."""
+    alphabet = string.ascii_letters + string.digits + "-._~"
+    verifier = "".join(secrets.choice(alphabet) for _ in range(43))
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def build_authorize_url(
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+) -> str:
+    """Build the ChatGPT OAuth authorize URL (Codex simplified flow)."""
+    params = {
+        "response_type": "code",
+        "client_id": CODEX_OAUTH_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "scope": OAUTH_SCOPE,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "state": state,
+        "originator": OAUTH_ORIGINATOR,
+    }
+    return f"{CHATGPT_OAUTH_AUTHORIZE_URL}?{urlencode(params)}"
+
+
+def _callback_page(title: str, message: str, *, success: bool) -> bytes:
+    color = "#10a37f" if success else "#d93025"
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; display: flex; min-height: 100vh;
+         align-items: center; justify-content: center; margin: 0;
+         background: #0d0d0d; color: #ececec; }}
+  .card {{ text-align: center; max-width: 420px; padding: 32px; }}
+  h1 {{ color: {color}; font-size: 1.4rem; margin-bottom: 12px; }}
+  p {{ color: #b4b4b4; line-height: 1.5; }}
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>{title}</h1>
+    <p>{message}</p>
+    <p>You can close this tab now.</p>
+  </div>
+  <script>setTimeout(function () {{ window.close(); }}, 3000);</script>
+</body>
+</html>""".encode("utf-8")
+
+
+def _exchange_code_for_tokens(
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict[str, Any]:
+    """Exchange an authorization code for OAuth tokens (PKCE)."""
+    response = httpx.post(
+        CODEX_OAUTH_TOKEN_URL,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": CODEX_OAUTH_CLIENT_ID,
+            "code_verifier": code_verifier,
+        },
+        timeout=httpx.Timeout(30.0),
+    )
+    if response.status_code != 200:
+        raise ChatGPTOAuthBrowserLoginError(
+            f"Token exchange failed: HTTP {response.status_code}"
+        )
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ChatGPTOAuthBrowserLoginError(
+            "Token exchange response was not a JSON object"
+        )
+    return data
+
+
+class _BrowserLoginFlow:
+    """State for one in-flight browser login."""
+
+    def __init__(self, port: int = OAUTH_CALLBACK_PORT) -> None:
+        self.port = port
+        self.verifier, self.challenge = _generate_pkce()
+        self.state = secrets.token_urlsafe(32)
+        self.done = threading.Event()
+        self.deadline = time.monotonic() + BROWSER_LOGIN_TIMEOUT_SECONDS
+        self.tokens: dict[str, Any] | None = None
+        self.error: str | None = None
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"http://localhost:{self.port}{OAUTH_CALLBACK_PATH}"
+
+    def finish_tokens(self, tokens: dict[str, Any]) -> None:
+        self.tokens = tokens
+        self.done.set()
+
+    def finish_error(self, message: str) -> None:
+        self.error = message
+        self.done.set()
+
+    @property
+    def expired(self) -> bool:
+        return time.monotonic() >= self.deadline
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """Handle the OAuth redirect from the user's browser."""
+
+    server: "_CallbackHTTPServer"
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+    def _send_page(self, status: int, title: str, message: str, *, success: bool) -> None:
+        body = _callback_page(title, message, success=success)
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        flow = self.server.active_flow
+
+        if parsed.path == OAUTH_CANCEL_PATH:
+            if flow is not None:
+                flow.finish_error("Login cancelled")
+            self._send_page(200, "Login cancelled", "The login was cancelled.", success=False)
+            return
+
+        if parsed.path != OAUTH_CALLBACK_PATH:
+            self.send_error(404)
+            return
+
+        params = parse_qs(parsed.query)
+        error = (params.get("error") or [None])[0]
+        if error is not None:
+            description = (params.get("error_description") or [error])[0]
+            if flow is not None:
+                flow.finish_error(description)
+            self._send_page(200, "Login failed", description, success=False)
+            return
+
+        code = (params.get("code") or [None])[0]
+        state = (params.get("state") or [None])[0]
+        if not code:
+            message = "Missing authorization code"
+            if flow is not None:
+                flow.finish_error(message)
+            self._send_page(400, "Login failed", message, success=False)
+            return
+
+        if flow is None or state != flow.state:
+            message = "Invalid state - potential CSRF attack"
+            if flow is not None:
+                flow.finish_error(message)
+            self._send_page(400, "Login failed", message, success=False)
+            return
+
+        try:
+            tokens = _exchange_code_for_tokens(code, flow.redirect_uri, flow.verifier)
+        except ChatGPTOAuthLoginError as exc:
+            flow.finish_error(str(exc))
+            self._send_page(200, "Login failed", str(exc), success=False)
+            return
+
+        flow.finish_tokens(tokens)
+        self._send_page(
+            200,
+            "Login successful",
+            "ChatGPT OAuth login completed. Returning to Free Claude Code...",
+            success=True,
+        )
+
+
+class _CallbackHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, port: int = OAUTH_CALLBACK_PORT) -> None:
+        self.active_flow: _BrowserLoginFlow | None = None
+        self.flow_lock = threading.Lock()
+        super().__init__((OAUTH_CALLBACK_HOST, port), _CallbackHandler)
+
+    def begin_flow(self, flow: _BrowserLoginFlow) -> None:
+        with self.flow_lock:
+            flow.port = self.server_address[1]
+            self.active_flow = flow
+
+
+_SERVER_LOCK = threading.Lock()
+_SERVER: _CallbackHTTPServer | None = None
+_SERVER_THREAD: threading.Thread | None = None
+
+
+def _ensure_callback_server() -> _CallbackHTTPServer:
+    """Start (or reuse) the local OAuth callback server."""
+    global _SERVER, _SERVER_THREAD
+    with _SERVER_LOCK:
+        if _SERVER is not None:
+            return _SERVER
+        try:
+            server = _CallbackHTTPServer()
+        except OSError as exc:
+            raise ChatGPTOAuthBrowserUnavailableError(
+                f"Could not start the local OAuth callback server on "
+                f"{OAUTH_CALLBACK_HOST}:{OAUTH_CALLBACK_PORT} ({exc}). "
+                "Close whatever is using that port or use the device login flow."
+            ) from exc
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name="chatgpt-oauth-callback",
+            daemon=True,
+        )
+        thread.start()
+        _SERVER = server
+        _SERVER_THREAD = thread
+        return server
+
+
+def start_browser_login() -> dict[str, str]:
+    """Begin a browser login and return the authorize URL to open.
+
+    Replaces any older pending flow. The caller opens the returned URL in the
+    user's browser and then polls :func:`browser_login_status`.
+    """
+    server = _ensure_callback_server()
+    flow = _BrowserLoginFlow()
+    server.begin_flow(flow)
+    return {
+        "authorize_url": build_authorize_url(
+            flow.redirect_uri, flow.challenge, flow.state
+        ),
+        "expires_in": str(int(BROWSER_LOGIN_TIMEOUT_SECONDS)),
+    }
+
+
+def browser_login_status(
+    *,
+    auth_path: Any = None,
+) -> dict[str, Any]:
+    """Return the status of the in-flight browser login.
+
+    Status values: ``idle`` (no flow started), ``pending``, ``complete``
+    (tokens persisted and included), or ``error``.
+    """
+    server = _SERVER
+    flow = server.active_flow if server is not None else None
+    if flow is None:
+        return {"status": "idle"}
+
+    if not flow.done.is_set():
+        if flow.expired:
+            flow.finish_error("OAuth callback timeout - authorization took too long")
+        else:
+            return {"status": "pending"}
+
+    if flow.tokens is not None:
+        tokens = flow.tokens
+        access_token = tokens.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return {"status": "error", "message": "Token exchange returned no access token"}
+        account_id = extract_account_id_from_tokens(
+            access_token=access_token,
+            id_token=tokens.get("id_token"),
+        )
+        tokens["account_id"] = account_id
+        _write_codex_auth_file(tokens, auth_path=auth_path)
+        return {
+            "status": "complete",
+            "access_token": access_token,
+            "account_id": account_id,
+            "message": "Login successful. Tokens saved to ~/.codex/auth.json.",
+        }
+
+    return {
+        "status": "error",
+        "message": flow.error or "Browser login failed",
+    }
+
+
+def perform_browser_login(
+    *,
+    timeout_seconds: float = BROWSER_LOGIN_TIMEOUT_SECONDS,
+    auth_path: Any = None,
+) -> dict[str, Any]:
+    """Run the full browser login: start server, open browser, wait, persist.
+
+    Raises ChatGPTOAuthBrowserUnavailableError when the flow cannot start,
+    ChatGPTOAuthLoginTimeoutError on timeout, or ChatGPTOAuthBrowserLoginError
+    on failure. Returns the token payload on success.
+    """
+    server = _ensure_callback_server()
+    flow = _BrowserLoginFlow()
+    server.begin_flow(flow)
+    authorize_url = build_authorize_url(flow.redirect_uri, flow.challenge, flow.state)
+
+    print("Opening ChatGPT OAuth login in your browser...", flush=True)
+    print(f"If it does not open, visit: {authorize_url}", flush=True)
+    if not webbrowser.open(authorize_url):
+        raise ChatGPTOAuthBrowserUnavailableError(
+            "Could not open a browser automatically. "
+            "Use --device for the headless device-code login instead."
+        )
+
+    if not flow.done.wait(timeout=timeout_seconds):
+        raise ChatGPTOAuthLoginTimeoutError(
+            "Timed out waiting for the OAuth callback."
+        )
+
+    if flow.tokens is None:
+        raise ChatGPTOAuthBrowserLoginError(flow.error or "Browser login failed")
+
+    tokens = flow.tokens
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise ChatGPTOAuthBrowserLoginError(
+            "Token exchange did not return an access_token"
+        )
+
+    account_id = extract_account_id_from_tokens(
+        access_token=access_token,
+        id_token=tokens.get("id_token"),
+    )
+    tokens["account_id"] = account_id
+    path = _write_codex_auth_file(tokens, auth_path=auth_path)
+    print(f"Tokens saved to: {path}", flush=True)
+    if account_id:
+        print(f"Account ID: {account_id}", flush=True)
+    return tokens

--- a/src/free_claude_code/providers/chatgpt_oauth/conversion.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/conversion.py
@@ -25,56 +25,103 @@ def _strip_openai_system_message(messages: list[dict[str, Any]]) -> tuple[str | 
     return None, messages
 
 
-def _openai_message_to_chatgpt_input(message: dict[str, Any]) -> dict[str, Any]:
-    """Convert one OpenAI-chat message to a ChatGPT Responses API input item."""
+def _openai_content_to_chatgpt_parts(
+    content: Any, *, assistant: bool
+) -> list[dict[str, Any]]:
+    """Convert OpenAI chat content parts to Responses API content parts.
+
+    User/system parts become ``input_text``/``input_image``; assistant parts
+    become ``output_text``. String content becomes a single text part.
+    """
+    text_type = "output_text" if assistant else "input_text"
+    if isinstance(content, str):
+        return [{"type": text_type, "text": content}] if content.strip() else []
+    if not isinstance(content, list):
+        return []
+    parts: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type == "text":
+            text = part.get("text", "")
+            if isinstance(text, str) and text.strip():
+                parts.append({"type": text_type, "text": text})
+        elif part_type == "image_url" and not assistant:
+            image_url = part.get("image_url")
+            if isinstance(image_url, dict):
+                image_url = image_url.get("url")
+            if isinstance(image_url, str) and image_url:
+                parts.append({"type": "input_image", "image_url": image_url})
+    return parts
+
+
+def _openai_message_to_chatgpt_items(message: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert one OpenAI-chat message to Responses API input items.
+
+    The Responses API has no ``tool_calls`` field on message items: assistant
+    tool calls are standalone ``function_call`` items, and tool results are
+    ``function_call_output`` items keyed by ``call_id``.
+    """
     role = message.get("role")
     content = message.get("content")
 
     if role == "tool":
-        return {
-            "type": "message",
-            "role": "user",
-            "content": [
-                {
-                    "type": "input_text",
-                    "text": f"Tool result ({message.get('tool_call_id')}): {content}",
-                }
-            ],
-        }
+        output = content if isinstance(content, str) else json.dumps(content)
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": message.get("tool_call_id") or "",
+                "output": output,
+            }
+        ]
 
     if role == "assistant":
-        item: dict[str, Any] = {
-            "type": "message",
-            "role": "assistant",
-        }
-        if isinstance(content, str):
-            item["content"] = [{"type": "output_text", "text": content}]
-        elif isinstance(content, list):
-            item["content"] = content
-        tool_calls = message.get("tool_calls")
-        if isinstance(tool_calls, list) and tool_calls:
-            item["tool_calls"] = tool_calls
-        return item
+        items: list[dict[str, Any]] = []
+        parts = _openai_content_to_chatgpt_parts(content, assistant=True)
+        if parts:
+            items.append(
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": parts,
+                }
+            )
+        for tool_call in message.get("tool_calls") or []:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function") or {}
+            arguments = function.get("arguments")
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": tool_call.get("id") or "",
+                    "name": function.get("name") or "unknown",
+                    "arguments": arguments
+                    if isinstance(arguments, str)
+                    else json.dumps(arguments or {}),
+                }
+            )
+        return items
 
     # user / system converted to user
     if role == "system":
         role = "user"
-    if isinstance(content, str):
-        return {
+    return [
+        {
             "type": "message",
             "role": role,
-            "content": [{"type": "input_text", "text": content}],
+            "content": _openai_content_to_chatgpt_parts(content, assistant=False),
         }
-    return {
-        "type": "message",
-        "role": role,
-        "content": content if isinstance(content, list) else [],
-    }
+    ]
 
 
 def _openai_messages_to_chatgpt_input(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert OpenAI-chat message list to Responses API input list."""
-    return [_openai_message_to_chatgpt_input(msg) for msg in messages]
+    items: list[dict[str, Any]] = []
+    for message in messages:
+        items.extend(_openai_message_to_chatgpt_items(message))
+    return items
 
 
 def _convert_tools(tools: list[Any] | None) -> list[dict[str, Any]] | None:

--- a/src/free_claude_code/providers/chatgpt_oauth/conversion.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/conversion.py
@@ -1,0 +1,221 @@
+"""Convert Anthropic Messages API requests to ChatGPT Responses API format."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.core.anthropic.conversion import (
+    AnthropicToOpenAIConverter,
+    OpenAIConversionError,
+    ReasoningReplayMode,
+)
+from free_claude_code.core.anthropic.models import MessagesRequest
+
+CHATGPT_DEFAULT_REASONING_EFFORT = "medium"
+CHATGPT_DEFAULT_REASONING_SUMMARY = "auto"
+
+
+def _strip_openai_system_message(messages: list[dict[str, Any]]) -> tuple[str | None, list[dict[str, Any]]]:
+    """Extract the leading system message as Responses API instructions."""
+    if messages and messages[0].get("role") == "system":
+        instructions = messages[0].get("content")
+        return instructions, messages[1:]
+    return None, messages
+
+
+def _openai_message_to_chatgpt_input(message: dict[str, Any]) -> dict[str, Any]:
+    """Convert one OpenAI-chat message to a ChatGPT Responses API input item."""
+    role = message.get("role")
+    content = message.get("content")
+
+    if role == "tool":
+        return {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": f"Tool result ({message.get('tool_call_id')}): {content}",
+                }
+            ],
+        }
+
+    if role == "assistant":
+        item: dict[str, Any] = {
+            "type": "message",
+            "role": "assistant",
+        }
+        if isinstance(content, str):
+            item["content"] = [{"type": "output_text", "text": content}]
+        elif isinstance(content, list):
+            item["content"] = content
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            item["tool_calls"] = tool_calls
+        return item
+
+    # user / system converted to user
+    if role == "system":
+        role = "user"
+    if isinstance(content, str):
+        return {
+            "type": "message",
+            "role": role,
+            "content": [{"type": "input_text", "text": content}],
+        }
+    return {
+        "type": "message",
+        "role": role,
+        "content": content if isinstance(content, list) else [],
+    }
+
+
+def _openai_messages_to_chatgpt_input(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OpenAI-chat message list to Responses API input list."""
+    return [_openai_message_to_chatgpt_input(msg) for msg in messages]
+
+
+def _convert_tools(tools: list[Any] | None) -> list[dict[str, Any]] | None:
+    """Convert Anthropic tools to ChatGPT Responses API tool definitions.
+
+    The ChatGPT/Codex backend historically exposes only a small set of built-in
+    tools, but we forward tools in the standard function shape so the backend
+    can reject or accept them with its own error message.
+    """
+    if not tools:
+        return None
+    result: list[dict[str, Any]] = []
+    for tool in tools:
+        schema = getattr(tool, "input_schema", None) or {"type": "object", "properties": {}}
+        result.append({
+            "type": "function",
+            "name": getattr(tool, "name", "unknown"),
+            "description": getattr(tool, "description", None) or "",
+            "parameters": schema,
+        })
+    return result
+
+
+def _convert_tool_choice(tool_choice: Any) -> Any:
+    """Convert Anthropic tool_choice to ChatGPT Responses API tool_choice."""
+    if not isinstance(tool_choice, dict):
+        return tool_choice
+    choice_type = tool_choice.get("type")
+    if choice_type == "tool":
+        name = tool_choice.get("name")
+        if name:
+            return {"type": "function", "function": {"name": name}}
+    if choice_type in {"auto", "none", "required"}:
+        return choice_type
+    if choice_type == "any":
+        return "required"
+    return tool_choice
+
+
+def _supports_reasoning(model: str) -> bool:
+    """Return True for models known to expose reasoning through the backend."""
+    name = model.lower()
+    return (
+        name.startswith("gpt-5")
+        or name.startswith("codex")
+        or name.startswith("o")
+    )
+
+
+def _extract_system_instructions(request: MessagesRequest) -> str | None:
+    """Return the top-level Anthropic system prompt as a single string."""
+    system = request.system
+    if system is None:
+        return None
+    if isinstance(system, str):
+        return system
+    if isinstance(system, list):
+        parts = []
+        for block in system:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            elif hasattr(block, "type") and getattr(block, "type", None) == "text":
+                parts.append(str(getattr(block, "text", "")))
+        text = "\n\n".join(parts)
+        return text if text else None
+    return None
+
+
+def build_chatgpt_oauth_request_body(
+    request: MessagesRequest,
+    *,
+    default_max_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Build a ChatGPT Responses API request body from an Anthropic request."""
+    if request.extra_body:
+        raise InvalidRequestError(
+            "ChatGPT OAuth provider does not support caller extra_body on requests."
+        )
+
+    try:
+        openai_messages = AnthropicToOpenAIConverter.convert_messages(
+            request.messages,
+            reasoning_replay=ReasoningReplayMode.THINK_TAGS,
+        )
+    except OpenAIConversionError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+
+    instructions = _extract_system_instructions(request)
+    _, chat_messages = _strip_openai_system_message(openai_messages)
+
+    body: dict[str, Any] = {
+        "model": request.model,
+        "input": _openai_messages_to_chatgpt_input(chat_messages),
+        "store": False,
+        "stream": True,
+        "parallel_tool_calls": False,
+    }
+
+    if instructions:
+        body["instructions"] = instructions
+
+    # OpenCode's codex plugin clears maxOutputTokens to match the Codex CLI:
+    # the ChatGPT/Codex Responses endpoint behaves best when the caller does
+    # not impose an explicit output limit. ``default_max_tokens`` is kept in
+    # the signature for backward compatibility with existing callers.
+    _ = default_max_tokens
+
+    tools = _convert_tools(request.tools)
+    if tools:
+        body["tools"] = tools
+        tool_choice = _convert_tool_choice(request.tool_choice)
+        if tool_choice is not None:
+            body["tool_choice"] = tool_choice
+
+    if _supports_reasoning(request.model):
+        body["reasoning"] = {
+            "effort": CHATGPT_DEFAULT_REASONING_EFFORT,
+            "summary": CHATGPT_DEFAULT_REASONING_SUMMARY,
+        }
+        body["include"] = ["reasoning.encrypted_content"]
+
+    return body
+
+
+def chatgpt_tool_call_to_anthropic(
+    item: dict[str, Any],
+    *,
+    tool_name_override: str | None = None,
+) -> dict[str, Any]:
+    """Convert one ChatGPT function_call item to an Anthropic tool_use block."""
+    name = item.get("name") or tool_name_override or "unknown"
+    arguments = item.get("arguments") or "{}"
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments)
+    try:
+        input_data = json.loads(arguments)
+    except json.JSONDecodeError:
+        input_data = {"raw": arguments}
+    return {
+        "type": "tool_use",
+        "id": item.get("id", ""),
+        "name": name,
+        "input": input_data,
+    }

--- a/src/free_claude_code/providers/chatgpt_oauth/credentials.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/credentials.py
@@ -1,0 +1,252 @@
+"""ChatGPT/Codex OAuth credential loading and refresh.
+
+This mirrors the token sources used by OpenAI's Codex CLI and the Hermes
+auth file. Tokens are read from disk (not written) and refreshed in memory
+when they are close to expiry.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+
+
+class ChatGPTOAuthError(Exception):
+    """Raised when ChatGPT OAuth credential handling fails."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ChatGPTOAuthCredentials:
+    """Resolved OAuth credentials for one request."""
+
+    access_token: str
+    account_id: str
+    refresh_token: str | None = None
+    expires_at: int | None = None
+    source_name: str = ""
+
+
+@dataclasses.dataclass(frozen=True)
+class _TokenSource:
+    name: str
+    path: Path
+    access_token: str | None
+    refresh_token: str | None
+
+    @property
+    def has_access_token(self) -> bool:
+        return isinstance(self.access_token, str) and self.access_token.strip() != ""
+
+    @property
+    def has_refresh_token(self) -> bool:
+        return isinstance(self.refresh_token, str) and self.refresh_token.strip() != ""
+
+
+def _home() -> Path:
+    return Path.home()
+
+
+def _codex_home() -> Path:
+    codex_home = Path(os.environ.get("CODEX_HOME", "")).expanduser()
+    if not str(codex_home).strip() or str(codex_home) == ".":
+        codex_home = _home() / ".codex"
+    return codex_home
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as exc:
+        raise ChatGPTOAuthError(f"Could not parse {path}: {exc}") from exc
+
+
+def _load_codex_cli_source() -> _TokenSource:
+    path = _codex_home() / "auth.json"
+    payload = _load_json(path)
+    tokens = payload.get("tokens") or {}
+    return _TokenSource(
+        name="codex-cli",
+        path=path,
+        access_token=tokens.get("access_token"),
+        refresh_token=tokens.get("refresh_token"),
+    )
+
+
+def _load_hermes_source() -> _TokenSource:
+    path = _home() / ".hermes" / "auth.json"
+    payload = _load_json(path)
+    provider = ((payload.get("providers") or {}).get("openai-codex") or {})
+    tokens = provider.get("tokens") or {}
+    return _TokenSource(
+        name="hermes-openai-codex",
+        path=path,
+        access_token=tokens.get("access_token"),
+        refresh_token=tokens.get("refresh_token"),
+    )
+
+
+def _load_sources() -> list[_TokenSource]:
+    return [_load_hermes_source(), _load_codex_cli_source()]
+
+
+def _decode_jwt_claims(token: str | None) -> dict[str, Any]:
+    if not token or token.count(".") < 2:
+        return {}
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload.encode("utf-8")))
+    except Exception:
+        return {}
+
+
+def _extract_account_id(access_token: str) -> str:
+    claims = _decode_jwt_claims(access_token)
+    auth_claim = claims.get("https://api.openai.com/auth") or {}
+    account_id = auth_claim.get("chatgpt_account_id")
+    if isinstance(account_id, str) and account_id:
+        return account_id
+    # Fallback: some tokens carry the account id in the top-level claim.
+    account_id = claims.get("chatgpt_account_id") or claims.get("account_id")
+    if isinstance(account_id, str) and account_id:
+        return account_id
+    return ""
+
+
+def _access_token_seconds_remaining(access_token: str) -> int | None:
+    claims = _decode_jwt_claims(access_token)
+    exp = claims.get("exp")
+    if not isinstance(exp, (int, float)):
+        return None
+    return int(exp - time.time())
+
+
+def _refresh_access_token(refresh_token: str) -> tuple[str, str | None, int | None]:
+    """Refresh an OAuth access token and return the new credential set."""
+    response = httpx.post(
+        CODEX_OAUTH_TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CODEX_OAUTH_CLIENT_ID,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=httpx.Timeout(30.0),
+    )
+    if response.status_code != 200:
+        raise ChatGPTOAuthError(
+            f"OAuth refresh failed with HTTP {response.status_code}"
+        )
+    payload = response.json()
+    new_access = payload.get("access_token")
+    new_refresh = payload.get("refresh_token") or refresh_token
+    expires_in = payload.get("expires_in")
+    if not isinstance(new_access, str) or not new_access:
+        raise ChatGPTOAuthError("OAuth refresh response did not contain an access token.")
+    expires_at = None
+    if isinstance(expires_in, (int, float)):
+        expires_at = int(time.time() + expires_in)
+    return new_access, new_refresh, expires_at
+
+
+def _ensure_fresh_source(source: _TokenSource) -> _TokenSource:
+    remaining = (
+        _access_token_seconds_remaining(source.access_token)
+        if source.access_token
+        else None
+    )
+    if remaining is None or remaining > 300:
+        return source
+    if not source.has_refresh_token or source.refresh_token is None:
+        # Token is expiring and we cannot refresh; return as-is and let the
+        # upstream request fail with a clear 401 if expired.
+        return source
+    new_access, new_refresh, _ = _refresh_access_token(source.refresh_token)
+    return dataclasses.replace(
+        source,
+        access_token=new_access,
+        refresh_token=new_refresh,
+    )
+
+
+def _choose_runtime_source(sources: list[_TokenSource]) -> _TokenSource:
+    refresh_errors: list[str] = []
+    for item in sources:
+        if item.name == "hermes-openai-codex" and item.has_access_token:
+            try:
+                return _ensure_fresh_source(item)
+            except ChatGPTOAuthError as exc:
+                refresh_errors.append(f"{item.name}: {exc}")
+    for item in sources:
+        if item.has_access_token:
+            try:
+                return _ensure_fresh_source(item)
+            except ChatGPTOAuthError as exc:
+                refresh_errors.append(f"{item.name}: {exc}")
+    suffix = f" Refresh failures: {'; '.join(refresh_errors)}" if refresh_errors else ""
+    raise ChatGPTOAuthError(
+        f"No usable Codex/ChatGPT OAuth access token found.{suffix}"
+    )
+
+
+def load_chatgpt_oauth_credentials(
+    *,
+    access_token: str | None = None,
+    account_id: str | None = None,
+) -> ChatGPTOAuthCredentials:
+    """Resolve OAuth credentials from explicit values or auth files.
+
+    Priority:
+      1. Explicit access_token / account_id.
+      2. Token files (~/.hermes/auth.json, ~/.codex/auth.json).
+    """
+    if access_token and access_token.strip():
+        resolved_account_id = (account_id or "").strip() or _extract_account_id(access_token)
+        return ChatGPTOAuthCredentials(
+            access_token=access_token.strip(),
+            account_id=resolved_account_id,
+        )
+
+    source = _choose_runtime_source(_load_sources())
+    resolved_account_id = (account_id or "").strip() or _extract_account_id(
+        source.access_token or ""
+    )
+    return ChatGPTOAuthCredentials(
+        access_token=source.access_token or "",
+        account_id=resolved_account_id,
+        refresh_token=source.refresh_token,
+        source_name=source.name,
+    )
+
+
+def import_codex_cli_tokens() -> ChatGPTOAuthCredentials:
+    """Load ChatGPT/Codex OAuth tokens from an existing Codex CLI installation.
+
+    Raises ChatGPTOAuthError when the auth file is missing, malformed, or does
+    not contain a usable access token.
+    """
+    source = _load_codex_cli_source()
+    if not source.has_access_token:
+        path = source.path
+        raise ChatGPTOAuthError(
+            f"No Codex CLI access token found at {path}. "
+            "Run 'codex login' first or use the ChatGPT OAuth Login button."
+        )
+    return ChatGPTOAuthCredentials(
+        access_token=source.access_token or "",
+        account_id=_extract_account_id(source.access_token or ""),
+        refresh_token=source.refresh_token,
+        source_name=source.name,
+    )

--- a/src/free_claude_code/providers/chatgpt_oauth/credentials.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/credentials.py
@@ -1,8 +1,10 @@
 """ChatGPT/Codex OAuth credential loading and refresh.
 
 This mirrors the token sources used by OpenAI's Codex CLI and the Hermes
-auth file. Tokens are read from disk (not written) and refreshed in memory
-when they are close to expiry.
+auth file. Refreshed tokens are written back to the source auth file so
+rotated refresh tokens survive restarts (matching OpenCode's behaviour of
+persisting refreshed credentials), and concurrent refreshes are deduplicated
+with a process-wide lock.
 """
 
 from __future__ import annotations
@@ -11,11 +13,13 @@ import base64
 import dataclasses
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Any
 
 import httpx
+from loguru import logger
 
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
@@ -42,6 +46,7 @@ class _TokenSource:
     path: Path
     access_token: str | None
     refresh_token: str | None
+    id_token: str | None = None
 
     @property
     def has_access_token(self) -> bool:
@@ -81,6 +86,7 @@ def _load_codex_cli_source() -> _TokenSource:
         path=path,
         access_token=tokens.get("access_token"),
         refresh_token=tokens.get("refresh_token"),
+        id_token=tokens.get("id_token"),
     )
 
 
@@ -94,7 +100,17 @@ def _load_hermes_source() -> _TokenSource:
         path=path,
         access_token=tokens.get("access_token"),
         refresh_token=tokens.get("refresh_token"),
+        id_token=tokens.get("id_token"),
     )
+
+
+def _reload_source(source: _TokenSource) -> _TokenSource:
+    """Re-read one token source from disk (e.g. after another thread refreshed)."""
+    if source.name == "codex-cli":
+        return _load_codex_cli_source()
+    if source.name == "hermes-openai-codex":
+        return _load_hermes_source()
+    return source
 
 
 def _load_sources() -> list[_TokenSource]:
@@ -112,16 +128,48 @@ def _decode_jwt_claims(token: str | None) -> dict[str, Any]:
         return {}
 
 
-def _extract_account_id(access_token: str) -> str:
-    claims = _decode_jwt_claims(access_token)
+def _extract_account_id_from_claims(claims: dict[str, Any]) -> str:
+    """Extract the ChatGPT account id from decoded JWT claims.
+
+    Mirrors OpenCode's extraction order: top-level ``chatgpt_account_id``,
+    then the namespaced auth claim, then a generic ``account_id``, then the
+    first organization id.
+    """
+    account_id = claims.get("chatgpt_account_id")
+    if isinstance(account_id, str) and account_id:
+        return account_id
     auth_claim = claims.get("https://api.openai.com/auth") or {}
     account_id = auth_claim.get("chatgpt_account_id")
     if isinstance(account_id, str) and account_id:
         return account_id
-    # Fallback: some tokens carry the account id in the top-level claim.
-    account_id = claims.get("chatgpt_account_id") or claims.get("account_id")
+    account_id = claims.get("account_id")
     if isinstance(account_id, str) and account_id:
         return account_id
+    organizations = claims.get("organizations")
+    if isinstance(organizations, list) and organizations:
+        first = organizations[0]
+        if isinstance(first, dict):
+            org_id = first.get("id")
+            if isinstance(org_id, str) and org_id:
+                return org_id
+    return ""
+
+
+def _extract_account_id(access_token: str) -> str:
+    return _extract_account_id_from_claims(_decode_jwt_claims(access_token))
+
+
+def extract_account_id_from_tokens(
+    access_token: str | None = None,
+    id_token: str | None = None,
+) -> str:
+    """Extract the account id, preferring the id token like OpenCode does."""
+    if id_token:
+        account_id = _extract_account_id_from_claims(_decode_jwt_claims(id_token))
+        if account_id:
+            return account_id
+    if access_token:
+        return _extract_account_id_from_claims(_decode_jwt_claims(access_token))
     return ""
 
 
@@ -158,7 +206,61 @@ def _refresh_access_token(refresh_token: str) -> tuple[str, str | None, int | No
     expires_at = None
     if isinstance(expires_in, (int, float)):
         expires_at = int(time.time() + expires_in)
-    return new_access, new_refresh, expires_at
+    new_id_token = payload.get("id_token")
+    return new_access, new_refresh, expires_at, new_id_token
+
+
+def _persist_refreshed_tokens(
+    source: _TokenSource,
+    *,
+    access_token: str,
+    refresh_token: str | None,
+    id_token: str | None,
+    expires_at: int | None,
+) -> None:
+    """Write refreshed tokens back to the source auth file.
+
+    OpenCode persists refreshed credentials so rotated refresh tokens keep
+    working across restarts; we do the same. Failures are logged but never
+    fatal — the in-memory refreshed token still serves this process.
+    """
+    try:
+        payload = _load_json(source.path)
+        if source.name == "hermes-openai-codex":
+            tokens = (
+                payload.setdefault("providers", {})
+                .setdefault("openai-codex", {})
+                .setdefault("tokens", {})
+            )
+        else:
+            tokens = payload.setdefault("tokens", {})
+        tokens["access_token"] = access_token
+        if refresh_token:
+            tokens["refresh_token"] = refresh_token
+        if id_token:
+            tokens["id_token"] = id_token
+        if expires_at is not None:
+            tokens["expires_at"] = expires_at
+        source.path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = source.path.with_suffix(source.path.suffix + ".tmp")
+        try:
+            temp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            os.replace(temp_path, source.path)
+        finally:
+            temp_path.unlink(missing_ok=True)
+        try:
+            os.chmod(source.path, 0o600)
+        except OSError:
+            pass
+    except Exception as exc:  # noqa: BLE001 - persistence must not break refresh
+        logger.warning(
+            "ChatGPT OAuth: could not persist refreshed tokens to {}: {}",
+            source.path,
+            exc,
+        )
+
+
+_REFRESH_LOCK = threading.Lock()
 
 
 def _ensure_fresh_source(source: _TokenSource) -> _TokenSource:
@@ -173,12 +275,33 @@ def _ensure_fresh_source(source: _TokenSource) -> _TokenSource:
         # Token is expiring and we cannot refresh; return as-is and let the
         # upstream request fail with a clear 401 if expired.
         return source
-    new_access, new_refresh, _ = _refresh_access_token(source.refresh_token)
-    return dataclasses.replace(
-        source,
-        access_token=new_access,
-        refresh_token=new_refresh,
-    )
+
+    with _REFRESH_LOCK:
+        # Another thread may have refreshed while we waited on the lock.
+        current = _reload_source(source)
+        if current.has_access_token:
+            remaining = _access_token_seconds_remaining(current.access_token)
+            if remaining is not None and remaining > 300:
+                return current
+        if not current.has_refresh_token or current.refresh_token is None:
+            return source
+
+        new_access, new_refresh, expires_at, new_id_token = _refresh_access_token(
+            current.refresh_token
+        )
+        _persist_refreshed_tokens(
+            current,
+            access_token=new_access,
+            refresh_token=new_refresh,
+            id_token=new_id_token,
+            expires_at=expires_at,
+        )
+        return dataclasses.replace(
+            current,
+            access_token=new_access,
+            refresh_token=new_refresh,
+            id_token=new_id_token or current.id_token,
+        )
 
 
 def _choose_runtime_source(sources: list[_TokenSource]) -> _TokenSource:
@@ -220,8 +343,9 @@ def load_chatgpt_oauth_credentials(
         )
 
     source = _choose_runtime_source(_load_sources())
-    resolved_account_id = (account_id or "").strip() or _extract_account_id(
-        source.access_token or ""
+    resolved_account_id = (account_id or "").strip() or extract_account_id_from_tokens(
+        access_token=source.access_token,
+        id_token=source.id_token,
     )
     return ChatGPTOAuthCredentials(
         access_token=source.access_token or "",
@@ -246,7 +370,10 @@ def import_codex_cli_tokens() -> ChatGPTOAuthCredentials:
         )
     return ChatGPTOAuthCredentials(
         access_token=source.access_token or "",
-        account_id=_extract_account_id(source.access_token or ""),
+        account_id=extract_account_id_from_tokens(
+            access_token=source.access_token,
+            id_token=source.id_token,
+        ),
         refresh_token=source.refresh_token,
         source_name=source.name,
     )

--- a/src/free_claude_code/providers/chatgpt_oauth/oauth_login.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/oauth_login.py
@@ -19,7 +19,7 @@ from .credentials import (
     CODEX_OAUTH_TOKEN_URL,
     _codex_home,
     _decode_jwt_claims,
-    _extract_account_id,
+    extract_account_id_from_tokens,
 )
 
 CHATGPT_OAUTH_ISSUER = "https://auth.openai.com"
@@ -103,6 +103,7 @@ def _poll_device_auth(
     user_code: str,
     *,
     deadline: float,
+    interval_ms: int = 5000,
     http_client: httpx.Client | None = None,
 ) -> dict[str, Any]:
     """Poll the device-auth token endpoint until success or timeout."""
@@ -140,15 +141,6 @@ def _poll_device_auth(
                     "Timed out waiting for ChatGPT OAuth login completion."
                 )
 
-            interval_ms = (
-                _parse_device_response(response).get("interval", 5)
-                if response.status_code == 200
-                else 5000
-            )
-            try:
-                interval_ms = max(int(interval_ms or 5), 1) * 1000
-            except (TypeError, ValueError):
-                interval_ms = 5000
             time.sleep((interval_ms + CHATGPT_OAUTH_POLL_SAFETY_MS) / 1000.0)
     finally:
         if http_client is None:
@@ -217,17 +209,19 @@ def _write_codex_auth_file(
 
     access_token = tokens.get("access_token")
     refresh_token = tokens.get("refresh_token")
+    id_token = tokens.get("id_token")
     expires_at = _extract_expires_at(tokens)
 
-    payload = {
-        "tokens": {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-        }
+    payload_tokens: dict[str, Any] = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
     }
+    if isinstance(id_token, str) and id_token:
+        payload_tokens["id_token"] = id_token
     if expires_at is not None:
-        payload["tokens"]["expires_at"] = expires_at
+        payload_tokens["expires_at"] = expires_at
 
+    payload = {"tokens": payload_tokens}
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return path
 
@@ -243,7 +237,7 @@ def perform_chatgpt_oauth_login(
     Returns the token payload. Raises ChatGPTOAuthLoginError or
     ChatGPTOAuthLoginTimeoutError on failure.
     """
-    device_auth_id, user_code, _interval_ms = _initiate_device_auth(http_client)
+    device_auth_id, user_code, interval_ms = _initiate_device_auth(http_client)
 
     print(
         "\n".join(
@@ -264,6 +258,7 @@ def perform_chatgpt_oauth_login(
         device_auth_id,
         user_code,
         deadline=deadline,
+        interval_ms=interval_ms,
         http_client=http_client,
     )
 
@@ -286,7 +281,10 @@ def perform_chatgpt_oauth_login(
     if not isinstance(access_token, str) or not access_token:
         raise ChatGPTOAuthLoginError("Token exchange did not return an access_token")
 
-    account_id = _extract_account_id(access_token)
+    account_id = extract_account_id_from_tokens(
+        access_token=access_token,
+        id_token=tokens.get("id_token"),
+    )
     tokens["account_id"] = account_id
 
     path = _write_codex_auth_file(tokens, auth_path=auth_path)
@@ -340,7 +338,10 @@ def exchange_device_auth_for_tokens(
     if not isinstance(access_token, str) or not access_token:
         raise ChatGPTOAuthLoginError("Token exchange did not return an access_token")
 
-    account_id = _extract_account_id(access_token)
+    account_id = extract_account_id_from_tokens(
+        access_token=access_token,
+        id_token=tokens.get("id_token"),
+    )
     tokens["account_id"] = account_id
     _write_codex_auth_file(tokens, auth_path=auth_path)
     return tokens

--- a/src/free_claude_code/providers/chatgpt_oauth/oauth_login.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/oauth_login.py
@@ -1,0 +1,358 @@
+"""Headless ChatGPT/Codex OAuth device-flow login.
+
+This mirrors the device-auth path used by OpenCode so Free Claude Code can
+obtain ChatGPT/Codex OAuth tokens without requiring the official ``codex`` CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .credentials import (
+    CODEX_OAUTH_CLIENT_ID,
+    CODEX_OAUTH_TOKEN_URL,
+    _codex_home,
+    _decode_jwt_claims,
+    _extract_account_id,
+)
+
+CHATGPT_OAUTH_ISSUER = "https://auth.openai.com"
+CHATGPT_OAUTH_DEVICE_URL = f"{CHATGPT_OAUTH_ISSUER}/api/accounts/deviceauth/usercode"
+CHATGPT_OAUTH_DEVICE_TOKEN_URL = (
+    f"{CHATGPT_OAUTH_ISSUER}/api/accounts/deviceauth/token"
+)
+CHATGPT_OAUTH_DEVICE_VERIFICATION_URL = f"{CHATGPT_OAUTH_ISSUER}/codex/device"
+CHATGPT_OAUTH_DEVICE_CALLBACK = f"{CHATGPT_OAUTH_ISSUER}/deviceauth/callback"
+CHATGPT_OAUTH_POLL_SAFETY_MS = 3000
+
+
+class _PendingChatGPTOAuthLogin(Exception):
+    """Internal signal that the user has not yet completed device authorization."""
+
+
+class ChatGPTOAuthLoginError(Exception):
+    """Raised when the ChatGPT OAuth login flow fails."""
+
+
+class ChatGPTOAuthLoginTimeoutError(ChatGPTOAuthLoginError):
+    """Raised when the user does not complete login before the deadline."""
+
+
+def _user_agent() -> str:
+    """Return a User-Agent for OAuth endpoints."""
+    from free_claude_code.core.version import package_version
+
+    return f"free-claude-code/{package_version()}"
+
+
+def _parse_device_response(response: httpx.Response) -> dict[str, Any]:
+    if response.status_code != 200:
+        raise ChatGPTOAuthLoginError(
+            f"Device auth initiation failed: HTTP {response.status_code}"
+        )
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ChatGPTOAuthLoginError("Device auth response was not a JSON object")
+    return data
+
+
+def _initiate_device_auth(
+    http_client: httpx.Client | None = None,
+) -> tuple[str, str, int]:
+    """Start a device-auth flow and return (device_auth_id, user_code, interval_ms)."""
+    client = http_client or httpx.Client()
+    try:
+        response = client.post(
+            CHATGPT_OAUTH_DEVICE_URL,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": _user_agent(),
+            },
+            json={"client_id": CODEX_OAUTH_CLIENT_ID},
+            timeout=httpx.Timeout(30.0),
+        )
+    finally:
+        if http_client is None:
+            client.close()
+
+    data = _parse_device_response(response)
+    device_auth_id = data.get("device_auth_id")
+    user_code = data.get("user_code")
+    interval = data.get("interval")
+    if not isinstance(device_auth_id, str) or not device_auth_id:
+        raise ChatGPTOAuthLoginError("Device auth response missing device_auth_id")
+    if not isinstance(user_code, str) or not user_code:
+        raise ChatGPTOAuthLoginError("Device auth response missing user_code")
+    try:
+        interval_ms = max(int(interval or 5), 1) * 1000
+    except (TypeError, ValueError) as exc:
+        raise ChatGPTOAuthLoginError(
+            f"Device auth response contained invalid interval: {interval}"
+        ) from exc
+    return device_auth_id, user_code, interval_ms
+
+
+def _poll_device_auth(
+    device_auth_id: str,
+    user_code: str,
+    *,
+    deadline: float,
+    http_client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Poll the device-auth token endpoint until success or timeout."""
+    client = http_client or httpx.Client()
+    try:
+        while True:
+            response = client.post(
+                CHATGPT_OAUTH_DEVICE_TOKEN_URL,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": _user_agent(),
+                },
+                json={
+                    "device_auth_id": device_auth_id,
+                    "user_code": user_code,
+                },
+                timeout=httpx.Timeout(30.0),
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                if isinstance(data, dict) and "authorization_code" in data:
+                    return data
+                raise ChatGPTOAuthLoginError(
+                    "Device auth token response missing authorization_code"
+                )
+
+            if response.status_code not in {403, 404}:
+                raise ChatGPTOAuthLoginError(
+                    f"Device auth token polling failed: HTTP {response.status_code}"
+                )
+
+            if time.monotonic() >= deadline:
+                raise ChatGPTOAuthLoginTimeoutError(
+                    "Timed out waiting for ChatGPT OAuth login completion."
+                )
+
+            interval_ms = (
+                _parse_device_response(response).get("interval", 5)
+                if response.status_code == 200
+                else 5000
+            )
+            try:
+                interval_ms = max(int(interval_ms or 5), 1) * 1000
+            except (TypeError, ValueError):
+                interval_ms = 5000
+            time.sleep((interval_ms + CHATGPT_OAUTH_POLL_SAFETY_MS) / 1000.0)
+    finally:
+        if http_client is None:
+            client.close()
+
+
+def _exchange_authorization_code(
+    authorization_code: str,
+    code_verifier: str,
+    *,
+    http_client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Exchange an authorization code for OAuth tokens."""
+    client = http_client or httpx.Client()
+    try:
+        response = client.post(
+            CODEX_OAUTH_TOKEN_URL,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": CHATGPT_OAUTH_DEVICE_CALLBACK,
+                "client_id": CODEX_OAUTH_CLIENT_ID,
+                "code_verifier": code_verifier,
+            },
+            timeout=httpx.Timeout(30.0),
+        )
+    finally:
+        if http_client is None:
+            client.close()
+
+    if response.status_code != 200:
+        raise ChatGPTOAuthLoginError(
+            f"Token exchange failed: HTTP {response.status_code}"
+        )
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ChatGPTOAuthLoginError("Token exchange response was not a JSON object")
+    return data
+
+
+def _extract_expires_at(tokens: dict[str, Any]) -> int | None:
+    """Return a Unix timestamp for token expiry, if known."""
+    # Prefer the explicit expires_in from the token response.
+    expires_in = tokens.get("expires_in")
+    if isinstance(expires_in, (int, float)):
+        return int(time.time() + expires_in)
+    # Fall back to the exp claim in the access token.
+    access_token = tokens.get("access_token")
+    if isinstance(access_token, str):
+        claims = _decode_jwt_claims(access_token)
+        exp = claims.get("exp")
+        if isinstance(exp, (int, float)):
+            return int(exp)
+    return None
+
+
+def _write_codex_auth_file(
+    tokens: dict[str, Any],
+    *,
+    auth_path: Path | None = None,
+) -> Path:
+    """Persist tokens to the Codex CLI auth file used by the provider loader."""
+    path = auth_path or (_codex_home() / "auth.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    access_token = tokens.get("access_token")
+    refresh_token = tokens.get("refresh_token")
+    expires_at = _extract_expires_at(tokens)
+
+    payload = {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        }
+    }
+    if expires_at is not None:
+        payload["tokens"]["expires_at"] = expires_at
+
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def perform_chatgpt_oauth_login(
+    *,
+    timeout_seconds: float = 600.0,
+    auth_path: Path | None = None,
+    http_client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Run the full ChatGPT/Codex device-auth flow and persist the tokens.
+
+    Returns the token payload. Raises ChatGPTOAuthLoginError or
+    ChatGPTOAuthLoginTimeoutError on failure.
+    """
+    device_auth_id, user_code, _interval_ms = _initiate_device_auth(http_client)
+
+    print(
+        "\n".join(
+            [
+                "",
+                "ChatGPT OAuth login",
+                "===================",
+                f"1. Open: {CHATGPT_OAUTH_DEVICE_VERIFICATION_URL}",
+                f"2. Enter code: {user_code}",
+                f"3. Waiting up to {int(timeout_seconds)} seconds for authorization...",
+            ]
+        ),
+        flush=True,
+    )
+
+    deadline = time.monotonic() + timeout_seconds
+    device_data = _poll_device_auth(
+        device_auth_id,
+        user_code,
+        deadline=deadline,
+        http_client=http_client,
+    )
+
+    authorization_code = device_data.get("authorization_code")
+    code_verifier = device_data.get("code_verifier")
+    if not isinstance(authorization_code, str) or not authorization_code:
+        raise ChatGPTOAuthLoginError(
+            "Device auth response missing authorization_code"
+        )
+    if not isinstance(code_verifier, str) or not code_verifier:
+        raise ChatGPTOAuthLoginError("Device auth response missing code_verifier")
+
+    tokens = _exchange_authorization_code(
+        authorization_code,
+        code_verifier,
+        http_client=http_client,
+    )
+
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise ChatGPTOAuthLoginError("Token exchange did not return an access_token")
+
+    account_id = _extract_account_id(access_token)
+    tokens["account_id"] = account_id
+
+    path = _write_codex_auth_file(tokens, auth_path=auth_path)
+    print(f"Tokens saved to: {path}", flush=True)
+    if account_id:
+        print(f"Account ID: {account_id}", flush=True)
+
+    return tokens
+
+
+def exchange_device_auth_for_tokens(
+    device_auth_id: str,
+    user_code: str,
+    *,
+    timeout_seconds: float = 5.0,
+    auth_path: Path | None = None,
+    http_client: httpx.Client | None = None,
+) -> dict[str, Any] | None:
+    """Poll for device-auth completion and exchange tokens.
+
+    Returns the token payload on success, or ``None`` if the user has not yet
+    completed authorization (the caller should retry). Raises
+    ChatGPTOAuthLoginError for terminal failures.
+    """
+    try:
+        device_data = _poll_device_auth(
+            device_auth_id,
+            user_code,
+            deadline=time.monotonic() + timeout_seconds,
+            http_client=http_client,
+        )
+    except ChatGPTOAuthLoginTimeoutError:
+        return None
+
+    authorization_code = device_data.get("authorization_code")
+    code_verifier = device_data.get("code_verifier")
+    if not isinstance(authorization_code, str) or not authorization_code:
+        raise ChatGPTOAuthLoginError(
+            "Device auth response missing authorization_code"
+        )
+    if not isinstance(code_verifier, str) or not code_verifier:
+        raise ChatGPTOAuthLoginError("Device auth response missing code_verifier")
+
+    tokens = _exchange_authorization_code(
+        authorization_code,
+        code_verifier,
+        http_client=http_client,
+    )
+
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise ChatGPTOAuthLoginError("Token exchange did not return an access_token")
+
+    account_id = _extract_account_id(access_token)
+    tokens["account_id"] = account_id
+    _write_codex_auth_file(tokens, auth_path=auth_path)
+    return tokens
+
+
+def chatgpt_oauth_login_command() -> None:
+    """CLI entry point for ``fcc-chatgpt-oauth-login``."""
+    try:
+        perform_chatgpt_oauth_login()
+    except ChatGPTOAuthLoginTimeoutError as exc:
+        print(f"Timeout: {exc}", file=sys.stderr, flush=True)
+        raise SystemExit(1) from exc
+    except ChatGPTOAuthLoginError as exc:
+        print(f"Login failed: {exc}", file=sys.stderr, flush=True)
+        raise SystemExit(1) from exc

--- a/src/free_claude_code/providers/chatgpt_oauth/oauth_login.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/oauth_login.py
@@ -348,8 +348,27 @@ def exchange_device_auth_for_tokens(
 
 
 def chatgpt_oauth_login_command() -> None:
-    """CLI entry point for ``fcc-chatgpt-oauth-login``."""
+    """CLI entry point for ``fcc-chatgpt-oauth-login``.
+
+    Uses the browser PKCE flow by default (opens the login page automatically)
+    and falls back to the headless device-code flow when a browser cannot be
+    opened. ``--device`` forces the device flow.
+    """
+    from .browser_login import (
+        ChatGPTOAuthBrowserUnavailableError,
+        perform_browser_login,
+    )
+
+    force_device = "--device" in sys.argv[1:]
+
     try:
+        if not force_device:
+            try:
+                perform_browser_login()
+                return
+            except ChatGPTOAuthBrowserUnavailableError as exc:
+                print(f"Browser login unavailable: {exc}", file=sys.stderr, flush=True)
+                print("Falling back to device-code login...", flush=True)
         perform_chatgpt_oauth_login()
     except ChatGPTOAuthLoginTimeoutError as exc:
         print(f"Timeout: {exc}", file=sys.stderr, flush=True)

--- a/src/free_claude_code/providers/chatgpt_oauth/provider.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/provider.py
@@ -156,6 +156,33 @@ class ChatGPTOAuthProvider(BaseProvider):
         """Validate the upstream request before streaming."""
         build_chatgpt_oauth_request_body(request)
 
+    async def _send_stream_request(
+        self,
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+    ) -> httpx.Response:
+        """Build and send a streaming POST, raising on HTTP errors.
+
+        ``httpx.AsyncClient.stream`` returns an async context manager, which is
+        not awaitable and therefore cannot be passed directly to the retry
+        helper. We instead build the request and call ``send(..., stream=True)``,
+        which returns an awaitable ``Response`` while still keeping the body
+        stream open until we explicitly close it.
+        """
+        request = self._client.build_request("POST", url, headers=headers, json=body)
+        response = await self._client.send(request, stream=True)
+        if response.status_code >= 400:
+            error_body = await response.aread()
+            await response.aclose()
+            error_text = error_body.decode("utf-8", errors="replace")
+            raise httpx.HTTPStatusError(
+                f"ChatGPT OAuth API error {response.status_code}: {error_text[:1000]}",
+                request=request,
+                response=response,
+            )
+        return response
+
     def stream_response(
         self,
         request: MessagesRequest,
@@ -214,30 +241,28 @@ class ChatGPTOAuthProvider(BaseProvider):
             async with self._rate_limiter.concurrency_slot():
                 try:
                     response = await self._rate_limiter.execute_with_retry(
-                        self._client.stream,
+                        self._send_stream_request,
                         provider_failure_override=self._provider_failure_override,
-                        method="POST",
                         url=url,
                         headers=headers,
-                        json=body,
+                        body=body,
                     )
-                    async with response as stream:
-                        if stream.status_code >= 400:
-                            error_text = ""
-                            async for chunk in stream.aiter_text():
-                                error_text += chunk
+                    try:
+                        if response.status_code >= 400:
                             self._log_error(tag, req_tag, None, request_id)
                             raise ApplicationUnavailableError(
-                                f"ChatGPT OAuth API error {stream.status_code}: {error_text[:500]}"
+                                f"ChatGPT OAuth API error {response.status_code}"
                             )
 
                         yield ledger.message_start()
-                        async for event in iter_chatgpt_oauth_sse_events(stream.aiter_raw()):
+                        async for event in iter_chatgpt_oauth_sse_events(response.aiter_raw()):
                             for sse_event in converter.feed(event):
                                 yield sse_event
 
                         for sse_event in converter.finish():
                             yield sse_event
+                    finally:
+                        await response.aclose()
 
                 except ApplicationUnavailableError:
                     raise

--- a/src/free_claude_code/providers/chatgpt_oauth/provider.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/provider.py
@@ -1,0 +1,297 @@
+"""Direct ChatGPT/Codex OAuth provider using the Responses API."""
+
+from __future__ import annotations
+
+import platform
+import re
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from free_claude_code.application.errors import ApplicationUnavailableError
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import HTTP_CONNECT_TIMEOUT_DEFAULT
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
+from free_claude_code.core.diagnostics import (
+    exception_cause_types,
+    redacted_exception_traceback,
+)
+from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
+from free_claude_code.core.trace import trace_event
+from free_claude_code.core.version import package_version
+from free_claude_code.providers.base import BaseProvider, ProviderConfig
+from free_claude_code.providers.failure_policy import classify_provider_failure
+from free_claude_code.providers.model_listing import model_infos_from_ids
+from free_claude_code.providers.rate_limit import ProviderRateLimiter
+
+from .conversion import build_chatgpt_oauth_request_body
+from .credentials import ChatGPTOAuthError, load_chatgpt_oauth_credentials
+from .streaming import ChatGPTOAuthStreamConverter, iter_chatgpt_oauth_sse_events
+
+CHATGPT_OAUTH_DEFAULT_BASE = "https://chatgpt.com/backend-api"
+
+# Model allowlist aligned with OpenCode's ChatGPT/Codex OAuth filter.
+# https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/plugin/openai/codex.ts
+_CHATGPT_OAUTH_ALLOWED_MODELS = frozenset({
+    "gpt-5.5",
+    "gpt-5.3-codex-spark",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+})
+_CHATGPT_OAUTH_DISALLOWED_MODELS = frozenset({"gpt-5.5-pro"})
+_CHATGPT_OAUTH_GPT_VERSION_RE = re.compile(r"^gpt-(\d+\.\d+)")
+
+
+def _user_agent() -> str:
+    """Return a User-Agent string matching the shape used by OpenCode."""
+    version = package_version()
+    return (
+        f"free-claude-code/{version} "
+        f"({platform.system()} {platform.release()}; {platform.machine()})"
+    )
+
+
+def _is_chatgpt_oauth_model(model_id: str) -> bool:
+    """Return True when ``model_id`` is exposed by the ChatGPT/Codex backend.
+
+    Mirrors OpenCode's model filter: a small allowlist, an explicit blocklist,
+    and a version heuristic for future GPT-5.x models.
+    """
+    if model_id in _CHATGPT_OAUTH_DISALLOWED_MODELS:
+        return False
+    if model_id == "gpt-5.6":
+        return False
+    if model_id in _CHATGPT_OAUTH_ALLOWED_MODELS:
+        return True
+    match = _CHATGPT_OAUTH_GPT_VERSION_RE.match(model_id)
+    if match:
+        return float(match.group(1)) > 5.4
+    return False
+
+
+def _build_headers(credentials: Any, session_id: str) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {credentials.access_token}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "OpenAI-Beta": "responses=experimental",
+        "originator": "free-claude-code",
+        "User-Agent": _user_agent(),
+        "session-id": session_id,
+    }
+    if credentials.account_id:
+        headers["ChatGPT-Account-ID"] = credentials.account_id
+    return headers
+
+
+class ChatGPTOAuthProvider(BaseProvider):
+    """ChatGPT/Codex OAuth provider using the Responses API."""
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        rate_limiter: ProviderRateLimiter,
+        account_id: str = "",
+    ):
+        super().__init__(config)
+        self._rate_limiter = rate_limiter
+        self._base_url = (config.base_url or CHATGPT_OAUTH_DEFAULT_BASE).rstrip("/")
+        self._account_id = account_id
+        self._api_key = config.api_key
+        self._proxy = config.proxy
+        self._session_id = str(uuid.uuid4())
+        self._client = httpx.AsyncClient(
+            proxy=config.proxy if config.proxy else None,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout or HTTP_CONNECT_TIMEOUT_DEFAULT,
+                read=config.http_read_timeout,
+                write=config.http_write_timeout,
+            ),
+        )
+
+    async def cleanup(self) -> None:
+        await self._client.aclose()
+
+    async def list_model_ids(self) -> frozenset[str]:
+        """Return a static set of known ChatGPT/Codex OAuth model ids.
+
+        The Responses API models endpoint requires a valid session and is not
+        reliably probe-able during discovery, so we expose the ids that the
+        upstream documentation and community implementations reference.
+        The list is filtered to match OpenCode's ChatGPT/Codex OAuth allowlist.
+        """
+        candidates = {
+            "gpt-5",
+            "gpt-5.2",
+            "gpt-5.4",
+            "gpt-5.5",
+            "gpt-5.6",
+            "gpt-5-codex",
+            "gpt-5.1-codex",
+            "gpt-5.2-codex",
+            "gpt-5.3-codex",
+            "gpt-5.3-codex-spark",
+            "gpt-5.4-mini",
+            "gpt-5.5-pro",
+            "codex-mini-latest",
+        }
+        return frozenset(m for m in candidates if _is_chatgpt_oauth_model(m))
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        return model_infos_from_ids(await self.list_model_ids())
+
+    def preflight_stream(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> None:
+        """Validate the upstream request before streaming."""
+        build_chatgpt_oauth_request_body(request)
+
+    def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> AsyncIterator[str]:
+        tag = "CHATGPT_OAUTH"
+        req_tag = f" request_id={request_id}" if request_id else ""
+        logger.debug("{}_STREAM: starting{}", tag, req_tag)
+
+        try:
+            credentials = load_chatgpt_oauth_credentials(
+                access_token=self._api_key or None,
+                account_id=self._account_id or None,
+            )
+        except ChatGPTOAuthError as exc:
+            logger.error("{}_ERROR:{} {}", tag, req_tag, exc)
+            raise ApplicationUnavailableError(str(exc)) from exc
+
+        body = build_chatgpt_oauth_request_body(request)
+        url = f"{self._base_url}/codex/responses"
+        headers = _build_headers(credentials, self._session_id)
+
+        trace_event(
+            stage="provider",
+            event="provider.request.sent",
+            source="provider",
+            provider=tag,
+            request_id=request_id,
+            gateway_model=request.model,
+            downstream_model=body.get("model"),
+            message_count=len(body.get("input", [])),
+            tool_count=len(body.get("tools", [])),
+            body={
+                "model": body.get("model"),
+                "input_count": len(body.get("input", [])),
+                "tool_count": len(body.get("tools", [])),
+            },
+        )
+
+        async def _stream() -> AsyncIterator[str]:
+            message_id = f"msg_{uuid.uuid4()}"
+            ledger = AnthropicStreamLedger(
+                message_id,
+                request.model,
+                input_tokens,
+                log_raw_events=self._config.log_raw_sse_events,
+            )
+            converter = ChatGPTOAuthStreamConverter(
+                ledger,
+                log_raw_events=self._config.log_raw_sse_events,
+            )
+
+            async with self._rate_limiter.concurrency_slot():
+                try:
+                    response = await self._rate_limiter.execute_with_retry(
+                        self._client.stream,
+                        provider_failure_override=self._provider_failure_override,
+                        method="POST",
+                        url=url,
+                        headers=headers,
+                        json=body,
+                    )
+                    async with response as stream:
+                        if stream.status_code >= 400:
+                            error_text = ""
+                            async for chunk in stream.aiter_text():
+                                error_text += chunk
+                            self._log_error(tag, req_tag, None, request_id)
+                            raise ApplicationUnavailableError(
+                                f"ChatGPT OAuth API error {stream.status_code}: {error_text[:500]}"
+                            )
+
+                        yield ledger.message_start()
+                        async for event in iter_chatgpt_oauth_sse_events(stream.aiter_raw()):
+                            for sse_event in converter.feed(event):
+                                yield sse_event
+
+                        for sse_event in converter.finish():
+                            yield sse_event
+
+                except ApplicationUnavailableError:
+                    raise
+                except Exception as error:
+                    self._log_error(tag, req_tag, error, request_id)
+                    failure = classify_provider_failure(
+                        error,
+                        provider_name=tag,
+                        read_timeout_s=self._config.http_read_timeout,
+                        request_id=request_id,
+                        mark_rate_limited=self._rate_limiter.extend_reactive_block,
+                        provider_failure_override=self._provider_failure_override,
+                    )
+                    trace_event(
+                        stage="provider",
+                        event="provider.response.error",
+                        source="provider",
+                        provider=tag,
+                        request_id=request_id,
+                        exc_type=type(error).__name__,
+                        failure_kind=failure.kind.value,
+                        status_code=failure.status_code,
+                        provider_retryable=failure.retryable,
+                    )
+                    raise failure from error
+
+        return _stream()
+
+    def _provider_failure_override(self, error: Exception) -> ExecutionFailure | None:
+        return None
+
+    def _log_error(
+        self,
+        tag: str,
+        req_tag: str,
+        error: Exception | None,
+        request_id: str | None,
+    ) -> None:
+        if error is None:
+            logger.error("{}_ERROR:{} transport error", tag, req_tag)
+            return
+        if self._config.log_api_error_tracebacks:
+            logger.error(
+                "{}_ERROR:{} exc_type={}\n{}",
+                tag,
+                req_tag,
+                type(error).__name__,
+                redacted_exception_traceback(error),
+            )
+        else:
+            logger.error(
+                "{}_ERROR:{} exc_type={} cause_types={}",
+                tag,
+                req_tag,
+                type(error).__name__,
+                ",".join(exception_cause_types(error)),
+            )

--- a/src/free_claude_code/providers/chatgpt_oauth/streaming.py
+++ b/src/free_claude_code/providers/chatgpt_oauth/streaming.py
@@ -1,0 +1,155 @@
+"""Convert ChatGPT Responses API SSE events to Anthropic SSE format."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
+
+
+def _finish_reason_from_status(status: Any) -> str:
+    if not isinstance(status, str):
+        return "end_turn"
+    status_lower = status.lower()
+    if status_lower in {"completed", "stop"}:
+        return "end_turn"
+    if status_lower in {"max_tokens", "length"}:
+        return "max_tokens"
+    if status_lower in {"content_filter"}:
+        return "content_filter"
+    return "end_turn"
+
+
+class ChatGPTOAuthStreamConverter:
+    """Own state for one ChatGPT Responses API stream."""
+
+    def __init__(
+        self,
+        ledger: AnthropicStreamLedger,
+        *,
+        log_raw_events: bool = False,
+    ) -> None:
+        self._ledger = ledger
+        self._log_raw_events = log_raw_events
+        self._active_tool_calls: dict[str, dict[str, Any]] = {}
+        self._usage: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+        self._finished = False
+
+    def _log_event(self, event: dict[str, Any]) -> None:
+        if self._log_raw_events:
+            import json
+
+            print(json.dumps({"chatgpt_oauth_event": event}, default=str))
+
+    def feed(self, event: dict[str, Any]) -> Iterator[str]:
+        """Yield Anthropic SSE events for one Responses API event."""
+        self._log_event(event)
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            return
+
+        if event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str) and delta:
+                yield from self._ledger.ensure_text_block()
+                yield self._ledger.emit_text_delta(delta)
+            return
+
+        if event_type == "response.output_item.added":
+            item = event.get("item") or {}
+            item_type = item.get("type")
+            if item_type == "function_call":
+                tool_id = item.get("id") or f"call_{len(self._active_tool_calls)}"
+                name = item.get("name") or "unknown"
+                self._active_tool_calls[tool_id] = {
+                    "id": tool_id,
+                    "name": name,
+                    "arguments": "",
+                    "index": len(self._active_tool_calls),
+                }
+                yield from self._ledger.close_content_blocks()
+                yield self._ledger.start_tool_block(
+                    tool_index=self._active_tool_calls[tool_id]["index"],
+                    tool_id=tool_id,
+                    name=name,
+                )
+            return
+
+        if event_type == "response.function_call_arguments.delta":
+            item_id = event.get("item_id")
+            delta = event.get("delta")
+            tool = self._active_tool_calls.get(item_id)
+            if tool is not None and isinstance(delta, str):
+                tool["arguments"] += delta
+                yield self._ledger.emit_tool_delta(tool["index"], delta)
+            return
+
+        if event_type == "response.output_item.done":
+            item = event.get("item") or {}
+            item_type = item.get("type")
+            if item_type == "function_call":
+                tool_id = item.get("id")
+                tool = self._active_tool_calls.get(tool_id)
+                if tool is not None:
+                    # Ensure the complete argument object has been emitted.
+                    full_args = item.get("arguments") or tool.get("arguments") or "{}"
+                    if tool["arguments"] != full_args:
+                        remaining = full_args[len(tool["arguments"]) :]
+                        if remaining:
+                            yield self._ledger.emit_tool_delta(tool["index"], remaining)
+                            tool["arguments"] = full_args
+                    yield self._ledger.stop_tool_block(tool["index"])
+            return
+
+        if event_type in {"response.completed", "response.done"}:
+            response = event.get("response") or event
+            if self._finished:
+                return
+            self._finished = True
+            yield from self._ledger.close_content_blocks()
+            usage = response.get("usage") if isinstance(response, dict) else None
+            if isinstance(usage, dict):
+                self._usage["input_tokens"] = usage.get("input_tokens", 0) or 0
+                self._usage["output_tokens"] = usage.get("output_tokens", 0) or 0
+            return
+
+    def finish(self, stop_reason: str | None = None) -> Iterator[str]:
+        """Emit final message_delta and message_stop events."""
+        yield from self._ledger.close_content_blocks()
+        reason = stop_reason or "end_turn"
+        yield self._ledger.message_delta(
+            reason,
+            self._usage.get("output_tokens", 0),
+            input_tokens=self._usage.get("input_tokens", 0),
+        )
+        yield self._ledger.message_stop()
+
+
+async def iter_chatgpt_oauth_sse_events(raw_stream: Any) -> AsyncIterator[dict[str, Any]]:
+    """Parse a raw async SSE byte stream into ChatGPT Responses API event dicts."""
+    buffer = ""
+    async for chunk in raw_stream:
+        if isinstance(chunk, bytes):
+            text = chunk.decode("utf-8", errors="replace")
+        else:
+            text = str(chunk)
+        buffer += text
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
+            line = line.strip()
+            if not line or not line.startswith("data: "):
+                continue
+            data = line[len("data: "):].strip()
+            if data == "[DONE]":
+                return
+            try:
+                event = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                yield event

--- a/src/free_claude_code/providers/runtime/config.py
+++ b/src/free_claude_code/providers/runtime/config.py
@@ -48,8 +48,9 @@ def build_provider_config(
     )
     resolved_base_url = base_url or descriptor.default_base_url
     if not resolved_base_url:
-        raise AssertionError(
-            f"Provider {descriptor.provider_id!r} has no configured base URL."
+        raise ApplicationUnavailableError(
+            f"{descriptor.provider_id.upper()}_BASE_URL is not set. "
+            f"Configure the base URL for provider {descriptor.provider_id!r}."
         )
     proxy = string_setting(settings, descriptor.proxy_attr)
     return ProviderConfig(

--- a/src/free_claude_code/providers/runtime/factory.py
+++ b/src/free_claude_code/providers/runtime/factory.py
@@ -107,6 +107,20 @@ def _create_github_models(
     return GitHubModelsProvider(config, rate_limiter=rate_limiter)
 
 
+def _create_chatgpt_oauth(
+    config: ProviderConfig,
+    settings: Settings,
+    rate_limiter: ProviderRateLimiter,
+) -> BaseProvider:
+    from free_claude_code.providers.chatgpt_oauth import ChatGPTOAuthProvider
+
+    return ChatGPTOAuthProvider(
+        config,
+        rate_limiter=rate_limiter,
+        account_id=settings.chatgpt_oauth_account_id,
+    )
+
+
 _SPECIAL_PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
@@ -116,6 +130,7 @@ _SPECIAL_PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "cloudflare": _create_cloudflare,
     "gemini": _create_gemini,
     "github_models": _create_github_models,
+    "chatgpt_oauth": _create_chatgpt_oauth,
 }
 
 _profiled_ids = set(OPENAI_CHAT_PROFILES)

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1072,3 +1072,148 @@ def test_admin_launch_url_uses_loopback_for_wildcard_host():
     settings = Settings.model_construct(host="0.0.0.0", port=8082)
 
     assert local_admin_url(settings) == "http://127.0.0.1:8082/admin"
+
+
+def test_admin_chatgpt_oauth_initiate_is_loopback_only(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+    remote_client = TestClient(app, client=("203.0.113.10", 50000))
+
+    response = remote_client.post("/admin/api/chatgpt-oauth/initiate")
+
+    assert response.status_code == 403
+
+
+def test_admin_chatgpt_oauth_initiate_returns_device_code(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    def fake_initiate():
+        return ("device_1", "ABCD-EFGH", 5000)
+
+    with patch(
+        "free_claude_code.api.admin_routes._initiate_device_auth",
+        fake_initiate,
+    ):
+        response = _local_client(app).post("/admin/api/chatgpt-oauth/initiate")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["device_auth_id"] == "device_1"
+    assert data["user_code"] == "ABCD-EFGH"
+    assert "auth.openai.com/codex/device" in data["verification_url"]
+
+
+def test_admin_chatgpt_oauth_exchange_returns_tokens(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    def fake_exchange(*args, **kwargs):
+        return {
+            "access_token": "access_1",
+            "refresh_token": "refresh_1",
+            "account_id": "acct_1",
+        }
+
+    with patch(
+        "free_claude_code.api.admin_routes.exchange_device_auth_for_tokens",
+        fake_exchange,
+    ):
+        response = _local_client(app).post(
+            "/admin/api/chatgpt-oauth/exchange",
+            json={"device_auth_id": "device_1", "user_code": "ABCD-EFGH"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "complete"
+    assert data["access_token"] == "access_1"
+    assert data["account_id"] == "acct_1"
+
+
+def test_admin_chatgpt_oauth_exchange_returns_pending(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    def fake_exchange(*args, **kwargs):
+        return None
+
+    with patch(
+        "free_claude_code.api.admin_routes.exchange_device_auth_for_tokens",
+        fake_exchange,
+    ):
+        response = _local_client(app).post(
+            "/admin/api/chatgpt-oauth/exchange",
+            json={"device_auth_id": "device_1", "user_code": "ABCD-EFGH"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "pending"
+
+
+def test_admin_chatgpt_oauth_import_codex_is_loopback_only(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+    remote_client = TestClient(app, client=("203.0.113.10", 50000))
+
+    response = remote_client.post("/admin/api/chatgpt-oauth/import-codex")
+
+    assert response.status_code == 403
+
+
+def test_admin_chatgpt_oauth_import_codex_returns_tokens(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    from free_claude_code.providers.chatgpt_oauth.credentials import (
+        ChatGPTOAuthCredentials,
+    )
+
+    def fake_import():
+        return ChatGPTOAuthCredentials(
+            access_token="codex_token",
+            account_id="codex_acct",
+            refresh_token="codex_refresh",
+            source_name="codex-cli",
+        )
+
+    with patch(
+        "free_claude_code.api.admin_routes.import_codex_cli_tokens",
+        fake_import,
+    ):
+        response = _local_client(app).post("/admin/api/chatgpt-oauth/import-codex")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "complete"
+    assert data["access_token"] == "codex_token"
+    assert data["account_id"] == "codex_acct"
+
+
+def test_admin_chatgpt_oauth_import_codex_reports_missing_tokens(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    from free_claude_code.providers.chatgpt_oauth.credentials import ChatGPTOAuthError
+
+    def fake_import():
+        raise ChatGPTOAuthError("No Codex CLI access token found")
+
+    with patch(
+        "free_claude_code.api.admin_routes.import_codex_cli_tokens",
+        fake_import,
+    ):
+        response = _local_client(app).post("/admin/api/chatgpt-oauth/import-codex")
+
+    assert response.status_code == 400
+    assert "Codex" in response.json()["detail"]

--- a/tests/contracts/test_feature_manifest.py
+++ b/tests/contracts/test_feature_manifest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
 from free_claude_code.messaging.platforms.factory import create_messaging_components
 from free_claude_code.providers.base import BaseProvider
+from free_claude_code.providers.chatgpt_oauth import ChatGPTOAuthProvider
 from free_claude_code.providers.cloudflare import CloudflareProvider
 from free_claude_code.providers.deepseek import DeepSeekProvider
 from free_claude_code.providers.gemini import GeminiProvider
@@ -98,6 +99,7 @@ def test_provider_and_platform_registries_include_advertised_builtins() -> None:
         "lmstudio": LMStudioProvider,
         "github_models": GitHubModelsProvider,
         "gemini": GeminiProvider,
+        "chatgpt_oauth": ChatGPTOAuthProvider,
     }
     assert set(OPENAI_CHAT_PROFILES).isdisjoint(specialized_provider_classes)
     assert set(PROVIDER_CATALOG) == (

--- a/tests/contracts/test_import_boundaries.py
+++ b/tests/contracts/test_import_boundaries.py
@@ -37,6 +37,27 @@ IMPORT_EXCEPTIONS: dict[tuple[str, str], str] = {
         "Owner: installed server command. "
         "Reason: the command delegates construction to the process composition root."
     ),
+    (
+        "free_claude_code.cli.commands",
+        "free_claude_code.providers.chatgpt_oauth",
+    ): (
+        "Owner: installed ChatGPT OAuth login command. "
+        "Reason: the command delegates to the provider's OAuth login utility."
+    ),
+    (
+        "free_claude_code.api.admin_routes",
+        "free_claude_code.providers.chatgpt_oauth.oauth_login",
+    ): (
+        "Owner: admin dashboard ChatGPT OAuth login API. "
+        "Reason: admin routes expose OAuth device-flow endpoints backed by the provider utility."
+    ),
+    (
+        "free_claude_code.api.admin_routes",
+        "free_claude_code.providers.chatgpt_oauth.credentials",
+    ): (
+        "Owner: admin dashboard ChatGPT OAuth import API. "
+        "Reason: admin routes expose the Codex CLI token import endpoint backed by the provider utility."
+    ),
 }
 
 FACADE_ONLY_BOUNDARIES = {

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -21,6 +21,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "wafer",
     "kimi",
     "kimi_code",
+    "chatgpt_oauth",
     "minimax",
     "cerebras",
     "groq",

--- a/tests/providers/test_chatgpt_oauth.py
+++ b/tests/providers/test_chatgpt_oauth.py
@@ -404,3 +404,40 @@ def test_perform_chatgpt_oauth_login_writes_auth_file(tmp_path, monkeypatch):
     assert saved["tokens"]["access_token"] == access_token
     assert saved["tokens"]["refresh_token"] == "refresh_1"
     assert "expires_at" in saved["tokens"]
+
+
+@pytest.mark.asyncio
+async def test_stream_response_uses_send_not_stream_context_manager(chatgpt_oauth_provider):
+    """Regression: awaiting httpx.AsyncClient.stream() raises TypeError."""
+    from unittest.mock import MagicMock
+
+    request = MessagesRequest(
+        model="gpt-5",
+        messages=[Message(role="user", content="hi")],
+    )
+
+    async def _raw_stream():
+        yield b'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
+        yield b'data: {"type":"response.completed","response":{}}\n\n'
+
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.aiter_raw = _raw_stream
+    fake_response.aclose = AsyncMock()
+
+    client = chatgpt_oauth_provider._client
+    client.build_request = MagicMock(return_value=MagicMock())
+    client.send = AsyncMock(return_value=fake_response)
+
+    chunks = [
+        chunk
+        async for chunk in chatgpt_oauth_provider.stream_response(
+            request, request_id="req_1"
+        )
+    ]
+
+    assert any("content_block_start" in chunk and "text" in chunk for chunk in chunks)
+    assert any("text_delta" in chunk and "hello" in chunk for chunk in chunks)
+    client.send.assert_awaited_once()
+    assert client.send.await_args.kwargs.get("stream") is True
+    fake_response.aclose.assert_awaited_once()

--- a/tests/providers/test_chatgpt_oauth.py
+++ b/tests/providers/test_chatgpt_oauth.py
@@ -243,6 +243,97 @@ def test_load_credentials_reads_codex_auth_file(tmp_path, monkeypatch):
     assert creds.access_token == "file_token"
 
 
+def _jwt(payload_dict: dict) -> str:
+    import base64
+
+    header = base64.urlsafe_b64encode(b"{}").decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(payload_dict).encode()).decode().rstrip("=")
+    return f"{header}.{payload}."
+
+
+def test_load_credentials_prefers_id_token_for_account_id(tmp_path, monkeypatch):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    access_token = _jwt({"exp": 9999999999})
+    id_token = _jwt({"chatgpt_account_id": "acct_from_id_token"})
+    (codex_home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": access_token, "id_token": id_token}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    creds = load_chatgpt_oauth_credentials()
+
+    assert creds.account_id == "acct_from_id_token"
+
+
+def test_load_credentials_falls_back_to_organization_id(tmp_path, monkeypatch):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    access_token = _jwt({"organizations": [{"id": "org_123"}], "exp": 9999999999})
+    (codex_home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": access_token}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    creds = load_chatgpt_oauth_credentials()
+
+    assert creds.account_id == "org_123"
+
+
+def test_refresh_persists_rotated_tokens_to_auth_file(tmp_path, monkeypatch):
+    import time
+
+    from free_claude_code.providers.chatgpt_oauth import credentials as creds_module
+
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    auth_path = codex_home / "auth.json"
+    expired_access = _jwt({"exp": int(time.time()) - 100})
+    auth_path.write_text(
+        json.dumps(
+            {"tokens": {"access_token": expired_access, "refresh_token": "refresh_old"}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    new_access = _jwt({"exp": 9999999999, "chatgpt_account_id": "acct_new"})
+    monkeypatch.setattr(
+        creds_module,
+        "_refresh_access_token",
+        lambda refresh: (new_access, "refresh_rotated", 9999999999, None),
+    )
+
+    creds = load_chatgpt_oauth_credentials()
+
+    assert creds.access_token == new_access
+    assert creds.account_id == "acct_new"
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["tokens"]["access_token"] == new_access
+    assert saved["tokens"]["refresh_token"] == "refresh_rotated"
+    assert saved["tokens"]["expires_at"] == 9999999999
+
+
+def test_write_codex_auth_file_stores_id_token(tmp_path, monkeypatch):
+    from free_claude_code.providers.chatgpt_oauth import oauth_login
+
+    auth_path = tmp_path / ".codex" / "auth.json"
+    oauth_login._write_codex_auth_file(
+        {
+            "access_token": "access_1",
+            "refresh_token": "refresh_1",
+            "id_token": "id_1",
+            "expires_in": 3600,
+        },
+        auth_path=auth_path,
+    )
+
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["tokens"]["id_token"] == "id_1"
+
+
 def test_load_credentials_extracts_account_id_from_jwt(tmp_path, monkeypatch):
     import base64
 

--- a/tests/providers/test_chatgpt_oauth.py
+++ b/tests/providers/test_chatgpt_oauth.py
@@ -1,0 +1,406 @@
+"""Tests for the direct ChatGPT OAuth Responses API provider."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from free_claude_code.application.errors import (
+    InvalidRequestError,
+)
+from free_claude_code.config.provider_catalog import CHATGPT_OAUTH_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import Message, MessagesRequest
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.chatgpt_oauth import ChatGPTOAuthProvider
+from free_claude_code.providers.chatgpt_oauth.conversion import (
+    build_chatgpt_oauth_request_body,
+    chatgpt_tool_call_to_anthropic,
+)
+from free_claude_code.providers.chatgpt_oauth.credentials import (
+    load_chatgpt_oauth_credentials,
+)
+from free_claude_code.providers.chatgpt_oauth.streaming import (
+    ChatGPTOAuthStreamConverter,
+)
+from tests.providers.support import passthrough_rate_limiter
+
+
+def _provider_config(**overrides) -> ProviderConfig:
+    return ProviderConfig(
+        api_key=overrides.get("api_key", "test_token"),
+        base_url=overrides.get("base_url", CHATGPT_OAUTH_DEFAULT_BASE),
+        rate_limit=overrides.get("rate_limit", 10),
+        rate_window=overrides.get("rate_window", 60),
+        max_concurrency=overrides.get("max_concurrency", 5),
+        http_read_timeout=overrides.get("http_read_timeout", 300.0),
+        http_write_timeout=overrides.get("http_write_timeout", 10.0),
+        http_connect_timeout=overrides.get("http_connect_timeout", 60.0),
+        proxy=overrides.get("proxy", ""),
+    )
+
+
+@pytest.fixture
+def chatgpt_oauth_provider():
+    return ChatGPTOAuthProvider(
+        _provider_config(),
+        rate_limiter=passthrough_rate_limiter(),
+        account_id="test_account_id",
+    )
+
+
+def test_provider_uses_default_base_url():
+    provider = ChatGPTOAuthProvider(
+        _provider_config(base_url=""),
+        rate_limiter=passthrough_rate_limiter(),
+    )
+    assert provider._base_url == CHATGPT_OAUTH_DEFAULT_BASE
+
+
+def test_provider_uses_configured_base_url():
+    provider = ChatGPTOAuthProvider(
+        _provider_config(base_url="https://example.com/backend-api"),
+        rate_limiter=passthrough_rate_limiter(),
+    )
+    assert provider._base_url == "https://example.com/backend-api"
+
+
+def test_build_request_body_converts_messages():
+    request = MessagesRequest(
+        model="gpt-5",
+        max_tokens=50,
+        messages=[Message(role="user", content="hi")],
+    )
+
+    body = build_chatgpt_oauth_request_body(request)
+
+    assert body["model"] == "gpt-5"
+    assert body["store"] is False
+    assert body["stream"] is True
+    assert body["parallel_tool_calls"] is False
+    assert "max_output_tokens" not in body
+    assert body["input"] == [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+    ]
+
+
+def test_build_request_body_adds_reasoning_for_gpt5():
+    request = MessagesRequest(
+        model="gpt-5",
+        messages=[Message(role="user", content="hi")],
+    )
+
+    body = build_chatgpt_oauth_request_body(request)
+
+    assert body["reasoning"] == {"effort": "medium", "summary": "auto"}
+    assert "reasoning.encrypted_content" in body["include"]
+
+
+def test_build_request_body_skips_reasoning_for_non_reasoning_model():
+    request = MessagesRequest(
+        model="unknown-model",
+        messages=[Message(role="user", content="hi")],
+    )
+
+    body = build_chatgpt_oauth_request_body(request)
+
+    assert "reasoning" not in body
+
+
+def test_build_request_body_extracts_system_as_instructions():
+    request = MessagesRequest(
+        model="gpt-5",
+        system="You are a helpful assistant.",
+        messages=[Message(role="user", content="hi")],
+    )
+
+    body = build_chatgpt_oauth_request_body(request)
+
+    assert body["instructions"] == "You are a helpful assistant."
+
+
+def test_build_request_body_rejects_extra_body():
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "x"}],
+            "extra_body": {"x": 1},
+        }
+    )
+
+    with pytest.raises(InvalidRequestError):
+        build_chatgpt_oauth_request_body(request)
+
+
+def test_chatgpt_tool_call_to_anthropic():
+    item = {
+        "id": "call_1",
+        "name": "bash",
+        "arguments": json.dumps({"command": "ls"}),
+    }
+
+    block = chatgpt_tool_call_to_anthropic(item)
+
+    assert block["type"] == "tool_use"
+    assert block["id"] == "call_1"
+    assert block["name"] == "bash"
+    assert block["input"] == {"command": "ls"}
+
+
+def test_stream_converter_emits_text_delta():
+    from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
+
+    ledger = AnthropicStreamLedger("msg_1", "gpt-5", input_tokens=0)
+    converter = ChatGPTOAuthStreamConverter(ledger)
+
+    events = list(converter.feed({"type": "response.output_text.delta", "delta": "hello"}))
+
+    assert any("content_block_start" in e and "text" in e for e in events)
+    assert any("text_delta" in e and "hello" in e for e in events)
+
+
+def test_stream_converter_emits_tool_call():
+    from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
+
+    ledger = AnthropicStreamLedger("msg_1", "gpt-5", input_tokens=0)
+    converter = ChatGPTOAuthStreamConverter(ledger)
+
+    events = list(converter.feed({
+        "type": "response.output_item.added",
+        "item": {"type": "function_call", "id": "call_1", "name": "bash"},
+    }))
+    events += list(converter.feed({
+        "type": "response.function_call_arguments.delta",
+        "item_id": "call_1",
+        "delta": '{"command":',
+    }))
+    events += list(converter.feed({
+        "type": "response.function_call_arguments.delta",
+        "item_id": "call_1",
+        "delta": '"ls"}',
+    }))
+    events += list(converter.feed({
+        "type": "response.output_item.done",
+        "item": {"type": "function_call", "id": "call_1", "arguments": '{"command":"ls"}'},
+    }))
+
+    assert any("tool_use" in e for e in events)
+    assert any('"bash"' in e for e in events)
+    # partial_json contains the raw argument string; look for the key without
+    # requiring exact JSON quote escaping in the serialized SSE line.
+    assert any("command" in e for e in events)
+
+
+@pytest.mark.asyncio
+async def test_list_model_ids_returns_known_models(chatgpt_oauth_provider):
+    models = await chatgpt_oauth_provider.list_model_ids()
+    # OpenCode-aligned allowlist: explicit allows, disallowed pro, and a
+    # version heuristic that keeps GPT-5.x models newer than 5.4.
+    assert "gpt-5.5" in models
+    assert "gpt-5.4" in models
+    assert "gpt-5.4-mini" in models
+    assert "gpt-5.3-codex-spark" in models
+    assert "gpt-5.5-pro" not in models
+    assert "gpt-5.6" not in models
+    assert "gpt-5.2-codex" not in models
+
+
+@pytest.mark.asyncio
+async def test_cleanup_closes_http_client(chatgpt_oauth_provider):
+    chatgpt_oauth_provider._client.aclose = AsyncMock()
+
+    await chatgpt_oauth_provider.cleanup()
+
+    chatgpt_oauth_provider._client.aclose.assert_awaited_once()
+
+
+def test_load_credentials_prefers_explicit_token(tmp_path, monkeypatch):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        '{"tokens": {"access_token": "file_token"}}', encoding="utf-8"
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    creds = load_chatgpt_oauth_credentials(
+        access_token="explicit_token",
+        account_id="explicit_account",
+    )
+
+    assert creds.access_token == "explicit_token"
+    assert creds.account_id == "explicit_account"
+
+
+def test_load_credentials_reads_codex_auth_file(tmp_path, monkeypatch):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        '{"tokens": {"access_token": "file_token"}}', encoding="utf-8"
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    creds = load_chatgpt_oauth_credentials()
+
+    assert creds.access_token == "file_token"
+
+
+def test_load_credentials_extracts_account_id_from_jwt(tmp_path, monkeypatch):
+    import base64
+
+    header = base64.urlsafe_b64encode(b'{}').decode().rstrip("=")
+    payload_dict = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"}
+    }
+    payload = base64.urlsafe_b64encode(
+        json.dumps(payload_dict).encode()
+    ).decode().rstrip("=")
+    token = f"{header}.{payload}."
+
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": token}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    creds = load_chatgpt_oauth_credentials()
+
+    assert creds.account_id == "acct_123"
+
+
+def test_build_headers_matches_opencode_shape(chatgpt_oauth_provider):
+    from free_claude_code.providers.chatgpt_oauth.credentials import (
+        ChatGPTOAuthCredentials,
+    )
+    from free_claude_code.providers.chatgpt_oauth.provider import _build_headers
+
+    credentials = ChatGPTOAuthCredentials(
+        access_token="test_token",
+        account_id="acct_123",
+    )
+    headers = _build_headers(credentials, chatgpt_oauth_provider._session_id)
+
+    assert headers["Authorization"] == "Bearer test_token"
+    assert headers["originator"] == "free-claude-code"
+    assert headers["session-id"] == chatgpt_oauth_provider._session_id
+    assert "User-Agent" in headers
+    assert headers["User-Agent"].startswith("free-claude-code/")
+    assert headers["ChatGPT-Account-ID"] == "acct_123"
+
+
+def test_session_id_is_stable_per_provider():
+    from free_claude_code.providers.base import ProviderConfig
+
+    config = ProviderConfig(
+        api_key="x",
+        base_url="",
+        rate_limit=10,
+        rate_window=60,
+        max_concurrency=5,
+        http_read_timeout=300.0,
+        http_write_timeout=10.0,
+        http_connect_timeout=60.0,
+        proxy="",
+    )
+    provider1 = ChatGPTOAuthProvider(
+        config,
+        rate_limiter=passthrough_rate_limiter(),
+    )
+    provider2 = ChatGPTOAuthProvider(
+        config,
+        rate_limiter=passthrough_rate_limiter(),
+    )
+    assert provider1._session_id
+    assert provider1._session_id == provider1._session_id
+    assert provider1._session_id != provider2._session_id
+
+
+def test_model_filter_logic():
+    from free_claude_code.providers.chatgpt_oauth.provider import (
+        _is_chatgpt_oauth_model,
+    )
+
+    assert _is_chatgpt_oauth_model("gpt-5.5") is True
+    assert _is_chatgpt_oauth_model("gpt-5.4") is True
+    assert _is_chatgpt_oauth_model("gpt-5.4-mini") is True
+    assert _is_chatgpt_oauth_model("gpt-5.7") is True
+    assert _is_chatgpt_oauth_model("gpt-5.5-pro") is False
+    assert _is_chatgpt_oauth_model("gpt-5.6") is False
+    assert _is_chatgpt_oauth_model("gpt-5.2-codex") is False
+    assert _is_chatgpt_oauth_model("codex-mini-latest") is False
+
+
+def test_perform_chatgpt_oauth_login_writes_auth_file(tmp_path, monkeypatch):
+    import base64
+
+    from free_claude_code.providers.chatgpt_oauth import oauth_login
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    monkeypatch.setattr(oauth_login, "CHATGPT_OAUTH_POLL_SAFETY_MS", 1)
+
+    header = base64.urlsafe_b64encode(b'{}').decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"https://api.openai.com/auth": {"chatgpt_account_id": "acct_xyz"}}).encode()
+    ).decode().rstrip("=")
+    access_token = f"{header}.{payload}."
+
+    responses = {
+        ("POST", oauth_login.CHATGPT_OAUTH_DEVICE_URL): {
+            "json": {
+                "device_auth_id": "device_1",
+                "user_code": "ABCD-EFGH",
+                "interval": "1",
+            }
+        },
+        ("POST", oauth_login.CHATGPT_OAUTH_DEVICE_TOKEN_URL): {
+            "json": {
+                "authorization_code": "auth_code_1",
+                "code_verifier": "verifier_1",
+            }
+        },
+        ("POST", oauth_login.CODEX_OAUTH_TOKEN_URL): {
+            "json": {
+                "access_token": access_token,
+                "refresh_token": "refresh_1",
+                "expires_in": 3600,
+            }
+        },
+    }
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+            self.status_code = 200
+
+        def json(self):
+            return self._payload["json"]
+
+    class FakeClient:
+        def __init__(self):
+            self.calls: list[tuple[str, str]] = []
+            self._poll_count = 0
+
+        def post(self, url, **kwargs):
+            key = ("POST", url)
+            self.calls.append(key)
+            if url == oauth_login.CHATGPT_OAUTH_DEVICE_TOKEN_URL:
+                self._poll_count += 1
+            return FakeResponse(responses[key])
+
+        def close(self):
+            pass
+
+    fake_client = FakeClient()
+    tokens = oauth_login.perform_chatgpt_oauth_login(
+        timeout_seconds=2,
+        http_client=fake_client,  # type: ignore
+    )
+
+    assert tokens["access_token"] == access_token
+    assert tokens["account_id"] == "acct_xyz"
+    auth_file = tmp_path / ".codex" / "auth.json"
+    assert auth_file.exists()
+    saved = json.loads(auth_file.read_text(encoding="utf-8"))
+    assert saved["tokens"]["access_token"] == access_token
+    assert saved["tokens"]["refresh_token"] == "refresh_1"
+    assert "expires_at" in saved["tokens"]

--- a/tests/providers/test_chatgpt_oauth.py
+++ b/tests/providers/test_chatgpt_oauth.py
@@ -83,6 +83,74 @@ def test_build_request_body_converts_messages():
     ]
 
 
+def test_build_request_body_converts_tool_calls_to_function_items():
+    """Assistant tool calls become function_call items; results become outputs."""
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-5",
+            "messages": [
+                {"role": "user", "content": "list files"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Let me check."},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "bash",
+                            "input": {"command": "ls"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": "file.txt",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    body = build_chatgpt_oauth_request_body(request)
+
+    items = body["input"]
+    types = [item["type"] for item in items]
+    assert "tool_calls" not in str(items)
+    function_calls = [item for item in items if item["type"] == "function_call"]
+    function_outputs = [
+        item for item in items if item["type"] == "function_call_output"
+    ]
+    assert function_calls == [
+        {
+            "type": "function_call",
+            "call_id": "toolu_1",
+            "name": "bash",
+            "arguments": '{"command": "ls"}',
+        }
+    ]
+    assert function_outputs == [
+        {
+            "type": "function_call_output",
+            "call_id": "toolu_1",
+            "output": "file.txt",
+        }
+    ]
+    assistant_messages = [
+        item
+        for item in items
+        if item["type"] == "message" and item["role"] == "assistant"
+    ]
+    assert assistant_messages[0]["content"] == [
+        {"type": "output_text", "text": "Let me check."}
+    ]
+    assert types[0] == "message"
+
+
 def test_build_request_body_adds_reasoning_for_gpt5():
     request = MessagesRequest(
         model="gpt-5",

--- a/tests/providers/test_chatgpt_oauth_browser.py
+++ b/tests/providers/test_chatgpt_oauth_browser.py
@@ -1,0 +1,157 @@
+"""Tests for the browser-based ChatGPT OAuth login (PKCE + local callback)."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.parse
+
+import httpx
+import pytest
+
+from free_claude_code.providers.chatgpt_oauth import browser_login
+from free_claude_code.providers.chatgpt_oauth.browser_login import (
+    _BrowserLoginFlow,
+    _CallbackHTTPServer,
+    _generate_pkce,
+    build_authorize_url,
+)
+
+FAKE_TOKENS = {
+    "access_token": "access_browser_1",
+    "refresh_token": "refresh_browser_1",
+    "id_token": "id_browser_1",
+    "expires_in": 3600,
+}
+
+
+def test_generate_pkce_shapes():
+    verifier, challenge = _generate_pkce()
+    assert len(verifier) == 43
+    assert len(challenge) == 43
+    assert "=" not in challenge
+    assert "+" not in challenge
+    assert "/" not in challenge
+
+
+def test_build_authorize_url_contains_codex_params():
+    url = build_authorize_url("http://localhost:1455/auth/callback", "chal", "st")
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(parsed.query)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "auth.openai.com"
+    assert parsed.path == "/oauth/authorize"
+    assert params["response_type"] == ["code"]
+    assert params["client_id"] == ["app_EMoamEEZ73f0CkXaXp7hrann"]
+    assert params["redirect_uri"] == ["http://localhost:1455/auth/callback"]
+    assert params["scope"] == ["openid profile email offline_access"]
+    assert params["code_challenge"] == ["chal"]
+    assert params["code_challenge_method"] == ["S256"]
+    assert params["id_token_add_organizations"] == ["true"]
+    assert params["codex_cli_simplified_flow"] == ["true"]
+    assert params["state"] == ["st"]
+    assert params["originator"] == ["free-claude-code"]
+
+
+@pytest.fixture
+def callback_server(monkeypatch):
+    """Start a throwaway callback server on an ephemeral port.
+
+    Tests never bind the production port (1455), so parallel xdist workers
+    cannot steal each other's OAuth callbacks on Windows.
+    """
+    try:
+        server = _CallbackHTTPServer(port=0)
+    except OSError as exc:
+        pytest.skip(f"Could not start callback server: {exc}")
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setattr(
+        browser_login,
+        "_exchange_code_for_tokens",
+        lambda code, redirect_uri, code_verifier: FAKE_TOKENS,
+    )
+    monkeypatch.setattr(browser_login, "_SERVER", server)
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+def _begin_flow(server: _CallbackHTTPServer) -> _BrowserLoginFlow:
+    flow = _BrowserLoginFlow()
+    server.begin_flow(flow)
+    return flow
+
+
+def _callback_url(server: _CallbackHTTPServer, flow: _BrowserLoginFlow, **extra) -> str:
+    params = {"code": "auth_code_1", "state": flow.state, **extra}
+    port = server.server_address[1]
+    return f"http://127.0.0.1:{port}/auth/callback?" + urllib.parse.urlencode(params)
+
+
+def test_browser_login_callback_completes_flow(callback_server, tmp_path):
+    flow = _begin_flow(callback_server)
+
+    response = httpx.get(_callback_url(callback_server, flow), timeout=10.0)
+
+    assert response.status_code == 200
+    assert "Login successful" in response.text
+    assert flow.done.is_set()
+    assert flow.tokens == FAKE_TOKENS
+
+    status = browser_login.browser_login_status(
+        auth_path=tmp_path / ".codex" / "auth.json"
+    )
+    assert status["status"] == "complete"
+    assert status["access_token"] == "access_browser_1"
+
+    saved = json.loads((tmp_path / ".codex" / "auth.json").read_text(encoding="utf-8"))
+    assert saved["tokens"]["access_token"] == "access_browser_1"
+    assert saved["tokens"]["refresh_token"] == "refresh_browser_1"
+    assert saved["tokens"]["id_token"] == "id_browser_1"
+
+
+def test_browser_login_callback_rejects_bad_state(callback_server, tmp_path):
+    flow = _begin_flow(callback_server)
+
+    url = _callback_url(callback_server, flow, state="forged-state")
+    response = httpx.get(url, timeout=10.0)
+
+    assert response.status_code == 400
+    assert "Invalid state" in response.text
+    assert flow.done.is_set()
+    assert flow.tokens is None
+    assert "CSRF" in (flow.error or "")
+
+    status = browser_login.browser_login_status(
+        auth_path=tmp_path / ".codex" / "auth.json"
+    )
+    assert status["status"] == "error"
+
+
+def test_browser_login_callback_surfaces_oauth_error(callback_server):
+    flow = _begin_flow(callback_server)
+
+    params = urllib.parse.urlencode(
+        {"error": "access_denied", "error_description": "User denied access"}
+    )
+    port = callback_server.server_address[1]
+    response = httpx.get(
+        f"http://127.0.0.1:{port}/auth/callback?{params}",
+        timeout=10.0,
+    )
+
+    assert response.status_code == 200
+    assert "User denied access" in response.text
+    assert flow.error == "User denied access"
+
+
+def test_start_browser_login_uses_server_port(callback_server):
+    payload = browser_login.start_browser_login()
+
+    parsed = urllib.parse.urlparse(payload["authorize_url"])
+    params = urllib.parse.parse_qs(parsed.query)
+    port = callback_server.server_address[1]
+    assert params["redirect_uri"] == [f"http://localhost:{port}/auth/callback"]
+    assert callback_server.active_flow is not None

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -19,6 +19,7 @@ from free_claude_code.config.provider_catalog import (
     VERCEL_AI_GATEWAY_DEFAULT_BASE,
     ZAI_DEFAULT_BASE,
 )
+from free_claude_code.providers.chatgpt_oauth import ChatGPTOAuthProvider
 from free_claude_code.providers.cloudflare import CloudflareProvider
 from free_claude_code.providers.deepseek import DeepSeekProvider
 from free_claude_code.providers.gemini import GeminiProvider
@@ -73,6 +74,10 @@ def _make_settings(**overrides):
     mock.kimi_api_key = "test_kimi_key"
     mock.kimi_code_proxy = ""
     mock.kimi_code_api_key = "test_kimi_code_key"
+    mock.chatgpt_oauth_access_token = "test_chatgpt_oauth_token"
+    mock.chatgpt_oauth_account_id = ""
+    mock.chatgpt_oauth_base_url = "http://localhost:9999/v1"
+    mock.chatgpt_oauth_proxy = ""
     mock.wafer_proxy = ""
     mock.minimax_proxy = ""
     mock.opencode_proxy = ""
@@ -392,6 +397,7 @@ def test_create_provider_instantiates_each_builtin():
         "deepseek": DeepSeekProvider,
         "kimi": OpenAIChatProvider,
         "kimi_code": OpenAIChatProvider,
+        "chatgpt_oauth": ChatGPTOAuthProvider,
         "minimax": OpenAIChatProvider,
         "fireworks": OpenAIChatProvider,
         "cloudflare": CloudflareProvider,


### PR DESCRIPTION
Split out from the too-large #1164 — this PR contains **only** the ChatGPT OAuth provider.

## What it adds

- New `chatgpt_oauth` provider calling the ChatGPT/Codex backend (`chatgpt.com/backend-api/codex/responses`) with OAuth tokens, aligned with OpenCode's codex plugin (model allowlist, request headers, no output-token cap).
- **Two login flows**: browser PKCE (S256 + local callback on 127.0.0.1:1455 with CSRF state check and auto-closing success page — the page opens automatically, no copy/paste) and a headless device-code flow (`fcc-chatgpt-oauth-login`, `--device` to force).
- **Credential handling**: tokens stored in `~/.codex/auth.json`, proactive refresh 30s before expiry, rotated refresh tokens persisted back to disk, concurrent refreshes deduplicated, account id extracted from id_token claims (with organizations fallback).
- **Responses API conversion**: Anthropic messages/tools mapped to Responses items (`function_call`/`function_call_output`) and SSE events streamed back as Anthropic events.
- **Admin dashboard**: ChatGPT OAuth login button (browser flow with fallback to device), import-existing-Codex-login button, access token / account id / base URL / proxy fields with the experimental warning.
- Fix: streaming uses `client.send(stream=True)` instead of awaiting the `AsyncClient.stream()` context manager.

All new modules are self-contained (`providers/chatgpt_oauth/`); touches to shared files are limited to catalog/settings/manifest/admin registration. 1183 tests pass, including dedicated provider, browser-flow, and conversion tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an experimental ChatGPT/Codex OAuth provider. The main changes are:

- Browser PKCE and device-code login flows.
- Credential loading, refresh, rotation, and persistence.
- Anthropic-to-Responses request and stream conversion.
- Admin controls, CLI registration, settings, and provider catalog integration.
- Tests for login, conversion, streaming, and runtime registration.

<h3>Confidence Score: 3/5</h3>

The OAuth callback, credential refresh, concurrent login, and tool-result paths need fixes before merging.

- File-backed tokens can remain stale after expiry or rotation.
- Concurrent logins overwrite each other's state.
- Tool results can be returned with the wrong call identifier.
- Callback errors can inject markup into the loopback page.
- Required annotation and release metadata checks are not satisfied.

browser_login.py, settings.py, streaming.py, the new OAuth modules, and pyproject.toml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused file-token credential lifecycle test reproduced that a file-backed credential remains cached after token rotation, with no reload or refresh invoked.
- The bounded two-flow concurrency harness reproduced that a second login flow replaces the first on the real callback server, while the first flow ends with a 400 invalid-state response and no token exchange occurs.
- The focused stream-to-continuation round-trip test reproduced that item.id is carried through as tool\_use.id in the emitted continuation, causing function\_call\_output.call\_id to reflect the item id.
- The required annotation check fails reproducibly on the configured policy command, identifying the banned from \_\_future\_\_ import annotations directive.
- UI verification showed the Log in with ChatGPT flow starting from the dashboard, opening the local authorization URL, and having Chromium block the external request.

<a href="https://app.greptile.com/trex/runs/14984055/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/chatgpt_oauth/browser_login.py | Adds the PKCE callback server, with unsafe error rendering and a single-flow concurrency bug. |
| src/free_claude_code/config/settings.py | Adds OAuth settings, but turns file-backed credentials into a stale explicit token. |
| src/free_claude_code/providers/chatgpt_oauth/streaming.py | Adds Responses SSE conversion but conflates function-call item and call identifiers. |
| src/free_claude_code/providers/chatgpt_oauth/conversion.py | Adds message and tool conversion but uses an annotation directive prohibited by required checks. |
| pyproject.toml | Registers the OAuth login command without the required release metadata update. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Client as Admin UI / CLI
participant Callback as Loopback Callback
participant Auth as OAuth Service
participant File as auth.json
participant Provider
participant API as Codex Responses API

User->>Client: Start login
Client->>Callback: Register PKCE flow
Client->>Auth: Open authorization URL
Auth->>Callback: Return code and state
Callback->>Auth: Exchange authorization code
Auth-->>Callback: Return tokens
Callback->>File: Persist tokens
Provider->>File: Load or refresh credentials
Provider->>API: Send Responses request
API-->>Provider: Stream SSE events
Provider-->>User: Emit Anthropic SSE
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Client as Admin UI / CLI
participant Callback as Loopback Callback
participant Auth as OAuth Service
participant File as auth.json
participant Provider
participant API as Codex Responses API

User->>Client: Start login
Client->>Callback: Register PKCE flow
Client->>Auth: Open authorization URL
Auth->>Callback: Return code and state
Callback->>Auth: Exchange authorization code
Auth-->>Callback: Return tokens
Callback->>File: Persist tokens
Provider->>File: Load or refresh credentials
Provider->>API: Send Responses request
API-->>Provider: Stream SSE events
Provider-->>User: Emit Anthropic SSE
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(chatgpt\_oauth): convert tool calls t..."](https://github.com/alishahryar1/free-claude-code/commit/6ec3b10aceba578dad78cec6219002ba048240cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45391524)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->