### PR TITLE
Contain MiniMax native tool markup across NIM streams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.12.8"
+version = "4.12.9"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
+++ b/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
@@ -29,6 +29,30 @@ class NimNativeToolProtocolError(RetryableToolProtocolError):
     """NIM exposed malformed model-native tool markup instead of tool deltas."""
 
 
+class _NormalizedNativeToolStream(AsyncIterator[Any]):
+    """Expose normalized chunks while retaining the raw stream's close contract."""
+
+    def __init__(self, iterator: AsyncIterator[Any], source: Any) -> None:
+        self._iterator = iterator
+        self._source = source
+        self._closed = False
+
+    def __aiter__(self) -> _NormalizedNativeToolStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._closed:
+            raise StopAsyncIteration
+        return await anext(self._iterator)
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await maybe_await_aclose(self._iterator)
+        await maybe_await_aclose(self._source)
+
+
 @dataclass(frozen=True, slots=True)
 class _Element:
     name: str
@@ -79,6 +103,19 @@ class _MiniMaxM3ToolFramer:
 
         candidate = "".join((self._text_tail, text))
         marker_index = candidate.find(_TOOL_BLOCK_START)
+        held_length = _partial_marker_suffix_length(candidate, _TOOL_BLOCK_START)
+        protected_namespace_index = (
+            marker_index
+            if marker_index >= 0
+            else len(candidate) - held_length
+            if held_length
+            else -1
+        )
+        namespace_index = candidate.find(_NAMESPACE)
+        if namespace_index >= 0 and namespace_index != protected_namespace_index:
+            raise NimNativeToolProtocolError(
+                "NVIDIA NIM returned malformed native MiniMax tool markup."
+            )
         if marker_index >= 0:
             visible = candidate[:marker_index]
             self._text_tail = ""
@@ -86,7 +123,6 @@ class _MiniMaxM3ToolFramer:
             self._feed_tool_block(candidate[marker_index + len(_TOOL_BLOCK_START) :])
             return visible
 
-        held_length = _partial_marker_suffix_length(candidate, _TOOL_BLOCK_START)
         if held_length:
             visible = candidate[:-held_length]
             self._text_tail = candidate[-held_length:]
@@ -102,6 +138,12 @@ class _MiniMaxM3ToolFramer:
             tail = self._text_tail
             self._text_tail = ""
             self._mode = _FramingMode.FINISHED
+            if _NAMESPACE in tail:
+                if require_complete:
+                    raise NimNativeToolProtocolError(
+                        "NVIDIA NIM returned an incomplete native MiniMax tool marker."
+                    )
+                return ""
             return tail
         if self._mode is _FramingMode.TOOL_BLOCK and require_complete:
             self._mode = _FramingMode.FINISHED
@@ -157,77 +199,84 @@ def normalize_nim_native_tool_stream(
 ) -> AsyncIterator[Any]:
     """Convert leaked MiniMax-M3 markup into ordinary OpenAI tool-call chunks."""
     schemas = _openai_tool_schemas(body)
-    if not schemas:
-        return stream
 
     async def _iter() -> AsyncIterator[Any]:
-        framer = _MiniMaxM3ToolFramer()
+        content_framer = _MiniMaxM3ToolFramer()
+        reasoning_framer = _MiniMaxM3ToolFramer()
         structured_tool_calls_seen = False
         finalized = False
 
-        try:
-            async for chunk in stream:
-                choices = getattr(chunk, "choices", None)
-                if not choices:
-                    yield chunk
-                    continue
+        async for chunk in stream:
+            choices = getattr(chunk, "choices", None)
+            if not choices:
+                yield chunk
+                continue
 
-                choice = choices[0]
-                delta = getattr(choice, "delta", None)
-                if delta is None:
-                    yield chunk
-                    continue
+            choice = choices[0]
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                yield chunk
+                continue
 
