### PR TITLE
Add Azure OpenAI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 NVIDIA_NIM_API_KEY=""
 
 
+# Azure OpenAI (resource-specific OpenAI v1 Chat Completions endpoint)
+AZURE_OPENAI_API_KEY=""
+AZURE_OPENAI_BASE_URL=""
+
+
 # OpenRouter Config
 OPENROUTER_API_KEY=""
 
@@ -116,7 +121,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -128,6 +133,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # provider even when MODEL/MODEL_* route to a different provider.
 FCC_SMOKE_MODEL_NVIDIA_NIM=
 FCC_SMOKE_MODEL_OPENAI=
+FCC_SMOKE_MODEL_AZURE_OPENAI=
 FCC_SMOKE_MODEL_OPEN_ROUTER=
 FCC_SMOKE_MODEL_MISTRAL=
 FCC_SMOKE_MODEL_MISTRAL_REASONING=
@@ -177,6 +183,7 @@ REASONING_HAIKU=inherit
 # Provider config
 # Per-provider proxy support: http and socks5, example: "http://username:password@host:port"
 OPENAI_PROXY=""
+AZURE_OPENAI_PROXY=""
 NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""
 MISTRAL_PROXY=""

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.
 - Run FCC in the background from a desktop launcher on Windows or macOS.
-- Switch among 30 cloud and local providers from the Admin UI.
+- Switch among 31 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
 - Route Fable, Opus, Sonnet, Haiku, and fallback traffic to different models.
 - Keep streaming, tool use, reasoning, and image input across compatible models.
