### PR TITLE
Improve issue version triage and remove title prefixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report something that is not working in Free Claude Code.
-title: "[Bug]: "
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,8 +8,8 @@ body:
     id: fcc-version
     attributes:
       label: FCC version
-      description: Run `fcc-server --version` and enter only the version number, such as `4.6.1`. If FCC did not install, enter `None`.
-      placeholder: "4.6.1 or None"
+      description: Run `fcc-server --version` and include one version in `number.number.number` format. If FCC did not install, enter `None`.
+      placeholder: "The version is 1.22.333, or None"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: Suggest an improvement to Free Claude Code.
-title: "[Feature]: "
 labels:
   - enhancement
 body:

--- a/.github/workflows/validate-bug-report-version.yml
+++ b/.github/workflows/validate-bug-report-version.yml
@@ -6,9 +6,10 @@ on:
 
 concurrency:
   group: bug-report-version-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -21,60 +22,152 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const issue = context.payload.issue;
-            const fieldPattern = "^### FCC version\\r?\\n+\\s*([^\\r\\n]+)";
-            const versionPattern = "^(?:(?:free-claude-code )?\\d+\\.\\d+\\.\\d+|None)$";
-            const match = (issue.body || "").match(new RegExp(fieldPattern, "m"));
-            const version = match?.[1]?.trim() || "";
-            const valid = new RegExp(versionPattern).test(version);
-            const labelName = "needs-fcc-version";
-            const marker = "<!-- fcc-version-validator -->";
-            const labels = new Set(issue.labels.map((label) => label.name));
             const repo = context.repo;
-            const issue_number = issue.number;
-
-            if (valid) {
-              if (labels.has(labelName)) {
-                await github.rest.issues.removeLabel({
-                  ...repo,
-                  issue_number,
-                  name: labelName,
-                });
-              }
-              return;
-            }
-
-            if (!labels.has(labelName)) {
-              try {
-                await github.rest.issues.getLabel({ ...repo, name: labelName });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-                try {
-                  await github.rest.issues.createLabel({
-                    ...repo,
-                    name: labelName,
-                    color: "d4c5f9",
-                    description: "FCC version must be number.number.number or None",
-                  });
-                } catch (createError) {
-                  if (createError.status !== 422) throw createError;
-                }
-              }
-              await github.rest.issues.addLabels({
-                ...repo,
-                issue_number,
-                labels: [labelName],
-              });
-            }
+            const issue_number = context.payload.issue.number;
+            const { data: issue } = await github.rest.issues.get({
+              ...repo,
+              issue_number,
+            });
+            const fieldPattern = "^### FCC version\\r?\\n+\\s*([^\\r\\n]+)";
+            const versionPattern = "(?:^|[^0-9A-Za-z_.])v?([0-9]+\\.[0-9]+\\.[0-9]+)(?![0-9A-Za-z_+-]|\\.[0-9A-Za-z_])";
+            const projectVersionPattern = "^\\s*version\\s*=\\s*\"([0-9]+\\.[0-9]+\\.[0-9]+)\"\\s*$";
+            const match = (issue.body || "").match(new RegExp(fieldPattern, "m"));
+            const fieldValue = match?.[1]?.trim() || "";
+            const versionMatches = [...fieldValue.matchAll(new RegExp(versionPattern, "g"))];
+            const reportedVersion = versionMatches.length === 1 ? versionMatches[0][1] : undefined;
+            const valid = reportedVersion !== undefined || fieldValue === "None";
+            const labelName = "needs-fcc-version";
+            const invalidMarker = "<!-- fcc-version-validator -->";
+            const outdatedMarker = "<!-- fcc-version-outdated -->";
+            const labels = new Set(issue.labels.map((label) => label.name));
 
             const comments = await github.paginate(
               github.rest.issues.listComments,
               { ...repo, issue_number, per_page: 100 },
             );
