### PR TITLE
Close interrupted tool turns before new user input

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -804,10 +804,12 @@ Top-level `system` content stays distinct from inline `system` messages.
 Target-protocol conversion owns their representation: neutral OpenAI Chat
 conversion emits top-level `system` content as the sole leading system message
 and maps inline `system` content into ordered `user` turns. After tool-result
-dependencies are ordered, adjacent user content is coalesced into one turn so
-strict chat templates do not receive consecutive user roles. Conversion
-preserves content order and rejects unrepresentable blocks instead of dropping
-them. Provider policies do not reinterpret this role mapping.
+dependencies are ordered, a neutral whitespace-only assistant boundary closes
+any completed tool round before subsequent user input. Adjacent user content
+is then coalesced into one turn so strict chat templates receive neither
+`tool → user` nor consecutive user roles. Conversion preserves content order
+and rejects unrepresentable blocks instead of dropping them. Provider policies
+do not reinterpret this role mapping.
 
 User image conversion is a pure protocol operation. Core maps Anthropic base64
 and URL image sources to ordered OpenAI `image_url` content parts without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.12.10"
+version = "4.12.11"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -172,6 +172,7 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
         (
             "test_provider_interleaved_thinking_tool_e2e",
             "test_provider_tool_result_continuation_e2e",
+            "test_provider_interrupted_tool_turn_resume_e2e",
             "test_gemini_thought_signature_tool_continuation_e2e",
             "test_provider_reasoning_tool_continuation_e2e",
         ),

