### PR TITLE
fix: detect NIM 500 context overflow as context_window_exceeded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.14.0"
+version = "4.14.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/nvidia_nim/client.py
+++ b/src/free_claude_code/providers/nvidia_nim/client.py
@@ -135,15 +135,18 @@ class NvidiaNimProvider(OpenAIChatProvider):
         return None
 
     def _provider_failure_override(self, error: Exception) -> ExecutionFailure | None:
-        """Classify NVIDIA-specific 400 responses by their actual semantics."""
-        if not isinstance(error, openai.BadRequestError):
+        """Classify NVIDIA-specific 400/500 responses by their actual semantics."""
+        if not isinstance(error, openai.BadRequestError | openai.InternalServerError):
             return None
-        if getattr(error, "status_code", None) != 400:
+        status = getattr(error, "status_code", None)
+        if status not in (400, 500):
             return None
         bodies = _nim_error_bodies(error)
         if any(_is_context_window_exhaustion(body) for body in bodies):
             return context_window_exceeded_provider_failure()
-        if any(_is_degraded_function(body) for body in bodies):
+        if isinstance(error, openai.BadRequestError) and any(
+            _is_degraded_function(body) for body in bodies
+        ):
             return overloaded_provider_failure()
         return None
 

--- a/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
+++ b/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
@@ -659,7 +659,7 @@ def _coerce_leaf(
             if isinstance(parsed, dict):
                 return parsed
             raise ValueError
-    except json.JSONDecodeError, ValueError:
+    except (json.JSONDecodeError, ValueError):
         raise NimNativeToolProtocolError(
             "NVIDIA NIM returned a native MiniMax argument with the wrong type."
         ) from None

--- a/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
+++ b/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
@@ -659,7 +659,7 @@ def _coerce_leaf(
             if isinstance(parsed, dict):
                 return parsed
             raise ValueError
-    except (json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError, ValueError:
         raise NimNativeToolProtocolError(
             "NVIDIA NIM returned a native MiniMax argument with the wrong type."
         ) from None

--- a/tests/providers/test_nvidia_nim_degraded_retry.py
+++ b/tests/providers/test_nvidia_nim_degraded_retry.py
@@ -77,18 +77,23 @@ def _context_window_error(
     ),
     param: str = "max_tokens",
     nested: bool = False,
-) -> openai.BadRequestError:
+    status_code: int = 400,
+) -> openai.BadRequestError | openai.InternalServerError:
     request = httpx.Request(
         "POST", "https://integrate.api.nvidia.com/v1/chat/completions"
     )
-    response = httpx.Response(400, request=request)
+    response = httpx.Response(status_code, request=request)
     error_body: dict[str, object] = {
         "message": message,
         "type": "BadRequestError",
         "param": param,
-        "code": 400,
+        "code": status_code,
     }
     body = {"error": error_body} if nested else error_body
+    if status_code == 500:
+        return openai.InternalServerError(
+            "Internal Server Error", response=response, body=body
+        )
     return openai.BadRequestError("Bad Request", response=response, body=body)
 
 
@@ -229,6 +234,42 @@ async def test_negative_derived_max_tokens_is_context_window_failure(
     )
     assert "max_tokens must be at least 1, got -853" in failure.message
     assert "Request ID: req_context" in failure.message
+    assert "prompt is too long" not in failure.message
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.asyncio
+async def test_negative_derived_max_tokens_is_context_window_failure_on_500(
+    nested: bool,
+) -> None:
+    provider = _nim(_admission())
+
+    with (
+        patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=_context_window_error(nested=nested, status_code=500),
+        ) as create,
+        pytest.raises(ExecutionFailure) as exc_info,
+    ):
+        [
+            event
+            async for event in provider.stream_response(
+                make_messages_request(), request_id="req_context_500"
+            )
+        ]
+
+    assert create.await_count == 1
+    failure = exc_info.value
+    assert failure.kind is FailureKind.CONTEXT_WINDOW_EXCEEDED
+    assert failure.status_code == 400
+    assert failure.retryable is False
+    assert "Mapped message: Provider input exceeds the model context window." in (
+        failure.message
+    )
+    assert "max_tokens must be at least 1, got -853" in failure.message
+    assert "Request ID: req_context_500" in failure.message
     assert "prompt is too long" not in failure.message
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.14.0"
+version = "4.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
NVIDIA NIM can return HTTP 500 for context overflow during long-context sessions, but _provider_failure_override() only checked openai.BadRequestError (400). The 500 fell through to generic UPSTREAM/500 classification, causing the admission controller to wastefully retry the same oversized payload up to 5 times instead of returning the context_window_exceeded failure that triggers Claude Code's compaction.

Extend the override to also handle openai.InternalServerError (500) with the same negative-max-tokens body pattern. Degraded function detection stays 400-only.

Also fix a Python except syntax bug in native_tool_stream.py where except json.JSONDecodeError, ValueError: caught only JSONDecodeError and shadowed the ValueError builtin.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates NVIDIA NIM context-overflow handling and release metadata:
- **[Files Changed]** Extends the NIM provider override, adds focused 500-response tests, and bumps `pyproject.toml` and `uv.lock` from 4.14.0 to 4.14.1.
- **[Logic Altered]** Recognizes negative-derived-`max_tokens` responses delivered as either HTTP 400 or 500 while keeping degraded-function detection restricted to 400 errors.
- **[Verification Method]** Adds parameterized coverage for nested and unnested HTTP 500 error bodies, including failure kind, retryability, request count, and mapped message assertions.
- **[Residual Risks]** None identified.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the pre-change contract validation results showing two assertion failures and three create attempts with upstream 500 and retryable=true.
- Verified the post-change results where both test cases pass and report create\_attempts=1, with failure\_kind=context\_window\_exceeded and response\_status=400, retryable=false.
- Checked the artifacts to confirm the pre- and post-change results and the validation script support the described outcomes.

<a href="https://app.greptile.com/trex/runs/16378905/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/nvidia_nim/client.py | Extends NIM context-window classification to matching InternalServerError responses while preserving 400-only degraded-function handling. |
| tests/providers/test_nvidia_nim_degraded_retry.py | Adds nested and unnested HTTP 500 coverage confirming immediate, non-retryable context-window classification. |
| pyproject.toml | Applies the required patch-version bump for the provider bug fix. |
| uv.lock | Synchronizes the editable package version with project metadata. |

<sub>Reviews (2): Last reviewed commit: ["Restore Python 3.14 exception syntax"](https://github.com/alishahryar1/free-claude-code/commit/dfe3aea8b531f75943c4b8c90d402457d3dc8cc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48278735)</sub>

<!-- /greptile_comment -->