### PR TITLE
Keep provider documentation aligned with the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.
 - Run FCC in the background from a desktop launcher on Windows or macOS.
-- Switch among 25 cloud and local providers from the Admin UI.
+- Switch among 29 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
 - Route Fable, Opus, Sonnet, Haiku, and fallback traffic to different models.
 - Keep streaming, tool use, reasoning, and image input across compatible models.

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -126,20 +126,10 @@ uv run pytest smoke/product -n 0 -s --tb=short
 - `FCC_ALLOW_NO_PROVIDER_SMOKE=1`: permits no-provider live smoke for harness work.
 - `FCC_SMOKE_TARGETS`: comma-separated targets, or `all`.
 - `FCC_SMOKE_PROVIDER_MATRIX`: comma-separated provider prefixes to require.
-- `FCC_SMOKE_MODEL_NVIDIA_NIM`, `FCC_SMOKE_MODEL_OPEN_ROUTER`,
-  `FCC_SMOKE_MODEL_MISTRAL`, `FCC_SMOKE_MODEL_MISTRAL_REASONING`,
-  `FCC_SMOKE_MODEL_MISTRAL_CODESTRAL`,
-  `FCC_SMOKE_MODEL_DEEPSEEK`, `FCC_SMOKE_MODEL_KIMI`,
-  `FCC_SMOKE_MODEL_KIMI_CODE`,
-  `FCC_SMOKE_MODEL_WAFER`, `FCC_SMOKE_MODEL_MINIMAX`,
-  `FCC_SMOKE_MODEL_OPENCODE`, `FCC_SMOKE_MODEL_OPENCODE_GO`,
-  `FCC_SMOKE_MODEL_BEDROCK`,
-  `FCC_SMOKE_MODEL_ZAI`, `FCC_SMOKE_MODEL_FIREWORKS`, `FCC_SMOKE_MODEL_CLOUDFLARE`,
-  `FCC_SMOKE_MODEL_GEMINI`, `FCC_SMOKE_MODEL_GROQ`, `FCC_SMOKE_MODEL_CEREBRAS`,
-  `FCC_SMOKE_MODEL_OLLAMA_CLOUD`, `FCC_SMOKE_MODEL_LMSTUDIO`,
-  `FCC_SMOKE_MODEL_LLAMACPP`, `FCC_SMOKE_MODEL_OLLAMA`: optional per-provider
-  smoke model overrides. Values may include the provider prefix or just the model
-  name for that provider.
+- `FCC_SMOKE_MODEL_<PROVIDER>`: optional per-provider smoke model override.
+  Use the uppercase provider ID, such as `FCC_SMOKE_MODEL_KILO`; the complete
+  variable inventory is in [.env.example](../.env.example). Values may include
+  the provider prefix or just the model name for that provider.
 - `FCC_SMOKE_MODEL_MISTRAL_REASONING`: optional override for the dedicated
   Mistral native reasoning smoke, default `mistral/mistral-medium-3-5`.
 - `FCC_SMOKE_NIM_MODELS`: optional comma-separated NVIDIA NIM CLI matrix models

--- a/tests/contracts/test_feature_manifest.py
+++ b/tests/contracts/test_feature_manifest.py
@@ -38,6 +38,7 @@ def test_readme_provider_table_covers_full_catalog() -> None:
     provider_section = readme.split("## Choose A Provider", 1)[1].split("\n## ", 1)[0]
     rows = [line for line in provider_section.splitlines() if line.startswith("| [")]
 
+    assert f"Switch among {len(PROVIDER_CATALOG)} cloud and local providers" in readme
     prefixes: list[str] = []
     for row in rows:
         example_cell = row.split("|")[3]


### PR DESCRIPTION
## Problem

The README advertised 25 providers while the catalog and provider table contain 29. The smoke guide also maintained an incomplete manual list of provider model override variables.

## Changes

| Before | After |
| --- | --- |
| The README advertised 25 providers. | The README advertises all 29 current providers. |
| The smoke guide duplicated an incomplete override inventory. | The smoke guide documents the generic override pattern and links to `.env.example`. |
| Provider-table coverage did not protect the headline count. | The catalog contract enforces the advertised provider count. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Keeps provider documentation synchronized with the catalog.
- Updates the README headline from 25 to 29 providers.
- Replaces the smoke guide’s manual override list with the generic provider-ID pattern and a link to `.env.example`.
- Extends the provider-table contract test to verify the advertised count against `PROVIDER_CATALOG`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or documentation issues identified.

The advertised count matches the 29-entry catalog used by the Admin UI, the generic smoke override naming matches the runtime lookup for every current provider ID, and `.env.example` contains the supported override inventory.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the contract flow and observed an initial failure when the README listed 25 providers and lacked the canonical .env.example link, causing the generated contract to exit with code 1.
- Checked the post-change state where the README advertises 29 providers, table coverage matches the full catalog, and the smoke link resolves to the .env.example file in the repository, resulting in the contract exiting with code 0.
- Ran Pytest on Python 3.14.0 and confirmed the tests passed independently.

<a href="https://app.greptile.com/trex/runs/16151637/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates the advertised provider count to match all 29 providers currently exposed through the catalog and Admin UI. |
| smoke/README.md | Documents the runtime’s generic uppercase-provider-ID override convention and redirects the complete inventory to `.env.example`. |
| tests/contracts/test_feature_manifest.py | Adds a contract assertion that keeps the README headline count synchronized with the provider catalog. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Sync provider documentation with catalog"](https://github.com/alishahryar1/free-claude-code/commit/a9c9a91e44a8d072457840ad91fd491c857fd54a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47835201)</sub>

<!-- /greptile_comment -->