### PR TITLE
Add OpenAI Chat Completions endpoint (/v1/chat/completions)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -351,6 +351,7 @@ and non-local origins.
 
 - `POST /v1/messages`: Anthropic Messages-compatible streaming requests.
 - `POST /v1/responses`: OpenAI Responses-compatible requests.
+- `POST /v1/chat/completions`: OpenAI Chat Completions-compatible requests.
 - `POST /v1/messages/count_tokens`: Anthropic token counting.
 - `GET /v1/models`: gateway and Claude-compatible model listing.
 - `GET /health`: health check.
@@ -860,6 +861,31 @@ does not synthesize reasoning summaries.
 Provider code should delegate protocol details to these modules. Avoid copying
 conversion code into individual providers, and avoid provider-to-provider imports
 for shared Anthropic behavior.
+
+[src/free_claude_code/core/openai_chat/](src/free_claude_code/core/openai_chat/) owns OpenAI Chat
+Completions support and mirrors the Responses dialect:
+
+- the permissive `OpenAIChatCompletionsRequest` ingress model used directly by
+  the FastAPI route and the protocol adapter;
+- the `OpenAIChatAdapter` facade used by the API layer;
+- both non-streaming and streaming `/v1/chat/completions` support;
+- Chat request conversion into Anthropic Messages payloads, covering
+  `system`/`user`/`assistant`/`tool` roles, `tool_calls` to `tool_use`,
+  `tool_choice`, multimodal `image_url` parts, and stop sequences;
+- non-streaming responses folded from the internal Anthropic SSE through the
+  shared `aggregate_anthropic_sse_to_message` and serialized as a single
+  `chat.completion`;
+- streaming responses assembled as `chat.completion.chunk` frames by
+  `streaming.py`, reusing the neutral Anthropic SSE parser under
+  `core/anthropic/`.
+
+Anthropic `stop_reason` maps to Chat `finish_reason` (`tool_use` to
+`tool_calls`, `max_tokens` to `length`, otherwise `stop`), and
+`stream_options.include_usage` appends a trailing usage-only chunk. The package
+reuses the OpenAI error envelope owned by `core/openai_responses`. Reasoning and
+thinking blocks are dropped from Chat Completions output because that dialect has
+no standard field for them; text and tool calls are unaffected. API code depends
+on the adapter, not on the internal module owners.
 
 ## Local Optimizations And Server Tools
 
@@ -1391,7 +1417,8 @@ when maintainers want branch-level assurance.
 
 1. Put shared Anthropic behavior under [src/free_claude_code/core/anthropic/](src/free_claude_code/core/anthropic/).
 2. Put OpenAI Responses behavior under
-   [src/free_claude_code/core/openai_responses/](src/free_claude_code/core/openai_responses/).
+   [src/free_claude_code/core/openai_responses/](src/free_claude_code/core/openai_responses/), and OpenAI
+   Chat Completions behavior under [src/free_claude_code/core/openai_chat/](src/free_claude_code/core/openai_chat/).
 3. Keep provider-specific request quirks inside the provider profile or specialized
    provider subclass.
 4. Add stream contract tests under [tests/contracts/](tests/contracts/) or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.11.0"
+version = "4.12.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/handlers/__init__.py
+++ b/src/free_claude_code/api/handlers/__init__.py
@@ -1,7 +1,13 @@
 """Product-flow handlers for public API routes."""
 
+from .chat_completions import ChatCompletionsHandler
 from .messages import MessagesHandler
 from .responses import ResponsesHandler
 from .token_count import TokenCountHandler
 
-__all__ = ["MessagesHandler", "ResponsesHandler", "TokenCountHandler"]
+__all__ = [
+    "ChatCompletionsHandler",
+    "MessagesHandler",
+    "ResponsesHandler",
+    "TokenCountHandler",
+]