--- a/smoke/product/test_provider_product_live.py
+++ b/smoke/product/test_provider_product_live.py
@@ -86,6 +86,15 @@ def test_provider_tool_result_continuation_e2e(
 
 
 @pytest.mark.smoke_target("tools")
+def test_provider_interrupted_tool_turn_resume_e2e(
+    smoke_config: SmokeConfig, provider_model: ProviderModel
+) -> None:
+    _run_provider_scenario(
+        smoke_config, provider_model, _scenario_interrupted_tool_turn_resume
+    )
+
+
+@pytest.mark.smoke_target("tools")
 def test_gemini_thought_signature_tool_continuation_e2e(
     smoke_config: SmokeConfig, provider_model: ProviderModel
 ) -> None:
@@ -441,6 +450,51 @@ def _scenario_tool_result_continuation(
         second = driver.stream(second_payload)
     _assert_provider_product_stream(first.events)
     _assert_provider_product_stream(second.events)
+
+
+def _scenario_interrupted_tool_turn_resume(
+    smoke_config: SmokeConfig, provider_model: ProviderModel
+) -> None:
+    tool_id = "toolu_interrupted123456789"
+    payload = {
+        "model": "claude-sonnet-4-5-20250929",
+        "max_tokens": 32,
+        "stream": True,
+        "messages": [
+            {"role": "user", "content": "Use echo_smoke with value FCC_INTERRUPTED."},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "echo_smoke",
+                        "input": {"value": "FCC_INTERRUPTED"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": "FCC_INTERRUPTED",
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": "Reply exactly OK without calling tools.",
+            },
+        ],
+        "tools": [echo_tool_schema()],
+    }
+    with _server_for_provider(
+        smoke_config, provider_model, "interrupted-tool-turn"
+    ) as server:
+        turn = ConversationDriver(server, smoke_config).stream(payload)
+    _assert_provider_product_stream(turn.events)
 
 
 def _scenario_gemini_thought_signature_tool_continuation(

--- a/src/free_claude_code/core/anthropic/__init__.py
+++ b/src/free_claude_code/core/anthropic/__init__.py
@@ -6,6 +6,7 @@ from .conversion import (
     OpenAIConversionError,
     ReasoningReplayMode,
     build_base_request_body,
+    is_synthetic_openai_tool_turn_boundary,
 )
 from .errors import (
     anthropic_error_payload,
@@ -92,6 +93,7 @@ __all__ = [
     "get_block_attr",
     "get_block_type",
     "get_token_count",
+    "is_synthetic_openai_tool_turn_boundary",
     "map_stop_reason",
     "serialize_tool_result_content",
     "set_if_not_none",

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -268,6 +268,17 @@ def _coalesce_openai_user_messages(
     return result
 
 
+class _SyntheticOpenAIToolTurnBoundary(dict[str, Any]):
+    """Identify an FCC-inserted assistant boundary until wire serialization."""
+
+    __slots__ = ()
+
+
+def is_synthetic_openai_tool_turn_boundary(message: object) -> bool:
+    """Return whether FCC inserted this message to close an OpenAI tool turn."""
+    return isinstance(message, _SyntheticOpenAIToolTurnBoundary)
+
+
 def _close_openai_tool_result_turns(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -282,7 +293,9 @@ def _close_openai_tool_result_turns(
             # Some OpenAI-compatible chat templates reject a user role directly
             # after tool output. Non-empty whitespace closes the assistant turn
             # without inventing model content.
-            result.append({"role": "assistant", "content": " "})
+            result.append(
+                _SyntheticOpenAIToolTurnBoundary(role="assistant", content=" ")
+            )
         result.append(message)
     return result
 

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -268,6 +268,25 @@ def _coalesce_openai_user_messages(
     return result
 
 
+def _close_openai_tool_result_turns(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Close completed tool rounds before subsequent user input."""
+    result: list[dict[str, Any]] = []
+    for message in messages:
+        if (
+            message.get("role") == "user"
+            and result
+            and result[-1].get("role") == "tool"
+        ):
+            # Some OpenAI-compatible chat templates reject a user role directly
+            # after tool output. Non-empty whitespace closes the assistant turn
+            # without inventing model content.
+            result.append({"role": "assistant", "content": " "})
+        result.append(message)
+    return result
+
+
 class _OpenAIChatHistoryLedger:
     """Assemble OpenAI chat history while respecting tool-result dependencies."""
 
@@ -431,7 +450,9 @@ class AnthropicToOpenAIConverter:
                 else:
                     ledger.add_tool_turn(segment)
 
-        return _coalesce_openai_user_messages(ledger.finish())
+        ordered_messages = ledger.finish()
+        closed_messages = _close_openai_tool_result_turns(ordered_messages)
+        return _coalesce_openai_user_messages(closed_messages)
 
     @staticmethod
     def _convert_message_to_segments(

--- a/src/free_claude_code/providers/open_router/client.py
+++ b/src/free_claude_code/providers/open_router/client.py
@@ -78,7 +78,11 @@ def _apply_openrouter_reasoning_details_replay(
     for details in assistant_details:
         for index in range(cursor, len(messages)):
             message = messages[index]
-            if not isinstance(message, dict) or message.get("role") != "assistant":
+            if (
+                not isinstance(message, dict)
+                or message.get("role") != "assistant"
+                or _is_tool_turn_boundary(messages, index)
+            ):
                 continue
             existing = message.get("reasoning_details")
             if isinstance(existing, list):
@@ -87,6 +91,22 @@ def _apply_openrouter_reasoning_details_replay(
                 message["reasoning_details"] = list(details)
             cursor = index + 1
             break
+
+
+def _is_tool_turn_boundary(messages: list[Any], index: int) -> bool:
+    message = messages[index]
+    return (
+        isinstance(message, dict)
+        and message.get("role") == "assistant"
+        and message.get("content") == " "
+        and "tool_calls" not in message
+        and index > 0
+        and isinstance(messages[index - 1], dict)
+        and messages[index - 1].get("role") == "tool"
+        and index + 1 < len(messages)
+        and isinstance(messages[index + 1], dict)
+        and messages[index + 1].get("role") == "user"
+    )
 
 
 _PROFILE = OpenAIChatProfile(

--- a/src/free_claude_code/providers/open_router/client.py
+++ b/src/free_claude_code/providers/open_router/client.py
@@ -6,7 +6,10 @@ from typing import Any
 
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
-from free_claude_code.core.anthropic import ReasoningReplayMode
+from free_claude_code.core.anthropic import (
+    ReasoningReplayMode,
+    is_synthetic_openai_tool_turn_boundary,
+)
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
@@ -81,7 +84,7 @@ def _apply_openrouter_reasoning_details_replay(
             if (
                 not isinstance(message, dict)
                 or message.get("role") != "assistant"
-                or _is_tool_turn_boundary(messages, index)
+                or is_synthetic_openai_tool_turn_boundary(message)
             ):
                 continue
             existing = message.get("reasoning_details")
@@ -91,22 +94,6 @@ def _apply_openrouter_reasoning_details_replay(
                 message["reasoning_details"] = list(details)
             cursor = index + 1
             break
-
-
-def _is_tool_turn_boundary(messages: list[Any], index: int) -> bool:
-    message = messages[index]
-    return (
-        isinstance(message, dict)
-        and message.get("role") == "assistant"
-        and message.get("content") == " "
-        and "tool_calls" not in message
-        and index > 0
-        and isinstance(messages[index - 1], dict)
-        and messages[index - 1].get("role") == "tool"
-        and index + 1 < len(messages)
-        and isinstance(messages[index + 1], dict)
-        and messages[index + 1].get("role") == "user"
-    )
 
 
 _PROFILE = OpenAIChatProfile(

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -7,6 +7,7 @@ from free_claude_code.core.anthropic import (
     OpenAIConversionError,
     ReasoningReplayMode,
     build_base_request_body,
+    is_synthetic_openai_tool_turn_boundary,
 )
 from free_claude_code.core.anthropic.models import MessagesRequest
 
@@ -1208,6 +1209,11 @@ def test_user_after_completed_tool_result_gets_neutral_assistant_boundary():
         "user",
     ]
     assert result[3] == {"role": "assistant", "content": " "}
+    assert is_synthetic_openai_tool_turn_boundary(result[3])
+    assert json.loads(json.dumps(result[3])) == {
+        "role": "assistant",
+        "content": " ",
+    }
     assert result[4]["content"] == "Please summarize it."
 
 

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -244,8 +244,10 @@ def test_inline_system_message_follows_completed_tool_result() -> None:
         "user",
         "assistant",
         "tool",
+        "assistant",
         "user",
     ]
+    assert body["messages"][3] == {"role": "assistant", "content": " "}
     assert body["messages"][-1]["content"] == "New instructions"
 
 
@@ -1137,7 +1139,26 @@ def test_convert_assistant_text_after_tool_use_inserts_after_tool_results():
     assert result[2] == {"role": "assistant", "content": "Post-tool commentary"}
 
 
-def test_unrelated_user_text_before_tool_result_is_buffered_until_after_tool_result():
+def _completed_single_tool_turn(*, user_text=None):
+    result_blocks = [
+        MockBlock(
+            type="tool_result",
+            tool_use_id="call_z",
+            content="file contents",
+        )
+    ]
+    if user_text is not None:
+        result_blocks.append(MockBlock(type="text", text=user_text))
+    return [
+        MockMessage(
+            "assistant",
+            [MockBlock(type="tool_use", id="call_z", name="Read", input={})],
+        ),
+        MockMessage("user", result_blocks),
+    ]
+
+
+def test_unrelated_user_text_before_tool_result_is_buffered_after_closed_tool_turn():
     messages = [
         MockMessage(
             "assistant",
@@ -1158,10 +1179,121 @@ def test_unrelated_user_text_before_tool_result_is_buffered_until_after_tool_res
 
     result = AnthropicToOpenAIConverter.convert_messages(messages)
 
-    assert [message["role"] for message in result] == ["assistant", "tool", "user"]
+    assert [message["role"] for message in result] == [
+        "assistant",
+        "tool",
+        "assistant",
+        "user",
+    ]
     assert result[0]["tool_calls"][0]["id"] == "call_z"
     assert result[1]["tool_call_id"] == "call_z"
-    assert result[2]["content"] == "Please also summarize it."
+    assert result[2] == {"role": "assistant", "content": " "}
+    assert result[3]["content"] == "Please also summarize it."
+
+
+def test_user_after_completed_tool_result_gets_neutral_assistant_boundary():
+    messages = [
+        MockMessage("user", "Read the file."),
+        *_completed_single_tool_turn(),
+        MockMessage("user", "Please summarize it."),
+    ]
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert [message["role"] for message in result] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+        "user",
+    ]
+    assert result[3] == {"role": "assistant", "content": " "}
+    assert result[4]["content"] == "Please summarize it."
+
+
+def test_user_text_beside_tool_result_follows_neutral_assistant_boundary():
+    messages = _completed_single_tool_turn(user_text="Please summarize it.")
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert [message["role"] for message in result] == [
+        "assistant",
+        "tool",
+        "assistant",
+        "user",
+    ]
+    assert result[2] == {"role": "assistant", "content": " "}
+    assert result[3]["content"] == "Please summarize it."
+
+
+def test_multiple_tool_results_get_one_assistant_boundary_before_user():
+    messages = [
+        MockMessage(
+            "assistant",
+            [
+                MockBlock(type="tool_use", id="call_a", name="ReadA", input={}),
+                MockBlock(type="tool_use", id="call_b", name="ReadB", input={}),
+            ],
+        ),
+        MockMessage(
+            "user",
+            [
+                MockBlock(
+                    type="tool_result",
+                    tool_use_id="call_b",
+                    content="result b",
+                ),
+                MockBlock(
+                    type="tool_result",
+                    tool_use_id="call_a",
+                    content="result a",
+                ),
+            ],
+        ),
+        MockMessage("user", "Compare both results."),
+    ]
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert [message["role"] for message in result] == [
+        "assistant",
+        "tool",
+        "tool",
+        "assistant",
+        "user",
+    ]
+    assert [message["tool_call_id"] for message in result[1:3]] == [
+        "call_a",
+        "call_b",
+    ]
+    assert result[3] == {"role": "assistant", "content": " "}
+    assert result[4]["content"] == "Compare both results."
+
+
+def test_terminal_tool_result_does_not_get_assistant_boundary():
+    messages = _completed_single_tool_turn()
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert [message["role"] for message in result] == ["assistant", "tool"]
+
+
+def test_existing_assistant_completion_prevents_extra_tool_turn_boundary():
+    messages = [
+        *_completed_single_tool_turn(),
+        MockMessage("assistant", "The file contains useful information."),
+        MockMessage("user", "Please summarize it."),
+    ]
+
+    result = AnthropicToOpenAIConverter.convert_messages(messages)
+
+    assert [message["role"] for message in result] == [
+        "assistant",
+        "tool",
+        "assistant",
+        "user",
+    ]
+    assert result[2]["content"] == "The file contains useful information."
 
 
 def test_unrelated_assistant_text_before_tool_result_is_buffered_until_after_tool_result():

--- a/tests/providers/test_open_router.py
+++ b/tests/providers/test_open_router.py
@@ -234,6 +234,71 @@ def test_reasoning_details_skip_neutral_tool_turn_boundary(open_router_provider)
     assert assistants[2]["reasoning_details"] == [second_detail]
 
 
+def test_reasoning_details_preserve_redacted_only_assistant_after_tool(
+    open_router_provider,
+):
+    first_detail = {"type": "reasoning.encrypted", "data": "first"}
+    second_detail = {"type": "reasoning.encrypted", "data": "second"}
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "redacted_thinking",
+                            "data": json.dumps(first_detail),
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "call_read",
+                            "name": "Read",
+                            "input": {},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_read",
+                            "content": "contents",
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "redacted_thinking",
+                            "data": json.dumps(second_detail),
+                        }
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+                {"role": "assistant", "content": "done"},
+            ],
+        }
+    )
+
+    body = open_router_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assistants = [
+        message for message in body["messages"] if message["role"] == "assistant"
+    ]
+    assert assistants[0]["reasoning_details"] == [first_detail]
+    assert assistants[1] == {
+        "role": "assistant",
+        "content": " ",
+        "reasoning_details": [second_detail],
+    }
+    assert "reasoning_details" not in assistants[2]
+
+
 @pytest.mark.asyncio
 async def test_stream_maps_reasoning_content_and_details(open_router_provider):
     redacted = {"type": "reasoning.encrypted", "data": "opaque"}

--- a/tests/providers/test_open_router.py
+++ b/tests/providers/test_open_router.py
@@ -1,5 +1,6 @@
 """Tests for the OpenRouter OpenAI-chat provider."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -172,6 +173,65 @@ def test_build_request_body_replays_openrouter_reasoning_details(
 
     assistant = next(msg for msg in body["messages"] if msg["role"] == "assistant")
     assert assistant["reasoning_details"] == [detail]
+
+
+def test_reasoning_details_skip_neutral_tool_turn_boundary(open_router_provider):
+    first_detail = {"type": "reasoning.encrypted", "data": "first"}
+    second_detail = {"type": "reasoning.encrypted", "data": "second"}
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "redacted_thinking",
+                            "data": json.dumps(first_detail),
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "call_read",
+                            "name": "Read",
+                            "input": {},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_read",
+                            "content": "contents",
+                        }
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "redacted_thinking",
+                            "data": json.dumps(second_detail),
+                        },
+                        {"type": "text", "text": "done"},
+                    ],
+                },
+            ],
+        }
+    )
+
+    body = open_router_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assistants = [
+        message for message in body["messages"] if message["role"] == "assistant"
+    ]
+    assert assistants[0]["reasoning_details"] == [first_detail]
+    assert assistants[1] == {"role": "assistant", "content": " "}
+    assert assistants[2]["reasoning_details"] == [second_detail]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.12.10"
+version = "4.12.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The remaining interrupted-session failure in #1269 replayed completed tool output directly before a new user prompt. Strict OpenAI-compatible chat templates reject this `tool → user` sequence.

## Changes

| Before | After |
| --- | --- |
| Shared conversion emitted a user turn immediately after completed tool output. | Shared conversion inserts one neutral whitespace-only assistant boundary before subsequent user input. |
| Terminal tool results and already-completed assistant turns had no explicit regression distinction. | Boundaries are added only for `tool → user`; terminal tools and existing assistant completions remain unchanged. |
| OpenRouter reasoning replay treated every converted assistant message as source history. | OpenRouter skips the structural boundary when restoring encrypted reasoning details. |
| The interrupted resume shape had no permanent live product scenario. | An opt-in provider smoke exercises the exact resume transcript. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR completes interrupted OpenAI-compatible tool turns before new user input.
- [Files Changed] Updates shared Anthropic-to-OpenAI conversion, OpenRouter reasoning replay, regression tests, live smoke coverage, architecture documentation, and package metadata.
- [Logic Altered] Inserts a marked whitespace-only assistant boundary for `tool → user` transitions and excludes that marker when assigning OpenRouter reasoning details.
- [Verification Method] Adds converter tests, OpenRouter replay tests covering redacted-only assistant turns, and an opt-in interrupted-resume provider smoke scenario.
- [Residual Risks] None identified within the scope of the previous review thread.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no blocking failure remaining in the OpenRouter reasoning-replay path.

The synthetic boundary retains its distinct identity through request conversion until OpenRouter reasoning replay, and the added regression test covers a genuine redacted-only assistant turn after a tool result.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general contract validation for the interrupted-tool-resume flow and confirmed the before-log records the exact requested smoke command and two skips.
- Inspected smoke diagnostics to verify the system produced HTTP 401 responses and the generated smoke-results report.
- Validated the after/fallback state by confirming 100 focused deterministic tests passed.
- Checked the configuration diagnostic to identify the two selected provider routes.

<a href="https://app.greptile.com/trex/runs/15979972/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/core/anthropic/conversion.py | Adds an identity-marked synthetic assistant boundary after completed tool results when subsequent user content exists. |
| src/free_claude_code/providers/open_router/client.py | Skips only identity-marked synthetic boundaries while assigning replayed encrypted reasoning details to genuine assistant turns. |
| tests/providers/test_open_router.py | Covers both structural-boundary skipping and preservation of a genuine redacted-only assistant turn after tool output. |
| tests/providers/test_converter.py | Verifies boundary insertion, terminal-tool behavior, multi-tool ordering, and preservation of existing assistant completions. |
| smoke/product/test_provider_product_live.py | Adds a live interrupted-tool-turn resume transcript exercising the changed conversion path. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Preserve synthetic tool boundary provena..."](https://github.com/alishahryar1/free-claude-code/commit/a834bca1ee6ec54070ef4282e7d540966f475223) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47486486)</sub>

<!-- /greptile_comment -->