### PR TITLE
Preserve Claude feature flags in interactive clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,7 @@ Install the [Claude Code extension](https://marketplace.visualstudio.com/items?i
   { "name": "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "value": "190000" },
   { "name": "DISABLE_AUTOUPDATER", "value": "1" },
   { "name": "DISABLE_FEEDBACK_COMMAND", "value": "1" },
-  { "name": "DISABLE_ERROR_REPORTING", "value": "1" },
-  { "name": "DISABLE_TELEMETRY", "value": "1" }
+  { "name": "DISABLE_ERROR_REPORTING", "value": "1" }
 ]
 ```
 
@@ -317,8 +316,7 @@ Set the environment for `acp.registry.claude-acp`:
   "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000",
   "DISABLE_AUTOUPDATER": "1",
   "DISABLE_FEEDBACK_COMMAND": "1",
-  "DISABLE_ERROR_REPORTING": "1",
-  "DISABLE_TELEMETRY": "1"
+  "DISABLE_ERROR_REPORTING": "1"
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.12.0"
+version = "4.12.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -34,5 +34,4 @@ def build_claude_proxy_env(
     env["DISABLE_AUTOUPDATER"] = "1"
     env["DISABLE_FEEDBACK_COMMAND"] = "1"
     env["DISABLE_ERROR_REPORTING"] = "1"
-    env["DISABLE_TELEMETRY"] = "1"
     return env

--- a/src/free_claude_code/cli/managed/claude.py
+++ b/src/free_claude_code/cli/managed/claude.py
@@ -107,6 +107,7 @@ def build_managed_claude_env(
         auth_token=auth_token,
         base_env=base_env,
     )
+    env["DISABLE_TELEMETRY"] = "1"
     env["TERM"] = "dumb"
     env["PYTHONIOENCODING"] = "utf-8"
     return env

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -414,7 +414,7 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
     assert env["DISABLE_AUTOUPDATER"] == "1"
     assert env["DISABLE_FEEDBACK_COMMAND"] == "1"
     assert env["DISABLE_ERROR_REPORTING"] == "1"
-    assert env["DISABLE_TELEMETRY"] == "1"
+    assert env["DISABLE_TELEMETRY"] == "0"
     assert env["NO_PROXY"] == "127.0.0.1,localhost,::1"
     assert env["no_proxy"] == env["NO_PROXY"]
     assert "ANTHROPIC_API_URL" not in env
@@ -446,6 +446,7 @@ def test_launch_claude_passes_args_and_child_env(
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "old-token")
     monkeypatch.setenv("KEEP_ME", "yes")
+    monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
     settings = _launcher_settings(port=9191, token="proxy-token")
 
     with (
@@ -480,7 +481,7 @@ def test_launch_claude_passes_args_and_child_env(
     assert child_env["DISABLE_AUTOUPDATER"] == "1"
     assert child_env["DISABLE_FEEDBACK_COMMAND"] == "1"
     assert child_env["DISABLE_ERROR_REPORTING"] == "1"
-    assert child_env["DISABLE_TELEMETRY"] == "1"
+    assert "DISABLE_TELEMETRY" not in child_env
     assert child_env["NO_PROXY"] == "127.0.0.1,localhost,::1"
     assert child_env["no_proxy"] == child_env["NO_PROXY"]
     assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in child_env

--- a/tests/cli/test_managed_claude.py
+++ b/tests/cli/test_managed_claude.py
@@ -137,7 +137,7 @@ def test_managed_claude_env_uses_sentinel_when_proxy_auth_blank() -> None:
     assert env["ANTHROPIC_AUTH_TOKEN"] == "fcc-no-auth"
 
 
-def test_managed_claude_env_only_adds_noninteractive_process_settings() -> None:
+def test_managed_claude_env_adds_noninteractive_process_policy() -> None:
     base_env = {
         "PATH": "keep",
         "ANTHROPIC_API_URL": "https://api.anthropic.com/v1",
@@ -159,6 +159,7 @@ def test_managed_claude_env_only_adds_noninteractive_process_settings() -> None:
 
     assert managed_env == {
         **proxy_env,
+        "DISABLE_TELEMETRY": "1",
         "TERM": "dumb",
         "PYTHONIOENCODING": "utf-8",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.12.0"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

`fcc-claude` and the documented IDE setups forced `DISABLE_TELEMETRY=1`. Claude Code disables feature-flag fetching with that variable, so rollout features such as fullscreen rendering and mouse support fell back to disabled defaults. Fixes #1238.

## Changes

| Before | After |
| --- | --- |
| Shared proxy policy forced telemetry off for interactive and managed Claude sessions. | Interactive Claude sessions preserve the user's telemetry choice, while managed headless tasks own the opt-out. |
| VS Code and JetBrains examples disabled Claude feature-flag fetching. | Both IDE examples allow Claude to fetch rollout feature flags. |
| Environment contracts expected every Claude surface to disable telemetry. | Regression tests distinguish interactive inheritance from managed enforcement. |
| Package metadata reported version 4.12.0. | Package metadata and the lockfile report version 4.12.1. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Preserve users' telemetry preferences in interactive Claude clients while continuing to disable telemetry in managed headless sessions.
- Removes the shared `DISABLE_TELEMETRY=1` override and the equivalent IDE setup examples.
- Adds the telemetry opt-out specifically to managed Claude environments.
- Updates regression tests to distinguish interactive inheritance from managed enforcement.
- Bumps package and lockfile metadata from 4.12.0 to 4.12.1.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with interactive inheritance and managed telemetry enforcement consistently implemented and tested.

The interactive launcher now passes through the parent telemetry preference, while the only managed subprocess path applies its telemetry opt-out after constructing the shared environment and passes that environment directly to process creation.

No files require additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the pre-change HEAD^ state to the new HEAD, confirming DISABLE\_TELEMETRY handling now preserves inherited values, omits when not inherited, forces 1 for managed environments and invocations, and removes the traffic-suppression flag, resulting in all six checks passing with exit code 0.

<a href="https://app.greptile.com/trex/runs/15618944/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/cli/claude_env.py | Removes the shared telemetry override so interactive Claude launches inherit the parent environment. |
| src/free_claude_code/cli/managed/claude.py | Restores the telemetry opt-out specifically for managed headless Claude subprocesses. |
| tests/cli/test_entrypoints.py | Verifies that interactive clients preserve an explicit telemetry setting and leave an absent setting unset. |
| tests/cli/test_managed_claude.py | Verifies that managed sessions enforce the noninteractive telemetry policy. |
| README.md | Removes telemetry-disabling configuration from the documented VS Code and JetBrains interactive setups. |
| pyproject.toml | Bumps the project version to 4.12.1. |
| uv.lock | Synchronizes the editable project package version without changing dependency resolutions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
Base[Parent environment] --> Shared[build_claude_proxy_env]
Shared --> Interactive[Interactive Claude client]
Shared --> Managed[build_managed_claude_env]
Interactive --> Preserve[Preserve user's DISABLE_TELEMETRY choice]
Managed --> Disable[Set DISABLE_TELEMETRY=1]
Disable --> Headless[Managed headless Claude process]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve Claude interactive feature..."](https://github.com/alishahryar1/free-claude-code/commit/cddcf0d61639a33aba46cac3f7bcbe0274cbcc60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46750932)</sub>

<!-- /greptile_comment -->