--- a/src/free_claude_code/api/handlers/chat_completions.py
+++ b/src/free_claude_code/api/handlers/chat_completions.py
@@ -1,0 +1,249 @@
+"""OpenAI Chat Completions API product flow."""
+
+import asyncio
+from typing import Any
+
+from fastapi.responses import JSONResponse, Response
+
+from free_claude_code.api.request_errors import (
+    http_status_for_unexpected_api_exception,
+    log_unexpected_api_exception,
+    require_non_empty_messages,
+)
+from free_claude_code.api.request_ids import new_request_id
+from free_claude_code.api.response_streams import (
+    openai_chat_sse_streaming_response,
+    terminal_execution_error_response,
+    trace_terminal_execution_error,
+)
+from free_claude_code.application.errors import ApplicationError, InvalidRequestError
+from free_claude_code.application.execution import ProviderExecutor
+from free_claude_code.application.ports import ProviderResolver
+from free_claude_code.application.routing import ModelRouter
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import (
+    MessagesRequest,
+    aggregate_anthropic_sse_to_message,
+    anthropic_status_for_error_type,
+)
+from free_claude_code.core.diagnostics import safe_exception_message
+from free_claude_code.core.failures import ExecutionFailure, find_execution_failure
+from free_claude_code.core.openai_chat import (
+    ChatCompletionsConversionError,
+    OpenAIChatAdapter,
+    OpenAIChatCompletionsRequest,
+)
+from free_claude_code.core.openai_responses import openai_error_type_for_failure
+
+
+class ChatCompletionsHandler:
+    """Handle OpenAI Chat Completions-compatible requests (streaming and not)."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        provider_resolver: ProviderResolver,
+        *,
+        model_router: ModelRouter | None = None,
+        chat_adapter: OpenAIChatAdapter | None = None,
+        provider_executor: ProviderExecutor | None = None,
+        generation_id: int | None = None,
+    ) -> None:
+        self._settings = settings
+        self._model_router = model_router or ModelRouter(settings)
+        self._chat_adapter = chat_adapter or OpenAIChatAdapter()
+        self._provider_executor = provider_executor or ProviderExecutor(
+            provider_resolver,
+            generation_id=generation_id,
+            log_raw_payloads=settings.log_raw_api_payloads,
+        )
+
+    async def create(
+        self,
+        request_data: OpenAIChatCompletionsRequest,
+        *,
+        request_id: str | None = None,
+    ) -> object:
+        """Create a Chat Completions response, streaming when ``stream`` is true."""
+        request_id = request_id or new_request_id()
+        request_payload = request_data.model_dump(mode="json", exclude_none=True)
+        stream = bool(request_data.stream)
+        try:
+            anthropic_payload = self._chat_adapter.to_anthropic_payload(request_data)
+            messages_request = MessagesRequest(**anthropic_payload)
+            require_non_empty_messages(messages_request.messages)
+            routed = self._model_router.resolve_messages_request(messages_request)
+
+            streamed = self._provider_executor.stream(
+                routed,
+                wire_api="chat",
+                raw_log_label="FULL_CHAT_PAYLOAD",
+                raw_log_payload=request_payload,
+                request_id=request_id,
+            )
+            if stream:
+                return await openai_chat_sse_streaming_response(
+                    self._chat_adapter.iter_sse_from_anthropic(
+                        streamed,
+                        request_data,
+                        on_post_start_terminal_failure=lambda exc: (
+                            self._trace_post_start_terminal_failure(
+                                exc, request_id=request_id
+                            )
+                        ),
+                    ),
+                    headers=self._chat_adapter.sse_headers,
+                    pre_start_error_response=lambda exc: self._pre_start_error_response(
+                        exc, request_id=request_id
+                    ),
+                )
+            return await self._collect_non_stream_response(
+                streamed, request_data, request_id=request_id
+            )
+        except ChatCompletionsConversionError as exc:
+            raise InvalidRequestError(str(exc)) from exc
+        except ApplicationError:
+            raise
+        except ExecutionFailure as exc:
+            return self._execution_failure_response(exc, request_id=request_id)
+        except Exception as exc:
+            failure = find_execution_failure(exc)
+            if failure is not None:
+                return self._execution_failure_response(failure, request_id=request_id)
+            return self._unexpected_execution_error_response(
+                exc, request_id=request_id, context="CREATE_CHAT_COMPLETION_ERROR"
+            )
+
+    async def _collect_non_stream_response(
+        self,
+        streamed: Any,
+        request_data: OpenAIChatCompletionsRequest,
+        *,
+        request_id: str,
+    ) -> object:
+        try:
+            message, error = await aggregate_anthropic_sse_to_message(streamed)
+        except GeneratorExit, asyncio.CancelledError:
+            raise
+        except ExecutionFailure as exc:
+            return self._execution_failure_response(exc, request_id=request_id)
+        except BaseExceptionGroup as exc:
+            failure = find_execution_failure(exc)
+            if failure is not None:
+                return self._execution_failure_response(failure, request_id=request_id)
+            return self._unexpected_execution_error_response(
+                exc,
+                request_id=request_id,
+                context="CREATE_CHAT_COMPLETION_NON_STREAM_ERROR",
+            )
+        except Exception as exc:
+            return self._unexpected_execution_error_response(
+                exc,
+                request_id=request_id,
+                context="CREATE_CHAT_COMPLETION_NON_STREAM_ERROR",
+            )
+        if error is not None:
+            return self._stream_error_response(error, request_id=request_id)
+        completion = self._chat_adapter.message_to_completion(message, request_data)
+        return JSONResponse(content=completion)
+
+    def _pre_start_error_response(
+        self, exc: BaseException, *, request_id: str
+    ) -> Response:
+        failure = find_execution_failure(exc)
+        if failure is not None:
+            return self._execution_failure_response(failure, request_id=request_id)
+        return self._unexpected_execution_error_response(
+            exc,
+            request_id=request_id,
+            context="CREATE_CHAT_COMPLETION_STREAM_START_ERROR",
+        )
+
+    def _execution_failure_response(
+        self, failure: ExecutionFailure, *, request_id: str
+    ) -> JSONResponse:
+        error_type = openai_error_type_for_failure(failure)
+        trace_terminal_execution_error(
+            wire_api="chat",
+            request_id=request_id,
+            status_code=failure.status_code,
+            error_type=error_type,
+            error=failure,
+        )
+        return terminal_execution_error_response(
+            status_code=failure.status_code,
+            content=self._chat_adapter.error_payload(
+                message=failure.message, error_type=error_type
+            ),
+        )
+
+    def _stream_error_response(
+        self, error: dict[str, Any], *, request_id: str
+    ) -> JSONResponse:
+        error_type, message_text = _stream_error_fields(error)
+        status_code = anthropic_status_for_error_type(error_type)
+        trace_terminal_execution_error(
+            wire_api="chat",
+            request_id=request_id,
+            status_code=status_code,
+            error_type=error_type,
+        )
+        return terminal_execution_error_response(
+            status_code=status_code,
+            content=self._chat_adapter.error_payload(
+                message=message_text, error_type=error_type
+            ),
+        )
+
+    def _unexpected_execution_error_response(
+        self, exc: BaseException, *, request_id: str, context: str
+    ) -> JSONResponse:
+        log_unexpected_api_exception(
+            self._settings, exc, context=context, request_id=request_id
+        )
+        status_code = http_status_for_unexpected_api_exception(exc)
+        trace_terminal_execution_error(
+            wire_api="chat",
+            request_id=request_id,
+            status_code=status_code,
+            error_type="api_error",
+            error=exc,
+        )
+        return terminal_execution_error_response(
+            status_code=status_code,
+            content=self._chat_adapter.error_payload(
+                message=safe_exception_message(exc), error_type="api_error"
+            ),
+        )
+
+    def _trace_post_start_terminal_failure(
+        self, exc: BaseException, *, request_id: str
+    ) -> None:
+        failure = find_execution_failure(exc)
+        trace_terminal_execution_error(
+            wire_api="chat",
+            request_id=request_id,
+            status_code=failure.status_code if failure is not None else 500,
+            error_type=(
+                openai_error_type_for_failure(failure)
+                if failure is not None
+                else "api_error"
+            ),
+            error=exc,
+        )
+
+
+def _stream_error_fields(error: dict[str, Any]) -> tuple[str, str]:
+    raw_type = error.get("type")
+    error_type = (
+        raw_type.strip()
+        if isinstance(raw_type, str) and raw_type.strip()
+        else "api_error"
+    )
+    raw_message = error.get("message")
+    message = (
+        raw_message.strip()
+        if isinstance(raw_message, str) and raw_message.strip()
+        else "Provider request failed unexpectedly."
+    )
+    return error_type, message

--- a/src/free_claude_code/api/request_errors.py
+++ b/src/free_claude_code/api/request_errors.py
@@ -21,7 +21,7 @@ from free_claude_code.core.openai_responses import (
     openai_error_type_for_failure,
 )
 
-WireApi = Literal["messages", "responses"]
+WireApi = Literal["messages", "responses", "chat"]
 
 
 def require_non_empty_messages(messages: list[Any]) -> None:
@@ -36,7 +36,7 @@ def ordinary_application_error_response(
     request_id: str,
 ) -> JSONResponse:
     """Serialize a deterministic application error without terminal headers."""
-    if wire_api == "responses":
+    if wire_api in ("responses", "chat"):
         return JSONResponse(
             status_code=error.status_code,
             content=openai_error_payload(

--- a/src/free_claude_code/api/response_streams.py
+++ b/src/free_claude_code/api/response_streams.py
@@ -31,7 +31,7 @@ PreStartErrorResponse = Callable[[BaseException], Response]
 TerminalFrameEmitter = Callable[[BaseException], str]
 TerminalFailureObserver = Callable[[BaseException], None]
 ReleaseResponseResource = Callable[[], Awaitable[None]]
-WireApi = Literal["messages", "responses"]
+WireApi = Literal["messages", "responses", "chat"]
 
 
 class EmptyStreamError(RuntimeError):
@@ -377,6 +377,26 @@ async def openai_responses_sse_streaming_response(
     pre_start_error_response: PreStartErrorResponse,
 ) -> Response:
     """Return a streaming response for OpenAI Responses-style SSE."""
+    return await _first_chunk_streaming_response(
+        body,
+        headers=headers,
+        pre_start_error_response=pre_start_error_response,
+        terminal_frame=None,
+        terminal_failure_observer=None,
+    )
+
+
+async def openai_chat_sse_streaming_response(
+    body: AsyncIterator[str],
+    *,
+    headers: Mapping[str, str],
+    pre_start_error_response: PreStartErrorResponse,
+) -> Response:
+    """Return a streaming response for OpenAI Chat Completions-style SSE.
+
+    The Chat adapter serializes its own terminal error frames into the body, so
+    no terminal frame emitter is bound here.
+    """
     return await _first_chunk_streaming_response(
         body,
         headers=headers,

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -12,6 +12,7 @@ from free_claude_code.core.anthropic import (
     TokenCountRequest,
     get_token_count,
 )
+from free_claude_code.core.openai_chat import OpenAIChatCompletionsRequest
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.trace import trace_event
 
@@ -21,7 +22,12 @@ from .dependencies import (
     require_proxy_auth,
     resolve_provider,
 )
-from .handlers import MessagesHandler, ResponsesHandler, TokenCountHandler
+from .handlers import (
+    ChatCompletionsHandler,
+    MessagesHandler,
+    ResponsesHandler,
+    TokenCountHandler,
+)
 from .model_catalog import ModelsListResponse, build_models_list_response
 from .ports import ApiServices
 from .request_errors import ordinary_application_error_response
@@ -98,6 +104,37 @@ async def _create_responses_response(
     return await bind_response_lifetime(response, lease.release)
 
 
+async def _create_chat_completions_response(
+    services: ApiServices,
+    request_data: OpenAIChatCompletionsRequest,
+    *,
+    request_id: str,
+) -> object:
+    lease: RequestRuntimeLease | None = None
+    try:
+        lease = await services.requests.acquire()
+        handler = ChatCompletionsHandler(
+            lease.settings,
+            provider_resolver=_provider_resolver(lease),
+            generation_id=lease.generation_id,
+        )
+        response = await handler.create(request_data, request_id=request_id)
+    except ApplicationError as exc:
+        if lease is not None:
+            await lease.release()
+        return ordinary_application_error_response(
+            exc,
+            wire_api="chat",
+            request_id=request_id,
+        )
+    except BaseException:
+        if lease is not None:
+            await lease.release()
+        raise
+    assert lease is not None
+    return await bind_response_lifetime(response, lease.release)
+
+
 def _probe_response(allow: str) -> Response:
     return Response(status_code=204, headers={"Allow": allow})
 
@@ -139,6 +176,26 @@ async def create_response(
 
 @router.api_route("/v1/responses", methods=["HEAD", "OPTIONS"])
 async def probe_responses(_auth=Depends(require_proxy_auth)):
+    return _probe_response("POST, HEAD, OPTIONS")
+
+
+@router.post("/v1/chat/completions")
+async def create_chat_completion(
+    request: Request,
+    request_data: OpenAIChatCompletionsRequest,
+    services: ApiServices = Depends(get_services),
+    _auth=Depends(require_proxy_auth),
+):
+    """Create an OpenAI Chat Completions-compatible response through this proxy."""
+    return await _create_chat_completions_response(
+        services,
+        request_data,
+        request_id=get_request_id(request),
+    )
+
+
+@router.api_route("/v1/chat/completions", methods=["HEAD", "OPTIONS"])
+async def probe_chat_completions(_auth=Depends(require_proxy_auth)):
     return _probe_response("POST, HEAD, OPTIONS")
 
 

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -26,7 +26,23 @@ TokenCounter = Callable[
     [list[Message], str | list[SystemContent] | None, list[Tool] | None],
     int,
 ]
-WireApi = Literal["messages", "responses"]
+WireApi = Literal["messages", "responses", "chat"]
+
+_INGRESS_EVENTS: dict[str, str] = {
+    "messages": "free_claude_code.api.request.received",
+    "responses": "free_claude_code.api.responses.request.received",
+    "chat": "free_claude_code.api.chat.request.received",
+}
+_STREAM_COMPLETE_EVENTS: dict[str, str] = {
+    "messages": "free_claude_code.api.response.stream_completed",
+    "responses": "free_claude_code.api.responses.stream_completed",
+    "chat": "free_claude_code.api.chat.stream_completed",
+}
+_STREAM_INTERRUPTED_EVENTS: dict[str, str] = {
+    "messages": "free_claude_code.api.response.stream_interrupted",
+    "responses": "free_claude_code.api.responses.stream_interrupted",
+    "chat": "free_claude_code.api.chat.stream_interrupted",
+}
 
 
 class ProviderExecutor:
@@ -78,19 +94,15 @@ class ProviderExecutor:
             ),
             "reasoning_budget_tokens": routed.reasoning.budget_tokens,
         }
-        if wire_api == "responses":
-            route_trace["wire_api"] = "responses"
+        if wire_api != "messages":
+            route_trace["wire_api"] = wire_api
         if self._generation_id is not None:
             route_trace["generation_id"] = self._generation_id
         trace_event(**route_trace)
 
         trace_event(
             stage="ingress",
-            event=(
-                "free_claude_code.api.responses.request.received"
-                if wire_api == "responses"
-                else "free_claude_code.api.request.received"
-            ),
+            event=_INGRESS_EVENTS[wire_api],
             source="api",
             message_count=len(routed.request.messages),
             snapshot=anthropic_request_snapshot(routed.request),
@@ -138,16 +150,8 @@ class ProviderExecutor:
             provider_body(),
             stage="egress",
             source="api",
-            complete_event=(
-                "free_claude_code.api.responses.stream_completed"
-                if wire_api == "responses"
-                else "free_claude_code.api.response.stream_completed"
-            ),
-            interrupted_event=(
-                "free_claude_code.api.responses.stream_interrupted"
-                if wire_api == "responses"
-                else "free_claude_code.api.response.stream_interrupted"
-            ),
+            complete_event=_STREAM_COMPLETE_EVENTS[wire_api],
+            interrupted_event=_STREAM_INTERRUPTED_EVENTS[wire_api],
             chunk_event=None,
             extra=stream_trace,
         )

--- a/src/free_claude_code/core/openai_chat/__init__.py
+++ b/src/free_claude_code/core/openai_chat/__init__.py
@@ -1,0 +1,11 @@
+"""OpenAI Chat Completions protocol adapter."""
+
+from .adapter import OpenAIChatAdapter
+from .errors import ChatCompletionsConversionError
+from .models import OpenAIChatCompletionsRequest
+
+__all__ = [
+    "ChatCompletionsConversionError",
+    "OpenAIChatAdapter",
+    "OpenAIChatCompletionsRequest",
+]

--- a/src/free_claude_code/core/openai_chat/adapter.py
+++ b/src/free_claude_code/core/openai_chat/adapter.py
@@ -1,0 +1,57 @@
+"""Facade for OpenAI Chat Completions protocol adaptation."""
+
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import Any, ClassVar
+
+from free_claude_code.core.openai_responses import openai_error_payload
+
+from .completion import anthropic_message_to_chat_completion
+from .errors import ChatCompletionsConversionError
+from .events import OPENAI_CHAT_SSE_HEADERS
+from .input import convert_request_to_anthropic_payload
+from .models import OpenAIChatCompletionsRequest
+from .streaming import (
+    PostStartTerminalFailureObserver,
+    iter_chat_completions_sse_from_anthropic,
+)
+
+
+class OpenAIChatAdapter:
+    """Convert between OpenAI Chat Completions and the proxy's Anthropic core path."""
+
+    ConversionError: ClassVar[type[ChatCompletionsConversionError]] = (
+        ChatCompletionsConversionError
+    )
+    sse_headers: ClassVar[dict[str, str]] = OPENAI_CHAT_SSE_HEADERS
+
+    def to_anthropic_payload(
+        self, request: OpenAIChatCompletionsRequest
+    ) -> dict[str, Any]:
+        return convert_request_to_anthropic_payload(request)
+
+    def iter_sse_from_anthropic(
+        self,
+        chunks: AsyncIterable[Any],
+        request: OpenAIChatCompletionsRequest,
+        *,
+        on_post_start_terminal_failure: PostStartTerminalFailureObserver | None = None,
+    ) -> AsyncIterator[str]:
+        return iter_chat_completions_sse_from_anthropic(
+            chunks,
+            request,
+            on_post_start_terminal_failure=on_post_start_terminal_failure,
+        )
+
+    def message_to_completion(
+        self,
+        message: dict[str, Any],
+        request: OpenAIChatCompletionsRequest,
+        *,
+        completion_id: str | None = None,
+    ) -> dict[str, Any]:
+        return anthropic_message_to_chat_completion(
+            message, request, completion_id=completion_id
+        )
+
+    def error_payload(self, *, message: str, error_type: str) -> dict[str, Any]:
+        return openai_error_payload(message=message, error_type=error_type)

