### PR TITLE
Report provider permission denials as HTTP 403

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.12.2"
+version = "4.12.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -30,6 +30,9 @@ _OVERLOAD_MARKERS = frozenset(
 )
 _INTERNAL_ERROR_MARKERS = frozenset({"internal_server_error", "internal server error"})
 _AUTHENTICATION_MESSAGE = "Provider authentication failed. Check API key."
+_PERMISSION_MESSAGE = (
+    "Provider denied access. Check credential permissions and model access."
+)
 _RATE_LIMIT_MESSAGE = "Provider rate limit reached. Please retry shortly."
 _INVALID_REQUEST_MESSAGE = "Invalid request sent to provider."
 _CONTEXT_WINDOW_EXCEEDED_MESSAGE = "Provider input exceeds the model context window."
@@ -160,7 +163,12 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
         return False
     if isinstance(exc, ExecutionFailure):
         return exc.retryable
-    if isinstance(exc, openai.AuthenticationError | openai.BadRequestError):
+    if isinstance(
+        exc,
+        openai.AuthenticationError
+        | openai.PermissionDeniedError
+        | openai.BadRequestError,
+    ):
         return False
     if retryable_transient_status(exc) is not None:
         return True
@@ -213,6 +221,8 @@ def provider_error_message(
         return _RATE_LIMIT_MESSAGE
     if isinstance(exc, openai.AuthenticationError):
         return _AUTHENTICATION_MESSAGE
+    if isinstance(exc, openai.PermissionDeniedError):
+        return _PERMISSION_MESSAGE
     if isinstance(exc, openai.BadRequestError):
         return _INVALID_REQUEST_MESSAGE
     return safe_exception_message(exc)
@@ -228,6 +238,8 @@ def _classify_provider_failure(
 
     if isinstance(exc, openai.AuthenticationError):
         return _failure(FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False)
+    if isinstance(exc, openai.PermissionDeniedError):
+        return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
     if isinstance(exc, openai.RateLimitError):
         return _failure(FailureKind.RATE_LIMIT, 429, _RATE_LIMIT_MESSAGE, True)
     if isinstance(exc, openai.BadRequestError):
@@ -259,6 +271,12 @@ def _classify_provider_failure(
         effective_status = status or getattr(exc, "status_code", None)
         if not isinstance(effective_status, int):
             effective_status = 500
+        if effective_status == 401:
+            return _failure(
+                FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
+            )
+        if effective_status == 403:
+            return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
         return _failure(
             FailureKind.UPSTREAM,
             effective_status,
@@ -268,10 +286,12 @@ def _classify_provider_failure(
 
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
-        if status in (401, 403):
+        if status == 401:
             return _failure(
                 FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
             )
+        if status == 403:
+            return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
         if status == 429:
             return _failure(FailureKind.RATE_LIMIT, 429, _RATE_LIMIT_MESSAGE, True)
         if status == 400:

--- a/tests/api/test_execution_failure_contract.py
+++ b/tests/api/test_execution_failure_contract.py
@@ -265,6 +265,51 @@ def test_messages_pre_start_execution_failure_is_correlated_terminal_json() -> N
     assert provider.stream_kwargs[0]["request_id"] == request_id
 
 
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/v1/messages", _messages_payload(stream=True)),
+        ("/v1/responses", _responses_payload()),
+    ],
+)
+def test_pre_start_permission_failure_preserves_403_without_client_retry(
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    provider = CanonicalFailureProvider(
+        [],
+        kind=FailureKind.PERMISSION,
+        status_code=403,
+        message="Provider denied access.",
+        retryable=False,
+    )
+    resolver_patch, client = _client_for(provider)
+
+    with (
+        resolver_patch,
+        patch("free_claude_code.api.response_streams.trace_event") as trace_mock,
+        client,
+    ):
+        response = client.post(path, json=payload)
+
+    request_id = response.headers["request-id"]
+    error = response.json()["error"]
+    assert response.status_code == 403
+    assert response.headers["x-should-retry"] == "false"
+    assert error["type"] == "permission_error"
+    assert error["message"] == f"Provider denied access.\n\nRequest ID: {request_id}"
+    if path == "/v1/messages":
+        assert response.json()["request_id"] == request_id
+        assert "x-request-id" not in response.headers
+    else:
+        assert response.headers["x-request-id"] == request_id
+    trace = _terminal_trace(trace_mock)
+    assert trace["failure_kind"] == "permission"
+    assert trace["status_code"] == 403
+    assert trace["error_type"] == "permission_error"
+    assert trace["provider_retryable"] is False
+
+
 def test_messages_context_window_failure_triggers_client_compaction() -> None:
     provider = CanonicalFailureProvider(
         [],

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -76,6 +76,39 @@ _CASES = (
         False,
     ),
     _ClassificationCase(
+        "openai_permission_denied",
+        lambda: _openai_status_error(
+            openai.PermissionDeniedError,
+            status_code=403,
+            message="Forbidden",
+        ),
+        FailureKind.PERMISSION,
+        403,
+        False,
+    ),
+    _ClassificationCase(
+        "generic_openai_401",
+        lambda: _openai_status_error(
+            openai.APIStatusError,
+            status_code=401,
+            message="Unauthorized",
+        ),
+        FailureKind.AUTHENTICATION,
+        401,
+        False,
+    ),
+    _ClassificationCase(
+        "generic_openai_403",
+        lambda: _openai_status_error(
+            openai.APIStatusError,
+            status_code=403,
+            message="Forbidden",
+        ),
+        FailureKind.PERMISSION,
+        403,
+        False,
+    ),
+    _ClassificationCase(
         "openai_rate_limit",
         lambda: _openai_status_error(
             openai.RateLimitError,
@@ -150,10 +183,17 @@ _CASES = (
         False,
     ),
     _ClassificationCase(
-        "http_403_keeps_authentication_quirk",
-        lambda: _http_status_error(403, "Forbidden"),
+        "http_401_maps_authentication",
+        lambda: _http_status_error(401, "Unauthorized"),
         FailureKind.AUTHENTICATION,
         401,
+        False,
+    ),
+    _ClassificationCase(
+        "http_403_maps_permission",
+        lambda: _http_status_error(403, "Forbidden"),
+        FailureKind.PERMISSION,
+        403,
         False,
     ),
     _ClassificationCase(
@@ -275,6 +315,39 @@ def test_auth_failure_preserves_model_error_body_instead_of_masking_it() -> None
     assert "Provider authentication failed. Check API key." in failure.message
     assert "Model qwen3.7-max is not supported for format oa-compat" in failure.message
     assert "Request ID: req_model" in failure.message
+
+
+def test_permission_failure_preserves_actionable_upstream_diagnostic() -> None:
+    error = _openai_status_error(
+        openai.PermissionDeniedError,
+        status_code=403,
+        message="Forbidden",
+        body={
+            "status": 403,
+            "title": "Forbidden",
+            "detail": "Authorization failed",
+        },
+    )
+
+    failure = classify_provider_failure(
+        error,
+        provider_name="NIM",
+        read_timeout_s=60.0,
+        request_id="req_permission",
+    )
+
+    assert failure.kind is FailureKind.PERMISSION
+    assert failure.status_code == 403
+    assert failure.retryable is False
+    assert not is_retryable_provider_error(error)
+    assert "Upstream provider NIM returned HTTP 403." in failure.message
+    assert "Category: permission" in failure.message
+    assert (
+        "Mapped message: Provider denied access. "
+        "Check credential permissions and model access."
+    ) in failure.message
+    assert '"detail":"Authorization failed"' in failure.message
+    assert "Request ID: req_permission" in failure.message
 
 
 def test_empty_http_error_body_is_reported_explicitly() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.12.2"
+version = "4.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Provider HTTP 403 responses were categorized as generic API failures or rewritten as authentication 401 errors. Users received misleading diagnostics for credential or model-access denials, as reported in #1242.

## Changes

| Before | After |
| --- | --- |
| Typed and generic OpenAI 403 errors fell through to generic API failures. | Typed and generic OpenAI 403 errors become canonical permission failures. |
| Raw HTTP 403 errors were rewritten as authentication failures with status 401. | Raw HTTP 403 errors retain permission semantics and status 403. |
| Permission diagnostics used generic provider-failure wording. | Permission diagnostics advise checking credential permissions and model access while retaining redacted upstream detail. |
| Access-denial wire behavior was implicit. | Messages and Responses return `permission_error` with `x-should-retry: false`. |
| The package version was 4.12.2. | The package version is 4.12.3. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves provider permission-denial semantics across classification and API responses.
- Maps typed and generic OpenAI 403 errors to non-retryable permission failures.
- Preserves HTTP 403 for raw HTTP permission denials instead of rewriting them as authentication failures.
- Adds permission-specific diagnostics and contract coverage for Messages and Responses.
- Bumps the package and lockfile version to 4.12.3.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with consistent permission classification, diagnostics, retry behavior, and API serialization.

The new branches preserve HTTP 403 semantics for all targeted exception forms, return the existing permission wire type without retrying, and retain redacted upstream detail; focused tests cover the changed behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The baseline tests were run against the detached head parent cac2db5 and showed 5 failed and 35 passed, confirming the prior 403 misclassification with redacted diagnostics.
- The same focused files were re-run on the head and produced 40 passed in 3.08s with case-level PASS output for generic OpenAI 403, raw HTTP 403, permission diagnostics, and both endpoint contracts.

<a href="https://app.greptile.com/trex/runs/15836774/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/failure_policy.py | Correctly classifies typed, generic OpenAI, and raw HTTP 403 failures as non-retryable permission errors while retaining redacted upstream diagnostics. |
| tests/providers/test_failure_policy.py | Adds focused coverage for typed and generic OpenAI 403 errors, raw HTTP 403 errors, retry behavior, and actionable diagnostics. |
| tests/api/test_execution_failure_contract.py | Verifies pre-start permission failures produce HTTP 403, permission_error payloads, and disabled client retries for both API protocols. |
| pyproject.toml | Bumps the project version from 4.12.2 to 4.12.3. |
| uv.lock | Synchronizes only the local package version; third-party dependency resolutions are unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Classify provider permission denials"](https://github.com/alishahryar1/free-claude-code/commit/edc5dcdeb19bc9efc1877099a30d87f9b16fa5ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47178905)</sub>

<!-- /greptile_comment -->