### PR TITLE
docs: add local-setup guide for using FCC locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,59 @@ Windows PowerShell:
 & ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/uninstall.ps1")))
 ```
 
+## Using Free Claude Code (FCC) locally (optional)
+
+FCC is a lightweight proxy that lets you point the Claude Code, Codex, or Pi CLI tools at any OpenAI-compatible LLM provider (e.g., NVIDIA NIM, OpenRouter, Gemini).
+
+### One-time setup
+
+```powershell
+# Install the UV tool (once)
+uv tool install --force --refresh-package free-claude-code --git https://github.com/Alishahryar1/free-claude-code.git
+```
+
+### Starting the proxy
+
+```powershell
+# Clear any env that could interfere (especially when using another agent framework)
+$env:VIRTUAL_ENV = $null
+$env:PYTHONPATH  = $null
+
+# Put your provider key here - never commit this value
+$env:NVIDIA_NIM_API_KEY = "***"   # replace with your actual key
+
+# Launch the server
+uv tool run free-claude-code fcc-server
+```
+
+The server listens on `http://127.0.0.1:8082`. Keep this window open while you work.
+
+### Using the wrapped CLIs
+
+In a **new** terminal (repeat the env-var block above, or source the same snippet):
+
+```powershell
+$env:VIRTUAL_ENV = $null
+$env:PYTHONPATH  = $null
+$env:NVIDIA_NIM_API_KEY = "***"
+$env:PATH = "$HOME\.local\bin;$env:PATH"
+
+# Examples
+fcc-claude "Explain how to reverse a string in Python."
+fcc-codex exec "ls -lt | head -5"
+fcc-pi --help
+```
+
+### Stopping the proxy
+
+Press **Ctrl+C** in the terminal where you ran `uv tool run ...`, or from another terminal:
+
+```powershell
+Get-Process | Where-Object { $_.Path -like "*fcc-server.exe" } | Stop-Process -Force
+```
+
+> **Security note:** Never commit your actual API key. If you prefer not to type it each time, create a `.env` file (added to `.gitignore`) and load it with `dotenv` or a similar method before launching the server.
+
 ## Project Links
 
 - [Report bugs or request features](https://github.com/Alishahryar1/free-claude-code/issues)


### PR DESCRIPTION
## Summary
- Adds an optional "Using Free Claude Code (FCC) locally" section to the README
- Covers one-time install via `uv tool install`, starting/stopping `fcc-server`, and using the wrapped CLI commands (`fcc-claude`, `fcc-codex`, `fcc-pi`) on Windows/PowerShell
- Includes a security note against committing API keys, with a `.env` alternative

## Test plan
- [x] Verified README renders correctly (no leaked diff markers, no encoding issues)
- [x] Confirmed the new section only appears once and doesn't duplicate existing content
- Docs-only change — no code/behavior affected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional Windows/PowerShell guide for running FCC locally.
- Documents uv-based installation and proxy startup.
- Shows use of the Claude, Codex, and Pi wrapper commands.
- Adds proxy shutdown and API-key handling guidance.

<h3>Confidence Score: 2/5</h3>

This PR should not merge until the installation and startup examples are corrected and the provider key is removed from the wrapped CLI environment.

The primary setup path omits the required interpreter selection, targets an executable the package does not define, and unnecessarily propagates the provider credential into wrapped CLI processes.

**Files Needing Attention:** README.md

<details open><summary><h3>Security Review</h3></summary>

The guide instructs users to copy the provider API key into wrapped CLI environments even though only the proxy server consumes it, unnecessarily exposing the credential to those CLI processes and their subprocesses.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the installation flow under three interpreter scenarios: no explicit interpreter (fails due to required Python \>= 3.14.0), default interpreter path (fails for the same reason), and explicit Python 3.14.0 (succeeds, installing 77 packages and five executables).
- Reproduced the startup behavior and verified that the documented startup command fails to resolve the executable and that the listener port is not active, while a control run of uv run fcc-server --version succeeds and reports free-claude-code 4.12.9.
- Validated the local README setup by checking that the pre-render log decodes cleanly with no leaked markers, then confirmed the after-render README has one H2, four H3 subsections, and a command fence in each subsection, and ran the validator against real repository inputs.

<a href="https://app.greptile.com/trex/runs/15860713/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds the local setup guide, but its installation and startup commands diverge from supported package contracts and its CLI setup unnecessarily propagates the provider credential. |

<sub>Reviews (1): Last reviewed commit: ["docs: add local-setup guide for Free Cla..."](https://github.com/alishahryar1/free-claude-code/commit/6bfa776e685b90e6c8476167e581d59a7dd514c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47229902)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->