### PR TITLE
Make configuration guidance easier to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ fcc-codex exec "hello"
 
 ## Choose A Provider
 
-Enter the listed setting in the Admin UI, open **Model Config**, then search the `MODEL` dropdown and select a model. FCC constructs each slug as `<provider-id>/<exact-provider-model-id>`; free-text entry remains available when a provider cannot list a model. Click **Validate** and **Apply**. Provider names link to their key, model, or setup pages.
+1. Open a provider link below for its key, models, or setup instructions.
+2. In the Admin UI, open **Model Config** and enter the listed setting.
+3. Search the `MODEL` dropdown and select a model. If the provider cannot list
+   models, enter `<provider-id>/<exact-provider-model-id>` manually.
+4. Click **Validate**, then **Apply**.
 
 | Provider | Admin UI setting | Example `MODEL` |
 | --- | --- | --- |
@@ -235,9 +239,16 @@ For example, route Opus to `nvidia_nim/moonshotai/kimi-k2.6`, Sonnet to `open_ro
 
 ### Reasoning Control
 
-Open **Admin UI → Model Config → Reasoning** to choose how FCC handles client reasoning controls. The default **From client** option preserves reasoning effort sent by Claude Code, Codex, or Pi; when the client sends no control, the provider keeps its own default.
+Open **Admin UI → Model Config → Reasoning** and select the behavior you want.
 
-You can instead select **Off**, **Low**, **Medium**, **High**, **X-High**, or **Max**. Fable, Opus, Sonnet, and Haiku each have the same choices plus **Inherit**, which uses the root policy. Providers with named effort receive those names; numeric-budget providers map **Low=512**, **Medium=1,024**, **High=2,048**, **X-High=4,096**, and **Max=8,192** reasoning tokens; boolean providers receive on or off. Unsupported controls safely remain provider-defined.
+| Selection | Behavior |
+| --- | --- |
+| **From client** (default) | Use the effort sent by Claude Code, Codex, or Pi. If none is sent, keep the provider default. |
+| **Off** | Request reasoning to be disabled. |
+| **Low**, **Medium**, **High**, **X-High**, or **Max** | Override the client with the selected reasoning level. |
+| **Inherit** (Fable, Opus, Sonnet, and Haiku only) | Use the root Reasoning selection. |
+
+Providers that do not support a selected control retain their own behavior.
 
 <a id="connect-your-client"></a>
 
@@ -435,10 +446,19 @@ Re-run the matching command from [Install Or Update](#install).
 
 ### Uninstall
 
-Stop every running FCC command first. The uninstaller removes the FCC desktop
-launcher and uv tool, verifies every FCC command is gone, and then deletes
-`~/.fcc/`. It leaves uv, Python, Claude Code, Codex, Pi, and shared PATH entries
-intact.
+Stop every running FCC command first. The uninstaller verifies every FCC command is gone
+before deleting its managed data.
+
+**Removes**
+
+- Free Claude Code, including its desktop launcher and commands
+- `~/.fcc/`
+
+**Keeps**
+
+- uv and Python
+- Claude Code, Codex, and Pi
+- Shared PATH entries
 
 macOS/Linux:
 


### PR DESCRIPTION
## Problem

Provider setup, reasoning choices, and uninstall boundaries were embedded in dense paragraphs, making customer guidance harder to scan.

## Changes

| Before | After |
| --- | --- |
| Provider setup compressed every action into one paragraph. | Provider setup follows a four-step workflow. |
| Reasoning guidance mixed user choices with provider translation internals. | Reasoning guidance presents only user-facing behaviors in a compact table. |
| Uninstall boundaries were buried in prose. | Uninstall guidance separates what FCC removes from what it keeps. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the configuration guidance easier to scan. The main changes are:

- Rewrites provider setup as a four-step workflow.
- Presents reasoning choices in a compact behavior table.
- Separates uninstall removal and retention boundaries.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed documentation. The revised guidance matches the inspected configuration and uninstall behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the baseline uninstall wording before changes and ran a focused test suite that passed.
- T-Rex captured the revised Removes/Keeps guidance after changes, re-ran the same focused test suite, and performed a clean diff check.
- T-Rex exercised removal and verification of FCC commands and data while preserving uv, Claude Code, Codex, and Pi, accounting for platform-dependent skips.

<a href="https://app.greptile.com/trex/runs/15276986/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Reorganizes provider, reasoning, and uninstall guidance without changing runtime behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: make configuration guidance easier..."](https://github.com/alishahryar1/free-claude-code/commit/6b2ce1ceeb54f3579049d9cf674161e412fd5cc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46022990)</sub>

<!-- /greptile_comment -->