-                native_tool_calls = getattr(delta, "tool_calls", None)
-                if _has_structured_tool_calls(native_tool_calls):
-                    structured_tool_calls_seen = True
+            native_tool_calls = getattr(delta, "tool_calls", None)
+            if _has_structured_tool_calls(native_tool_calls):
+                structured_tool_calls_seen = True
 
-                content = getattr(delta, "content", None)
-                safe_content = (
-                    framer.feed(content) if isinstance(content, str) else content
-                )
-                finish_reason = getattr(choice, "finish_reason", None)
-                generated_calls: tuple[_NativeToolCall, ...] = ()
-                if finish_reason is not None:
-                    tail = framer.finish(
-                        require_complete=not structured_tool_calls_seen
+            content = getattr(delta, "content", None)
+            safe_content = (
+                content_framer.feed(content) if isinstance(content, str) else content
+            )
+            reasoning = getattr(delta, "reasoning_content", None)
+            safe_reasoning = (
+                reasoning_framer.feed(reasoning)
+                if isinstance(reasoning, str)
+                else reasoning
+            )
+            finish_reason = getattr(choice, "finish_reason", None)
+            generated_calls: tuple[_NativeToolCall, ...] = ()
+            if finish_reason is not None:
+                safe_content, safe_reasoning, generated_calls = (
+                    _finish_native_tool_framers(
+                        content_framer,
+                        reasoning_framer,
+                        content=safe_content,
+                        reasoning_content=safe_reasoning,
+                        schemas=schemas,
+                        structured_tool_calls_seen=structured_tool_calls_seen,
                     )
-                    finalized = True
-                    safe_content = _join_optional_text(safe_content, tail)
-                    if not structured_tool_calls_seen and framer.tool_block is not None:
-                        generated_calls = _parse_tool_block(
-                            framer.tool_block,
-                            schemas,
-                        )
-
-                normalized = _normalized_chunks(
-                    chunk,
-                    choice,
-                    delta,
-                    content=safe_content,
-                    generated_calls=generated_calls,
-                    terminal=finish_reason is not None,
                 )
-                for normalized_chunk in normalized:
+                finalized = True
+
+            normalized = _normalized_chunks(
+                chunk,
+                choice,
+                delta,
+                content=safe_content,
+                reasoning_content=safe_reasoning,
+                generated_calls=generated_calls,
+                terminal=finish_reason is not None,
+            )
+            for normalized_chunk in normalized:
+                yield normalized_chunk
+
+        if not finalized:
+            content, reasoning, generated_calls = _finish_native_tool_framers(
+                content_framer,
+                reasoning_framer,
+                content=None,
+                reasoning_content=None,
+                schemas=schemas,
+                structured_tool_calls_seen=structured_tool_calls_seen,
+            )
+            if content or reasoning or generated_calls:
+                for normalized_chunk in _synthetic_chunks(
+                    content=content,
+                    reasoning_content=reasoning,
+                    generated_calls=generated_calls,
+                ):
                     yield normalized_chunk
 
-            if not finalized:
-                tail = framer.finish(require_complete=not structured_tool_calls_seen)
-                generated_calls = (
-                    ()
-                    if structured_tool_calls_seen or framer.tool_block is None
-                    else _parse_tool_block(framer.tool_block, schemas)
-                )
-                if tail or generated_calls:
-                    for normalized_chunk in _synthetic_chunks(
-                        content=tail or None,
-                        generated_calls=generated_calls,
-                    ):
-                        yield normalized_chunk
-        finally:
-            await maybe_await_aclose(stream)
-
-    return _iter()
+    return _NormalizedNativeToolStream(_iter(), stream)
 
 
 def _normalized_chunks(
@@ -236,23 +285,34 @@ def _normalized_chunks(
     source_delta: Any,
     *,
     content: Any,
+    reasoning_content: Any,
     generated_calls: tuple[_NativeToolCall, ...],
     terminal: bool,
 ) -> list[Any]:
-    reasoning = getattr(source_delta, "reasoning_content", None)
+    source_content = getattr(source_delta, "content", None)
+    source_reasoning = getattr(source_delta, "reasoning_content", None)
     structured_calls = getattr(source_delta, "tool_calls", None)
     source_finish_reason = getattr(source_choice, "finish_reason", None)
     source_usage = getattr(source_chunk, "usage", None)
 
+    if (
+        not generated_calls
+        and content == source_content
+        and reasoning_content == source_reasoning
+    ):
+        return [source_chunk]
+
     chunks: list[Any] = []
     has_source_payload = (
-        bool(content) or bool(reasoning) or _has_structured_tool_calls(structured_calls)
+        bool(content)
+        or bool(reasoning_content)
+        or _has_structured_tool_calls(structured_calls)
     )
     if has_source_payload or not generated_calls:
         chunks.append(
             _chunk(
                 content=content,
-                reasoning_content=reasoning,
+                reasoning_content=reasoning_content,
                 tool_calls=structured_calls,
             )
         )
@@ -271,11 +331,50 @@ def _normalized_chunks(
 def _synthetic_chunks(
     *,
     content: str | None,
+    reasoning_content: str | None,
     generated_calls: tuple[_NativeToolCall, ...],
 ) -> list[Any]:
-    chunks = [_chunk(content=content)] if content else []
+    chunks = (
+        [_chunk(content=content, reasoning_content=reasoning_content)]
+        if content or reasoning_content
+        else []
+    )
     chunks.extend(_tool_call_chunk(call) for call in generated_calls)
     return chunks
+
+
+def _finish_native_tool_framers(
+    content_framer: _MiniMaxM3ToolFramer,
+    reasoning_framer: _MiniMaxM3ToolFramer,
+    *,
+    content: Any,
+    reasoning_content: Any,
+    schemas: Mapping[str, dict[str, Any]],
+    structured_tool_calls_seen: bool,
+) -> tuple[Any, Any, tuple[_NativeToolCall, ...]]:
+    require_complete = not structured_tool_calls_seen
+    content = _join_optional_text(
+        content,
+        content_framer.finish(require_complete=require_complete),
+    )
+    reasoning_content = _join_optional_text(
+        reasoning_content,
+        reasoning_framer.finish(require_complete=require_complete),
+    )
+    if structured_tool_calls_seen:
+        return content, reasoning_content, ()
+
+    blocks = tuple(
+        block
+        for block in (content_framer.tool_block, reasoning_framer.tool_block)
+        if block is not None
+    )
+    if len(blocks) > 1:
+        raise NimNativeToolProtocolError(
+            "NVIDIA NIM returned native MiniMax tool calls in multiple output fields."
+        )
+    generated_calls = _parse_tool_block(blocks[0], schemas) if blocks else ()
+    return content, reasoning_content, generated_calls
 
 
 def _chunk(

--- a/tests/providers/test_nvidia_nim.py
+++ b/tests/providers/test_nvidia_nim.py
@@ -619,6 +619,89 @@ async def test_native_minimax_tool_markup_becomes_anthropic_tool_use(nim_provide
 
 
 @pytest.mark.asyncio
+async def test_native_minimax_reasoning_markup_becomes_anthropic_tool_use(
+    nim_provider,
+):
+    req = make_request(
+        tools=[
+            tool(
+                "Write",
+                "Write one file",
+                {
+                    "type": "object",
+                    "properties": {"file_path": {"type": "string"}},
+                    "required": ["file_path"],
+                },
+            )
+        ]
+    )
+    namespace = "]<]minimax[>["
+    raw = (
+        f"{namespace}<tool_call>"
+        f'{namespace}<invoke name="Write">'
+        f"{namespace}<file_path>output.md{namespace}</file_path>"
+        f"{namespace}</invoke>"
+        f"{namespace}</tool_call>"
+    )
+
+    async def mock_stream():
+        yield _content_chunk(
+            None,
+            reasoning_content=raw,
+            finish_reason="tool_calls",
+        )
+
+    with patch.object(
+        nim_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [event async for event in nim_provider.stream_response(req)]
+
+    event_text = "".join(events)
+    assert namespace not in event_text
+    assert '"type": "tool_use"' in event_text
+    assert '"name": "Write"' in event_text
+    assert json.loads(_input_json_deltas(events)[0]) == {"file_path": "output.md"}
+
+
+@pytest.mark.asyncio
+async def test_native_minimax_markup_without_tools_retries_without_leaking(
+    nim_provider,
+):
+    req = make_request(tools=None)
+    namespace = "]<]minimax[>["
+    raw = (
+        f"{namespace}<tool_call>"
+        f'{namespace}<invoke name="Write">'
+        f"{namespace}<file_path>output.md{namespace}</file_path>"
+        f"{namespace}</invoke>"
+        f"{namespace}</tool_call>"
+    )
+
+    async def native_stream():
+        yield _content_chunk(raw, finish_reason="tool_calls")
+
+    async def recovered_stream():
+        yield _content_chunk("Recovered safely.", finish_reason="stop")
+
+    attempts = [native_stream() for _ in range(UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS - 1)]
+    attempts.append(recovered_stream())
+    with patch.object(
+        nim_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.side_effect = attempts
+
+        events = [event async for event in nim_provider.stream_response(req)]
+
+    event_text = "".join(events)
+    assert mock_create.await_count == UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS
+    assert namespace not in event_text
+    assert event_text.count("Recovered safely.") == 1
+    assert '"type": "tool_use"' not in event_text
+
+
+@pytest.mark.asyncio
 async def test_native_minimax_tool_markup_restores_nim_argument_aliases(nim_provider):
     req = make_request(
         tools=[

--- a/tests/providers/test_nvidia_nim_native_tool_stream.py
+++ b/tests/providers/test_nvidia_nim_native_tool_stream.py
@@ -30,6 +30,7 @@ def _tool_block(*invokes: str) -> str:
 def _chunk(
     *,
     content: str | None = None,
+    reasoning_content: str | None = None,
     tool_calls: list[object] | None = None,
     finish_reason: str | None = None,
 ) -> SimpleNamespace:
@@ -38,7 +39,7 @@ def _chunk(
             SimpleNamespace(
                 delta=SimpleNamespace(
                     content=content,
-                    reasoning_content=None,
+                    reasoning_content=reasoning_content,
                     tool_calls=tool_calls,
                 ),
                 finish_reason=finish_reason,
@@ -100,6 +101,21 @@ def _content(chunks: list[SimpleNamespace]) -> str:
     )
 
 
+def _reasoning(chunks: list[SimpleNamespace]) -> str:
+    return "".join(
+        reasoning
+        for chunk in chunks
+        if (
+            reasoning := getattr(
+                chunk.choices[0].delta,
+                "reasoning_content",
+                None,
+            )
+        )
+        is not None
+    )
+
+
 def _tool_calls(chunks: list[SimpleNamespace]) -> list[SimpleNamespace]:
     calls: list[SimpleNamespace] = []
     for chunk in chunks:
@@ -135,6 +151,118 @@ async def test_normalizer_preserves_ordinary_text_incrementally() -> None:
     assert _content(normalized) == "Hello world"
     assert not _tool_calls(normalized)
     assert normalized[-1].choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_normalizer_preserves_ordinary_stream_without_tool_schemas() -> None:
+    source = _chunk(
+        content="Answer",
+        reasoning_content="Thinking",
+        finish_reason="stop",
+    )
+
+    normalized = await _normalize([source], {})
+
+    assert normalized == [source]
+    assert normalized[0] is source
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["content", "reasoning_content"])
+async def test_normalizer_decodes_tool_block_from_each_text_field(field: str) -> None:
+    raw = "Preparing. " + _tool_block(
+        _invoke("Read", _element("file_path", "README.md"))
+    )
+    body = _body(
+        _function(
+            "Read",
+            {"file_path": {"type": "string"}},
+            ["file_path"],
+        )
+    )
+
+    normalized = await _normalize(
+        [
+            _chunk(
+                content=raw if field == "content" else None,
+                reasoning_content=raw if field == "reasoning_content" else None,
+                finish_reason="tool_calls",
+            )
+        ],
+        body,
+    )
+
+    assert NS not in _content(normalized)
+    assert NS not in _reasoning(normalized)
+    assert (_content(normalized) if field == "content" else _reasoning(normalized)) == (
+        "Preparing. "
+    )
+    calls = _tool_calls(normalized)
+    assert len(calls) == 1
+    assert calls[0].function.name == "Read"
+    assert json.loads(calls[0].function.arguments) == {"file_path": "README.md"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["content", "reasoning_content"])
+async def test_normalizer_rejects_native_calls_without_tool_schemas(
+    field: str,
+) -> None:
+    raw = _tool_block(_invoke("Write", _element("file_path", "output.md")))
+
+    with pytest.raises(NimNativeToolProtocolError, match="undeclared tool"):
+        await _normalize(
+            [
+                _chunk(
+                    content=raw if field == "content" else None,
+                    reasoning_content=raw if field == "reasoning_content" else None,
+                    finish_reason="tool_calls",
+                )
+            ],
+            {},
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["content", "reasoning_content"])
+async def test_normalizer_rejects_unframed_native_namespace(field: str) -> None:
+    raw = f'{NS}<invoke name="Write">'
+
+    with pytest.raises(NimNativeToolProtocolError, match="malformed"):
+        await _normalize(
+            [
+                _chunk(
+                    content=raw if field == "content" else None,
+                    reasoning_content=raw if field == "reasoning_content" else None,
+                    finish_reason="stop",
+                )
+            ],
+            {},
+        )
+
+
+@pytest.mark.asyncio
+async def test_normalizer_rejects_native_calls_in_multiple_text_fields() -> None:
+    raw = _tool_block(_invoke("Read", _element("file_path", "README.md")))
+    body = _body(
+        _function(
+            "Read",
+            {"file_path": {"type": "string"}},
+            ["file_path"],
+        )
+    )
+
+    with pytest.raises(NimNativeToolProtocolError, match="multiple output fields"):
+        await _normalize(
+            [
+                _chunk(
+                    content=raw,
+                    reasoning_content=raw,
+                    finish_reason="tool_calls",
+                )
+            ],
+            body,
+        )
 
 
 @pytest.mark.asyncio
@@ -247,9 +375,10 @@ async def test_normalizer_decodes_parallel_recursive_arguments_in_order() -> Non
 
 
 @pytest.mark.asyncio
-async def test_normalizer_prefers_structured_calls_and_only_strips_raw_duplicate() -> (
-    None
-):
+@pytest.mark.parametrize("field", ["content", "reasoning_content"])
+async def test_normalizer_prefers_structured_calls_and_strips_raw_duplicate(
+    field: str,
+) -> None:
     raw = "Checking. " + _tool_block(f'{NS}<invoke name="">{INVOKE_END}')
     structured = _structured_call("Read", '{"file_path":"README.md"}')
     body = _body(
@@ -262,15 +391,22 @@ async def test_normalizer_prefers_structured_calls_and_only_strips_raw_duplicate
 
     normalized = await _normalize(
         [
-            _chunk(content=raw, tool_calls=[structured]),
+            _chunk(
+                content=raw if field == "content" else None,
+                reasoning_content=raw if field == "reasoning_content" else None,
+                tool_calls=[structured],
+            ),
             _chunk(finish_reason="tool_calls"),
         ],
         body,
     )
 
-    assert _content(normalized) == "Checking. "
+    assert (_content(normalized) if field == "content" else _reasoning(normalized)) == (
+        "Checking. "
+    )
     assert _tool_calls(normalized) == [structured]
     assert NS not in _content(normalized)
+    assert NS not in _reasoning(normalized)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.12.8"
+version = "4.12.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

MiniMax models served through NVIDIA NIM can emit private tool-call markup in content or reasoning output, including requests without tool schemas. FCC only inspected tool-bearing content streams, so control tokens could reach clients; this partially addresses #1254.

## Changes

| Before | After |
| --- | --- |
| Native normalization ran only when tool schemas were present. | Every NVIDIA NIM stream contains the MiniMax control namespace while preserving ordinary chunks unchanged. |
| Only content deltas were inspected for native tool calls. | Content and reasoning deltas share the same framing and validation contract. |
| Undeclared or malformed native calls could appear as assistant text. | Declared calls become structured tool calls, while invalid calls enter FCC's existing bounded recovery lifecycle without leaking markup. |
| The normalizer could let raw-stream cleanup replace the established request outcome. | The normalizer delegates closure so the provider runner preserves the original outcome and correlated diagnostics. |
| Coverage assumed declared tools in content output. | Coverage includes no-tool requests, reasoning output, split markers, structured-call precedence, and duplicate-free recovery. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates NVIDIA NIM stream normalization to contain MiniMax native tool markup across content and reasoning streams.
- Normalizes streams even when requests contain no tool schemas.
- Converts valid native markup into structured tool calls and routes malformed or undeclared calls through existing recovery.
- Preserves ordinary chunks and delegates raw-stream closure through a wrapper.
- Adds coverage for reasoning output, schema-free requests, split markers, structured-call precedence, and recovery behavior.
- Bumps the package version from 4.12.8 to 4.12.9.
</details>

<h3>Confidence Score: 5/5</h3>

The change appears safe to merge.

The normalizer consistently contains MiniMax control markup across content and reasoning fields, preserves ordinary chunks, integrates malformed calls with existing recovery, and retains the provider runner’s stream-closure behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change run where focused tests failed due to leaked reasoning control tokens and no retry, evidenced by await\_count = 1 instead of 5.
- Confirmed the post-change run where both named tests passed with exit code 0.
- Verified the tests used mocked async streams and did not invoke any live NVIDIA API.

<a href="https://app.greptile.com/trex/runs/15857258/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/nvidia_nim/native_tool_stream.py | Extends native MiniMax framing to content and reasoning fields, validates namespace leakage, preserves unchanged chunks, and delegates stream closure without an identified correctness defect. |
| tests/providers/test_nvidia_nim_native_tool_stream.py | Adds focused unit coverage for schema-free streams, both text fields, malformed namespaces, split framing, and structured-call precedence. |
| tests/providers/test_nvidia_nim.py | Adds provider-level coverage for reasoning-based tool calls and bounded recovery when native calls appear without declared tools. |
| pyproject.toml | Bumps the project patch version to 4.12.9. |
| uv.lock | Synchronizes the editable package version with pyproject.toml without changing resolved dependency versions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  NIM[NVIDIA NIM stream] --> NORMALIZER[Native tool stream normalizer]
  NORMALIZER --> CONTENT[Content framer]
  NORMALIZER --> REASONING[Reasoning framer]
  CONTENT --> VALIDATE[Validate native tool block]
  REASONING --> VALIDATE
  VALIDATE -->|Valid declared call| TOOL[Structured tool-call chunks]
  VALIDATE -->|Malformed or undeclared| RECOVERY[Provider recovery lifecycle]
  NORMALIZER -->|Ordinary output| PASS[Preserved stream chunks]
  TOOL --> ADAPTER[OpenAI-chat stream adapter]
  PASS --> ADAPTER
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Contain NIM native tool markup across st..."](https://github.com/alishahryar1/free-claude-code/commit/510ceeed78b1570f929277a1d5a12f4b23b0035a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47222964)</sub>

<!-- /greptile_comment -->