--- a/src/free_claude_code/core/openai_chat/completion.py
+++ b/src/free_claude_code/core/openai_chat/completion.py
@@ -1,0 +1,86 @@
+"""Build non-streaming OpenAI Chat Completions responses.
+
+The internal provider pipeline is always SSE, so a non-streaming client response
+is produced by aggregating the Anthropic stream into a single Message (see
+``core.anthropic.aggregate_anthropic_sse_to_message``) and converting that here.
+"""
+
+import json
+import time
+from typing import Any
+
+from .ids import new_chat_completion_id
+from .models import OpenAIChatCompletionsRequest
+from .stop_reason import finish_reason_from_stop_reason
+
+
+def anthropic_message_to_chat_completion(
+    message: dict[str, Any],
+    request: OpenAIChatCompletionsRequest,
+    *,
+    completion_id: str | None = None,
+) -> dict[str, Any]:
+    """Convert an aggregated Anthropic Message into a ``chat.completion`` object."""
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for block in message.get("content") or []:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text_parts.append(str(block.get("text", "")))
+        elif block_type == "tool_use":
+            tool_calls.append(
+                {
+                    "id": str(block.get("id") or ""),
+                    "type": "function",
+                    "function": {
+                        "name": str(block.get("name") or ""),
+                        "arguments": json.dumps(block.get("input") or {}),
+                    },
+                }
+            )
+
+    content = "".join(text_parts)
+    chat_message: dict[str, Any] = {
+        "role": "assistant",
+        "content": content if content else None,
+    }
+    if tool_calls:
+        chat_message["tool_calls"] = tool_calls
+
+    finish_reason = finish_reason_from_stop_reason(
+        _optional_str(message.get("stop_reason")), has_tool_calls=bool(tool_calls)
+    )
+    raw_usage = message.get("usage")
+    usage = raw_usage if isinstance(raw_usage, dict) else {}
+    prompt_tokens = _int(usage.get("input_tokens"))
+    completion_tokens = _int(usage.get("output_tokens"))
+
+    return {
+        "id": completion_id or new_chat_completion_id(),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": request.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": chat_message,
+                "finish_reason": finish_reason,
+                "logprobs": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _int(value: Any) -> int:
+    return value if isinstance(value, int) else 0

--- a/src/free_claude_code/core/openai_chat/errors.py
+++ b/src/free_claude_code/core/openai_chat/errors.py
@@ -1,0 +1,11 @@
+"""Errors for OpenAI Chat Completions compatibility.
+
+The OpenAI wire error envelope and the neutral-failure-to-error-type mapping are
+shared with the Responses dialect and live in ``core.openai_responses`` (already
+treated as shared OpenAI helpers by ``api.request_errors``); this module only
+owns the Chat-specific deterministic conversion error.
+"""
+
+
+class ChatCompletionsConversionError(ValueError):
+    """Raised when a Chat Completions request cannot be converted deterministically."""

--- a/src/free_claude_code/core/openai_chat/events.py
+++ b/src/free_claude_code/core/openai_chat/events.py
@@ -1,0 +1,18 @@
+"""OpenAI Chat Completions SSE formatting."""
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+OPENAI_CHAT_SSE_HEADERS: dict[str, str] = {
+    "X-Accel-Buffering": "no",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+}
+
+CHAT_COMPLETION_SSE_DONE = "data: [DONE]\n\n"
+
+
+def format_chat_sse_chunk(data: Mapping[str, Any]) -> str:
+    """Format one OpenAI Chat Completions ``chat.completion.chunk`` SSE frame."""
+    return f"data: {json.dumps(data)}\n\n"

--- a/src/free_claude_code/core/openai_chat/ids.py
+++ b/src/free_claude_code/core/openai_chat/ids.py
@@ -1,0 +1,13 @@
+"""Identifier helpers for OpenAI Chat Completions payloads."""
+
+import uuid
+
+
+def new_chat_completion_id() -> str:
+    """Return an OpenAI-style ``chatcmpl-`` identifier."""
+    return f"chatcmpl-{uuid.uuid4().hex}"
+
+
+def new_tool_call_id() -> str:
+    """Return an OpenAI-style ``call_`` tool-call identifier."""
+    return f"call_{uuid.uuid4().hex[:24]}"

--- a/src/free_claude_code/core/openai_chat/input.py
+++ b/src/free_claude_code/core/openai_chat/input.py
@@ -1,0 +1,235 @@
+"""Convert OpenAI Chat Completions requests into Anthropic Messages payloads."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from .errors import ChatCompletionsConversionError
+from .ids import new_tool_call_id
+from .models import OpenAIChatCompletionsRequest
+from .tools import convert_tool_choice, convert_tools, parse_arguments
+
+
+def convert_request_to_anthropic_payload(
+    request: OpenAIChatCompletionsRequest,
+) -> dict[str, Any]:
+    """Convert an OpenAI Chat Completions request into an Anthropic Messages payload."""
+    system_parts: list[str] = []
+    messages: list[dict[str, Any]] = []
+
+    for raw in request.messages:
+        if not isinstance(raw, dict):
+            raise ChatCompletionsConversionError(
+                f"Unsupported chat message: {type(raw).__name__}"
+            )
+        role = raw.get("role")
+        if role in {"system", "developer"}:
+            if text := _content_as_text(raw.get("content")):
+                system_parts.append(text)
+        elif role == "user":
+            messages.append(
+                {"role": "user", "content": _convert_user_content(raw.get("content"))}
+            )
+        elif role == "assistant":
+            _append_assistant_message(messages, raw)
+        elif role == "tool":
+            _append_tool_message(messages, raw)
+        else:
+            raise ChatCompletionsConversionError(
+                f"Unsupported chat message role: {role!r}"
+            )
+
+    if not messages:
+        raise ChatCompletionsConversionError(
+            "Chat request must include at least one non-system message"
+        )
+
+    payload: dict[str, Any] = {
+        "model": _required_model(request.model),
+        "messages": messages,
+        "stream": True,
+    }
+    if system_parts:
+        payload["system"] = "\n\n".join(system_parts)
+    if request.temperature is not None:
+        payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        payload["top_p"] = request.top_p
+    max_tokens = (
+        request.max_completion_tokens
+        if request.max_completion_tokens is not None
+        else request.max_tokens
+    )
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if request.metadata is not None:
+        payload["metadata"] = request.metadata
+    if stop_sequences := _normalize_stop(request.stop):
+        payload["stop_sequences"] = stop_sequences
+
+    tools = convert_tools(request.tools)
+    # Validate tool_choice unconditionally so an invalid value is a client error
+    # even when no tools are present, matching the Responses dialect.
+    tool_choice = convert_tool_choice(request.tool_choice)
+    if tools and request.tool_choice != "none":
+        payload["tools"] = tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+
+    return payload
+
+
+def _append_assistant_message(
+    messages: list[dict[str, Any]], raw: Mapping[str, Any]
+) -> None:
+    blocks: list[dict[str, Any]] = list(_convert_assistant_content(raw.get("content")))
+    for tool_call in raw.get("tool_calls") or []:
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function")
+        function = function if isinstance(function, dict) else {}
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": _optional_str(tool_call.get("id")) or new_tool_call_id(),
+                "name": _optional_str(function.get("name")),
+                "input": parse_arguments(function.get("arguments")),
+            }
+        )
+    if not blocks:
+        # An assistant turn with neither text nor tool calls still needs content.
+        messages.append({"role": "assistant", "content": ""})
+        return
+    if len(blocks) == 1 and blocks[0].get("type") == "text":
+        messages.append({"role": "assistant", "content": blocks[0]["text"]})
+        return
+    messages.append({"role": "assistant", "content": blocks})
+
+
+def _append_tool_message(
+    messages: list[dict[str, Any]], raw: Mapping[str, Any]
+) -> None:
+    tool_call_id = raw.get("tool_call_id")
+    if not isinstance(tool_call_id, str) or not tool_call_id:
+        raise ChatCompletionsConversionError(
+            "tool message requires a string tool_call_id"
+        )
+    block = {
+        "type": "tool_result",
+        "tool_use_id": tool_call_id,
+        "content": _content_as_text(raw.get("content")),
+    }
+    pending = _last_user_tool_result_message(messages)
+    if pending is not None:
+        pending["content"].append(block)
+        return
+    messages.append({"role": "user", "content": [block]})
+
+
+def _last_user_tool_result_message(
+    messages: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not messages:
+        return None
+    message = messages[-1]
+    if message.get("role") != "user":
+        return None
+    content = message.get("content")
+    if not isinstance(content, list) or not content:
+        return None
+    if all(
+        isinstance(block, dict) and block.get("type") == "tool_result"
+        for block in content
+    ):
+        return message
+    return None
+
+
+def _convert_user_content(content: Any) -> str | list[dict[str, Any]]:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        blocks: list[dict[str, Any]] = []
+        for part in content:
+            if isinstance(part, str):
+                blocks.append({"type": "text", "text": part})
+                continue
+            if not isinstance(part, dict):
+                raise ChatCompletionsConversionError(
+                    f"Unsupported content part: {type(part).__name__}"
+                )
+            part_type = part.get("type")
+            if part_type == "image_url":
+                blocks.append(_convert_image_part(part.get("image_url")))
+                continue
+            if part_type in {"text", "input_text", "output_text"} or "text" in part:
+                blocks.append({"type": "text", "text": _text_from_part(part)})
+                continue
+            raise ChatCompletionsConversionError(
+                f"Unsupported content part type: {part_type!r}"
+            )
+        return blocks
+    raise ChatCompletionsConversionError(
+        f"Unsupported message content: {type(content).__name__}"
+    )
+
+
+def _convert_assistant_content(content: Any) -> list[dict[str, Any]]:
+    if content in (None, ""):
+        return []
+    converted = _convert_user_content(content)
+    if isinstance(converted, str):
+        return [{"type": "text", "text": converted}] if converted else []
+    return [block for block in converted if block.get("type") == "text"]
+
+
+def _content_as_text(content: Any) -> str:
+    converted = _convert_user_content(content)
+    if isinstance(converted, str):
+        return converted
+    return "\n".join(
+        str(block.get("text", "")) for block in converted if block.get("type") == "text"
+    )
+
+
+def _convert_image_part(image_url: Any) -> dict[str, Any]:
+    url = image_url.get("url") if isinstance(image_url, dict) else image_url
+    if not isinstance(url, str) or not url:
+        raise ChatCompletionsConversionError("image_url content part requires a url")
+    if url.startswith("data:"):
+        header, _, data = url.partition(",")
+        media_type = header[len("data:") :].split(";", 1)[0] or "image/png"
+        return {
+            "type": "image",
+            "source": {"type": "base64", "media_type": media_type, "data": data},
+        }
+    return {"type": "image", "source": {"type": "url", "url": url}}
+
+
+def _normalize_stop(stop: Any) -> list[str]:
+    if stop is None:
+        return []
+    if isinstance(stop, str):
+        return [stop]
+    if isinstance(stop, list):
+        return [item for item in stop if isinstance(item, str)]
+    return []
+
+
+def _text_from_part(part: Mapping[str, Any]) -> str:
+    for key in ("text", "input_text", "output_text"):
+        value = part.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _optional_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _required_model(model: Any) -> str:
+    if not isinstance(model, str) or not model:
+        raise ChatCompletionsConversionError("model is required")
+    return model

--- a/src/free_claude_code/core/openai_chat/models.py
+++ b/src/free_claude_code/core/openai_chat/models.py
@@ -1,0 +1,31 @@
+"""Pydantic models for OpenAI Chat Completions-compatible ingress."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class OpenAIChatCompletionsRequest(BaseModel):
+    """Permissive subset of the OpenAI Chat Completions API request shape."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    messages: list[dict[str, Any]] = []
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: Any = None
+    parallel_tool_calls: bool | None = None
+    stream: bool | None = None
+    stream_options: dict[str, Any] | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    max_completion_tokens: int | None = None
+    stop: Any = None
+    metadata: dict[str, Any] | None = None
+    reasoning_effort: str | None = None
+
+    def wants_usage(self) -> bool:
+        """Return whether the client asked for a trailing usage chunk when streaming."""
+        options = self.stream_options
+        return isinstance(options, dict) and bool(options.get("include_usage"))

--- a/src/free_claude_code/core/openai_chat/stop_reason.py
+++ b/src/free_claude_code/core/openai_chat/stop_reason.py
@@ -1,0 +1,13 @@
+"""Map Anthropic stop reasons to OpenAI Chat Completions finish reasons."""
+
+
+def finish_reason_from_stop_reason(
+    stop_reason: str | None, *, has_tool_calls: bool
+) -> str:
+    """Translate an Anthropic ``stop_reason`` into an OpenAI ``finish_reason``."""
+    if has_tool_calls or stop_reason == "tool_use":
+        return "tool_calls"
+    if stop_reason == "max_tokens":
+        return "length"
+    # end_turn, stop_sequence, and unknown/None all map to the normal stop.
+    return "stop"

--- a/src/free_claude_code/core/openai_chat/streaming.py
+++ b/src/free_claude_code/core/openai_chat/streaming.py
@@ -1,0 +1,356 @@
+"""Translate Anthropic SSE streams into OpenAI Chat Completions SSE streams."""
+
+import asyncio
+import sys
+import time
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Mapping
+from typing import Any
+
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.diagnostics import safe_exception_message
+from free_claude_code.core.failures import ExecutionFailure, find_execution_failure
+from free_claude_code.core.openai_responses import (
+    openai_error_payload,
+    openai_error_type_for_failure,
+)
+from free_claude_code.core.trace import close_stream_input
+
+from .events import CHAT_COMPLETION_SSE_DONE, format_chat_sse_chunk
+from .ids import new_chat_completion_id, new_tool_call_id
+from .models import OpenAIChatCompletionsRequest
+from .stop_reason import finish_reason_from_stop_reason
+
+PostStartTerminalFailureObserver = Callable[[BaseException], None]
+
+
+class ChatCompletionStreamAssembler:
+    """Assemble ``chat.completion.chunk`` SSE frames from Anthropic content blocks."""
+
+    def __init__(self, request: OpenAIChatCompletionsRequest) -> None:
+        self._request = request
+        self._id = new_chat_completion_id()
+        self._created = int(time.time())
+        self._model = request.model
+        self._include_usage = request.wants_usage()
+        self._role_sent = False
+        self._emitted_content = False
+        self._tool_index_by_block: dict[int, int] = {}
+        self._next_tool_index = 0
+        self._stop_reason: str | None = None
+        self._prompt_tokens = 0
+        self._completion_tokens = 0
+        self.terminal = False
+
+    def process_anthropic_event(self, payload: Mapping[str, Any]) -> list[str]:
+        if self.terminal:
+            return []
+        event_type = payload.get("type")
+        if event_type == "message_start":
+            self._record_message_start(payload)
+            return []
+        if event_type == "content_block_start":
+            return self._handle_block_start(payload)
+        if event_type == "content_block_delta":
+            return self._handle_block_delta(payload)
+        if event_type == "message_delta":
+            self._record_message_delta(payload)
+            return []
+        if event_type == "message_stop":
+            return self.finish()
+        if event_type == "error":
+            return self.fail_error(payload.get("error"))
+        return []
+
+    def finish(self) -> list[str]:
+        if self.terminal:
+            return []
+        self.terminal = True
+        chunks = self._ensure_role()
+        finish_reason = finish_reason_from_stop_reason(
+            self._stop_reason, has_tool_calls=bool(self._tool_index_by_block)
+        )
+        chunks.append(
+            format_chat_sse_chunk(self._chunk({}, finish_reason=finish_reason))
+        )
+        if self._include_usage:
+            chunks.append(format_chat_sse_chunk(self._usage_chunk()))
+        chunks.append(CHAT_COMPLETION_SSE_DONE)
+        return chunks
+
+    def finish_incomplete_stream(self) -> list[str]:
+        """Terminal handling when the provider stream ended with no message_stop.
+
+        If the model already signaled completion through
+        ``message_delta.stop_reason``, only the SSE terminator was missing, so
+        finish normally. If content was streamed with no completion signal at
+        all, the stream was cut off, so emit an error frame instead of a
+        fabricated successful completion. An empty stream (nothing emitted)
+        finishes normally, matching the Responses dialect.
+        """
+        if self.terminal:
+            return []
+        if self._stop_reason is not None or not self._emitted_content:
+            return self.finish()
+        self.terminal = True
+        payload = openai_error_payload(
+            message="Provider stream ended before completion.",
+            error_type="api_error",
+        )
+        return [format_chat_sse_chunk(payload), CHAT_COMPLETION_SSE_DONE]
+
+    def fail_error(self, error: Any) -> list[str]:
+        if self.terminal:
+            return []
+        self.terminal = True
+        error_type = "api_error"
+        message = "Provider request failed unexpectedly."
+        if isinstance(error, Mapping):
+            error_type = _string_value(error.get("type")) or error_type
+            message = _string_value(error.get("message")) or message
+        payload = openai_error_payload(message=message, error_type=error_type)
+        return [format_chat_sse_chunk(payload), CHAT_COMPLETION_SSE_DONE]
+
+    def fail_execution(self, failure: ExecutionFailure) -> list[str]:
+        if self.terminal:
+            return []
+        self.terminal = True
+        payload = openai_error_payload(
+            message=failure.message,
+            error_type=openai_error_type_for_failure(failure),
+        )
+        return [format_chat_sse_chunk(payload), CHAT_COMPLETION_SSE_DONE]
+
+    def fail_unexpected(self, exc: BaseException) -> list[str]:
+        if self.terminal:
+            return []
+        self.terminal = True
+        payload = openai_error_payload(
+            message=safe_exception_message(exc), error_type="api_error"
+        )
+        return [format_chat_sse_chunk(payload), CHAT_COMPLETION_SSE_DONE]
+
+    def _handle_block_start(self, payload: Mapping[str, Any]) -> list[str]:
+        block = payload.get("content_block")
+        if not isinstance(block, Mapping):
+            return []
+        if block.get("type") != "tool_use":
+            # Text blocks stream via deltas; thinking blocks are dropped for chat.
+            if block.get("type") == "text":
+                return self._ensure_role()
+            return []
+        index = _event_index(payload)
+        if index is None:
+            return []
+        tool_index = self._next_tool_index
+        self._next_tool_index += 1
+        self._tool_index_by_block[index] = tool_index
+        self._emitted_content = True
+        chunks = self._ensure_role()
+        chunks.append(
+            format_chat_sse_chunk(
+                self._chunk(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": tool_index,
+                                "id": _string_value(block.get("id"))
+                                or new_tool_call_id(),
+                                "type": "function",
+                                "function": {
+                                    "name": _string_value(block.get("name")),
+                                    "arguments": "",
+                                },
+                            }
+                        ]
+                    }
+                )
+            )
+        )
+        return chunks
+
+    def _handle_block_delta(self, payload: Mapping[str, Any]) -> list[str]:
+        delta = payload.get("delta")
+        if not isinstance(delta, Mapping):
+            return []
+        delta_type = delta.get("type")
+        if delta_type == "text_delta":
+            text = _string_value(delta.get("text"))
+            if not text:
+                return []
+            self._emitted_content = True
+            chunks = self._ensure_role()
+            chunks.append(format_chat_sse_chunk(self._chunk({"content": text})))
+            return chunks
+        if delta_type == "input_json_delta":
+            index = _event_index(payload)
+            tool_index = (
+                self._tool_index_by_block.get(index) if index is not None else None
+            )
+            if tool_index is None:
+                return []
+            self._emitted_content = True
+            partial = _string_value(delta.get("partial_json"))
+            return [
+                format_chat_sse_chunk(
+                    self._chunk(
+                        {
+                            "tool_calls": [
+                                {
+                                    "index": tool_index,
+                                    "function": {"arguments": partial},
+                                }
+                            ]
+                        }
+                    )
+                )
+            ]
+        return []
+
+    def _record_message_start(self, payload: Mapping[str, Any]) -> None:
+        message = payload.get("message")
+        if not isinstance(message, Mapping):
+            return
+        if model := _string_value(message.get("model")):
+            self._model = model
+        usage = message.get("usage")
+        if isinstance(usage, Mapping):
+            self._prompt_tokens = _int(usage.get("input_tokens"), self._prompt_tokens)
+            self._completion_tokens = _int(
+                usage.get("output_tokens"), self._completion_tokens
+            )
+
+    def _record_message_delta(self, payload: Mapping[str, Any]) -> None:
+        delta = payload.get("delta")
+        if isinstance(delta, Mapping):
+            stop_reason = delta.get("stop_reason")
+            if isinstance(stop_reason, str):
+                self._stop_reason = stop_reason
+        usage = payload.get("usage")
+        if isinstance(usage, Mapping):
+            self._completion_tokens = _int(
+                usage.get("output_tokens"), self._completion_tokens
+            )
+            self._prompt_tokens = _int(usage.get("input_tokens"), self._prompt_tokens)
+
+    def _ensure_role(self) -> list[str]:
+        if self._role_sent:
+            return []
+        self._role_sent = True
+        return [format_chat_sse_chunk(self._chunk({"role": "assistant"}))]
+
+    def _chunk(
+        self, delta: dict[str, Any], *, finish_reason: str | None = None
+    ) -> dict[str, Any]:
+        chunk: dict[str, Any] = {
+            "id": self._id,
+            "object": "chat.completion.chunk",
+            "created": self._created,
+            "model": self._model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+        if self._include_usage:
+            chunk["usage"] = None
+        return chunk
+
+    def _usage_chunk(self) -> dict[str, Any]:
+        return {
+            "id": self._id,
+            "object": "chat.completion.chunk",
+            "created": self._created,
+            "model": self._model,
+            "choices": [],
+            "usage": {
+                "prompt_tokens": self._prompt_tokens,
+                "completion_tokens": self._completion_tokens,
+                "total_tokens": self._prompt_tokens + self._completion_tokens,
+            },
+        }
+
+
+async def iter_chat_completions_sse_from_anthropic(
+    chunks: AsyncIterable[Any],
+    request: OpenAIChatCompletionsRequest,
+    *,
+    on_post_start_terminal_failure: PostStartTerminalFailureObserver | None = None,
+) -> AsyncIterator[str]:
+    """Yield Chat Completions SSE frames translated from an Anthropic SSE stream."""
+    assembler = ChatCompletionStreamAssembler(request)
+    emitted_any_chunk = False
+    buffer = ""
+    iterator = aiter(chunks)
+    try:
+        async for chunk in iterator:
+            text = (
+                chunk.decode("utf-8", "replace")
+                if isinstance(chunk, bytes)
+                else str(chunk)
+            )
+            # Normalize CRLF framing/line-endings so events split on "\n\n"
+            # regardless of whether the provider uses LF or CRLF.
+            buffer += text.replace("\r\n", "\n")
+            while "\n\n" in buffer:
+                raw_event, buffer = buffer.split("\n\n", 1)
+                for event in parse_sse_text(raw_event + "\n\n"):
+                    for frame in assembler.process_anthropic_event(event.data):
+                        yield frame
+                        emitted_any_chunk = True
+                    if assembler.terminal:
+                        return
+        for frame in assembler.finish_incomplete_stream():
+            yield frame
+            emitted_any_chunk = True
+    except GeneratorExit, asyncio.CancelledError:
+        raise
+    except ExecutionFailure as exc:
+        if not emitted_any_chunk:
+            raise
+        _observe(on_post_start_terminal_failure, exc)
+        for frame in assembler.fail_execution(exc):
+            yield frame
+    except BaseExceptionGroup as exc:
+        if not emitted_any_chunk:
+            raise
+        failure = find_execution_failure(exc)
+        _observe(on_post_start_terminal_failure, failure or exc)
+        frames = (
+            assembler.fail_execution(failure)
+            if failure is not None
+            else assembler.fail_unexpected(exc)
+        )
+        for frame in frames:
+            yield frame
+    except Exception as exc:
+        if not emitted_any_chunk:
+            raise
+        _observe(on_post_start_terminal_failure, exc)
+        for frame in assembler.fail_unexpected(exc):
+            yield frame
+    finally:
+        await close_stream_input(
+            iterator,
+            owner="openai_chat.streaming",
+            source="core",
+            preserved_error=sys.exception(),
+        )
+
+
+def _observe(
+    observer: PostStartTerminalFailureObserver | None, exc: BaseException
+) -> None:
+    if observer is not None:
+        observer(exc)
+
+
+def _event_index(payload: Mapping[str, Any]) -> int | None:
+    value = payload.get("index")
+    return value if isinstance(value, int) else None
+
+
+def _string_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return value if isinstance(value, str) else str(value)
+
+
+def _int(value: Any, default: int) -> int:
+    return value if isinstance(value, int) else default

--- a/src/free_claude_code/core/openai_chat/tools.py
+++ b/src/free_claude_code/core/openai_chat/tools.py
@@ -1,0 +1,95 @@
+"""Tool and tool-choice conversion for OpenAI Chat Completions ingress."""
+
+import json
+from typing import Any
+
+from .errors import ChatCompletionsConversionError
+
+
+def convert_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Convert OpenAI Chat Completions ``tools`` into Anthropic tool definitions.
+
+    Malformed entries are rejected rather than silently dropped, so a request
+    never reaches the provider with fewer tools than the caller declared (which
+    would silently change the model's capabilities). Mirrors the strict
+    validation in ``core/openai_responses``.
+    """
+    if not tools:
+        return []
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            raise ChatCompletionsConversionError(
+                f"Unsupported chat tool: {type(tool).__name__}"
+            )
+        tool_type = tool.get("type")
+        if tool_type not in (None, "function"):
+            raise ChatCompletionsConversionError(
+                f"Unsupported chat tool type: {tool_type!r}"
+            )
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            raise ChatCompletionsConversionError(
+                "chat tool requires a 'function' object"
+            )
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            raise ChatCompletionsConversionError(
+                "chat tool function requires a non-empty name"
+            )
+        anthropic_tool: dict[str, Any] = {
+            "name": name,
+            "input_schema": _tool_input_schema(function.get("parameters")),
+        }
+        if description := function.get("description"):
+            anthropic_tool["description"] = str(description)
+        converted.append(anthropic_tool)
+    return converted
+
+
+def convert_tool_choice(tool_choice: Any) -> dict[str, Any] | None:
+    """Convert an OpenAI ``tool_choice`` into an Anthropic ``tool_choice``.
+
+    Unknown or malformed values raise instead of falling back to automatic tool
+    selection, so a typo in a required named choice becomes a client error
+    rather than silently letting the model pick a different tool or none.
+    """
+    if tool_choice in (None, "auto", "none"):
+        return None
+    if tool_choice == "required":
+        return {"type": "any"}
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        function = tool_choice.get("function")
+        name = function.get("name") if isinstance(function, dict) else None
+        if not isinstance(name, str) or not name:
+            raise ChatCompletionsConversionError(
+                "tool_choice.function.name is required"
+            )
+        return {"type": "tool", "name": name}
+    raise ChatCompletionsConversionError(
+        f"Unsupported chat tool_choice: {tool_choice!r}"
+    )
+
+
+def parse_arguments(arguments: Any) -> Any:
+    """Parse an OpenAI tool-call ``arguments`` payload into Anthropic tool input."""
+    if arguments in (None, ""):
+        return {}
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        try:
+            return json.loads(arguments)
+        except json.JSONDecodeError as exc:
+            raise ChatCompletionsConversionError(
+                f"Invalid tool call arguments JSON: {exc}"
+            ) from exc
+    raise ChatCompletionsConversionError(
+        f"Unsupported tool call arguments type: {type(arguments).__name__}"
+    )
+
+
+def _tool_input_schema(parameters: Any) -> dict[str, Any]:
+    if isinstance(parameters, dict):
+        return parameters
+    return {"type": "object", "properties": {}}

--- a/tests/api/test_openai_chat.py
+++ b/tests/api/test_openai_chat.py
@@ -1,0 +1,218 @@
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.core.anthropic.streaming import format_sse_event
+from tests.api.support import create_test_app
+
+
+class FakeProvider:
+    def __init__(self, chunks: list[str]) -> None:
+        self.chunks = chunks
+        self.preflight_stream = MagicMock()
+        self.requests: list[Any] = []
+        self.stream_kwargs: list[dict[str, Any]] = []
+
+    async def stream_response(self, request_data, **_kwargs):
+        self.requests.append(request_data)
+        self.stream_kwargs.append(_kwargs)
+        for chunk in self.chunks:
+            yield chunk
+
+
+def _anthropic_text_stream(text: str, *, stop_reason: str = "end_turn") -> list[str]:
+    return [
+        format_sse_event(
+            "message_start",
+            {"type": "message_start", "message": {"usage": {"input_tokens": 3}}},
+        ),
+        format_sse_event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": text},
+            },
+        ),
+        format_sse_event(
+            "content_block_stop", {"type": "content_block_stop", "index": 0}
+        ),
+        format_sse_event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason},
+                "usage": {"output_tokens": 5},
+            },
+        ),
+        format_sse_event("message_stop", {"type": "message_stop"}),
+    ]
+
+
+def _anthropic_tool_use_stream() -> list[str]:
+    return [
+        format_sse_event("message_start", {"type": "message_start", "message": {}}),
+        format_sse_event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": {},
+                },
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": '{"city": "Paris"}',
+                },
+            },
+        ),
+        format_sse_event(
+            "content_block_stop", {"type": "content_block_stop", "index": 0}
+        ),
+        format_sse_event(
+            "message_delta",
+            {"type": "message_delta", "delta": {"stop_reason": "tool_use"}},
+        ),
+        format_sse_event("message_stop", {"type": "message_stop"}),
+    ]
+
+
+@pytest.fixture
+def chat_client():
+    provider = FakeProvider(_anthropic_text_stream("Hello from provider"))
+    app = create_test_app()
+    with (
+        patch("free_claude_code.api.routes.resolve_provider", return_value=provider),
+        TestClient(app) as client,
+    ):
+        yield client, provider
+
+
+def test_chat_probe_endpoints_return_204(chat_client) -> None:
+    client, _provider = chat_client
+    assert client.head("/v1/chat/completions").status_code == 204
+    assert client.options("/v1/chat/completions").status_code == 204
+
+
+def test_non_stream_chat_completion_routes_through_provider(chat_client) -> None:
+    client, provider = chat_client
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "nvidia_nim/test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 32,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["object"] == "chat.completion"
+    choice = body["choices"][0]
+    assert choice["message"]["content"] == "Hello from provider"
+    assert choice["finish_reason"] == "stop"
+    assert body["usage"]["prompt_tokens"] == 3
+    assert body["usage"]["completion_tokens"] == 5
+    assert provider.preflight_stream.called
+    routed = provider.requests[0]
+    assert routed.model == "test-model"
+    assert routed.messages[0].role == "user"
+    assert routed.max_tokens == 32
+
+
+def test_stream_chat_completion_emits_chunks_and_done(chat_client) -> None:
+    client, _provider = chat_client
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "nvidia_nim/test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+        },
+    )
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+    payloads = [
+        line[len("data: ") :]
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert payloads[-1] == "[DONE]"
+    objects = [json.loads(p) for p in payloads if p != "[DONE]"]
+    assert objects[0]["choices"][0]["delta"] == {"role": "assistant"}
+    content = "".join(
+        obj["choices"][0]["delta"].get("content", "")
+        for obj in objects
+        if obj["choices"]
+    )
+    assert content == "Hello from provider"
+    assert objects[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_non_stream_tool_call_completion() -> None:
+    provider = FakeProvider(_anthropic_tool_use_stream())
+    app = create_test_app()
+    with (
+        patch("free_claude_code.api.routes.resolve_provider", return_value=provider),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "nvidia_nim/test-model",
+                "messages": [{"role": "user", "content": "weather in Paris?"}],
+                "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+            },
+        )
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tool_call = choice["message"]["tool_calls"][0]
+    assert tool_call["function"]["name"] == "get_weather"
+    assert json.loads(tool_call["function"]["arguments"]) == {"city": "Paris"}
+
+
+def test_preflight_rejection_is_ordinary_openai_error() -> None:
+    provider = FakeProvider(_anthropic_text_stream("unused"))
+    provider.preflight_stream.side_effect = InvalidRequestError("bad tool shape")
+    app = create_test_app()
+    with (
+        patch("free_claude_code.api.routes.resolve_provider", return_value=provider),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "nvidia_nim/test-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+    assert response.status_code == 400
+    assert response.json()["error"] == {
+        "message": "bad tool shape",
+        "type": "invalid_request_error",
+        "param": None,
+        "code": None,
+    }
+    assert provider.requests == []

--- a/tests/core/openai_chat/test_chat_completion.py
+++ b/tests/core/openai_chat/test_chat_completion.py
@@ -1,0 +1,82 @@
+import json
+
+from free_claude_code.core.openai_chat import OpenAIChatCompletionsRequest
+from free_claude_code.core.openai_chat.completion import (
+    anthropic_message_to_chat_completion,
+)
+
+
+def _request(model: str = "nvidia_nim/x") -> OpenAIChatCompletionsRequest:
+    return OpenAIChatCompletionsRequest(
+        model=model, messages=[{"role": "user", "content": "hi"}]
+    )
+
+
+def test_text_message_becomes_chat_completion() -> None:
+    message = {
+        "content": [{"type": "text", "text": "Hello there"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 2},
+    }
+    completion = anthropic_message_to_chat_completion(
+        message, _request(), completion_id="chatcmpl-fixed"
+    )
+    assert completion["id"] == "chatcmpl-fixed"
+    assert completion["object"] == "chat.completion"
+    assert completion["model"] == "nvidia_nim/x"
+    choice = completion["choices"][0]
+    assert choice["message"] == {"role": "assistant", "content": "Hello there"}
+    assert choice["finish_reason"] == "stop"
+    assert completion["usage"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 2,
+        "total_tokens": 7,
+    }
+
+
+def test_tool_use_message_maps_to_tool_calls_and_finish_reason() -> None:
+    message = {
+        "content": [
+            {"type": "text", "text": ""},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+            },
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 8, "output_tokens": 6},
+    }
+    completion = anthropic_message_to_chat_completion(message, _request())
+    choice = completion["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tool_call = choice["message"]["tool_calls"][0]
+    assert tool_call["id"] == "toolu_1"
+    assert tool_call["type"] == "function"
+    assert tool_call["function"]["name"] == "get_weather"
+    assert json.loads(tool_call["function"]["arguments"]) == {"city": "Paris"}
+    # No text content -> null content alongside tool_calls, per OpenAI shape.
+    assert choice["message"]["content"] is None
+
+
+def test_max_tokens_stop_reason_maps_to_length() -> None:
+    message = {
+        "content": [{"type": "text", "text": "partial"}],
+        "stop_reason": "max_tokens",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    completion = anthropic_message_to_chat_completion(message, _request())
+    assert completion["choices"][0]["finish_reason"] == "length"
+
+
+def test_missing_usage_defaults_to_zero() -> None:
+    completion = anthropic_message_to_chat_completion(
+        {"content": [{"type": "text", "text": "x"}]}, _request()
+    )
+    assert completion["usage"] == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
+    assert completion["choices"][0]["finish_reason"] == "stop"

--- a/tests/core/openai_chat/test_chat_input.py
+++ b/tests/core/openai_chat/test_chat_input.py
@@ -1,0 +1,284 @@
+import json
+
+import pytest
+
+from free_claude_code.core.openai_chat import (
+    ChatCompletionsConversionError,
+    OpenAIChatCompletionsRequest,
+)
+from free_claude_code.core.openai_chat.input import (
+    convert_request_to_anthropic_payload,
+)
+
+
+def _payload(**kwargs):
+    return convert_request_to_anthropic_payload(OpenAIChatCompletionsRequest(**kwargs))
+
+
+def test_system_messages_collapse_into_system_field() -> None:
+    payload = _payload(
+        model="nvidia_nim/x",
+        messages=[
+            {"role": "system", "content": "be terse"},
+            {"role": "developer", "content": "obey policy"},
+            {"role": "user", "content": "hello"},
+        ],
+    )
+    assert payload["system"] == "be terse\n\nobey policy"
+    assert payload["messages"] == [{"role": "user", "content": "hello"}]
+    assert payload["stream"] is True
+
+
+def test_multimodal_user_content_becomes_blocks() -> None:
+    payload = _payload(
+        model="m",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,QUJD"},
+                    },
+                ],
+            }
+        ],
+    )
+    content = payload["messages"][0]["content"]
+    assert content[0] == {"type": "text", "text": "look"}
+    assert content[1] == {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "QUJD"},
+    }
+
+
+def test_assistant_tool_calls_become_tool_use_blocks() -> None:
+    payload = _payload(
+        model="m",
+        messages=[
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_abc", "content": "sunny"},
+        ],
+    )
+    assistant = payload["messages"][1]
+    assert assistant["role"] == "assistant"
+    assert assistant["content"] == [
+        {
+            "type": "tool_use",
+            "id": "call_abc",
+            "name": "get_weather",
+            "input": {"city": "Paris"},
+        }
+    ]
+    tool_turn = payload["messages"][2]
+    assert tool_turn == {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "call_abc", "content": "sunny"}
+        ],
+    }
+
+
+def test_consecutive_tool_results_merge_into_one_user_turn() -> None:
+    payload = _payload(
+        model="m",
+        messages=[
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "a", "function": {"name": "f", "arguments": "{}"}},
+                    {"id": "b", "function": {"name": "g", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "a", "content": "1"},
+            {"role": "tool", "tool_call_id": "b", "content": "2"},
+        ],
+    )
+    tool_turn = payload["messages"][-1]
+    assert [block["tool_use_id"] for block in tool_turn["content"]] == ["a", "b"]
+
+
+def test_tools_and_tool_choice_convert() -> None:
+    payload = _payload(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "find things",
+                    "parameters": {"type": "object", "properties": {"q": {}}},
+                },
+            }
+        ],
+        tool_choice={"type": "function", "function": {"name": "lookup"}},
+    )
+    assert payload["tools"] == [
+        {
+            "name": "lookup",
+            "input_schema": {"type": "object", "properties": {"q": {}}},
+            "description": "find things",
+        }
+    ]
+    assert payload["tool_choice"] == {"type": "tool", "name": "lookup"}
+
+
+def test_tool_choice_none_drops_tools() -> None:
+    payload = _payload(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "lookup"}}],
+        tool_choice="none",
+    )
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+def test_tool_choice_required_maps_to_any() -> None:
+    payload = _payload(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "lookup"}}],
+        tool_choice="required",
+    )
+    assert payload["tool_choice"] == {"type": "any"}
+
+
+def test_sampling_stop_and_token_limits() -> None:
+    payload = _payload(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.2,
+        top_p=0.9,
+        max_tokens=100,
+        max_completion_tokens=64,
+        stop=["STOP", "END"],
+    )
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 0.9
+    # max_completion_tokens takes precedence over the legacy max_tokens field.
+    assert payload["max_tokens"] == 64
+    assert payload["stop_sequences"] == ["STOP", "END"]
+
+
+def test_invalid_tool_call_arguments_raise_conversion_error() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(
+            model="m",
+            messages=[
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "a", "function": {"name": "f", "arguments": "{not json"}}
+                    ],
+                }
+            ],
+        )
+
+
+def test_missing_non_system_message_raises() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(model="m", messages=[{"role": "system", "content": "only system"}])
+
+
+def test_tool_message_without_id_raises() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(model="m", messages=[{"role": "tool", "content": "orphan"}])
+
+
+def test_json_arguments_survive_roundtrip() -> None:
+    payload = _payload(
+        model="m",
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "a",
+                        "function": {"name": "f", "arguments": '{"nested": {"x": 1}}'},
+                    }
+                ],
+            }
+        ],
+    )
+    assert (
+        json.dumps(payload["messages"][0]["content"][0]["input"])
+        == '{"nested": {"x": 1}}'
+    )
+
+
+def test_malformed_tool_entry_raises() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {"type": "function", "function": {"name": "ok"}},
+                {"type": "function"},  # missing function object
+            ],
+        )
+
+
+def test_unsupported_tool_type_raises() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "retrieval", "function": {"name": "x"}}],
+        )
+
+
+def test_tool_function_missing_name_raises() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"description": "no name"}}],
+        )
+
+
+def test_unknown_string_tool_choice_raises() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+            tool_choice="lookuq",  # typo for a real choice
+        )
+
+
+def test_named_tool_choice_missing_name_raises() -> None:
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+            tool_choice={"type": "function", "function": {}},
+        )
+
+
+def test_invalid_tool_choice_raises_even_without_tools() -> None:
+    # tool_choice is validated unconditionally, matching the Responses dialect.
+    with pytest.raises(ChatCompletionsConversionError):
+        _payload(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            tool_choice="bogus",
+        )