-            if (!comments.some((comment) => comment.body?.includes(marker))) {
+            const managedComment = (marker) => comments.find(
+              (comment) => comment.user?.login === "github-actions[bot]"
+                && comment.body?.includes(marker),
+            );
+            const outdatedComment = managedComment(outdatedMarker);
+
+            const deleteOutdatedComment = async () => {
+              if (outdatedComment === undefined) return;
+              await github.rest.issues.deleteComment({
+                ...repo,
+                comment_id: outdatedComment.id,
+              });
+            };
+
+            const isOlderVersion = (reported, latest) => {
+              const reportedParts = reported.split(".").map((part) => BigInt(part));
+              const latestParts = latest.split(".").map((part) => BigInt(part));
+              for (let index = 0; index < reportedParts.length; index += 1) {
+                if (reportedParts[index] < latestParts[index]) return true;
+                if (reportedParts[index] > latestParts[index]) return false;
+              }
+              return false;
+            };
+
+            const projectVersionFromToml = (pyproject) => {
+              let inProjectSection = false;
+              for (const line of pyproject.split(/\r?\n/)) {
+                const stripped = line.trim();
+                if (stripped === "[project]") {
+                  inProjectSection = true;
+                  continue;
+                }
+                if (inProjectSection && stripped.startsWith("[")) return undefined;
+                if (!inProjectSection) continue;
+                const projectVersion = line.match(new RegExp(projectVersionPattern));
+                if (projectVersion !== null) return projectVersion[1];
+              }
+              return undefined;
+            };
+
+            if (!valid) {
+              await deleteOutdatedComment();
+              if (!labels.has(labelName)) {
+                try {
+                  await github.rest.issues.getLabel({ ...repo, name: labelName });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                  try {
+                    await github.rest.issues.createLabel({
+                      ...repo,
+                      name: labelName,
+                      color: "d4c5f9",
+                      description: "FCC version must contain number.number.number or be None",
+                    });
+                  } catch (createError) {
+                    if (createError.status !== 422) throw createError;
+                  }
+                }
+                await github.rest.issues.addLabels({
+                  ...repo,
+                  issue_number,
+                  labels: [labelName],
+                });
+              }
+              if (managedComment(invalidMarker) === undefined) {
+                await github.rest.issues.createComment({
+                  ...repo,
+                  issue_number,
+                  body: `${invalidMarker}\nPlease edit **FCC version** so it contains one \`number.number.number\` value, such as \`1.22.333\`, or is exactly \`None\`. Run \`fcc-server --version\` to find the installed version.`,
+                });
+              }
+              return;
+            }
+
+            if (labels.has(labelName)) {
+              await github.rest.issues.removeLabel({
+                ...repo,
+                issue_number,
+                name: labelName,
+              });
+            }
+
+            if (reportedVersion === undefined) {
+              await deleteOutdatedComment();
+              return;
+            }
+
+            const defaultBranch = context.payload.repository.default_branch;
+            const { data: versionFile } = await github.rest.repos.getContent({
+              ...repo,
+              path: "pyproject.toml",
+              ref: defaultBranch,
+            });
+            if (
+              Array.isArray(versionFile)
+              || versionFile.type !== "file"
+              || versionFile.encoding !== "base64"
+              || !versionFile.content
+            ) {
+              throw new Error(`Could not read pyproject.toml from ${defaultBranch}`);
+            }
+            const pyproject = Buffer.from(versionFile.content, "base64").toString("utf8");
+            const latestVersion = projectVersionFromToml(pyproject);
+            if (latestVersion === undefined) {
+              throw new Error(`Could not read the project version from ${defaultBranch}`);
+            }
+
+            if (!isOlderVersion(reportedVersion, latestVersion)) {
+              await deleteOutdatedComment();
+              return;
+            }
+
+            const body = `${outdatedMarker}\nThis report uses FCC \`${reportedVersion}\`, while the current version on \`${defaultBranch}\` is \`${latestVersion}\`. Please [update FCC](${context.payload.repository.html_url}#install), restart FCC, and check whether the issue still occurs. The update may already contain the fix.`;
+            if (outdatedComment === undefined) {
               await github.rest.issues.createComment({
                 ...repo,
                 issue_number,
-                body: `${marker}\nPlease edit **FCC version** to contain only an exact \`number.number.number\` value, such as \`4.6.1\`, or \`None\`. Run \`fcc-server --version\` to find the installed version.`,
+                body,
+              });
+            } else if (outdatedComment.body !== body) {
+              await github.rest.issues.updateComment({
+                ...repo,
+                comment_id: outdatedComment.id,
+                body,
               });
             }

--- a/.github/workflows/validate-bug-report-version.yml
+++ b/.github/workflows/validate-bug-report-version.yml
@@ -30,7 +30,7 @@ jobs:
             });
             const fieldPattern = "^### FCC version\\r?\\n+\\s*([^\\r\\n]+)";
             const versionPattern = "(?:^|[^0-9A-Za-z_.])v?([0-9]+\\.[0-9]+\\.[0-9]+)(?![0-9A-Za-z_+-]|\\.[0-9A-Za-z_])";
