### PR TITLE
Keep FCC-local traffic off outbound proxies

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -938,6 +938,14 @@ otherwise the Messages handler rejects them before provider execution.
 
 ## CLI Launchers And Managed Claude
 
+[cli/local_http.py](src/free_claude_code/cli/local_http.py) owns the direct
+agent-to-FCC connection boundary. Launcher health checks and local model-catalog
+requests never inherit environment or operating-system forward proxies. Every
+spawned agent environment preserves the user's outbound proxy configuration but
+adds the configured FCC host and standard loopback names to both `NO_PROXY` and
+`no_proxy`. Provider-specific upstream proxies remain provider-owned and do not
+participate in this local boundary.
+
 [cli/proxy_auth.py](src/free_claude_code/cli/proxy_auth.py) owns the neutral
 proxy-auth token policy shared by client launchers. A blank configured token
 becomes the local-only `fcc-no-auth` sentinel so clients cross their login gates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.11.2"
+version = "4.11.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping
 
+from free_claude_code.cli.local_http import with_local_proxy_bypass
 from free_claude_code.cli.proxy_auth import proxy_auth_token
 
 CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"
@@ -17,12 +18,15 @@ def build_claude_proxy_env(
     """Return the canonical environment for Claude Code proxy sessions."""
 
     # Claude's aggregate traffic flag also suppresses gateway model discovery.
-    env = {
-        key: value
-        for key, value in base_env.items()
-        if not key.startswith("ANTHROPIC_")
-        and key != "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"
-    }
+    env = with_local_proxy_bypass(
+        {
+            key: value
+            for key, value in base_env.items()
+            if not key.startswith("ANTHROPIC_")
+            and key != "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"
+        },
+        proxy_root_url=proxy_root_url,
+    )
     env["ANTHROPIC_BASE_URL"] = proxy_root_url
     env["ANTHROPIC_AUTH_TOKEN"] = proxy_auth_token(auth_token)
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"

--- a/src/free_claude_code/cli/launchers/codex.py
+++ b/src/free_claude_code/cli/launchers/codex.py
@@ -4,8 +4,12 @@ import json
 import os
 import sys
 from collections.abc import Mapping, Sequence
-from urllib.request import Request, urlopen
+from urllib.request import Request
 
+from free_claude_code.cli.local_http import (
+    open_local_request,
+    with_local_proxy_bypass,
+)
 from free_claude_code.cli.proxy_auth import proxy_auth_token
 from free_claude_code.config.paths import codex_model_catalog_path
 from free_claude_code.config.server_urls import local_proxy_root_url
@@ -71,6 +75,7 @@ def launch(argv: Sequence[str] | None = None) -> None:
             catalog_config_args=catalog_args,
         ),
         env=build_codex_launcher_env(
+            proxy_root_url=proxy_root_url,
             auth_token=settings.anthropic_auth_token,
             base_env=os.environ,
         ),