--- a/tests/core/openai_chat/test_chat_streaming.py
+++ b/tests/core/openai_chat/test_chat_streaming.py
@@ -1,0 +1,242 @@
+import asyncio
+import json
+from collections.abc import AsyncIterator
+
+from free_claude_code.core.anthropic.streaming import format_sse_event
+from free_claude_code.core.openai_chat import OpenAIChatCompletionsRequest
+from free_claude_code.core.openai_chat.streaming import (
+    iter_chat_completions_sse_from_anthropic,
+)
+
+
+def _request(**kwargs) -> OpenAIChatCompletionsRequest:
+    kwargs.setdefault("model", "nvidia_nim/x")
+    kwargs.setdefault("messages", [{"role": "user", "content": "hi"}])
+    return OpenAIChatCompletionsRequest(**kwargs)
+
+
+async def _source(chunks: list[str]) -> AsyncIterator[str]:
+    for chunk in chunks:
+        yield chunk
+
+
+def _collect(chunks: list[str], request: OpenAIChatCompletionsRequest) -> list[str]:
+    async def run() -> list[str]:
+        return [
+            frame
+            async for frame in iter_chat_completions_sse_from_anthropic(
+                _source(chunks), request
+            )
+        ]
+
+    return asyncio.run(run())
+
+
+def _data_objects(frames: list[str]) -> list[dict]:
+    objects: list[dict] = []
+    for frame in frames:
+        payload = frame.removeprefix("data: ").strip()
+        if payload and payload != "[DONE]":
+            objects.append(json.loads(payload))
+    return objects
+
+
+def _text_stream(text: str, *, stop_reason: str = "end_turn") -> list[str]:
+    return [
+        format_sse_event(
+            "message_start",
+            {"type": "message_start", "message": {"usage": {"input_tokens": 3}}},
+        ),
+        format_sse_event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": text},
+            },
+        ),
+        format_sse_event(
+            "content_block_stop", {"type": "content_block_stop", "index": 0}
+        ),
+        format_sse_event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason},
+                "usage": {"output_tokens": 4},
+            },
+        ),
+        format_sse_event("message_stop", {"type": "message_stop"}),
+    ]
+
+
+def test_text_stream_emits_role_content_and_finish() -> None:
+    frames = _collect(_text_stream("Hello world"), _request())
+    assert frames[-1] == "data: [DONE]\n\n"
+    objects = _data_objects(frames)
+    assert objects[0]["choices"][0]["delta"] == {"role": "assistant"}
+    assert all(obj["object"] == "chat.completion.chunk" for obj in objects)
+    content = "".join(
+        obj["choices"][0]["delta"].get("content", "")
+        for obj in objects
+        if obj["choices"]
+    )
+    assert content == "Hello world"
+    assert objects[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_max_tokens_stream_finish_reason_is_length() -> None:
+    frames = _collect(_text_stream("partial", stop_reason="max_tokens"), _request())
+    objects = _data_objects(frames)
+    assert objects[-1]["choices"][0]["finish_reason"] == "length"
+
+
+def test_tool_use_stream_emits_tool_call_deltas() -> None:
+    chunks = [
+        format_sse_event("message_start", {"type": "message_start", "message": {}}),
+        format_sse_event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_9",
+                    "name": "get_weather",
+                    "input": {},
+                },
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": '{"city":'},
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": ' "Paris"}'},
+            },
+        ),
+        format_sse_event(
+            "content_block_stop", {"type": "content_block_stop", "index": 0}
+        ),
+        format_sse_event(
+            "message_delta",
+            {"type": "message_delta", "delta": {"stop_reason": "tool_use"}},
+        ),
+        format_sse_event("message_stop", {"type": "message_stop"}),
+    ]
+    objects = _data_objects(_collect(chunks, _request()))
+    tool_deltas = [
+        obj["choices"][0]["delta"]["tool_calls"][0]
+        for obj in objects
+        if obj["choices"] and obj["choices"][0]["delta"].get("tool_calls")
+    ]
+    assert tool_deltas[0]["index"] == 0
+    assert tool_deltas[0]["id"] == "toolu_9"
+    assert tool_deltas[0]["function"]["name"] == "get_weather"
+    arguments = "".join(delta["function"]["arguments"] for delta in tool_deltas)
+    assert json.loads(arguments) == {"city": "Paris"}
+    assert objects[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+def test_include_usage_emits_trailing_usage_chunk() -> None:
+    frames = _collect(
+        _text_stream("hi"),
+        _request(stream_options={"include_usage": True}),
+    )
+    objects = _data_objects(frames)
+    # Every content chunk carries usage=None; the trailing chunk has empty choices.
+    assert objects[0]["usage"] is None
+    usage_chunk = objects[-1]
+    assert usage_chunk["choices"] == []
+    assert usage_chunk["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 4,
+        "total_tokens": 7,
+    }
+
+
+def test_crlf_framed_stream_parses() -> None:
+    crlf = [chunk.replace("\n", "\r\n") for chunk in _text_stream("Hello world")]
+    objects = _data_objects(_collect(crlf, _request()))
+    content = "".join(
+        o["choices"][0]["delta"].get("content", "") for o in objects if o["choices"]
+    )
+    assert content == "Hello world"
+    assert objects[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_truncated_stream_without_completion_emits_error() -> None:
+    # Content, then the provider connection ends with no message_delta/message_stop.
+    chunks = [
+        format_sse_event("message_start", {"type": "message_start", "message": {}}),
+        format_sse_event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "partial"},
+            },
+        ),
+    ]
+    frames = _collect(chunks, _request())
+    assert frames[-1] == "data: [DONE]\n\n"
+    objects = _data_objects(frames)
+    assert any("error" in o for o in objects)
+    # never fabricate a successful finish_reason for a cut-off stream
+    assert not any(
+        o.get("choices") and o["choices"][0].get("finish_reason") for o in objects
+    )
+
+
+def test_stop_reason_without_message_stop_finishes_normally() -> None:
+    # The model signaled completion via message_delta; only message_stop is missing.
+    chunks = [
+        format_sse_event("message_start", {"type": "message_start", "message": {}}),
+        format_sse_event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "done"},
+            },
+        ),
+        format_sse_event(
+            "message_delta",
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+        ),
+    ]
+    objects = _data_objects(_collect(chunks, _request()))
+    assert not any("error" in o for o in objects)
+    assert objects[-1]["choices"][0]["finish_reason"] == "stop"

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.11.0"
+version = "4.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