-            const projectVersionPattern = "^\\s*version\\s*=\\s*\"([0-9]+\\.[0-9]+\\.[0-9]+)\"\\s*$";
+            const projectVersionPattern = "^\\s*version\\s*=\\s*([\"'])([0-9]+\\.[0-9]+\\.[0-9]+)\\1\\s*(?:#.*)?$";
             const match = (issue.body || "").match(new RegExp(fieldPattern, "m"));
             const fieldValue = match?.[1]?.trim() || "";
             const versionMatches = [...fieldValue.matchAll(new RegExp(versionPattern, "g"))];
@@ -49,13 +49,14 @@ jobs:
               (comment) => comment.user?.login === "github-actions[bot]"
                 && comment.body?.includes(marker),
             );
+            const invalidComment = managedComment(invalidMarker);
             const outdatedComment = managedComment(outdatedMarker);
 
-            const deleteOutdatedComment = async () => {
-              if (outdatedComment === undefined) return;
+            const deleteManagedComment = async (comment) => {
+              if (comment === undefined) return;
               await github.rest.issues.deleteComment({
                 ...repo,
-                comment_id: outdatedComment.id,
+                comment_id: comment.id,
               });
             };
 
@@ -80,13 +81,13 @@ jobs:
                 if (inProjectSection && stripped.startsWith("[")) return undefined;
                 if (!inProjectSection) continue;
                 const projectVersion = line.match(new RegExp(projectVersionPattern));
-                if (projectVersion !== null) return projectVersion[1];
+                if (projectVersion !== null) return projectVersion[2];
               }
               return undefined;
             };
 
             if (!valid) {
-              await deleteOutdatedComment();
+              await deleteManagedComment(outdatedComment);
               if (!labels.has(labelName)) {
                 try {
                   await github.rest.issues.getLabel({ ...repo, name: labelName });
@@ -109,7 +110,7 @@ jobs:
                   labels: [labelName],
                 });
               }
-              if (managedComment(invalidMarker) === undefined) {
+              if (invalidComment === undefined) {
                 await github.rest.issues.createComment({
                   ...repo,
                   issue_number,
@@ -126,9 +127,10 @@ jobs:
                 name: labelName,
               });
             }
+            await deleteManagedComment(invalidComment);
 
             if (reportedVersion === undefined) {
-              await deleteOutdatedComment();
+              await deleteManagedComment(outdatedComment);
               return;
             }
 
@@ -153,7 +155,7 @@ jobs:
             }
 
             if (!isOlderVersion(reportedVersion, latestVersion)) {
-              await deleteOutdatedComment();
+              await deleteManagedComment(outdatedComment);
               return;
             }
 

--- a/tests/contracts/test_issue_form_version_validation.py
+++ b/tests/contracts/test_issue_form_version_validation.py
@@ -172,7 +172,10 @@ def test_workflow_reads_and_compares_the_default_branch_version() -> None:
     project_pattern = _workflow_pattern("projectVersionPattern")
     function = _javascript_function("projectVersionFromToml")
     scoped_project = (
-        '[tool.before]\nversion = "99.0.0"\n\n[project]\nversion = "1.2.3"\n'
+        "[tool.before]\nversion = \"99.0.0\"\n\n[project]\nversion = '1.2.3'\n"
+    )
+    commented_project = (
+        '[project]\nname = "demo"\nversion = "2.3.4" # current release\n'
     )
     missing_project_version = (
         '[project]\nname = "demo"\n\n[[tool.items]]\nversion = "99.0.0"\n'
@@ -183,11 +186,12 @@ def test_workflow_reads_and_compares_the_default_branch_version() -> None:
         "process.stdout.write(JSON.stringify(["
         f"projectVersionFromToml({json.dumps(pyproject)}),"
         f"projectVersionFromToml({json.dumps(scoped_project)}),"
+        f"projectVersionFromToml({json.dumps(commented_project)}),"
         f"projectVersionFromToml({json.dumps(missing_project_version)})"
         "]));"
     )
 
