### PR TITLE
Add branded README wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
 
-# 🤖 Free Claude Code
-
-<picture>
-  <source media="(prefers-color-scheme: light)" srcset="assets/free-claude-code-wordmark-light.svg">
-  <img src="assets/free-claude-code-wordmark-dark.svg" alt="Free Claude Code" width="610">
-</picture>
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="assets/free-claude-code-wordmark-light.svg">
+    <img src="assets/free-claude-code-wordmark-dark.svg" alt="Free Claude Code" width="610">
+  </picture>
+</h1>
 
 Use Claude Code, Codex, Pi, or their IDE extensions through your own provider-backed proxy.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # 🤖 Free Claude Code
 
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="assets/free-claude-code-wordmark-light.svg">
+  <img src="assets/free-claude-code-wordmark-dark.svg" alt="Free Claude Code" width="610">
+</picture>
+
 Use Claude Code, Codex, Pi, or their IDE extensions through your own provider-backed proxy.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)

--- a/assets/free-claude-code-wordmark-dark.svg
+++ b/assets/free-claude-code-wordmark-dark.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1220" height="300" viewBox="0 0 1220 300" role="img" aria-labelledby="title">
+  <title id="title">Free Claude Code</title>
+  <g transform="translate(16 38) scale(.22)">
+    <rect x="32" y="32" width="960" height="960" rx="216" fill="#080b12"/>
+    <g fill="none" stroke="#f97316" stroke-linecap="round" stroke-linejoin="round" stroke-width="56">
+      <path d="M220 300h170c24 0 38 9 52 28l130 162c12 15 22 22 46 22h48"/>
+      <path d="M220 512h446"/>
+      <path d="M220 724h170c24 0 38-9 52-28l130-162c12-15 22-22 46-22h48"/>
+    </g>
+    <g fill="#f97316">
+      <circle cx="220" cy="300" r="62"/>
+      <circle cx="220" cy="512" r="62"/>
+      <circle cx="220" cy="724" r="62"/>
+    </g>
+    <rect x="648" y="372" width="244" height="280" rx="62" fill="#080b12" stroke="#f97316" stroke-width="56"/>
+    <path d="m742 454 58 58-58 58" fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round" stroke-width="48"/>
+  </g>
+  <text x="280" y="190" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="118" font-weight="700" letter-spacing="-3">
+    <tspan fill="#f97316">Free</tspan><tspan dx="28" fill="#f8fafc">Claude Code</tspan>
+  </text>
+</svg>

--- a/assets/free-claude-code-wordmark-dark.svg
+++ b/assets/free-claude-code-wordmark-dark.svg
@@ -15,7 +15,5 @@
     <rect x="648" y="372" width="244" height="280" rx="62" fill="#080b12" stroke="#f97316" stroke-width="56"/>
     <path d="m742 454 58 58-58 58" fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round" stroke-width="48"/>
   </g>
-  <text x="280" y="190" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="118" font-weight="700" letter-spacing="-3">
-    <tspan fill="#f97316">Free</tspan><tspan dx="28" fill="#f8fafc">Claude Code</tspan>
-  </text>
+  <text x="280" y="190" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="118" font-weight="700" letter-spacing="-3">Free Claude Code</text>
 </svg>

--- a/assets/free-claude-code-wordmark-light.svg
+++ b/assets/free-claude-code-wordmark-light.svg
@@ -15,7 +15,5 @@
     <rect x="648" y="372" width="244" height="280" rx="62" fill="#080b12" stroke="#f97316" stroke-width="56"/>
     <path d="m742 454 58 58-58 58" fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round" stroke-width="48"/>
   </g>
-  <text x="280" y="190" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="118" font-weight="700" letter-spacing="-3">
-    <tspan fill="#f97316">Free</tspan><tspan dx="28" fill="#0f172a">Claude Code</tspan>
-  </text>
+  <text x="280" y="190" fill="#0f172a" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="118" font-weight="700" letter-spacing="-3">Free Claude Code</text>
 </svg>

--- a/assets/free-claude-code-wordmark-light.svg
+++ b/assets/free-claude-code-wordmark-light.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1220" height="300" viewBox="0 0 1220 300" role="img" aria-labelledby="title">
+  <title id="title">Free Claude Code</title>
+  <g transform="translate(16 38) scale(.22)">
+    <rect x="32" y="32" width="960" height="960" rx="216" fill="#080b12"/>
+    <g fill="none" stroke="#f97316" stroke-linecap="round" stroke-linejoin="round" stroke-width="56">
+      <path d="M220 300h170c24 0 38 9 52 28l130 162c12 15 22 22 46 22h48"/>
+      <path d="M220 512h446"/>
+      <path d="M220 724h170c24 0 38-9 52-28l130-162c12-15 22-22 46-22h48"/>
+    </g>
+    <g fill="#f97316">
+      <circle cx="220" cy="300" r="62"/>
+      <circle cx="220" cy="512" r="62"/>
+      <circle cx="220" cy="724" r="62"/>
+    </g>
+    <rect x="648" y="372" width="244" height="280" rx="62" fill="#080b12" stroke="#f97316" stroke-width="56"/>
+    <path d="m742 454 58 58-58 58" fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round" stroke-width="48"/>
+  </g>
+  <text x="280" y="190" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="118" font-weight="700" letter-spacing="-3">
+    <tspan fill="#f97316">Free</tspan><tspan dx="28" fill="#0f172a">Claude Code</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## Problem

The README title does not present Free Claude Code's established visual identity. The new application mark is only visible after installation.

## Changes

| Before | After |
| --- | --- |
| The README header uses only a text title and generic robot emoji. | The README header adds a centered FCC symbol-and-name wordmark. |
| One header treatment must serve every GitHub theme. | Light and dark SVG variants preserve contrast in either theme. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a branded, theme-aware README wordmark.
- Replaces the text-and-emoji README heading with a centered HTML picture heading.
- Adds light- and dark-theme SVG wordmark variants with accessible alternative text.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The README references both newly added assets correctly, preserves a semantic top-level heading and accessible name, and selects contrasting wordmarks according to the viewer's color scheme.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured a before-state snapshot showing HEAD^:README.md and an after-state snapshot showing the current README with a light-to-dark theme transition.
- T-Rex verified that in light mode the currentSrc resolves to the light wordmark SVG and in dark mode it resolves to the dark wordmark SVG.
- T-Rex confirmed the after-state image is located inside the H1 and within a centered container, and that both selected images have valid intrinsic dimensions.
- T-Rex reviewed the accompanying video and image artifacts and logs to corroborate the state changes and the asset integrity.

<a href="https://app.greptile.com/trex/runs/15851538/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Replaces the Markdown title with a semantic, theme-aware wordmark heading using repository-local assets. |
| assets/free-claude-code-wordmark-dark.svg | Adds the dark-background wordmark variant with valid SVG structure and accessible labeling. |
| assets/free-claude-code-wordmark-light.svg | Adds the light-background wordmark variant with valid SVG structure and accessible labeling. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Refine README wordmark"](https://github.com/alishahryar1/free-claude-code/commit/6663814afc75ee67a08f26ea8b3bc1cb3da99b26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47211473)</sub>

<!-- /greptile_comment -->