### PR TITLE
Fix Gemini 400 when reasoning_effort and thinking_config both set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.11.1"
+version = "4.11.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/gemini/client.py
+++ b/src/free_claude_code/providers/gemini/client.py
@@ -1,12 +1,13 @@
 """Google AI Studio Gemini provider (OpenAI-compatible chat completions)."""
 
 from free_claude_code.core.anthropic import ReasoningReplayMode
-from free_claude_code.core.reasoning import ReasoningEffort
 from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.base import ProviderConfig
-from free_claude_code.providers.google_openai import GoogleOpenAIProvider
+from free_claude_code.providers.google_openai import (
+    GeminiReasoning,
+    GoogleOpenAIProvider,
+)
 from free_claude_code.providers.openai_chat import (
-    NamedEffortReasoning,
     OpenAIChatProfile,
     OpenAIChatRequestPolicy,
 )
@@ -15,20 +16,7 @@ _REQUEST_POLICY = OpenAIChatRequestPolicy(
     provider_name="GEMINI",
     reasoning_replay=ReasoningReplayMode.REASONING_CONTENT,
 )
-_PROFILE = OpenAIChatProfile(
-    _REQUEST_POLICY,
-    NamedEffortReasoning(
-        (
-            (ReasoningEffort.MINIMAL, "minimal"),
-            (ReasoningEffort.LOW, "low"),
-            (ReasoningEffort.MEDIUM, "medium"),
-            (ReasoningEffort.HIGH, "high"),
-            (ReasoningEffort.XHIGH, "high"),
-            (ReasoningEffort.MAX, "high"),
-        ),
-        disabled_value="none",
-    ),
-)
+_PROFILE = OpenAIChatProfile(_REQUEST_POLICY, GeminiReasoning())
 
 
 class GeminiProvider(GoogleOpenAIProvider):

--- a/src/free_claude_code/providers/google_openai/__init__.py
+++ b/src/free_claude_code/providers/google_openai/__init__.py
@@ -1,10 +1,15 @@
 """Shared Google OpenAI-compatible provider family."""
 
-from .provider import GoogleOpenAIProvider, GoogleThinkingBudgetReasoning
+from .provider import (
+    GeminiReasoning,
+    GoogleOpenAIProvider,
+    GoogleThinkingBudgetReasoning,
+)
 from .quirks import GOOGLE_SKIP_THOUGHT_SIGNATURE_VALIDATOR
 
 __all__ = [
     "GOOGLE_SKIP_THOUGHT_SIGNATURE_VALIDATOR",
+    "GeminiReasoning",
     "GoogleOpenAIProvider",
     "GoogleThinkingBudgetReasoning",
 ]

--- a/src/free_claude_code/providers/google_openai/provider.py
+++ b/src/free_claude_code/providers/google_openai/provider.py
@@ -2,13 +2,14 @@
 
 from collections.abc import Mapping
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.reasoning import (
     DEFAULT_REASONING_POLICY,
     ReasoningControl,
+    ReasoningEffort,
     ReasoningPolicy,
 )
 from free_claude_code.providers.admission import ProviderAdmissionController
@@ -20,9 +21,22 @@ from free_claude_code.providers.openai_chat import (
     build_openai_chat_request_body,
 )
 
-from .quirks import apply_google_request_quirks, google_thinking_config
+from .quirks import (
+    apply_google_request_quirks,
+    clear_google_thinking_config,
+    google_thinking_config,
+)
 
 _MAX_TOOL_CALL_EXTRA_CONTENT_CACHE = 4096
