### PR TITLE
Continue installation when Pi is skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Windows PowerShell:
 
 Re-run the same command whenever you want to update. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
 
+Pi is optional. If you decline Pi's installer, FCC continues installing with Claude Code and Codex.
+
 ### 2. Start FCC
 
 #### Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.12.3"
+version = "4.12.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -340,6 +340,7 @@ function Ensure-Codex {
 
 function Ensure-Pi {
     $script:PiAvailable = $false
+    Add-PiBinDirectories
     $existingPi = Get-ApplicationCommand "pi"
     if ($existingPi -and ($DryRun -or (Test-PiApplication $existingPi))) {
         Write-Host "Pi already found on PATH; verifying it."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -20,6 +20,7 @@ $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"
 $UvInstallUrl = "https://astral.sh/uv/install.ps1"
+$script:PiAvailable = $false
 $FccCommands = @(
     # Include retired entry points so updates reject older FCC processes before replacement.
     "fcc-desktop",
@@ -35,7 +36,7 @@ function Show-Usage {
     @"
 Usage: install.ps1 [options]
 
-Installs Claude Code, Codex, and Pi if missing, ensures a compatible uv, and installs or updates Free Claude Code.
+Installs Claude Code and Codex, offers to install Pi, ensures a compatible uv, and installs or updates Free Claude Code.
 
 Options:
   -VoiceNim              Install NVIDIA NIM voice transcription support.
@@ -338,6 +339,7 @@ function Ensure-Codex {
 }
 
 function Ensure-Pi {
+    $script:PiAvailable = $false
     $existingPi = Get-ApplicationCommand "pi"
     if ($existingPi -and ($DryRun -or (Test-PiApplication $existingPi))) {
         Write-Host "Pi already found on PATH; verifying it."
@@ -348,9 +350,24 @@ function Ensure-Pi {
         }
         Invoke-DownloadedPowerShellInstaller -Url $PiInstallUrl -Name "Pi"
         Add-PiBinDirectories
+
+        if (-not $DryRun) {
+            $currentPi = Get-ApplicationCommand "pi"
+            $unchangedIncompatiblePi = (
+                $currentPi -and
+                $existingPi -and
+                $currentPi.Source -eq $existingPi.Source -and
+                -not (Test-PiApplication $currentPi)
+            )
+            if ((-not $currentPi) -or $unchangedIncompatiblePi) {
+                Write-Host "Pi was not installed; continuing without it."
+                return
+            }
+        }
     }
 
     Confirm-PiApplication
+    $script:PiAvailable = $true
 }
 
 function Convert-UvVersionOutput {
@@ -630,7 +647,7 @@ Ensure-ClaudeCode
 Write-Step "Ensuring Codex is installed"
 Ensure-Codex
 
-Write-Step "Ensuring Pi is installed"
+Write-Step "Checking or installing Pi"
 Ensure-Pi
 
 Write-Step "Ensuring uv $MinUvVersion or newer is installed"
@@ -651,5 +668,7 @@ else {
     Write-Host "For terminal use, start the proxy with: fcc-server"
     Write-Host "Run Claude Code with: fcc-claude"
     Write-Host "Run Codex with: fcc-codex"
-    Write-Host "Run Pi with: fcc-pi"
+    if ($script:PiAvailable) {
+        Write-Host "Run Pi with: fcc-pi"
+    }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,12 +20,13 @@ voice_all=0
 torch_backend=""
 temporary_script=""
 tool_bin=""
+pi_available=0
 
 show_usage() {
     cat <<'USAGE'
 Usage: install.sh [options]
 
-Installs Claude Code, Codex, and Pi if missing, ensures a compatible uv, and installs or updates Free Claude Code.
+Installs Claude Code and Codex, offers to install Pi, ensures a compatible uv, and installs or updates Free Claude Code.
 
 Options:
   --voice-nim              Install NVIDIA NIM voice transcription support.
@@ -299,19 +300,34 @@ ensure_codex() {
 }
 
 ensure_pi() {
+    pi_available=0
+    existing_pi_path=$(command -v pi 2>/dev/null || true)
+
     if [ "$dry_run" -eq 1 ] && command -v pi >/dev/null 2>&1; then
         printf 'Pi already found on PATH; verifying it.\n'
     elif pi_command_is_compatible; then
         printf 'Pi already found on PATH; verifying it.\n'
     else
-        if existing_pi_path=$(command -v pi 2>/dev/null); then
+        if [ -n "$existing_pi_path" ]; then
             printf "The existing 'pi' command at %s is not Pi Coding Agent; installing Pi.\n" "$existing_pi_path"
         fi
         download_and_run "$PI_INSTALL_URL" sh "Pi"
         add_pi_bin_directories
+
+        if [ "$dry_run" -eq 0 ]; then
+            current_pi_path=$(command -v pi 2>/dev/null || true)
+            if [ -z "$current_pi_path" ] ||
+                { [ -n "$existing_pi_path" ] &&
+                    [ "$current_pi_path" = "$existing_pi_path" ] &&
+                    ! pi_command_is_compatible; }; then
+                printf 'Pi was not installed; continuing without it.\n'
+                return 0
+            fi
+        fi
     fi
 
     verify_pi_command
+    pi_available=1
 }
 
 current_uv_version() {
@@ -619,7 +635,7 @@ ensure_claude
 step "Ensuring Codex is installed"
 ensure_codex
 
-step "Ensuring Pi is installed"
+step "Checking or installing Pi"
 ensure_pi
 
 step "Ensuring uv $MIN_UV_VERSION or newer is installed"
@@ -647,5 +663,7 @@ else
     fi
     printf 'Run Claude Code with: fcc-claude\n'
     printf 'Run Codex with: fcc-codex\n'
-    printf 'Run Pi with: fcc-pi\n'
+    if [ "$pi_available" -eq 1 ]; then
+        printf 'Run Pi with: fcc-pi\n'
+    fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -301,6 +301,7 @@ ensure_codex() {
 
 ensure_pi() {
     pi_available=0
+    add_pi_bin_directories
     existing_pi_path=$(command -v pi 2>/dev/null || true)
 
     if [ "$dry_run" -eq 1 ] && command -v pi >/dev/null 2>&1; then

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -493,6 +493,28 @@ def test_install_sh_continues_when_unrelated_pi_is_unchanged(
     assert "fcc-server:--version" in calls
 
 
+def test_install_sh_continues_when_pi_resolution_changes_to_unrelated_command(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_unrelated_pi()
+    npm_prefix = posix_harness.root / "custom-npm"
+    posix_harness.add_npm_prefix(npm_prefix)
+    _write_executable(
+        npm_prefix / "bin" / "pi",
+        _posix_command("other-unrelated-pi"),
+    )
+
+    result = posix_harness.run(fail_step="pi-skip")
+
+    assert result.returncode == 0, result.stderr
+    assert "Pi was not installed; continuing without it." in result.stdout
+    assert "Run Pi with: fcc-pi" not in result.stdout
+    calls = posix_harness.calls()
+    assert "other-unrelated-pi:--help" in calls
+    assert "other-unrelated-pi:--version" not in calls
+    assert "fcc-server:--version" in calls
+
+
 def test_install_sh_replaces_obsolete_uv(posix_harness: PosixHarness) -> None:
     posix_harness.add_client("claude")
     posix_harness.add_client("codex")
@@ -1139,6 +1161,28 @@ def test_install_ps1_continues_when_unrelated_pi_is_unchanged(
     calls = powershell_harness.calls()
     assert "unrelated-pi:--help" in calls
     assert "unrelated-pi:--version" not in calls
+    assert "fcc-server:--version" in calls
+
+
+def test_install_ps1_continues_when_pi_resolution_changes_to_unrelated_command(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_unrelated_pi()
+    npm_prefix = powershell_harness.root / "custom-npm"
+    powershell_harness.add_npm_prefix(npm_prefix)
+    _write_executable(
+        npm_prefix / "pi.cmd",
+        _batch_client("other-unrelated-pi"),
+    )
+
+    result = powershell_harness.run(fail_step="pi-skip")
+
+    assert result.returncode == 0, result.stderr
+    assert "Pi was not installed; continuing without it." in result.stdout
+    assert "Run Pi with: fcc-pi" not in result.stdout
+    calls = powershell_harness.calls()
+    assert "other-unrelated-pi:--help" in calls
+    assert "other-unrelated-pi:--version" not in calls
     assert "fcc-server:--version" in calls
 
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -258,6 +258,7 @@ chmod +x "$HOME/.local/bin/codex"
         """#!/bin/sh
 echo "pi-install" >> "$CALL_LOG"
 [ "$FAIL_STEP" = "pi-install" ] && exit 24
+[ "$FAIL_STEP" = "pi-skip" ] && exit 0
 if [ -n "${FAKE_NPM_PREFIX:-}" ]; then
     pi_bin="$FAKE_NPM_PREFIX/bin"
 else
@@ -459,6 +460,37 @@ def test_install_sh_discovers_custom_pi_npm_prefix(
     assert "npm:prefix -g" in calls
     assert "pi:--help" in calls
     assert "pi:--version" in calls
+
+
+def test_install_sh_continues_when_pi_is_not_installed(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run(fail_step="pi-skip")
+
+    assert result.returncode == 0, result.stderr
+    assert "Pi was not installed; continuing without it." in result.stdout
+    assert "Run Pi with: fcc-pi" not in result.stdout
+    calls = posix_harness.calls()
+    assert "pi-install" in calls
+    assert not any(call.startswith("pi:") for call in calls)
+    assert "uv-install" in calls
+    assert "fcc-server:--version" in calls
+
+
+def test_install_sh_continues_when_unrelated_pi_is_unchanged(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_unrelated_pi()
+
+    result = posix_harness.run(fail_step="pi-skip")
+
+    assert result.returncode == 0, result.stderr
+    assert "Pi was not installed; continuing without it." in result.stdout
+    assert "Run Pi with: fcc-pi" not in result.stdout
+    calls = posix_harness.calls()
+    assert "unrelated-pi:--help" in calls
+    assert "unrelated-pi:--version" not in calls
+    assert "fcc-server:--version" in calls
 
 
 def test_install_sh_replaces_obsolete_uv(posix_harness: PosixHarness) -> None:
@@ -863,6 +895,10 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "codex-install:$env:CODEX_NON_INTE
     )
     (fixtures / "pi-installer.ps1").write_text(
         r"""if ($env:FAIL_STEP -eq "pi-install") { exit 64 }
+if ($env:FAIL_STEP -eq "pi-skip") {
+    Add-Content -LiteralPath $env:CALL_LOG -Value "pi-install"
+    return
+}
 $bin = if ($env:FAKE_NPM_PREFIX) { $env:FAKE_NPM_PREFIX } else { Join-Path $env:APPDATA "npm" }
 New-Item -ItemType Directory -Force -Path $bin | Out-Null
 Copy-Item (Join-Path $env:FAKE_FIXTURES "pi-command.cmd") (Join-Path $bin "pi.cmd") -Force
@@ -1073,6 +1109,37 @@ def test_install_ps1_discovers_custom_pi_npm_prefix(
     assert "npm:prefix -g" in calls
     assert "pi:--help" in calls
     assert "pi:--version" in calls
+
+
+def test_install_ps1_continues_when_pi_is_not_installed(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    result = powershell_harness.run(fail_step="pi-skip")
+
+    assert result.returncode == 0, result.stderr
+    assert "Pi was not installed; continuing without it." in result.stdout
+    assert "Run Pi with: fcc-pi" not in result.stdout
+    calls = powershell_harness.calls()
+    assert "pi-install" in calls
+    assert not any(call.startswith("pi:") for call in calls)
+    assert "uv-install" in calls
+    assert "fcc-server:--version" in calls
+
+
+def test_install_ps1_continues_when_unrelated_pi_is_unchanged(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_unrelated_pi()
+
+    result = powershell_harness.run(fail_step="pi-skip")
+
+    assert result.returncode == 0, result.stderr
+    assert "Pi was not installed; continuing without it." in result.stdout
+    assert "Run Pi with: fcc-pi" not in result.stdout
+    calls = powershell_harness.calls()
+    assert "unrelated-pi:--help" in calls
+    assert "unrelated-pi:--version" not in calls
+    assert "fcc-server:--version" in calls
 
 
 def test_install_ps1_replaces_obsolete_uv(

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.12.3"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Selecting "Do nothing" in Pi's installer returned success without installing Pi. FCC then required the missing command and stopped before installing itself. Fixes #1240.

## Changes

| Before | After |
| --- | --- |
| A successful Pi installer exit always required a compatible `pi` command. | A successful Pi installer exit may leave Pi unavailable while FCC installation continues. |
| Pi verification and completion guidance always ran. | Pi verification and completion guidance run only when Pi is available. |
| Installer documentation described Pi as mandatory. | Installer documentation describes Pi as optional. |
| Skip behavior lacked cross-platform regression coverage. | Skip behavior is covered on PowerShell and POSIX, including an unrelated existing `pi` command. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes Pi optional during installation.
- Continues FCC installation when Pi’s installer succeeds without installing Pi.
- Runs Pi verification and completion guidance only when a compatible Pi command is available.
- Adds POSIX and PowerShell regression coverage and updates installer documentation and package metadata.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain in the follow-up fix.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the change, the resolution-change flow exited 1 during incompatible Pi verification and never reached FCC installation.
- After the change, all three cases exited 0, printed 'Pi was not installed; continuing without it.', installed FCC, and verified fcc-server.
- The verbose after log was captured, showing selected test identities, full installer output, and recorded harness calls.
- The general contract validation compared the before and after outcomes to confirm the after-state aligns with the expected flow.

<a href="https://app.greptile.com/trex/runs/15846099/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/install.sh | Expands Pi search paths before baseline detection and allows installation to continue when Pi remains unavailable or unchanged and incompatible. |
| scripts/install.ps1 | Implements the corresponding optional-Pi behavior and conditional completion guidance for PowerShell. |
| tests/scripts/test_installers.py | Adds cross-platform coverage for skipped Pi installation and unrelated Pi commands. |
| README.md | Documents that Pi is optional and declining its installer does not stop FCC installation. |
| pyproject.toml | Bumps the project version to 4.12.4. |
| uv.lock | Synchronizes the editable project version with pyproject.toml. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(installer): stabilize Pi availabilit..."](https://github.com/alishahryar1/free-claude-code/commit/0b6a7b0ed07cbd433ed97004d67581f62e2defb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47194575)</sub>

<!-- /greptile_comment -->