| Before | After |
| --- | --- |
| The proxy served the Anthropic Messages (`/v1/messages`) and OpenAI Responses (`/v1/responses`) dialects, but **not** OpenAI Chat Completions. | The proxy also serves a native **`POST /v1/chat/completions`** (with a `HEAD`/`OPTIONS` probe), so any OpenAI chat-completions client can use it directly. |
| Clients that only speak chat-completions — e.g. **jcode's `openai-compatible` provider profile**, LiteLLM-style routers — got `404` and could not connect. | Those clients connect unchanged: point them at `<base>/v1` with the proxy bearer token. |

## Approach

The Chat Completions handler mirrors the existing Responses flow. It converts the incoming chat request into the shared internal Anthropic `MessagesRequest`, runs it through the **same** provider pipeline (`ProviderExecutor`), and re-serializes the result in the Chat Completions dialect:

- **non-streaming** → aggregate the internal SSE via the existing `aggregate_anthropic_sse_to_message`, then emit a single `chat.completion`;
- **streaming** → translate the Anthropic SSE into `chat.completion.chunk` frames (role delta, content deltas, `tool_calls` deltas, `finish_reason`, `[DONE]`).

Coverage: `system`/`user`/`assistant`/`tool` roles, `tool_calls` ↔ Anthropic `tool_use`, `tool_choice` (`auto`/`none`/`required`/named), multimodal `image_url` parts, `stop` sequences, and `stream_options.include_usage`. Anthropic `stop_reason` maps to `finish_reason` (`end_turn`/`stop_sequence`→`stop`, `max_tokens`→`length`, `tool_use`→`tool_calls`).

