### PR TITLE
Structure startup instructions by platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,34 @@ Windows PowerShell:
 
 Re-run the same command whenever you want to update. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
 
-### 2. Start The Server
+### 2. Start FCC
 
-On Windows, open **Free Claude Code** from the desktop or Start menu. On
-macOS, open **Free Claude Code** from the desktop or your Applications folder.
-FCC runs in the system tray or menu bar without a terminal window. Use its menu
-to open Admin, check server status, restart, or quit; on Windows, left-clicking
-the tray icon opens Admin directly.
+#### Windows
 
-For Linux or terminal use, run:
+Open **Free Claude Code** from your desktop or Start menu.
+
+#### macOS
+
+Open **Free Claude Code** from your desktop or Applications folder.
+
+#### Linux
+
+Run:
 
 ```bash
 fcc-server
 ```
 
+On Windows and macOS, FCC runs in the system tray or menu bar without opening a
+terminal. Use its menu to open Admin, check server status, restart, or quit. On
+Windows, left-clicking the tray icon opens Admin directly.
+
 To print the installed Free Claude Code version without starting the server,
 run `fcc-server --version`.
 
-Keep this process running. In terminal mode, the Admin UI opens in your browser
-once the server is healthy by default. Its address is shown in the startup log:
+When using `fcc-server`, keep the terminal open. The Admin UI opens in your
+browser once the server is healthy by default. Its address is shown in the
+startup log:
 
 ```text
 INFO:     Admin UI: http://127.0.0.1:8082/admin (local-only)

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1292,7 +1292,7 @@ def test_installers_use_native_clients_and_single_python_selection() -> None:
 def test_readme_install_section_has_no_manual_git_prerequisite() -> None:
     readme = (_repo_root() / "README.md").read_text(encoding="utf-8")
     install_section = readme.split("### 1. Install Or Update", 1)[1].split(
-        "### 2. Start The Server", 1
+        "### 2. Start FCC", 1
     )[0]
 
     assert "Install Git" not in install_section


### PR DESCRIPTION
## Problem

The startup section combines Windows, macOS, Linux, desktop, and terminal behavior in one block, making each platform's launch path harder to scan.

## Changes

| Before | After |
| --- | --- |
| Startup instructions mixed all platforms in one paragraph. | Startup instructions use separate Windows, macOS, and Linux subsections. |
| Desktop and terminal details interrupted the platform-specific steps. | Shared desktop and terminal details follow the platform-specific steps. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the startup instructions easier to scan by platform. The main changes are:

- Separate Windows, macOS, and Linux startup subsections.
- Shared tray, terminal, and Admin UI guidance after the platform steps.
- Updated installer test boundary for the renamed heading.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the Start The Server section before and after the change to confirm the introduction of distinct platform subsections.
- Verified that the post-change guidance aligns with the new platform headings and is consistently applied.
- Ran the focused regression guard and confirmed it exited with code 0.

<a href="https://app.greptile.com/trex/runs/15272052/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Reorganizes startup guidance by platform while preserving the documented launch behavior. |
| tests/scripts/test_installers.py | Updates the README section delimiter to match the renamed, unique startup heading. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: structure startup instructions by ..."](https://github.com/alishahryar1/free-claude-code/commit/5bb17feb41bea8c15c6efe770774dbf84954c4a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46014084)</sub>

<!-- /greptile_comment -->