### PR TITLE
feat: add Kilo.ai provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,10 @@ GROQ_API_KEY=""
 SAMBANOVA_API_KEY=""
 
 
+# Kilo.ai Config (OpenAI-compatible Chat Completions gateway at api.kilo.ai/api/gateway)
+KILO_API_KEY=""
+
+
 # Cerebras Inference (OpenAI-compatible Chat Completions; see https://inference-docs.cerebras.ai/resources/openai)
 CEREBRAS_API_KEY=""
 
@@ -112,7 +116,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -194,6 +198,7 @@ GEMINI_PROXY=""
 VERTEX_PROXY=""
 GROQ_PROXY=""
 SAMBANOVA_PROXY=""
+KILO_PROXY=""
 CEREBRAS_PROXY=""
 OLLAMA_CLOUD_PROXY=""
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ fcc-codex exec "hello"
 | [Cerebras Inference](https://cloud.cerebras.ai/) | `CEREBRAS_API_KEY` | `cerebras/gpt-oss-120b` |
 | [Groq](https://console.groq.com/keys) | `GROQ_API_KEY` | `groq/llama-3.3-70b-versatile` |
 | [SambaNova](https://cloud.sambanova.ai/apis) | `SAMBANOVA_API_KEY` | `sambanova/Meta-Llama-3.3-70B-Instruct` |
+| [Kilo.ai](https://kilo.ai) | `KILO_API_KEY` | `kilo/kilo-auto/free` |
 | [Fireworks AI](https://fireworks.ai/account/api-keys) | `FIREWORKS_API_KEY` | `fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct` |
 | [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` | `cloudflare/@cf/moonshotai/kimi-k2.6` |
 | [Z.ai](https://z.ai/manage-apikey/apikey-list) | `ZAI_API_KEY` | `zai/glm-5.2` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.12.11"
+version = "4.13.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -232,6 +232,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=KIMI_CODE_DEFAULT_BASE,
         proxy_attr="kimi_code_proxy",
     ),
+    "kilo": ProviderDescriptor(
+        provider_id="kilo",
+        display_name="Kilo.ai",
+        credential_env="KILO_API_KEY",
+        credential_url="https://app.kilo.ai",
+        credential_attr="kilo_api_key",
+        default_base_url=KILO_DEFAULT_BASE,
+        proxy_attr="kilo_proxy",
+    ),
     "minimax": ProviderDescriptor(
         provider_id="minimax",
         display_name="MiniMax",
@@ -267,15 +276,6 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="sambanova_api_key",
         default_base_url=SAMBANOVA_DEFAULT_BASE,
         proxy_attr="sambanova_proxy",
-    ),
-    "kilo": ProviderDescriptor(
-        provider_id="kilo",
-        display_name="Kilo.ai",
-        credential_env="KILO_API_KEY",
-        credential_url="https://app.kilo.ai",
-        credential_attr="kilo_api_key",
-        default_base_url=KILO_DEFAULT_BASE,
-        proxy_attr="kilo_proxy",
     ),
     "fireworks": ProviderDescriptor(
         provider_id="fireworks",

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -45,6 +45,8 @@ VERTEX_AI_API_ROOT = "https://aiplatform.googleapis.com"
 GROQ_DEFAULT_BASE = "https://api.groq.com/openai/v1"
 CEREBRAS_DEFAULT_BASE = "https://api.cerebras.ai/v1"
 SAMBANOVA_DEFAULT_BASE = "https://api.sambanova.ai/v1"
+# Kilo.ai gateway OpenAI-compatible Chat Completions API.
+KILO_DEFAULT_BASE = "https://api.kilo.ai/api/gateway"
 
 
 @dataclass(frozen=True, slots=True)
@@ -265,6 +267,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="sambanova_api_key",
         default_base_url=SAMBANOVA_DEFAULT_BASE,
         proxy_attr="sambanova_proxy",
+    ),
+    "kilo": ProviderDescriptor(
+        provider_id="kilo",
+        display_name="Kilo.ai",
+        credential_env="KILO_API_KEY",
+        credential_url="https://app.kilo.ai",
+        credential_attr="kilo_api_key",
+        default_base_url=KILO_DEFAULT_BASE,
+        proxy_attr="kilo_proxy",
     ),
     "fireworks": ProviderDescriptor(
         provider_id="fireworks",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -74,6 +74,9 @@ class Settings(BaseSettings):
     # ==================== SambaNova Cloud ====================
     sambanova_api_key: str = Field(default="", validation_alias="SAMBANOVA_API_KEY")
 
+    # ==================== Kilo.ai Config ====================
+    kilo_api_key: str = Field(default="", validation_alias="KILO_API_KEY")
+
     # ==================== Z.ai Config ====================
     zai_api_key: str = Field(default="", validation_alias="ZAI_API_KEY")
 
@@ -170,6 +173,7 @@ class Settings(BaseSettings):
     cohere_proxy: str = Field(default="", validation_alias="COHERE_PROXY")
     github_models_proxy: str = Field(default="", validation_alias="GITHUB_MODELS_PROXY")
     sambanova_proxy: str = Field(default="", validation_alias="SAMBANOVA_PROXY")
+    kilo_proxy: str = Field(default="", validation_alias="KILO_PROXY")
     zai_proxy: str = Field(default="", validation_alias="ZAI_PROXY")
     fireworks_proxy: str = Field(default="", validation_alias="FIREWORKS_PROXY")
     cloudflare_proxy: str = Field(default="", validation_alias="CLOUDFLARE_PROXY")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -295,6 +295,15 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             enabled_value="medium",
         ),
     ),
+    "kilo": OpenAIChatProfile(
+        _policy(
+            "KILO",
+            ReasoningReplayMode.REASONING_CONTENT,
+            include_extra_body=True,
+            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+        ),
+        ReasoningObject(_ALL_EFFORTS),
+    ),
     "fireworks": OpenAIChatProfile(
         _policy(
             "FIREWORKS",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -23,6 +23,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "wafer",
     "kimi",
     "kimi_code",
+    "kilo",
     "minimax",
     "cerebras",
     "groq",

--- a/tests/providers/test_kilo.py
+++ b/tests/providers/test_kilo.py
@@ -1,0 +1,139 @@
+"""Tests for the Kilo.ai OpenAI-chat provider."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import KILO_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import Message, MessagesRequest
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+@pytest.fixture
+def kilo_config():
+    return ProviderConfig(
+        api_key="test_kilo_key",
+        base_url=KILO_DEFAULT_BASE,
+        rate_limit=10,
+        rate_window=60,
+    )
+
+
+@pytest.fixture
+def kilo_provider(kilo_config):
+    return profiled_provider(
+        "kilo",
+        kilo_config,
+        admission=immediate_admission(),
+    )
+
+
+def test_default_base_url():
+    assert KILO_DEFAULT_BASE == "https://api.kilo.ai/api/gateway"
+
+
+def test_init_uses_openai_chat_provider(kilo_provider):
+    assert isinstance(kilo_provider, OpenAIChatProvider)
+    assert kilo_provider._api_key == "test_kilo_key"
+    assert kilo_provider._base_url == KILO_DEFAULT_BASE
+    assert kilo_provider._provider_name == "KILO"
+
+
+def test_build_request_body_openai_shape(kilo_provider):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "anthropic/claude-sonnet-4.5",
+            "messages": [Message(role="user", content="Hello")],
+            "max_tokens": 100,
+        }
+    )
+
+    body = kilo_provider._build_request_body(request, reasoning=reasoning_for(request))
+
+    assert body["model"] == "anthropic/claude-sonnet-4.5"
+    assert body["messages"][0] == {"role": "user", "content": "Hello"}
+    assert body["max_tokens"] == 100
+
+
+def test_build_request_body_forwards_caller_extra_body(kilo_provider):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "extra_body": {"custom_field": "value"},
+        }
+    )
+
+    body = kilo_provider._build_request_body(request, reasoning=reasoning_for(request))
+
+    assert body.get("extra_body", {}).get("custom_field") == "value"
+
+
+def test_build_request_body_sends_reasoning_object(kilo_provider):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "enabled", "budget_tokens": 2048},
+        }
+    )
+
+    body = kilo_provider._build_request_body(request, reasoning=reasoning_for(request))
+
+    assert body.get("extra_body", {}).get("reasoning") is not None
+
+
+def test_build_request_body_sends_reasoning_disabled(kilo_provider):
+    from free_claude_code.core.reasoning import ReasoningControl, ReasoningPolicy
+
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
+
+    body = kilo_provider._build_request_body(
+        request,
+        reasoning=ReasoningPolicy(control=ReasoningControl.OFF),
+    )
+
+    assert body["extra_body"]["reasoning"] == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_model_list_uses_openai_client_models_endpoint(kilo_provider):
+    kilo_provider._client.models.list = AsyncMock(
+        return_value=MagicMock(
+            data=[
+                MagicMock(id="anthropic/claude-sonnet-4.5"),
+                MagicMock(id="openai/gpt-5.4"),
+            ]
+        )
+    )
+
+    assert await kilo_provider.list_model_infos() == frozenset(
+        {
+            ProviderModelInfo("anthropic/claude-sonnet-4.5"),
+            ProviderModelInfo("openai/gpt-5.4"),
+        }
+    )
+
+    kilo_provider._client.models.list.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_closes_openai_client(kilo_provider):
+    kilo_provider._client = MagicMock()
+    kilo_provider._client.close = AsyncMock()
+
+    await kilo_provider.cleanup()
+
+    kilo_provider._client.close.assert_awaited_once()

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -102,6 +102,8 @@ def _make_settings(**overrides):
     mock.cerebras_api_key = ""
     mock.cerebras_proxy = ""
     mock.ollama_cloud_proxy = ""
+    mock.kilo_api_key = "test_kilo_key"
+    mock.kilo_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
     mock.provider_max_concurrency = 5
@@ -439,6 +441,7 @@ def test_create_provider_instantiates_each_builtin():
         "vertex": VertexProvider,
         "groq": OpenAIChatProvider,
         "sambanova": OpenAIChatProvider,
+        "kilo": OpenAIChatProvider,
         "cerebras": OpenAIChatProvider,
     }
     sentinel_admission = MagicMock(spec=ProviderAdmissionController)

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.12.11"
+version = "4.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Declarative OpenAI-compatible profile for the Kilo.ai gateway (api.kilo.ai/api/gateway). One entry in the provider catalog, one OpenAIChatProfile with reasoning passthrough and extra_body forwarding.

Kilo is an OpenRouter-compatible gateway that proxies to upstream providers. Model IDs follow the provider/model-name convention.

Verified live:
- Model listing returns 348 models including kilo-auto/frontier, kilo-auto/balanced, kilo-auto/free, and provider-specific models
- Chat completion on kilo-auto/free routed to inclusionai/ling-3.0-flash:free
- Reasoning tokens reported in completion_tokens_details

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Kilo.ai as an OpenAI-compatible provider.
- Registers Kilo credentials, proxy configuration, catalog metadata, and gateway base URL.
- Adds an OpenAI-chat profile with reasoning passthrough and caller `extra_body` forwarding.
- Documents the provider and adds provider construction, request-shape, model-listing, and cleanup tests.
- Bumps the package version to 4.13.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failures eligible for this follow-up review remain.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the focused contract validation using the exact pytest command and confirmed all tests passed (45/45) with exit code 0.
- I checked the origin/main runtime probe and confirmed Kilo was absent from the catalog and settings.
- I checked the HEAD runtime probe and confirmed Kilo is registered with the expected credential environment and base URL.
- I verified that no credential values were requested, printed, persisted, or invented during the process.

<a href="https://app.greptile.com/trex/runs/16059435/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/config/provider_catalog.py | Registers Kilo’s fixed gateway endpoint and catalog metadata used by provider runtime and configuration surfaces. |
| src/free_claude_code/config/settings.py | Adds environment-backed Kilo API-key and proxy settings. |
| src/free_claude_code/providers/openai_chat/profiles.py | Adds the Kilo OpenAI-chat policy with reasoning replay, reasoning-object encoding, and validated extra-body forwarding. |
| tests/providers/test_kilo.py | Covers Kilo provider initialization, request construction, reasoning encoding, model listing, and cleanup. |
| tests/providers/test_provider_runtime.py | Extends built-in provider factory coverage to assert that Kilo resolves to the shared OpenAI-chat provider. |
| pyproject.toml | Advances the project version from 4.12.11 to 4.13.0, synchronized with the lockfile. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant FCC as FCC routing
  participant Runtime as Provider runtime
  participant Kilo as Kilo OpenAI-chat profile
  participant Gateway as api.kilo.ai

  Client->>FCC: Request using kilo/provider-model
  FCC->>Runtime: Resolve Kilo catalog entry
  Runtime->>Kilo: Create provider with key, proxy, and base URL
  Kilo->>Kilo: Build OpenAI-compatible body and reasoning fields
  Kilo->>Gateway: Chat completion or model-list request
  Gateway-->>Kilo: OpenAI-compatible response
  Kilo-->>Client: Normalized response stream
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: place kilo in canonical provider ca..."](https://github.com/alishahryar1/free-claude-code/commit/1a1ac6a8077dc115dc52977ef10f16839e415cfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47655482)</sub>

<!-- /greptile_comment -->