### PR TITLE
Add ChatGPT OAuth as an OpenAI Codex provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,7 +116,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -127,6 +127,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # Optional live smoke model overrides. Provider smoke runs once per configured
 # provider even when MODEL/MODEL_* route to a different provider.
 FCC_SMOKE_MODEL_NVIDIA_NIM=
+FCC_SMOKE_MODEL_OPENAI=
 FCC_SMOKE_MODEL_OPEN_ROUTER=
 FCC_SMOKE_MODEL_MISTRAL=
 FCC_SMOKE_MODEL_MISTRAL_REASONING=
@@ -175,6 +176,7 @@ REASONING_HAIKU=inherit
 
 # Provider config
 # Per-provider proxy support: http and socks5, example: "http://username:password@host:port"
+OPENAI_PROXY=""
 NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""
 MISTRAL_PROXY=""

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -263,9 +263,11 @@ not read global settings or construct runtime resources.
 
 [runtime/application.py](src/free_claude_code/runtime/application.py) owns process startup and shutdown, optional messaging,
 the selected transcriber, the managed CLI session manager, Admin pending state,
-and the injected restart callback. Shutdown is serialized and ordered: quiesce
+connected-account use cases, and the injected restart callback. Shutdown is
+serialized and ordered: quiesce
 messaging ingress, cancel and drain workflow/CLI work, flush persistence, close
-delivery, close transcription, then close providers. An owner reference is
+delivery, close transcription, close providers, then close connected-account
+login and HTTP resources. An owner reference is
 released only after its cleanup succeeds; cancellation or failure leaves the
 incomplete graph retryable. Teardown stops at a failed dependency gate rather
 than closing resources that still-live upstream work may need, and the ASGI
@@ -295,6 +297,10 @@ every owned runtime closes.
 
 The manager also owns one application-lifetime provider model catalog and its
 single best-effort discovery task. The catalog survives provider replacement.
+Settings-configured providers and currently connected accounts contribute to
+the same availability set. Account connect/disconnect performs a targeted model
+refresh or eviction; it does not mutate settings or replace a provider
+generation.
 This keeps the server model inventory stable without extra synchronization;
 Claude clients may independently retain the list they fetched at startup.
 
@@ -543,7 +549,7 @@ passes it as `model_catalog_json`. Codex users open the native picker with
 
 Provider metadata is neutral and centralized in
 [config/provider_catalog.py](src/free_claude_code/config/provider_catalog.py). Each
-`ProviderDescriptor` declares provider ID, display name, locality, credential env
+`ProviderDescriptor` declares provider ID, display name, authentication kind, locality, credential env
 var, default base URL, settings attribute names, configuration readiness, and
 proxy support. Readiness may require multiple ordinary settings or a non-secret
 project ID; it is not inferred exclusively from API-key presence. The catalog
@@ -553,9 +559,11 @@ does not select a concrete adapter.
 closable provider generation: construction policy, resolved provider
 configuration, lazy provider instances, provider-owned admission controllers, and
 cleanup. [providers/runtime/factory.py](src/free_claude_code/providers/runtime/factory.py)
-constructs ordinary provider IDs from `OPENAI_CHAT_PROFILES` and keeps a sparse
-factory mapping only for adapters with real state or algorithms. The union of
-those two construction owners must exactly equal the neutral provider catalog.
+constructs ordinary provider IDs from `OPENAI_CHAT_PROFILES`, keeps a sparse
+factory mapping for adapters with real state or algorithms, and accepts explicit
+composition-root factories for providers with process-lifetime dependencies.
+The union of those construction owners must exactly equal the neutral provider
+catalog.
 `ProviderRuntime` directly guarantees one provider and admission controller per
 provider ID within a generation; there is no pass-through cache object, process
 singleton, or second admission registry.
@@ -610,7 +618,7 @@ compatibility layer.
   `list_model_infos()`. Providers return application-owned `ProviderModelInfo`
   values directly; there is no parallel IDs-only catalog contract.
 
-There is one upstream transport family:
+There are two upstream transport families:
 [providers/openai_chat/](src/free_claude_code/providers/openai_chat/) implements the concrete
 `OpenAIChatProvider` used by every OpenAI-compatible `/chat/completions`
 upstream. `OpenAIChatProfile` contains immutable request policy, an explicit
@@ -621,6 +629,18 @@ empty subclasses. The package also
 owns the exactly typed private per-request runner, recovery operations, tool-call
 assembly, and streamed usage handling. No obsolete generic transport namespace
 or untyped provider backchannel remains.
+
+[providers/openai_codex/](src/free_claude_code/providers/openai_codex/) owns
+ChatGPT subscription authentication and the Codex backend's OpenAI Responses
+transport. Its process-lifetime auth manager owns FCC's credential file,
+browser/device authorization, refresh, and revocation; provider generations
+borrow it and resolve fresh headers for each operation. The provider owns HTTP
+failure classification, model discovery, admission, and commit-boundary retry.
+Neutral Anthropic-to-Responses input and Responses-to-Anthropic stream
+conversion remain in
+[core/openai_responses/](src/free_claude_code/core/openai_responses/), which
+never imports OAuth, account IDs, or provider endpoints. The Admin API exposes
+only safe connected-account state and never serializes token objects.
 
 [providers/google_openai/](src/free_claude_code/providers/google_openai/) owns the
 Google-specific protocol behavior shared by AI Studio and Vertex AI: literal

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.
 - Run FCC in the background from a desktop launcher on Windows or macOS.
-- Switch among 29 cloud and local providers from the Admin UI.
+- Switch among 30 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
 - Route Fable, Opus, Sonnet, Haiku, and fallback traffic to different models.
 - Keep streaming, tool use, reasoning, and image input across compatible models.
@@ -159,7 +159,8 @@ fcc-codex exec "hello"
 ## Choose A Provider
 
 1. Open a provider link below for its key, models, or setup instructions.
-2. In the Admin UI, open **Model Config** and enter the listed setting.
+2. In the Admin UI, configure the listed setting. For OpenAI, use
+   **Providers → Connected accounts** instead.
 3. Search the `MODEL` dropdown and select a model. If the provider cannot list
    models, enter `<provider-id>/<exact-provider-model-id>` manually.
 4. Click **Validate**, then **Apply**.