### Changes
- New `core/openai_chat/` adapter package (request model, input conversion, tool/tool_choice conversion, streaming assembler, non-stream completion builder, finish-reason mapping, SSE formatting).
- New `api/handlers/chat_completions.py` + route + `HEAD`/`OPTIONS` probe, wired through `ApiServices` exactly like the other dialects.
- `wire_api="chat"` trace labels in `application/execution.py`; the shared OpenAI error envelope owned by `core/openai_responses` is reused (as `api/request_errors` already does).
- **`ARCHITECTURE.md` updated** per the "Maintenance Rules" (this adds a public route + wire protocol): the routes list, a new `core/openai_chat/` protocol-conversion section mirroring the Responses one, and the "Add Protocol Behavior" extension checklist.
- Tests for request conversion, streaming chunks, non-stream aggregation, and the HTTP endpoint (stream, non-stream, tool calls, auth-required, preflight rejection).
- MINOR version bump `4.11.0` → `4.12.0` with matching `uv.lock`.

## Verification
- `./scripts/ci.sh`: ruff-format, ruff-check, ty, and pytest all pass (the new suite adds 25 tests). *(The only failures in my environment are the pre-existing `tests/scripts/` installer tests, which also fail on a clean `main` checkout here.)*
- **Live, end-to-end against real providers** (running the branch server, driving it with `curl` and with jcode):
  - `GET /openapi.json` lists `POST /v1/chat/completions`; unauthenticated calls return `401`.
  - Non-streaming completion through NVIDIA NIM returns a well-formed `chat.completion` (correct `finish_reason`, `usage`).
  - Streaming completion returns ordered `chat.completion.chunk` frames ending in `[DONE]`, with a correct trailing usage chunk under `stream_options.include_usage`.
  - **jcode's `openai-compatible` provider profile** (`jcode provider add ... --base-url http://HOST/v1`) runs a full multi-turn agentic session (including tool calls) through the endpoint — the exact client that could not connect before.

