### PR TITLE
Fix: NIM max_tokens clamping, proxy URL validation, and localhost health check proxy bypass (#1198, #1023, #1199)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.11.1"
+version = "4.11.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.11.0"
+version = "4.11.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/common.py
+++ b/src/free_claude_code/cli/launchers/common.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from collections.abc import Mapping
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import ProxyHandler, Request, build_opener
 
 from free_claude_code.cli.process_registry import (
     kill_pid_tree_best_effort,
@@ -16,6 +16,12 @@ from free_claude_code.cli.process_registry import (
 PROXY_PREFLIGHT_PATH = "/health"
 PROXY_PREFLIGHT_TIMEOUT_SECONDS = 1.5
 
+# Health checks always target localhost — system proxy settings must be
+# bypassed so the request reaches the local server directly.  On Windows a
+# configured system proxy (v2rayN, Clash, etc.) would otherwise intercept
+# the 127.0.0.1 request and return a spurious 502.
+_NO_PROXY_OPENER = build_opener(ProxyHandler({}))
+
 
 def preflight_proxy(proxy_root_url: str) -> str | None:
     """Return an error message when the local proxy health check is unreachable."""
@@ -23,7 +29,9 @@ def preflight_proxy(proxy_root_url: str) -> str | None:
     url = f"{proxy_root_url.rstrip('/')}{PROXY_PREFLIGHT_PATH}"
     request = Request(url, method="GET")
     try:
-        with urlopen(request, timeout=PROXY_PREFLIGHT_TIMEOUT_SECONDS) as response:
+        with _NO_PROXY_OPENER.open(
+            request, timeout=PROXY_PREFLIGHT_TIMEOUT_SECONDS
+        ) as response:
             status_code = response.getcode()
     except HTTPError as exc:
         return f"returned HTTP {exc.code}"

--- a/src/free_claude_code/providers/nvidia_nim/request_options.py
+++ b/src/free_claude_code/providers/nvidia_nim/request_options.py
@@ -49,7 +49,9 @@ def apply_nim_request_options(
     """Apply NIM schema repairs and configured request defaults."""
     sanitize_nim_tool_schemas(body)
 
-    max_tokens = body.get("max_tokens") or request_data.max_tokens
+    max_tokens = body.get("max_tokens")
+    if max_tokens is None or max_tokens <= 0:
+        max_tokens = request_data.max_tokens
     if max_tokens is None:
         max_tokens = nim.max_tokens
     elif nim.max_tokens:

--- a/src/free_claude_code/providers/runtime/config.py
+++ b/src/free_claude_code/providers/runtime/config.py
@@ -1,9 +1,15 @@
 """Provider configuration construction from neutral catalog metadata."""
 
+from urllib.parse import urlparse
+
+from loguru import logger
+
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.config.provider_catalog import ProviderDescriptor
 from free_claude_code.config.settings import Settings
 from free_claude_code.providers.base import ProviderConfig
+
+_SUPPORTED_PROXY_SCHEMES = frozenset({"http", "https", "socks4", "socks5", "socks5h"})
 
 
 def string_setting(settings: Settings, attr_name: str | None, default: str = "") -> str:
@@ -47,6 +53,31 @@ def require_provider_credential(
     raise ApplicationUnavailableError(message)
 
 
+def _normalize_proxy_url(raw: str) -> str:
+    """Validate and normalise a provider proxy URL.
+
+    Bare ``host:port`` strings are upgraded to ``http://host:port``.
+    Unsupported schemes are rejected with a clear error so users get
+    immediate feedback instead of a silent failure at request time.
+    """
+    if not raw or not raw.strip():
+        return ""
+    stripped = raw.strip()
+    if "://" not in stripped:
+        stripped = f"http://{stripped}"
+    parsed = urlparse(stripped)
+    if parsed.scheme not in _SUPPORTED_PROXY_SCHEMES:
+        logger.warning(
+            "PROXY: unsupported proxy scheme {!r} in {!r}; "
+            "httpx supports http, https, socks4, socks5, socks5h. "
+            "The proxy setting will be ignored.",
+            parsed.scheme,
+            raw,
+        )
+        return ""
+    return stripped
+
+
 def build_provider_config(
     descriptor: ProviderDescriptor, settings: Settings
 ) -> ProviderConfig:
@@ -61,7 +92,7 @@ def build_provider_config(
         raise AssertionError(
             f"Provider {descriptor.provider_id!r} has no configured base URL."
         )
-    proxy = string_setting(settings, descriptor.proxy_attr)
+    proxy = _normalize_proxy_url(string_setting(settings, descriptor.proxy_attr))
     return ProviderConfig(
         api_key=credential,
         base_url=resolved_base_url,

--- a/tests/providers/test_nvidia_nim_request.py
+++ b/tests/providers/test_nvidia_nim_request.py
@@ -162,6 +162,32 @@ class TestBuildRequestBody:
         body = build_request_body(req, nim, reasoning=REASONING_ON)
         assert body["max_tokens"] == 4096
 
+    def test_max_tokens_negative_body_value_replaced(self, req):
+        """Negative max_tokens in the body must not survive the guard clause."""
+        nim = NimSettings(max_tokens=4096)
+        body = build_request_body(req, nim, reasoning=REASONING_ON)
+        body["max_tokens"] = -1
+        from free_claude_code.providers.nvidia_nim.request_options import (
+            apply_nim_request_options,
+        )
+
+        apply_nim_request_options(body, req, REASONING_ON, nim=nim)
+        assert body["max_tokens"] == req.max_tokens
+
+    def test_max_tokens_zero_body_value_replaced(self, req):
+        """Zero max_tokens in the body must be replaced by request max_tokens."""
+        body = build_request_body(
+            req, NimSettings(max_tokens=4096), reasoning=REASONING_ON
+        )
+        body["max_tokens"] = 0
+        nim = NimSettings(max_tokens=4096)
+        from free_claude_code.providers.nvidia_nim.request_options import (
+            apply_nim_request_options,
+        )
+
+        apply_nim_request_options(body, req, REASONING_ON, nim=nim)
+        assert body["max_tokens"] == req.max_tokens
+
     def test_presence_penalty_included_when_nonzero(self, req):
         nim = NimSettings(presence_penalty=0.5)
         body = build_request_body(req, nim, reasoning=REASONING_ON)

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -609,3 +609,38 @@ async def test_provider_runtime_cleanup_exceptiongroup_on_multiple_failures() ->
 
     assert not runtime.is_cached("x")
     assert not runtime.is_cached("y")
+
+
+class TestProxyUrlNormalization:
+    """Proxy URL validation and normalisation in ``build_provider_config``."""
+
+    def test_http_proxy_passes_through(self):
+        descriptor = PROVIDER_CATALOG["nvidia_nim"]
+        settings = _make_settings(nvidia_nim_proxy="http://proxy.test:8080")
+        config = build_provider_config(descriptor, settings)
+        assert config.proxy == "http://proxy.test:8080"
+
+    def test_socks5_proxy_passes_through(self):
+        """socks5:// is a supported scheme when httpx[socks] is installed."""
+        descriptor = PROVIDER_CATALOG["nvidia_nim"]
+        settings = _make_settings(nvidia_nim_proxy="socks5://127.0.0.1:1080")
+        config = build_provider_config(descriptor, settings)
+        assert config.proxy == "socks5://127.0.0.1:1080"
+
+    def test_bare_host_port_gets_http_scheme(self):
+        descriptor = PROVIDER_CATALOG["nvidia_nim"]
+        settings = _make_settings(nvidia_nim_proxy="127.0.0.1:8080")
+        config = build_provider_config(descriptor, settings)
+        assert config.proxy == "http://127.0.0.1:8080"
+
+    def test_empty_proxy_returns_empty_string(self):
+        descriptor = PROVIDER_CATALOG["nvidia_nim"]
+        settings = _make_settings(nvidia_nim_proxy="")
+        config = build_provider_config(descriptor, settings)
+        assert config.proxy == ""
+
+    def test_whitespace_only_proxy_returns_empty_string(self):
+        descriptor = PROVIDER_CATALOG["nvidia_nim"]
+        settings = _make_settings(nvidia_nim_proxy="   ")
+        config = build_provider_config(descriptor, settings)
+        assert config.proxy == ""

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.11.1"
+version = "4.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.11.0"
+version = "4.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes three bugs identified from the issue tracker:

### Bug #1199 — fcc-claude HTTP 502 on Windows with system proxy

**Root cause:** `preflight_proxy()` in `src/free_claude_code/cli/launchers/common.py` uses `urlopen()` to health-check the local FCC server at `http://127.0.0.1:{port}/health`. On Windows, a configured system proxy (v2rayN, Clash, etc.) intercepts this request — the proxy cannot reach localhost and returns HTTP 502. `preflight_proxy()` treats any non-2xx status as a failure, so `fcc-claude` reports the local server as unreachable.

**Fix:** Replace `urlopen()` with a module-level no-proxy opener created via `build_opener(ProxyHandler({}))`. This bypasses all system proxy settings and connects directly to localhost.

### Bug #1198 — NIM negative/zero max_tokens clamping

**Root cause:** Python `or` operator treats negative integers as truthy, so `body.get("max_tokens") or request_data.max_tokens` would let `-1` pass through to `min(max_tokens, nim.max_tokens)`, which returns the negative value since `min(-1, 4096) = -1`.

**Fix:** Changed to explicit `None/<=0` guard:

```python
max_tokens = body.get("max_tokens")
if max_tokens is None or max_tokens <= 0:
    max_tokens = request_data.max_tokens
```

Zero is also rejected now, since a max_tokens of 0 is semantically invalid (no output possible).

### Bug #1023 — Proxy URL validation for unsupported schemes

**Root cause:** No proxy URL validation in `build_provider_config`. Bare `host:port` strings silently defaulted to HTTP proxy without informing the user, and unsupported schemes produced cryptic httpx errors at request time.

**Fix:** Added `_normalize_proxy_url()` that:
- Upgrades bare `host:port` to `http://host:port`
- Rejects unsupported schemes (anything not http/https/socks4/socks5/socks5h) with a clear warning
- Returns empty string for blank/whitespace input

### Changes

| File | Change |
|------|--------|
| `src/free_claude_code/cli/launchers/common.py` | Use no-proxy opener for localhost health check |
| `src/free_claude_code/providers/nvidia_nim/request_options.py` | Fix `or` guard → explicit None/<=0 check |
| `src/free_claude_code/providers/runtime/config.py` | Add `_normalize_proxy_url()` with scheme validation |
| `tests/providers/test_nvidia_nim_request.py` | Tests for negative/zero max_tokens |
| `tests/providers/test_provider_runtime.py` | Tests for proxy URL normalization (5 scenarios) |
| `pyproject.toml` + `uv.lock` | Version bump 4.11.1 → 4.11.2 |

### Verification

- [x] ruff format / ruff check / ty — all pass
- [x] pytest — 54 entrypoint tests + full suite pass

---

Closes #1198, closes #1023, closes #1199

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes provider request and proxy handling around NIM and local launcher flows. The main changes are:

- Replaces truthiness-based NIM `max_tokens` handling with explicit fallback for `None`, zero, and negative values.
- Normalizes provider proxy URLs and ignores unsupported proxy schemes before constructing provider clients.
- Bypasses system proxy settings for local launcher `/health` preflight checks.
- Adds tests for NIM token clamping and proxy URL normalization.
- Bumps the package version and lockfile entry.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one non-blocking test coverage gap.

Production changes are small and localized to request option handling, provider config construction, and launcher preflight behavior. The remaining issue is limited to missing tests for the unsupported proxy scheme branch.

`tests/providers/test_provider_runtime.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The provider validation workflow was executed, including running the targeted pytest command and style checks.
- The targeted pytest command exited successfully with 7 tests passed in 2.14 seconds.
- Ruff and Ty checks completed with all checks passed.
- A transcript log capturing commands, working directory, stdout/stderr, and exit codes was saved for review.

<a href="https://app.greptile.com/trex/runs/15016534/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/runtime/config.py | Normalizes provider proxy settings and drops unsupported proxy schemes before constructing `ProviderConfig`. |
| src/free_claude_code/providers/nvidia_nim/request_options.py | Replaces truthiness-based NIM `max_tokens` fallback with explicit invalid-token handling. |
| src/free_claude_code/cli/launchers/common.py | Bypasses system proxy handlers for local `/health` preflight requests. |
| tests/providers/test_provider_runtime.py | Adds proxy normalization tests, but omits coverage for unsupported proxy scheme rejection. |
| tests/providers/test_nvidia_nim_request.py | Adds tests for negative and zero NIM `max_tokens` body values. |
| pyproject.toml | Bumps the project patch version for the production fixes. |
| uv.lock | Updates the editable package version to match `pyproject.toml`. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User as User settings / request
participant Runtime as providers/runtime config
participant Provider as Provider client
participant NIM as NVIDIA NIM request options
participant Launcher as CLI launcher preflight
participant Local as Local FCC /health

User->>Runtime: Provider proxy setting
Runtime->>Runtime: Trim, add http:// for bare host:port
alt Supported proxy scheme
    Runtime->>Provider: "ProviderConfig(proxy=normalized URL)"
else Unsupported or blank proxy
    Runtime->>Provider: "ProviderConfig(proxy="")"
end

User->>NIM: Request body max_tokens
NIM->>NIM: "Replace None or <= 0 with request/default cap"
NIM-->>Provider: Sanitized request body

Launcher->>Local: GET /health via no-proxy opener
Local-->>Launcher: Health status without system proxy interception
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User as User settings / request
participant Runtime as providers/runtime config
participant Provider as Provider client
participant NIM as NVIDIA NIM request options
participant Launcher as CLI launcher preflight
participant Local as Local FCC /health

User->>Runtime: Provider proxy setting
Runtime->>Runtime: Trim, add http:// for bare host:port
alt Supported proxy scheme
    Runtime->>Provider: "ProviderConfig(proxy=normalized URL)"
else Unsupported or blank proxy
    Runtime->>Provider: "ProviderConfig(proxy="")"
end

User->>NIM: Request body max_tokens
NIM->>NIM: "Replace None or <= 0 with request/default cap"
NIM-->>Provider: Sanitized request body

Launcher->>Local: GET /health via no-proxy opener
Local-->>Launcher: Health status without system proxy interception
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: bypass system proxy for localhost h..."](https://github.com/alishahryar1/free-claude-code/commit/74874d2f1a25c24081177f157703838bc3936e59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45454406)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/alishahryar1/github/Alishahryar1/free-claude-code/-/custom-context?memory=d2fd24d8-0dec-4faf-8ee4-e085e215a2f8))

<!-- /greptile_comment -->