@@ -167,6 +168,7 @@ fcc-codex exec "hello"
 | Provider | Admin UI setting | Example `MODEL` |
 | --- | --- | --- |
 | [NVIDIA NIM](https://build.nvidia.com/settings/api-keys) | `NVIDIA_NIM_API_KEY` | `nvidia_nim/nvidia/nemotron-3-super-120b-a12b` |
+| [OpenAI / ChatGPT](https://learn.chatgpt.com/docs/auth) | Connect ChatGPT in the Admin UI | `openai/<model-id>` |
 | [OpenRouter](https://openrouter.ai/keys) | `OPENROUTER_API_KEY` | `open_router/openrouter/free` |
 | [Google AI Studio (Gemini)](https://aistudio.google.com/apikey) | `GEMINI_API_KEY` | `gemini/models/gemini-3.1-flash-lite` |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/start/openai) | `VERTEX_PROJECT_ID` + ADC | `vertex/google/gemini-3.5-flash` |
@@ -198,6 +200,11 @@ fcc-codex exec "hello"
 
 Important provider notes:
 
+- OpenAI uses your ChatGPT subscription rather than an API key. Connect from
+  **Providers → Connected accounts**; browser PKCE is the default and device
+  code is available for headless setups. FCC stores its own renewable
+  credentials under `~/.fcc/auth/` and leaves Codex login untouched. Restart
+  an already-running agent after connecting to refresh its model picker.
 - Mistral Codestral uses a separate key from Mistral La Plateforme.
 - Kimi Code subscription keys use `kimi_code/`; Kimi API credit keys use
   `kimi/`. Kimi Code plans are for personal interactive coding-agent use under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.13.1"
+version = "4.14.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -9,6 +9,7 @@ from free_claude_code.config.model_refs import parse_model_name, parse_provider_
 from free_claude_code.config.provider_catalog import (
     PROVIDER_CATALOG,
     SUPPORTED_PROVIDER_IDS,
+    ProviderAuthKind,
 )
 from free_claude_code.config.settings import Settings, get_settings
 from free_claude_code.providers.runtime.config import has_provider_configuration
@@ -259,6 +260,8 @@ class SmokeConfig:
         descriptor = PROVIDER_CATALOG.get(provider)
         if descriptor is None:
             return False
+        if descriptor.auth_kind is ProviderAuthKind.CONNECTED_ACCOUNT:
+            return bool(os.getenv(f"FCC_SMOKE_MODEL_{provider.upper()}"))
         return has_provider_configuration(descriptor, self.settings)
 
 
@@ -300,17 +303,8 @@ def _normalize_provider_model(provider: str, raw_model: str) -> str:
     if not model:
         msg = f"FCC_SMOKE_MODEL_{provider.upper()} must not be empty"
         raise ValueError(msg)
-    if "/" not in model:
-        return f"{provider}/{model}"
-    prefix = parse_provider_type(model)
-    if prefix == provider:
+    if "/" in model and parse_provider_type(model) == provider:
         return model
-    if prefix in SUPPORTED_PROVIDER_IDS:
-        msg = (
-            f"FCC_SMOKE_MODEL_{provider.upper()} must use provider prefix "
-            f"{provider!r}, got {model!r}"
-        )
-        raise ValueError(msg)
     return f"{provider}/{model}"
 
 

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -7,14 +7,21 @@ from urllib.parse import urlsplit
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, Field
 
+from free_claude_code.application.connected_accounts import (
+    ConnectedAccountLoginMode,
+)
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
 from free_claude_code.config.admin.manifest import FIELD_BY_KEY
 from free_claude_code.config.admin.persistence import validate_updates
 from free_claude_code.config.admin.values import load_config_response
 from free_claude_code.config.model_refs import configured_chat_model_refs
+from free_claude_code.config.provider_catalog import (
+    PROVIDER_CATALOG,
+    ProviderAuthKind,
+)
 
 from .dependencies import get_services
 from .ports import ApiServices
@@ -33,6 +40,12 @@ class AdminConfigPayload(BaseModel):
     """Partial config update submitted by the admin UI."""
 
     values: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConnectedAccountLoginPayload(BaseModel):
+    """Interactive connected-account login selection."""
+
+    mode: ConnectedAccountLoginMode = ConnectedAccountLoginMode.BROWSER
 
 
 def _is_loopback_host(host: str | None) -> bool:
@@ -145,6 +158,63 @@ async def test_provider(
     return await services.admin.test_provider(provider_id)
 
 
+@router.get("/admin/api/providers/{provider_id}/auth")
+async def connected_account_status(
+    provider_id: str,
+    request: Request,
+    services: ApiServices = Depends(get_services),
+):
+    require_loopback_admin(request)
+    _require_connected_account_provider(provider_id)
+    status = await services.admin.connected_account_status(provider_id)
+    return _no_store(status.as_dict())
+
+
+@router.post("/admin/api/providers/{provider_id}/auth/login")
+async def start_connected_account_login(
+    provider_id: str,
+    payload: ConnectedAccountLoginPayload,
+    request: Request,
+    services: ApiServices = Depends(get_services),
+):
+    require_loopback_admin(request)
+    _require_connected_account_provider(provider_id)
+    try:
+        status = await services.admin.start_connected_account_login(
+            provider_id, payload.mode
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=(f"Could not start connected-account login ({type(exc).__name__})."),
+        ) from exc
+    return _no_store(status.as_dict())
+
+
+@router.post("/admin/api/providers/{provider_id}/auth/cancel")
+async def cancel_connected_account_login(
+    provider_id: str,
+    request: Request,
+    services: ApiServices = Depends(get_services),
+):
+    require_loopback_admin(request)
+    _require_connected_account_provider(provider_id)
+    status = await services.admin.cancel_connected_account_login(provider_id)
+    return _no_store(status.as_dict())
+
+
+@router.delete("/admin/api/providers/{provider_id}/auth")
+async def disconnect_connected_account(
+    provider_id: str,
+    request: Request,
+    services: ApiServices = Depends(get_services),
+):
+    require_loopback_admin(request)
+    _require_connected_account_provider(provider_id)
+    status = await services.admin.disconnect_connected_account(provider_id)
+    return _no_store(status.as_dict())
+
+
 @router.get("/admin/api/models")
 async def models(
     request: Request,
@@ -231,3 +301,19 @@ async def _check_local_provider(
             "base_url": base_url,
             "error_type": type(exc).__name__,
         }
+
+
+def _require_connected_account_provider(provider_id: str) -> None:
+    descriptor = PROVIDER_CATALOG.get(provider_id)
+    if (
+        descriptor is None
+        or descriptor.auth_kind is not ProviderAuthKind.CONNECTED_ACCOUNT
+    ):
+        raise HTTPException(
+            status_code=404,
+            detail="Provider does not support connected-account login.",
+        )
+
+
+def _no_store(payload: Any) -> JSONResponse:
+    return JSONResponse(payload, headers={"Cache-Control": "no-store"})

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -337,6 +337,13 @@ textarea:focus-visible,
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
+.provider-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
 /* Button & Form Controls styling */
 .test-button,
 .ghost-button,

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -4,6 +4,7 @@ const state = {
   localStatus: new Map(),
   modelOptions: [],
   modelComboboxes: new Set(),
+  authPollers: new Map(),
   activeView: "providers",
 };
 
@@ -59,8 +60,8 @@ function sourceText(field) {
 }
 
 function statusClass(status) {
-  if (["configured", "reachable", "running"].includes(status)) return "ok";
-  if (["missing_key", "missing_config", "missing_url", "unknown"].includes(status)) return "warn";
+  if (["configured", "reachable", "running", "connected"].includes(status)) return "ok";
+  if (["missing_key", "missing_config", "missing_url", "unknown", "connecting"].includes(status)) return "warn";
   if (["offline", "error"].includes(status)) return "error";
   return "neutral";
 }
@@ -72,7 +73,14 @@ async function api(path, options = {}) {
     cache: "no-store",
   });
   if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
+    let detail = "";
+    try {
+      const payload = await response.json();
+      detail = typeof payload.detail === "string" ? payload.detail : "";
+    } catch {
+      // The status remains useful when an upstream proxy returns a non-JSON page.
+    }
+    throw new Error(detail || `${response.status} ${response.statusText}`);
   }
   return response.json();
 }
@@ -86,6 +94,7 @@ async function load() {
   renderProviders(config.provider_status);
   renderSections(config.sections, config.fields);
   byId("configPath").textContent = config.paths.managed;
+  await refreshConnectedAccounts();
   await hydrateModelOptions();
   await validate(false);
   await refreshLocalStatus();
@@ -142,8 +151,18 @@ function setActiveView(viewId, { scroll = false } = {}) {
 
 function renderProviders(providerStatus) {
   const grid = byId("providerGrid");
+  const connectedGrid = byId("connectedAccountGrid");
   grid.innerHTML = "";
+  connectedGrid.innerHTML = "";
+  const connected = providerStatus.filter(
+    (provider) => provider.kind === "connected_account",
+  );
+  byId("connectedAccountsSection").hidden = connected.length === 0;
   providerStatus.forEach((provider) => {
+    if (provider.kind === "connected_account") {
+      connectedGrid.appendChild(renderConnectedAccountCard(provider));
+      return;
+    }
     const card = document.createElement("article");
     card.className = "provider-card";
     card.dataset.provider = provider.provider_id;
@@ -173,6 +192,230 @@ function renderProviders(providerStatus) {
     card.append(title, meta, button);
     grid.appendChild(card);
   });
+}
+
+function renderConnectedAccountCard(provider, status = provider) {
+  const card = document.createElement("article");
+  card.className = "provider-card";
+  card.dataset.provider = provider.provider_id;
+  card.dataset.connectedAccount = "true";
+
+  const title = document.createElement("div");
+  title.className = "provider-title";
+  const name = document.createElement("strong");
+  name.textContent = provider.display_name || provider.provider_id;
+  const pill = document.createElement("span");
+  pill.className = `status-pill ${statusClass(status.state || status.status)}`;
+  pill.textContent = connectedAccountLabel(status);
+  title.append(name, pill);
+
+  const meta = document.createElement("div");
+  meta.className = "provider-meta";
+  meta.textContent = connectedAccountMeta(status);
+
+  const actions = document.createElement("div");
+  actions.className = "provider-actions";
+  populateConnectedAccountActions(provider, status, actions);
+  card.append(title, meta, actions);
+  return card;
+}
+
+function connectedAccountLabel(status) {
+  const labels = {
+    disconnected: "Not connected",
+    connecting: "Connecting",
+    connected: "Connected",
+    error: "Needs attention",
+  };
+  return labels[status.state] || status.label || "Not connected";
+}
+
+function connectedAccountMeta(status) {
+  if (status.connected) {
+    const identity = status.email || "ChatGPT subscription connected";
+    const models = Number.isInteger(status.model_count)
+      ? `${status.model_count} model${status.model_count === 1 ? "" : "s"} available. `
+      : "";
+    const error = status.message ? `${status.message} ` : "";
+    return `${identity}. ${models}${error}Restart your agent to refresh its model picker.`;
+  }
+  if (status.mode === "device" && status.user_code) {
+    return `Enter code ${status.user_code} at ${status.verification_url}`;
+  }
+  if (status.state === "connecting") {
+    return "Finish signing in, then return to this page.";
+  }
+  return status.message || "Connect a ChatGPT account to discover subscription models.";
+}
+
+function populateConnectedAccountActions(provider, status, actions) {
+  const providerId = provider.provider_id;
+  if (status.state === "connecting") {
+    const target = status.authorization_url || status.verification_url;
+    if (target) {
+      actions.appendChild(authButton("Open sign-in", () => window.open(target, "_blank", "noopener")));
+    }
+    if (status.mode === "device" && status.user_code) {
+      actions.appendChild(
+        authButton(
+          "Copy code",
+          () => copyDeviceCode(status.user_code),
+          "secondary-button",
+        ),
+      );
+    }
+    actions.appendChild(
+      authButton("Cancel", () => cancelConnectedAccountLogin(providerId), "secondary-button"),
+    );
+    return;
+  }
+  if (status.connected) {
+    actions.appendChild(
+      authButton(
+        "Reconnect",
+        (button) => startConnectedAccountLogin(providerId, "browser", button),
+      ),
+    );
+    actions.appendChild(
+      authButton(
+        "Disconnect",
+        () => disconnectConnectedAccount(providerId),
+        "secondary-button",
+      ),
+    );
+    return;
+  }
+  actions.appendChild(
+    authButton("Connect", (button) => startConnectedAccountLogin(providerId, "browser", button)),
+    authButton(
+      "Use device code",
+      (button) => startConnectedAccountLogin(providerId, "device", button),
+      "secondary-button",
+    ),
+  );
+}
+
+function authButton(label, action, className = "test-button") {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = className;
+  button.textContent = label;
+  button.addEventListener("click", () => action(button));
+  return button;
+}
+
+async function refreshConnectedAccounts() {
+  const providers = (state.config?.provider_status || []).filter(
+    (provider) => provider.kind === "connected_account",
+  );
+  await Promise.all(
+    providers.map(async (provider) => {
+      try {
+        const status = await api(`/admin/api/providers/${provider.provider_id}/auth`);
+        updateConnectedAccountCard(provider, status);
+        if (status.state === "connecting") pollConnectedAccount(provider);
+      } catch (error) {
+        updateConnectedAccountCard(provider, {
+          state: "error",
+          connected: false,
+          message: error.message,
+        });
+      }
+    }),
+  );
+}
+
+function updateConnectedAccountCard(provider, status) {
+  const current = document.querySelector(
+    `[data-provider="${provider.provider_id}"][data-connected-account="true"]`,
+  );
+  if (current) current.replaceWith(renderConnectedAccountCard(provider, status));
+}
+
+async function startConnectedAccountLogin(providerId, mode, button) {
+  button.disabled = true;
+  const popup = window.open("about:blank", "_blank");
+  if (popup) popup.opener = null;
+  try {
+    const status = await api(`/admin/api/providers/${providerId}/auth/login`, {
+      method: "POST",
+      body: JSON.stringify({ mode }),
+    });
+    const provider = connectedAccountDescriptor(providerId);
+    updateConnectedAccountCard(provider, status);
+    const target = status.authorization_url || status.verification_url;
+    if (target && popup) {
+      popup.location.replace(target);
+    } else if (target) {
+      window.open(target, "_blank", "noopener");
+    } else if (popup) {
+      popup.close();
+    }
+    pollConnectedAccount(provider);
+  } catch (error) {
+    if (popup) popup.close();
+    showMessage(error.message, true);
+    button.disabled = false;
+  }
+}
+
+async function cancelConnectedAccountLogin(providerId) {
+  clearConnectedAccountPoll(providerId);
+  const status = await api(`/admin/api/providers/${providerId}/auth/cancel`, {
+    method: "POST",
+  });
+  updateConnectedAccountCard(connectedAccountDescriptor(providerId), status);
+}
+
+async function disconnectConnectedAccount(providerId) {
+  if (!window.confirm("Disconnect this ChatGPT account from FCC?")) return;
+  clearConnectedAccountPoll(providerId);
+  const status = await api(`/admin/api/providers/${providerId}/auth`, {
+    method: "DELETE",
+  });
+  updateConnectedAccountCard(connectedAccountDescriptor(providerId), status);
+  await hydrateModelOptions();
+}
+
+function pollConnectedAccount(provider) {
+  clearConnectedAccountPoll(provider.provider_id);
+  const poll = async () => {
+    try {
+      const status = await api(`/admin/api/providers/${provider.provider_id}/auth`);
+      updateConnectedAccountCard(provider, status);
+      if (status.state === "connecting") {
+        state.authPollers.set(provider.provider_id, window.setTimeout(poll, 1000));
+      } else {
+        state.authPollers.delete(provider.provider_id);
+        if (status.connected) await hydrateModelOptions();
+      }
+    } catch (error) {
+      state.authPollers.delete(provider.provider_id);
+      showMessage(error.message, true);
+    }
+  };
+  state.authPollers.set(provider.provider_id, window.setTimeout(poll, 1000));
+}
+
+function clearConnectedAccountPoll(providerId) {
+  const timer = state.authPollers.get(providerId);
+  if (timer) window.clearTimeout(timer);
+  state.authPollers.delete(providerId);
+}
+
+function connectedAccountDescriptor(providerId) {
+  return state.config.provider_status.find(
+    (provider) => provider.provider_id === providerId,
+  );
+}
+
+async function copyDeviceCode(code) {
+  try {
+    await navigator.clipboard.writeText(code);
+    showMessage("Device code copied.");
+  } catch {
+    showMessage(`Copy this device code: ${code}`);
+  }
 }
 
 function updateProviderCard(providerId, status, label, metaText) {

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -29,6 +29,20 @@
 
         <div id="adminViews" class="admin-views">
           <section id="view-providers" class="admin-view active" data-view="providers">
+            <section
+              id="connectedAccountsSection"
+              class="provider-strip"
+              aria-label="Connected accounts"
+              hidden
+            >
+              <div class="strip-header">
+                <div>
+                  <h3>Connected accounts</h3>
+                  <p>Use an existing subscription without storing credentials in .env.</p>
+                </div>
+              </div>
+              <div id="connectedAccountGrid" class="provider-grid"></div>
+            </section>
             <section class="provider-strip" aria-label="Provider status">
               <div class="strip-header">
                 <h3>Providers</h3>

--- a/src/free_claude_code/api/ports.py
+++ b/src/free_claude_code/api/ports.py
@@ -4,6 +4,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from free_claude_code.application.connected_accounts import (
+    ConnectedAccountLoginMode,
+    ConnectedAccountStatus,
+)
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
 from free_claude_code.application.ports import RequestRuntimePort, TaskController
 
@@ -22,6 +26,24 @@ class AdminRuntimePort(Protocol):
     async def refresh_models(self) -> ProviderModelRefreshResult: ...
 
     async def request_restart(self) -> None: ...
+
+    async def connected_account_status(
+        self, provider_id: str
+    ) -> ConnectedAccountStatus: ...
+
+    async def start_connected_account_login(
+        self,
+        provider_id: str,
+        mode: ConnectedAccountLoginMode,
+    ) -> ConnectedAccountStatus: ...
+
+    async def cancel_connected_account_login(
+        self, provider_id: str
+    ) -> ConnectedAccountStatus: ...
+
+    async def disconnect_connected_account(
+        self, provider_id: str
+    ) -> ConnectedAccountStatus: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/free_claude_code/application/connected_accounts.py
+++ b/src/free_claude_code/application/connected_accounts.py
@@ -1,0 +1,63 @@
+"""Safe application boundary for provider connected accounts."""
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class ConnectedAccountLoginMode(StrEnum):
+    """Supported interactive authorization flows."""
+
+    BROWSER = "browser"
+    DEVICE = "device"
+
+
+class ConnectedAccountState(StrEnum):
+    """Customer-visible connected-account lifecycle states."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    ERROR = "error"
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectedAccountStatus:
+    """Credential-free state safe to return from the local Admin API."""
+
+    provider_id: str
+    state: ConnectedAccountState
+    connected: bool
+    revision: int
+    attempt_id: str | None = None
+    email: str | None = None
+    mode: ConnectedAccountLoginMode | None = None
+    authorization_url: str | None = None
+    verification_url: str | None = None
+    user_code: str | None = None
+    expires_at: int | None = None
+    model_count: int | None = None
+    message: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize only the explicitly safe status contract."""
+
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+
+class ConnectedAccountPort(Protocol):
+    """One process-lifetime provider authentication owner."""
+
+    def is_connected(self) -> bool: ...
+
+    def status(self) -> ConnectedAccountStatus: ...
+
+    async def start_login(
+        self, mode: ConnectedAccountLoginMode
+    ) -> ConnectedAccountStatus: ...
+
+    async def cancel_login(self) -> ConnectedAccountStatus: ...
+
+    async def disconnect(self) -> ConnectedAccountStatus: ...
+
+    async def close(self) -> None: ...

--- a/src/free_claude_code/cli/desktop.py
+++ b/src/free_claude_code/cli/desktop.py
@@ -1,10 +1,8 @@
 """Platform-neutral lifecycle for the FCC desktop shell."""
 
-import os
 import threading
 from collections.abc import Callable
-from pathlib import Path
-from typing import BinaryIO, Protocol
+from typing import Protocol
 
 from free_claude_code.cli.commands import (
     ServerStatus,
@@ -17,38 +15,7 @@ from free_claude_code.cli.launchers.common import preflight_proxy
 from free_claude_code.config.paths import config_dir_path
 from free_claude_code.config.server_urls import local_proxy_root_url
 from free_claude_code.config.settings import get_settings
-
-if os.name == "nt":
-    import msvcrt
-
-    def _try_lock(handle: BinaryIO) -> bool:
-        if os.fstat(handle.fileno()).st_size == 0:
-            handle.seek(0)
-            handle.write(b"\0")
-            handle.flush()
-        handle.seek(0)
-        try:
-            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-        except OSError:
-            return False
-        return True
-
-    def _unlock(handle: BinaryIO) -> None:
-        handle.seek(0)
-        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-
-else:
-    import fcntl
-
-    def _try_lock(handle: BinaryIO) -> bool:
-        try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            return False
-        return True
-
-    def _unlock(handle: BinaryIO) -> None:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+from free_claude_code.core.interprocess_lock import InterprocessFileLock
 
 
 class DesktopTray(Protocol):
@@ -78,39 +45,6 @@ class ServerOwner(Protocol):
     def request_restart(self) -> bool: ...
 
     def request_stop(self) -> None: ...
-
-
-class DesktopInstanceLock:
-    """Cross-process lock automatically released by the operating system."""
-
-    def __init__(self, path: Path | None = None) -> None:
-        self._path = path or config_dir_path() / "desktop.lock"
-        self._handle: BinaryIO | None = None
-
-    def acquire(self) -> bool:
-        """Acquire the singleton lock without waiting."""
-
-        if self._handle is not None:
-            return True
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        handle = self._path.open("a+b")
-        if not _try_lock(handle):
-            handle.close()
-            return False
-        self._handle = handle
-        return True
-
-    def release(self) -> None:
-        """Release a held lock; repeated calls are harmless."""
-
-        handle = self._handle
-        if handle is None:
-            return
-        self._handle = None
-        try:
-            _unlock(handle)
-        finally:
-            handle.close()
 
 
 class DesktopController:
@@ -185,7 +119,7 @@ def launch_desktop(tray_factory: DesktopTrayFactory) -> None:
     """Start the singleton desktop host or focus the already running FCC UI."""
 
     settings = load_server_settings()
-    instance_lock = DesktopInstanceLock()
+    instance_lock = InterprocessFileLock(config_dir_path() / "desktop.lock")
     if not instance_lock.acquire():
         open_admin_when_ready(settings)
         return

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -6,6 +6,13 @@ from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
 from free_claude_code.config.settings import Settings
 
 _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
+    "OPENAI_PROXY": {
+        "description": (
+            "Optional proxy used for OpenAI sign-in and ChatGPT Codex requests. "
+            "Changing it restarts FCC."
+        ),
+        "restart_required": True,
+    },
     "NVIDIA_NIM_API_KEY": {
         "label": "NVIDIA NIM API Key",
         "description": "Used by NVIDIA NIM chat and optional NIM voice transcription.",

--- a/src/free_claude_code/config/admin/status.py
+++ b/src/free_claude_code/config/admin/status.py
@@ -3,7 +3,10 @@
 from collections.abc import Mapping
 from typing import Any
 
-from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
+from free_claude_code.config.provider_catalog import (
+    PROVIDER_CATALOG,
+    ProviderAuthKind,
+)
 
 from .manifest import FIELDS
 
@@ -14,6 +17,17 @@ def provider_config_status(
     """Return provider configuration status without making network calls."""
     statuses: list[dict[str, Any]] = []
     for provider_id, descriptor in PROVIDER_CATALOG.items():
+        if descriptor.auth_kind is ProviderAuthKind.CONNECTED_ACCOUNT:
+            statuses.append(
+                {
+                    "provider_id": provider_id,
+                    "display_name": descriptor.display_name,
+                    "kind": "connected_account",
+                    "status": "disconnected",
+                    "label": "Not connected",
+                }
+            )
+            continue
         if descriptor.local:
             base_url = ""
             if descriptor.base_url_attr is not None:

--- a/src/free_claude_code/config/paths.py
+++ b/src/free_claude_code/config/paths.py
@@ -10,6 +10,9 @@ MESSAGING_STATE_DIRNAME = "agent_workspace"
 FCC_LOGS_DIRNAME = "logs"
 SERVER_LOG_FILENAME = "server.log"
 CODEX_MODEL_CATALOG_FILENAME = "codex-model-catalog.json"
+AUTH_DIRNAME = "auth"
+OPENAI_AUTH_FILENAME = "openai.json"
+OPENAI_AUTH_LOCK_FILENAME = "openai.lock"
 
 
 def config_dir_path() -> Path:
@@ -50,3 +53,15 @@ def codex_model_catalog_path() -> Path:
     """Return the generated Codex model catalog path."""
 
     return config_dir_path() / CODEX_MODEL_CATALOG_FILENAME
+
+
+def openai_auth_path() -> Path:
+    """Return FCC's private ChatGPT credential file path."""
+
+    return config_dir_path() / AUTH_DIRNAME / OPENAI_AUTH_FILENAME
+
+
+def openai_auth_lock_path() -> Path:
+    """Return the cross-process lock path for ChatGPT credentials."""
+
+    return config_dir_path() / AUTH_DIRNAME / OPENAI_AUTH_LOCK_FILENAME

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -5,6 +5,7 @@ provider implementation imports (see contract tests).
 """
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 # Default upstream base URLs are owned here with the provider catalog.
 NVIDIA_NIM_DEFAULT_BASE = "https://integrate.api.nvidia.com/v1"
@@ -47,6 +48,14 @@ CEREBRAS_DEFAULT_BASE = "https://api.cerebras.ai/v1"
 SAMBANOVA_DEFAULT_BASE = "https://api.sambanova.ai/v1"
 # Kilo.ai gateway OpenAI-compatible Chat Completions API.
 KILO_DEFAULT_BASE = "https://api.kilo.ai/api/gateway"
+OPENAI_CODEX_DEFAULT_BASE = "https://chatgpt.com/backend-api/codex"
+
+
+class ProviderAuthKind(StrEnum):
+    """How a customer makes one provider available."""
+
+    CONFIGURATION = "configuration"
+    CONNECTED_ACCOUNT = "connected_account"
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +64,7 @@ class ProviderDescriptor:
 
     provider_id: str
     display_name: str
+    auth_kind: ProviderAuthKind = ProviderAuthKind.CONFIGURATION
     local: bool = False
     credential_env: str | None = None
     credential_url: str | None = None
@@ -85,6 +95,13 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="nvidia_nim_api_key",
         default_base_url=NVIDIA_NIM_DEFAULT_BASE,
         proxy_attr="nvidia_nim_proxy",
+    ),
+    "openai": ProviderDescriptor(
+        provider_id="openai",
+        display_name="OpenAI / ChatGPT",
+        auth_kind=ProviderAuthKind.CONNECTED_ACCOUNT,
+        default_base_url=OPENAI_CODEX_DEFAULT_BASE,
+        proxy_attr="openai_proxy",
     ),
     "open_router": ProviderDescriptor(
         provider_id="open_router",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -153,6 +153,7 @@ class Settings(BaseSettings):
     model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
 
     # ==================== Per-Provider Proxy ====================
+    openai_proxy: str = Field(default="", validation_alias="OPENAI_PROXY")
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
     mistral_proxy: str = Field(default="", validation_alias="MISTRAL_PROXY")

--- a/src/free_claude_code/core/interprocess_lock.py
+++ b/src/free_claude_code/core/interprocess_lock.py
@@ -1,0 +1,90 @@
+"""Small cross-platform advisory file lock."""
+
+import os
+import time
+from pathlib import Path
+from typing import BinaryIO
+
+if os.name == "nt":
+    import msvcrt
+
+    def _try_lock(handle: BinaryIO) -> bool:
+        if os.fstat(handle.fileno()).st_size == 0:
+            handle.seek(0)
+            handle.write(b"\0")
+            handle.flush()
+        handle.seek(0)
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            return False
+        return True
+
+    def _unlock(handle: BinaryIO) -> None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _try_lock(handle: BinaryIO) -> bool:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return False
+        return True
+
+    def _unlock(handle: BinaryIO) -> None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class InterprocessFileLock:
+    """Advisory lock released automatically if its process exits."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._handle: BinaryIO | None = None
+
+    def acquire(
+        self,
+        *,
+        wait: bool = False,
+        timeout: float | None = None,
+        poll_interval: float = 0.05,
+    ) -> bool:
+        """Acquire the lock, optionally waiting for a bounded interval."""
+
+        if self._handle is not None:
+            return True
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout must be non-negative")
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self._path.open("a+b")
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while not _try_lock(handle):
+            if not wait or (deadline is not None and time.monotonic() >= deadline):
+                handle.close()
+                return False
+            time.sleep(poll_interval)
+        self._handle = handle
+        return True
+
+    def release(self) -> None:
+        """Release a held lock; repeated calls are harmless."""
+
+        handle = self._handle
+        if handle is None:
+            return
+        self._handle = None
+        try:
+            _unlock(handle)
+        finally:
+            handle.close()
+
+    def __enter__(self) -> InterprocessFileLock:
+        if not self.acquire(wait=True):
+            raise TimeoutError(f"Could not acquire file lock: {self._path}")
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.release()

--- a/src/free_claude_code/core/openai_responses/__init__.py
+++ b/src/free_claude_code/core/openai_responses/__init__.py
@@ -2,15 +2,22 @@
 
 from .adapter import OpenAIResponsesAdapter
 from .errors import (
+    ResponsesConversionError,
     openai_error_payload,
     openai_error_type_for_failure,
     openai_failure_payload,
 )
 from .models import OpenAIResponsesRequest
+from .provider_input import build_responses_provider_request
+from .provider_stream import ResponsesProviderStream, ResponsesStreamFailure
 
 __all__ = [
     "OpenAIResponsesAdapter",
     "OpenAIResponsesRequest",
+    "ResponsesConversionError",
+    "ResponsesProviderStream",
+    "ResponsesStreamFailure",
+    "build_responses_provider_request",
     "openai_error_payload",
     "openai_error_type_for_failure",
     "openai_failure_payload",

--- a/src/free_claude_code/core/openai_responses/input.py
+++ b/src/free_claude_code/core/openai_responses/input.py
@@ -1,6 +1,7 @@
 """Convert OpenAI Responses requests into Anthropic Messages payloads."""
 
 from collections.abc import Mapping
+from dataclasses import dataclass, field
 from typing import Any
 
 from free_claude_code.core.trace import trace_event
@@ -9,6 +10,7 @@ from .errors import ResponsesConversionError
 from .models import OpenAIResponsesRequest
 from .reasoning import (
     combine_reasoning,
+    encrypted_reasoning_from_item,
     reasoning_text_from_item,
     responses_reasoning_to_output_config,
 )
@@ -24,6 +26,27 @@ from .tools import (
 )
 
 
+@dataclass(slots=True)
+class _PendingReasoning:
+    text: str | None = None
+    encrypted: list[str] = field(default_factory=list)
+
+    def add_item(self, item: Mapping[str, Any]) -> None:
+        self.text = combine_reasoning(self.text, reasoning_text_from_item(item))
+        if encrypted := encrypted_reasoning_from_item(item):
+            self.encrypted.append(encrypted)
+
+    def take(self) -> tuple[str | None, list[dict[str, str]]]:
+        text = self.text
+        blocks = [
+            {"type": "redacted_thinking", "data": encrypted}
+            for encrypted in self.encrypted
+        ]
+        self.text = None
+        self.encrypted.clear()
+        return text, blocks
+
+
 def convert_request_to_anthropic_payload(
     request: OpenAIResponsesRequest,
 ) -> dict[str, Any]:
@@ -34,10 +57,10 @@ def convert_request_to_anthropic_payload(
         system_parts.append(instructions)
 
     messages: list[dict[str, Any]] = []
-    pending_reasoning: str | None = None
+    pending_reasoning = _PendingReasoning()
     quarantined_function_call_ids: set[str] = set()
     for item in _iter_input_items(request.input):
-        pending_reasoning = _append_input_item(
+        _append_input_item(
             item,
             messages=messages,
             system_parts=system_parts,
@@ -84,13 +107,13 @@ def _append_input_item(
     *,
     messages: list[dict[str, Any]],
     system_parts: list[str],
-    pending_reasoning: str | None,
+    pending_reasoning: _PendingReasoning,
     quarantined_function_call_ids: set[str],
-) -> str | None:
+) -> None:
     if isinstance(item, str):
         _append_pending_reasoning(messages, pending_reasoning)
         messages.append({"role": "user", "content": item})
-        return None
+        return
     if not isinstance(item, dict):
         raise ResponsesConversionError(
             f"Unsupported Responses input item: {type(item).__name__}"
@@ -107,10 +130,10 @@ def _append_input_item(
                 system_parts,
                 reasoning_content=pending_reasoning,
             )
-            return None
+            return
         _append_pending_reasoning(messages, pending_reasoning)
         _append_message_item(role, item.get("content", ""), messages, system_parts)
-        return None
+        return
     if item_type in {"function_call", "custom_tool_call"}:
         namespace = optional_str(item.get("namespace"))
         field_name = f"{item_type}.name"
@@ -124,7 +147,7 @@ def _append_input_item(
             except ResponsesConversionError as exc:
                 quarantined_function_call_ids.add(call_id)
                 _trace_quarantined_function_call(call_id, exc)
-                return pending_reasoning
+                return
         tool_use = {
             "type": "tool_use",
             "id": call_id,
@@ -136,14 +159,14 @@ def _append_input_item(
             tool_use,
             reasoning_content=pending_reasoning,
         )
-        return None
+        return
     if item_type in {"function_call_output", "custom_tool_call_output"}:
         call_id = call_id_from_item(item)
         if (
             item_type == "function_call_output"
             and call_id in quarantined_function_call_ids
         ):
-            return pending_reasoning
+            return
         _append_pending_reasoning_before_tool_output(messages, pending_reasoning)
         _append_tool_result_message(
             messages,
@@ -153,13 +176,14 @@ def _append_input_item(
                 "content": item.get("output", ""),
             },
         )
-        return None
+        return
     if item_type == "reasoning":
-        return combine_reasoning(pending_reasoning, reasoning_text_from_item(item))
+        pending_reasoning.add_item(item)
+        return
     if item_type in {"input_text", "output_text", "text"}:
         _append_pending_reasoning(messages, pending_reasoning)
         messages.append({"role": "user", "content": _text_from_part(item)})
-        return None
+        return
 
     raise ResponsesConversionError(
         f"Unsupported Responses input item type: {item_type!r}"
@@ -184,7 +208,7 @@ def _append_message_item(
     messages: list[dict[str, Any]],
     system_parts: list[str],
     *,
-    reasoning_content: str | None = None,
+    reasoning_content: _PendingReasoning | None = None,
 ) -> None:
     normalized_role = "system" if role == "developer" else role
     if normalized_role == "system":
@@ -194,52 +218,72 @@ def _append_message_item(
         return
     if normalized_role not in {"user", "assistant"}:
         raise ResponsesConversionError(f"Unsupported Responses message role: {role!r}")
+    converted_content = _convert_message_content(content)
+    reasoning_text: str | None = None
+    reasoning_blocks: list[dict[str, str]] = []
+    if normalized_role == "assistant" and reasoning_content is not None:
+        reasoning_text, reasoning_blocks = reasoning_content.take()
+    if reasoning_blocks:
+        if isinstance(converted_content, str):
+            converted_blocks: list[dict[str, Any]] = list(reasoning_blocks)
+            if converted_content:
+                converted_blocks.append({"type": "text", "text": converted_content})
+            converted_content = converted_blocks
+        else:
+            converted_content = [*reasoning_blocks, *converted_content]
     message = {
         "role": normalized_role,
-        "content": _convert_message_content(content),
+        "content": converted_content,
     }
-    if normalized_role == "assistant" and reasoning_content is not None:
-        message["reasoning_content"] = reasoning_content
+    if reasoning_text is not None:
+        message["reasoning_content"] = reasoning_text
     messages.append(message)
 
 
 def _append_pending_reasoning(
-    messages: list[dict[str, Any]], pending_reasoning: str | None
+    messages: list[dict[str, Any]], pending_reasoning: _PendingReasoning
 ) -> None:
-    if pending_reasoning is not None:
-        messages.append(
-            {
-                "role": "assistant",
-                "content": "",
-                "reasoning_content": pending_reasoning,
-            }
-        )
+    reasoning_text, reasoning_blocks = pending_reasoning.take()
+    if reasoning_text is None and not reasoning_blocks:
+        return
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": reasoning_blocks or "",
+    }
+    if reasoning_text is not None:
+        message["reasoning_content"] = reasoning_text
+    messages.append(message)
 
 
 def _append_pending_reasoning_before_tool_output(
-    messages: list[dict[str, Any]], pending_reasoning: str | None
+    messages: list[dict[str, Any]], pending_reasoning: _PendingReasoning
 ) -> None:
-    if pending_reasoning is None:
+    if pending_reasoning.text is None and not pending_reasoning.encrypted:
         return
     message = _last_assistant_tool_use_message(messages)
     if message is None:
         _append_pending_reasoning(messages, pending_reasoning)
         return
-    _merge_message_reasoning(message, pending_reasoning)
+    reasoning_text, reasoning_blocks = pending_reasoning.take()
+    if reasoning_text is not None:
+        _merge_message_reasoning(message, reasoning_text)
+    _prepend_reasoning_blocks(message, reasoning_blocks)
 
 
 def _append_tool_use_message(
     messages: list[dict[str, Any]],
     tool_use: dict[str, Any],
     *,
-    reasoning_content: str | None,
+    reasoning_content: _PendingReasoning,
 ) -> None:
     message = _last_assistant_tool_use_message(messages)
     if message is None:
         message = {"role": "assistant", "content": []}
         messages.append(message)
-    if reasoning_content is not None:
-        _merge_message_reasoning(message, reasoning_content)
+    reasoning_text, reasoning_blocks = reasoning_content.take()
+    if reasoning_text is not None:
+        _merge_message_reasoning(message, reasoning_text)
+    _prepend_reasoning_blocks(message, reasoning_blocks)
     content = message["content"]
     if isinstance(content, list):
         content.append(tool_use)
@@ -269,8 +313,12 @@ def _last_assistant_tool_use_message(
     content = message.get("content")
     if not isinstance(content, list) or not content:
         return None
-    if all(
-        isinstance(block, dict) and block.get("type") == "tool_use" for block in content
+    block_types = [
+        block.get("type") if isinstance(block, dict) else None for block in content
+    ]
+    if "tool_use" in block_types and all(
+        block_type in {"redacted_thinking", "thinking", "tool_use"}
+        for block_type in block_types
     ):
         return message
     return None
@@ -299,6 +347,16 @@ def _merge_message_reasoning(message: dict[str, Any], reasoning: str) -> None:
     existing = message.get("reasoning_content")
     existing_reasoning = existing if isinstance(existing, str) else None
     message["reasoning_content"] = combine_reasoning(existing_reasoning, reasoning)
+
+
+def _prepend_reasoning_blocks(
+    message: dict[str, Any], blocks: list[dict[str, str]]
+) -> None:
+    if not blocks:
+        return
+    content = message.get("content")
+    if isinstance(content, list):
+        content[:0] = blocks
 
 
 def _iter_input_items(value: Any) -> list[Any]:

--- a/src/free_claude_code/core/openai_responses/provider_input.py
+++ b/src/free_claude_code/core/openai_responses/provider_input.py
@@ -1,0 +1,316 @@
+"""Convert Anthropic Messages into an upstream OpenAI Responses request."""
+
+import json
+from typing import Any
+
+from free_claude_code.core.anthropic.content import get_block_attr, get_block_type
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.request_serialization import (
+    serialize_tool_result_content,
+)
+from free_claude_code.core.reasoning import ReasoningControl, ReasoningPolicy
+
+from .errors import ResponsesConversionError
+
+
+def build_responses_provider_request(
+    request: MessagesRequest,
+    *,
+    reasoning: ReasoningPolicy,
+) -> dict[str, Any]:
+    """Build a stateless Responses request without silently dropping fields."""
+
+    _validate_supported_request(request)
+    instructions = _system_text(request)
+    input_items: list[dict[str, Any]] = []
+    for message in request.messages:
+        if message.role == "system":
+            text = _message_text(message.content, context="system message")
+            if text:
+                instructions.append(text)
+        elif message.role == "assistant":
+            input_items.extend(
+                _assistant_items(
+                    message.content,
+                    reasoning_content=message.reasoning_content,
+                )
+            )
+        else:
+            input_items.extend(_user_items(message.content))
+
+    if not input_items:
+        raise ResponsesConversionError(
+            "OpenAI Responses conversion requires at least one user or assistant item."
+        )
+
+    body: dict[str, Any] = {
+        "model": request.model,
+        "input": input_items,
+        "stream": True,
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+    }
+    if instructions:
+        body["instructions"] = "\n\n".join(instructions)
+    if request.max_tokens is not None:
+        body["max_output_tokens"] = request.max_tokens
+    if request.temperature is not None:
+        body["temperature"] = request.temperature
+    if request.top_p is not None:
+        body["top_p"] = request.top_p
+    if request.metadata is not None:
+        body["metadata"] = request.metadata
+    if request.tools:
+        body["tools"] = [
+            {
+                "type": "function",
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.input_schema or {"type": "object", "properties": {}},
+                "strict": False,
+            }
+            for tool in request.tools
+        ]
+    if request.tool_choice is not None:
+        body["tool_choice"] = _tool_choice(request.tool_choice)
+    if reasoning_config := _reasoning_config(reasoning):
+        body["reasoning"] = reasoning_config
+    return body
+
+
+def _validate_supported_request(request: MessagesRequest) -> None:
+    if request.model_extra:
+        raise ResponsesConversionError(
+            "OpenAI Responses does not support these request fields: "
+            f"{sorted(str(key) for key in request.model_extra)}."
+        )
+    provider_tool_types = sorted(
+        {tool.type for tool in request.tools or () if tool.type is not None}
+    )
+    if provider_tool_types:
+        raise ResponsesConversionError(
+            "OpenAI Responses cannot represent provider-managed tool types: "
+            f"{provider_tool_types}."
+        )
+    unsupported: list[str] = []
+    if request.stop_sequences:
+        unsupported.append("stop_sequences")
+    if request.top_k is not None:
+        unsupported.append("top_k")
+    if request.context_management:
+        unsupported.append("context_management")
+    if request.output_config:
+        unsupported.append("output_config")
+    if request.mcp_servers:
+        unsupported.append("mcp_servers")
+    if request.extra_body:
+        unsupported.append("extra_body")
+    if unsupported:
+        raise ResponsesConversionError(
+            "OpenAI Responses cannot represent these fields without data loss: "
+            f"{unsupported}."
+        )
+
+
+def _system_text(request: MessagesRequest) -> list[str]:
+    if request.system is None:
+        return []
+    if isinstance(request.system, str):
+        return [request.system] if request.system else []
+    return [part.text for part in request.system if part.text]
+
+
+def _assistant_items(
+    content: Any,
+    *,
+    reasoning_content: str | None,
+) -> list[dict[str, Any]]:
+    if isinstance(content, str):
+        items = [_assistant_message([{"type": "output_text", "text": content}])]
+        if reasoning_content is not None:
+            items.insert(
+                0,
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": reasoning_content}],
+                },
+            )
+        return items
+    if not isinstance(content, list):
+        raise ResponsesConversionError(
+            "Assistant content must be text or content blocks."
+        )
+
+    items: list[dict[str, Any]] = []
+    text_parts: list[dict[str, Any]] = []
+    thinking_parts: list[str] = (
+        [reasoning_content] if reasoning_content is not None else []
+    )
+    encrypted_parts: list[str] = []
+
+    def flush_text() -> None:
+        if text_parts:
+            items.append(_assistant_message(list(text_parts)))
+            text_parts.clear()
+
+    for block in content:
+        block_type = get_block_type(block)
+        if block_type == "text":
+            text_parts.append(
+                {
+                    "type": "output_text",
+                    "text": str(get_block_attr(block, "text", "")),
+                }
+            )
+        elif block_type == "thinking":
+            thinking_parts.append(str(get_block_attr(block, "thinking", "")))
+        elif block_type == "redacted_thinking":
+            encrypted_parts.append(str(get_block_attr(block, "data", "")))
+        elif block_type == "tool_use":
+            flush_text()
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": str(get_block_attr(block, "id", "")),
+                    "name": str(get_block_attr(block, "name", "")),
+                    "arguments": json.dumps(
+                        get_block_attr(block, "input", {}),
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                }
+            )
+        else:
+            raise ResponsesConversionError(
+                "OpenAI Responses cannot represent assistant content block "
+                f"{block_type!r}."
+            )
+    if thinking_parts or encrypted_parts:
+        summary = [
+            {"type": "summary_text", "text": text} for text in thinking_parts if text
+        ]
+        if encrypted_parts:
+            for index, encrypted in enumerate(encrypted_parts):
+                item: dict[str, Any] = {
+                    "type": "reasoning",
+                    "summary": summary if index == 0 else [],
+                    "encrypted_content": encrypted,
+                }
+                items.insert(index, item)
+        else:
+            items.insert(0, {"type": "reasoning", "summary": summary})
+    flush_text()
+    return items
+
+
+def _user_items(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, str):
+        return [_user_message([{"type": "input_text", "text": content}])]
+    if not isinstance(content, list):
+        raise ResponsesConversionError("User content must be text or content blocks.")
+
+    items: list[dict[str, Any]] = []
+    message_parts: list[dict[str, Any]] = []
+
+    def flush_message() -> None:
+        if message_parts:
+            items.append(_user_message(list(message_parts)))
+            message_parts.clear()
+
+    for block in content:
+        block_type = get_block_type(block)
+        if block_type == "text":
+            message_parts.append(
+                {
+                    "type": "input_text",
+                    "text": str(get_block_attr(block, "text", "")),
+                }
+            )
+        elif block_type == "image":
+            message_parts.append(_image_part(block))
+        elif block_type == "tool_result":
+            flush_message()
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": str(get_block_attr(block, "tool_use_id", "")),
+                    "output": serialize_tool_result_content(
+                        get_block_attr(block, "content")
+                    ),
+                }
+            )
+        elif block_type == "document":
+            raise ResponsesConversionError(
+                "OpenAI Responses provider does not support Anthropic document blocks."
+            )
+        else:
+            raise ResponsesConversionError(
+                f"OpenAI Responses cannot represent user content block {block_type!r}."
+            )
+    flush_message()
+    return items
+
+
+def _image_part(block: Any) -> dict[str, Any]:
+    source = get_block_attr(block, "source", {})
+    source_type = get_block_attr(source, "type")
+    if source_type == "url":
+        url = get_block_attr(source, "url")
+    elif source_type == "base64":
+        media_type = get_block_attr(source, "media_type")
+        data = get_block_attr(source, "data")
+        if not isinstance(media_type, str) or not isinstance(data, str):
+            raise ResponsesConversionError("Base64 images require media_type and data.")
+        url = f"data:{media_type};base64,{data}"
+    else:
+        raise ResponsesConversionError(
+            f"Unsupported image source type {source_type!r}."
+        )
+    if not isinstance(url, str) or not url:
+        raise ResponsesConversionError("Image source requires a non-empty URL.")
+    return {"type": "input_image", "image_url": url}
+
+
+def _message_text(content: Any, *, context: str) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        raise ResponsesConversionError(f"{context} must contain only text.")
+    parts: list[str] = []
+    for block in content:
+        if get_block_type(block) != "text":
+            raise ResponsesConversionError(f"{context} must contain only text.")
+        parts.append(str(get_block_attr(block, "text", "")))
+    return "\n\n".join(parts)
+
+
+def _assistant_message(content: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"type": "message", "role": "assistant", "content": content}
+
+
+def _user_message(content: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"type": "message", "role": "user", "content": content}
+
+
+def _tool_choice(choice: dict[str, Any]) -> str | dict[str, str]:
+    choice_type = choice.get("type")
+    if choice_type in {"auto", "none"}:
+        return str(choice_type)
+    if choice_type == "any":
+        return "required"
+    if choice_type == "tool":
+        name = choice.get("name")
+        if not isinstance(name, str) or not name:
+            raise ResponsesConversionError("Forced tool choice requires a tool name.")
+        return {"type": "function", "name": name}
+    raise ResponsesConversionError(f"Unsupported tool_choice type {choice_type!r}.")
+
+
+def _reasoning_config(reasoning: ReasoningPolicy) -> dict[str, str]:
+    if reasoning.control is ReasoningControl.OFF:
+        return {"effort": "none"}
+    if reasoning.effort is not None:
+        return {"effort": reasoning.effort.value, "summary": "auto"}
+    if reasoning.requests_reasoning:
+        return {"summary": "auto"}
+    return {}

--- a/src/free_claude_code/core/openai_responses/provider_stream.py
+++ b/src/free_claude_code/core/openai_responses/provider_stream.py
@@ -1,0 +1,246 @@
+"""Translate upstream OpenAI Responses events into Anthropic Messages SSE."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
+
+
+class ResponsesStreamFailure(RuntimeError):
+    """An upstream Responses stream reported a terminal failure."""
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+@dataclass(slots=True)
+class _ToolState:
+    tool_index: int
+    call_id: str
+    name: str
+    started: bool = False
+    received_delta: bool = False
+    stopped: bool = False
+
+
+class ResponsesProviderStream:
+    """Stateful one-way adapter for one upstream response."""
+
+    def __init__(
+        self,
+        *,
+        message_id: str,
+        model: str,
+        input_tokens: int,
+        log_raw_events: bool = False,
+    ) -> None:
+        self.ledger = AnthropicStreamLedger(
+            message_id,
+            model,
+            input_tokens,
+            log_raw_events=log_raw_events,
+        )
+        self.completed = False
+        self.generated_output = False
+        self._tools: dict[str, _ToolState] = {}
+        self._encrypted_reasoning: dict[str, str] = {}
+
+    def start(self) -> list[str]:
+        """Return the Anthropic message_start event."""
+
+        return [self.ledger.message_start()]
+
+    def feed(self, event_type: str, data: dict[str, Any]) -> list[str]:
+        """Consume one Responses event and return zero or more Anthropic events."""
+
+        if self.completed:
+            return []
+        if event_type == "response.output_item.added":
+            return self._item_added(data)
+        if event_type in {
+            "response.reasoning_text.delta",
+            "response.reasoning_summary_text.delta",
+        }:
+            return self._reasoning_delta(data)
+        if event_type == "response.output_text.delta":
+            return self._text_delta(data)
+        if event_type == "response.function_call_arguments.delta":
+            return self._tool_delta(data)
+        if event_type == "response.output_item.done":
+            return self._item_done(data)
+        if event_type in {"response.completed", "response.incomplete"}:
+            return self._finish(data, incomplete=event_type == "response.incomplete")
+        if event_type in {"response.failed", "error", "response.error"}:
+            raise _stream_failure(data)
+        return []
+
+    def _item_added(self, data: dict[str, Any]) -> list[str]:
+        item = data.get("item")
+        if not isinstance(item, dict):
+            return []
+        item_id = _string(item.get("id"))
+        if item.get("type") == "function_call" and item_id:
+            self._tools[item_id] = _ToolState(
+                tool_index=len(self._tools),
+                call_id=_string(item.get("call_id")) or item_id,
+                name=_string(item.get("name")),
+            )
+        if item.get("type") == "reasoning" and item_id:
+            encrypted = item.get("encrypted_content")
+            if isinstance(encrypted, str) and encrypted:
+                self._encrypted_reasoning[item_id] = encrypted
+        return []
+
+    def _reasoning_delta(self, data: dict[str, Any]) -> list[str]:
+        delta = data.get("delta")
+        if not isinstance(delta, str) or not delta:
+            return []
+        events = list(self.ledger.ensure_thinking_block())
+        events.append(self.ledger.emit_thinking_delta(delta))
+        self.generated_output = True
+        return events
+
+    def _text_delta(self, data: dict[str, Any]) -> list[str]:
+        delta = data.get("delta")
+        if not isinstance(delta, str) or not delta:
+            return []
+        events = list(self.ledger.ensure_text_block())
+        events.append(self.ledger.emit_text_delta(delta))
+        self.generated_output = True
+        return events
+
+    def _tool_delta(self, data: dict[str, Any]) -> list[str]:
+        item_id = _string(data.get("item_id"))
+        delta = data.get("delta")
+        if not item_id or not isinstance(delta, str):
+            return []
+        state = self._tools.get(item_id)
+        if state is None:
+            state = _ToolState(
+                tool_index=len(self._tools),
+                call_id=item_id,
+                name="",
+            )
+            self._tools[item_id] = state
+        events = list(self.ledger.close_content_blocks())
+        events.extend(self._ensure_tool_started(state))
+        if delta:
+            events.append(self.ledger.emit_tool_delta(state.tool_index, delta))
+            state.received_delta = True
+            self.generated_output = True
+        return events
+
+    def _item_done(self, data: dict[str, Any]) -> list[str]:
+        item = data.get("item")
+        if not isinstance(item, dict):
+            return []
+        item_type = item.get("type")
+        item_id = _string(item.get("id"))
+        if item_type == "function_call":
+            state = self._tools.get(item_id)
+            if state is None:
+                state = _ToolState(
+                    tool_index=len(self._tools),
+                    call_id=_string(item.get("call_id")) or item_id,
+                    name=_string(item.get("name")),
+                )
+                self._tools[item_id] = state
+            if not state.name:
+                state.name = _string(item.get("name"))
+            events = list(self.ledger.close_content_blocks())
+            events.extend(self._ensure_tool_started(state))
+            arguments = item.get("arguments")
+            if not state.received_delta and isinstance(arguments, str) and arguments:
+                events.append(self.ledger.emit_tool_delta(state.tool_index, arguments))
+                self.generated_output = True
+            if not state.stopped:
+                events.append(self.ledger.stop_tool_block(state.tool_index))
+                state.stopped = True
+                self.ledger.blocks.tool_states[state.tool_index].started = False
+            return events
+        if item_type == "reasoning":
+            encrypted = item.get("encrypted_content")
+            if not isinstance(encrypted, str) or not encrypted:
+                encrypted = self._encrypted_reasoning.get(item_id)
+            if isinstance(encrypted, str) and encrypted:
+                events = list(self.ledger.close_content_blocks())
+                index = self.ledger.blocks.allocate_index()
+                events.append(
+                    self.ledger.content_block_start(
+                        index, "redacted_thinking", data=encrypted
+                    )
+                )
+                events.append(self.ledger.content_block_stop(index))
+                self.generated_output = True
+                return events
+        return []
+
+    def _ensure_tool_started(self, state: _ToolState) -> list[str]:
+        if state.started:
+            return []
+        state.started = True
+        self.generated_output = True
+        return [
+            self.ledger.start_tool_block(
+                state.tool_index,
+                state.call_id,
+                state.name,
+            )
+        ]
+
+    def _finish(self, data: dict[str, Any], *, incomplete: bool) -> list[str]:
+        response = data.get("response")
+        response = response if isinstance(response, dict) else {}
+        events = list(self.ledger.close_all_blocks())
+        if not self.ledger.has_content_block():
+            events.extend(self.ledger.ensure_text_block())
+            events.append(self.ledger.emit_text_delta(" "))
+            events.append(self.ledger.stop_text_block())
+        usage = response.get("usage")
+        usage = usage if isinstance(usage, dict) else {}
+        input_tokens = _integer(usage.get("input_tokens"))
+        output_tokens = _integer(usage.get("output_tokens"))
+        details = usage.get("input_tokens_details")
+        details = details if isinstance(details, dict) else {}
+        cached_tokens = _integer(details.get("cached_tokens"))
+        stop_reason = "max_tokens" if incomplete else "end_turn"
+        events.append(
+            self.ledger.message_delta(
+                self.ledger.final_stop_reason(stop_reason),
+                output_tokens
+                if output_tokens is not None
+                else self.ledger.estimate_output_tokens(),
+                input_tokens=input_tokens,
+                usage_fields=(
+                    {"cache_read_input_tokens": cached_tokens}
+                    if cached_tokens is not None
+                    else None
+                ),
+            )
+        )
+        events.append(self.ledger.message_stop())
+        self.completed = True
+        return events
+
+
+def _stream_failure(data: dict[str, Any]) -> ResponsesStreamFailure:
+    response = data.get("response")
+    response = response if isinstance(response, dict) else {}
+    error = response.get("error", data.get("error"))
+    error = error if isinstance(error, dict) else {}
+    message = error.get("message")
+    code = error.get("code", error.get("type"))
+    return ResponsesStreamFailure(
+        message if isinstance(message, str) and message else "OpenAI response failed.",
+        code=code if isinstance(code, str) else None,
+    )
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _integer(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None

--- a/src/free_claude_code/core/openai_responses/reasoning.py
+++ b/src/free_claude_code/core/openai_responses/reasoning.py
@@ -20,6 +20,12 @@ def reasoning_text_from_item(item: Mapping[str, Any]) -> str | None:
     return None
 
 
+def encrypted_reasoning_from_item(item: Mapping[str, Any]) -> str | None:
+    """Return opaque reasoning content without interpreting it."""
+
+    return optional_str(item.get("encrypted_content"))
+
+
 def combine_reasoning(existing: str | None, addition: str | None) -> str | None:
     if addition is None:
         return existing

--- a/src/free_claude_code/providers/openai_codex/__init__.py
+++ b/src/free_claude_code/providers/openai_codex/__init__.py
@@ -1,0 +1,11 @@
+"""ChatGPT subscription provider using OpenAI's Codex backend."""
+
+from .auth import OpenAIAccess, OpenAIAuthManager, OpenAIReconnectRequired
+from .provider import OpenAICodexProvider
+
+__all__ = [
+    "OpenAIAccess",
+    "OpenAIAuthManager",
+    "OpenAICodexProvider",
+    "OpenAIReconnectRequired",
+]

--- a/src/free_claude_code/providers/openai_codex/auth.py
+++ b/src/free_claude_code/providers/openai_codex/auth.py
@@ -1,0 +1,608 @@
+"""FCC-owned ChatGPT credential lifecycle."""
+
+import asyncio
+import base64
+import json
+import os
+import time
+import uuid
+from collections.abc import Awaitable
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from free_claude_code.application.connected_accounts import (
+    ConnectedAccountLoginMode,
+    ConnectedAccountState,
+    ConnectedAccountStatus,
+)
+from free_claude_code.config.paths import openai_auth_lock_path, openai_auth_path
+from free_claude_code.core.interprocess_lock import InterprocessFileLock
+
+from .login import (
+    OPENAI_CODEX_ORIGINATOR,
+    OPENAI_OAUTH_CLIENT_ID,
+    OPENAI_REVOKE_URL,
+    OPENAI_TOKEN_URL,
+    AuthorizationGrant,
+    BrowserAuthorization,
+    OpenAILoginError,
+    request_device_authorization,
+    wait_for_device_grant,
+)
+
+REFRESH_EARLY_SECONDS = 5 * 60
+
+
+class OpenAIReconnectRequired(RuntimeError):
+    """The saved ChatGPT session is absent or no longer renewable."""
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class OpenAIAccess:
+    """Current upstream authorization headers."""
+
+    access_token: str
+    account_id: str
+    fedramp: bool
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _Credentials:
+    access_token: str
+    refresh_token: str
+    id_token: str
+    account_id: str
+    email: str | None
+    expires_at: int
+    fedramp: bool
+
+    @classmethod
+    def from_tokens(
+        cls,
+        *,
+        access_token: str,
+        refresh_token: str,
+        id_token: str,
+    ) -> _Credentials:
+        access_claims = _optional_jwt_claims(access_token)
+        id_claims = _jwt_claims(id_token)
+        auth_claims = _mapping_claim(
+            access_claims, "https://api.openai.com/auth"
+        ) or _mapping_claim(id_claims, "https://api.openai.com/auth")
+        account_id = _string_claim(auth_claims, "chatgpt_account_id")
+        if not account_id:
+            raise OpenAILoginError(
+                "OpenAI sign-in did not return a ChatGPT account identifier."
+            )
+        profile = _mapping_claim(id_claims, "https://api.openai.com/profile")
+        email = _string_claim(id_claims, "email") or _string_claim(profile, "email")
+        expires_at = _integer_claim(access_claims, "exp")
+        if expires_at is None:
+            expires_at = int(time.time()) + 8 * 24 * 60 * 60
+        return cls(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            id_token=id_token,
+            account_id=account_id,
+            email=email,
+            expires_at=expires_at,
+            fedramp=auth_claims.get("chatgpt_account_is_fedramp") is True,
+        )
+
+    @classmethod
+    def from_json(cls, payload: Any) -> _Credentials:
+        if not isinstance(payload, dict):
+            raise ValueError("credential document must be an object")
+        required = ("access_token", "refresh_token", "id_token", "account_id")
+        values = {key: payload.get(key) for key in required}
+        if not all(isinstance(value, str) and value for value in values.values()):
+            raise ValueError("credential document is missing a token field")
+        expires_at = payload.get("expires_at")
+        if not isinstance(expires_at, int) or isinstance(expires_at, bool):
+            raise ValueError("credential document is missing expires_at")
+        id_claims = _jwt_claims(values["id_token"])
+        profile = _mapping_claim(id_claims, "https://api.openai.com/profile")
+        email = _string_claim(id_claims, "email") or _string_claim(profile, "email")
+        return cls(
+            access_token=values["access_token"],
+            refresh_token=values["refresh_token"],
+            id_token=values["id_token"],
+            account_id=values["account_id"],
+            email=email if isinstance(email, str) else None,
+            expires_at=expires_at,
+            fedramp=payload.get("fedramp") is True,
+        )
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "id_token": self.id_token,
+            "account_id": self.account_id,
+            "expires_at": self.expires_at,
+            "fedramp": self.fedramp,
+        }
+
+
+class OpenAIAuthManager:
+    """Own credentials, interactive login, refresh, and revocation."""
+
+    provider_id = "openai"
+
+    def __init__(
+        self,
+        *,
+        proxy: str = "",
+        credential_path: Path | None = None,
+        lock_path: Path | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._credential_path = credential_path or openai_auth_path()
+        self._lock_path = lock_path or openai_auth_lock_path()
+        self._client = client or httpx.AsyncClient(
+            proxy=proxy or None,
+            timeout=httpx.Timeout(30.0),
+            headers={"originator": OPENAI_CODEX_ORIGINATOR},
+        )
+        self._owns_client = client is None
+        self._credentials: _Credentials | None = None
+        self._revision = 0
+        self._operation_lock = asyncio.Lock()
+        self._state_lock = asyncio.Lock()
+        self._login_task: asyncio.Task[None] | None = None
+        self._browser_login: BrowserAuthorization | None = None
+        self._attempt_id: str | None = None
+        self._mode: ConnectedAccountLoginMode | None = None
+        self._authorization_url: str | None = None
+        self._verification_url: str | None = None
+        self._user_code: str | None = None
+        self._expires_at: int | None = None
+        self._last_error: str | None = None
+        self._closed = False
+        try:
+            self._credentials = self._read_credentials()
+        except ValueError:
+            self._last_error = (
+                "Saved OpenAI credentials are invalid. Disconnect and sign in again."
+            )
+        if self._credentials is not None:
+            self._revision = 1
+
+    def is_connected(self) -> bool:
+        """Return whether renewable credentials are present."""
+
+        return self._credentials is not None
+
+    def connected_provider_ids(self) -> tuple[str, ...]:
+        """Return the provider availability contributed by this manager."""
+
+        return (self.provider_id,) if self.is_connected() else ()
+
+    def status(self) -> ConnectedAccountStatus:
+        """Return a credential-free snapshot."""
+
+        credentials = self._credentials
+        connecting = self._login_task is not None and not self._login_task.done()
+        if connecting:
+            state = ConnectedAccountState.CONNECTING
+        elif self._last_error:
+            state = ConnectedAccountState.ERROR
+        elif credentials is not None:
+            state = ConnectedAccountState.CONNECTED
+        else:
+            state = ConnectedAccountState.DISCONNECTED
+        return ConnectedAccountStatus(
+            provider_id=self.provider_id,
+            state=state,
+            connected=credentials is not None,
+            revision=self._revision,
+            attempt_id=self._attempt_id if connecting else None,
+            email=credentials.email if credentials is not None else None,
+            mode=self._mode if connecting else None,
+            authorization_url=self._authorization_url if connecting else None,
+            verification_url=self._verification_url if connecting else None,
+            user_code=self._user_code if connecting else None,
+            expires_at=self._expires_at if connecting else None,
+            message=self._last_error,
+        )
+
+    async def start_login(
+        self, mode: ConnectedAccountLoginMode
+    ) -> ConnectedAccountStatus:
+        """Start browser PKCE or device authorization without exposing secrets."""
+
+        async with self._operation_lock:
+            async with self._state_lock:
+                self._ensure_open()
+                if self._login_task is not None and not self._login_task.done():
+                    return self.status()
+                self._clear_attempt()
+                self._last_error = None
+                self._attempt_id = f"login_{uuid.uuid4().hex}"
+                self._mode = mode
+            browser: BrowserAuthorization | None = None
+            device = None
+            try:
+                if mode is ConnectedAccountLoginMode.BROWSER:
+                    browser = await BrowserAuthorization.start()
+                else:
+                    device = await request_device_authorization(self._client)
+                async with self._state_lock:
+                    if browser is not None:
+                        self._browser_login = browser
+                        self._authorization_url = browser.auth_url
+                        self._expires_at = int(time.time()) + 15 * 60
+                        self._login_task = asyncio.create_task(
+                            self._complete_browser_login(browser),
+                            name="openai-browser-login",
+                        )
+                    else:
+                        assert device is not None
+                        self._verification_url = device.verification_url
+                        self._user_code = device.user_code
+                        self._expires_at = device.expires_at
+                        self._login_task = asyncio.create_task(
+                            self._complete_login(
+                                wait_for_device_grant(self._client, device)
+                            ),
+                            name="openai-device-login",
+                        )
+                    return self.status()
+            except asyncio.CancelledError:
+                if browser is not None:
+                    with suppress(Exception):
+                        await browser.close()
+                async with self._state_lock:
+                    self._clear_attempt()
+                raise
+            except Exception:
+                if browser is not None:
+                    with suppress(Exception):
+                        await browser.close()
+                async with self._state_lock:
+                    self._clear_attempt()
+                    self._last_error = "OpenAI sign-in could not start."
+                raise
+
+    async def cancel_login(self) -> ConnectedAccountStatus:
+        """Cancel a pending login while preserving current credentials."""
+
+        async with self._operation_lock:
+            async with self._state_lock:
+                login = self._detach_login_locked()
+                self._last_error = None
+            await self._close_detached_login(*login)
+            return self.status()
+
+    async def disconnect(self) -> ConnectedAccountStatus:
+        """Best-effort revoke, then always remove FCC-owned credentials."""
+
+        async with self._operation_lock:
+            async with self._state_lock:
+                self._ensure_open()
+                login = self._detach_login_locked()
+            await self._close_detached_login(*login)
+            async with self._state_lock:
+                credentials = self._credentials
+                if credentials is not None:
+                    with suppress(httpx.HTTPError):
+                        await self._client.post(
+                            OPENAI_REVOKE_URL,
+                            json={
+                                "client_id": OPENAI_OAUTH_CLIENT_ID,
+                                "token": credentials.refresh_token,
+                                "token_type_hint": "refresh_token",
+                            },
+                        )
+                await self._delete_credentials()
+                self._credentials = None
+                self._revision += 1
+                self._last_error = None
+                return self.status()
+
+    async def access(self, *, force_refresh: bool = False) -> OpenAIAccess:
+        """Return current request headers, refreshing once before expiry."""
+
+        async with self._state_lock:
+            self._ensure_open()
+            credentials = self._credentials
+            if credentials is None:
+                raise OpenAIReconnectRequired(
+                    "Connect an OpenAI ChatGPT account in the FCC Admin UI."
+                )
+            if force_refresh:
+                credentials = await self._refresh_locked(credentials)
+            elif credentials.expires_at <= int(time.time()) + REFRESH_EARLY_SECONDS:
+                try:
+                    credentials = await self._refresh_locked(credentials)
+                except httpx.HTTPError as exc:
+                    if not _is_transient_refresh_error(exc):
+                        raise
+            return OpenAIAccess(
+                access_token=credentials.access_token,
+                account_id=credentials.account_id,
+                fedramp=credentials.fedramp,
+            )
+
+    async def recover_unauthorized(self, rejected_token: str) -> OpenAIAccess:
+        """Reload cross-process state, then force at most one token refresh."""
+
+        async with self._state_lock:
+            current = self._credentials
+            reloaded = await asyncio.to_thread(self._read_credentials)
+            if reloaded is not None and (
+                current is None or reloaded.access_token != current.access_token
+            ):
+                self._credentials = reloaded
+                current = reloaded
+            if current is None:
+                raise OpenAIReconnectRequired(
+                    "OpenAI credentials are no longer available. Reconnect in Admin."
+                )
+            if current.access_token != rejected_token:
+                return OpenAIAccess(
+                    current.access_token, current.account_id, current.fedramp
+                )
+            refreshed = await self._refresh_locked(current)
+            return OpenAIAccess(
+                refreshed.access_token, refreshed.account_id, refreshed.fedramp
+            )
+
+    async def close(self) -> None:
+        """Cancel login resources and close the owned HTTP client."""
+
+        async with self._operation_lock:
+            async with self._state_lock:
+                if self._closed:
+                    return
+                self._closed = True
+                login = self._detach_login_locked()
+            await self._close_detached_login(*login)
+            if self._owns_client:
+                await self._client.aclose()
+
+    async def _complete_browser_login(self, browser: BrowserAuthorization) -> None:
+        try:
+            await self._complete_login(browser.wait())
+        finally:
+            await browser.close()
+
+    async def _complete_login(
+        self, grant_awaitable: Awaitable[AuthorizationGrant]
+    ) -> None:
+        try:
+            grant = await grant_awaitable
+            credentials = await self._exchange_code(grant)
+            await self._write_credentials(credentials)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            async with self._state_lock:
+                self._last_error = (
+                    "OpenAI sign-in failed. Retry or use the device-code option."
+                )
+        else:
+            async with self._state_lock:
+                self._credentials = credentials
+                self._revision += 1
+                self._last_error = None
+        finally:
+            async with self._state_lock:
+                if self._login_task is asyncio.current_task():
+                    self._login_task = None
+                    self._browser_login = None
+                    self._clear_attempt()
+
+    async def _exchange_code(self, grant: AuthorizationGrant) -> _Credentials:
+        response = await self._client.post(
+            OPENAI_TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "client_id": OPENAI_OAUTH_CLIENT_ID,
+                "code": grant.code,
+                "redirect_uri": grant.redirect_uri,
+                "code_verifier": grant.code_verifier,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return _credentials_from_token_response(payload)
+
+    async def _refresh_locked(self, current: _Credentials) -> _Credentials:
+        file_lock = InterprocessFileLock(self._lock_path)
+        acquired = await asyncio.to_thread(file_lock.acquire, wait=True, timeout=30.0)
+        if not acquired:
+            raise OpenAIReconnectRequired(
+                "Timed out waiting for another FCC process to refresh OpenAI."
+            )
+        try:
+            reloaded = await asyncio.to_thread(self._read_credentials)
+            if reloaded is not None and (
+                reloaded != current
+                and reloaded.expires_at > int(time.time()) + REFRESH_EARLY_SECONDS
+            ):
+                self._credentials = reloaded
+                return reloaded
+            response = await self._client.post(
+                OPENAI_TOKEN_URL,
+                json={
+                    "grant_type": "refresh_token",
+                    "client_id": OPENAI_OAUTH_CLIENT_ID,
+                    "refresh_token": current.refresh_token,
+                },
+            )
+            if response.status_code in {400, 401, 403}:
+                await asyncio.to_thread(self._delete_credentials_unlocked)
+                self._credentials = None
+                self._revision += 1
+                self._last_error = (
+                    "OpenAI sign-in expired. Reconnect the account in Admin."
+                )
+                raise OpenAIReconnectRequired(self._last_error)
+            response.raise_for_status()
+            payload = response.json()
+            refreshed = _credentials_from_token_response(payload, previous=current)
+            await asyncio.to_thread(self._write_credentials_unlocked, refreshed)
+            self._credentials = refreshed
+            self._revision += 1
+            return refreshed
+        finally:
+            await asyncio.to_thread(file_lock.release)
+
+    async def _write_credentials(self, credentials: _Credentials) -> None:
+        file_lock = InterprocessFileLock(self._lock_path)
+        acquired = await asyncio.to_thread(file_lock.acquire, wait=True, timeout=30.0)
+        if not acquired:
+            raise OpenAILoginError("Could not lock the OpenAI credential file.")
+        try:
+            await asyncio.to_thread(self._write_credentials_unlocked, credentials)
+        finally:
+            await asyncio.to_thread(file_lock.release)
+
+    def _write_credentials_unlocked(self, credentials: _Credentials) -> None:
+        path = self._credential_path
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name != "nt":
+            os.chmod(path.parent, 0o700)
+        temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            temporary.write_text(
+                json.dumps(
+                    {"version": 1, "credentials": credentials.as_json()},
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, path)
+            os.chmod(path, 0o600)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    async def _delete_credentials(self) -> None:
+        file_lock = InterprocessFileLock(self._lock_path)
+        acquired = await asyncio.to_thread(file_lock.acquire, wait=True, timeout=30.0)
+        if not acquired:
+            raise OpenAIReconnectRequired("Could not lock the OpenAI credential file.")
+        try:
+            await asyncio.to_thread(self._delete_credentials_unlocked)
+        finally:
+            await asyncio.to_thread(file_lock.release)
+
+    def _delete_credentials_unlocked(self) -> None:
+        self._credential_path.unlink(missing_ok=True)
+
+    def _read_credentials(self) -> _Credentials | None:
+        if not self._credential_path.is_file():
+            return None
+        try:
+            payload = json.loads(self._credential_path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict) or payload.get("version") != 1:
+                raise ValueError("credential document has an unsupported schema")
+            return _Credentials.from_json(payload.get("credentials"))
+        except (OSError, json.JSONDecodeError, OpenAILoginError, ValueError) as exc:
+            raise ValueError("OpenAI credential file is invalid") from exc
+
+    def _detach_login_locked(
+        self,
+    ) -> tuple[asyncio.Task[None] | None, BrowserAuthorization | None]:
+        task = self._login_task
+        browser = self._browser_login
+        self._login_task = None
+        self._browser_login = None
+        self._clear_attempt()
+        return task, browser
+
+    @staticmethod
+    async def _close_detached_login(
+        task: asyncio.Task[None] | None,
+        browser: BrowserAuthorization | None,
+    ) -> None:
+        if task is not None and not task.done():
+            task.cancel()
+        if task is not None:
+            await asyncio.gather(task, return_exceptions=True)
+        if browser is not None:
+            await browser.close()
+
+    def _clear_attempt(self) -> None:
+        self._attempt_id = None
+        self._mode = None
+        self._authorization_url = None
+        self._verification_url = None
+        self._user_code = None
+        self._expires_at = None
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise OpenAIReconnectRequired("OpenAI authentication is shutting down.")
+
+
+def _credentials_from_token_response(
+    payload: Any,
+    *,
+    previous: _Credentials | None = None,
+) -> _Credentials:
+    if not isinstance(payload, dict):
+        raise OpenAILoginError("OpenAI returned an invalid token response.")
+    access_token = payload.get("access_token")
+    refresh_token = payload.get("refresh_token")
+    id_token = payload.get("id_token")
+    if previous is not None:
+        access_token = access_token or previous.access_token
+        refresh_token = refresh_token or previous.refresh_token
+        id_token = id_token or previous.id_token
+    if not all(
+        isinstance(value, str) and value
+        for value in (access_token, refresh_token, id_token)
+    ):
+        raise OpenAILoginError("OpenAI token response is missing credentials.")
+    return _Credentials.from_tokens(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        id_token=id_token,
+    )
+
+
+def _jwt_claims(token: str) -> dict[str, Any]:
+    try:
+        encoded = token.split(".")[1]
+        encoded += "=" * (-len(encoded) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(encoded))
+    except (IndexError, ValueError, json.JSONDecodeError) as exc:
+        raise OpenAILoginError("OpenAI returned an invalid identity token.") from exc
+    if not isinstance(payload, dict):
+        raise OpenAILoginError("OpenAI returned invalid identity claims.")
+    return payload
+
+
+def _optional_jwt_claims(token: str) -> dict[str, Any]:
+    try:
+        return _jwt_claims(token)
+    except OpenAILoginError:
+        return {}
+
+
+def _mapping_claim(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _string_claim(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _integer_claim(payload: dict[str, Any], key: str) -> int | None:
+    value = payload.get(key)
+    return value if isinstance(value, int) else None
+
+
+def _is_transient_refresh_error(error: httpx.HTTPError) -> bool:
+    if isinstance(error, httpx.HTTPStatusError):
+        return error.response.status_code == 429 or error.response.status_code >= 500
+    return isinstance(error, httpx.TransportError)

--- a/src/free_claude_code/providers/openai_codex/login.py
+++ b/src/free_claude_code/providers/openai_codex/login.py
@@ -24,6 +24,7 @@ OPENAI_DEVICE_USER_CODE_URL = f"{OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/use
 OPENAI_DEVICE_TOKEN_URL = f"{OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/token"
 OPENAI_DEVICE_VERIFICATION_URL = f"{OPENAI_AUTH_ISSUER}/codex/device"
 OPENAI_DEVICE_REDIRECT_URI = f"{OPENAI_AUTH_ISSUER}/deviceauth/callback"
+OPENAI_CALLBACK_HOST = "localhost"
 LOGIN_LIFETIME_SECONDS = 15 * 60
 
 
@@ -80,7 +81,9 @@ class BrowserAuthorization:
         runner: web.AppRunner | None = None
         redirect_uri = ""
         for candidate in (1455, 1457):
-            candidate_redirect_uri = f"http://localhost:{candidate}/auth/callback"
+            candidate_redirect_uri = (
+                f"http://{OPENAI_CALLBACK_HOST}:{candidate}/auth/callback"
+            )
             app = web.Application()
 
             async def callback(
@@ -115,7 +118,11 @@ class BrowserAuthorization:
             candidate_runner = web.AppRunner(app, access_log=None)
             await candidate_runner.setup()
             try:
-                candidate_site = web.TCPSite(candidate_runner, "127.0.0.1", candidate)
+                candidate_site = web.TCPSite(
+                    candidate_runner,
+                    OPENAI_CALLBACK_HOST,
+                    candidate,
+                )
                 await candidate_site.start()
             except OSError:
                 await candidate_runner.cleanup()

--- a/src/free_claude_code/providers/openai_codex/login.py
+++ b/src/free_claude_code/providers/openai_codex/login.py
@@ -1,0 +1,258 @@
+"""OpenAI browser and device authorization flows."""
+
+import asyncio
+import base64
+import hashlib
+import html
+import secrets
+import time
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import httpx
+from aiohttp import web
+
+OPENAI_AUTH_ISSUER = "https://auth.openai.com"
+OPENAI_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+OPENAI_CODEX_ORIGINATOR = "codex_cli_rs"
+OPENAI_OAUTH_SCOPE = (
+    "openid profile email offline_access api.connectors.read api.connectors.invoke"
+)
+OPENAI_TOKEN_URL = f"{OPENAI_AUTH_ISSUER}/oauth/token"
+OPENAI_REVOKE_URL = f"{OPENAI_AUTH_ISSUER}/oauth/revoke"
+OPENAI_DEVICE_USER_CODE_URL = f"{OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/usercode"
+OPENAI_DEVICE_TOKEN_URL = f"{OPENAI_AUTH_ISSUER}/api/accounts/deviceauth/token"
+OPENAI_DEVICE_VERIFICATION_URL = f"{OPENAI_AUTH_ISSUER}/codex/device"
+OPENAI_DEVICE_REDIRECT_URI = f"{OPENAI_AUTH_ISSUER}/deviceauth/callback"
+LOGIN_LIFETIME_SECONDS = 15 * 60
+
+
+class OpenAILoginError(RuntimeError):
+    """An interactive authorization flow could not complete."""
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class AuthorizationGrant:
+    """OAuth authorization code and matching PKCE material."""
+
+    code: str
+    redirect_uri: str
+    code_verifier: str
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _DeviceAuthorization:
+    verification_url: str
+    user_code: str
+    expires_at: int
+    interval: float
+    device_auth_id: str
+
+
+class BrowserAuthorization:
+    """Short-lived loopback callback server for one PKCE login."""
+
+    def __init__(
+        self,
+        *,
+        auth_url: str,
+        redirect_uri: str,
+        code_verifier: str,
+        runner: web.AppRunner,
+        result: asyncio.Future[AuthorizationGrant],
+    ) -> None:
+        self.auth_url = auth_url
+        self.redirect_uri = redirect_uri
+        self.code_verifier = code_verifier
+        self._runner = runner
+        self._result = result
+        self._closed = False
+
+    @classmethod
+    async def start(cls) -> BrowserAuthorization:
+        """Bind an allow-listed loopback port and construct the authorization URL."""
+
+        state = secrets.token_urlsafe(32)
+        verifier = secrets.token_urlsafe(64)
+        challenge = _base64url(hashlib.sha256(verifier.encode()).digest())
+        loop = asyncio.get_running_loop()
+        result: asyncio.Future[AuthorizationGrant] = loop.create_future()
+        runner: web.AppRunner | None = None
+        redirect_uri = ""
+        for candidate in (1455, 1457):
+            candidate_redirect_uri = f"http://localhost:{candidate}/auth/callback"
+            app = web.Application()
+
+            async def callback(
+                request: web.Request,
+                callback_redirect_uri: str = candidate_redirect_uri,
+            ) -> web.Response:
+                if request.query.get("state") != state:
+                    return web.Response(status=400, text="State mismatch")
+                if error := request.query.get("error"):
+                    description = request.query.get("error_description", error)
+                    if not result.done():
+                        result.set_exception(OpenAILoginError(description))
+                    return _callback_page("Sign-in failed", description, status=400)
+                code = request.query.get("code")
+                if not code:
+                    return web.Response(status=400, text="Missing authorization code")
+                if not result.done():
+                    result.set_result(
+                        AuthorizationGrant(
+                            code=code,
+                            redirect_uri=callback_redirect_uri,
+                            code_verifier=verifier,
+                        )
+                    )
+                return _callback_page(
+                    "Connected",
+                    "OpenAI is connected to Free Claude Code. You can close this tab.",
+                    close_window=True,
+                )
+
+            app.router.add_get("/auth/callback", callback)
+            candidate_runner = web.AppRunner(app, access_log=None)
+            await candidate_runner.setup()
+            try:
+                candidate_site = web.TCPSite(candidate_runner, "127.0.0.1", candidate)
+                await candidate_site.start()
+            except OSError:
+                await candidate_runner.cleanup()
+                continue
+            runner = candidate_runner
+            redirect_uri = candidate_redirect_uri
+            break
+        if runner is None:
+            raise OpenAILoginError(
+                "OpenAI sign-in could not bind localhost ports 1455 or 1457."
+            )
+
+        auth_url = f"{OPENAI_AUTH_ISSUER}/oauth/authorize?" + urlencode(
+            {
+                "response_type": "code",
+                "client_id": OPENAI_OAUTH_CLIENT_ID,
+                "redirect_uri": redirect_uri,
+                "scope": OPENAI_OAUTH_SCOPE,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": state,
+                "id_token_add_organizations": "true",
+                "codex_cli_simplified_flow": "true",
+                "originator": OPENAI_CODEX_ORIGINATOR,
+            }
+        )
+        return cls(
+            auth_url=auth_url,
+            redirect_uri=redirect_uri,
+            code_verifier=verifier,
+            runner=runner,
+            result=result,
+        )
+
+    async def wait(self) -> AuthorizationGrant:
+        """Wait for one valid callback, bounded by the login lifetime."""
+
+        try:
+            return await asyncio.wait_for(self._result, timeout=LOGIN_LIFETIME_SECONDS)
+        except TimeoutError as exc:
+            raise OpenAILoginError("OpenAI sign-in timed out.") from exc
+
+    async def close(self) -> None:
+        """Stop the callback listener."""
+
+        if self._closed:
+            return
+        self._closed = True
+        if not self._result.done():
+            self._result.cancel()
+        await self._runner.cleanup()
+
+
+async def request_device_authorization(
+    client: httpx.AsyncClient,
+) -> _DeviceAuthorization:
+    """Request a device code from OpenAI's documented Codex flow."""
+
+    response = await client.post(
+        OPENAI_DEVICE_USER_CODE_URL,
+        json={"client_id": OPENAI_OAUTH_CLIENT_ID},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    device_auth_id = payload.get("device_auth_id")
+    user_code = payload.get("user_code", payload.get("usercode"))
+    if not isinstance(device_auth_id, str) or not isinstance(user_code, str):
+        raise OpenAILoginError("OpenAI returned an invalid device-code response.")
+    try:
+        interval = max(1.0, float(payload.get("interval", 5)))
+    except TypeError, ValueError:
+        interval = 5.0
+    return _DeviceAuthorization(
+        verification_url=OPENAI_DEVICE_VERIFICATION_URL,
+        user_code=user_code,
+        expires_at=int(time.time()) + LOGIN_LIFETIME_SECONDS,
+        interval=interval,
+        device_auth_id=device_auth_id,
+    )
+
+
+async def wait_for_device_grant(
+    client: httpx.AsyncClient,
+    authorization: _DeviceAuthorization,
+) -> AuthorizationGrant:
+    """Poll until OpenAI issues the PKCE-backed authorization code."""
+
+    while time.time() < authorization.expires_at:
+        response = await client.post(
+            OPENAI_DEVICE_TOKEN_URL,
+            json={
+                "device_auth_id": authorization.device_auth_id,
+                "user_code": authorization.user_code,
+            },
+        )
+        if response.is_success:
+            payload = response.json()
+            code = payload.get("authorization_code")
+            verifier = payload.get("code_verifier")
+            if not isinstance(code, str) or not isinstance(verifier, str):
+                raise OpenAILoginError(
+                    "OpenAI returned an invalid device authorization response."
+                )
+            return AuthorizationGrant(
+                code=code,
+                redirect_uri=OPENAI_DEVICE_REDIRECT_URI,
+                code_verifier=verifier,
+            )
+        if response.status_code not in {403, 404}:
+            response.raise_for_status()
+        await asyncio.sleep(authorization.interval)
+    raise OpenAILoginError("OpenAI device sign-in timed out.")
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode().rstrip("=")
+
+
+def _callback_page(
+    title: str,
+    message: str,
+    *,
+    status: int = 200,
+    close_window: bool = False,
+) -> web.Response:
+    safe_title = html.escape(title)
+    safe_message = html.escape(message)
+    close_script = "<script>window.close()</script>" if close_window else ""
+    return web.Response(
+        status=status,
+        content_type="text/html",
+        text=(
+            "<!doctype html><meta charset='utf-8'>"
+            f"<title>{safe_title}</title>"
+            "<style>body{font-family:system-ui;max-width:36rem;margin:12vh auto;"
+            "padding:2rem;color:#202124}h1{font-size:1.6rem}</style>"
+            f"<h1>{safe_title}</h1><p>{safe_message}</p>"
+            f"{close_script}"
+        ),
+    )

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -1,0 +1,445 @@
+"""ChatGPT Codex backend provider using OpenAI Responses."""
+
+import asyncio
+import json
+import uuid
+from collections.abc import AsyncIterator
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+import httpx
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.diagnostics import (
+    ERROR_DETAIL_DISPLAY_CAP_BYTES,
+    attach_upstream_error_body,
+    extract_upstream_error_detail,
+)
+from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.core.openai_responses import (
+    ResponsesConversionError,
+    ResponsesProviderStream,
+    ResponsesStreamFailure,
+    build_responses_provider_request,
+)
+from free_claude_code.core.reasoning import (
+    DEFAULT_REASONING_POLICY,
+    ReasoningPolicy,
+)
+from free_claude_code.core.trace import trace_event
+from free_claude_code.providers.admission import (
+    ProviderAdmissionController,
+    ProviderAttempt,
+)
+from free_claude_code.providers.base import BaseProvider, ProviderConfig
+from free_claude_code.providers.failure_policy import (
+    RetryableProviderProtocolError,
+    classify_provider_failure,
+)
+from free_claude_code.providers.stream_recovery import RecoveryController
+
+from .auth import OpenAIAccess, OpenAIAuthManager, OpenAIReconnectRequired
+from .login import OPENAI_CODEX_ORIGINATOR
+
+try:
+    FCC_VERSION = version("free-claude-code")
+except PackageNotFoundError:
+    FCC_VERSION = "dev"
+
+
+class _TruncatedResponsesStream(RetryableProviderProtocolError):
+    """A Responses stream ended without a terminal lifecycle event."""
+
+
+class OpenAICodexProvider(BaseProvider):
+    """Use a ChatGPT subscription through OpenAI's Codex backend."""
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        auth: OpenAIAuthManager,
+        admission: ProviderAdmissionController,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._auth = auth
+        self._admission = admission
+        self._client_headers = {
+            "User-Agent": f"{OPENAI_CODEX_ORIGINATOR}/{FCC_VERSION}",
+            "originator": OPENAI_CODEX_ORIGINATOR,
+            "version": FCC_VERSION,
+        }
+        self._client = client or httpx.AsyncClient(
+            base_url=f"{config.base_url.rstrip('/')}/",
+            proxy=config.proxy or None,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout,
+                write=config.http_write_timeout,
+            ),
+            headers=self._client_headers,
+        )
+        self._owns_client = client is None
+
+    def preflight_stream(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> None:
+        """Validate lossless request conversion before any upstream I/O."""
+
+        self._build_body(request, reasoning=reasoning)
+
+    async def cleanup(self) -> None:
+        """Close only provider-owned transport resources."""
+
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        """Discover models visible to the currently connected ChatGPT account."""
+
+        async def fetch() -> Any:
+            access = await self._auth.access()
+            response = await self._client.get(
+                "models",
+                params={"client_version": FCC_VERSION},
+                headers={**self._client_headers, **_auth_headers(access)},
+            )
+            if response.status_code == 401:
+                access = await self._auth.recover_unauthorized(access.access_token)
+                response = await self._client.get(
+                    "models",
+                    params={"client_version": FCC_VERSION},
+                    headers={**self._client_headers, **_auth_headers(access)},
+                )
+            response.raise_for_status()
+            return response.json()
+
+        payload = await self._admission.run_with_retry(fetch)
+        return _model_infos(payload)
+
+    def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> AsyncIterator[str]:
+        """Stream Responses output in Anthropic Messages format."""
+
+        body = self._build_body(request, reasoning=reasoning)
+        return self._run_stream(
+            body,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            response_model=response_model or request.model,
+        )
+
+    @staticmethod
+    def _build_body(
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
+    ) -> dict[str, Any]:
+        try:
+            return build_responses_provider_request(request, reasoning=reasoning)
+        except ResponsesConversionError as exc:
+            raise InvalidRequestError(str(exc)) from exc
+
+    async def _run_stream(
+        self,
+        body: dict[str, Any],
+        *,
+        input_tokens: int,
+        request_id: str | None,
+        response_model: str,
+    ) -> AsyncIterator[str]:
+        retry_session = self._admission.new_retry_session(request_id=request_id)
+        recovery = RecoveryController()
+        message_id = f"msg_{uuid.uuid4()}"
+        session_id = str(uuid.uuid4())
+        authentication_recovered = False
+        trace_event(
+            stage="provider",
+            event="provider.request.sent",
+            source="provider",
+            provider="openai",
+            request_id=request_id,
+            gateway_model=response_model,
+            downstream_model=body.get("model"),
+            item_count=len(body.get("input", [])),
+            tool_count=len(body.get("tools", [])),
+        )
+
+        while retry_session.can_attempt:
+            stream = ResponsesProviderStream(
+                message_id=message_id,
+                model=response_model,
+                input_tokens=input_tokens,
+                log_raw_events=self._config.log_raw_sse_events,
+            )
+            for event in stream.start():
+                for held in recovery.push(event):
+                    yield held
+
+            response: httpx.Response | None = None
+            attempt: ProviderAttempt | None = None
+            stream_opened = False
+            try:
+                access = await self._auth.access()
+                attempt = await self._admission.open_attempt(retry_session)
+                response = await self._client.send(
+                    self._client.build_request(
+                        "POST",
+                        "responses",
+                        json=body,
+                        headers={
+                            **self._client_headers,
+                            **_auth_headers(access),
+                            "Accept": "text/event-stream",
+                            "session_id": session_id,
+                        },
+                    ),
+                    stream=True,
+                )
+                if response.status_code == 401 and not authentication_recovered:
+                    await _read_bounded_body(response)
+                    await self._auth.recover_unauthorized(access.access_token)
+                    await attempt.retry_immediately()
+                    authentication_recovered = True
+                    recovery.discard()
+                    continue
+                if not response.is_success:
+                    body_bytes, body_truncated = await _read_bounded_body(response)
+                    try:
+                        response.raise_for_status()
+                    except httpx.HTTPStatusError as exc:
+                        attach_upstream_error_body(
+                            exc,
+                            body_bytes,
+                            truncated=body_truncated,
+                        )
+                        raise
+                content_type = response.headers.get("content-type", "")
+                if "text/event-stream" not in content_type.lower():
+                    body_bytes, body_truncated = await _read_bounded_body(response)
+                    error = _TruncatedResponsesStream(
+                        "OpenAI returned a non-streaming Responses payload."
+                    )
+                    attach_upstream_error_body(
+                        error,
+                        body_bytes,
+                        truncated=body_truncated,
+                    )
+                    raise error
+                stream_opened = True
+
+                async for event_type, payload in _iter_sse(response):
+                    if not attempt.accepted:
+                        await attempt.succeeded()
+                    for event in stream.feed(event_type, payload):
+                        for held in recovery.push(event):
+                            yield held
+                if not stream.completed:
+                    raise _TruncatedResponsesStream(
+                        "OpenAI Responses stream ended without a terminal event."
+                    )
+                for event in recovery.flush():
+                    yield event
+                trace_event(
+                    stage="provider",
+                    event="provider.response.completed",
+                    source="provider",
+                    provider="openai",
+                    request_id=request_id,
+                )
+                return
+            except asyncio.CancelledError, GeneratorExit:
+                raise
+            except Exception as raw_error:
+                error = _effective_error(raw_error)
+                if attempt is not None and not attempt.accepted:
+                    await attempt.retry(error)
+                retryable = (
+                    attempt.failure_retryable
+                    if attempt is not None and attempt.failure_retryable is not None
+                    else None
+                )
+                decision = recovery.advance_failure(
+                    error,
+                    stream_opened=stream_opened,
+                    generated_output=recovery.committed,
+                    complete_tool_salvageable=False,
+                    attempts_remaining=retry_session.attempts_remaining,
+                    retryable_override=retryable,
+                )
+                if (
+                    not decision.committed
+                    and decision.retryable
+                    and retry_session.can_attempt
+                ):
+                    recovery.discard()
+                    trace_event(
+                        stage="provider",
+                        event="provider.recovery.early_retry",
+                        source="provider",
+                        provider="openai",
+                        request_id=request_id,
+                        attempts_started=retry_session.attempts_started,
+                        max_attempts=retry_session.max_attempts,
+                    )
+                    continue
+
+                failure = classify_provider_failure(
+                    error,
+                    provider_name="OpenAI",
+                    read_timeout_s=self._config.http_read_timeout,
+                    request_id=request_id,
+                )
+                self._log_stream_transport_error(
+                    "OPENAI",
+                    f" request_id={request_id}" if request_id else "",
+                    error,
+                    request_id=request_id,
+                )
+                if not decision.committed:
+                    recovery.discard()
+                    raise failure from raw_error
+                for event in stream.ledger.close_unclosed_blocks():
+                    yield event
+                raise failure from raw_error
+            finally:
+                if response is not None:
+                    await response.aclose()
+                if attempt is not None:
+                    await attempt.aclose()
+
+        raise RuntimeError("OpenAI retry session ended without a terminal result.")
+
+
+async def _iter_sse(
+    response: httpx.Response,
+) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+    event_type = ""
+    data_lines: list[str] = []
+    async for line in response.aiter_lines():
+        if not line:
+            if not data_lines:
+                event_type = ""
+                continue
+            raw_data = "\n".join(data_lines)
+            data_lines = []
+            if raw_data == "[DONE]":
+                return
+            try:
+                payload = json.loads(raw_data)
+            except json.JSONDecodeError as exc:
+                raise _TruncatedResponsesStream(
+                    "OpenAI returned malformed Responses SSE."
+                ) from exc
+            if not isinstance(payload, dict):
+                raise _TruncatedResponsesStream(
+                    "OpenAI returned a non-object Responses event."
+                )
+            resolved_type = event_type or payload.get("type")
+            event_type = ""
+            if isinstance(resolved_type, str) and resolved_type:
+                yield resolved_type, payload
+            continue
+        if line.startswith("event:"):
+            event_type = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    if data_lines:
+        raise _TruncatedResponsesStream(
+            "OpenAI Responses stream ended during an SSE event."
+        )
+
+
+async def _read_bounded_body(
+    response: httpx.Response,
+) -> tuple[bytes, bool]:
+    limit = ERROR_DETAIL_DISPLAY_CAP_BYTES
+    body = bytearray()
+    async for chunk in response.aiter_bytes():
+        remaining = limit + 1 - len(body)
+        if remaining <= 0:
+            break
+        body.extend(chunk[:remaining])
+        if len(body) > limit:
+            break
+    truncated = len(body) > limit
+    return bytes(body[:limit]), truncated
+
+
+def _auth_headers(access: OpenAIAccess) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {access.access_token}",
+        "ChatGPT-Account-ID": access.account_id,
+    }
+    if access.fedramp:
+        headers["X-OpenAI-Fedramp"] = "true"
+    return headers
+
+
+def _model_infos(payload: Any) -> frozenset[ProviderModelInfo]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        raise ValueError("OpenAI model-list response is missing the models array.")
+    infos: set[ProviderModelInfo] = set()
+    for model in payload["models"]:
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("slug")
+        visibility = model.get("visibility")
+        if (
+            not isinstance(model_id, str)
+            or not model_id.strip()
+            or visibility != "list"
+        ):
+            continue
+        efforts = model.get(
+            "supported_reasoning_levels",
+            model.get("supported_reasoning_efforts"),
+        )
+        infos.add(
+            ProviderModelInfo(
+                model_id=model_id,
+                supports_thinking=bool(efforts) if isinstance(efforts, list) else None,
+            )
+        )
+    if not infos:
+        raise ValueError("OpenAI did not advertise any visible models.")
+    return frozenset(infos)
+
+
+def _effective_error(error: Exception) -> Exception:
+    if isinstance(error, OpenAIReconnectRequired):
+        return ExecutionFailure(
+            kind=FailureKind.AUTHENTICATION,
+            status_code=401,
+            message=str(error),
+            retryable=False,
+        )
+    if isinstance(error, ResponsesStreamFailure):
+        message = (
+            extract_upstream_error_detail(error).exception_text
+            or "OpenAI response failed."
+        )
+        code = (error.code or "").lower()
+        if "rate" in code or "429" in code:
+            return ExecutionFailure(FailureKind.RATE_LIMIT, 429, message, True)
+        if any(marker in code for marker in ("overload", "capacity", "529")):
+            return ExecutionFailure(FailureKind.OVERLOADED, 529, message, True)
+        retryable = any(
+            marker in code
+            for marker in ("server", "internal", "unavailable", "timeout")
+        )
+        return ExecutionFailure(FailureKind.UPSTREAM, 502, message, retryable)
+    return error

--- a/src/free_claude_code/providers/runtime/discovery.py
+++ b/src/free_claude_code/providers/runtime/discovery.py
@@ -44,21 +44,33 @@ def referenced_provider_ids(settings: Settings) -> tuple[str, ...]:
     )
 
 
-def model_cache_provider_ids_for_settings(settings: Settings) -> tuple[str, ...]:
+def model_cache_provider_ids_for_settings(
+    settings: Settings,
+    connected_provider_ids: tuple[str, ...] = (),
+) -> tuple[str, ...]:
     """Return providers whose model metadata is valid for these settings."""
-    return tuple(
+    configured = tuple(
         provider_id
         for provider_id, descriptor in PROVIDER_CATALOG.items()
         if has_provider_configuration(descriptor, settings)
     )
+    available = set(configured) | set(connected_provider_ids)
+    return tuple(
+        provider_id for provider_id in PROVIDER_CATALOG if provider_id in available
+    )
 
 
-def model_list_provider_ids_for_settings(settings: Settings) -> tuple[str, ...]:
+def model_list_provider_ids_for_settings(
+    settings: Settings,
+    connected_provider_ids: tuple[str, ...] = (),
+) -> tuple[str, ...]:
     """Return providers worth discovering for this process configuration."""
     referenced_ids = referenced_provider_ids(settings)
     return tuple(
         provider_id
-        for provider_id in model_cache_provider_ids_for_settings(settings)
+        for provider_id in model_cache_provider_ids_for_settings(
+            settings, connected_provider_ids
+        )
         if not PROVIDER_CATALOG[provider_id].local or provider_id in referenced_ids
     )
 
@@ -71,10 +83,12 @@ class ProviderModelDiscovery:
         settings: Settings,
         provider_resolver: ProviderResolver,
         model_cache: ProviderModelCache,
+        connected_provider_ids: tuple[str, ...] = (),
     ) -> None:
         self._settings = settings
         self._provider_resolver = provider_resolver
         self._model_cache = model_cache
+        self._connected_provider_ids = connected_provider_ids
 
     async def warm_referenced_model_cache(self) -> ProviderModelRefreshResult:
         """Synchronously cache model metadata for routed providers."""
@@ -84,7 +98,9 @@ class ProviderModelDiscovery:
         self, *, only_missing: bool = False
     ) -> ProviderModelRefreshResult:
         """Best-effort refresh of model lists for usable providers."""
-        provider_ids = model_list_provider_ids_for_settings(self._settings)
+        provider_ids = model_list_provider_ids_for_settings(
+            self._settings, self._connected_provider_ids
+        )
         if only_missing:
             provider_ids = tuple(
                 provider_id
@@ -92,6 +108,11 @@ class ProviderModelDiscovery:
                 if not self._model_cache.has_provider(provider_id)
             )
         return await self._refresh_model_infos(provider_ids)
+
+    async def refresh_provider(self, provider_id: str) -> ProviderModelRefreshResult:
+        """Refresh exactly one dynamically changed provider."""
+
+        return await self._refresh_model_infos((provider_id,))
 
     async def _refresh_model_infos(
         self, provider_ids: tuple[str, ...]

--- a/src/free_claude_code/providers/runtime/factory.py
+++ b/src/free_claude_code/providers/runtime/factory.py
@@ -1,8 +1,11 @@
 """Provider construction from declarative profiles and exceptional adapters."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
-from free_claude_code.application.errors import UnknownProviderError
+from free_claude_code.application.errors import (
+    ApplicationUnavailableError,
+    UnknownProviderError,
+)
 from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
 from free_claude_code.config.settings import Settings
 from free_claude_code.providers.admission import ProviderAdmissionController
@@ -144,20 +147,30 @@ _SPECIAL_PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "vertex": _create_vertex,
     "github_models": _create_github_models,
 }
+_INJECTED_PROVIDER_IDS = {"openai"}
 
 _profiled_ids = set(OPENAI_CHAT_PROFILES)
 _special_ids = set(_SPECIAL_PROVIDER_FACTORIES)
-if _profiled_ids & _special_ids or _profiled_ids | _special_ids != set(
-    PROVIDER_CATALOG
+_construction_ids = _profiled_ids | _special_ids | _INJECTED_PROVIDER_IDS
+if (
+    _profiled_ids & _special_ids
+    or _profiled_ids & _INJECTED_PROVIDER_IDS
+    or _special_ids & _INJECTED_PROVIDER_IDS
+    or _construction_ids != set(PROVIDER_CATALOG)
 ):
     raise AssertionError(
         "Every provider must have exactly one construction owner: "
         f"profiles={_profiled_ids!r} special={_special_ids!r} "
-        f"catalog={set(PROVIDER_CATALOG)!r}"
+        f"injected={_INJECTED_PROVIDER_IDS!r} catalog={set(PROVIDER_CATALOG)!r}"
     )
 
 
-def create_provider(provider_id: str, settings: Settings) -> BaseProvider:
+def create_provider(
+    provider_id: str,
+    settings: Settings,
+    *,
+    injected_factories: Mapping[str, ProviderFactory] | None = None,
+) -> BaseProvider:
     """Create a provider instance for a supported provider id."""
     descriptor = PROVIDER_CATALOG.get(provider_id)
     if descriptor is None:
@@ -170,7 +183,12 @@ def create_provider(provider_id: str, settings: Settings) -> BaseProvider:
         rate_window=config.rate_window or 60.0,
         max_concurrency=config.max_concurrency,
     )
-    factory = _SPECIAL_PROVIDER_FACTORIES.get(provider_id)
+    factory = (injected_factories or {}).get(provider_id)
+    if provider_id in _INJECTED_PROVIDER_IDS and factory is None:
+        raise ApplicationUnavailableError(
+            f"Provider {provider_id!r} is unavailable in this runtime."
+        )
+    factory = factory or _SPECIAL_PROVIDER_FACTORIES.get(provider_id)
     if factory is not None:
         return factory(config, settings, admission)
     return create_openai_chat_provider(provider_id, config, admission)

--- a/src/free_claude_code/providers/runtime/model_cache.py
+++ b/src/free_claude_code/providers/runtime/model_cache.py
@@ -36,6 +36,17 @@ class ProviderModelCache:
             if provider_id in self._available_provider_ids
         }
 
+    def add_provider(self, provider_id: str) -> None:
+        """Make one dynamically authenticated provider cacheable."""
+
+        self._available_provider_ids = self._available_provider_ids | {provider_id}
+
+    def remove_provider(self, provider_id: str) -> None:
+        """Evict one provider and stop accepting its discovered metadata."""
+
+        self._available_provider_ids = self._available_provider_ids - {provider_id}
+        self._model_infos_by_provider.pop(provider_id, None)
+
     def cached_model_ids(self) -> dict[str, frozenset[str]]:
         """Return cached raw provider model ids by provider."""
         return {

--- a/src/free_claude_code/providers/runtime/runtime.py
+++ b/src/free_claude_code/providers/runtime/runtime.py
@@ -1,12 +1,14 @@
 """One closable generation of lazily constructed provider clients."""
 
 import asyncio
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
 
 from free_claude_code.config.settings import Settings
 from free_claude_code.providers.base import BaseProvider
 
 from .factory import create_provider
+
+ProviderConstructor = Callable[[str, Settings], BaseProvider]
 
 
 class ProviderRuntime:
@@ -16,9 +18,12 @@ class ProviderRuntime:
         self,
         settings: Settings,
         providers: MutableMapping[str, BaseProvider] | None = None,
+        *,
+        provider_constructor: ProviderConstructor = create_provider,
     ) -> None:
         self.settings = settings
         self._providers = providers if providers is not None else {}
+        self._provider_constructor = provider_constructor
 
     def is_cached(self, provider_id: str) -> bool:
         """Return whether a provider for this id is already cached."""
@@ -27,7 +32,9 @@ class ProviderRuntime:
     def resolve_provider(self, provider_id: str) -> BaseProvider:
         """Return an existing provider or create it lazily."""
         if provider_id not in self._providers:
-            self._providers[provider_id] = create_provider(provider_id, self.settings)
+            self._providers[provider_id] = self._provider_constructor(
+                provider_id, self.settings
+            )
         return self._providers[provider_id]
 
     async def cleanup(self) -> None:

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -6,6 +6,7 @@ import logging
 import os
 import traceback
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import replace
 from typing import Any
 
 from loguru import logger
@@ -13,6 +14,11 @@ from loguru import logger
 import free_claude_code.cli.managed as cli_managed
 import free_claude_code.messaging.session as messaging_session
 import free_claude_code.messaging.workflow as messaging_workflow_module
+from free_claude_code.application.connected_accounts import (
+    ConnectedAccountLoginMode,
+    ConnectedAccountPort,
+    ConnectedAccountStatus,
+)
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
 from free_claude_code.application.ports import StopResult
@@ -107,10 +113,16 @@ class ApplicationRuntime:
         *,
         transcriber: Transcriber | None,
         restart_callback: RestartCallback | None = None,
+        connected_accounts: Mapping[str, ConnectedAccountPort] | None = None,
     ) -> None:
         self.provider_manager = provider_manager
         self._transcriber = transcriber
         self._restart_callback = restart_callback
+        self._connected_accounts = dict(connected_accounts or {})
+        self._connected_account_revisions = {
+            provider_id: manager.status().revision
+            for provider_id, manager in self._connected_accounts.items()
+        }
         self._config_lock = asyncio.Lock()
         self._pending_fields: list[str] = []
         self._messaging_runtime: MessagingRuntime | None = None
@@ -121,6 +133,7 @@ class ApplicationRuntime:
         self._started = False
         self._closed = False
         self._provider_manager_closed = False
+        self._connected_accounts_closed = False
         self._close_lock = asyncio.Lock()
 
     @property
@@ -247,6 +260,50 @@ class ApplicationRuntime:
 
     async def refresh_models(self) -> ProviderModelRefreshResult:
         return await self.provider_manager.refresh_model_list_cache()
+
+    async def connected_account_status(
+        self, provider_id: str
+    ) -> ConnectedAccountStatus:
+        """Return safe account state and synchronize model availability."""
+
+        manager = self._connected_account(provider_id)
+        status = manager.status()
+        previous_revision = self._connected_account_revisions.get(provider_id)
+        if status.revision != previous_revision:
+            await self.provider_manager.connected_provider_changed(
+                provider_id, connected=status.connected
+            )
+            self._connected_account_revisions[provider_id] = status.revision
+        model_count = len(self.provider_manager.cached_model_ids().get(provider_id, ()))
+        return replace(status, model_count=model_count)
+
+    async def start_connected_account_login(
+        self,
+        provider_id: str,
+        mode: ConnectedAccountLoginMode,
+    ) -> ConnectedAccountStatus:
+        """Start one provider-owned interactive login."""
+
+        return await self._connected_account(provider_id).start_login(mode)
+
+    async def cancel_connected_account_login(
+        self, provider_id: str
+    ) -> ConnectedAccountStatus:
+        """Cancel one pending provider login."""
+
+        return await self._connected_account(provider_id).cancel_login()
+
+    async def disconnect_connected_account(
+        self, provider_id: str
+    ) -> ConnectedAccountStatus:
+        """Disconnect an account and evict only that provider's models."""
+
+        status = await self._connected_account(provider_id).disconnect()
+        await self.provider_manager.connected_provider_changed(
+            provider_id, connected=False
+        )
+        self._connected_account_revisions[provider_id] = status.revision
+        return status
 
     async def request_restart(self) -> None:
         callback = self._restart_callback
@@ -387,15 +444,37 @@ class ApplicationRuntime:
             return False
         if not await self._cleanup_transcriber():
             return False
-        if self._provider_manager_closed:
-            return True
         verbose = self.settings.log_api_error_tracebacks
-        self._provider_manager_closed = await best_effort(
-            "provider_manager.close",
-            self.provider_manager.close(),
-            log_verbose_errors=verbose,
+        if not self._provider_manager_closed:
+            self._provider_manager_closed = await best_effort(
+                "provider_manager.close",
+                self.provider_manager.close(),
+                log_verbose_errors=verbose,
+            )
+            if not self._provider_manager_closed:
+                return False
+        if self._connected_accounts_closed:
+            return True
+        results = await asyncio.gather(
+            *(
+                best_effort(
+                    f"connected_account.{provider_id}.close",
+                    manager.close(),
+                    log_verbose_errors=verbose,
+                )
+                for provider_id, manager in self._connected_accounts.items()
+            )
         )
-        return self._provider_manager_closed
+        self._connected_accounts_closed = all(results)
+        return self._connected_accounts_closed
+
+    def _connected_account(self, provider_id: str) -> ConnectedAccountPort:
+        manager = self._connected_accounts.get(provider_id)
+        if manager is None:
+            raise ApplicationUnavailableError(
+                f"Provider {provider_id!r} does not support connected-account login."
+            )
+        return manager
 
     async def _cleanup_messaging(self) -> bool:
         verbose = self.settings.log_api_error_tracebacks

--- a/src/free_claude_code/runtime/bootstrap.py
+++ b/src/free_claude_code/runtime/bootstrap.py
@@ -1,6 +1,7 @@
 """Single production composition root for the FCC server."""
 
 import os
+from functools import partial
 from pathlib import Path
 
 from free_claude_code.api.app import create_app
@@ -10,7 +11,15 @@ from free_claude_code.config.paths import server_log_path
 from free_claude_code.config.settings import Settings
 from free_claude_code.messaging.transcription import TranscriptionService
 from free_claude_code.messaging.voice import Transcriber
+from free_claude_code.providers.admission import ProviderAdmissionController
+from free_claude_code.providers.base import BaseProvider, ProviderConfig
 from free_claude_code.providers.nvidia_nim.voice import NvidiaNimTranscriber
+from free_claude_code.providers.openai_codex import (
+    OpenAIAuthManager,
+    OpenAICodexProvider,
+)
+from free_claude_code.providers.runtime import ProviderRuntime
+from free_claude_code.providers.runtime.factory import create_provider
 
 from .application import ApplicationRuntime, RestartCallback
 from .asgi import RuntimeASGIApp
@@ -28,11 +37,26 @@ def build_asgi_app(
         level=settings.log_level,
         verbose_third_party=settings.log_raw_api_payloads,
     )
-    provider_manager = ProviderRuntimeManager(settings)
+    openai_auth = OpenAIAuthManager(proxy=settings.openai_proxy)
+    openai_factory = partial(_create_openai_provider, auth=openai_auth)
+    provider_constructor = partial(
+        create_provider,
+        injected_factories={"openai": openai_factory},
+    )
+    runtime_factory = partial(
+        ProviderRuntime,
+        provider_constructor=provider_constructor,
+    )
+    provider_manager = ProviderRuntimeManager(
+        settings,
+        runtime_factory=runtime_factory,
+        connected_provider_ids=openai_auth.connected_provider_ids,
+    )
     runtime = ApplicationRuntime(
         provider_manager,
         transcriber=_create_transcriber(settings),
         restart_callback=restart_callback,
+        connected_accounts={"openai": openai_auth},
     )
     services = ApiServices(
         requests=provider_manager,
@@ -40,6 +64,16 @@ def build_asgi_app(
         tasks=runtime,
     )
     return RuntimeASGIApp(create_app(services), runtime)
+
+
+def _create_openai_provider(
+    config: ProviderConfig,
+    _settings: Settings,
+    admission: ProviderAdmissionController,
+    *,
+    auth: OpenAIAuthManager,
+) -> BaseProvider:
+    return OpenAICodexProvider(config, auth=auth, admission=admission)
 
 
 def _create_transcriber(settings: Settings) -> Transcriber | None:

--- a/src/free_claude_code/runtime/provider_manager.py
+++ b/src/free_claude_code/runtime/provider_manager.py
@@ -22,6 +22,7 @@ from free_claude_code.providers.runtime.discovery import (
 from free_claude_code.providers.runtime.model_cache import ProviderModelCache
 
 ProviderRuntimeFactory = Callable[[Settings], ProviderRuntime]
+ConnectedProviderIds = Callable[[], tuple[str, ...]]
 CommitConfig = Callable[[], None]
 
 
@@ -87,12 +88,14 @@ class ProviderRuntimeManager:
         settings: Settings,
         *,
         runtime_factory: ProviderRuntimeFactory = ProviderRuntime,
+        connected_provider_ids: ConnectedProviderIds = tuple,
     ) -> None:
         self._runtime_factory = runtime_factory
+        self._connected_provider_ids = connected_provider_ids
         self._replace_lock = asyncio.Lock()
         self._close_lock = asyncio.Lock()
         self._model_cache = ProviderModelCache(
-            model_cache_provider_ids_for_settings(settings)
+            model_cache_provider_ids_for_settings(settings, connected_provider_ids())
         )
         self._refresh_task: asyncio.Task[None] | None = None
         self._next_generation_id = 2
@@ -123,14 +126,17 @@ class ProviderRuntimeManager:
         return self._current.settings
 
     def cached_model_ids(self) -> dict[str, frozenset[str]]:
+        self._synchronize_model_cache_scope()
         return self._model_cache.cached_model_ids()
 
     def cached_model_supports_thinking(
         self, provider_id: str, model_id: str
     ) -> bool | None:
+        self._synchronize_model_cache_scope()
         return self._model_cache.cached_model_supports_thinking(provider_id, model_id)
 
     def cached_prefixed_model_infos(self) -> tuple[ProviderModelInfo, ...]:
+        self._synchronize_model_cache_scope()
         return self._model_cache.cached_prefixed_model_infos()
 
     def cache_model_infos(
@@ -148,6 +154,7 @@ class ProviderRuntimeManager:
                 lease.settings,
                 lease.resolve_provider,
                 self._model_cache,
+                self._connected_provider_ids(),
             )
             return await discovery.warm_referenced_model_cache()
         finally:
@@ -171,6 +178,35 @@ class ProviderRuntimeManager:
                 raise ApplicationUnavailableError("Provider runtime is shutting down.")
             await self._cancel_refresh()
             return await self._refresh_generation(self._current, only_missing=False)
+
+    async def connected_provider_changed(
+        self, provider_id: str, *, connected: bool
+    ) -> ProviderModelRefreshResult:
+        """Synchronize one connected account without replacing a generation."""
+
+        async with self._replace_lock:
+            if self._closing or self._closed:
+                raise ApplicationUnavailableError("Provider runtime is shutting down.")
+            if not connected:
+                self._model_cache.remove_provider(provider_id)
+                return ProviderModelRefreshResult()
+            self._model_cache.add_provider(provider_id)
+            discovery = ProviderModelDiscovery(
+                self._current.settings,
+                self._current.runtime.resolve_provider,
+                self._model_cache,
+                self._connected_provider_ids(),
+            )
+            return await discovery.refresh_provider(provider_id)
+
+    def _synchronize_model_cache_scope(self) -> None:
+        """Drop metadata whose settings or connected account is no longer usable."""
+
+        self._model_cache.set_available_providers(
+            model_cache_provider_ids_for_settings(
+                self._current.settings, self._connected_provider_ids()
+            )
+        )
 
     async def replace(
         self,
@@ -214,7 +250,9 @@ class ProviderRuntimeManager:
             )
             self._current = candidate
             self._model_cache.set_available_providers(
-                model_cache_provider_ids_for_settings(settings)
+                model_cache_provider_ids_for_settings(
+                    settings, self._connected_provider_ids()
+                )
             )
             previous.retired = True
             self._retired[previous.generation_id] = previous
@@ -283,6 +321,7 @@ class ProviderRuntimeManager:
                 generation.settings,
                 generation.runtime.resolve_provider,
                 self._model_cache,
+                self._connected_provider_ids(),
             )
             return await discovery.refresh_model_list_cache(only_missing=only_missing)
         finally:

--- a/tests/api/support.py
+++ b/tests/api/support.py
@@ -1,11 +1,12 @@
 """Explicit test composition for the API adapter."""
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 
 from fastapi import FastAPI
 
 from free_claude_code.api.app import create_app
 from free_claude_code.api.ports import ApiServices
+from free_claude_code.application.connected_accounts import ConnectedAccountPort
 from free_claude_code.config.settings import Settings
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.runtime import ProviderRuntime
@@ -18,11 +19,24 @@ def create_test_app(
     *,
     providers: MutableMapping[str, BaseProvider] | None = None,
     restart_callback: RestartCallback | None = None,
+    connected_accounts: Mapping[str, ConnectedAccountPort] | None = None,
 ) -> FastAPI:
     """Build an API app with explicit in-memory runtime services."""
     settings = settings or Settings()
+    connected_accounts = dict(connected_accounts or {})
+
+    def connected_provider_ids() -> tuple[str, ...]:
+        return tuple(
+            provider_id
+            for provider_id, account in connected_accounts.items()
+            if account.is_connected()
+        )
+
     if providers is None:
-        manager = ProviderRuntimeManager(settings)
+        manager = ProviderRuntimeManager(
+            settings,
+            connected_provider_ids=connected_provider_ids,
+        )
     else:
         manager = ProviderRuntimeManager(
             settings,
@@ -30,11 +44,13 @@ def create_test_app(
                 snapshot,
                 dict(providers),
             ),
+            connected_provider_ids=connected_provider_ids,
         )
     runtime = ApplicationRuntime(
         manager,
         transcriber=None,
         restart_callback=restart_callback,
+        connected_accounts=connected_accounts,
     )
     return create_app(
         ApiServices(

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -5,6 +5,11 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from free_claude_code.application.connected_accounts import (
+    ConnectedAccountLoginMode,
+    ConnectedAccountState,
+    ConnectedAccountStatus,
+)
 from free_claude_code.application.model_metadata import (
     ProviderModelInfo,
     ProviderModelRefreshResult,
@@ -150,6 +155,113 @@ def test_admin_api_fetches_bypass_browser_cache():
     )
 
     assert 'cache: "no-store"' in script
+
+
+def test_admin_connected_account_login_preopens_sign_in_window():
+    script = Path("src/free_claude_code/api/admin_static/admin.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'window.open("about:blank", "_blank")' in script
+    assert "popup.location.replace(target)" in script
+    assert "if (popup) popup.close()" in script
+    assert '"Reconnect"' in script
+    assert '"Copy code"' in script
+    assert "Restart your agent to refresh its model picker." in script
+    assert 'window.confirm("Disconnect this ChatGPT account from FCC?")' in script
+
+
+class _FakeConnectedAccount:
+    def __init__(self) -> None:
+        self.connected = False
+        self.revision = 0
+        self.cancelled = False
+
+    def is_connected(self) -> bool:
+        return self.connected
+
+    def status(self) -> ConnectedAccountStatus:
+        return ConnectedAccountStatus(
+            provider_id="openai",
+            state=(
+                ConnectedAccountState.CONNECTED
+                if self.connected
+                else ConnectedAccountState.DISCONNECTED
+            ),
+            connected=self.connected,
+            revision=self.revision,
+            email="safe@example.com" if self.connected else None,
+        )
+
+    async def start_login(
+        self, mode: ConnectedAccountLoginMode
+    ) -> ConnectedAccountStatus:
+        return ConnectedAccountStatus(
+            provider_id="openai",
+            state=ConnectedAccountState.CONNECTING,
+            connected=False,
+            revision=self.revision,
+            attempt_id="login_safe",
+            mode=mode,
+            authorization_url="https://auth.openai.com/safe",
+        )
+
+    async def cancel_login(self) -> ConnectedAccountStatus:
+        self.cancelled = True
+        return self.status()
+
+    async def disconnect(self) -> ConnectedAccountStatus:
+        self.connected = False
+        self.revision += 1
+        return self.status()
+
+    async def close(self) -> None:
+        return None
+
+
+def test_admin_connected_account_routes_are_safe_loopback_only_and_uncached(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    account = _FakeConnectedAccount()
+    app = create_test_app(connected_accounts={"openai": account})
+    client = _local_client(app)
+
+    status_response = client.get("/admin/api/providers/openai/auth")
+    login_response = client.post(
+        "/admin/api/providers/openai/auth/login",
+        json={"mode": "browser"},
+    )
+    cancel_response = client.post("/admin/api/providers/openai/auth/cancel")
+
+    assert status_response.status_code == 200
+    assert status_response.headers["cache-control"] == "no-store"
+    assert status_response.json()["state"] == "disconnected"
+    assert login_response.status_code == 200
+    assert login_response.json() == {
+        "provider_id": "openai",
+        "state": "connecting",
+        "connected": False,
+        "revision": 0,
+        "attempt_id": "login_safe",
+        "mode": "browser",
+        "authorization_url": "https://auth.openai.com/safe",
+    }
+    assert "token" not in login_response.text.lower()
+    assert cancel_response.status_code == 200
+    assert account.cancelled is True
+    remote = TestClient(app, client=("203.0.113.10", 50000))
+    assert remote.get("/admin/api/providers/openai/auth").status_code == 403
+
+
+def test_admin_rejects_auth_routes_for_non_connected_provider(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+
+    response = _local_client(create_test_app()).get(
+        "/admin/api/providers/nvidia_nim/auth"
+    )
+
+    assert response.status_code == 404
 
 
 def test_admin_provider_cards_support_non_key_configuration():

--- a/tests/cli/test_desktop.py
+++ b/tests/cli/test_desktop.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from free_claude_code.cli.commands import ServerStatus, ServerSupervisor
-from free_claude_code.cli.desktop import DesktopController, DesktopInstanceLock
+from free_claude_code.cli.desktop import DesktopController
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.interprocess_lock import InterprocessFileLock
 
 
 def _settings() -> Settings:
@@ -15,8 +16,8 @@ def _settings() -> Settings:
 
 def test_desktop_instance_lock_is_exclusive_and_reusable(tmp_path: Path) -> None:
     lock_path = tmp_path / "desktop.lock"
-    first = DesktopInstanceLock(lock_path)
-    second = DesktopInstanceLock(lock_path)
+    first = InterprocessFileLock(lock_path)
+    second = InterprocessFileLock(lock_path)
 
     assert first.acquire() is True
     assert first.acquire() is True
@@ -214,7 +215,7 @@ def test_second_desktop_launch_opens_existing_admin_without_new_server() -> None
 
     with (
         patch.object(desktop, "load_server_settings", return_value=settings),
-        patch.object(desktop, "DesktopInstanceLock", return_value=instance_lock),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
         patch.object(desktop, "open_admin_when_ready", return_value=True) as open_admin,
         patch.object(desktop, "ServerSupervisor") as supervisor,
     ):
@@ -234,7 +235,7 @@ def test_desktop_attaches_to_terminal_server_instead_of_binding_twice() -> None:
 
     with (
         patch.object(desktop, "load_server_settings", return_value=settings),
-        patch.object(desktop, "DesktopInstanceLock", return_value=instance_lock),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
         patch.object(desktop, "preflight_proxy", return_value=None),
         patch.object(desktop, "open_admin_when_ready", return_value=True) as open_admin,
         patch.object(desktop, "ServerSupervisor") as supervisor,
@@ -257,7 +258,7 @@ def test_fresh_desktop_launch_disables_console_and_automatic_browser() -> None:
 
     with (
         patch.object(desktop, "load_server_settings", return_value=settings),
-        patch.object(desktop, "DesktopInstanceLock", return_value=instance_lock),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
         patch.object(desktop, "preflight_proxy", return_value="connection refused"),
         patch.object(desktop, "ServerSupervisor", return_value=supervisor) as owner,
         patch.object(desktop, "DesktopController", return_value=controller) as shell,

--- a/tests/config/test_provider_catalog.py
+++ b/tests/config/test_provider_catalog.py
@@ -4,6 +4,7 @@ import pytest
 
 from free_claude_code.config.provider_catalog import (
     PROVIDER_CATALOG,
+    ProviderAuthKind,
     ProviderDescriptor,
 )
 
@@ -54,6 +55,17 @@ def test_provider_configuration_attrs_cover_multi_field_and_adc_providers() -> N
 
 def test_every_provider_declares_its_configuration_boundary() -> None:
     assert all(
-        descriptor.configuration_attrs() or descriptor.static_credential is not None
+        descriptor.configuration_attrs()
+        or descriptor.static_credential is not None
+        or descriptor.auth_kind is ProviderAuthKind.CONNECTED_ACCOUNT
         for descriptor in PROVIDER_CATALOG.values()
     )
+
+
+def test_openai_is_a_connected_account_without_api_key_configuration() -> None:
+    descriptor = PROVIDER_CATALOG["openai"]
+
+    assert descriptor.auth_kind is ProviderAuthKind.CONNECTED_ACCOUNT
+    assert descriptor.credential_env is None
+    assert descriptor.configuration_attrs() == ()
+    assert descriptor.default_base_url == "https://chatgpt.com/backend-api/codex"

--- a/tests/contracts/test_admin_provider_manifest.py
+++ b/tests/contracts/test_admin_provider_manifest.py
@@ -1,7 +1,10 @@
 """Ensure admin UI manifest exposes every catalog credential/proxy binding."""
 
 from free_claude_code.config.admin.manifest import FIELD_BY_KEY
-from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
+from free_claude_code.config.provider_catalog import (
+    PROVIDER_CATALOG,
+    ProviderAuthKind,
+)
 from free_claude_code.config.settings import Settings
 
 
@@ -107,7 +110,13 @@ def test_provider_catalog_display_names_are_admin_status_source() -> None:
     assert set(status_by_provider) == set(PROVIDER_CATALOG)
     for provider_id, desc in PROVIDER_CATALOG.items():
         assert status_by_provider[provider_id]["display_name"] == desc.display_name
-        expected_kind = "local" if desc.local else "remote"
+        expected_kind = (
+            "connected_account"
+            if desc.auth_kind is ProviderAuthKind.CONNECTED_ACCOUNT
+            else "local"
+            if desc.local
+            else "remote"
+        )
         assert status_by_provider[provider_id]["kind"] == expected_kind
 
 

--- a/tests/contracts/test_feature_manifest.py
+++ b/tests/contracts/test_feature_manifest.py
@@ -17,6 +17,7 @@ from free_claude_code.providers.openai_chat import (
     OPENAI_CHAT_PROFILES,
     OpenAIChatProvider,
 )
+from free_claude_code.providers.openai_codex import OpenAICodexProvider
 from free_claude_code.providers.vertex import VertexProvider
 from smoke.features import FEATURE_INVENTORY, README_FEATURES, feature_ids
 
@@ -93,6 +94,7 @@ def test_product_coverage_is_not_satisfied_by_prereq_probes() -> None:
 
 def test_provider_and_platform_registries_include_advertised_builtins() -> None:
     specialized_provider_classes = {
+        "openai": OpenAICodexProvider,
         "nvidia_nim": NvidiaNimProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -7,6 +7,7 @@ from free_claude_code.config.provider_catalog import (
 
 _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "nvidia_nim",
+    "openai",
     "open_router",
     "gemini",
     "vertex",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -15,6 +15,7 @@ from smoke.lib.config import (
     OPT_IN_TARGETS,
     PROVIDER_SMOKE_DEFAULT_MODELS,
     TARGET_REQUIRED_ENV,
+    ProviderModel,
     SmokeConfig,
     nvidia_nim_cli_model_refs,
     openrouter_free_cli_model_refs,
@@ -145,6 +146,30 @@ def test_provider_smoke_models_cover_configured_providers_independent_of_model_m
     assert [model.provider for model in models] == ["deepseek"]
     assert models[0].full_model == PROVIDER_SMOKE_DEFAULT_MODELS["deepseek"]
     assert models[0].source == "provider_default"
+
+
+def test_connected_account_provider_smoke_requires_explicit_model(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_OPENAI", raising=False)
+    config = _smoke_config(
+        provider_matrix=frozenset({"openai"}),
+        settings=_settings(ollama_base_url=""),
+    )
+
+    assert not config.has_provider_configuration("openai")
+    assert config.provider_smoke_models() == []
+
+    monkeypatch.setenv("FCC_SMOKE_MODEL_OPENAI", "gpt-5.3-codex")
+
+    assert config.has_provider_configuration("openai")
+    assert config.provider_smoke_models() == [
+        ProviderModel(
+            provider="openai",
+            full_model="openai/gpt-5.3-codex",
+            source="FCC_SMOKE_MODEL_OPENAI",
+        )
+    ]
 
 
 def test_openrouter_provider_smoke_uses_concrete_free_model(monkeypatch) -> None:
@@ -407,7 +432,7 @@ def test_provider_smoke_model_override_accepts_owner_model_name(
     assert models[0].source == "FCC_SMOKE_MODEL_NVIDIA_NIM"
 
 
-def test_provider_smoke_model_override_rejects_wrong_provider_prefix(
+def test_provider_smoke_model_override_preserves_namespaced_upstream_model(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("FCC_SMOKE_MODEL_DEEPSEEK", "ollama/llama3.1")
@@ -419,12 +444,9 @@ def test_provider_smoke_model_override_rejects_wrong_provider_prefix(
         provider_matrix=frozenset({"deepseek"}),
     )
 
-    try:
-        config.provider_smoke_models()
-    except ValueError as exc:
-        assert "FCC_SMOKE_MODEL_DEEPSEEK" in str(exc)
-    else:
-        raise AssertionError("expected wrong provider prefix to fail")
+    models = config.provider_smoke_models()
+
+    assert models[0].full_model == "deepseek/ollama/llama3.1"
 
 
 def test_mistral_reasoning_smoke_uses_reasoning_default(monkeypatch) -> None:
@@ -570,13 +592,12 @@ def test_nvidia_nim_cli_models_reject_empty_override() -> None:
         raise AssertionError("expected empty NVIDIA NIM CLI model override to fail")
 
 
-def test_nvidia_nim_cli_models_reject_wrong_provider_prefix() -> None:
-    try:
-        nvidia_nim_cli_model_refs({"FCC_SMOKE_NIM_MODELS": "open_router/model"})
-    except ValueError as exc:
-        assert "nvidia_nim" in str(exc)
-    else:
-        raise AssertionError("expected wrong provider prefix to fail")
+def test_nvidia_nim_cli_models_preserve_namespaced_upstream_model() -> None:
+    refs = nvidia_nim_cli_model_refs({"FCC_SMOKE_NIM_MODELS": "open_router/model"})
+
+    assert refs == {
+        "nvidia_nim/open_router/model": "FCC_SMOKE_NIM_MODELS",
+    }
 
 
 def test_smoke_config_returns_nvidia_nim_cli_provider_models(monkeypatch) -> None:
@@ -642,15 +663,14 @@ def test_openrouter_free_cli_models_reject_empty_override() -> None:
         raise AssertionError("expected empty OpenRouter free CLI override to fail")
 
 
-def test_openrouter_free_cli_models_reject_wrong_provider_prefix() -> None:
-    try:
-        openrouter_free_cli_model_refs(
-            {"FCC_SMOKE_OPENROUTER_FREE_MODELS": "nvidia_nim/model"}
-        )
-    except ValueError as exc:
-        assert "open_router" in str(exc)
-    else:
-        raise AssertionError("expected wrong provider prefix to fail")
+def test_openrouter_free_cli_models_preserve_namespaced_upstream_model() -> None:
+    refs = openrouter_free_cli_model_refs(
+        {"FCC_SMOKE_OPENROUTER_FREE_MODELS": "nvidia_nim/model"}
+    )
+
+    assert refs == {
+        "open_router/nvidia_nim/model": "FCC_SMOKE_OPENROUTER_FREE_MODELS",
+    }
 
 
 def test_smoke_config_returns_openrouter_free_cli_provider_models(monkeypatch) -> None:

--- a/tests/core/openai_responses/test_conversion.py
+++ b/tests/core/openai_responses/test_conversion.py
@@ -525,6 +525,45 @@ def test_responses_reasoning_between_tool_call_and_output_attaches_to_tool_messa
     assert payload["messages"][1]["content"][0]["tool_use_id"] == "call_1"
 
 
+def test_responses_encrypted_reasoning_attaches_before_tool_call() -> None:
+    payload = _to_anthropic_payload(
+        {
+            "model": "openai/gpt-test",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "Need the result."}],
+                    "encrypted_content": "opaque-reasoning",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "echo",
+                    "arguments": '{"value":"FCC"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "FCC",
+                },
+            ],
+        }
+    )
+
+    assistant = payload["messages"][0]
+    assert assistant["reasoning_content"] == "Need the result."
+    assert assistant["content"] == [
+        {"type": "redacted_thinking", "data": "opaque-reasoning"},
+        {
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "echo",
+            "input": {"value": "FCC"},
+        },
+    ]
+    assert payload["messages"][1]["content"][0]["tool_use_id"] == "call_1"
+
+
 def test_responses_empty_reasoning_attaches_to_prior_tool_call() -> None:
     payload = _to_anthropic_payload(
         {

--- a/tests/core/openai_responses/test_provider_input.py
+++ b/tests/core/openai_responses/test_provider_input.py
@@ -1,0 +1,208 @@
+import json
+
+import pytest
+
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.openai_responses import (
+    OpenAIResponsesAdapter,
+    OpenAIResponsesRequest,
+)
+from free_claude_code.core.openai_responses.errors import ResponsesConversionError
+from free_claude_code.core.openai_responses.provider_input import (
+    build_responses_provider_request,
+)
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+
+
+def test_build_responses_provider_request_preserves_multiturn_protocol() -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "max_tokens": 4096,
+            "system": "System instructions",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "summary"},
+                        {"type": "redacted_thinking", "data": "opaque"},
+                        {"type": "text", "text": "Calling a tool"},
+                        {
+                            "type": "tool_use",
+                            "id": "call_1",
+                            "name": "lookup",
+                            "input": {"q": "value"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_1",
+                            "content": {"answer": 42},
+                        },
+                        {"type": "text", "text": "Continue"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "aGVsbG8=",
+                            },
+                        },
+                    ],
+                },
+            ],
+            "tools": [
+                {
+                    "name": "lookup",
+                    "description": "Look up a value",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                }
+            ],
+            "tool_choice": {"type": "tool", "name": "lookup"},
+        }
+    )
+
+    body = build_responses_provider_request(
+        request,
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.XHIGH),
+    )
+
+    assert body["model"] == "gpt-test"
+    assert body["instructions"] == "System instructions"
+    assert body["max_output_tokens"] == 4096
+    assert body["stream"] is True
+    assert body["store"] is False
+    assert body["include"] == ["reasoning.encrypted_content"]
+    assert body["reasoning"] == {"effort": "xhigh", "summary": "auto"}
+    assert body["tool_choice"] == {"type": "function", "name": "lookup"}
+    assert body["input"][0] == {
+        "type": "reasoning",
+        "summary": [{"type": "summary_text", "text": "summary"}],
+        "encrypted_content": "opaque",
+    }
+    assert body["input"][1]["role"] == "assistant"
+    assert body["input"][2] == {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": "lookup",
+        "arguments": json.dumps(
+            {"q": "value"}, ensure_ascii=False, separators=(",", ":")
+        ),
+    }
+    assert body["input"][3] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": '{"answer": 42}',
+    }
+    assert body["input"][4]["content"][1] == {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,aGVsbG8=",
+    }
+
+
+def test_responses_round_trip_preserves_encrypted_reasoning_and_tool_ids() -> None:
+    adapter = OpenAIResponsesAdapter()
+    ingress = OpenAIResponsesRequest.model_validate(
+        {
+            "model": "openai/gpt-test",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "Use a tool."}],
+                    "encrypted_content": "opaque-reasoning",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_stable",
+                    "name": "lookup",
+                    "arguments": '{"q":"value"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_stable",
+                    "output": "done",
+                },
+            ],
+        }
+    )
+    anthropic = MessagesRequest.model_validate(adapter.to_anthropic_payload(ingress))
+
+    body = build_responses_provider_request(
+        anthropic,
+        reasoning=ReasoningPolicy.provider_default(),
+    )
+
+    assert body["input"][:3] == [
+        {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "Use a tool."}],
+            "encrypted_content": "opaque-reasoning",
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_stable",
+            "name": "lookup",
+            "arguments": '{"q":"value"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_stable",
+            "output": "done",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("stop_sequences", ["stop"]),
+        ("top_k", 4),
+        ("context_management", {"edits": []}),
+        ("output_config", {"effort": "high"}),
+        ("mcp_servers", [{"name": "server"}]),
+        ("extra_body", {"unknown": True}),
+    ],
+)
+def test_build_responses_provider_request_rejects_lossy_fields(
+    field: str, value: object
+) -> None:
+    payload = {
+        "model": "gpt-test",
+        "messages": [{"role": "user", "content": "hello"}],
+        field: value,
+    }
+
+    with pytest.raises(ResponsesConversionError, match=field):
+        build_responses_provider_request(
+            MessagesRequest.model_validate(payload),
+            reasoning=ReasoningPolicy.provider_default(),
+        )
+
+
+def test_build_responses_provider_request_rejects_provider_managed_tools() -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [
+                {
+                    "name": "web_search",
+                    "type": "web_search_20250305",
+                    "input_schema": {"type": "object"},
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(ResponsesConversionError, match="web_search_20250305"):
+        build_responses_provider_request(
+            request,
+            reasoning=ReasoningPolicy.provider_default(),
+        )

--- a/tests/core/openai_responses/test_provider_stream.py
+++ b/tests/core/openai_responses/test_provider_stream.py
@@ -1,0 +1,153 @@
+import pytest
+
+from free_claude_code.core.anthropic.stream_contracts import (
+    assert_anthropic_stream_contract,
+    parse_sse_text,
+    thinking_content,
+)
+from free_claude_code.core.openai_responses.provider_stream import (
+    ResponsesProviderStream,
+    ResponsesStreamFailure,
+)
+
+
+def test_responses_provider_stream_preserves_reasoning_tools_usage_and_ids() -> None:
+    stream = ResponsesProviderStream(
+        message_id="msg_test",
+        model="openai/gpt-test",
+        input_tokens=12,
+    )
+    output = stream.start()
+    output.extend(
+        stream.feed(
+            "response.output_item.added",
+            {
+                "item": {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                }
+            },
+        )
+    )
+    output.extend(
+        stream.feed(
+            "response.reasoning_summary_text.delta",
+            {"item_id": "rs_1", "delta": "reasoning"},
+        )
+    )
+    output.extend(
+        stream.feed(
+            "response.output_item.done",
+            {
+                "item": {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "encrypted_content": "opaque",
+                }
+            },
+        )
+    )
+    output.extend(
+        stream.feed(
+            "response.output_item.added",
+            {
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                }
+            },
+        )
+    )
+    output.extend(
+        stream.feed(
+            "response.function_call_arguments.delta",
+            {"item_id": "fc_1", "delta": '{"q":'},
+        )
+    )
+    output.extend(
+        stream.feed(
+            "response.function_call_arguments.delta",
+            {"item_id": "fc_1", "delta": '"x"}'},
+        )
+    )
+    output.extend(
+        stream.feed(
+            "response.output_item.done",
+            {
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": '{"q":"x"}',
+                }
+            },
+        )
+    )
+    output.extend(
+        stream.feed(
+            "response.completed",
+            {
+                "response": {
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 8,
+                        "input_tokens_details": {"cached_tokens": 15},
+                    }
+                }
+            },
+        )
+    )
+
+    events = parse_sse_text("".join(output))
+    assert_anthropic_stream_contract(events)
+    assert thinking_content(events) == "reasoning"
+    starts = [
+        event.data["content_block"]
+        for event in events
+        if event.event == "content_block_start"
+    ]
+    assert {"type": "redacted_thinking", "data": "opaque"} in starts
+    assert {
+        "type": "tool_use",
+        "id": "call_1",
+        "name": "lookup",
+        "input": {},
+    } in starts
+    argument_deltas = [
+        event.data["delta"]["partial_json"]
+        for event in events
+        if event.data.get("delta", {}).get("type") == "input_json_delta"
+    ]
+    assert argument_deltas == ['{"q":', '"x"}']
+    message_delta = next(event for event in events if event.event == "message_delta")
+    assert message_delta.data["usage"] == {
+        "input_tokens": 20,
+        "output_tokens": 8,
+        "cache_read_input_tokens": 15,
+    }
+
+
+def test_responses_provider_stream_surfaces_failed_event() -> None:
+    stream = ResponsesProviderStream(
+        message_id="msg_test",
+        model="gpt-test",
+        input_tokens=0,
+    )
+
+    with pytest.raises(ResponsesStreamFailure, match="capacity") as exc_info:
+        stream.feed(
+            "response.failed",
+            {
+                "response": {
+                    "error": {
+                        "code": "server_error",
+                        "message": "No capacity",
+                    }
+                }
+            },
+        )
+
+    assert exc_info.value.code == "server_error"

--- a/tests/providers/test_openai_codex_auth.py
+++ b/tests/providers/test_openai_codex_auth.py
@@ -1,0 +1,433 @@
+import asyncio
+import base64
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from free_claude_code.application.connected_accounts import (
+    ConnectedAccountLoginMode,
+)
+from free_claude_code.providers.openai_codex.auth import (
+    OpenAIAuthManager,
+    OpenAIReconnectRequired,
+)
+from free_claude_code.providers.openai_codex.login import BrowserAuthorization
+
+
+def _jwt(payload: dict[str, object]) -> str:
+    encoded = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    )
+    return f"header.{encoded}.signature"
+
+
+def _credential_document(*, expires_at: int) -> dict[str, object]:
+    id_token = _jwt(
+        {
+            "email": "person@example.com",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "account_1",
+                "chatgpt_account_is_fedramp": False,
+            },
+        }
+    )
+    return {
+        "version": 1,
+        "credentials": {
+            "access_token": _jwt({"exp": expires_at}),
+            "refresh_token": "refresh_secret",
+            "id_token": id_token,
+            "account_id": "account_1",
+            "email": "person@example.com",
+            "expires_at": expires_at,
+            "fedramp": False,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_auth_manager_refreshes_atomically_without_exposing_tokens(
+    tmp_path: Path,
+) -> None:
+    credential_path = tmp_path / "auth" / "openai.json"
+    credential_path.parent.mkdir()
+    credential_path.write_text(
+        json.dumps(_credential_document(expires_at=1)),
+        encoding="utf-8",
+    )
+    refreshed_access = _jwt({"exp": 4_000_000_000})
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"access_token": refreshed_access},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    manager = OpenAIAuthManager(
+        credential_path=credential_path,
+        lock_path=tmp_path / "auth" / "openai.lock",
+        client=client,
+    )
+
+    access = await manager.access()
+
+    assert access.access_token == refreshed_access
+    assert access.account_id == "account_1"
+    assert len(requests) == 1
+    assert b"refresh_secret" in requests[0].content
+    assert requests[0].headers["content-type"] == "application/json"
+    assert json.loads(requests[0].content) == {
+        "grant_type": "refresh_token",
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+        "refresh_token": "refresh_secret",
+    }
+    safe_status = json.dumps(manager.status().as_dict())
+    assert "refresh_secret" not in safe_status
+    assert refreshed_access not in safe_status
+    saved = json.loads(credential_path.read_text(encoding="utf-8"))
+    assert saved["credentials"]["access_token"] == refreshed_access
+    assert "email" not in saved["credentials"]
+    if os.name != "nt":
+        assert stat.S_IMODE(credential_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(credential_path.stat().st_mode) == 0o600
+    await manager.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_refresh_is_deduplicated_across_auth_managers(
+    tmp_path: Path,
+) -> None:
+    credential_path = tmp_path / "openai.json"
+    credential_path.write_text(
+        json.dumps(_credential_document(expires_at=1)),
+        encoding="utf-8",
+    )
+    refreshed_access = _jwt({"exp": 4_000_000_000})
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        return httpx.Response(
+            200,
+            json={"access_token": refreshed_access},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    managers = [
+        OpenAIAuthManager(
+            credential_path=credential_path,
+            lock_path=tmp_path / "openai.lock",
+            client=client,
+        )
+        for _ in range(2)
+    ]
+
+    accesses = await asyncio.gather(*(manager.access() for manager in managers))
+
+    assert request_count == 1
+    assert {access.access_token for access in accesses} == {refreshed_access}
+    await asyncio.gather(*(manager.close() for manager in managers))
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_permanent_refresh_failure_requires_reconnect_and_deletes_file(
+    tmp_path: Path,
+) -> None:
+    credential_path = tmp_path / "openai.json"
+    credential_path.write_text(
+        json.dumps(_credential_document(expires_at=1)),
+        encoding="utf-8",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"error": "invalid_grant"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    manager = OpenAIAuthManager(
+        credential_path=credential_path,
+        lock_path=tmp_path / "openai.lock",
+        client=client,
+    )
+
+    with pytest.raises(OpenAIReconnectRequired, match="expired"):
+        await manager.access()
+
+    assert not credential_path.exists()
+    assert manager.status().connected is False
+    assert manager.status().state == "error"
+    await manager.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_proactive_transient_refresh_failure_preserves_unauthorized_recovery(
+    tmp_path: Path,
+) -> None:
+    credential_path = tmp_path / "openai.json"
+    document = _credential_document(expires_at=1)
+    credential_path.write_text(json.dumps(document), encoding="utf-8")
+    current_access = _jwt({"exp": 1})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    manager = OpenAIAuthManager(
+        credential_path=credential_path,
+        lock_path=tmp_path / "openai.lock",
+        client=client,
+    )
+
+    access = await manager.access()
+
+    assert access.access_token == current_access
+    assert manager.is_connected() is True
+    assert credential_path.exists()
+    await manager.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_revokes_refresh_token_and_always_deletes_credentials(
+    tmp_path: Path,
+) -> None:
+    credential_path = tmp_path / "openai.json"
+    credential_path.write_text(
+        json.dumps(_credential_document(expires_at=4_000_000_000)),
+        encoding="utf-8",
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(500, request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    manager = OpenAIAuthManager(
+        credential_path=credential_path,
+        lock_path=tmp_path / "openai.lock",
+        client=client,
+    )
+
+    status = await manager.disconnect()
+
+    assert status.connected is False
+    assert not credential_path.exists()
+    assert len(requests) == 1
+    assert requests[0].headers["content-type"] == "application/json"
+    assert json.loads(requests[0].content) == {
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+        "token": "refresh_secret",
+        "token_type_hint": "refresh_token",
+    }
+    await manager.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_browser_authorization_validates_state_and_returns_pkce_grant() -> None:
+    browser = await BrowserAuthorization.start()
+    query = parse_qs(urlparse(browser.auth_url).query)
+    redirect_uri = query["redirect_uri"][0]
+    state = query["state"][0]
+
+    async with httpx.AsyncClient(trust_env=False) as client:
+        rejected = await client.get(
+            redirect_uri,
+            params={"code": "wrong_state_code", "state": "wrong_state"},
+        )
+        response = await client.get(
+            redirect_uri,
+            params={"code": "authorization_code", "state": state},
+        )
+    grant = await browser.wait()
+
+    assert rejected.status_code == 400
+    assert rejected.text == "State mismatch"
+    assert response.status_code == 200
+    assert grant.code == "authorization_code"
+    assert grant.redirect_uri == redirect_uri
+    assert grant.code_verifier
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["originator"] == ["codex_cli_rs"]
+    assert "window.close()" in response.text
+    await browser.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "document",
+    [
+        [],
+        {"version": 2, "credentials": {}},
+    ],
+)
+async def test_auth_manager_rejects_invalid_credential_schema_without_crashing(
+    tmp_path: Path,
+    document: object,
+) -> None:
+    credential_path = tmp_path / "openai.json"
+    credential_path.write_text(json.dumps(document), encoding="utf-8")
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: pytest.fail(f"unexpected request: {request.url}")
+        )
+    )
+
+    manager = OpenAIAuthManager(
+        credential_path=credential_path,
+        lock_path=tmp_path / "openai.lock",
+        client=client,
+    )
+
+    assert manager.is_connected() is False
+    assert manager.status().state == "error"
+    assert manager.status().message == (
+        "Saved OpenAI credentials are invalid. Disconnect and sign in again."
+    )
+    await manager.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_device_login_persists_account_and_reports_only_safe_state(
+    tmp_path: Path,
+) -> None:
+    id_token = _jwt(
+        {
+            "email": "device@example.com",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "account_device",
+            },
+        }
+    )
+    access_token = "opaque_access_token"
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path.endswith("/deviceauth/usercode"):
+            return httpx.Response(
+                200,
+                json={
+                    "device_auth_id": "device_private",
+                    "user_code": "ABCD-EFGH",
+                    "interval": "0",
+                },
+                request=request,
+            )
+        if request.url.path.endswith("/deviceauth/token"):
+            return httpx.Response(
+                200,
+                json={
+                    "authorization_code": "authorization_private",
+                    "code_challenge": "challenge",
+                    "code_verifier": "verifier_private",
+                },
+                request=request,
+            )
+        if request.url.path.endswith("/oauth/token"):
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": access_token,
+                    "refresh_token": "refresh_private",
+                    "id_token": id_token,
+                },
+                request=request,
+            )
+        raise AssertionError(request.url)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    manager = OpenAIAuthManager(
+        credential_path=tmp_path / "openai.json",
+        lock_path=tmp_path / "openai.lock",
+        client=client,
+    )
+
+    pending = await manager.start_login(ConnectedAccountLoginMode.DEVICE)
+    assert pending.state == "connecting"
+    assert pending.user_code == "ABCD-EFGH"
+    for _ in range(50):
+        status = manager.status()
+        if status.state != "connecting":
+            break
+        await asyncio.sleep(0.01)
+
+    assert status.state == "connected"
+    assert status.email == "device@example.com"
+    serialized = json.dumps(status.as_dict())
+    assert "device_private" not in serialized
+    assert "refresh_private" not in serialized
+    assert calls == [
+        "/api/accounts/deviceauth/usercode",
+        "/api/accounts/deviceauth/token",
+        "/oauth/token",
+    ]
+    await manager.close()
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_pending_login_resource_cleanup(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    class PendingBrowser:
+        auth_url = "https://auth.openai.com/pending"
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def wait(self):
+            await asyncio.Event().wait()
+
+        async def close(self) -> None:
+            self.closed = True
+
+    browser = PendingBrowser()
+    monkeypatch.setattr(
+        BrowserAuthorization,
+        "start",
+        AsyncMock(return_value=browser),
+    )
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: pytest.fail(f"unexpected request: {request.url}")
+        )
+    )
+    manager = OpenAIAuthManager(
+        credential_path=tmp_path / "openai.json",
+        lock_path=tmp_path / "openai.lock",
+        client=client,
+    )
+
+    await manager.start_login(ConnectedAccountLoginMode.BROWSER)
+    task = manager._login_task
+    assert task is not None
+
+    await manager.close()
+
+    assert task.done()
+    assert browser.closed is True
+    with pytest.raises(OpenAIReconnectRequired, match="shutting down"):
+        await manager.access()
+    await client.aclose()

--- a/tests/providers/test_openai_codex_auth.py
+++ b/tests/providers/test_openai_codex_auth.py
@@ -13,6 +13,7 @@ import pytest
 from free_claude_code.application.connected_accounts import (
     ConnectedAccountLoginMode,
 )
+from free_claude_code.providers.openai_codex import login as openai_login
 from free_claude_code.providers.openai_codex.auth import (
     OpenAIAuthManager,
     OpenAIReconnectRequired,
@@ -243,7 +244,17 @@ async def test_disconnect_revokes_refresh_token_and_always_deletes_credentials(
 
 
 @pytest.mark.asyncio
-async def test_browser_authorization_validates_state_and_returns_pkce_grant() -> None:
+async def test_browser_authorization_validates_state_and_returns_pkce_grant(
+    monkeypatch,
+) -> None:
+    callback_hosts: list[str] = []
+    tcp_site = openai_login.web.TCPSite
+
+    def recording_site(runner, host: str, port: int):
+        callback_hosts.append(host)
+        return tcp_site(runner, host, port)
+
+    monkeypatch.setattr(openai_login.web, "TCPSite", recording_site)
     browser = await BrowserAuthorization.start()
     query = parse_qs(urlparse(browser.auth_url).query)
     redirect_uri = query["redirect_uri"][0]
@@ -266,6 +277,8 @@ async def test_browser_authorization_validates_state_and_returns_pkce_grant() ->
     assert grant.code == "authorization_code"
     assert grant.redirect_uri == redirect_uri
     assert grant.code_verifier
+    assert urlparse(redirect_uri).hostname == "localhost"
+    assert callback_hosts and set(callback_hosts) == {"localhost"}
     assert query["code_challenge_method"] == ["S256"]
     assert query["originator"] == ["codex_cli_rs"]
     assert "window.close()" in response.text

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -1,0 +1,537 @@
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.stream_contracts import (
+    assert_anthropic_stream_contract,
+    parse_sse_text,
+    text_content,
+)
+from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers.admission import ProviderAdmissionController
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_codex.auth import (
+    OpenAIAccess,
+    OpenAIAuthManager,
+)
+from free_claude_code.providers.openai_codex.provider import OpenAICodexProvider
+
+
+class _FakeAuth(OpenAIAuthManager):
+    def __init__(self) -> None:
+        self.access_calls = 0
+        self.recovery_calls = 0
+        self.current_token = "access_1"
+
+    async def access(self, *, force_refresh: bool = False) -> OpenAIAccess:
+        self.access_calls += 1
+        return OpenAIAccess(self.current_token, "account_1", False)
+
+    async def recover_unauthorized(self, rejected_token: str) -> OpenAIAccess:
+        assert rejected_token == self.current_token
+        self.recovery_calls += 1
+        self.current_token = "access_2"
+        return OpenAIAccess(self.current_token, "account_1", False)
+
+
+def _config() -> ProviderConfig:
+    return ProviderConfig(
+        api_key="",
+        base_url="https://chatgpt.com/backend-api/codex",
+        rate_limit=100,
+        rate_window=1,
+        max_concurrency=2,
+    )
+
+
+def _admission() -> ProviderAdmissionController:
+    return ProviderAdmissionController(
+        provider_name="openai",
+        rate_limit=100,
+        rate_window=1,
+        max_concurrency=2,
+        base_delay=0,
+        max_delay=0,
+        jitter=0,
+    )
+
+
+def _request() -> MessagesRequest:
+    return MessagesRequest(
+        model="gpt-test",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "hello"}],
+        stream=True,
+    )
+
+
+def _sse(*events: tuple[str, dict[str, Any]]) -> str:
+    return "".join(
+        f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+        for event_type, payload in events
+    )
+
+
+def _complete_stream(text: str) -> str:
+    return _sse(
+        (
+            "response.created",
+            {"type": "response.created", "response": {"id": "resp_1"}},
+        ),
+        (
+            "response.output_text.delta",
+            {"type": "response.output_text.delta", "delta": text},
+        ),
+        (
+            "response.completed",
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_1",
+                    "usage": {"input_tokens": 3, "output_tokens": 2},
+                },
+            },
+        ),
+    )
+
+
+async def _collect(stream: AsyncIterator[str]) -> str:
+    return "".join([chunk async for chunk in stream])
+
+
+@pytest.mark.asyncio
+async def test_provider_uses_subscription_headers_and_visible_model_catalog() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/models"):
+            return httpx.Response(
+                200,
+                json={
+                    "models": [
+                        {
+                            "slug": "gpt-visible",
+                            "visibility": "list",
+                            "supported_in_api": False,
+                            "supported_reasoning_levels": [{"effort": "high"}],
+                        },
+                        {"slug": "gpt-hidden", "visibility": "hide"},
+                    ]
+                },
+                request=request,
+            )
+        assert request.url.path.endswith("/responses")
+        return httpx.Response(
+            200,
+            text=_complete_stream("hello"),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    auth = _FakeAuth()
+    provider = OpenAICodexProvider(
+        _config(), auth=auth, admission=_admission(), client=client
+    )
+
+    infos = await provider.list_model_infos()
+    body = await _collect(
+        provider.stream_response(
+            _request(),
+            input_tokens=3,
+            request_id="req_test",
+            response_model="claude-opus-4",
+            reasoning=ReasoningPolicy.provider_default(),
+        )
+    )
+
+    assert {(info.model_id, info.supports_thinking) for info in infos} == {
+        ("gpt-visible", True)
+    }
+    response_request = requests[-1]
+    assert response_request.headers["authorization"] == "Bearer access_1"
+    assert response_request.headers["chatgpt-account-id"] == "account_1"
+    assert response_request.headers["originator"] == "codex_cli_rs"
+    assert response_request.headers["accept"] == "text/event-stream"
+    assert response_request.headers["session_id"]
+    payload = json.loads(response_request.content)
+    assert payload["model"] == "gpt-test"
+    assert payload["store"] is False
+    events = parse_sse_text(body)
+    assert_anthropic_stream_contract(events)
+    assert text_content(events) == "hello"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_early_truncated_attempt_is_retried_without_duplicate_output() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            body = _sse(
+                (
+                    "response.created",
+                    {"type": "response.created", "response": {"id": "first"}},
+                ),
+                (
+                    "response.output_text.delta",
+                    {"type": "response.output_text.delta", "delta": "abandoned"},
+                ),
+            )
+        else:
+            body = _complete_stream("kept")
+        return httpx.Response(
+            200,
+            text=body,
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    body = await _collect(
+        provider.stream_response(
+            _request(),
+            request_id="req_retry",
+            response_model="claude-opus-4",
+        )
+    )
+
+    events = parse_sse_text(body)
+    assert_anthropic_stream_contract(events)
+    assert attempts == 2
+    assert text_content(events) == "kept"
+    assert "abandoned" not in body
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pre_stream_retry_discards_held_message_start() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(
+                429,
+                json={"error": {"message": "try again"}},
+                request=request,
+            )
+        return httpx.Response(
+            200,
+            text=_complete_stream("kept"),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    body = await _collect(
+        provider.stream_response(
+            _request(),
+            request_id="req_pre_stream",
+            response_model="claude-opus-4",
+        )
+    )
+
+    events = parse_sse_text(body)
+    assert_anthropic_stream_contract(events)
+    assert attempts == 2
+    assert body.count("event: message_start") == 1
+    assert text_content(events) == "kept"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(
+            200,
+            json={"error": {"message": "upstream contract changed"}},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await _collect(
+            provider.stream_response(
+                _request(),
+                request_id="req_non_stream",
+                response_model="claude-opus-4",
+            )
+        )
+
+    assert attempts > 1
+    assert "upstream contract changed" in exc_info.value.message
+    assert "Request ID: req_non_stream" in exc_info.value.message
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_truncated_attempt_after_commit_is_not_retried_or_duplicated() -> None:
+    attempts = 0
+    committed_text = "x" * 70_000
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(
+            200,
+            text=_sse(
+                (
+                    "response.created",
+                    {"type": "response.created", "response": {"id": "first"}},
+                ),
+                (
+                    "response.output_text.delta",
+                    {
+                        "type": "response.output_text.delta",
+                        "delta": committed_text,
+                    },
+                ),
+            ),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+    chunks: list[str] = []
+
+    with pytest.raises(ExecutionFailure):
+        async for chunk in provider.stream_response(
+            _request(),
+            request_id="req_committed",
+            response_model="claude-opus-4",
+        ):
+            chunks.extend((chunk,))
+
+    body = "".join(chunks)
+    assert attempts == 1
+    assert body.count(committed_text) == 1
+    assert body.count("event: message_start") == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_response_forces_one_auth_refresh() -> None:
+    authorizations: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        authorizations.append(request.headers["authorization"])
+        if len(authorizations) == 1:
+            return httpx.Response(
+                401,
+                json={"error": {"message": "expired"}},
+                request=request,
+            )
+        return httpx.Response(
+            200,
+            text=_complete_stream("recovered"),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    auth = _FakeAuth()
+    provider = OpenAICodexProvider(
+        _config(), auth=auth, admission=_admission(), client=client
+    )
+
+    body = await _collect(
+        provider.stream_response(
+            _request(),
+            request_id="req_auth",
+            response_model="claude-opus-4",
+        )
+    )
+
+    assert authorizations == ["Bearer access_1", "Bearer access_2"]
+    assert auth.recovery_calls == 1
+    assert text_content(parse_sse_text(body)) == "recovered"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transient_auth_refresh_failure_uses_coordinated_provider_retry() -> None:
+    class TransientRecoveryAuth(_FakeAuth):
+        async def recover_unauthorized(self, rejected_token: str) -> OpenAIAccess:
+            assert rejected_token == self.current_token
+            self.recovery_calls += 1
+            if self.recovery_calls == 1:
+                raise httpx.ReadError(
+                    "refresh interrupted",
+                    request=httpx.Request(
+                        "POST", "https://auth.openai.com/oauth/token"
+                    ),
+                )
+            self.current_token = "access_2"
+            return OpenAIAccess(self.current_token, "account_1", False)
+
+    authorizations: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        authorization = request.headers["authorization"]
+        authorizations.append(authorization)
+        if authorization == "Bearer access_1":
+            return httpx.Response(401, request=request)
+        return httpx.Response(
+            200,
+            text=_complete_stream("recovered"),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    auth = TransientRecoveryAuth()
+    provider = OpenAICodexProvider(
+        _config(), auth=auth, admission=_admission(), client=client
+    )
+
+    body = await _collect(
+        provider.stream_response(
+            _request(),
+            request_id="req_auth_transient",
+            response_model="claude-opus-4",
+        )
+    )
+
+    assert authorizations == [
+        "Bearer access_1",
+        "Bearer access_1",
+        "Bearer access_2",
+    ]
+    assert auth.recovery_calls == 2
+    assert text_content(parse_sse_text(body)) == "recovered"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_second_unauthorized_response_is_terminal_without_refresh_loop() -> None:
+    authorizations: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        authorizations.append(request.headers["authorization"])
+        return httpx.Response(
+            401,
+            json={"error": {"message": "still expired"}},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    auth = _FakeAuth()
+    provider = OpenAICodexProvider(
+        _config(), auth=auth, admission=_admission(), client=client
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await _collect(
+            provider.stream_response(
+                _request(),
+                request_id="req_auth_terminal",
+                response_model="claude-opus-4",
+            )
+        )
+
+    assert exc_info.value.status_code == 401
+    assert authorizations == ["Bearer access_1", "Bearer access_2"]
+    assert auth.recovery_calls == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_failure_redacts_credentials_from_customer_diagnostic() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=_sse(
+                (
+                    "response.failed",
+                    {
+                        "type": "response.failed",
+                        "response": {
+                            "error": {
+                                "code": "invalid_request",
+                                "message": (
+                                    "Authorization: Bearer "
+                                    "sk-this-must-never-be-returned"
+                                ),
+                            }
+                        },
+                    },
+                )
+            ),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await _collect(
+            provider.stream_response(
+                _request(),
+                request_id="req_redaction",
+                response_model="claude-opus-4",
+            )
+        )
+
+    assert "sk-this-must-never-be-returned" not in exc_info.value.message
+    assert "Authorization: <redacted>" in exc_info.value.message
+    await client.aclose()

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -34,6 +34,7 @@ from free_claude_code.providers.openai_chat import (
     OPENAI_CHAT_PROFILES,
     OpenAIChatProvider,
 )
+from free_claude_code.providers.openai_codex import OpenAICodexProvider
 from free_claude_code.providers.runtime import (
     ProviderRuntime,
     build_provider_config,
@@ -105,6 +106,7 @@ def _make_settings(**overrides):
     mock.ollama_cloud_proxy = ""
     mock.kilo_api_key = "test_kilo_key"
     mock.kilo_proxy = ""
+    mock.openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
     mock.provider_max_concurrency = 5
@@ -416,6 +418,7 @@ def test_create_provider_instantiates_each_builtin():
     )
     cases = {
         "nvidia_nim": NvidiaNimProvider,
+        "openai": OpenAICodexProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,
         "mistral_codestral": OpenAIChatProvider,
@@ -446,6 +449,14 @@ def test_create_provider_instantiates_each_builtin():
         "cerebras": OpenAIChatProvider,
     }
     sentinel_admission = MagicMock(spec=ProviderAdmissionController)
+    auth = MagicMock()
+    injected_factories = {
+        "openai": lambda config, _settings, admission: OpenAICodexProvider(
+            config,
+            auth=auth,
+            admission=admission,
+        )
+    }
 
     with (
         patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"),
@@ -456,7 +467,11 @@ def test_create_provider_instantiates_each_builtin():
         ) as admission_factory,
     ):
         for provider_id, provider_cls in cases.items():
-            provider = create_provider(provider_id, settings)
+            provider = create_provider(
+                provider_id,
+                settings,
+                injected_factories=injected_factories,
+            )
 
             assert isinstance(provider, provider_cls)
             assert provider._admission is sentinel_admission

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -5,6 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import free_claude_code.messaging.session.persistence as persistence_module
+from free_claude_code.application.connected_accounts import (
+    ConnectedAccountState,
+    ConnectedAccountStatus,
+)
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.admin.persistence import PreparedAdminUpdate
 from free_claude_code.config.settings import Settings
 from free_claude_code.messaging.command_context import StopOutcome
@@ -402,6 +407,69 @@ async def test_close_retries_runtime_before_closing_later_resources() -> None:
     assert runtime._messaging_runtime is None
     assert runtime._transcriber is None
     assert runtime._closed is True
+
+
+@pytest.mark.asyncio
+async def test_close_retries_connected_account_without_reclosing_providers() -> None:
+    factory = TrackingFactory()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/model"),
+        runtime_factory=factory,
+    )
+    account = MagicMock()
+    account.status.return_value = MagicMock(revision=0)
+    account.close = AsyncMock(side_effect=[RuntimeError("auth cleanup failed"), None])
+    runtime = ApplicationRuntime(
+        manager,
+        transcriber=None,
+        connected_accounts={"openai": account},
+    )
+
+    assert await runtime.close() is False
+    assert manager._closed is True
+    assert factory.runtimes[0].cleanup_calls == 1
+
+    assert await runtime.close() is True
+    assert account.close.await_count == 2
+    assert factory.runtimes[0].cleanup_calls == 1
+    assert runtime.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_connected_account_status_reports_cached_model_count() -> None:
+    account = MagicMock()
+    account.is_connected.return_value = True
+    account.status.return_value = ConnectedAccountStatus(
+        provider_id="openai",
+        state=ConnectedAccountState.CONNECTED,
+        connected=True,
+        revision=1,
+        email="person@example.com",
+    )
+    account.close = AsyncMock()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/model"),
+        connected_provider_ids=lambda: ("openai",),
+    )
+    manager.cache_model_infos(
+        "openai",
+        {
+            ProviderModelInfo(model_id="gpt-one"),
+            ProviderModelInfo(model_id="gpt-two"),
+        },
+    )
+    runtime = ApplicationRuntime(
+        manager,
+        transcriber=None,
+        connected_accounts={"openai": account},
+    )
+
+    status = await runtime.connected_account_status("openai")
+
+    assert status.email == "person@example.com"
+    assert status.model_count == 2
+    assert status.as_dict()["model_count"] == 2
+    assert await runtime.close() is True
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_manager.py
+++ b/tests/runtime/test_provider_manager.py
@@ -79,6 +79,36 @@ async def test_startup_generation_lease_and_shutdown_close_exactly_once() -> Non
 
 
 @pytest.mark.asyncio
+async def test_connected_provider_refresh_and_eviction_are_targeted() -> None:
+    factory = RuntimeFactory()
+    connected: set[str] = set()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/one"),
+        runtime_factory=factory,
+        connected_provider_ids=lambda: tuple(connected),
+    )
+    factory.runtimes[0].provider.list_model_infos = AsyncMock(
+        return_value=frozenset(
+            {ProviderModelInfo(model_id="gpt-visible", supports_thinking=True)}
+        )
+    )
+
+    connected.add("openai")
+    result = await manager.connected_provider_changed("openai", connected=True)
+
+    assert result.refreshed_provider_ids == ("openai",)
+    assert manager.cached_model_ids()["openai"] == frozenset({"gpt-visible"})
+
+    connected.clear()
+    assert "openai" not in manager.cached_model_ids()
+
+    await manager.connected_provider_changed("openai", connected=False)
+
+    assert "openai" not in manager.cached_model_ids()
+    await manager.close()
+
+
+@pytest.mark.asyncio
 async def test_replacement_keeps_leased_generation_open_until_final_release() -> None:
     factory = RuntimeFactory()
     first_settings = _settings("nvidia_nim/one")

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.13.1"
+version = "4.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC supports API-key and local providers, but customers cannot use models included with their ChatGPT subscription. Reusing Codex credentials would also couple FCC to another application's mutable authentication state.

## Changes

| Before | After |
| --- | --- |
| OpenAI subscription access was unavailable. | Customers connect ChatGPT from the local Admin UI with browser PKCE or device code. |
| Provider availability came only from static settings. | A process-owned connected account adds, refreshes, and evicts OpenAI models dynamically. |
| FCC had no ChatGPT Codex transport. | `openai/<model-id>` uses FCC-owned renewable credentials and neutral Responses conversion. |
| Retries and reasoning continuity had no subscription-provider coverage. | Commit-boundary retries prevent duplicate output while encrypted reasoning and tool IDs survive round trips. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds ChatGPT OAuth and an OpenAI Codex subscription provider.
- Adds browser PKCE and device-code authentication, renewable credential persistence, account lifecycle APIs, and connected-account Admin UI controls.
- Adds the Codex Responses transport, request/stream conversion, reasoning continuity, retry handling, dynamic model discovery, and provider-runtime integration.
- Adds cross-process credential locking, lifecycle cleanup, configuration and documentation updates, focused tests, and a minor version bump.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because browser OAuth can fail when one localhost address family cannot bind even though the other remains usable.

The callback change aligns the advertised hostname and listener, but a single hostname-backed listener makes successful login depend on every resolved loopback family binding the selected port.

**Files Needing Attention:** src/free_claude_code/providers/openai_codex/login.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced a partial loopback bind scenario where OAuth starts but only IPv6 ports are bound, while IPv4 callback servers remain reachable.
- I verified that the IPv4 OAuth callback endpoints on ports 1455 and 1457 returned HTTP 200, confirming IPv4 reachability despite the IPv6 port-bind blockage.
- I observed the startup failures: aiohttp reported an address-in-use for ::1 and the BrowserAuthorization.start path raised OpenAILoginError indicating the OpenAI sign-in could not bind localhost ports.
- I traced the Providers UI flow where the page advanced from no connected accounts to a Connecting state with Open sign-in and Cancel controls during sign-in.
- I completed cancellation flow verification, returning the card to Not connected and captured browser logs showing the route, network responses, and the asserted UI text.

<a href="https://app.greptile.com/trex/runs/16369293/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/openai_codex/login.py | Adds browser and device OAuth flows, but the browser callback fix can reject an otherwise usable loopback family when another resolved family cannot bind. |
| src/free_claude_code/providers/openai_codex/auth.py | Adds process-owned credential loading, refresh, persistence, revocation, and interactive-login lifecycle management. |
| src/free_claude_code/providers/openai_codex/provider.py | Adds the authenticated Codex Responses transport, model discovery, failure classification, and commit-boundary retry behavior. |
| src/free_claude_code/api/admin_routes.py | Adds loopback-restricted connected-account status, login, cancellation, and disconnect endpoints. |
| src/free_claude_code/core/openai_responses/provider_input.py | Adds neutral Anthropic-to-Responses provider request conversion. |
| src/free_claude_code/core/openai_responses/provider_stream.py | Adds Responses stream conversion with tool, reasoning, usage, and terminal-event handling. |
| src/free_claude_code/runtime/application.py | Integrates connected-account ownership, provider availability changes, and ordered shutdown into the application runtime. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Admin UI
  participant API as Admin API
  participant Auth as OpenAIAuthManager
  participant Callback as Loopback Callback
  participant OpenAI as OpenAI OAuth
  UI->>API: Start browser login
  API->>Auth: start_login(browser)
  Auth->>Callback: Bind localhost callback port
  Auth-->>UI: Authorization URL
  UI->>OpenAI: Open authorization URL
  OpenAI->>Callback: Redirect with code and state
  Callback->>Auth: AuthorizationGrant
  Auth->>OpenAI: Exchange code and PKCE verifier
  OpenAI-->>Auth: Renewable credentials
  Auth-->>UI: Connected status
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22feat%2Fopenai-chatgpt-oauth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fopenai-chatgpt-oauth%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fproviders%2Fopenai_codex%2Flogin.py%3A118-122%0A**Partial%20loopback%20bind%20blocks%20OAuth**%0A%0AWhen%20%60localhost%60%20resolves%20to%20both%20IPv4%20and%20IPv6%20but%20the%20selected%20port%20is%20unavailable%20on%20one%20family%2C%20%60web.TCPSite%60%20rejects%20the%20entire%20multi-address%20bind%20instead%20of%20listening%20on%20the%20usable%20family.%20This%20can%20reject%20both%20candidate%20ports%20and%20fail%20browser%20sign-in%20even%20though%20a%20valid%20loopback%20listener%20could%20still%20be%20created.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Match OAuth callback listener host"](https://github.com/alishahryar1/free-claude-code/commit/8d356b643b1661c5438dff015c79c22eeca03378) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48265082)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->