-    assert _run_javascript(script) == [expected, "1.2.3", None]
+    assert _run_javascript(script) == [expected, "1.2.3", "2.3.4", None]
     assert "contents: read" in workflow
     assert "github.rest.repos.getContent" in workflow
     assert 'path: "pyproject.toml"' in workflow
@@ -217,12 +221,18 @@ const github = {
       },
       getLabel: async (args) => record("getLabel", args),
       createLabel: async (args) => record("createLabel", args),
-      addLabels: async (args) => record("addLabels", args),
-      removeLabel: async (args) => record("removeLabel", args),
+      addLabels: async (args) => {
+        record("addLabels", args);
+        liveIssue.labels.push(...args.labels.map((name) => ({ name })));
+      },
+      removeLabel: async (args) => {
+        record("removeLabel", args);
+        liveIssue.labels = liveIssue.labels.filter((label) => label.name !== args.name);
+      },
       createComment: async (args) => {
         record("createComment", args);
         comments.push({
-          id: 101,
+          id: 100 + calls.filter((call) => call.name === "createComment").length,
           user: { login: "github-actions[bot]" },
           body: args.body,
         });
@@ -240,7 +250,7 @@ const github = {
     repos: {
       getContent: async (args) => {
         record("getContent", args);
-        const content = `[tool.before]\nversion = "99.0.0"\n\n[project]\nversion = "${latestVersion}"\n`;
+        const content = `[tool.before]\nversion = "99.0.0"\n\n[project]\nversion = '${latestVersion}' # current release\n`;
         return {
           data: {
             type: "file",
@@ -264,6 +274,8 @@ const context = {
 };
 const bodyFor = (value) => `### FCC version\n\n${value}\n\n### CLI\n\nClaude Code`;
 
+liveIssue.body = bodyFor("latest");
+await run(github, context);
 liveIssue.body = bodyFor("The version is 17.23.454");
 await run(github, context);
 await run(github, context);
@@ -291,17 +303,22 @@ process.stdout.write(JSON.stringify({ calls, comments }));
     names = [call["name"] for call in calls]
     content_reads = [call for call in calls if call["name"] == "getContent"]
 
-    assert names.count("createComment") == 1
+    assert names.count("createComment") == 2
     assert names.count("updateComment") == 1
-    assert names.count("deleteComment") == 2
+    assert names.count("deleteComment") == 3
     assert names.count("getContent") == 4
-    assert names.count("getIssue") == 5
-    assert names.count("removeLabel") == 1
-    assert not {"getLabel", "createLabel", "addLabels"} & set(names)
+    assert names.count("getIssue") == 6
+    assert names.count("getLabel") == 1
+    assert names.count("addLabels") == 1
+    assert names.count("removeLabel") == 2
+    assert "createLabel" not in names
     assert all(call["args"]["path"] == "pyproject.toml" for call in content_reads)
     assert all(call["args"]["ref"] == "main" for call in content_reads)
     assert "`17.23.454`" in next(
-        call["args"]["body"] for call in calls if call["name"] == "createComment"
+        call["args"]["body"]
+        for call in calls
+        if call["name"] == "createComment"
+        and "fcc-version-outdated" in call["args"]["body"]
     )
     assert "`17.23.455`" in next(
         call["args"]["body"] for call in calls if call["name"] == "updateComment"

--- a/tests/contracts/test_issue_form_version_validation.py
+++ b/tests/contracts/test_issue_form_version_validation.py
@@ -1,6 +1,11 @@
 import json
 import re
+import shutil
+import subprocess
+import textwrap
+import tomllib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -10,36 +15,75 @@ WORKFLOW = Path(".github/workflows/validate-bug-report-version.yml")
 
 def _workflow_pattern(name: str) -> str:
     workflow = WORKFLOW.read_text(encoding="utf-8")
-    match = re.search(rf"const {name} = (\"[^\"]+\");", workflow)
+    match = re.search(rf'const {name} = ("(?:\\.|[^"\\])*");', workflow)
     assert match is not None
     return json.loads(match.group(1))
 
 
-def test_bug_form_requests_an_exact_version_or_none() -> None:
+def _reported_version(value: str) -> str | None:
+    matches = re.findall(_workflow_pattern("versionPattern"), value)
+    return matches[0] if len(matches) == 1 else None
+
+
+def _javascript_function(name: str) -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^            const {name} = .*?^            }};",
+        workflow,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert match is not None
+    return textwrap.dedent(match.group(0))
+
+
+def _workflow_script() -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    marker = "          script: |\n"
+    _, separator, script = workflow.partition(marker)
+    assert separator == marker
+    return textwrap.dedent(script)
+
+
+def _run_javascript(script: str) -> Any:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required to execute the GitHub workflow contract")
+    completed = subprocess.run(
+        [node, "--input-type=module", "--eval", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_bug_form_requests_a_contained_version_or_none() -> None:
     form = BUG_FORM.read_text(encoding="utf-8")
 
     assert "Run `fcc-server --version`" in form
-    assert "enter only the version number" in form
+    assert "include one version" in form
+    assert "`number.number.number` format" in form
     assert "enter `None`" in form
-    assert 'placeholder: "4.6.1 or None"' in form
+    assert 'placeholder: "The version is 1.22.333, or None"' in form
     assert "not installed" not in form
-    assert "free-claude-code" not in form
 
 
 @pytest.mark.parametrize(
-    "value",
+    ("value", "expected"),
     [
-        "0.0.0",
-        "4.6.1",
-        "123.45.678",
-        "free-claude-code 0.0.0",
-        "free-claude-code 4.6.1",
-        "free-claude-code 123.45.678",
-        "None",
+        ("0.0.0", "0.0.0"),
+        ("1.22.333", "1.22.333"),
+        ("The version is 1.22.333", "1.22.333"),
+        ("free-claude-code 4.11.4", "4.11.4"),
+        ("v123.45.678", "123.45.678"),
+        ("Version 4.6.1.", "4.6.1"),
     ],
 )
-def test_version_pattern_accepts_supported_values(value: str) -> None:
-    assert re.fullmatch(_workflow_pattern("versionPattern"), value)
+def test_version_pattern_extracts_a_contained_version(
+    value: str,
+    expected: str,
+) -> None:
+    assert _reported_version(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -49,17 +93,47 @@ def test_version_pattern_accepts_supported_values(value: str) -> None:
         "latest",
         "4.6",
         "4.6.1.2",
-        "v4.6.1",
+        ".4.6.1",
         "4.6.x",
         "none",
         "free-claude-code",
-        "free-claude-code v4.6.1",
         "free-claude-code 4.6",
-        "free-claude-code 4.6.1 extra",
+        "the version is 4.6.1.2",
+        "upgraded from 4.6.1 to 4.11.4",
+        "build4.6.1",
+        "4.6.1-beta",
+        "4.6.1+build",
+        "4.6.1.x",
     ],
 )
 def test_version_pattern_rejects_ambiguous_values(value: str) -> None:
-    assert re.fullmatch(_workflow_pattern("versionPattern"), value) is None
+    assert _reported_version(value) is None
+
+
+def test_none_remains_an_exact_escape_hatch() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'fieldValue === "None"' in workflow
+    assert _reported_version("None") is None
+    assert _reported_version("The version is None") is None
+
+
+def test_numeric_version_comparison_uses_all_three_components() -> None:
+    function = _javascript_function("isOlderVersion")
+    cases = [
+        ["4.9.99", "4.10.0"],
+        ["4.10.0", "4.10.0"],
+        ["4.10.1", "4.10.0"],
+        ["9007199254740993.0.0", "9007199254740994.0.0"],
+    ]
+    script = (
+        f"{function}\n"
+        f"const cases = {json.dumps(cases)};\n"
+        "process.stdout.write(JSON.stringify("
+        "cases.map(([reported, latest]) => isOlderVersion(reported, latest))));"
+    )
+
+    assert _run_javascript(script) == [True, False, False, True]
 
 
 def test_field_pattern_extracts_the_issue_form_value() -> None:
@@ -88,4 +162,154 @@ def test_workflow_owns_one_idempotent_triage_state() -> None:
     assert "github.rest.issues.createLabel" in workflow
     assert "github.rest.issues.addLabels" in workflow
     assert "github.rest.issues.removeLabel" in workflow
-    assert "comments.some" in workflow
+    assert "comments.find" in workflow
+
+
+def test_workflow_reads_and_compares_the_default_branch_version() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+    expected = tomllib.loads(pyproject)["project"]["version"]
+    project_pattern = _workflow_pattern("projectVersionPattern")
+    function = _javascript_function("projectVersionFromToml")
+    scoped_project = (
+        '[tool.before]\nversion = "99.0.0"\n\n[project]\nversion = "1.2.3"\n'
+    )
+    missing_project_version = (
+        '[project]\nname = "demo"\n\n[[tool.items]]\nversion = "99.0.0"\n'
+    )
+    script = (
+        f"const projectVersionPattern = {json.dumps(project_pattern)};\n"
+        f"{function}\n"
+        "process.stdout.write(JSON.stringify(["
+        f"projectVersionFromToml({json.dumps(pyproject)}),"
+        f"projectVersionFromToml({json.dumps(scoped_project)}),"
+        f"projectVersionFromToml({json.dumps(missing_project_version)})"
+        "]));"
+    )
+
+    assert _run_javascript(script) == [expected, "1.2.3", None]
+    assert "contents: read" in workflow
+    assert "github.rest.repos.getContent" in workflow
+    assert 'path: "pyproject.toml"' in workflow
+    assert "context.payload.repository.default_branch" in workflow
+    assert 'split(".").map((part) => BigInt(part))' in workflow
+    assert "isOlderVersion(reportedVersion, latestVersion)" in workflow
+
+
+def test_outdated_version_comment_is_reconciled_across_edits() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    latest = "17.23.456"
+    source = f"return (async () => {{\n{_workflow_script()}\n}})();"
+    harness = r"""
+const run = new Function("github", "context", __SOURCE__);
+const latestVersion = __LATEST__;
+const comments = [];
+const calls = [];
+const liveIssue = { number: 7, labels: [], body: "" };
+const record = (name, args) => calls.push({ name, args });
+const github = {
+  paginate: async () => comments,
+  rest: {
+    issues: {
+      get: async (args) => {
+        record("getIssue", args);
+        return { data: liveIssue };
+      },
+      getLabel: async (args) => record("getLabel", args),
+      createLabel: async (args) => record("createLabel", args),
+      addLabels: async (args) => record("addLabels", args),
+      removeLabel: async (args) => record("removeLabel", args),
+      createComment: async (args) => {
+        record("createComment", args);
+        comments.push({
+          id: 101,
+          user: { login: "github-actions[bot]" },
+          body: args.body,
+        });
+      },
+      updateComment: async (args) => {
+        record("updateComment", args);
+        comments.find((comment) => comment.id === args.comment_id).body = args.body;
+      },
+      deleteComment: async (args) => {
+        record("deleteComment", args);
+        const index = comments.findIndex((comment) => comment.id === args.comment_id);
+        if (index !== -1) comments.splice(index, 1);
+      },
+    },
+    repos: {
+      getContent: async (args) => {
+        record("getContent", args);
+        const content = `[tool.before]\nversion = "99.0.0"\n\n[project]\nversion = "${latestVersion}"\n`;
+        return {
+          data: {
+            type: "file",
+            encoding: "base64",
+            content: Buffer.from(content).toString("base64"),
+          },
+        };
+      },
+    },
+  },
+};
+const context = {
+  repo: { owner: "owner", repo: "repo" },
+  payload: {
+    issue: { number: 7, labels: [], body: "stale event snapshot" },
+    repository: {
+      default_branch: "main",
+      html_url: "https://github.com/owner/repo",
+    },
+  },
+};
+const bodyFor = (value) => `### FCC version\n\n${value}\n\n### CLI\n\nClaude Code`;
+
+liveIssue.body = bodyFor("The version is 17.23.454");
+await run(github, context);
+await run(github, context);
+liveIssue.body = bodyFor("free-claude-code 17.23.455");
+await run(github, context);
+liveIssue.body = bodyFor(latestVersion);
+await run(github, context);
+comments.push({
+  id: 102,
+  user: { login: "github-actions[bot]" },
+  body: "<!-- fcc-version-outdated -->\nstale",
+});
+liveIssue.labels = [{ name: "needs-fcc-version" }];
+liveIssue.body = bodyFor("None");
+await run(github, context);
+
+process.stdout.write(JSON.stringify({ calls, comments }));
+"""
+    result = _run_javascript(
+        harness.replace("__SOURCE__", json.dumps(source)).replace(
+            "__LATEST__", json.dumps(latest)
+        )
+    )
+    calls = result["calls"]
+    names = [call["name"] for call in calls]
+    content_reads = [call for call in calls if call["name"] == "getContent"]
+
+    assert names.count("createComment") == 1
+    assert names.count("updateComment") == 1
+    assert names.count("deleteComment") == 2
+    assert names.count("getContent") == 4
+    assert names.count("getIssue") == 5
+    assert names.count("removeLabel") == 1
+    assert not {"getLabel", "createLabel", "addLabels"} & set(names)
+    assert all(call["args"]["path"] == "pyproject.toml" for call in content_reads)
+    assert all(call["args"]["ref"] == "main" for call in content_reads)
+    assert "`17.23.454`" in next(
+        call["args"]["body"] for call in calls if call["name"] == "createComment"
+    )
+    assert "`17.23.455`" in next(
+        call["args"]["body"] for call in calls if call["name"] == "updateComment"
+    )
+    assert f"`{latest}`" in next(
+        call["args"]["body"] for call in calls if call["name"] == "updateComment"
+    )
+    assert result["comments"] == []
+    assert "cancel-in-progress: false" in workflow
+    assert "github.rest.issues.update({" not in workflow
+    assert 'state: "closed"' not in workflow

--- a/tests/contracts/test_issue_forms.py
+++ b/tests/contracts/test_issue_forms.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("filename", "label"),
+    [
+        ("bug-report.yml", "bug"),
+        ("feature-request.yml", "enhancement"),
+    ],
+)
+def test_issue_forms_classify_with_labels_not_title_prefixes(
+    filename: str,
+    label: str,
+) -> None:
+    form = Path(".github/ISSUE_TEMPLATE", filename).read_text(encoding="utf-8")
+
+    assert f"  - {label}" in form
+    assert not any(line.startswith("title:") for line in form.splitlines())


### PR DESCRIPTION
## Problem

Bug-report validation rejected useful prose even when the FCC version was unambiguous, and older installations received no update guidance. Issue forms also duplicated their existing labels with forced title prefixes.

## Changes

| Before | After |
| --- | --- |
| The FCC version field accepted only a bare version, copied command output, or `None`. | The field accepts exactly one standalone `number.number.number` value anywhere in the text, while preserving exact `None` and rejecting ambiguous input. |
| Valid versions were not compared with the currently installable code. | The workflow reads the live issue and project version from the default branch, then compares numeric components safely. |
| Older reports received no update guidance. | One bot-owned comment asks the reporter to update; edits update or remove that comment without labels or issue closure. |
| Bug and feature forms forced `[Bug]` and `[Feature]` title prefixes. | Existing `bug` and `enhancement` labels own classification without changing the reporter's title. |
| Contract coverage inspected only workflow source fragments. | Contract coverage executes the JavaScript lifecycle and protects label-only issue classification. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves issue classification and FCC version triage. The main changes are:

- Removes forced title prefixes from bug and feature forms.
- Accepts one unambiguous numeric FCC version within descriptive text.
- Compares reported versions with the default branch project version.
- Reconciles invalid-version and update-guidance comments after edits.
- Adds executable workflow lifecycle and issue-form contract tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Corrected version fields now remove stale invalid-version comments. Common valid TOML quote and comment formats are handled.

No blocking issues remain in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reviewed the pre-change contract-validation baseline for forms, which showed 12 failures and 18 passes under origin/main.
- I executed the post-change contract-validation test run with the environment set for the project and the pytest suite targeting the contract tests, and it completed with exit code 0 and 30 passes.

<a href="https://app.greptile.com/trex/runs/15163869/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validate-bug-report-version.yml | Adds live issue reconciliation, project-version parsing, numeric comparison, and managed invalid and outdated comments. |
| tests/contracts/test_issue_form_version_validation.py | Adds executable coverage for version extraction, TOML parsing, numeric comparison, and comment reconciliation. |
| .github/ISSUE_TEMPLATE/bug-report.yml | Removes the title prefix and allows one numeric version within descriptive text. |
| .github/ISSUE_TEMPLATE/feature-request.yml | Removes the title prefix while retaining enhancement classification. |
| tests/contracts/test_issue_forms.py | Checks that issue forms use labels instead of title prefixes. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Reconcile bug version triage state"](https://github.com/alishahryar1/free-claude-code/commit/8efe7aaf95bd2a96719b1d0811afb83b06c5d79c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45775911)</sub>

<!-- /greptile_comment -->