## Residual Risks
- Thinking/reasoning content blocks are intentionally dropped from the Chat Completions output (that dialect has no standard field for them); text and tool calls are unaffected.
- The shared OpenAI error envelope now has two dialect consumers; a future cleanup could hoist it into a neutral `core/openai_shared` module (kept out of scope here to keep the diff focused).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds native OpenAI Chat Completions support to the proxy. The main changes are:

- Adds authenticated `POST`, `HEAD`, and `OPTIONS` handling for `/v1/chat/completions`.
- Converts Chat Completions requests into the shared Anthropic Messages pipeline.
- Translates streaming and non-streaming provider output into OpenAI-compatible responses.
- Supports tools, tool choices, multimodal input, stop sequences, and usage chunks.
- Adds endpoint and adapter tests, architecture documentation, and the 4.12.0 version update.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The updated stream framing handles CRLF events. Incomplete content-bearing streams no longer report normal completion without a completion signal. Tool and tool-choice validation now rejects the malformed cases covered by the original fixes. No additional publishable blocking issue was found in the updated code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared pre-change behavior and confirmed that POST /v1/chat/completions returned 404 Not Found before the revision.
- Verified post-change exposure: OpenAPI now supports POST, HEAD, and OPTIONS; probes returned 204, and non-stream, streaming, and tool-call requests returned 200, with invalid preflight yielding a 400 envelope.
- Collected streaming evidence showing ordered frames including role, content, stop, usage, and \[DONE\].
- Diagnostic runner and pytest completed successfully with exit code 0.

<a href="https://app.greptile.com/trex/runs/15034300/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/openai_chat/streaming.py | Translates Anthropic SSE events into Chat Completions chunks and handles framing, termination, errors, tool calls, and usage. |
| src/free_claude_code/core/openai_chat/input.py | Converts Chat Completions messages, tools, images, and generation options into Anthropic request payloads. |
| src/free_claude_code/api/handlers/chat_completions.py | Runs chat requests through provider execution and serializes streaming, aggregated, and error responses. |
| src/free_claude_code/api/routes.py | Registers the authenticated Chat Completions endpoint and preserves request-runtime lease ownership. |

<sub>Reviews (2): Last reviewed commit: ["Add OpenAI Chat Completions endpoint (/v..."](https://github.com/alishahryar1/free-claude-code/commit/8d177e0146345483a3a8ed67456deefe875ce3c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45489776)</sub>

<!-- /greptile_comment -->