@@ -169,6 +169,7 @@ fcc-codex exec "hello"
 | --- | --- | --- |
 | [NVIDIA NIM](https://build.nvidia.com/settings/api-keys) | `NVIDIA_NIM_API_KEY` | `nvidia_nim/nvidia/nemotron-3-super-120b-a12b` |
 | [OpenAI / ChatGPT](https://learn.chatgpt.com/docs/auth) | Connect ChatGPT in the Admin UI | `openai/<model-id>` |
+| [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |
 | [OpenRouter](https://openrouter.ai/keys) | `OPENROUTER_API_KEY` | `open_router/openrouter/free` |
 | [Google AI Studio (Gemini)](https://aistudio.google.com/apikey) | `GEMINI_API_KEY` | `gemini/models/gemini-3.1-flash-lite` |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/start/openai) | `VERTEX_PROJECT_ID` + ADC | `vertex/google/gemini-3.5-flash` |
@@ -205,6 +206,12 @@ Important provider notes:
   code is available for headless setups. FCC stores its own renewable
   credentials under `~/.fcc/auth/` and leaves Codex login untouched. Restart
   an already-running agent after connecting to refresh its model picker.
+- Azure OpenAI uses the deployment names from your resource. Set
+  `AZURE_OPENAI_BASE_URL` to its complete v1 endpoint, such as
+  `https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1/`, and select a
+  deployment that supports Chat Completions. Azure does not expose custom
+  deployment names through its data-plane model list, so enter the deployment
+  name as a custom model slug.
 - Mistral Codestral uses a separate key from Mistral La Plateforme.
 - Kimi Code subscription keys use `kimi_code/`; Kimi API credit keys use
   `kimi/`. Kimi Code plans are for personal interactive coding-agent use under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.14.1"
+version = "4.15.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -47,6 +47,7 @@ SECRET_KEY_PARTS = ("KEY", "TOKEN", "SECRET", "WEBHOOK", "AUTH")
 
 PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "nvidia_nim": "nvidia_nim/nvidia/nemotron-3-super-120b-a12b",
+    "azure_openai": "azure_openai/gpt-5.1",
     "open_router": "open_router/moonshotai/kimi-k2.6:free",
     "mistral": "mistral/devstral-small-latest",
     "mistral_codestral": "mistral_codestral/codestral-latest",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -13,6 +13,15 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
         ),
         "restart_required": True,
     },
+    "AZURE_OPENAI_API_KEY": {
+        "description": "API key for the Azure OpenAI resource.",
+    },
+    "AZURE_OPENAI_BASE_URL": {
+        "description": (
+            "Resource-specific OpenAI v1 base URL, for example "
+            "https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1/."
+        ),
+    },
     "NVIDIA_NIM_API_KEY": {
         "label": "NVIDIA NIM API Key",
         "description": "Used by NVIDIA NIM chat and optional NIM voice transcription.",

--- a/src/free_claude_code/config/admin/status.py
+++ b/src/free_claude_code/config/admin/status.py
@@ -44,15 +44,17 @@ def provider_config_status(
             )
             continue
 
-        configured = all(
-            _value_for_settings_attr(state, attr).strip()
-            for attr in descriptor.configuration_attrs()
+        configuration_attrs = descriptor.configuration_attrs()
+        missing_attrs = tuple(
+            attr
+            for attr in configuration_attrs
+            if not _value_for_settings_attr(state, attr).strip()
         )
+        configured = not missing_attrs
         configuration = " + ".join(
-            _field_key_for_settings_attr(attr)
-            for attr in descriptor.configuration_attrs()
+            _field_key_for_settings_attr(attr) for attr in configuration_attrs
         )
-        missing_key = descriptor.credential_env is not None
+        missing_key = descriptor.credential_attr in missing_attrs
         statuses.append(
             {
                 "provider_id": provider_id,

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -103,6 +103,19 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=OPENAI_CODEX_DEFAULT_BASE,
         proxy_attr="openai_proxy",
     ),
+    "azure_openai": ProviderDescriptor(
+        provider_id="azure_openai",
+        display_name="Azure OpenAI",
+        credential_env="AZURE_OPENAI_API_KEY",
+        credential_url="https://ai.azure.com/",
+        credential_attr="azure_openai_api_key",
+        base_url_attr="azure_openai_base_url",
+        proxy_attr="azure_openai_proxy",
+        required_settings_attrs=(
+            "azure_openai_api_key",
+            "azure_openai_base_url",
+        ),
+    ),
     "open_router": ProviderDescriptor(
         provider_id="open_router",
         display_name="OpenRouter",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -20,6 +20,14 @@ from .reasoning import ReasoningPreference
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
+    # ==================== Azure OpenAI ====================
+    azure_openai_api_key: str = Field(
+        default="", validation_alias="AZURE_OPENAI_API_KEY"
+    )
+    azure_openai_base_url: str = Field(
+        default="", validation_alias="AZURE_OPENAI_BASE_URL"
+    )
+
     # ==================== OpenRouter Config ====================
     open_router_api_key: str = Field(default="", validation_alias="OPENROUTER_API_KEY")
 
@@ -154,6 +162,7 @@ class Settings(BaseSettings):
 
     # ==================== Per-Provider Proxy ====================
     openai_proxy: str = Field(default="", validation_alias="OPENAI_PROXY")
+    azure_openai_proxy: str = Field(default="", validation_alias="AZURE_OPENAI_PROXY")
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
     mistral_proxy: str = Field(default="", validation_alias="MISTRAL_PROXY")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -61,6 +61,7 @@ class OpenAIChatProfile:
     request_policy: OpenAIChatRequestPolicy
     reasoning: ReasoningEncoder
     postprocessors: tuple[OpenAIChatPostprocessor, ...] = ()
+    model_ids_are_routable: bool = True
     normalize_base_url: bool = False
     reasoning_delta_field: Literal["reasoning_content", "reasoning"] = (
         "reasoning_content"
@@ -138,6 +139,19 @@ def _policy(
 
 
 OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
+    "azure_openai": OpenAIChatProfile(
+        _policy(
+            "AZURE_OPENAI",
+            ReasoningReplayMode.THINK_TAGS,
+            max_tokens_field="max_completion_tokens",
+        ),
+        NamedEffortReasoning(
+            _LOW_MEDIUM_HIGH,
+            disabled_value="none",
+            enabled_value="medium",
+        ),
+        model_ids_are_routable=False,
+    ),
     "mistral_codestral": OpenAIChatProfile(
         _policy("CODESTRAL", ReasoningReplayMode.THINK_TAGS),
         NO_REASONING,

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -140,6 +140,8 @@ class OpenAIChatProvider(BaseProvider):
     async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
         """Return model metadata from the OpenAI-compatible models endpoint."""
         payload = await self._list_models_payload()
+        if not self._profile.model_ids_are_routable:
+            return frozenset()
         return extract_openai_model_infos(payload, provider_name=self._provider_name)
 
     async def _list_models_payload(self) -> Any:

--- a/src/free_claude_code/providers/runtime/config.py
+++ b/src/free_claude_code/providers/runtime/config.py
@@ -58,8 +58,14 @@ def build_provider_config(
     )
     resolved_base_url = base_url or descriptor.default_base_url
     if not resolved_base_url:
-        raise AssertionError(
-            f"Provider {descriptor.provider_id!r} has no configured base URL."
+        if descriptor.base_url_attr is None:
+            raise AssertionError(
+                f"Provider {descriptor.provider_id!r} has no base URL owner."
+            )
+        field = Settings.model_fields[descriptor.base_url_attr]
+        env_name = field.validation_alias or descriptor.base_url_attr
+        raise ApplicationUnavailableError(
+            f"{env_name} is not set. Add it to your .env file."
         )
     proxy = string_setting(settings, descriptor.proxy_attr)
     return ProviderConfig(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -339,6 +339,24 @@ class TestSettings:
         assert settings.cloudflare_account_id == "cf-account"
         assert settings.cloudflare_proxy == "http://proxy.test:8080"
 
+    def test_azure_openai_settings_from_env(self, monkeypatch):
+        """Azure OpenAI key, resource URL, and proxy load into settings."""
+        from free_claude_code.config.settings import Settings
+
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-key")
+        monkeypatch.setenv(
+            "AZURE_OPENAI_BASE_URL",
+            "https://resource.openai.azure.com/openai/v1/",
+        )
+        monkeypatch.setenv("AZURE_OPENAI_PROXY", "http://proxy.test:8080")
+        settings = Settings()
+
+        assert settings.azure_openai_api_key == "azure-key"
+        assert settings.azure_openai_base_url == (
+            "https://resource.openai.azure.com/openai/v1/"
+        )
+        assert settings.azure_openai_proxy == "http://proxy.test:8080"
+
     def test_vertex_settings_from_env(self, monkeypatch):
         """Vertex project, location, and proxy env vars load into settings."""
         from free_claude_code.config.settings import Settings

--- a/tests/config/test_provider_catalog.py
+++ b/tests/config/test_provider_catalog.py
@@ -46,6 +46,10 @@ def test_ollama_cloud_is_remote_and_distinct_from_local_ollama() -> None:
 
 
 def test_provider_configuration_attrs_cover_multi_field_and_adc_providers() -> None:
+    assert PROVIDER_CATALOG["azure_openai"].configuration_attrs() == (
+        "azure_openai_api_key",
+        "azure_openai_base_url",
+    )
     assert PROVIDER_CATALOG["cloudflare"].configuration_attrs() == (
         "cloudflare_api_token",
         "cloudflare_account_id",

--- a/tests/contracts/test_admin_provider_manifest.py
+++ b/tests/contracts/test_admin_provider_manifest.py
@@ -155,3 +155,40 @@ def test_vertex_admin_status_uses_project_configuration_not_an_api_key() -> None
     assert vertex_status("")["label"] == "Missing configuration"
     assert vertex_status("")["configuration"] == "VERTEX_PROJECT_ID"
     assert vertex_status("vertex-project")["status"] == "configured"
+
+
+def test_azure_openai_admin_status_distinguishes_key_and_url() -> None:
+    from free_claude_code.config.admin.status import provider_config_status
+
+    def azure_status(api_key: str, base_url: str) -> dict[str, object]:
+        statuses = provider_config_status(
+            {
+                "AZURE_OPENAI_API_KEY": {"value": api_key},
+                "AZURE_OPENAI_BASE_URL": {"value": base_url},
+            }
+        )
+        return next(
+            status for status in statuses if status["provider_id"] == "azure_openai"
+        )
+
+    missing_key = azure_status(
+        "",
+        "https://resource.openai.azure.com/openai/v1/",
+    )
+    assert missing_key["status"] == "missing_key"
+    assert missing_key["label"] == "Missing key"
+
+    missing_url = azure_status("azure-key", "")
+    assert missing_url["status"] == "missing_config"
+    assert missing_url["label"] == "Missing configuration"
+    assert missing_url["configuration"] == (
+        "AZURE_OPENAI_API_KEY + AZURE_OPENAI_BASE_URL"
+    )
+
+    assert (
+        azure_status(
+            "azure-key",
+            "https://resource.openai.azure.com/openai/v1/",
+        )["status"]
+        == "configured"
+    )

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -8,6 +8,7 @@ from free_claude_code.config.provider_catalog import (
 _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "nvidia_nim",
     "openai",
+    "azure_openai",
     "open_router",
     "gemini",
     "vertex",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -29,6 +29,8 @@ def _settings(**overrides):
         "model_opus": None,
         "model_sonnet": None,
         "model_haiku": None,
+        "azure_openai_api_key": "",
+        "azure_openai_base_url": "",
         "nvidia_nim_api_key": "",
         "open_router_api_key": "",
         "mistral_api_key": "",
@@ -213,6 +215,29 @@ def test_bedrock_provider_configuration_uses_official_api_key(monkeypatch) -> No
     assert [model.provider for model in models] == ["bedrock"]
     assert models[0].full_model == "bedrock/openai.gpt-oss-120b"
     assert models[0].source == "provider_default"
+
+
+def test_azure_openai_provider_configuration_requires_key_and_resource_url(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_AZURE_OPENAI", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            azure_openai_api_key="azure-key",
+            azure_openai_base_url=("https://resource.openai.azure.com/openai/v1/"),
+        )
+    )
+
+    assert config.has_provider_configuration("azure_openai")
+    models = config.provider_smoke_models()
+    assert [model.provider for model in models] == ["azure_openai"]
+    assert models[0].full_model == "azure_openai/gpt-5.1"
+    assert models[0].source == "provider_default"
+
+    config.settings.azure_openai_base_url = ""
+    assert not config.has_provider_configuration("azure_openai")
 
 
 def test_vertex_provider_configuration_uses_project_id(monkeypatch) -> None:

--- a/tests/providers/test_azure_openai.py
+++ b/tests/providers/test_azure_openai.py
@@ -1,0 +1,142 @@
+"""Tests for the Azure OpenAI v1 provider profile."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.request_factory import make_messages_request
+from tests.providers.support import immediate_admission, profiled_provider
+
+AZURE_OPENAI_BASE_URL = "https://example-resource.openai.azure.com/openai/v1/"
+AZURE_OPENAI_DEPLOYMENT = "gpt-5.1"
+
+
+def _provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "azure_openai",
+        ProviderConfig(
+            api_key="azure-key",
+            base_url=AZURE_OPENAI_BASE_URL,
+        ),
+        admission=immediate_admission(),
+    )
+
+
+def test_init_uses_resource_v1_url_and_api_key() -> None:
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI"
+    ) as openai_client:
+        provider = _provider()
+
+    assert provider._provider_name == "AZURE_OPENAI"
+    assert provider._api_key == "azure-key"
+    assert provider._base_url == AZURE_OPENAI_BASE_URL.rstrip("/")
+    assert openai_client.call_args.kwargs["api_key"] == "azure-key"
+    assert openai_client.call_args.kwargs["base_url"] == AZURE_OPENAI_BASE_URL.rstrip(
+        "/"
+    )
+
+
+def test_request_uses_deployment_name_modern_token_field_tools_and_reasoning() -> None:
+    request = make_messages_request(
+        AZURE_OPENAI_DEPLOYMENT,
+        temperature=None,
+        top_p=None,
+        tools=[
+            {
+                "name": "read_file",
+                "description": "Read one file",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }
+        ],
+    )
+
+    body = _provider()._build_request_body(
+        request,
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+
+    assert body["model"] == AZURE_OPENAI_DEPLOYMENT
+    assert body["messages"][0] == {"role": "system", "content": "System prompt"}
+    assert body["max_completion_tokens"] == 100
+    assert "max_tokens" not in body
+    assert body["reasoning_effort"] == "high"
+    assert body["tools"][0]["function"]["name"] == "read_file"
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected"),
+    [
+        (ReasoningPolicy.off(), "none"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.MINIMAL), "low"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.XHIGH), "high"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.MAX), "high"),
+    ],
+)
+def test_reasoning_uses_azure_supported_provider_vocabulary(
+    policy: ReasoningPolicy,
+    expected: str,
+) -> None:
+    body = _provider()._build_request_body(
+        make_messages_request(
+            AZURE_OPENAI_DEPLOYMENT,
+            temperature=None,
+            top_p=None,
+        ),
+        reasoning=policy,
+    )
+
+    assert body["reasoning_effort"] == expected
+
+
+def test_reasoning_history_replays_as_portable_think_tags() -> None:
+    request = make_messages_request(
+        AZURE_OPENAI_DEPLOYMENT,
+        temperature=None,
+        top_p=None,
+        messages=[
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Inspect the repository."},
+                    {"type": "text", "text": "I found the file."},
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ],
+    )
+
+    body = _provider()._build_request_body(request)
+    assistant = next(
+        message for message in body["messages"] if message["role"] == "assistant"
+    )
+
+    assert assistant["content"] == (
+        "<think>\nInspect the repository.\n</think>\n\nI found the file."
+    )
+    assert "reasoning_content" not in assistant
+    assert "reasoning" not in assistant
+
+
+@pytest.mark.asyncio
+async def test_model_discovery_does_not_advertise_model_ids_as_deployments() -> None:
+    provider = _provider()
+    provider._client.models.list = AsyncMock(
+        return_value=SimpleNamespace(
+            data=[
+                SimpleNamespace(id="gpt-5.1"),
+                SimpleNamespace(id="gpt-4.1"),
+            ]
+        )
+    )
+
+    assert await provider.list_model_infos() == frozenset()
+    provider._client.models.list.assert_awaited_once_with()

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from free_claude_code.application.errors import UnknownProviderError
+from free_claude_code.application.errors import (
+    ApplicationUnavailableError,
+    UnknownProviderError,
+)
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.config.provider_catalog import (
     BEDROCK_DEFAULT_BASE,
@@ -50,6 +53,8 @@ def _make_settings(**overrides):
     mock.model_opus = None
     mock.model_sonnet = None
     mock.model_haiku = None
+    mock.azure_openai_api_key = "test_azure_openai_key"
+    mock.azure_openai_base_url = "https://test-resource.openai.azure.com/openai/v1/"
     mock.nvidia_nim_api_key = "test_key"
     mock.open_router_api_key = "test_openrouter_key"
     mock.mistral_api_key = "test_mistral_key"
@@ -107,6 +112,7 @@ def _make_settings(**overrides):
     mock.kilo_api_key = "test_kilo_key"
     mock.kilo_proxy = ""
     mock.openai_proxy = ""
+    mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
     mock.provider_max_concurrency = 5
@@ -190,6 +196,42 @@ def test_bedrock_provider_config_uses_regional_base_key_and_proxy() -> None:
     assert config.api_key == "bedrock-token"
     assert config.base_url == "https://bedrock-mantle.eu-west-1.api.aws/v1"
     assert config.proxy == "http://proxy.test:8080"
+
+
+def test_azure_openai_provider_config_uses_resource_base_key_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["azure_openai"]
+    settings = _make_settings(
+        azure_openai_api_key="azure-token",
+        azure_openai_base_url=("https://resource.openai.azure.com/openai/v1/"),
+        azure_openai_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+
+    assert descriptor.default_base_url is None
+    assert descriptor.configuration_attrs() == (
+        "azure_openai_api_key",
+        "azure_openai_base_url",
+    )
+    assert config.api_key == "azure-token"
+    assert config.base_url == "https://resource.openai.azure.com/openai/v1/"
+    assert config.proxy == "http://proxy.test:8080"
+
+
+def test_azure_openai_provider_config_reports_missing_resource_url() -> None:
+    descriptor = PROVIDER_CATALOG["azure_openai"]
+
+    with pytest.raises(
+        ApplicationUnavailableError,
+        match="AZURE_OPENAI_BASE_URL is not set",
+    ):
+        build_provider_config(
+            descriptor,
+            _make_settings(
+                azure_openai_api_key="azure-token",
+                azure_openai_base_url="",
+            ),
+        )
 
 
 @pytest.mark.parametrize(
@@ -419,6 +461,7 @@ def test_create_provider_instantiates_each_builtin():
     cases = {
         "nvidia_nim": NvidiaNimProvider,
         "openai": OpenAICodexProvider,
+        "azure_openai": OpenAIChatProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,
         "mistral_codestral": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.14.1"
+version = "4.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Azure OpenAI deployments cannot be routed through FCC even though Azure exposes an OpenAI-compatible v1 Chat Completions endpoint. Fixes #1268.

## Changes

| Before | After |
| --- | --- |
| Azure resource credentials and deployment routes had no FCC owner. | `azure_openai` requires an API key and exact `/openai/v1/` resource URL, then routes `azure_openai/<deployment-name>` through the shared OpenAI Chat adapter. |
| A missing resource URL surfaced as an internal provider-construction failure. | Admin and runtime readiness distinguish a missing API key from a missing resource URL. |
| OpenAI-compatible model discovery assumed every returned model ID was routable. | Azure validates its model endpoint without advertising underlying model IDs as custom deployment names. |
| Provider documentation and smoke configuration omitted Azure OpenAI. | Setup, deployment-name guidance, proxy configuration, and opt-in smoke coverage include Azure OpenAI. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Azure OpenAI as a configurable OpenAI-compatible provider, including Azure credentials and endpoint settings, Admin provider metadata, runtime configuration, documentation, smoke defaults, and provider tests.

A reproduced failure remains in Azure model discovery: the provider calls the Azure `/models` endpoint before applying its non-routable model policy. Azure resources that reject or do not expose that endpoint can therefore appear unhealthy during provider testing despite having valid credentials and deployment configuration.
</details>


<h3>Confidence Score: 3/5</h3>

Not safe to merge until T-Rex findings are addressed.

The Azure provider's intended non-routable behavior is bypassed by an upstream request that can fail independently of the configured deployment. The failure was reproduced with the actual provider implementation and an upstream-style 404 response.

T-Rex reproduced 2 failing behaviors at runtime in src/free_claude_code/providers/openai_chat/provider.py; the change needs fixes before it is safe to merge.

**Files Needing Attention:** src/free_claude_code/providers/openai_chat/provider.py needs the non-routable guard moved before `_list_models_payload()`. tests/providers/test_azure_openai.py should cover an exception-raising `models.list` client and assert it is not awaited.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reproduced the Azure model-list failure using the provided Python reproduction source and captured the reproduction output.
- The reproduction results were reviewed against the posted P1 finding to confirm alignment with the reproduction steps.
- T-Rex validated the contract behavior by confirming that the GET /models rejection path reaches the caller even when the Azure profile is non-routable.
- It was noted that the existing test suite checks the success path and does not exercise the endpoint-rejection case.
- Artifacts from proof 0 and the contract validation proof were organized and linked to support reviewer inspection.

<a href="https://app.greptile.com/trex/runs/16526200/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Azure discovery calls unsupported model-list endpoint before applying non-routable policy**

   - **Bug**
     - `OpenAIChatProvider.list_model_infos()` first awaits `_list_models_payload()` and only afterward returns an empty set for Azure. A deterministic Azure-profile repro made `client.models.list` raise an OpenAI `NotFoundError`; the original exception propagated and the mock was awaited once.
   - **Cause**
     - The `model_ids_are_routable` guard is ordered after the network-backed `_list_models_payload()` call.
   - **Fix**
     - Move `if not self._profile.model_ids_are_routable: return frozenset()` before `_list_models_payload()` in `src/free_claude_code/providers/openai_chat/provider.py`, and add a regression test whose Azure `models.list` raises and is asserted not awaited.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22feat%2Fazure-openai%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fazure-openai%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fproviders%2Fopenai_chat%2Fprovider.py%3A142-144%0A**Azure%20discovery%20calls%20a%20non-routable%20endpoint**%0A%0AAzure%20resources%20route%20requests%20through%20deployment%20names%2C%20so%20this%20profile%20deliberately%20marks%20model%20IDs%20as%20non-routable.%20However%2C%20%60list_model_infos%28%29%60%20fetches%20%60%2Fmodels%60%20before%20checking%20that%20flag.%20If%20an%20Azure%20resource%20rejects%20or%20does%20not%20expose%20that%20endpoint%2C%20the%20upstream%20error%20propagates%20even%20though%20the%20result%20should%20always%20be%20an%20empty%20set.%20This%20makes%20Admin%20provider%20testing%20report%20a%20configured%20Azure%20provider%20as%20failed%20and%20causes%20avoidable%20discovery%20failures.%20Return%20early%20for%20non-routable%20profiles%20before%20calling%20%60_list_models_payload%28%29%60%2C%20and%20add%20a%20regression%20test%20asserting%20%60models.list%60%20is%20not%20awaited%20for%20Azure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add Azure OpenAI provider"](https://github.com/alishahryar1/free-claude-code/commit/ff2b0520b85ebfa01e928c1ec021ceb2094975dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48580568)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->