@@ -109,16 +114,20 @@ def build_codex_launcher_command(
 
 def build_codex_launcher_env(
     *,
+    proxy_root_url: str,
     auth_token: str,
     base_env: Mapping[str, str],
 ) -> dict[str, str]:
     """Return a Codex environment that targets the local proxy provider."""
 
-    env = {
-        key: value
-        for key, value in base_env.items()
-        if key not in _STRIPPED_CODEX_ENV_KEYS and not key.startswith("OPENAI_")
-    }
+    env = with_local_proxy_bypass(
+        {
+            key: value
+            for key, value in base_env.items()
+            if key not in _STRIPPED_CODEX_ENV_KEYS and not key.startswith("OPENAI_")
+        },
+        proxy_root_url=proxy_root_url,
+    )
     env[_CODEX_AUTH_ENV_KEY] = proxy_auth_token(auth_token)
     return env
 
@@ -165,7 +174,9 @@ def fetch_proxy_models_response(
         headers["Authorization"] = f"Bearer {token}"
 
     request = Request(url, headers=headers, method="GET")
-    with urlopen(request, timeout=PROXY_PREFLIGHT_TIMEOUT_SECONDS) as response:
+    with open_local_request(
+        request, timeout=PROXY_PREFLIGHT_TIMEOUT_SECONDS
+    ) as response:
         payload = json.loads(response.read().decode("utf-8"))
 
     if not isinstance(payload, dict):

--- a/src/free_claude_code/cli/launchers/common.py
+++ b/src/free_claude_code/cli/launchers/common.py
@@ -5,8 +5,9 @@ import subprocess
 import sys
 from collections.abc import Mapping
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import Request
 
+from free_claude_code.cli.local_http import open_local_request
 from free_claude_code.cli.process_registry import (
     kill_pid_tree_best_effort,
     register_pid,
@@ -23,7 +24,9 @@ def preflight_proxy(proxy_root_url: str) -> str | None:
     url = f"{proxy_root_url.rstrip('/')}{PROXY_PREFLIGHT_PATH}"
     request = Request(url, method="GET")
     try:
-        with urlopen(request, timeout=PROXY_PREFLIGHT_TIMEOUT_SECONDS) as response:
+        with open_local_request(
+            request, timeout=PROXY_PREFLIGHT_TIMEOUT_SECONDS
+        ) as response:
             status_code = response.getcode()
     except HTTPError as exc:
         return f"returned HTTP {exc.code}"

--- a/src/free_claude_code/cli/launchers/pi.py
+++ b/src/free_claude_code/cli/launchers/pi.py
@@ -6,6 +6,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+from free_claude_code.cli.local_http import with_local_proxy_bypass
 from free_claude_code.cli.proxy_auth import proxy_auth_token
 from free_claude_code.config.server_urls import local_proxy_root_url
 from free_claude_code.config.settings import get_settings
@@ -114,9 +115,14 @@ def build_pi_launcher_env(
 ) -> dict[str, str]:
     """Return a Pi environment containing only FCC-owned proxy variables."""
 
-    env = {
-        key: value for key, value in base_env.items() if not key.startswith("FCC_PI_")
-    }
+    env = with_local_proxy_bypass(
+        {
+            key: value
+            for key, value in base_env.items()
+            if not key.startswith("FCC_PI_")
+        },
+        proxy_root_url=proxy_root_url,
+    )
     env[_BASE_URL_ENV] = proxy_root_url.rstrip("/")
     env[_API_KEY_ENV] = proxy_auth_token(auth_token)
     return env

--- a/src/free_claude_code/cli/local_http.py
+++ b/src/free_claude_code/cli/local_http.py
@@ -1,0 +1,51 @@
+"""Direct HTTP and child-environment policy for FCC-local traffic."""
+
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit
+from urllib.request import ProxyHandler, Request, build_opener
+
+_DIRECT_OPENER = build_opener(ProxyHandler({}))
+_LOOPBACK_BYPASS_HOSTS = ("127.0.0.1", "localhost", "::1")
+_NO_PROXY_KEYS = ("NO_PROXY", "no_proxy")
+
+
+def open_local_request(request: Request, *, timeout: float) -> Any:
+    """Open an FCC-local request without consulting machine proxy settings."""
+
+    return _DIRECT_OPENER.open(request, timeout=timeout)
+
+
+def with_local_proxy_bypass(
+    base_env: Mapping[str, str],
+    *,
+    proxy_root_url: str,
+) -> dict[str, str]:
+    """Copy an environment and keep its FCC-local destination off proxies."""
+
+    host = urlsplit(proxy_root_url).hostname
+    if host is None:
+        raise ValueError("Local proxy root URL must include a host.")
+
+    env = dict(base_env)
+    entries: list[str] = []
+    seen: set[str] = set()
+    for key in _NO_PROXY_KEYS:
+        for raw_entry in base_env.get(key, "").split(","):
+            _append_unique(entries, seen, raw_entry)
+    for local_host in (*_LOOPBACK_BYPASS_HOSTS, host):
+        _append_unique(entries, seen, local_host)
+
+    value = ",".join(entries)
+    for key in _NO_PROXY_KEYS:
+        env[key] = value
+    return env
+
+
+def _append_unique(entries: list[str], seen: set[str], raw_entry: str) -> None:
+    entry = raw_entry.strip()
+    normalized = entry.casefold()
+    if not entry or normalized in seen:
+        return
+    entries.append(entry)
+    seen.add(normalized)

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -503,6 +503,8 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert env["DISABLE_FEEDBACK_COMMAND"] == "1"
     assert env["DISABLE_ERROR_REPORTING"] == "1"
     assert env["DISABLE_TELEMETRY"] == "1"
+    assert env["NO_PROXY"] == "127.0.0.1,localhost,::1"
+    assert env["no_proxy"] == env["NO_PROXY"]
     assert "ANTHROPIC_API_URL" not in env
     assert "ANTHROPIC_API_KEY" not in env
     assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in env
@@ -567,6 +569,8 @@ def test_launch_claude_passes_args_and_child_env(
     assert child_env["DISABLE_FEEDBACK_COMMAND"] == "1"
     assert child_env["DISABLE_ERROR_REPORTING"] == "1"
     assert child_env["DISABLE_TELEMETRY"] == "1"
+    assert child_env["NO_PROXY"] == "127.0.0.1,localhost,::1"
+    assert child_env["no_proxy"] == child_env["NO_PROXY"]
     assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in child_env
     assert child_env["KEEP_ME"] == "yes"
     register_pid.assert_called_once_with(12345)
@@ -627,7 +631,10 @@ def test_launch_codex_passes_responses_config_and_child_env(
             "free_claude_code.cli.launchers.codex.codex_model_catalog_path",
             return_value=catalog_path,
         ),
-        patch("free_claude_code.cli.launchers.codex.urlopen", side_effect=fake_urlopen),
+        patch(
+            "free_claude_code.cli.launchers.codex.open_local_request",
+            side_effect=fake_urlopen,
+        ),
         patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
         patch("free_claude_code.cli.launchers.common.register_pid") as register_pid,
         patch("free_claude_code.cli.launchers.common.unregister_pid") as unregister_pid,
@@ -659,6 +666,8 @@ def test_launch_codex_passes_responses_config_and_child_env(
     child_env = popen.call_args.kwargs["env"]
     assert child_env["FCC_CODEX_API_KEY"] == "proxy-token"
     assert child_env["CODEX_HOME"] == "keep-home"
+    assert child_env["NO_PROXY"] == "127.0.0.1,localhost,::1"
+    assert child_env["no_proxy"] == child_env["NO_PROXY"]
     assert "CODEX_INTERNAL_ORIGINATOR_OVERRIDE" not in child_env
     assert "CODEX_PERMISSION_PROFILE" not in child_env
     assert "CODEX_SHELL" not in child_env
@@ -693,7 +702,8 @@ def test_launch_codex_catalog_failure_warns_and_continues(
             return_value=tmp_path / "codex-model-catalog.json",
         ),
         patch(
-            "free_claude_code.cli.launchers.codex.urlopen", side_effect=URLError("boom")
+            "free_claude_code.cli.launchers.codex.open_local_request",
+            side_effect=URLError("boom"),
         ),
         patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
         patch("free_claude_code.cli.launchers.common.register_pid"),
@@ -749,6 +759,8 @@ def test_pi_launcher_builds_scoped_session_command_and_proxy_env(
     assert env == {
         "PATH": "keep",
         "ANTHROPIC_API_KEY": "native-pi-credential",
+        "NO_PROXY": "127.0.0.1,localhost,::1",
+        "no_proxy": "127.0.0.1,localhost,::1",
         "FCC_PI_BASE_URL": "http://127.0.0.1:9191",
         "FCC_PI_API_KEY": "proxy-token",
     }
@@ -816,6 +828,8 @@ def test_launch_pi_registers_bundled_extension_for_sessions(
     child_env = popen.call_args.kwargs["env"]
     assert child_env["FCC_PI_BASE_URL"] == "http://127.0.0.1:9191"
     assert child_env["FCC_PI_API_KEY"] == "proxy-token"
+    assert child_env["NO_PROXY"] == "127.0.0.1,localhost,::1"
+    assert child_env["no_proxy"] == child_env["NO_PROXY"]
     assert child_env["KEEP_ME"] == "yes"
 
 

--- a/tests/cli/test_local_http.py
+++ b/tests/cli/test_local_http.py
@@ -1,0 +1,84 @@
+"""Local FCC transport must never escape through an outbound proxy."""
+
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from free_claude_code.cli.launchers.common import preflight_proxy
+from free_claude_code.cli.local_http import with_local_proxy_bypass
+
+
+@contextmanager
+def _status_server(status_code: int) -> Iterator[tuple[str, list[str]]]:
+    hits: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            hits.append(self.path)
+            self.send_response(status_code)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", hits
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def test_proxy_preflight_connects_directly_when_http_proxy_is_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _status_server(502) as (forward_proxy_url, forward_proxy_hits):
+        monkeypatch.setenv("HTTP_PROXY", forward_proxy_url)
+        monkeypatch.setenv("http_proxy", forward_proxy_url)
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        with _status_server(200) as (fcc_url, fcc_hits):
+            assert preflight_proxy(fcc_url) is None
+
+    assert fcc_hits == ["/health"]
+    assert forward_proxy_hits == []
+
+
+def test_child_proxy_bypass_preserves_existing_proxy_policy() -> None:
+    base_env = {
+        "HTTP_PROXY": "http://proxy.example:3128",
+        "NO_PROXY": "example.com, localhost",
+        "no_proxy": "10.0.0.0/8,EXAMPLE.COM",
+        "KEEP_ME": "yes",
+    }
+
+    env = with_local_proxy_bypass(
+        base_env,
+        proxy_root_url="http://fcc.internal:8082",
+    )
+
+    assert env["HTTP_PROXY"] == "http://proxy.example:3128"
+    assert env["KEEP_ME"] == "yes"
+    assert env["NO_PROXY"] == (
+        "example.com,localhost,10.0.0.0/8,127.0.0.1,::1,fcc.internal"
+    )
+    assert env["no_proxy"] == env["NO_PROXY"]
+    assert base_env["NO_PROXY"] == "example.com, localhost"
+    assert base_env["no_proxy"] == "10.0.0.0/8,EXAMPLE.COM"
+
+
+def test_child_proxy_bypass_uses_all_loopback_spellings_without_duplicates() -> None:
+    env = with_local_proxy_bypass(
+        {"NO_PROXY": "127.0.0.1"},
+        proxy_root_url="http://127.0.0.1:8082",
+    )
+
+    assert env["NO_PROXY"] == "127.0.0.1,localhost,::1"
+    assert env["no_proxy"] == env["NO_PROXY"]

--- a/tests/cli/test_managed_claude.py
+++ b/tests/cli/test_managed_claude.py
@@ -72,6 +72,8 @@ def test_managed_claude_builds_new_task_command_and_env() -> None:
     assert invocation.env["DISABLE_FEEDBACK_COMMAND"] == "1"
     assert invocation.env["DISABLE_ERROR_REPORTING"] == "1"
     assert invocation.env["DISABLE_TELEMETRY"] == "1"
+    assert invocation.env["NO_PROXY"] == "127.0.0.1,localhost,::1"
+    assert invocation.env["no_proxy"] == invocation.env["NO_PROXY"]
     assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in invocation.env
     assert "ANTHROPIC_API_URL" not in invocation.env
     assert "ANTHROPIC_API_KEY" not in invocation.env

--- a/tests/contracts/test_import_boundaries.py
+++ b/tests/contracts/test_import_boundaries.py
@@ -226,6 +226,31 @@ def test_google_reasoning_wire_fields_have_one_owner() -> None:
     assert sorted(offenders) == []
 
 
+def test_cli_local_http_transport_has_one_owner() -> None:
+    cli_root = _PACKAGE_ROOT / "cli"
+    owner = cli_root / "local_http.py"
+    owned_urllib_names = {"ProxyHandler", "build_opener", "urlopen"}
+    owned_environment_keys = {"NO_PROXY", "no_proxy"}
+    offenders: list[str] = []
+
+    for path in cli_root.rglob("*.py"):
+        if path == owner:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        relative_path = path.relative_to(_REPO_ROOT).as_posix()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "urllib.request":
+                offenders.extend(
+                    f"{relative_path}:{node.lineno}: urllib.request.{alias.name}"
+                    for alias in node.names
+                    if alias.name in owned_urllib_names
+                )
+            if isinstance(node, ast.Constant) and node.value in owned_environment_keys:
+                offenders.append(f"{relative_path}:{node.lineno}: {node.value}")
+
+    assert sorted(offenders) == []
+
+
 def test_provider_backchannel_detector_reports_untyped_private_access(
     tmp_path: Path,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.11.2"
+version = "4.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC-local health and model-catalog requests inherited machine proxy settings, so an outbound proxy could return HTTP 502 even while `fcc-server` was healthy. Spawned agents inherited the same missing loopback bypass. Fixes #1199.

## Changes

| Before | After |
| --- | --- |
| Launcher probes used the process-wide urllib proxy policy. | FCC-local probes use one proxy-disabled transport owner. |
| Codex catalog loading could leave through an outbound proxy. | Codex catalog loading uses the same direct local transport. |
| Claude, Codex, Pi, and managed messaging inherited incomplete bypass lists. | Spawned clients preserve outbound proxies while merging FCC and loopback hosts into `NO_PROXY` and `no_proxy`. |
| Local and upstream proxy responsibilities overlapped. | CLI-local transport and provider-specific upstream proxies have explicit separate owners. |
| Tests mocked launcher reachability without exercising proxy interception. | A real fake-proxy regression proves loopback traffic never reaches the proxy, and an ownership contract prevents raw local transports from returning. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps FCC-local traffic separate from configured outbound proxies. The main changes are:

- Adds one direct HTTP transport for FCC health and model-catalog requests.
- Adds FCC and loopback hosts to spawned clients' proxy-bypass environments.
- Updates Claude, Codex, and Pi launcher integration.
- Adds proxy-interception and transport-ownership tests.
- Documents the boundary and bumps the package version.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. Updated callers supply the new Codex environment argument. The direct opener changes proxy handling while retaining urllib's standard request handlers. Tests cover real proxy interception and preservation of existing bypass policy.

No changed files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex validated the contract by comparing preflight and forward-proxy state before and after HEAD, noting the preflight result moved from HTTP 502 and the forward-proxy hits to a clean health-check state.
- T-Rex confirmed all three tests in tests/cli/test\_local\_http.py passed.

<a href="https://app.greptile.com/trex/runs/15066178/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/local_http.py | Adds the shared direct opener and proxy-bypass environment policy. |
| src/free_claude_code/cli/launchers/common.py | Routes FCC health checks through the direct local transport. |
| src/free_claude_code/cli/launchers/codex.py | Routes catalog requests directly and adds local bypass entries to the Codex environment. |
| src/free_claude_code/cli/claude_env.py | Adds FCC and loopback proxy bypasses to Claude environments. |
| src/free_claude_code/cli/launchers/pi.py | Adds FCC and loopback proxy bypasses to Pi environments. |
| tests/cli/test_local_http.py | Tests direct local access, proxy interception, environment merging, and deduplication. |
| tests/contracts/test_import_boundaries.py | Enforces one owner for direct local transports and proxy-bypass variables. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
L[Launcher] --> R[FCC health or catalog request]
R --> D[Direct local opener]
D --> F[FCC server]
L --> E[Build child environment]
E --> N[Merge FCC and loopback hosts into NO_PROXY]
N --> C[Claude, Codex, or Pi]
C -->|FCC-local traffic| F
C -->|Other outbound traffic| P[Configured outbound proxy]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
L[Launcher] --> R[FCC health or catalog request]
R --> D[Direct local opener]
D --> F[FCC server]
L --> E[Build child environment]
E --> N[Merge FCC and loopback hosts into NO_PROXY]
N --> C[Claude, Codex, or Pi]
C -->|FCC-local traffic| F
C -->|Other outbound traffic| P[Configured outbound proxy]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Keep FCC-local traffic off outbound prox..."](https://github.com/alishahryar1/free-claude-code/commit/072cc4b7474c1b33bfc368d148da5c1aa24914b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45589926)</sub>

<!-- /greptile_comment -->