### PR TITLE
Fix Windows desktop icon installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.12.5"
+version = "4.12.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -517,6 +517,40 @@ function Install-FreeClaudeCode {
     Invoke-NativeCommand -FilePath $uvPath -Arguments $arguments
 }
 
+function Export-FccDesktopIcon {
+    param(
+        [string] $DesktopCommand,
+        [string] $IconPath
+    )
+
+    $arguments = @("--export-icon", $IconPath)
+    $commandText = Format-Command -FilePath $DesktopCommand -Arguments $arguments
+    Write-Host "+ $commandText"
+    if ($DryRun) {
+        return
+    }
+
+    # PowerShell does not wait when directly invoking a Windows GUI executable.
+    $process = Start-Process `
+        -FilePath $DesktopCommand `
+        -ArgumentList @("--export-icon", ('"' + $IconPath + '"')) `
+        -WindowStyle Hidden `
+        -Wait `
+        -PassThru
+    try {
+        $exitCode = $process.ExitCode
+    }
+    finally {
+        $process.Dispose()
+    }
+    if ($exitCode -ne 0) {
+        throw "Command failed with exit code ${exitCode}: $commandText"
+    }
+    if (-not (Test-Path -LiteralPath $IconPath -PathType Leaf)) {
+        throw "Free Claude Code did not export its Windows app icon to '$IconPath'."
+    }
+}
+
 function Configure-AndConfirmFreeClaudeCode {
     $iconPath = Join-Path $env:USERPROFILE ".fcc\app-icon.ico"
     if ($DryRun) {
@@ -524,10 +558,9 @@ function Configure-AndConfirmFreeClaudeCode {
         Write-Host "+ uv tool dir --bin"
         Write-Host "+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, and fcc-pi in the uv tool bin directory"
         Write-Host "+ fcc-server --version"
-        Invoke-NativeCommand -FilePath "<uv-tool-bin>\fcc-desktop.exe" -Arguments @(
-            "--export-icon",
-            $iconPath
-        )
+        Export-FccDesktopIcon `
+            -DesktopCommand "<uv-tool-bin>\fcc-desktop.exe" `
+            -IconPath $iconPath
         Install-FccDesktopShortcuts `
             -DesktopCommand "<uv-tool-bin>\fcc-desktop.exe" `
             -IconPath $iconPath
@@ -566,13 +599,9 @@ function Configure-AndConfirmFreeClaudeCode {
     }
 
     Invoke-NativeCommand -FilePath $installedCommands["fcc-server"] -Arguments @("--version")
-    Invoke-NativeCommand -FilePath $installedCommands["fcc-desktop"] -Arguments @(
-        "--export-icon",
-        $iconPath
-    )
-    if (-not (Test-Path -LiteralPath $iconPath -PathType Leaf)) {
-        throw "Free Claude Code did not export its Windows app icon to '$iconPath'."
-    }
+    Export-FccDesktopIcon `
+        -DesktopCommand $installedCommands["fcc-desktop"] `
+        -IconPath $iconPath
     Install-FccDesktopShortcuts `
         -DesktopCommand $installedCommands["fcc-desktop"] `
         -IconPath $iconPath

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -746,6 +747,77 @@ def _powershells() -> tuple[str, ...]:
     return tuple(dict.fromkeys(path for path in candidates if path is not None))
 
 
+def test_install_ps1_waits_for_gui_icon_export() -> None:
+    installer = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    body = _braced_body(installer, "function Export-FccDesktopIcon")
+
+    assert "Start-Process" in body
+    assert "-WindowStyle Hidden" in body
+    assert "-Wait" in body
+    assert "-PassThru" in body
+    assert "$process.ExitCode" in body
+
+
+@pytest.mark.parametrize(
+    "powershell",
+    _powershells() or (None,),
+    ids=lambda path: Path(path).name if path is not None else "unavailable",
+)
+def test_install_ps1_gui_icon_export_completes_before_returning(
+    powershell: str | None,
+    tmp_path: Path,
+) -> None:
+    if powershell is None or os.name != "nt":
+        pytest.skip("PowerShell GUI process behavior runs on Windows hosts")
+
+    installer = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    function_declarations = (
+        "function Format-Argument",
+        "function Format-Command",
+        "function Export-FccDesktopIcon",
+    )
+    functions = "\n".join(
+        f"{declaration} {{{_braced_body(installer, declaration)}}}"
+        for declaration in function_declarations
+    )
+    installed_desktop_command = Path(sys.executable).with_name("fcc-desktop.exe")
+    desktop_command = tmp_path / "icon-exporter.exe"
+    shutil.copy2(installed_desktop_command, desktop_command)
+    destination = tmp_path / "profile with spaces" / ".fcc" / "app-icon.ico"
+    env = os.environ | {
+        "FCC_TEST_DESKTOP_COMMAND": str(desktop_command),
+        "FCC_TEST_ICON_PATH": str(destination),
+    }
+    script = "\n".join(
+        (
+            '$ErrorActionPreference = "Stop"',
+            "$DryRun = $false",
+            functions,
+            (
+                "Export-FccDesktopIcon "
+                "-DesktopCommand $env:FCC_TEST_DESKTOP_COMMAND "
+                "-IconPath $env:FCC_TEST_ICON_PATH"
+            ),
+        )
+    )
+
+    completed = subprocess.run(
+        [powershell, "-NoProfile", "-Command", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert (
+        destination.read_bytes()
+        == (
+            _repo_root() / "src" / "free_claude_code" / "assets" / "app-icon.ico"
+        ).read_bytes()
+    )
+
+
 def _create_windows_shortcut(
     powershell: str,
     shortcut_path: Path,
@@ -1104,7 +1176,7 @@ def test_install_ps1_fresh_install_is_verified(
     app_data = Path(powershell_harness.env["APPDATA"])
     icon = home / ".fcc" / "app-icon.ico"
     assert icon.read_text(encoding="utf-8").strip() == "fake icon"
-    assert calls[-1] == f"fcc-desktop:--export-icon {icon}"
+    assert calls[-1] == f'fcc-desktop:--export-icon "{icon}"'
     desktop_shortcut = home / "Desktop" / "Free Claude Code.lnk"
     assert desktop_shortcut.is_file()
     assert (

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.12.5"
+version = "4.12.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

PowerShell does not wait when directly invoking the Windows `fcc-desktop` GUI executable. The installer checked for the exported ICO before the GUI process finished, then stopped before replacing generic shortcut icons.

## Changes

| Before | After |
| --- | --- |
| Icon export used the synchronous command helper even though Windows launched the GUI executable asynchronously. | A Windows-specific icon export helper starts the GUI process hidden and waits for completion. |
| Export success could be checked before the process exited. | The installer validates the completed process exit code and exported file before writing shortcuts. |
| Installer tests used only synchronous batch commands for the desktop entrypoint. | Regression coverage runs a real Windows GUI launcher through PowerShell 5.1 and 7, including a destination path containing spaces. |
| The package version was 4.12.5. | The package and lockfile version are 4.12.6. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates Windows desktop icon installation to wait for GUI export completion before creating shortcuts.
- Adds a Windows-specific icon export helper that launches the desktop executable hidden, waits for termination, and validates its exit code and output file.
- Adds Windows regression coverage for PowerShell 5.1/7 and destination paths containing spaces.
- Bumps the package and lockfile version from 4.12.5 to 4.12.6.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defects identified.

The installer waits for the GUI exporter, checks its exit status and generated file before creating shortcuts, and the added Windows test exercises the real launcher with a space-containing path.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The pytest suite for installers tests was executed with uv run pytest tests/scripts/test\_installers.py -q --tb=short and exited with code 0.
- In the focused run, test\_install\_ps1\_waits\_for\_gui\_icon\_export passed.
- test\_install\_ps1\_gui\_icon\_export\_completes\_before\_returning was skipped due to Windows-host requirements.
- Capability checks show the environment is Linux and that pwsh, powershell, and wine are unavailable.

<a href="https://app.greptile.com/trex/runs/15850386/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/install.ps1 | Adds synchronous Windows GUI-process handling and validates successful icon export before shortcut creation. |
| tests/scripts/test_installers.py | Adds Windows PowerShell regression coverage using the real GUI launcher, including a destination path containing spaces. |
| pyproject.toml | Bumps the project version to 4.12.6. |
| uv.lock | Keeps the editable root-package version synchronized at 4.12.6. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Installer as install.ps1
participant Desktop as fcc-desktop.exe
participant FileSystem as User profile
Installer->>Desktop: Start-Process --export-icon (hidden)
Installer->>Desktop: Wait for process completion
Desktop->>FileSystem: Write app-icon.ico
Desktop-->>Installer: Exit code
Installer->>FileSystem: Verify icon exists
Installer->>FileSystem: Create desktop shortcuts
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Wait for Windows app icon export"](https://github.com/alishahryar1/free-claude-code/commit/9d6b93f20477ab2bcf86407d7019eb47c085287a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47209642)</sub>

<!-- /greptile_comment -->