+
+_GEMINI_EFFORT_VALUES = {
+    ReasoningEffort.MINIMAL: "minimal",
+    ReasoningEffort.LOW: "low",
+    ReasoningEffort.MEDIUM: "medium",
+    ReasoningEffort.HIGH: "high",
+    ReasoningEffort.XHIGH: "high",
+    ReasoningEffort.MAX: "high",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,6 +55,37 @@ class GoogleThinkingBudgetReasoning:
         thinking = google_thinking_config(body)
         thinking.setdefault("thinking_budget", budget)
         thinking.setdefault("include_thoughts", True)
+
+
+@dataclass(frozen=True, slots=True)
+class GeminiReasoning:
+    """Encode Gemini with either reasoning_effort or thinking_config, never both."""
+
+    disabled_value: str = "none"
+    _thinking_budget: GoogleThinkingBudgetReasoning = field(
+        default_factory=GoogleThinkingBudgetReasoning
+    )
+
+    def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
+        if policy.control is ReasoningControl.OFF:
+            body["reasoning_effort"] = self.disabled_value
+            clear_google_thinking_config(body)
+            return
+
+        if policy.budget_tokens is not None:
+            body.pop("reasoning_effort", None)
+            self._thinking_budget.encode(body, policy)
+            return
+
+        effort = _GEMINI_EFFORT_VALUES.get(policy.effort)
+        if effort is not None:
+            body["reasoning_effort"] = effort
+            clear_google_thinking_config(body)
+            return
+
+        body.pop("reasoning_effort", None)
+        if policy.requests_reasoning:
+            self._thinking_budget.encode(body, policy)
 
 
 class GoogleOpenAIProvider(OpenAIChatProvider):

--- a/src/free_claude_code/providers/google_openai/quirks.py
+++ b/src/free_claude_code/providers/google_openai/quirks.py
@@ -22,7 +22,7 @@ def apply_google_request_quirks(
     if isinstance(request_extra, dict):
         extra_body.update(deepcopy(request_extra))
 
-    if reasoning.requests_reasoning:
+    if reasoning.requests_reasoning and reasoning.effort is None:
         _thinking_config(extra_body).setdefault("include_thoughts", True)
 
     if extra_body:
@@ -38,6 +38,26 @@ def google_thinking_config(body: dict[str, Any]) -> dict[str, Any]:
     """Return Google's literal ``extra_body.google.thinking_config`` object."""
     extra_body = _ensure_dict(body, "extra_body")
     return _thinking_config(extra_body)
+
+
+def clear_google_thinking_config(body: dict[str, Any]) -> None:
+    """Drop thinking_config so it cannot coexist with reasoning_effort."""
+    extra_body = body.get("extra_body")
+    if not isinstance(extra_body, dict):
+        return
+    literal_extra_body = extra_body.get("extra_body")
+    if not isinstance(literal_extra_body, dict):
+        return
+    google = literal_extra_body.get("google")
+    if not isinstance(google, dict):
+        return
+    google.pop("thinking_config", None)
+    if not google:
+        literal_extra_body.pop("google", None)
+    if not literal_extra_body:
+        extra_body.pop("extra_body", None)
+    if not extra_body:
+        body.pop("extra_body", None)
 
 
 def _thinking_config(extra_body: dict[str, Any]) -> dict[str, Any]:

--- a/tests/providers/test_gemini.py
+++ b/tests/providers/test_gemini.py
@@ -99,6 +99,34 @@ def test_build_request_body_sdk_wire_json_has_literal_extra_body(gemini_provider
     assert thinking_config.get("include_thoughts") is True
 
 
+def test_build_request_body_named_effort_omits_thinking_config(gemini_provider):
+    req = make_request(
+        thinking={"type": "enabled"},
+        output_config={"effort": "high"},
+    )
+
+    body = gemini_provider._build_request_body(req, reasoning=reasoning_for(req))
+    wire_json = _simulate_openai_sdk_wire_json(body)
+
+    assert body["reasoning_effort"] == "high"
+    assert wire_json["reasoning_effort"] == "high"
+    assert "extra_body" not in wire_json
+
+
+def test_build_request_body_budget_uses_thinking_config_only(gemini_provider):
+    req = make_request(thinking={"type": "enabled", "budget_tokens": 2048})
+
+    body = gemini_provider._build_request_body(req, reasoning=reasoning_for(req))
+    wire_json = _simulate_openai_sdk_wire_json(body)
+
+    assert "reasoning_effort" not in body
+    assert "reasoning_effort" not in wire_json
+    assert wire_json["extra_body"]["google"]["thinking_config"] == {
+        "include_thoughts": True,
+        "thinking_budget": 2048,
+    }
+
+
 def test_build_request_body_reasoning_off_sets_reasoning_none():
     """When thinking is off, Gemini uses reasoning_effort none (Gemini 2.5 convention)."""
     provider = GeminiProvider(

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.11.1"
+version = "4.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Context
- Fixes #1206: Gemini returns HTTP 400 when a request includes both `reasoning_effort` and `thinking_config`.
- Claude Code often enables thinking and also sends a named effort, which previously produced both wire fields.

## Changes
- Add `GeminiReasoning` so Gemini encodes exactly one control: off/`none`, named effort, or `thinking_config` for budgets/enabled-without-effort.
- Skip quirk `include_thoughts` when named effort wins, and clear `thinking_config` whenever `reasoning_effort` is sent.
- Wire Gemini to `GeminiReasoning` and add focused regression tests.

## Testing
- `uv run pytest -v --tb=short tests/providers/test_gemini.py tests/providers/test_vertex.py`
- `uv run ruff format --check` / `uv run ruff check` / `uv run ty check` on touched paths
- Full `./scripts/ci.sh` locally: suppressions, ruff, and ty passed; unrelated local sandbox/process failures only in installer/codex harness tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents Gemini requests from sending conflicting reasoning controls. The main changes are:

- Adds Gemini-specific reasoning control selection.
- Removes `thinking_config` when named effort or disabled reasoning is used.
- Adds tests for named-effort and token-budget requests.
- Bumps the package version to `4.11.2` and refreshes `uv.lock`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The package version and lockfile now match. The previously missing release metadata is fully updated. No blocking issues were found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex compared the previous head revision af12e7b with the current head ce7f1ab and confirmed that the prior regression tests failed two items: named effort retained extra\_body/thinking config and budget mode omitting thinking\_budget: 2048.
- T-Rex verified that ce7f1ab passes all 43 focused Gemini/Vertex tests, including test\_build\_request\_body\_named\_effort\_omits\_thinking\_config, test\_build\_request\_body\_budget\_uses\_thinking\_config\_only, test\_build\_request\_body\_reasoning\_off\_sets\_reasoning\_none, and test\_build\_request\_body\_basic.
- T-Rex reviewed the static proof and confirmed that 5 changed files were already formatted and Ruff and Ty reported all checks passed.

<a href="https://app.greptile.com/trex/runs/15051927/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/gemini/client.py | Wires Gemini requests to the new Gemini-specific reasoning encoder. |
| src/free_claude_code/providers/google_openai/provider.py | Adds exclusive selection between named reasoning effort and Gemini thinking configuration. |
| src/free_claude_code/providers/google_openai/quirks.py | Avoids injecting thought settings for named effort and cleans up conflicting thinking configuration. |
| tests/providers/test_gemini.py | Covers named-effort and token-budget request encoding. |
| pyproject.toml | Bumps the package patch version to 4.11.2. |
| uv.lock | Synchronizes the locked package metadata with version 4.11.2. |

<sub>Reviews (2): Last reviewed commit: ["Bump patch version for Gemini reasoning ..."](https://github.com/alishahryar1/free-claude-code/commit/ce7f1ab77049faf1e5abcb237e032740c1f72240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45559299)</sub>

<!-- /greptile_comment -->