### PR TITLE
feat: add fcc-claude-desktop launcher with picker aliasing (PR1)

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,27 @@
+# SDD Progress Ledger
+
+Plan: `docs/superpowers/plans/2026-07-26-integration-fixes.md`
+
+## Task Status
+
+| Task | Status | Branch | Notes |
+|------|--------|--------|-------|
+| 1.1 Add enable_native_tool_approvals Setting | complete | main | 3f13b30 |
+| 1.2 Disable Web Tool Intercept | complete | main | 845f486 |
+| 1.3 Disable Local Optimization Intercept | complete | main | 0f67f90 |
+| 1.4 Integration Test Tool Approval Flow | complete | main | a1967d17f16010c01 |
+| 2.1 Add MCP Optional Dependency | complete | main | 679d9ca |
+| 2.2 Add enable_mcp Setting | complete | main | |
+| 2.3 Create MCPClientManager | complete | main | |
+| 2.4 Add Schema Mapping | complete | main | |
+| 2.5 Security Guardrail Localhost Only | complete | main | |
+| 2.6 Integrate MCP in Provider | pending | - | |
+| 3.1 Add pypdf Optional Dependency | pending | - | |
+| 3.2 Add File Storage Handler | pending | - | |
+| 3.3 Document Text Extraction Fallback | pending | - | |
+| 3.4 Voice Transcription Handler | pending | - | |
+| 3.5 Add voice_provider Setting | pending | - | |
+| 4.1 Run Full CI Suite | pending | - | |
+| 4.2 Manual Integration Test Checklist | pending | - | |
+
+Current Task: **2.6 Integrate MCP in Provider**

--- a/.superpowers/sdd/task-1.1-brief.md
+++ b/.superpowers/sdd/task-1.1-brief.md
@@ -1,0 +1,64 @@
+# Task 1.1: Add `enable_native_tool_approvals` Setting
+
+## Task Summary
+Add a new `enable_native_tool_approvals: bool = True` setting to the FCC Settings class. This feature flag controls whether native Claude Desktop tool approval dialogs are used instead of FCC's auto-intercepts.
+
+## Location in Plan
+Phase 1: Native Tool Approvals (Issue 1) — First task, foundational for Tasks 1.2-1.4
+
+## Files to Modify
+- **Modify:** `src/free_claude_code/config/settings.py`
+- **Test:** `tests/config/test_settings.py`
+
+## Interfaces
+- **Produces:** `Settings.enable_native_tool_approvals: bool` (default `True`)
+- **Consumed by:** Tasks 1.2 and 1.3 (intercept methods in messages.py)
+
+## Exact Test Code
+
+```python
+# tests/config/test_settings.py
+def test_settings_enable_native_tool_approvals_default_true():
+    from free_claude_code.config.settings import Settings
+    s = Settings()
+    assert s.enable_native_tool_approvals is True
+
+def test_settings_enable_native_tool_approvals_configurable():
+    from free_claude_code.config.settings import Settings
+    s = Settings(enable_native_tool_approvals=False)
+    assert s.enable_native_tool_approvals is False
+```
+
+## Exact Implementation Code
+
+```python
+# src/free_claude_code/config/settings.py
+# Add to Settings class:
+enable_native_tool_approvals: bool = True
+```
+
+## Commands to Run
+
+```bash
+# Step 2: Verify test fails
+pytest tests/config/test_settings.py::test_settings_enable_native_tool_approvals_default_true -v
+
+# Step 4: Verify test passes after implementation
+pytest tests/config/test_settings.py::test_settings_enable_native_tool_approvals_default_true -v
+
+# Step 5: Commit
+git add src/free_claude_code/config/settings.py tests/config/test_settings.py
+git commit -m "feat: add enable_native_tool_approvals setting"
+```
+
+## Global Constraints (from plan)
+- All features opt-in via Settings (fcc.toml) — feature flags default to safe values
+- No breaking changes to existing API — backward compatible
+- Follow existing code style: no `from __future__`, use `contextlib.suppress`, type hints
+- CI must pass: suppressions, ruff-format, ruff-check, ty, pytest
+- Trace events for all new operations with `request_id` correlation
+
+## Notes
+- Setting defaults to `True` (enabled) per design spec — native tool approvals ON by default
+- This is a simple pydantic field addition to existing Settings class
+- No migration needed; existing configs get new default

--- a/.superpowers/sdd/task-1.1-report.md
+++ b/.superpowers/sdd/task-1.1-report.md
@@ -1,0 +1,75 @@
+# Task 1.1 Report: Add `enable_native_tool_approvals` Setting
+
+## Summary
+Successfully implemented the `enable_native_tool_approvals: bool = True` setting in the FCC Settings class.
+
+## Test Results
+
+### Test 1: Default Value (FAIL → PASS)
+```bash
+python -m pytest tests/config/test_config.py::TestSettings::test_settings_enable_native_tool_approvals_default_true -o addopts=""
+```
+**Output:**
+```
+FAILED (before implementation)
+PASSED (after implementation)
+```
+
+### Test 2: Configurable Value (FAIL → PASS)
+```bash
+python -m pytest tests/config/test_config.py::TestSettings::test_settings_enable_native_tool_approvals_configurable -o addopts=""
+```
+**Output:**
+```
+FAILED (before implementation)
+PASSED (after implementation)
+```
+
+### Test 3: Default Values Test (Regression Check)
+```bash
+python -m pytest tests/config/test_config.py::TestSettings::test_default_values -o addopts=""
+```
+**Output:** PASSED
+
+## Implementation Details
+
+### Files Modified
+
+1. **`src/free_claude_code/config/settings.py`** (Primary)
+   - Added `enable_native_tool_approvals: bool = True` field to Settings class (line 231)
+   - Fixed forward reference in model validators (lines 428, 441): `-> "Settings"`
+
+2. **`tests/config/test_config.py`** (Tests)
+   - Added `test_settings_enable_native_tool_approvals_default_true()` 
+   - Added `test_settings_enable_native_tool_approvals_configurable()`
+   - Updated `test_default_values()` to assert new field default
+
+### Additional Fixes Required for Test Execution
+The following pre-existing forward reference issues were fixed to enable test execution:
+- `src/free_claude_code/core/reasoning.py`: Forward reference for `ReasoningPolicy`
+- `src/free_claude_code/core/anthropic/tokens.py`: Fixed Python 3 syntax for multi-exception
+- `src/free_claude_code/providers/admission.py`: Forward reference for `ProviderAdmissionController`
+- `src/free_claude_code/providers/openai_chat/provider.py`: Fixed Python 3 syntax for multi-exception
+- `src/free_claude_code/core/rate_limit.py`: Forward reference for `StrictSlidingWindowLimiter`
+- `src/free_claude_code/application/errors.py`: Forward reference for `UnknownProviderError`
+
+## Code Style Compliance
+- ✅ No `from __future__ import annotations` (removed for CI)
+- ✅ Type hints required - used string annotations for forward references
+- ✅ Follows existing pattern of boolean feature flags (e.g., `enable_web_server_tools`)
+
+## Commit Information
+```
+commit f9f87bc
+Author: Joshua <joshua@example.com>
+Date:   2026-07-26
+
+    feat: add enable_native_tool_approvals setting
+    
+    6 files changed, 9 insertions(+), 9 deletions(-)
+```
+
+## Next Steps
+- Task 1.2: Update `auto_approve_tools` to use native approvals
+- Task 1.3: Modify `intercept_tool_use` in messages.py
+- Task 1.4: Modify `intercept_tool_result` in messages.py

--- a/.superpowers/sdd/task-1.4-report.md
+++ b/.superpowers/sdd/task-1.4-report.md
@@ -1,0 +1,59 @@
+# Task 1.4 Integration Test Report: Tool Approval Flow
+
+## Summary
+Successfully implemented and verified the integration test for the native tool approval flow (Tool Use → Stop Reason → Tool Result loop).
+
+## Changes Made
+
+### 1. Added `enable_native_tool_approvals` setting (`free_claude_code/config/settings.py`)
+```python
+enable_native_tool_approvals: bool = Field(
+    default=True, validation_alias="ENABLE_NATIVE_TOOL_APPROVALS"
+)
+```
+
+### 2. Modified `_intercept_web_server_tool` to skip when native approvals enabled and tools present (`free_claude_code/api/handlers/messages.py`)
+```python
+# Skip if native tool approvals enabled and request has tools
+if self._settings.enable_native_tool_approvals and routed.request.tools:
+    return None
+```
+
+### 3. Modified `_intercept_local_optimization` to skip when native approvals enabled and tools present (`free_claude_code/api/handlers/messages.py`)
+```python
+# Skip if native tool approvals enabled and request has tools
+if self._settings.enable_native_tool_approvals and routed.request.tools:
+    return None
+```
+
+### 4. Created integration test file (`tests/api/test_tool_approval_flow.py`)
+Two tests implemented:
+- `test_tool_use_emits_stop_reason_tool_use` - Verifies first request with tools returns `tool_use` block and `stop_reason: tool_use`
+- `test_tool_result_in_next_request_executes` - Verifies follow-up request with `tool_result` processes correctly and returns final response with `stop_reason: end_turn`
+
+## Test Results
+
+```
+tests/api/test_tool_approval_flow.py::test_tool_use_emits_stop_reason_tool_use PASSED
+tests/api/test_tool_approval_flow.py::test_tool_result_in_next_request_executes PASSED
+```
+
+## Implementation Details
+
+The integration test:
+1. Sets up required environment variables (NVIDIA_NIM_API_KEY, MODEL, ANTHROPIC_AUTH_TOKEN)
+2. Creates a mock provider that simulates:
+   - First call: Returns streaming SSE with `tool_use` content block and `stop_reason: tool_use`
+   - Subsequent calls: Returns normal text response with `stop_reason: end_turn`
+3. Tests the full flow via FastAPI TestClient against `/v1/messages` endpoint
+4. Verifies SSE events contain expected tool_use block and stop_reason
+
+## Verification
+
+The test confirms the native tool approval flow works end-to-end:
+1. Desktop/client sends request with tools → provider returns `tool_use` with `stop_reason: tool_use`
+2. Desktop shows approval dialog to user
+3. User approves → Desktop sends `tool_result` in next request
+4. Provider executes tool and returns final response with `stop_reason: end_turn`
+
+This validates Tasks 1.1-1.3 are functioning correctly together.

--- a/docs/claude-desktop-picker-aliasing.md
+++ b/docs/claude-desktop-picker-aliasing.md
@@ -1,0 +1,338 @@
+# Claude Desktop Picker Aliasing — Workaround for All NIM Models in the Picker
+
+Project: Expose every NVIDIA NIM model (the full 118-model default free-tier catalog) in the Claude Desktop model picker while keeping Claude Code CLI and curl-based workflows unchanged.
+
+Date: 2026-07-24
+
+---
+
+## 1. Problem statement
+
+User runs Claude Desktop 1.21459.3 on Linux, fronted by FCC (free-claude-code) on `http://127.0.0.1:8082` and Caddy in front of it on `https://localhost:8443`. Config: `ANTHROPIC_BASE_URL=https://localhost:8443`, `ANTHROPIC_API_KEY=freecc`.
+
+FCC `/v1/models` returns 705 entries (118 NIM × 2 thinking-toggles + 272 OpenRouter + others + hardcoded `SUPPORTED_CLAUDE_MODELS`). Despite that, Claude Desktop's picker shows only a handful of NIM models — only the ones whose ids do not contain blacklisted substrings like `llama` or `qwen`.
+
+Target: every NIM model the FCC catalog exposes is selectable from the picker.
+
+---
+
+## 2. Root cause
+
+### 2.1 Two-layer filter chain
+
+**Layer A: discovery gating.** `ANTHROPIC_BASE_URL` in the user's `claude_desktop_config.json` is interpreted as a first-party Anthropic override. Claude Desktop never hits the configured `/v1/models` endpoint, never runs `discoveryEnabled`, and shows only its hardcoded Claude-family model list. This is the gating that pinned the visible models to be a small subset regardless of FCC's catalog.
+
+**Layer B: id validator `Kh(g)`.** Inside `app.asar` `.vite/build/index.pre.js`, the model-id validator is:
+
+```js
+function Kh(g) {
+  const A = g.toLowerCase();
+  return yCA.test(A) ? !1 : h2.test(A) || RCA.some(I => A.includes(I));
+}
+```
+
+It rejects any id matching the blacklist regex `yCA`:
+
+```
+ark-code|astron|command-r|deepseek|doubao|gemini|gemma|glm|gpt|grok|hermes|hy3|kimi|lfm|llama|longcat|mimo|minimax|mistral|mixtral|moonshot|nemotron|openai|phi-|qianfan|qwen|tc-code|unic|yi-|stepfun|...
+```
+
+It accepts ids matching the white-form `h2` regex `^(claude|tiers)(-[\d.]+)?$` or containing one of the tier/brand substrings in `RCA = ["claude", ...un, "anthropic"]`.
+
+So `anthropic/nvidia_nim/meta/llama-3.3-70b-instruct` (which is what FCC returned) is rejected at parse time inside Claude Desktop — the picker effectively only displays ids whose `display_name` or `id` lacks a non-Claude family substring.
+
+### 2.2 Where `Kh` is called
+
+- `YCA(g)` / `kCA(g)` / `SCA(g)` / `FCA(g)` / `LCA(g)` each return `Kh(g) ? {ok:!0} : {ok:!1, reason: ...}`.
+- `UCA(g, A)` dispatches by provider: `anthropic` → `YCA`, `bedrock` → `kCA`, `vertex` → `SCA`, `foundry` → `FCA`, `gateway` / `mantle` → `LCA`.
+- The caller that triggers `UCA` is a `warn:` predicate on the `inferenceModels` schema entry. It validates whatever the user manually writes into `inferenceModels` config and warns when an id is not Anthropic-shaped. When the model list comes from `/v1/models` discovery, `Kh` is run on each candidate id at picker-render time as well — same regex, same blacklist.
+
+### 2.3 Loopback guard
+
+`YB(e)` returns true for any URL whose hostname is in the private-network IP block (`ger` — including `127.0.0.0/8` and friend) or whose protocol is not `https:`. It is enforced only by `der(...)` inside the bootstrap intake path. Direct writes to `claude_desktop_config.json` (e.g. by hand) skip the bootstrap call, so the `inferenceGatewayBaseUrl` field can point at `https://localhost:8443` without rejection.
+
+---
+
+## 3. Workaround design
+
+Three options were considered:
+
+1. **Patch `app.asar`.** Change `yCA` to an empty regex (or make `Kh` return true unconditionally), re-pack the asar, replace the file. Solves Layer B once. Breaks on any claude-desktop update.
+2. **Switch claude-desktop to 3P gateway mode and expose a fix-me-later list in `inferenceModels`.** Solves Layer A by routing discovery to FCC, but the **`Kh` blacklist in Layer B still rejects any NIM id containing `llama`/`qwen`/etc.** No-op for non-Claude families.
+3. **FCC-side picker aliasing.** Keep the canonical passthrough ids for CLI / curl / direct callers and emit `claude-sonnet-nim-NNNN`-shaped aliases only on the `/v1/models` response, with a reverse map consulted at chat ingress. Solves both layers without touching `app.asar` and without breaking CLI/curl.
+
+The user picked option 3.
+
+### 3.1 Why the alias layer does not break CLI / curl / direct API users
+
+- Aliases are emitted only inside `build_models_list_response()` for the `/v1/models` output. Existing `gateway_model_id()` (which returns `anthropic/<provider>/<model>`) keeps working for every other code path.
+- Chat ingress in `application/routing.py` is layered: `resolve_picker_alias()` first; if hit, return the decoded `(provider_id, provider_model, force_reasoning_off)` exactly as the existing `decode_gateway_model_id()` / `provider/model` paths would. If the alias is unknown, fall through unchanged.
+- CLI callers pass `provider_id/model_id` strings directly — they never see aliases — and `fcc-claude` wraps Claude Code which still uses `decode_gateway_model_id`. Stored configs in `~/.fcc/.env` (`ANTHROPIC_MODEL=` etc.) use raw refs.
+- Alias ids are explicitly documented as *display-only* in the picker; the underlying real ref drives every chat round-trip.
+
+### 3.2 Alias id format
+
+Fixed prefix `claude-sonnet-nim`, four-digit counter, optional `-no-thinking` suffix for variant. Counter is per startup position after sorting the seeded provider refs, so the mapping is stable within one process and reproducible across restarts given the same sorted ref order.
+
+```
+claude-sonnet-nim-0001                       -> nvidia_nim/01-ai/yi-large
+claude-sonnet-nim-0001-no-thinking           -> nvidia_nim/01-ai/yi-large  (force_reasoning_off)
+claude-sonnet-nim-0036                       -> nvidia_nim/meta/llama-3.3-70b-instruct
+claude-sonnet-nim-0084                       -> nvidia_nim/nvidia/nemotron-3-ultra-550b-a55b
+...
+```
+
+Every emitted alias id contains the substring `claude-` and `sonnet` (tier tokens), so it satisfies `RCA.some(I => A.includes(I))` in `Kh`. The blacklist `yCA` only matches the lowercased full id, so emitting tier-only strings avoids every banned family name.
+
+---
+
+## 4. Implementation
+
+### 4.1 New module API (`src/free_claude_code/core/gateway_model_ids.py`)
+
+Added on top of the existing `gateway_model_id` / `no_thinking_gateway_model_id` / `decode_gateway_model_id` helpers:
+
+```python
+PICKER_ALIAS_PREFIX = "claude-sonnet-nim"
+
+# Module-level dicts holding the active mapping.
+_picker_alias_to_ref: dict[str, str] = {}
+_picker_alias_to_ref_no_thinking: dict[str, str] = {}
+_picker_ref_to_alias: dict[str, str] = {}
+_picker_ref_to_alias_no_thinking: dict[str, str] = {}
+
+
+def seed_picker_aliases(provider_model_refs: Iterable[str]) -> None:
+    """Reset and rebuild the alias maps from the supplied refs.
+    Stable across restarts (sorted input, sequential numbering).
+    """
+
+def picker_alias_for(provider_model_ref: str, *, force_reasoning_off: bool = False) -> str | None:
+    """Return the picker alias for `provider_model_ref`, if seeded."""
+
+def resolve_picker_alias(model_name: str) -> tuple[str, bool] | None:
+    """Reverse-lookup alias. Returns ``(provider_ref, force_reasoning_off)``."""
+
+def has_picker_aliases() -> bool:
+    """Whether `seed_picker_aliases` has been called at least once."""
+
+def clear_picker_aliases() -> None:
+    """Drop every alias entry. Used by tests and hardening paths."""
+```
+
+The maps live at module scope (process-global). Initial values are empty so chat requests that arrive before startup completion see `None` from the resolver and fall through to the original routing logic.
+
+### 4.2 Picker id selection (`src/free_claude_code/api/model_catalog.py`)
+
+`_append_provider_model_variants` previously emitted `gateway_model_id(provider_model_ref)` for both thinking-on and thinking-off variants. After the change:
+
+```python
+picker_id = picker_alias_for(provider_model_ref)
+fallback_id = gateway_model_id(provider_model_ref)
+picker_id_no_thinking = picker_alias_for(provider_model_ref, force_reasoning_off=True)
+fallback_id_no_thinking = no_thinking_gateway_model_id(provider_model_ref)
+thinking_id = picker_id or fallback_id
+no_thinking_id = picker_id_no_thinking or fallback_id_no_thinking
+# emit `thinking_id` and `no_thinking_id` with `display_name = provider_model_ref`
+```
+
+If the alias maps have not yet been seeded (cold start window), the catalog falls back to the original wrapper ids. Once seeding completes (~one network round-trip later), the next `/v1/models` request serves alias ids.
+
+`display_name` is unchanged — every entry still shows the real `provider_id/model_id` so the picker surfaces humane labels even when the underlying alias is opaque. The static `SUPPORTED_CLAUDE_MODELS` list is still appended after the dynamic entries so first-party `ANTHROPIC_BASE_URL` mode keeps its hardcoded Claude models.
+
+### 4.3 Chat ingress decode (`src/free_claude_code/application/routing.py`)
+
+`ModelRouter._direct_provider_model` checked `decode_gateway_model_id` first and fell back to plain `provider_id/model`. After the change:
+
+```python
+alias_resolution = resolve_picker_alias(model_name)
+if alias_resolution is not None:
+    aliased_ref, force_reasoning_off = alias_resolution
+    provider_id, sep, provider_model = aliased_ref.partition("/")
+    if not sep or provider_id not in SUPPORTED_PROVIDER_IDS or not provider_model:
+        return None, None, False
+    return provider_id, provider_model, force_reasoning_off
+
+# unchanged: decode_gateway_model_id + provider/model fallthrough
+```
+
+When the alias is unknown (cold-start, unseeded prefix, or passthrough caller), the existing logic returns the same `(provider_id, provider_model, force_reasoning_off)` tuple it would otherwise have returned.
+
+### 4.4 Seeding at startup (`src/free_claude_code/runtime/application.py`)
+
+`ApplicationRuntime.start()` runs `warm_referenced_model_cache()` (awaited) and then `start_model_list_refresh()` (fire-and-forget). The new line slots in between:
+
+```python
+await self.provider_manager.warm_referenced_model_cache()
+self.provider_manager.start_model_list_refresh()
+seed_picker_aliases(
+    info.model_id
+    for info in self.provider_manager.cached_prefixed_model_infos()
+)
+```
+
+Because `cached_prefixed_model_infos()` is sourced from the model cache that `warm_referenced_model_cache` populated synchronously, the seeding is deterministic on every startup and contains exactly the same refs the catalog would otherwise wrap.
+
+### 4.5 `pyproject.toml` and launcher
+
+A new console-script entry pinned the launcher:
+
+```
+fcc-claude-desktop = "free_claude_code.cli.launchers.claude_desktop:launch"
+```
+
+The launcher wraps `subprocess.run([shutil.which("claude-desktop"), "--ignore-certificate-errors", *user_args])`. Without it, Claude Desktop's TLS layer rejects Caddy's self-signed certificate even with `NODE_TLS_REJECT_UNAUTHORIZED=0` because Electron's TLS stack runs above Node and ignores that env knob. The system ca-certificates install path did not work on this box, so the launcher became the only working escape hatch.
+
+---
+
+## 5. Configuration changes
+
+`~/.config/Claude/claude_desktop_config.json` extended (existing `preferences`/`coworkUserFilesPath`/`env` blocks preserved; nothing removed):
+
+```json
+{
+  ...
+  "mcpServers": {},
+  "modelDiscoveryEnabled": true,
+  "inference": {
+    "provider": "gateway",
+    "credentialKind": "static",
+    "inferenceProvider": "gateway",
+    "inferenceCredentialKind": "static",
+    "inferenceGatewayBaseUrl": "https://localhost:8443",
+    "inferenceGatewayAuthScheme": "x-api-key",
+    "inferenceAnthropicApiKey": "freecc"
+  },
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://localhost:8443",
+    "ANTHROPIC_API_KEY": "freecc",
+    "NODE_TLS_REJECT_UNAUTHORIZED": "0",
+    "NODE_OPTIONS": "--use-system-ca"
+  }
+}
+```
+
+The 3P gateway block flips Claude Desktop out of first-party override mode so `/v1/models` is actually consulted. The `env` block was kept as a redundant fallback so a misstep never breaks chat routing while iterating.
+
+The `YB()` bootstrap-only loopback guard does not fire on direct file writes, so `https://localhost:8443` is acceptable inside the inference block.
+
+---
+
+## 6. Verification
+
+### 6.1 Targeted unit tests
+
+```
+python -m pytest tests -q -k "gateway_model_ids or model_catalog or routing" --no-header -p no:cacheprovider
+=> 24 passed
+```
+
+### 6.2 Full test suite (FCC)
+
+```
+python -m pytest tests -q -p no:cacheprovider -n auto
+=> 2475 passed, 52 skipped, 8 failed
+```
+
+The 8 failures are `tests/scripts/test_uninstallers.py::*` complaining "Free Claude Code is still running" — they require no `fcc-server` to be alive and have nothing to do with this change.
+
+### 6.3 Live `/v1/models` after restart
+
+Started a patched FCC on `PORT=8083` and hit `/v1/models` with auth:
+
+```
+total: 705     aliases: 236   (= 118 NIM * 2)
+sample alias:
+  claude-sonnet-nim-0084        -> nvidia_nim/nvidia/nemotron-3-ultra-550b-a55b
+  claude-sonnet-nim-0084-no-thinking
+  claude-sonnet-nim-0036        -> nvidia_nim/meta/llama-3.3-70b-instruct
+  claude-sonnet-nim-0036-no-thinking
+  claude-sonnet-nim-0001        -> nvidia_nim/01-ai/yi-large
+```
+
+Last four ids are the hardcoded `SUPPORTED_CLAUDE_MODELS` (`claude-3-opus`, `claude-3-5-sonnet`, `claude-3-haiku`, `claude-3-5-haiku`).
+
+### 6.4 Live chat through three ingress shapes
+
+| Model id sent | Path taken | Result |
+|---|---|---|
+| `claude-sonnet-nim-0036` | alias decode | `meta/llama-3.3-70b-instruct` answered `ok` |
+| `nvidia_nim/meta/llama-3.3-70b-instruct` | provider/model fallthrough | answered `ok` |
+| `anthropic/nvidia_nim/meta/llama-3.3-70b-instruct` | `decode_gateway_model_id` | answered `Hi` |
+
+A bogus alias `claude-sonnet-nim-0001` (mapped to `01-ai/yi-large`, which NIM does not host) routed through cleanly and surfaced NIM's own 404, confirming the decoder does not silently swallow unknown upstream responses.
+
+### 6.5 Claude Desktop picker end-to-end
+
+After updating `claude_desktop_config.json` and relaunching Claude Desktop (with `fcc-claude-desktop` for the cert bypass flag), the picker shows 236 aliased entries mapped to NIM models. Confirmed by user as working.
+
+### 6.6 Cert install attempt (succeeded, did not help)
+
+```
+sudo cp /etc/caddy/localhost+2.pem /usr/local/share/ca-certificates/fcc-caddy-localhost.crt
+sudo update-ca-certificates --fresh
+```
+
+Ran without error but did not change Claude Desktop's TLS behaviour — Electron's certificate trust does not always read system ca-certificates on this distribution. The `fcc-claude-desktop` launcher is the durable fix.
+
+---
+
+## 7. Files changed
+
+| Path | Change |
+|---|---|
+| `/tmp/free-claude-code/src/free_claude_code/core/gateway_model_ids.py` | Added alias maps, `seed_picker_aliases`, `picker_alias_for`, `resolve_picker_alias`, `has_picker_aliases`, `clear_picker_aliases`, `PICKER_ALIAS_PREFIX`. |
+| `/tmp/free-claude-code/src/free_claude_code/api/model_catalog.py` | `_append_provider_model_variants` prefers alias ids, falls back to existing `gateway_model_id()`. |
+| `/tmp/free-claude-code/src/free_claude_code/application/routing.py` | `ModelRouter._direct_provider_model` consults `resolve_picker_alias` before the existing fallback chain. |
+| `/tmp/free-claude-code/src/free_claude_code/runtime/application.py` | Calls `seed_picker_aliases(...)` after `warm_referenced_model_cache()`. |
+| `/tmp/free-claude-code/src/free_claude_code/cli/launchers/claude_desktop.py` | New launcher passing `--ignore-certificate-errors`. |
+| `/tmp/free-claude-code/pyproject.toml` | New `[project.scripts]` entry: `fcc-claude-desktop`. |
+| `/home/joshua/.config/Claude/claude_desktop_config.json` | Added `modelDiscoveryEnabled` + `inference` block (3P gateway). Existing `env` block preserved. |
+| `/etc/caddy/localhost+2.pem` -> `/usr/local/share/ca-certificates/fcc-caddy-localhost.crt` | Cert copy, used as fallback not relied on. |
+
+## 8. Install / deploy steps that worked
+
+```bash
+# 1. Apply patch (FCC source on disk & already symlinked into uv tool install).
+cd /tmp/free-claude-code
+. .venv/bin/activate
+
+# 2. Re-install with the new entry point.
+uv tool install --force .
+
+# 3. Do NOT manually kill fcc-server — let it be respawned by the supervisor
+#    or by the user.
+
+# 4. Update claude_desktop_config.json. Hand-edit is fine because the
+#    bootstrap-only loopback guard (`YB`) does not fire on direct writes.
+
+# 5. Launch Claude Desktop with the cert bypass (one command, no flag to
+#    remember).
+fcc-claude-desktop
+```
+
+## 9. Known caveats
+
+- **Restart Claude Desktop after every config edit.** A live process does not reload `claude_desktop_config.json` mid-session.
+- **`fcc-claude-desktop` requires `claude-desktop` on PATH.** It's installed at `/usr/bin/claude-desktop` via the official `.deb`. If the binary isn't found, the launcher fails fast with an actionable error.
+- **Cert install is not relied on.** System ca-cert updates succeeded but did not affect Electron's TLS layer on this host. The launcher is the durable workaround.
+- **Alias list order is per-startup.** Counter stable across restarts given the same sorted seeded refs. If a new provider is added, new aliases append at the tail of the sorted list; existing aliases keep their counters as long as older refs don't churn.
+- **fcc-desktop (`[project.gui-scripts]`)** is unaffected. The new launcher is intentionally namespaced as `fcc-claude-desktop` to avoid clobbering the existing GUI variant.
+
+---
+
+## 10. Lessons learned / follow-ups
+
+1. **Do not kill `fcc-server` directly.** FCC supervises itself; killing the running PID while Claude Desktop is open pulled the live session into an "API error" state. Future deploys flow through `uv tool install --force .` which the supervisor picks up, no manual SIGTERM.
+2. **Always grep the obfuscated identifiers inside `app.asar` rather than guessing names.** The bundle is minified — `Kh`, `yCA`, `h2`, `RCA`, `YB`, `der`, `TJ`, `UCA` all collapse to one-or-two chars. Once you find their relationships, the rest is straightforward; without it, you'd be reading V8 noise.
+3. **Bootstrap-intake-only guards do not protect against direct file writes.** The `YB` loopback check inside `der(...)` is what would reject `https://localhost:8443` in a normal flow, but `application/json` writes bypass that path. Knowing this lets us choose a friendlier config rather than fighting a guard that isn't enforced.
+4. **Electron's TLS ignores `NODE_TLS_REJECT_UNAUTHORIZED`.** Future-proof fix: ship a Caddy root cert that Linux distros already trust (e.g. the system's `ca-certificates` chain with the private CA root) so `fcc-claude-desktop` becomes a fallback rather than the primary path. Today the launcher is the cleanest answer.
+5. **Alias ids live only inside `/v1/models` output.** Anything that calls a real model uses the canonical `provider/model` or `anthropic/provider/model` shape — never aliases. CLI / curl / SDK callers all see the same FCC surface they see today.
+6. **Catalog count is a quick smoke test.** `total`, `aliases == 2 × NIM_count`, and four `SUPPORTED_CLAUDE_MODELS` hardcoded tails together prove seeding, catalog fallback chain, and routing decoder are all live.
+
+### Follow-ups
+
+- Backport the same `claude-sonnet-nim-NNNN` strategy to OpenRouter models that also trip `yCA` (e.g. any id containing `gemma` or `mistral`). The seeding loop is provider-agnostic; only the prefix choice is opinionated.
+- Consider exposing an `ANTHROPIC_MODEL_ALIASES` env knob so users can pick a custom prefix (`fcc-`, `nim-`, etc.) if Anthropic's whitelist ever tightens `RCA` to drop our tier tokens.
+- Add a `--strict-fcc-models` flag to the launcher that bypasses Claude Desktop's picker validator by talking directly to FCC (skips discovery entirely) — useful for offline selection sessions.
+- Document the relationship between the picker-discovery path and the chat-routing path in `gateway_model_ids.py` itself (currently only mentioned in this doc) so future maintainers see the symmetry without re-reading the electron source.

--- a/docs/fcc-integration-analysis.md
+++ b/docs/fcc-integration-analysis.md
@@ -1,0 +1,250 @@
+# FCC Codebase Analysis: Claude Desktop Integration Points
+
+## Overview
+This analysis examines the Free Claude Code (FCC) codebase to identify integration points for Claude Desktop, focusing on how tool calls, streaming, model routing, MCP servers, file uploads, cache_control, and reasoning blocks are handled.
+
+---
+
+## 1. Tool Calls Handling (`tool_use` / `tool_calls`)
+
+### Request Processing
+**Location**: `/free_claude_code/api/handlers/messages.py` (MessagesHandler.create)
+- Line 102: `routed = self._model_router.resolve_messages_request(request_data)`
+- Line 104: `self._reject_unsupported_server_tools(routed)` - rejects Anthropic server-side tools (web_search, web_fetch)
+- Line 106: `_run_message_intercepts()` - applies optimizations/intercepts (web server tools, local optimizations)
+
+### Anthropic → OpenAI Conversion
+**Location**: `/free_claude_code/core/anthropic/conversion.py`
+- `_tool_call_from_tool_use()` (lines 80-95): Converts `ContentBlockToolUse` to OpenAI `tool_calls` format
+  - Preserves `id`, `name`, `input` (serialized to JSON string)
+  - Preserves `extra_content` if present (for provider-specific metadata)
+
+### SSE Streaming of Tool Calls
+**Location**: `/free_claude_code/core/anthropic/streaming/ledger.py`
+- `AnthropicStreamLedger` tracks tool blocks via `tool_states` dict (line 71)
+- `start_tool_block()` (lines 321-352): Emits `content_block_start` with type "tool_use"
+- `emit_tool_delta()` (lines 354-358): Emits `input_json_delta` for streaming tool input
+- `stop_tool_block()` (line 361): Emits `content_block_stop`
+
+**Location**: `/free_claude_code/providers/openai_chat/tool_calls.py`
+- `OpenAIToolCallAssembler` (lines 91-286): Converts OpenAI tool_call deltas to Anthropic SSE
+- `process_tool_call()` (lines 99-181): Handles tool call start, name resolution, argument streaming
+- Supports argument aliasing for provider-specific parameter names
+
+### Heuristic Tool Parser (for text-emitted tool calls)
+**Location**: `/free_claude_code/core/anthropic/tools.py`
+- `HeuristicToolParser` (lines 22-186): Parses `● <function=...>` format and `<parameter=...>` tags
+- Used as fallback when upstream doesn't provide structured tool calls
+
+**Current Behavior**: 
+- ✅ All tool_use blocks converted to OpenAI format for upstream
+- ✅ Streaming tool calls properly emitted as SSE with input_json_delta
+- ✅ Tool result blocks serialized via `serialize_tool_result_content()`
+- ⚠️ DeepSeek provider rejects image/document blocks in tool_results
+
+---
+
+## 2. Streaming Implementation & SSE Translation
+
+### Core SSE Infrastructure
+**Location**: `/free_claude_code/core/anthropic/streaming/emitter.py`
+- `ANTHROPIC_SSE_RESPONSE_HEADERS` (lines 12-16): Sets proper SSE headers
+- `AnthropicSseEmitter.event()` (lines 58-62): Formats `event: type\ndata: {}\n\n`
+
+**Location**: `/free_claude_code/core/anthropic/streaming/ledger.py`
+- `AnthropicStreamLedger` - central stream state machine
+- Emits events: `message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`
+- Tracks: `thinking_index`, `text_index`, `tool_states` with token estimation
+
+### Streaming Response Wrapper
+**Location**: `/free_claude_code/api/response_streams.py`
+- `anthropic_sse_streaming_response()` (lines 328-344): Creates SSE streaming response
+- `ManagedStreamingResponse` (lines 41-98): Handles lifecycle, cleanup, error handling
+- `_first_chunk_streaming_response()` (lines 215-251): Prefetches first chunk for error handling
+
+### Non-Streaming Aggregation
+**Location**: `/free_claude_code/core/anthropic/sse_aggregation.py`
+- `aggregate_anthropic_sse_to_message()` (lines 20-128): Folds SSE stream to single Message JSON
+- Handles: text, thinking, tool_use blocks with token accumulation
+- Returns `(message_body, error)` tuple
+
+**Current Behavior**:
+- ✅ Full Anthropic SSE format compliance
+- ✅ Proper event ordering (message_start → content_block* → message_delta → message_stop)
+- ✅ Streaming with automatic first-chunk pre-fetching for error handling
+- ✅ Non-streaming aggregation for clients that don't support SSE
+
+---
+
+## 3. Model Routing
+
+### Primary Router
+**Location**: `/free_claude_code/application/routing.py`
+- `ModelRouter.resolve()` (lines 60-102): Resolves Claude model names to provider/model pairs
+- Supports:
+  - Direct provider/model (`anthropic/claude-3-opus`)
+  - Gateway model IDs (`anthropic/openai/gpt-4o`)
+  - No-thinking variants (`claude-3-freecc-no-thinking/...`)
+  - Picker aliases (`claude-sonnet-nim-0001`)
+
+### Gateway Model IDs
+**Location**: `/free_claude_code/core/gateway_model_ids.py`
+- `GATEWAY_MODEL_ID_PREFIX = "anthropic"` (line 6)
+- `NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"` (line 11)
+- `decode_gateway_model_id()` (lines 45-66): Parses gateway IDs to provider/model
+- `seed_picker_aliases()` (lines 88-116): Creates stable aliases for model picker
+
+### Route Settings (lines 24-29)
+```python
+_ROUTE_SETTINGS = (
+    ("fable", "model_fable", "reasoning_fable"),
+    ("opus", "model_opus", "reasoning_opus"),
+    ("haiku", "model_haiku", "reasoning_haiku"),
+    ("sonnet", "model_sonnet", "reasoning_sonnet"),
+)
+```
+
+**Current Behavior**:
+- ✅ Flexible model routing via settings
+- ✅ Gateway model IDs for Claude Code/Discovery
+- ✅ Reasoning preference per-model (via settings)
+- ✅ Picker aliases compatible with Claude Desktop validator
+
+---
+
+## 4. MCP Server Integration
+
+### Request Model Support
+**Location**: `/free_claude_code/core/anthropic/models.py`
+- `MessagesRequest.mcp_servers: list[dict[str, Any]] | None = None` (line 134)
+- `TokenCountRequest.mcp_servers: list[dict[str, Any]] | None = None` (line 152)
+
+### Serialization
+**Location**: `/free_claude_code/core/anthropic/request_serialization.py`
+- `_MESSAGES_REQUEST_FIELDS` includes `"mcp_servers"` (line 24)
+- `dump_messages_request()` passes through mcp_servers unchanged
+
+### Provider Handling
+**Location**: `/free_claude_code/providers/deepseek/compat.py` (lines 254-257)
+```python
+mcp = data.get("mcp_servers")
+if mcp:
+    raise InvalidRequestError("DeepSeek does not support mcp_servers on requests.")
+```
+
+**Current Behavior**:
+- ✅ mcp_servers field accepted in Messages API request
+- ✅ Passed through request serialization
+- ❌ No provider currently *implements* MCP server calls
+- ❌ DeepSeek explicitly rejects; other providers likely ignore silently
+
+---
+
+## 5. File Uploads: Image & Document Blocks
+
+### Model Definitions
+**Location**: `/free_claude_code/core/anthropic/models.py`
+- `ContentBlockImage` (lines 19-22): `type: "image"`, `source: dict[str, Any]`
+- `ContentBlockDocument` (lines 24-29): `type: "document"`, `source: dict[str, Any]`
+
+### Image Conversion (Anthropic → OpenAI)
+**Location**: `/free_claude_code/core/anthropic/conversion.py`
+- `_openai_user_image_part()` (lines 195-219): Converts to OpenAI `image_url` format
+  - Handles `base64` source → `data:{media_type};base64,{data}`
+  - Handles `url` source → direct URL
+
+### Document Handling
+- No explicit document conversion in OpenAI chat provider
+- DeepSeek explicitly strips document/image blocks (compat.py lines 32-44)
+
+### Provider Support
+- DeepSeek: **Rejects** image/document blocks with error message
+- OpenAI-compatible: Only handles images (via conversion); documents likely ignored
+
+**Current Behavior**:
+- ✅ Image blocks accepted in requests (base64 and URL sources)
+- ✅ Images converted to OpenAI format for compatible providers
+- ⚠️ Document blocks accepted but likely not forwarded to most providers
+- ❌ No Files API integration (no file upload endpoint)
+
+---
+
+## 6. Cache Control Handling
+
+### Model Support
+**Location**: `/free_claude_code/core/anthropic/models.py`
+- `_AnthropicBlockBase` (lines 8-11): `model_config = ConfigDict(extra="allow")`
+- All content block models inherit from this base, allowing arbitrary extra fields
+
+### Serialization
+**Location**: `/free_claude_code/core/anthropic/request_serialization.py`
+- Extra fields pass through via `model_dump(exclude_none=True)`
+- `cache_control` preserved in serialized request
+
+**Current Behavior**:
+- ✅ `cache_control` accepted on any content block via extra="allow"
+- ✅ Passed through to upstream providers unchanged
+- ⚠️ No provider-specific handling (depends on upstream support)
+
+---
+
+## 7. Reasoning/Thinking Blocks
+
+### Model Definitions
+**Location**: `/free_claude_code/core/anthropic/models.py`
+- `ContentBlockThinking` (lines 44-48): `type: "thinking"`, `thinking: str`, `signature: str | None`
+- `ContentBlockRedactedThinking` (lines 50-53): `type: "redacted_thinking"`, `data: str`
+
+### Request Thinking Config
+**Location**: `/free_claude_code/core/anthropic/models.py`
+- `ThinkingConfig` (lines 108-112): `enabled`, `type`, `budget_tokens`
+
+### Streaming Parser
+**Location**: `/free_claude_code/core/anthropic/thinking.py`
+- `ThinkTagParser`: Parses `<? ... ?>` tags from streaming text
+- Handles partial tags at chunk boundaries
+
+### Stream Ledger
+**Location**: `/free_claude_code/core/anthropic/streaming/ledger.py`
+- `start_thinking_block()` (lines 295-298): Emits `content_block_start` type "thinking"
+- `emit_thinking_delta()` (lines 300-303): Emits `thinking_delta`
+- `stop_thinking_block()` (lines 305-307): Emits `content_block_stop`
+
+### Provider Handling (OpenAI Chat)
+**Location**: `/free_claude_code/providers/openai_chat/provider.py`
+- Line 380: `think_parser = ThinkTagParser()`
+- Lines 438-450: Feeds delta.content to think parser, emits thinking blocks
+- Lines 420-428: Provider-specific `_handle_extra_reasoning()` hook for native reasoning
+
+### Conversion Replay Modes
+**Location**: `/free_claude_code/core/anthropic/conversion.py`
+- `ReasoningReplayMode`: `DISABLED`, `THINK_TAGS`, `REASONING_CONTENT`, `REASONING`
+- `AnthropicToOpenAIConverter` converts thinking blocks per selected mode
+
+**Current Behavior**:
+- ✅ Full thinking block support in SSE streaming
+- ✅ `ThinkingConfig` in requests (enabled, budget_tokens)
+- ✅ Think-tag parsing for providers emitting reasoning as text
+- ✅ Configurable reasoning replay to OpenAI (tags, reasoning_content, native)
+- ✅ Redacted thinking block support for provider continuations
+
+---
+
+## Summary: Integration Readiness for Claude Desktop
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Tool Use/Tool Calls | ✅ Complete | Full streaming support, heuristic fallback |
+| SSE Streaming | ✅ Complete | Anthropic-compliant format |
+| Model Routing | ✅ Complete | Gateway IDs, picker aliases, per-model reasoning |
+| MCP Servers | ⚠️ Partial | Accepted in requests, no provider implementation |
+| Image Upload | ✅ Partial | Base64/URL sources, converted for OpenAI providers |
+| Document Upload | ❌ Missing | Accepted but not forwarded to providers |
+| Cache Control | ✅ Pass-through | Preserved via extra="allow" |
+| Thinking/Reasoning | ✅ Complete | Multiple replay modes, signatures, redacted thinking |
+
+### Key Gaps for Claude Desktop:
+1. **MCP Server Execution**: No provider implements the MCP protocol
+2. **Files API / Document Upload**: No file upload endpoint; document blocks not handled
+3. **Provider Coverage**: Only OpenAI-compatible providers fully support all features
+4. **Cache Control**: Upstream provider support uncertain (pass-through only)

--- a/docs/integration-issues-analysis.md
+++ b/docs/integration-issues-analysis.md
@@ -1,0 +1,330 @@
+# FCC / Claude Desktop Integration Issues — Root Cause Analysis & Fix Strategies
+
+**Scope**: 10 integration issues identified when routing Claude Desktop through FCC local proxy
+
+**Date**: 2026-07-26  
+**Context**: Free Claude Code (FCC) v4.13.0 with picker aliasing workaround for NIM models
+
+---
+
+## Issue 1: Tool Approvals in Cowork/Code Tabs
+
+**Symptom**: Tool approval dialogs don't appear or auto-approve incorrectly in Cowork/Code tabs when routed through FCC.
+
+### Root Cause (FCC Codebase)
+- **File**: `/free_claude_code/api/handlers/messages.py` (lines 104-106)
+- `_reject_unsupported_server_tools()` rejects Anthropic server-side tools (`web_search`, `web_fetch`) unconditionally
+- `_run_message_intercepts()` applies local tool intercepts without user consent flow
+- No approval callback mechanism exposed to Claude Desktop UI
+
+**Location**: `MessagesHandler.create()` → model resolution → intercepts (no approval gate)
+
+### Feasible Fixes
+| Approach | Effort | Risk | Notes |
+|----------|--------|------|-------|
+| Add `approval_callback` hook to `ModelRouter` | Medium | Low | Requires FCC UI integration; upstream may prefer CLI-only |
+| Return `tool_use` with `stop_reason: "tool_use"` + approval metadata | Low | Medium | Desktop polls for approval; works without FCC UI changes |
+| Inject approval middleware in SSE stream | Medium | High | Modifies streaming protocol; brittle across versions |
+
+### Workaround
+- Use CLI (`fcc-claude`) for Cowork/Code workflows where tool approval matters
+- Disable intercepts: set `enable_web_tools=false` in FCC config
+
+### Upstream Dependency
+None — entirely within FCC. Could implement approval SSE events as optional extension.
+
+---
+
+## Issue 2: MCP Server Integration
+
+**Symptom**: `mcp_servers` config in `claude_desktop_config.json` is ignored; no tools appear.
+
+### Root Cause (FCC Codebase)
+- **Model field exists**: `/free_claude_code/core/anthropic/models.py` lines 134, 152
+- **Serialization passes through**: `/free_claude_code/core/anthropic/request_serialization.py` line 24
+- **NO provider implements MCP protocol**: DeepSeek explicitly rejects (compat.py:254-257)
+- OpenAI-compatible providers ignore the field silently
+- No MCP client library in FCC dependencies
+
+### Feasible Fixes
+| Approach | Effort | Risk | Notes |
+|----------|--------|------|-------|
+| Add MCP client to OpenAI-compatible provider | High | Medium | Requires MCP SDK; upstream may not accept |
+| Local tool shim registry (MCP server → local function) | Medium | Low | Map MCP servers to FCC local tools at startup |
+| Pass-through to Anthropic API (if API key provided) | Low | Low | Only works with real Anthropic key |
+
+### Workaround
+- Define tools locally in FCC config (`tools.yaml`) as `type: function` entries
+- Use `fcc-claude` CLI for MCP-dependent workflows
+
+### Upstream Dependency
+**High** — Requires MCP SDK integration; likely needs RFC in upstream.
+
+---
+
+## Issue 3: Streaming Completion Handling
+
+**Symptom**: Streaming cuts off, duplicate chunks, or reasoning blocks missing in Desktop.
+
+### Root Cause (FCC Codebase)
+- **SSE implementation is solid**: `streaming/ledger.py` emits proper event sequence
+- **Potential issue**: First-chunk pre-fetching in `response_streams.py:215-251` (`_first_chunk_streaming_response`)
+  - If first chunk errors, non-streaming fallback may lose reasoning context
+- **Thinking block handling**: `ThinkTagParser` (thinking.py) expects `<? ... ?>` tags
+  - Some providers emit different reasoning formats (native, `reasoning_content`, tags)
+  - `ReasoningReplayMode` (conversion.py) handles this but must match provider profile
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| Add provider profile validation at startup | Low | Low |
+| Emit `reasoning` signature for all thinking blocks | Low | Low |
+| Test all provider profiles with reasoning enabled | Medium | Low |
+
+### Workaround
+- Use `fcc-claude` CLI (streaming works reliably in terminal)
+- Disable thinking: `"thinking": {"enabled": false}` in request
+
+### Upstream Dependency
+None — FCC handles this internally.
+
+---
+
+## Issue 4: File Uploads (Images, Documents)
+
+**Symptom**: Images don't render; PDF uploads fail silently.
+
+### Root Cause (FCC Codebase)
+- **Images**: ✅ Supported — `ContentBlockImage` → OpenAI `image_url` conversion (conversion.py:195-219)
+  - Base64 and URL sources both handled
+- **Documents**: ❌ Not forwarded
+  - `ContentBlockDocument` accepted in model (models.py:24-29)
+  - No conversion path in any provider
+  - DeepSeek strips explicitly (compat.py:32-44)
+- **No Files API endpoint**: FCC has no `/v1/files` implementation
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| Add document → base64 conversion for OpenAI-compatible | Medium | Medium |
+| Implement minimal Files API (local storage + signed URLs) | High | Medium |
+| Add provider-specific document handling | Medium | High |
+
+### Workaround
+- Images: Use base64 encoding (works with OpenAI-compatible)
+- Documents: Extract text first, send as text block
+
+### Upstream Dependency
+**Medium** — Files API would be new feature; document support depends on provider capabilities.
+
+---
+
+## Issue 5: Conversation / Message History Sync
+
+**Symptom**: History not shared between Desktop tabs; Cowork/Code tabs show different context.
+
+### Root Cause (Architectural)
+- **FCC is stateless proxy**: No conversation storage; each request independent
+- **Claude Desktop manages history**: Stored locally in `~/.config/Claude/conversations/`
+- **Routing through FCC**: Desktop sends full history each request; FCC forwards to provider
+- **No divergence in FCC** — but provider context limits may truncate differently per tab
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| N/A — not an FCC issue | — | — |
+| Provider context window awareness | Medium | Low |
+
+### Workaround
+- Ensure all tabs use same provider/model (consistent context limits)
+- Monitor `usage.input_tokens` to detect truncation
+
+### Upstream Dependency
+**None** — this is expected behavior; Desktop manages history.
+
+---
+
+## Issue 6: Model Features (Thinking, Tool Use, Vision)
+
+**Symptom**: Some models lack thinking, tool use, or vision when selected in picker.
+
+### Root Cause (FCC Codebase)
+- **Thinking**: ✅ Fully supported — `ThinkingConfig`, stream ledger, `ReasoningReplayMode`
+- **Tool Use**: ✅ Fully supported — streaming `tool_use` blocks, heuristic parser fallback
+- **Vision**: ⚠️ Partial — images work, but *model capability advertisement* may be incomplete
+  - Model catalog (`model_catalog.py`) emits capabilities from provider metadata
+  - NIM models may not advertise vision in `/v1/models` payload
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| Enhance model catalog capability detection | Medium | Low |
+| Add `vision: true` to NIM model metadata if supported | Low | Low |
+| Validate per-model feature matrix at startup | Medium | Low |
+
+### Workaround
+- Use picker aliases (`claude-sonnet-nim-XXXX`) — they inherit full Anthropic capability profile
+- For direct gateway IDs, check provider docs
+
+### Upstream Dependency
+**Low** — FCC handles feature translation; depends on upstream provider metadata accuracy.
+
+---
+
+## Issue 7: Auth / Billing Headers
+
+**Symptom**: "Invalid API key" or billing errors in Desktop when using `ANTHROPIC_API_KEY=freecc`.
+
+### Root Cause (Architectural)
+- **FCC ignores `ANTHROPIC_API_KEY`**: Hardcoded to accept any key (or `freecc`)
+- **No billing integration**: FCC is free proxy; no usage reporting to Anthropic
+- **Desktop expects Anthropic headers**: `anthropic-beta`, `anthropic-version`, usage in response
+
+### Current Behavior (FCC)
+- `x-anthropic-billing-header: cc_version=2.1.209.e2b; cc_entrypoint=cli` sent in responses (verify in code)
+- Usage tracking: `Usage` model includes `cache_creation_input_tokens`, `cache_read_input_tokens`
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| Pass through Anthropic headers unchanged | Low | Low |
+| Add usage tracking endpoint for local analytics | Medium | Low |
+| Mock billing header for Desktop compatibility | Low | Low |
+
+### Workaround
+- Use `fcc-configure-claude-desktop` which sets correct config
+- Accept that billing shows $0 (FCC is free)
+
+### Upstream Dependency
+**None** — FCC controls response headers.
+
+---
+
+## Issue 8: Extensions (Voice, Prompt Library, etc.)
+
+**Symptom**: Voice input, prompt library, or extensions don't work through FCC.
+
+### Root Cause
+- **Voice**: Requires WebRTC/gRPC to NVIDIA Riva or local Whisper
+  - FCC has `voice` optional dependency (grpcio, nvidia-riva-client)
+  - No voice endpoint in FCC API — only CLI `fcc-pi` has voice support
+- **Prompt Library**: Desktop feature; stores locally; not proxied
+- **Extensions**: Desktop loads from Electron app; FCC unaware
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| Add `/v1/voice/transcribe` endpoint | High | Medium |
+| Delegate voice to local whisper.cpp via FCC CLI | Medium | Low |
+| Document: extensions work natively (Desktop manages) | Zero | Zero |
+
+### Workaround
+- Voice: Use `fcc-pi` CLI for voice→text, then paste into Desktop
+- Extensions: Native Desktop behavior unaffected by proxy
+
+### Upstream Dependency
+**Low** — Voice endpoint would be new FCC feature; extensions are Desktop-local.
+
+---
+
+## Issue 9: Telemetry / Analytics
+
+**Symptom**: Desktop telemetry fails or shows errors in console.
+
+### Root Cause
+- **Desktop sends telemetry to Anthropic**: Requires valid API key + billing
+- **FCC returns 200 but no real backend**: Telemetry calls may 404 or return mock data
+- **No telemetry endpoint in FCC**: `/v1/telemetry` not implemented
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| Implement `/v1/telemetry` no-op endpoint | Low | Zero |
+| Proxy telemetry to local file (opt-in) | Medium | Low |
+| Document: telemetry disabled in FCC mode | Zero | Zero |
+
+### Workaround
+- Disable telemetry in Desktop: `preferences.telemetryEnabled = false`
+- Accept console warnings (harmless)
+
+### Upstream Dependency
+**None** — No-op endpoint trivial to add.
+
+---
+
+## Issue 10: Voice / Language Support
+
+**Symptom**: Voice input doesn't work; non-English languages have issues.
+
+### Root Cause
+- **Voice**: Covered in Issue 8 — no API endpoint
+- **Languages**: FCC passes through all text unchanged (UTF-8)
+  - No language detection or translation layer
+  - Provider-dependent: NIM models support multilingual; OpenAI-compatible vary
+
+### Feasible Fixes
+| Approach | Effort | Risk |
+|----------|--------|------|
+| Document language support per provider | Low | Zero |
+| Add language hint in system prompt | Low | Low |
+
+### Workaround
+- Use providers with strong multilingual support (Nemotron, Llama-3.3)
+- Set system prompt language explicitly
+
+### Upstream Dependency
+**None** — Pass-through behavior is correct.
+
+---
+
+## Summary Matrix
+
+| # | Issue | FCC Root Cause | Fix Effort | Workaround Exists? | Upstream Needed? |
+|---|-------|----------------|------------|-------------------|------------------|
+| 1 | Tool Approvals | No approval callback in intercepts | Medium | ✅ CLI | No |
+| 2 | MCP Servers | No provider implements MCP | High | ✅ Local tools | Yes (RFC) |
+| 3 | Streaming | First-chunk pre-fetch edge case | Low | ✅ CLI | No |
+| 4 | File Uploads | No Files API; docs dropped | Medium/High | ⚠️ Partial | Yes (Files API) |
+| 5 | History Sync | Not an FCC issue | — | ✅ Native | No |
+| 6 | Model Features | Capability metadata incomplete | Medium | ✅ Picker aliases | No |
+| 7 | Auth/Billing | FCC ignores key; no billing | Low | ✅ `freecc` key | No |
+| 8 | Extensions/Voice | No voice endpoint; extensions local | Medium/High | ⚠️ CLI voice | Maybe (voice) |
+| 9 | Telemetry | No endpoint | Low | ✅ Disable | No |
+| 10 | Voice/Languages | No voice API; pass-through text | Low | ✅ Provider choice | No |
+
+---
+
+## Recommended Prioritization for Upstream PR
+
+**Phase 1 (Low effort, high impact)**:
+1. Add `/v1/telemetry` no-op endpoint
+2. Mock billing header for Desktop compatibility
+3. Enhance model catalog with vision/tool-use flags per provider
+
+**Phase 2 (Medium effort)**:
+4. Add document → base64 conversion for OpenAI-compatible providers
+5. Implement approval SSE events (optional, gated by config)
+6. Add voice transcription endpoint (delegate to local whisper.cpp)
+
+**Phase 3 (RFC required)**:
+7. MCP server execution (local shim or MCP SDK integration)
+8. Files API implementation
+
+---
+
+## Files to Reference for PR
+
+| File | Purpose |
+|------|---------|
+| `docs/fcc-integration-analysis.md` | Full codebase analysis (7 integration points) |
+| `docs/claude-desktop-picker-aliasing.md` | Picker aliasing workaround (v4.13.0) |
+| `docs/integration-issues-analysis.md` | This document (10 issues) |
+| `src/free_claude_code/api/handlers/messages.py` | Tool approval / intercept logic |
+| `src/free_claude_code/providers/openai_chat/provider.py` | Streaming, thinking, reasoning |
+| `src/free_claude_code/core/anthropic/models.py` | All Anthropic protocol models |
+| `src/free_claude_code/core/anthropic/conversion.py` | Format translation |
+| `pyproject.toml` | Dependencies (voice optional) |
+
+---
+
+*End of analysis. Ready for upstream contribution preparation.*

--- a/docs/superpowers/plans/2026-07-26-integration-fixes.md
+++ b/docs/superpowers/plans/2026-07-26-integration-fixes.md
@@ -1,0 +1,1027 @@
+# FCC Integration Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement three priority integration fixes: native tool approvals flow, MCP SDK integration, Files/Voice proxy endpoints
+
+**Architecture:** Three independent phases. Phase 1 disables auto-intercepts so Desktop drives tool approval loop natively. Phase 2 adds MCP client to OpenAIChatProvider with security guardrails. Phase 3 adds `/v1/files` and `/v1/audio/transcriptions` handlers with text extraction fallback for documents.
+
+**Tech Stack:** Python 3.14+, FastAPI, mcp>=1.0.0, pypdf>=5.0, existing FCC codebase patterns
+
+## Global Constraints
+
+- All features opt-in via `Settings` (fcc.toml) — feature flags default to safe values
+- No breaking changes to existing API — backward compatible
+- Follow existing code style: `from __future__` removed, `contextlib.suppress`, type hints
+- CI must pass: suppressions, ruff-format, ruff-check, ty, pytest
+- Trace events for all new operations with `request_id` correlation
+
+---
+
+## Phase 1: Native Tool Approvals (Issue 1)
+
+### Task 1.1: Add `enable_native_tool_approvals` Setting
+
+**Files:**
+- Create: (none)
+- Modify: `src/free_claude_code/config/settings.py`
+- Test: `tests/config/test_settings.py`
+
+**Interfaces:**
+- Produces: `Settings.enable_native_tool_approvals: bool` (default `True`)
+
+```markdown
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/config/test_settings.py
+def test_settings_enable_native_tool_approvals_default_true():
+    from free_claude_code.config.settings import Settings
+    s = Settings()
+    assert s.enable_native_tool_approvals is True
+
+def test_settings_enable_native_tool_approvals_configurable():
+    from free_claude_code.config.settings import Settings
+    s = Settings(enable_native_tool_approvals=False)
+    assert s.enable_native_tool_approvals is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/config/test_settings.py::test_settings_enable_native_tool_approvals_default_true -v`
+Expected: FAIL — attribute missing
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/free_claude_code/config/settings.py
+# Add to Settings class:
+enable_native_tool_approvals: bool = True
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/config/test_settings.py::test_settings_enable_native_tool_approvals_default_true -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/free_claude_code/config/settings.py tests/config/test_settings.py
+git commit -m "feat: add enable_native_tool_approvals setting"
+```
+
+### Task 1.2: Disable Web Server Tool Intercept When Tools Present
+
+**Files:**
+- Modify: `src/free_claude_code/api/handlers/messages.py`
+- Test: `tests/api/test_messages_handler.py`
+
+**Interfaces:**
+- Consumes: `Settings.enable_native_tool_approvals` from Task 1.1
+- Produces: `_intercept_web_server_tool` returns `None` when request has tools AND setting enabled
+
+```markdown
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/api/test_messages_handler.py
+@pytest.mark.asyncio
+async def test_intercept_web_server_tool_skipped_when_tools_present():
+    from free_claude_code.api.handlers.messages import MessagesHandler
+    from free_claude_code.config.settings import Settings
+    from free_claude_code.core.anthropic.models import MessagesRequest, Tool
+    
+    settings = Settings(enable_native_tool_approvals=True)
+    handler = MessagesHandler(settings=settings, provider_resolver=lambda x: None)
+    
+    request = MessagesRequest(
+        model="test",
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[Tool(name="web_search", description="", input_schema={})]
+    )
+    
+    routed = MagicMock()
+    routed.request = request
+    
+    result = handler._intercept_web_server_tool(routed)
+    assert result is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/api/test_messages_handler.py::test_intercept_web_server_tool_skipped_when_tools_present -v`
+Expected: FAIL — intercept returns result
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/free_claude_code/api/handlers/messages.py
+def _intercept_web_server_tool(
+    self, routed: RoutedMessagesRequest
+) -> _MessagesResult | None:
+    if not self._settings.enable_web_server_tools:
+        return None
+    if not is_web_server_tool_request(routed.request):
+        return None
+    # NEW: skip if native tool approvals enabled and request has tools
+    if self._settings.enable_native_tool_approvals and routed.request.tools:
+        return None
+    # ... rest unchanged
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/api/test_messages_handler.py::test_intercept_web_server_tool_skipped_when_tools_present -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/free_claude_code/api/handlers/messages.py tests/api/test_messages_handler.py
+git commit -m "feat: disable web tool intercept when native approvals enabled and tools present"
+```
+
+### Task 1.3: Disable Local Optimization Intercept When Tools Present
+
+**Files:**
+- Modify: `src/free_claude_code/api/handlers/messages.py`
+- Test: `tests/api/test_messages_handler.py`
+
+```markdown
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/api/test_messages_handler.py
+@pytest.mark.asyncio
+async def test_intercept_local_optimization_skipped_when_tools_present():
+    from free_claude_code.api.handlers.messages import MessagesHandler
+    from free_claude_code.config.settings import Settings
+    from free_claude_code.core.anthropic.models import MessagesRequest, Tool
+    
+    settings = Settings(enable_native_tool_approvals=True)
+    handler = MessagesHandler(settings=settings, provider_resolver=lambda x: None)
+    
+    request = MessagesRequest(
+        model="test",
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[Tool(name="some=[Tool(name="any_tool", description="", input_schema={})]
+    )
+    
+    routed = MagicMock()
+    routed.request = request
+    
+    result = handler._intercept_local_optimization(routed)
+    assert result is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/api/test_messages_handler.py::test_intercept_local_optimization_skipped_when_tools_present -v`
+Expected: FAIL
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/free_claude_code/api/handlers/messages.py
+def _intercept_local_optimization(
+    self, routed: RoutedMessagesRequest
+) -> _MessagesResult | None:
+    if self._settings.enable_native_tool_approvals and routed.request.tools:
+        return None
+    # ... rest unchanged
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/api/test_messages_handler.py::test_intercept_local_optimization_skipped_when_tools_present -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/free_claude_code/api/handlers/messages.py tests/api/test_messages_handler.py
+git commit -m "feat: disable local optimization intercept when native approvals enabled and tools present"
+```
+
+### Task 1.4: Integration Test — Tool Use → Stop Reason → Tool Result Loop
+
+**Files:**
+- Test: `tests/api/test_tool_approval_flow.py` (new)
+
+```markdown
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/api/test_tool_approval_flow.py
+@pytest.mark.asyncio
+async def test_tool_use_emits_stop_reason_tool_use():
+    """First request returns tool_use + stop_reason: tool_use; second with tool_result executes."""
+    # Uses test client against /v1/messages endpoint
+    # Request contains tools + user message triggering tool
+    # Verify SSE stream ends with message_stop, stop_reason: tool_use
+    pass
+
+@pytest.mark.asyncio
+async def test_tool_result_in_next_request_executes():
+    """Follow-up request with tool_result processes correctly."""
+    pass
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/api/test_tool_approval_flow.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Write minimal implementation** (verify existing provider behavior handles this)
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+---
+
+## Phase 2: MCP SDK Integration (Issue 2)
+
+### Task 2.1: Add MCP Optional Dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+```markdown
+- [ ] **Step 1: Add dependency**
+
+```toml
+[project.optional-dependencies]
+mcp = ["mcp>=1.0.0"]
+```
+
+- [ ] **Step 2: Verify install**
+
+Run: `uv sync --extra mcp`
+Expected: mcp installed
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "feat: add mcp optional dependency"
+```
+
+### Task 2.2: Add `enable_mcp` Setting
+
+**Files:**
+- Modify: `src/free_claude_code/config/settings.py`
+- Test: `tests/config/test_settings.py`
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_settings_enable_mcp_default_false():
+    from free_claude_code.config.settings import Settings
+    s = Settings()
+    assert s.enable_mcp is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# src/free_claude_code/config/settings.py
+enable_mcp: bool = False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 2.3: Create MCPClientManager
+
+**Files:**
+- Create: `src/free_claude_code/providers/openai_chat/mcp_client.py`
+- Test: `tests/providers/test_mcp_client.py`
+
+**Interfaces:**
+- Produces: `MCPClientManager` class with methods:
+  - `connect(servers: list[MCPServerConfig]) -> list[MCPTool]`
+  - `execute_tool(tool_name: str, arguments: dict) -> ToolResult`
+  - `close() -> None`
+- Consumes: `mcp` SDK, `Settings.enable_mcp`
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/providers/test_mcp_client.py
+@pytest.fixture
+def mock_mcp_server():
+    # stdio mock that responds to initialize, list_tools, call_tool
+    pass
+
+@pytest.mark.asyncio
+async def test_mcp_client_manager_connects_and_lists_tools(mock_mcp_server):
+    from free_claude_code.providers.openai_chat.mcp_client import MCPClientManager, MCPServerConfig
+    
+    manager = MCPClientManager()
+    servers = [MCPServerConfig(transport="stdio", command="uvx", args=["mcp-server-git"])]
+    
+    tools = await manager.connect(servers)
+    assert len(tools) > 0
+    assert all("name" in t and "inputSchema" in t for t in tools)
+    await manager.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/providers/test_mcp_client.py::test_mcp_client_manager_connects_and_lists_tools -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/free_claude_code/providers/openai_chat/mcp_client.py
+"""MCP client manager for per-request MCP server lifecycle."""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Literal
+from contextlib import asynccontextmanager
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+@dataclass
+class MCPServerConfig:
+    transport: Literal["stdio", "sse"]
+    command: str | None = None
+    args: list[str] | None = None
+    url: str | None = None
+    headers: dict[str, str] | None = None
+
+
+@dataclass
+class MCPTool:
+    name: str
+    description: str
+    input_schema: dict[str, Any]  # MCP JSON Schema
+
+
+@dataclass
+class ToolResult:
+    content: Any
+    is_error: bool = False
+
+
+class MCPClientManager:
+    """Manages MCP client connections for a single request."""
+    
+    def __init__(self) -> None:
+        self._sessions: list[ClientSession] = []
+        self._streams: list[Any] = []
+    
+    async def connect(self, servers: list[MCPServerConfig]) -> list[MCPTool]:
+        all_tools: list[MCPTool] = []
+        for config in servers:
+            if config.transport == "stdio":
+                params = StdioServerParameters(
+                    command=config.command or "",
+                    args=config.args or [],
+                )
+                read_stream, write_stream = await stdio_client(params).__aenter__()
+                self._streams.append((read_stream, write_stream))
+                session = ClientSession(read_stream, write_stream)
+            else:  # sse
+                # SSE transport not in stdio_client — use sse_client
+                from mcp.client.sse import sse_client
+                read_stream, write_stream = await sse_client(config.url).__aenter__()
+                self._streams.append((read_stream, write_stream))
+                session = ClientSession(read_stream, write_stream)
+            
+            await session.__aenter__()
+            await session.initialize()
+            self._sessions.append(session)
+            
+            tools_result = await session.list_tools()
+            for tool in tools_result.tools:
+                all_tools.append(MCPTool(
+                    name=tool.name,
+                    description=tool.description or "",
+                    input_schema=tool.inputSchema,
+                ))
+        return all_tools
+    
+    async def execute_tool(self, tool_name: str, arguments: dict) -> ToolResult:
+        for session in self._sessions:
+            try:
+                result = await session.call_tool(tool_name, arguments)
+                return ToolResult(
+                    content=result.content,
+                    is_error=result.isError,
+                )
+            except Exception:
+                continue
+        raise ValueError(f"Tool {tool_name} not found in any MCP server")
+    
+    async def close(self) -> None:
+        for session in self._sessions:
+            await session.__aexit__(None, None, None)
+        for read_stream, write_stream in self._streams:
+            await read_stream.__aexit__(None, None, None)
+            await write_stream.__aexit__(None, None, None)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/providers/test_mcp_client.py::test_mcp_client_manager_connects_and_lists_tools -v`
+Expected: PASS (with mock)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/free_claude_code/providers/openai_chat/mcp_client.py tests/providers/test_mcp_client.py
+git commit -m "feat: add MCPClientManager for per-request MCP lifecycle"
+```
+
+### Task 2.4: Add Schema Mapping (MCP JSON Schema → OpenAI Function Declaration)
+
+**Files:**
+- Modify: `src/free_claude_code/providers/openai_chat/mcp_client.py`
+- Test: `tests/providers/test_mcp_client.py`
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/providers/test_mcp_client.py
+def test_mcp_tool_to_openai_function_declaration():
+    from free_claude_code.providers.openai_chat.mcp_client import mcp_tool_to_openai_function
+    
+    mcp_tool = MCPTool(
+        name="git_status",
+        description="Get git status",
+        input_schema={"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}
+    )
+    
+    openai_func = mcp_tool_to_openai_function(mcp_tool)
+    
+    assert openai_func["type"] == "function"
+    assert openai_func["function"]["name"] == "git_status"
+    assert openai_func["function"]["description"] == "Get git status"
+    assert openai_func["function"]["parameters"] == mcp_tool.input_schema
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# In mcp_client.py, add:
+def mcp_tool_to_openai_function(tool: MCPTool) -> dict[str, Any]:
+    """Convert MCP tool to OpenAI function declaration format."""
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.input_schema,
+        },
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 2.5: Security Guardrail — Localhost Only
+
+**Files:**
+- Modify: `src/free_claude_code/providers/openai_chat/mcp_client.py`
+- Modify: `src/free_claude_code/providers/openai_chat/provider.py`
+- Test: `tests/providers/test_mcp_client.py`
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/providers/test_mcp_client.py
+@pytest.mark.asyncio
+async def test_mcp_skipped_for_non_localhost_request():
+    # When request.client.host != localhost, MCPClientManager.connect should return []
+    pass
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Modify connect to accept request context**
+
+```python
+# In mcp_client.py
+async def connect(self, servers: list[MCPServerConfig], client_host: str | None = None) -> list[MCPTool]:
+    if client_host not in ("127.0.0.1", "::1", "localhost", None):
+        logger.warning("MCP skipped for non-localhost request: {}", client_host)
+        return []
+    # ... rest unchanged
+```
+
+- [ ] **Step 4: In provider.py, pass client host**
+
+```python
+# In stream_response, before calling manager.connect():
+client_host = getattr(request, "client", None)
+if client_host:
+    client_host = client_host.host
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+- [ ] **Step 6: Commit**
+
+### Task 2.6: Integrate MCP in OpenAIChatProvider.stream_response
+
+**Files:**
+- Modify: `src/free_claude_code/providers/openai_chat/provider.py`
+- Test: `tests/providers/test_provider_mcp.py` (new)
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/providers/test_provider_mcp.py
+@pytest.mark.asyncio
+async def test_provider_includes_mcp_tools_in_upstream_request():
+    # Mock provider with mcp_servers in request
+    # Verify tools sent upstream include MCP-discovered tools
+    pass
+
+@pytest.mark.asyncio
+async def test_provider_executes_mcp_tool_via_client():
+    # Mock MCPClientManager.execute_tool
+    # Verify tool_result emitted in stream
+    pass
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Write implementation in provider.py**
+
+```python
+# In stream_response, after preflight_stream:
+if request.mcp_servers and self._config.enable_mcp:
+    from .mcp_client import MCPClientManager, MCPServerConfig, mcp_tool_to_openai_function
+    
+    manager = MCPClientManager()
+    try:
+        mcp_configs = [
+            MCPServerConfig(
+                transport=s.get("transport", "stdio"),
+                command=s.get("command"),
+                args=s.get("args"),
+                url=s.get("url"),
+                headers=s.get("headers"),
+            )
+            for s in request.mcp_servers
+        ]
+        
+        client_host = request.client.host if getattr(request, "client", None) else None
+        mcp_tools = await manager.connect(mcp_configs, client_host=client_host)
+        
+        # Convert to OpenAI format and merge with existing tools
+        mcp_openai_tools = [mcp_tool_to_openai_function(t) for t in mcp_tools]
+        if routed_request.request.tools:
+            all_tools = list(routed_request.request.tools) + mcp_openai_tools
+        else:
+            all_tools = mcp_openai_tools
+        
+        # Store manager for tool execution during streaming
+        self._mcp_manager = manager
+        
+    except Exception as e:
+        logger.warning("MCP initialization failed: {}", e)
+        await manager.close()
+
+# In streaming loop, when tool_use detected for MCP tool:
+if hasattr(self, "_mcp_manager") and tool_name in mcp_tool_names:
+    result = await self._mcp_manager.execute_tool(tool_name, arguments)
+    # Emit tool_result block
+    yield format_sse_event(...)
+    
+# In finally block:
+if hasattr(self, "_mcp_manager"):
+    await self._mcp_manager.close()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+---
+
+## Phase 3: Files/Voice Proxy Endpoints (Issues 4, 8)
+
+### Task 3.1: Add pypdf Optional Dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+```markdown
+- [ ] **Step 1: Add dependency**
+
+```toml
+[project.optional-dependencies]
+voice = ["grpcio>=1.82.1", "grpcio-tools>=1.81.1", "nvidia-riva-client>=2.26.0", "pypdf>=5.0.0"]
+```
+
+- [ ] **Step 2: Verify install**
+
+Run: `uv sync --extra voice`
+Expected: pypdf installed
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "feat: add pypdf for document text extraction"
+```
+
+### Task 3.2: Add File Storage Handler
+
+**Files:**
+- Create: `src/free_claude_code/api/handlers/files.py`
+- Create: `src/free_claude_code/api/handlers/__init__.py` (if missing)
+- Test: `tests/api/test_files_handler.py`
+
+**Interfaces:**
+- Produces: `POST /v1/files`, `GET /v1/files/{file_id}/content`
+- Storage: local temp dir with TTL cleanup
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/api/test_files_handler.py
+@pytest.mark.asyncio
+async def test_upload_file_returns_file_object():
+    from fastapi.testclient import TestClient
+    from free_claude_code.api.main import app
+    
+    client = TestClient(app)
+    response = client.post("/v1/files", files={"file": ("test.txt", b"hello", "text/plain")})
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "id" in data
+    assert data["bytes"] == 5
+    assert data["filename"] == "test.txt"
+    assert data["purpose"] == "assistants"
+
+@pytest.mark.asyncio
+async def test_download_file_content():
+    # Upload then download
+    pass
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/api/test_files_handler.py -v`
+Expected: FAIL — 404
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# src/free_claude_code/api/handlers/files.py
+"""Files API handler for document upload/download."""
+
+import uuid
+import time
+from pathlib import Path
+from typing import Any
+from contextlib import asynccontextmanager
+
+from fastapi import APIRouter, File, UploadFile, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/v1", tags=["files"])
+
+
+class FileObject(BaseModel):
+    id: str
+    object: str = "file"
+    bytes: int
+    created_at: int
+    filename: str
+    purpose: str
+
+
+UPLOAD_DIR = Path("/tmp/fcc_files")
+UPLOAD_DIR.mkdir(exist_ok=True, parents=True)
+FILE_TTL_SECONDS = 3600  # 1 hour
+
+_file_metadata: dict[str, dict[str, Any]] = {}
+
+
+@router.post("/files")
+async def upload_file(
+    file: UploadFile = File(...),
+    purpose: str = "assistants",
+) -> FileObject:
+    file_id = f"file-{uuid.uuid4().hex}"
+    content = await file.read()
+    
+    file_path = UPLOAD_DIR / file_id
+    file_path.write_bytes(content)
+    
+    metadata = {
+        "id": file_id,
+        "object": "file",
+        "bytes": len(content),
+        "created_at": int(time.time()),
+        "filename": file.filename or "unknown",
+        "purpose": purpose,
+        "path": str(file_path),
+    }
+    _file_metadata[file_id] = metadata
+    
+    # Cleanup old files (simple approach)
+    _cleanup_expired_files()
+    
+    return FileObject(**metadata)
+
+
+@router.get("/files/{file_id}/content")
+async def download_file_content(file_id: str) -> StreamingResponse:
+    metadata = _file_metadata.get(file_id)
+    if not metadata:
+        raise HTTPException(status_code=404, detail="File not found")
+    
+    file_path = Path(metadata["path"])
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="File content missing")
+    
+    def iter_file():
+        with file_path.open("rb") as f:
+            while chunk := f.read(65536):
+                yield chunk
+    
+    return StreamingResponse(
+        iter_file(),
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{metadata["filename"]}"'},
+    )
+
+
+def _cleanup_expired_files() -> None:
+    now = time.time()
+    expired = [
+        fid for fid, meta in _file_metadata.items()
+        if now - meta["created_at"] > FILE_TTL_SECONDS
+    ]
+    for fid in expired:
+        meta = _file_metadata.pop(fid)
+        Path(meta["path"]).unlink(missing_ok=True)
+```
+
+- [ ] **Step 4: Register router in main app**
+
+```python
+# src/free_claude_code/api/main.py
+from free_claude_code.api.handlers.files import router as files_router
+app.include_router(files_router)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/api/test_files_handler.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/free_claude_code/api/handlers/files.py src/free_claude_code/api/main.py tests/api/test_files_handler.py
+git commit -m "feat: add /v1/files upload and download endpoints"
+```
+
+### Task 3.3: Document Text Extraction Fallback in Conversion
+
+**Files:**
+- Modify: `src/free_claude_code/core/anthropic/conversion.py`
+- Test: `tests/core/test_conversion_document.py`
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/core/test_conversion_document.py
+def test_openai_user_document_part_extracts_text_when_provider_lacks_support():
+    from free_claude_code.core.anthropic.conversion import _openai_user_document_part
+    from free_claude_code.providers.openai_chat.profiles import OpenAIChatProfile
+    
+    # Profile with supports_documents=False
+    profile = OpenAIChatProfile(
+        provider_name="test",
+        base_url="http://localhost",
+        supports_documents=False,
+    )
+    
+    # Upload a test PDF first, get file_id
+    # Then call with document block referencing file_id
+    # Verify returns text block with extracted content
+    pass
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# In conversion.py
+def _openai_user_document_part(
+    block: ContentBlockDocument,
+    request: MessagesRequest,
+    profile: OpenAIChatProfile,
+) -> dict[str, Any] | None:
+    source = block.source
+    
+    # If provider supports documents natively, try to pass through
+    if profile.supports_documents:
+        # ... existing logic for native document support
+        return _openai_document_native(block)
+    
+    # FALLBACK: Extract text locally
+    if source.get("type") == "file_id":
+        file_id = source["file_id"]
+        # Read from file storage
+        from free_claude_code.api.handlers.files import _file_metadata
+        meta = _file_metadata.get(file_id)
+        if not meta:
+            return None
+        
+        file_path = Path(meta["path"])
+        if file_path.suffix.lower() == ".pdf":
+            import pypdf
+            reader = pypdf.PdfReader(file_path)
+            text_parts = []
+            for page in reader.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    text_parts.append(page_text)
+            extracted = "\n\n".join(text_parts)
+        else:
+            # Plain text, markdown, etc.
+            extracted = file_path.read_text()
+        
+        return {
+            "type": "text",
+            "text": f"<document name='{meta['filename']}'>\n{extracted}\n</document>",
+        }
+    
+    return None
+```
+
+- [ ] **Step 4: Add supports_documents to profile**
+
+```python
+# src/free_claude_code/providers/openai_chat/profiles.py
+@dataclass
+class OpenAIChatProfile:
+    # ... existing fields
+    supports_documents: bool = False
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+- [ ] **Step 6: Commit**
+
+### Task 3.4: Voice Transcription Handler
+
+**Files:**
+- Create: `src/free_claude_code/api/handlers/audio.py`
+- Test: `tests/api/test_audio_handler.py`
+
+```markdown
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/api/test_audio_handler.py
+@pytest.mark.asyncio
+async def test_transcribe_audio_returns_text():
+    from fastapi.testclient import TestClient
+    from free_claude_code.api.main import app
+    
+    client = TestClient(app)
+    # Use a small test audio file
+    response = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("test.wav", SAMPLE_WAV_BYTES, "audio/wav")},
+        data={"model": "parakeet", "language": "en"},
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "text" in data
+    assert data["language"] == "en"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/api/test_audio_handler.py -v`
+Expected: FAIL — 404
+
+- [ ] **Step 3: Write implementation**
+
+```python
+# src/free_claude_code/api/handlers/audio.py
+"""Audio transcription endpoint proxying to upstream providers."""
+
+from fastapi import APIRouter, File, Form, UploadFile, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/v1", tags=["audio"])
+
+
+class TranscriptionResponse(BaseModel):
+    text: str
+    language: str
+
+
+@router.post("/audio/transcriptions")
+async def transcribe_audio(
+    file: UploadFile = File(...),
+    model: str = Form("parakeet"),
+    language: str | None = Form(None),
+    prompt: str | None = Form(None),
+) -> TranscriptionResponse:
+    # Read audio content
+    audio_content = await file.read()
+    
+    # Determine provider from model or settings
+    # For now, proxy to NVIDIA NIM parakeet or OpenAI-compatible
+    from free_claude_code.config.settings import Settings
+    settings = Settings()
+    provider_name = settings.voice_provider or "nvidia_nim/parakeet"
+    
+    # Get provider from resolver
+    from free_claude_code.application.ports import ProviderResolver
+    # ... resolve provider and call audio endpoint
+    
+    # Simplified: return placeholder
+    # Real impl: call provider with audio bytes
+    
+    return TranscriptionResponse(
+        text="[Transcription would be here]",
+        language=language or "en",
+    )
+```
+
+- [ ] **Step 4: Register router in main app**
+- [ ] **Step 5: Implement actual provider proxy** (connect to NVIDIA NIM or OpenAI Whisper)
+- [ ] **Step 6: Run test to verify it passes**
+- [ ] **Step 7: Commit**
+
+### Task 3.5: Add `voice_provider` Setting
+
+**Files:**
+- Modify: `src/free_claude_code/config/settings.py`
+- Test: `tests/config/test_settings.py`
+
+```markdown
+- [ ] **Step 1: Write failing test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write implementation**
+```python
+voice_provider: str | None = None
+```
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+---
+
+## Final Validation
+
+### Task 4.1: Run Full CI Suite
+
+```markdown
+- [ ] **Step 1: Run all CI checks**
+
+Run: `./scripts/ci.sh`
+Expected: All checks PASS (suppressions, ruff-format, ruff-check, ty, pytest)
+
+- [ ] **Step 2: Fix any failures**
+- [ ] **Step 3: Commit final fixes**
+```
+
+### Task 4.2: Manual Integration Test Checklist
+
+```markdown
+- [ ] Tool Approvals: Desktop picker → chat → tool_use → approval → tool_result → response
+- [ ] MCP: Desktop config with mcp_servers → FCC → MCP server → tool execution
+- [ ] Files: Upload PDF → document block in chat → text extraction fallback works
+- [ ] Voice: POST audio → transcription returned
+```
+
+---
+
+## Plan Complete
+
+**Execution options:**
+
+1. **Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks
+2. **Inline Execution** - Execute tasks in this session using executing-plans
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-07-26-integration-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-26-integration-fixes-design.md
@@ -1,0 +1,184 @@
+# FCC Integration Fixes — Unified Design Spec
+
+**Date**: 2026-07-26  
+**Scope**: Three priority integration fixes for Claude Desktop ↔ FCC proxy
+
+---
+
+## 1. Tool Approvals Callback Mechanism (Issue 1)
+
+### Problem
+Claude Desktop's Cowork/Code tabs need native tool approval dialogs. Currently FCC auto-executes intercepts without user consent.
+
+### Root Cause
+`MessagesHandler.create()` → `_intercept_web_server_tool()` / `_intercept_local_optimization()` execute immediately. Desktop expects standard Anthropic protocol: model emits `tool_use` block → turn ends with `stop_reason: "tool_use"` → Desktop shows approval UI → user clicks → Desktop sends new request with `tool_result`.
+
+### Correct Design: Pass-Through Tool Use Flow
+
+**No custom SSE events. No polling. Standard protocol only.**
+
+**Changes**:
+
+1. **Settings**: `enable_native_tool_approvals: bool = True` (on by default)
+2. **Remove auto-execution in intercepts**: 
+   - `_intercept_web_server_tool()` → return `None` if request has tools that could be called
+   - `_intercept_local_optimization()` → return `None` if tools present
+3. **Let provider streaming handle tool_use**: OpenAIChatProvider already emits proper `tool_use` blocks via `OpenAIToolCallAssembler`
+4. **Desktop drives the loop**:
+   - Turn 1: Model returns `tool_use` + `stop_reason: "tool_use"` → Desktop shows approval
+   - User clicks "Allow" → Desktop POSTs `/v1/messages` with `tool_result`
+   - Turn 2: FCC routes `tool_result` to provider → execution happens
+
+**For intercepts that MUST execute locally** (web_search/web_fetch):
+- Only execute if `enable_web_server_tools` AND no upstream tool approval needed
+- OR: expose as regular `tools` in request so Desktop approves them too
+- Simplest: disable intercepts when `enable_native_tool_approvals=True` and tools exist
+
+**CLI (`fcc-claude`)**: No change — already works via turn-based tool loop.
+
+### Testing
+- Unit: Verify `_run_message_intercepts` returns `None` when tools in request
+- Integration: Emit `tool_use` + `stop_reason: tool_use` → Desktop approval → `tool_result` in next request → execution
+
+---
+
+## 2. Full MCP SDK Integration (Issue 2)
+
+### Problem
+`mcp_servers` in Desktop config ignored. No provider implements MCP.
+
+### Design: MCP Client in OpenAI-Chat Provider (with guardrails)
+
+**Dependency**: `mcp>=1.0.0` in `[project.optional-dependencies] mcp`
+
+**Architecture**:
+```
+Claude Desktop → FCC /v1/messages (with mcp_servers list)
+               → OpenAIChatProvider.stream_response()
+               → MCPClientManager (per-request lifecycle)
+               → stdio/SSE transport per configured server
+               → Tool discovery: list_tools() on connect
+               → Schema mapping: MCP JSON Schema → OpenAI function declaration
+               → Tool execution: call_tool() with timeout
+               → Results returned as tool_result blocks
+```
+
+**Components**:
+
+1. **`free_claude_code/providers/openai_chat/mcp_client.py`**
+   - `MCPClientManager`: lifecycle per request
+   - `MCPServerConfig`: parsed from `mcp_servers` request field
+   - Transport: stdio (local) or SSE (remote)
+   - **Security guardrail**: Only启动 MCP if `request.client.host in {"127.0.0.1", "::1", "localhost"}` (via Starlette request)
+   - Tool discovery: `list_tools()` on connect
+   - **Schema mapping guardrail**: Convert MCP JSON Schema → OpenAI `{"type": "function", "function": {...}}` for generic upstream
+   - Tool execution: `call_tool()` with 30s timeout
+   - Cleanup on request end (success or error)
+
+2. **Integration in `provider.py` (`stream_response`)**:
+   - If `request.mcp_servers` and `settings.enable_mcp`:
+     - Start MCP clients, discover tools
+     - Merge MCP tools into `tools` sent to upstream
+     - Stream response; on `tool_use` for MCP tool:
+       - Execute via MCP client
+       - Emit `tool_result` block to stream
+   - Error handling: MCP connect failure → log, continue without MCP tools
+
+### Testing
+- Unit: Mock MCP server (stdio); verify schema mapping + tool execution
+- Integration: End-to-end with `uvx mcp-server-git` or similar
+- Security: Verify non-localhost requests skip MCP
+
+---
+
+## 3. Files/Voice Proxy to Upstream Providers (Issues 4, 8)
+
+### Problem
+- No `/v1/files` endpoint; document blocks dropped
+- No `/v1/voice/transcribe`; voice input broken
+- Standard LLMs (NIM llama-3.3-70b, DeepSeek) don't natively parse PDFs
+
+### Design: Proxy Endpoints + Text Extraction Fallback
+
+**Files API** (`/v1/files` + `/v1/files/{id}/content`):
+
+1. **New handler** (`free_claude_code/api/handlers/files.py`):
+   - `POST /v1/files` (multipart) → upload to local temp storage (TTL 1h)
+   - Return `FileObject`: `{id, bytes, filename, purpose, created_at}`
+   - `GET /v1/files/{id}/content` → stream file bytes
+   - Cleanup: background task sweeps expired files
+
+2. **Document block conversion** in `conversion.py`:
+   - `_openai_user_document_part()` → if provider supports `document` natively: pass through
+   - **Fallback for non-document providers**: Extract text locally (`pypdf`/`pdfplumber`)
+     - Inject as text block: `{"type": "text", "text": "<document name='...'>[Extracted Text]</document>"}`
+     - Requires new optional dep: `pypdf>=5.0` in `voice` or new `documents` extra
+
+3. **Provider capability flag**: `supports_documents: bool` in `OpenAIChatProfile`
+
+**Voice API** (`/v1/audio/transcriptions`):
+
+1. **New handler** (`free_claude_code/api/handlers/audio.py`):
+   - `POST /v1/audio/transcriptions` (multipart: file, model, language, prompt)
+   - Proxy to configured upstream with audio support
+   - Current targets: NVIDIA NIM `parakeet` or OpenAI-compatible Whisper
+   - Return standard: `{text: "...", language: "..."}`
+
+2. **Settings**: `voice_provider: str | None` — which provider handles voice
+
+### Testing
+- Files: Upload → download round-trip; document block → text fallback injection
+- Voice: POST audio → get transcription; ensure multilingual
+
+---
+
+## Cross-Cutting Concerns
+
+### Configuration
+All features opt-in via `Settings` (fcc.toml):
+```toml
+[features]
+enable_native_tool_approvals = true
+enable_mcp = false
+voice_provider = "nvidia_nim/parakeet"
+```
+
+### Dependencies
+```toml
+[project.optional-dependencies]
+mcp = ["mcp>=1.0.0"]
+voice = ["grpcio", "nvidia-riva-client", "pypdf>=5.0"]
+```
+
+### Observability
+- Trace events: `mcp.client.connected`, `mcp.tool.executed`, `files.uploaded`, `voice.transcribed`
+- Structured logs with `request_id` correlation
+
+---
+
+## File Map (New/Modified)
+
+| Path | Role |
+|------|------|
+| `src/free_claude_code/api/handlers/messages.py` | Disable intercepts when tools present |
+| `src/free_claude_code/providers/openai_chat/mcp_client.py` | MCP client manager (NEW) |
+| `src/free_claude_code/providers/openai_chat/provider.py` | MCP integration + security guard |
+| `src/free_claude_code/api/handlers/files.py` | Files API handler (NEW) |
+| `src/free_claude_code/api/handlers/audio.py` | Voice transcription handler (NEW) |
+| `src/free_claude_code/core/anthropic/conversion.py` | Document text extraction fallback |
+| `pyproject.toml` | New optional deps (mcp, pypdf) |
+| `src/free_claude_code/config/settings.py` | Feature flags |
+
+---
+
+## Rollout Order
+
+1. **Phase 1**: Tool Approvals — disable intercepts when tools present (lowest risk)
+2. **Phase 2**: MCP SDK — new dep, provider-side only, security guardrails
+3. **Phase 3**: Files/Voice — new endpoints, upstream proxy + text extraction
+
+Each phase independently testable; no cross-dependencies.
+
+---
+
+*Design ready for review. Approve to proceed to implementation plan.*

--- a/docs/superpowers/specs/2026-07-29-pr1-desktop-picker-aliasing-design.md
+++ b/docs/superpowers/specs/2026-07-29-pr1-desktop-picker-aliasing-design.md
@@ -1,0 +1,138 @@
+# PR1: Claude Desktop Picker Aliasing + Launcher
+
+Date: 2026-07-29
+Project: free-claude-code v4.13.1 → 4.14.0
+
+## Goal
+
+Route every NIM entry through Claude Desktop's model picker without modifying
+the obfuscated validator inside `app.asar`. Emit `claude-sonnet-nim-NNNN`-shaped
+picker ids on `/v1/models`; resolve them to canonical `provider/model` ref on
+chat ingress. Ship a `fcc-claude-desktop` launcher and `fcc-claude-desktop
+--configure` helper so install auto-writes user's `claude_desktop_config.json`.
+
+## Background
+
+Source documents:
+
+- `docs/claude-desktop-picker-aliasing.md` (full design, earlier lost work)
+- `docs/fcc-integration-analysis.md` §3 (model routing + aliases row)
+- `docs/integration-issues-analysis.md` Issue 6 (capability advertisement)
+
+## Architecture
+
+Five thin layers; failure-isolated:
+
+1. **Mapping layer** (`core/gateway_model_ids.py`)
+   Pure functions. Module-scope dicts. Deterministic sorted-input → counter.
+   Cold-start state (empty maps) → resolver returns `None` → fallback wins.
+
+2. **Catalog layer** (`api/model_catalog.py`)
+   `_append_provider_model_variants` prefers aliased id; falls back to existing
+   `gateway_model_id()`. `display_name` stays as `provider/model_ref`.
+
+3. **Routing layer** (`application/routing.py`)
+   `ModelRouter._direct_provider_model` checks `resolve_picker_alias` first;
+   falls through to `decode_gateway_model_id` / provider/model chain.
+
+4. **Lifecycle layer** (`runtime/application.py`)
+   After `warm_referenced_model_cache()` succeeds, call `seed_picker_aliases`
+   exactly once with the sorted refs `cached_prefixed_model_infos()` exposes.
+
+5. **OS layer** (`cli/launchers/claude_desktop.py`)
+   Two modes:
+   - Default: launch `claude-desktop --ignore-certificate-errors`.
+   - `--configure`: read/merge `~/.config/Claude/claude_desktop_config.json`
+     via stdlib `json` (no jq dependency). Idempotent.
+   - `--unconfigure`: reverse the merge.
+
+## Behavior — alias resolution
+
+Stable counter given sorted ref list:
+
+```
+nvidia_nim/01-ai/yi-large                   -> claude-sonnet-nim-0001
+nvidia_nim/01-ai/yi-large (no-thinking)     -> claude-sonnet-nim-0001-no-thinking
+nvidia_nim/meta/llama-3.3-70b-instruct      -> claude-sonnet-nim-0002
+...
+```
+
+Aliases always contain `claude-` and `sonnet` tokens; satisfy
+`RCA.some(I => A.includes(I))` in the desktop validator. Blacklist substrings
+(`llama`, `qwen`, ...) absent in ids.
+
+## JSON merge contract
+
+`--configure` writes the following keys idempotently under existing file:
+
+```json
+{
+  "modelDiscoveryEnabled": true,
+  "inference": {
+    "provider": "gateway",
+    "credentialKind": "static",
+    "inferenceProvider": "gateway",
+    "inferenceCredentialKind": "static",
+    "inferenceGatewayBaseUrl": "https://localhost:8443",
+    "inferenceGatewayAuthScheme": "x-api-key",
+    "inferenceAnthropicApiKey": "freecc"
+  }
+}
+```
+
+Preserves `preferences`, `coworkUserFilesPath`, `mcpServers`, `env`. Does not
+clobber unknown keys. `env` may carry `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY`
+as fallback.
+
+`--unconfigure` removes only the keys above; preserves every other key byte-for-byte.
+
+## Install script flow
+
+`scripts/install.sh` / `install.ps1`: after `uv tool install --force .`
+succeeds and before surfacing completion, invoke the Python helper. Cross-
+platform: `python3 -m free_claude_code.cli.launchers.claude_desktop --configure`
+on POSIX, `\1 -m free_claude_code.cli.launchers.claude_desktop --configure` on
+Windows. Helper is in the just-installed tool so it's reachable. Fail loudly if
+config path unreachable; silent if file absent.
+
+Best-effort cert copy into `ca-certificates` after configure — Electron
+ignores it on some distros, so log only.
+
+## Tests (TDD)
+
+- `tests/core/test_gateway_model_ids.py`: seed/lookup round-trip, no-thinking
+  variant, unknown alias returns None, clear resets state, counter deterministic
+  from sorted input.
+- `tests/api/test_model_catalog.py`: alias id selected when seeded, fallback
+  to wrapper when unseeded, `display_name` equals real ref.
+- `tests/application/test_routing.py`: alias decode hits before gateway id,
+  before `provider/model` passthrough, bogus alias surfaces upstream 404.
+- `tests/cli/test_claude_desktop_launcher.py`: subprocess args, binary-not-found,
+  exit-code passthrough, JSON merge idempotency, unconfigure round-trip.
+- `tests/scripts/test_install_invokes_configure.py`: install script argparse
+  contains `python3 -m free_claude_code.cli.launchers.claude_desktop --configure`.
+
+## Version
+
+`pyproject.toml` version `4.13.1` → `4.14.0` (MINOR — backward-compatible
+feature add). Same commit as production diff; `uv lock` updated.
+
+## Out of scope (PR2+)
+
+- `/v1/telemetry` 200 / payload
+- Capability flag surfacing
+- MCP provider implementation
+- Files API
+- Voice endpoint
+- Document upload
+
+## Residual risks
+
+- Counter stability across restarts depends on `cached_prefixed_model_infos()`
+  returning same sorted refs post-restart. If FCC adds a ref-sorted seam later
+  that changes order, alias numbering shifts. Mitigated: alias map is
+  deterministic, never reused — but callers should treat alias ids as
+  ephemeral labels.
+- Electron TLS: `--ignore-certificate-errors` is per-binary; updating
+  `claude-desktop` binary drops it. Re-install required. Documented in
+  launcher help text.

--- a/free_claude_code/api/handlers/messages.py
+++ b/free_claude_code/api/handlers/messages.py
@@ -1,0 +1,388 @@
+"""Claude Messages API product flow."""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, replace
+from typing import Any
+
+from fastapi.responses import JSONResponse, Response
+from loguru import logger
+
+from free_claude_code.api.detection import is_safety_classifier_request
+from free_claude_code.api.model_router import ModelRouter, RoutedMessagesRequest
+from free_claude_code.api.models.anthropic import MessagesRequest
+from free_claude_code.api.optimization_handlers import try_optimizations
+from free_claude_code.api.provider_execution import (
+    ProviderExecutionService,
+    TokenCounter,
+)
+from free_claude_code.api.request_errors import (
+    http_status_for_unexpected_api_exception,
+    log_unexpected_api_exception,
+    require_non_empty_messages,
+    unexpected_http_exception,
+)
+from free_claude_code.api.request_ids import new_request_id
+from free_claude_code.api.response_streams import (
+    EmptyStreamError,
+    anthropic_sse_streaming_response,
+    terminal_execution_error_response,
+)
+from free_claude_code.api.web_tools.egress import (
+    WebFetchEgressPolicy,
+    web_fetch_allowed_scheme_set,
+)
+from free_claude_code.api.web_tools.request import (
+    is_web_server_tool_request,
+    openai_chat_upstream_server_tool_error,
+)
+from free_claude_code.api.web_tools.streaming import stream_web_server_tool_response
+from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import (
+    aggregate_anthropic_sse_to_message,
+    anthropic_error_payload,
+    anthropic_status_for_error_type,
+    get_token_count,
+    get_user_facing_error_message,
+)
+from free_claude_code.core.trace import trace_event
+from free_claude_code.providers.base import BaseProvider
+from free_claude_code.providers.exceptions import InvalidRequestError, ProviderError
+
+_OPENAI_CHAT_UPSTREAM_IDS = frozenset(
+    provider_id
+    for provider_id, descriptor in PROVIDER_CATALOG.items()
+    if descriptor.transport_type == "openai_chat"
+)
+
+
+@dataclass(frozen=True)
+class _MessagesStreamResult:
+    body: AsyncIterator[str]
+
+
+@dataclass(frozen=True)
+class _MessagesCompleteResult:
+    response: object
+
+
+ProviderGetter = Callable[[str], BaseProvider]
+_MessagesResult = _MessagesStreamResult | _MessagesCompleteResult
+MessageIntercept = Callable[[RoutedMessagesRequest], _MessagesResult | None]
+
+
+class MessagesHandler:
+    """Handle Anthropic-compatible Messages requests."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        provider_getter: ProviderGetter,
+        *,
+        model_router: ModelRouter | None = None,
+        token_counter: TokenCounter = get_token_count,
+        provider_execution: ProviderExecutionService | None = None,
+    ) -> None:
+        self._settings = settings
+        self._model_router = model_router or ModelRouter(settings)
+        self._token_counter = token_counter
+        self._provider_execution = provider_execution or ProviderExecutionService(
+            settings,
+            provider_getter,
+            token_counter=token_counter,
+        )
+        self._message_intercepts: tuple[MessageIntercept, ...] = (
+            self._intercept_web_server_tool,
+            self._intercept_local_optimization,
+        )
+
+    async def create(
+        self,
+        request_data: MessagesRequest,
+        *,
+        request_id: str | None = None,
+        request: Any = None,
+    ) -> object:
+        """Create an Anthropic-compatible message response."""
+        request_id = request_id or new_request_id()
+        try:
+            require_non_empty_messages(request_data.messages)
+            routed = self._model_router.resolve_messages_request(request_data)
+            routed = self._apply_message_routing_policies(routed)
+            self._reject_unsupported_server_tools(routed)
+
+            result = self._run_message_intercepts(routed)
+            if result is None:
+                logger.debug("No optimization matched, routing to provider")
+                result = _MessagesStreamResult(
+                    self._provider_execution.stream(
+                        routed,
+                        wire_api="messages",
+                        raw_log_label="FULL_PAYLOAD",
+                        raw_log_payload=routed.request.model_dump(),
+                        request_id=request_id,
+                        request=request,
+                    )
+                )
+            return await self._to_public_response(
+                result,
+                stream=request_data.stream,
+                request_id=request_id,
+            )
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise unexpected_http_exception(
+                self._settings, exc, context="CREATE_MESSAGE_ERROR"
+            ) from exc
+
+    async def _to_public_response(
+        self,
+        result: _MessagesResult,
+        *,
+        stream: bool | None,
+        request_id: str,
+    ) -> object:
+        if isinstance(result, _MessagesCompleteResult):
+            return result.response
+        if stream is False:
+            # Non-streaming clients (e.g. Claude Code utility calls) need a
+            # complete JSON Message; the internal pipeline is always SSE, so
+            # serving that raw here breaks the client SDK's response parse.
+            try:
+                message, error = await aggregate_anthropic_sse_to_message(result.body)
+            except GeneratorExit:
+                raise
+            except asyncio.CancelledError:
+                raise
+            except ProviderError as exc:
+                return self._provider_execution_error_response(
+                    exc, request_id=request_id
+                )
+            except BaseExceptionGroup as exc:
+                return self._unexpected_execution_error_response(
+                    exc,
+                    request_id=request_id,
+                    context="CREATE_MESSAGE_NON_STREAM_ERROR",
+                )
+            except Exception as exc:
+                return self._unexpected_execution_error_response(
+                    exc,
+                    request_id=request_id,
+                    context="CREATE_MESSAGE_NON_STREAM_ERROR",
+                )
+            if error is not None:
+                error_type, message_text = _stream_error_fields(error)
+                status_code = anthropic_status_for_error_type(error_type)
+                self._trace_terminal_execution_error(
+                    request_id=request_id,
+                    status_code=status_code,
+                    error_type=error_type,
+                )
+                return terminal_execution_error_response(
+                    status_code=status_code,
+                    content=anthropic_error_payload(
+                        error_type=error_type,
+                        message=message_text,
+                        request_id=request_id,
+                    ),
+                )
+            return JSONResponse(content=message)
+        return await anthropic_sse_streaming_response(
+            result.body,
+            pre_start_error_response=lambda exc: self._pre_start_error_response(
+                exc, request_id=request_id
+            ),
+        )
+
+    def _pre_start_error_response(
+        self, exc: BaseException, *, request_id: str
+    ) -> Response:
+        if isinstance(exc, ProviderError):
+            return self._provider_execution_error_response(exc, request_id=request_id)
+        context = (
+            "CREATE_MESSAGE_EMPTY_STREAM"
+            if isinstance(exc, EmptyStreamError)
+            else "CREATE_MESSAGE_STREAM_START_ERROR"
+        )
+        return self._unexpected_execution_error_response(
+            exc,
+            request_id=request_id,
+            context=context,
+        )
+
+    def _provider_execution_error_response(
+        self, exc: ProviderError, *, request_id: str
+    ) -> JSONResponse:
+        self._trace_terminal_execution_error(
+            request_id=request_id,
+            status_code=exc.status_code,
+            error_type=exc.error_type,
+        )
+        return terminal_execution_error_response(
+            status_code=exc.status_code,
+            content=anthropic_error_payload(
+                error_type=exc.error_type,
+                message=exc.message,
+                request_id=request_id,
+            ),
+        )
+
+    def _unexpected_execution_error_response(
+        self,
+        exc: BaseException,
+        *,
+        request_id: str,
+        context: str,
+    ) -> JSONResponse:
+        log_unexpected_api_exception(
+            self._settings,
+            exc,
+            context=context,
+            request_id=request_id,
+        )
+        status_code = http_status_for_unexpected_api_exception(exc)
+        self._trace_terminal_execution_error(
+            request_id=request_id,
+            status_code=status_code,
+            error_type="api_error",
+            exc_type=type(exc).__name__,
+        )
+        return terminal_execution_error_response(
+            status_code=status_code,
+            content=anthropic_error_payload(
+                error_type="api_error",
+                message=get_user_facing_error_message(exc),
+                request_id=request_id,
+            ),
+        )
+
+    @staticmethod
+    def _trace_terminal_execution_error(
+        *,
+        request_id: str,
+        status_code: int,
+        error_type: str,
+        exc_type: str | None = None,
+    ) -> None:
+        fields: dict[str, object] = {
+            "stage": "egress",
+            "event": "free_claude_code.api.response.terminal_execution_error",
+            "source": "api",
+            "wire_api": "messages",
+            "request_id": request_id,
+            "status_code": status_code,
+            "error_type": error_type,
+            "client_should_retry": False,
+        }
+        if exc_type is not None:
+            fields["exc_type"] = exc_type
+        trace_event(**fields)
+
+    def _reject_unsupported_server_tools(self, routed: RoutedMessagesRequest) -> None:
+        if routed.resolved.provider_id not in _OPENAI_CHAT_UPSTREAM_IDS:
+            return
+        tool_err = openai_chat_upstream_server_tool_error(
+            routed.request,
+            web_tools_enabled=self._settings.enable_web_server_tools,
+        )
+        if tool_err is not None:
+            raise InvalidRequestError(tool_err)
+
+    def _apply_message_routing_policies(
+        self, routed: RoutedMessagesRequest
+    ) -> RoutedMessagesRequest:
+        if not is_safety_classifier_request(routed.request):
+            return routed
+        changed = routed.resolved.thinking_enabled
+        trace_event(
+            stage="routing",
+            event="free_claude_code.api.optimization.safety_classifier_no_thinking",
+            source="api",
+            model=routed.request.model,
+            changed=changed,
+        )
+        if not changed:
+            return routed
+        return RoutedMessagesRequest(
+            request=routed.request,
+            resolved=replace(routed.resolved, thinking_enabled=False),
+        )
+
+    def _run_message_intercepts(
+        self, routed: RoutedMessagesRequest
+    ) -> _MessagesResult | None:
+        for intercept in self._message_intercepts:
+            result = intercept(routed)
+            if result is not None:
+                return result
+        return None
+
+    def _intercept_web_server_tool(
+        self, routed: RoutedMessagesRequest
+    ) -> _MessagesResult | None:
+        if not self._settings.enable_web_server_tools:
+            return None
+        if not is_web_server_tool_request(routed.request):
+            return None
+        # Skip if native tool approvals enabled and request has tools
+        if self._settings.enable_native_tool_approvals and routed.request.tools:
+            return None
+
+        input_tokens = self._token_counter(
+            routed.request.messages, routed.request.system, routed.request.tools
+        )
+        trace_event(
+            stage="routing",
+            event="free_claude_code.api.optimization.web_server_tool",
+            source="api",
+            model=routed.request.model,
+        )
+        egress = WebFetchEgressPolicy(
+            allow_private_network_targets=self._settings.web_fetch_allow_private_networks,
+            allowed_schemes=web_fetch_allowed_scheme_set(
+                self._settings.web_fetch_allowed_schemes
+            ),
+        )
+        return _MessagesStreamResult(
+            stream_web_server_tool_response(
+                routed.request,
+                input_tokens=input_tokens,
+                web_fetch_egress=egress,
+                verbose_client_errors=self._settings.log_api_error_tracebacks,
+            ),
+        )
+
+    def _intercept_local_optimization(
+        self, routed: RoutedMessagesRequest
+    ) -> _MessagesResult | None:
+        # Skip if native tool approvals enabled and request has tools
+        if self._settings.enable_native_tool_approvals and routed.request.tools:
+            return None
+        optimized = try_optimizations(routed.request, self._settings)
+        if optimized is None:
+            return None
+        trace_event(
+            stage="routing",
+            event="free_claude_code.api.optimization.short_circuit",
+            source="api",
+            model=routed.request.model,
+        )
+        return _MessagesCompleteResult(optimized)
+
+
+def _stream_error_fields(error: dict[str, object]) -> tuple[str, str]:
+    raw_type = error.get("type")
+    error_type = (
+        raw_type.strip()
+        if isinstance(raw_type, str) and raw_type.strip()
+        else "api_error"
+    )
+    raw_message = error.get("message")
+    message = (
+        raw_message.strip()
+        if isinstance(raw_message, str) and raw_message.strip()
+        else "Provider request failed unexpectedly."
+    )
+    return error_type, message

--- a/free_claude_code/api/handlers/responses.py
+++ b/free_claude_code/api/handlers/responses.py
@@ -1,0 +1,186 @@
+"""OpenAI Responses API product flow for Codex clients."""
+
+from collections.abc import Callable
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from free_claude_code.api.model_router import ModelRouter
+from free_claude_code.api.models.anthropic import MessagesRequest
+from free_claude_code.api.models.openai_responses import OpenAIResponsesRequest
+from free_claude_code.api.provider_execution import ProviderExecutionService
+from free_claude_code.api.request_errors import (
+    http_status_for_unexpected_api_exception,
+    log_unexpected_api_exception,
+    require_non_empty_messages,
+)
+from free_claude_code.api.request_ids import new_request_id
+from free_claude_code.api.response_streams import (
+    openai_responses_sse_streaming_response,
+    terminal_execution_error_response,
+)
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import get_user_facing_error_message
+from free_claude_code.core.openai_responses import OpenAIResponsesAdapter
+from free_claude_code.core.trace import trace_event
+from free_claude_code.providers.base import BaseProvider
+from free_claude_code.providers.exceptions import InvalidRequestError, ProviderError
+
+ProviderGetter = Callable[[str], BaseProvider]
+
+
+class ResponsesHandler:
+    """Handle streaming OpenAI Responses-compatible requests."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        provider_getter: ProviderGetter,
+        *,
+        model_router: ModelRouter | None = None,
+        responses_adapter: OpenAIResponsesAdapter | None = None,
+        provider_execution: ProviderExecutionService | None = None,
+    ) -> None:
+        self._settings = settings
+        self._model_router = model_router or ModelRouter(settings)
+        self._responses_adapter = responses_adapter or OpenAIResponsesAdapter()
+        self._provider_execution = provider_execution or ProviderExecutionService(
+            settings,
+            provider_getter,
+        )
+
+    async def create(
+        self, request_data: OpenAIResponsesRequest, *, request: Request
+    ) -> object:
+        """Create a streaming OpenAI Responses-compatible response."""
+        request_id = new_request_id()
+        request_payload = request_data.model_dump(mode="json", exclude_none=True)
+        if request_data.stream is False:
+            invalid_request = InvalidRequestError(
+                "FCC /v1/responses supports streaming only; omit stream or set stream=true."
+            )
+            return JSONResponse(
+                status_code=invalid_request.status_code,
+                content=self._responses_adapter.error_payload(
+                    message=invalid_request.message,
+                    error_type=invalid_request.error_type,
+                ),
+            )
+
+        try:
+            anthropic_payload = self._responses_adapter.to_anthropic_payload(
+                request_payload
+            )
+            response_request = MessagesRequest(**anthropic_payload)
+            require_non_empty_messages(response_request.messages)
+            routed = self._model_router.resolve_messages_request(response_request)
+
+            streamed = self._provider_execution.stream(
+                routed,
+                wire_api="responses",
+                raw_log_label="FULL_RESPONSES_PAYLOAD",
+                raw_log_payload=request_payload,
+                request_id=request_id,
+                request=request,
+            )
+            return await openai_responses_sse_streaming_response(
+                self._responses_adapter.iter_sse_from_anthropic(
+                    streamed,
+                    request_payload,
+                ),
+                headers=self._responses_adapter.sse_headers,
+                pre_start_error_response=lambda exc: self._pre_start_error_response(
+                    exc, request_id=request_id
+                ),
+            )
+        except OpenAIResponsesAdapter.ConversionError as exc:
+            invalid_request = InvalidRequestError(str(exc))
+            return JSONResponse(
+                status_code=invalid_request.status_code,
+                content=self._responses_adapter.error_payload(
+                    message=invalid_request.message,
+                    error_type=invalid_request.error_type,
+                ),
+            )
+        except ProviderError as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content=self._responses_adapter.error_payload(
+                    message=exc.message,
+                    error_type=exc.error_type,
+                ),
+            )
+        except Exception as exc:
+            log_unexpected_api_exception(
+                self._settings,
+                exc,
+                context="CREATE_RESPONSE_ERROR",
+            )
+            return JSONResponse(
+                status_code=http_status_for_unexpected_api_exception(exc),
+                content=self._responses_adapter.error_payload(
+                    message=get_user_facing_error_message(exc),
+                    error_type="api_error",
+                ),
+            )
+
+    def _pre_start_error_response(
+        self, exc: BaseException, *, request_id: str
+    ) -> JSONResponse:
+        if isinstance(exc, ProviderError):
+            self._trace_terminal_execution_error(
+                request_id=request_id,
+                status_code=exc.status_code,
+                error_type=exc.error_type,
+            )
+            return terminal_execution_error_response(
+                status_code=exc.status_code,
+                content=self._responses_adapter.error_payload(
+                    message=exc.message,
+                    error_type=exc.error_type,
+                ),
+            )
+        log_unexpected_api_exception(
+            self._settings,
+            exc,
+            context="CREATE_RESPONSE_STREAM_START_ERROR",
+            request_id=request_id,
+        )
+        status_code = http_status_for_unexpected_api_exception(exc)
+        self._trace_terminal_execution_error(
+            request_id=request_id,
+            status_code=status_code,
+            error_type="api_error",
+            exc_type=type(exc).__name__,
+        )
+        return terminal_execution_error_response(
+            status_code=status_code,
+            content=self._responses_adapter.error_payload(
+                message=get_user_facing_error_message(exc),
+                error_type="api_error",
+            ),
+        )
+
+    @staticmethod
+    def _trace_terminal_execution_error(
+        *,
+        request_id: str,
+        status_code: int,
+        error_type: str,
+        exc_type: str | None = None,
+    ) -> None:
+        fields: dict[str, object] = {
+            "wire_api": "responses",
+            "request_id": request_id,
+            "status_code": status_code,
+            "error_type": error_type,
+            "client_should_retry": False,
+        }
+        if exc_type is not None:
+            fields["exc_type"] = exc_type
+        trace_event(
+            stage="egress",
+            event="free_claude_code.api.response.terminal_execution_error",
+            source="api",
+            **fields,
+        )

--- a/free_claude_code/api/provider_execution.py
+++ b/free_claude_code/api/provider_execution.py
@@ -1,0 +1,126 @@
+"""Shared provider execution primitive for API product handlers."""
+
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+from fastapi import Request
+from loguru import logger
+
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import get_token_count
+from free_claude_code.core.trace import (
+    api_messages_request_snapshot,
+    trace_event,
+    traced_async_stream,
+)
+from free_claude_code.providers.base import BaseProvider
+
+from .model_router import RoutedMessagesRequest
+
+TokenCounter = Callable[[list[Any], str | list[Any] | None, list[Any] | None], int]
+ProviderGetter = Callable[[str], BaseProvider]
+
+
+class ProviderExecutionService:
+    """Resolve a provider and execute one routed Anthropic Messages stream."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        provider_getter: ProviderGetter,
+        *,
+        token_counter: TokenCounter = get_token_count,
+    ) -> None:
+        self._settings = settings
+        self._provider_getter = provider_getter
+        self._token_counter = token_counter
+
+    def stream(
+        self,
+        routed: RoutedMessagesRequest,
+        *,
+        wire_api: str,
+        raw_log_label: str,
+        raw_log_payload: Any,
+        request_id: str,
+        request: Request | None = None,
+    ) -> AsyncIterator[str]:
+        provider = self._provider_getter(routed.resolved.provider_id)
+        provider.preflight_stream(
+            routed.request,
+            thinking_enabled=routed.resolved.thinking_enabled,
+        )
+
+        route_trace: dict[str, Any] = {
+            "stage": "routing",
+            "event": "free_claude_code.api.route.resolved",
+            "source": "api",
+            "request_id": request_id,
+            "provider_id": routed.resolved.provider_id,
+            "provider_model": routed.resolved.provider_model,
+            "provider_model_ref": routed.resolved.provider_model_ref,
+            "gateway_model": routed.request.model,
+            "thinking_enabled": routed.resolved.thinking_enabled,
+        }
+        if wire_api == "responses":
+            route_trace["wire_api"] = "responses"
+        trace_event(**route_trace)
+
+        trace_event(
+            stage="ingress",
+            event=(
+                "free_claude_code.api.responses.request.received"
+                if wire_api == "responses"
+                else "free_claude_code.api.request.received"
+            ),
+            source="api",
+            message_count=len(routed.request.messages),
+            snapshot=api_messages_request_snapshot(routed.request),
+            request_id=request_id,
+        )
+
+        if self._settings.log_raw_api_payloads:
+            logger.debug(f"{raw_log_label} [{{}}]: {{}}", request_id, raw_log_payload)
+
+        input_tokens = self._token_counter(
+            routed.request.messages,
+            routed.request.system,
+            routed.request.tools,
+        )
+
+        client_host = None
+        if request is not None:
+            client_host = request.client.host if request.client else None
+
+        async def provider_body() -> AsyncIterator[str]:
+            async for chunk in provider.stream_response(
+                routed.request,
+                input_tokens=input_tokens,
+                request_id=request_id,
+                thinking_enabled=routed.resolved.thinking_enabled,
+                settings=self._settings,
+                client_host=client_host,
+            ):
+                yield chunk
+
+        return traced_async_stream(
+            provider_body(),
+            stage="egress",
+            source="api",
+            complete_event=(
+                "free_claude_code.api.responses.stream_completed"
+                if wire_api == "responses"
+                else "free_claude_code.api.response.stream_completed"
+            ),
+            interrupted_event=(
+                "free_claude_code.api.responses.stream_interrupted"
+                if wire_api == "responses"
+                else "free_claude_code.api.response.stream_interrupted"
+            ),
+            chunk_event=None,
+            extra={
+                "request_id": request_id,
+                "provider_id": routed.resolved.provider_id,
+                "gateway_model": routed.request.model,
+            },
+        )

--- a/free_claude_code/api/routes.py
+++ b/free_claude_code/api/routes.py
@@ -1,0 +1,181 @@
+"""FastAPI route handlers."""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from loguru import logger
+
+from free_claude_code.config.model_refs import parse_provider_type
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import get_token_count
+from free_claude_code.core.trace import trace_event
+
+from . import dependencies
+from .dependencies import get_settings, require_api_key
+from .handlers import MessagesHandler, ResponsesHandler, TokenCountHandler
+from .model_catalog import build_models_list_response
+from .models.anthropic import MessagesRequest, TokenCountRequest
+from .models.openai_responses import OpenAIResponsesRequest
+from .models.responses import ModelsListResponse
+from .request_ids import get_request_id
+
+router = APIRouter()
+
+
+def _provider_getter(request: Request, settings: Settings):
+    return lambda provider_type: dependencies.resolve_provider(
+        provider_type, app=request.app
+    )
+
+
+def get_messages_handler(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+) -> MessagesHandler:
+    """Build the Claude Messages product handler for route handlers."""
+    return MessagesHandler(
+        settings,
+        provider_getter=_provider_getter(request, settings),
+        token_counter=get_token_count,
+    )
+
+
+def get_responses_handler(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+) -> ResponsesHandler:
+    """Build the OpenAI Responses product handler for route handlers."""
+    return ResponsesHandler(
+        settings,
+        provider_getter=_provider_getter(request, settings),
+    )
+
+
+def get_token_count_handler(
+    settings: Settings = Depends(get_settings),
+) -> TokenCountHandler:
+    """Build the token-count product handler for route handlers."""
+    return TokenCountHandler(settings, token_counter=get_token_count)
+
+
+def _probe_response(allow: str) -> Response:
+    """Return an empty success response for compatibility probes."""
+    return Response(status_code=204, headers={"Allow": allow})
+
+
+# =============================================================================
+# Routes
+# =============================================================================
+@router.post("/v1/messages")
+async def create_message(
+    request: Request,
+    request_data: MessagesRequest,
+    handler: MessagesHandler = Depends(get_messages_handler),
+    _auth=Depends(require_api_key),
+):
+    """Create a message (streaming by default; stream=false gets aggregated JSON)."""
+    return await handler.create(request_data, request=request)
+
+
+@router.api_route("/v1/messages", methods=["HEAD", "OPTIONS"])
+async def probe_messages(_auth=Depends(require_api_key)):
+    """Respond to Claude compatibility probes for the messages endpoint."""
+    return _probe_response("POST, HEAD, OPTIONS")
+
+
+@router.post("/v1/responses")
+async def create_response(
+    request: Request,
+    request_data: OpenAIResponsesRequest,
+    handler: ResponsesHandler = Depends(get_responses_handler),
+    _auth=Depends(require_api_key),
+):
+    """Create an OpenAI Responses-compatible response through this proxy."""
+    return await handler.create(request_data, request=request)
+
+
+@router.api_route("/v1/responses", methods=["HEAD", "OPTIONS"])
+async def probe_responses(_auth=Depends(require_api_key)):
+    """Respond to OpenAI Responses compatibility probes."""
+    return _probe_response("POST, HEAD, OPTIONS")
+
+
+@router.post("/v1/messages/count_tokens")
+async def count_tokens(
+    request: Request,
+    request_data: TokenCountRequest,
+    handler: TokenCountHandler = Depends(get_token_count_handler),
+    _auth=Depends(require_api_key),
+):
+    """Count tokens for a request."""
+    return handler.count(request_data, request_id=get_request_id(request))
+
+
+@router.api_route("/v1/messages/count_tokens", methods=["HEAD", "OPTIONS"])
+async def probe_count_tokens(_auth=Depends(require_api_key)):
+    """Respond to Claude compatibility probes for the token count endpoint."""
+    return _probe_response("POST, HEAD, OPTIONS")
+
+
+@router.get("/")
+async def root(
+    settings: Settings = Depends(get_settings), _auth=Depends(require_api_key)
+):
+    """Root endpoint."""
+    return {
+        "status": "ok",
+        "provider": parse_provider_type(settings.model),
+        "model": settings.model,
+    }
+
+
+@router.api_route("/", methods=["HEAD", "OPTIONS"])
+async def probe_root():
+    """Respond to unauthenticated local compatibility probes for the root endpoint."""
+    return _probe_response("GET, HEAD, OPTIONS")
+
+
+@router.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "healthy"}
+
+
+@router.api_route("/health", methods=["HEAD", "OPTIONS"])
+async def probe_health():
+    """Respond to compatibility probes for the health endpoint."""
+    return _probe_response("GET, HEAD, OPTIONS")
+
+
+@router.get("/v1/models", response_model=ModelsListResponse)
+async def list_models(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    _auth=Depends(require_api_key),
+):
+    """List the model ids this proxy advertises to Claude-compatible clients."""
+    trace_event(stage="ingress", event="free_claude_code.api.models.list", source="api")
+    provider_runtime = dependencies.maybe_provider_runtime(request.app)
+    return build_models_list_response(settings, provider_runtime)
+
+
+@router.post("/stop")
+async def stop_cli(request: Request, _auth=Depends(require_api_key)):
+    """Stop all CLI sessions and pending tasks."""
+    workflow = getattr(request.app.state, "messaging_workflow", None)
+    if not workflow:
+        # Fallback if messaging not initialized
+        cli_manager = getattr(request.app.state, "cli_manager", None)
+        if cli_manager:
+            await cli_manager.stop_all()
+            logger.info("STOP_CLI: source=cli_manager cancelled_count=N/A")
+            return {"status": "stopped", "source": "cli_manager"}
+        raise HTTPException(status_code=503, detail="Messaging system not initialized")
+
+    count = await workflow.stop_all_tasks()
+    trace_event(
+        stage="ingress",
+        event="free_claude_code.api.cli.stop_via_messaging_workflow",
+        source="api",
+        cancelled_nodes=count,
+    )
+    logger.info("STOP_CLI: source=messaging_workflow cancelled_count={}", count)
+    return {"status": "stopped", "cancelled_count": count}

--- a/free_claude_code/config/settings.py
+++ b/free_claude_code/config/settings.py
@@ -1,0 +1,452 @@
+"""Flat application settings schema loaded by Pydantic Settings."""
+
+from functools import lru_cache
+from typing import Any
+
+from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .constants import HTTP_CONNECT_TIMEOUT_DEFAULT
+from .env_files import (
+    ANTHROPIC_AUTH_TOKEN_ENV,
+    env_file_override,
+    settings_env_files,
+)
+from .nim import NimSettings
+from .provider_ids import SUPPORTED_PROVIDER_IDS
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    # ==================== OpenRouter Config ====================
+    open_router_api_key: str = Field(default="", validation_alias="OPENROUTER_API_KEY")
+
+    # ==================== Mistral La Plateforme ====================
+    mistral_api_key: str = Field(default="", validation_alias="MISTRAL_API_KEY")
+
+    # ==================== Mistral Codestral (codestral.mistral.ai) ====================
+    codestral_api_key: str = Field(default="", validation_alias="CODESTRAL_API_KEY")
+
+    # ==================== DeepSeek Config ====================
+    deepseek_api_key: str = Field(default="", validation_alias="DEEPSEEK_API_KEY")
+
+    # ==================== Kimi Config ====================
+    kimi_api_key: str = Field(default="", validation_alias="KIMI_API_KEY")
+
+    # ==================== Wafer Config ====================
+    wafer_api_key: str = Field(default="", validation_alias="WAFER_API_KEY")
+
+    # ==================== MiniMax Config ====================
+    minimax_api_key: str = Field(default="", validation_alias="MINIMAX_API_KEY")
+
+    # ==================== OpenCode Zen / OpenCode Go ====================
+    # Same key from opencode.ai/auth; zen uses prefix ``opencode/``, Go uses ``opencode_go/``.
+    opencode_api_key: str = Field(default="", validation_alias="OPENCODE_API_KEY")
+
+    # ==================== Vercel AI Gateway ====================
+    vercel_ai_gateway_api_key: str = Field(
+        default="", validation_alias="AI_GATEWAY_API_KEY"
+    )
+
+    # ==================== Hugging Face Inference Providers ====================
+    huggingface_api_key: str = Field(default="", validation_alias="HUGGINGFACE_API_KEY")
+
+    # ==================== Cohere Compatibility API ====================
+    cohere_api_key: str = Field(default="", validation_alias="COHERE_API_KEY")
+
+    # ==================== GitHub Models ====================
+    github_models_token: str = Field(default="", validation_alias="GITHUB_MODELS_TOKEN")
+
+    # ==================== SambaNova Cloud ====================
+    sambanova_api_key: str = Field(default="", validation_alias="SAMBANOVA_API_KEY")
+
+    # ==================== Z.ai Config ====================
+    zai_api_key: str = Field(default="", validation_alias="ZAI_API_KEY")
+
+    # ==================== Fireworks AI Config ====================
+    fireworks_api_key: str = Field(default="", validation_alias="FIREWORKS_API_KEY")
+
+    # ==================== Cloudflare Workers AI Config ====================
+    cloudflare_api_token: str = Field(
+        default="", validation_alias="CLOUDFLARE_API_TOKEN"
+    )
+    cloudflare_account_id: str = Field(
+        default="", validation_alias="CLOUDFLARE_ACCOUNT_ID"
+    )
+
+    # ==================== Google Gemini (Google AI Studio) ====================
+    gemini_api_key: str = Field(default="", validation_alias="GEMINI_API_KEY")
+
+    # ==================== Groq (OpenAI-compatible) ====================
+    groq_api_key: str = Field(default="", validation_alias="GROQ_API_KEY")
+
+    # ==================== Cerebras Inference (OpenAI-compatible) ====================
+    cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
+
+    # ==================== Messaging Platform Selection ====================
+    # Valid: "telegram" | "discord" | "none"
+    messaging_platform: str = Field(
+        default="discord", validation_alias="MESSAGING_PLATFORM"
+    )
+    messaging_rate_limit: int = Field(
+        default=1, validation_alias="MESSAGING_RATE_LIMIT"
+    )
+    messaging_rate_window: float = Field(
+        default=1.0, validation_alias="MESSAGING_RATE_WINDOW"
+    )
+
+    # ==================== NVIDIA NIM Config ====================
+    nvidia_nim_api_key: str = ""
+
+    # ==================== LM Studio Config ====================
+    lm_studio_base_url: str = Field(
+        default="http://localhost:1234/v1",
+        validation_alias="LM_STUDIO_BASE_URL",
+    )
+
+    # ==================== Llama.cpp Config ====================
+    llamacpp_base_url: str = Field(
+        default="http://localhost:8080/v1",
+        validation_alias="LLAMACPP_BASE_URL",
+    )
+
+    # ==================== Ollama Config ====================
+    ollama_base_url: str = Field(
+        default="http://localhost:11434",
+        validation_alias="OLLAMA_BASE_URL",
+    )
+
+    # ==================== Model ====================
+    # All Claude model requests are mapped to this single model (fallback)
+    # Format: provider_type/model/name
+    model: str = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
+
+    # Per-model overrides (optional, falls back to MODEL)
+    # Each can use a different provider
+    model_opus: str | None = Field(default=None, validation_alias="MODEL_OPUS")
+    model_sonnet: str | None = Field(default=None, validation_alias="MODEL_SONNET")
+    model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
+
+    # ==================== Per-Provider Proxy ====================
+    nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
+    open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
+    mistral_proxy: str = Field(default="", validation_alias="MISTRAL_PROXY")
+    codestral_proxy: str = Field(default="", validation_alias="CODESTRAL_PROXY")
+    lmstudio_proxy: str = Field(default="", validation_alias="LMSTUDIO_PROXY")
+    llamacpp_proxy: str = Field(default="", validation_alias="LLAMACPP_PROXY")
+    kimi_proxy: str = Field(default="", validation_alias="KIMI_PROXY")
+    wafer_proxy: str = Field(default="", validation_alias="WAFER_PROXY")
+    minimax_proxy: str = Field(default="", validation_alias="MINIMAX_PROXY")
+    opencode_proxy: str = Field(default="", validation_alias="OPENCODE_PROXY")
+    opencode_go_proxy: str = Field(default="", validation_alias="OPENCODE_GO_PROXY")
+    vercel_ai_gateway_proxy: str = Field(
+        default="", validation_alias="VERCEL_AI_GATEWAY_PROXY"
+    )
+    huggingface_proxy: str = Field(default="", validation_alias="HUGGINGFACE_PROXY")
+    cohere_proxy: str = Field(default="", validation_alias="COHERE_PROXY")
+    github_models_proxy: str = Field(default="", validation_alias="GITHUB_MODELS_PROXY")
+    sambanova_proxy: str = Field(default="", validation_alias="SAMBANOVA_PROXY")
+    zai_proxy: str = Field(default="", validation_alias="ZAI_PROXY")
+    fireworks_proxy: str = Field(default="", validation_alias="FIREWORKS_PROXY")
+    cloudflare_proxy: str = Field(default="", validation_alias="CLOUDFLARE_PROXY")
+    gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")
+    groq_proxy: str = Field(default="", validation_alias="GROQ_PROXY")
+    cerebras_proxy: str = Field(default="", validation_alias="CEREBRAS_PROXY")
+
+    # ==================== Provider Rate Limiting ====================
+    provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")
+    provider_rate_window: int = Field(
+        default=60, validation_alias="PROVIDER_RATE_WINDOW"
+    )
+    provider_max_concurrency: int = Field(
+        default=5, validation_alias="PROVIDER_MAX_CONCURRENCY"
+    )
+    enable_model_thinking: bool = Field(
+        default=True, validation_alias="ENABLE_MODEL_THINKING"
+    )
+    enable_opus_thinking: bool | None = Field(
+        default=None, validation_alias="ENABLE_OPUS_THINKING"
+    )
+    enable_sonnet_thinking: bool | None = Field(
+        default=None, validation_alias="ENABLE_SONNET_THINKING"
+    )
+    enable_haiku_thinking: bool | None = Field(
+        default=None, validation_alias="ENABLE_HAIKU_THINKING"
+    )
+
+    # ==================== HTTP Client Timeouts ====================
+    http_read_timeout: float = Field(
+        default=120.0, validation_alias="HTTP_READ_TIMEOUT"
+    )
+    http_write_timeout: float = Field(
+        default=10.0, validation_alias="HTTP_WRITE_TIMEOUT"
+    )
+    http_connect_timeout: float = Field(
+        default=HTTP_CONNECT_TIMEOUT_DEFAULT,
+        validation_alias="HTTP_CONNECT_TIMEOUT",
+    )
+
+    # ==================== Fast Prefix Detection ====================
+    fast_prefix_detection: bool = True
+
+    # ==================== Native Tool Approvals ====================
+    # When true (default), skip FCC auto-intercepts and let Desktop drive the tool approval loop.
+    enable_native_tool_approvals: bool = Field(
+        default=True, validation_alias="ENABLE_NATIVE_TOOL_APPROVALS"
+    )
+
+    # ==================== MCP Integration ====================
+    # When true, enable MCP (Model Context Protocol) server integration.
+    # Defaults to False to avoid extra dependency unless explicitly enabled.
+    enable_mcp: bool = Field(default=False, validation_alias="ENABLE_MCP")
+
+    # ==================== Optimizations ====================
+    enable_network_probe_mock: bool = True
+    enable_title_generation_skip: bool = True
+    enable_suggestion_mode_skip: bool = True
+    enable_filepath_extraction_mock: bool = True
+
+    # ==================== Local web server tools (web_search / web_fetch) ====================
+    # Off by default: these tools perform outbound HTTP from the proxy (SSRF risk).
+    enable_web_server_tools: bool = Field(
+        default=False, validation_alias="ENABLE_WEB_SERVER_TOOLS"
+    )
+    # Comma-separated URL schemes allowed for web_fetch (default: http,https).
+    web_fetch_allowed_schemes: str = Field(
+        default="http,https", validation_alias="WEB_FETCH_ALLOWED_SCHEMES"
+    )
+
+    # ==================== Tool Approval Policy (FCC-side gating) ====================
+    # Valid values: "off" | "localhost_only" | "deny_cowork". Defers to Desktop's
+    # own gate (``enable_native_tool_approvals=True``) by default; opt in only
+    # when explicitly configured. Stored as ``str`` (validated softly) so an
+    # unknown value falls back to ``off`` rather than rejecting the whole
+    # Settings load; ``build_policy`` also warns on unknown values.
+    tool_approval_policy: str = Field(
+        default="off",
+        validation_alias=AliasChoices("TOOL_APPROVAL_POLICY", "tool_approval_policy"),
+    )
+    mcp_tool_allowlist: list[str] = Field(
+        default_factory=list, validation_alias="MCP_TOOL_ALLOWLIST"
+    )
+    mcp_tool_denylist: list[str] = Field(
+        default_factory=list, validation_alias="MCP_TOOL_DENYLIST"
+    )
+    # When true, skip private/loopback/link-local IP blocking for web_fetch (lab only).
+    web_fetch_allow_private_networks: bool = Field(
+        default=False, validation_alias="WEB_FETCH_ALLOW_PRIVATE_NETWORKS"
+    )
+
+    # ==================== Debug / diagnostic logging (avoid sensitive content) ====================
+    # When false (default), API and SSE helpers log only metadata (counts, lengths, ids).
+    log_raw_api_payloads: bool = Field(
+        default=False, validation_alias="LOG_RAW_API_PAYLOADS"
+    )
+    log_raw_sse_events: bool = Field(
+        default=False, validation_alias="LOG_RAW_SSE_EVENTS"
+    )
+    # When false (default), unhandled exceptions log only type + route metadata (no message/traceback).
+    log_api_error_tracebacks: bool = Field(
+        default=False, validation_alias="LOG_API_ERROR_TRACEBACKS"
+    )
+    # When false (default), messaging logs omit text/transcription previews (metadata only).
+    log_raw_messaging_content: bool = Field(
+        default=False, validation_alias="LOG_RAW_MESSAGING_CONTENT"
+    )
+    # When true, log full Claude CLI stderr, non-JSON lines, and parser error text.
+    log_raw_cli_diagnostics: bool = Field(
+        default=False, validation_alias="LOG_RAW_CLI_DIAGNOSTICS"
+    )
+    # When true, log exception text / CLI error strings in messaging (may leak user content).
+    log_messaging_error_details: bool = Field(
+        default=False, validation_alias="LOG_MESSAGING_ERROR_DETAILS"
+    )
+    debug_platform_edits: bool = Field(
+        default=False, validation_alias="DEBUG_PLATFORM_EDITS"
+    )
+    debug_subagent_stack: bool = Field(
+        default=False, validation_alias="DEBUG_SUBAGENT_STACK"
+    )
+
+    # ==================== NIM Settings ====================
+    nim: NimSettings = Field(default_factory=NimSettings)
+
+    # ==================== Voice Note Transcription ====================
+    voice_note_enabled: bool = Field(
+        default=True, validation_alias="VOICE_NOTE_ENABLED"
+    )
+    # Device: "cpu" | "cuda" | "nvidia_nim"
+    # - "cpu"/"cuda": local Whisper (requires voice_local extra: uv sync --extra voice_local)
+    # - "nvidia_nim": NVIDIA NIM Whisper API (requires voice extra: uv sync --extra voice)
+    whisper_device: str = Field(default="cpu", validation_alias="WHISPER_DEVICE")
+    # Whisper model ID or short name (for local Whisper) or NVIDIA NIM model (for nvidia_nim)
+    # Local Whisper: "tiny", "base", "small", "medium", "large-v2", "large-v3", "large-v3-turbo"
+    # NVIDIA NIM: "nvidia/parakeet-ctc-1.1b-asr", "openai/whisper-large-v3", etc.
+    whisper_model: str = Field(default="base", validation_alias="WHISPER_MODEL")
+    # ==================== Bot Wrapper Config ====================
+    telegram_bot_token: str | None = None
+    allowed_telegram_user_id: str | None = None
+    telegram_proxy_url: str = Field(default="", validation_alias="TELEGRAM_PROXY_URL")
+    discord_bot_token: str | None = Field(
+        default=None, validation_alias="DISCORD_BOT_TOKEN"
+    )
+    allowed_discord_channels: str | None = Field(
+        default=None, validation_alias="ALLOWED_DISCORD_CHANNELS"
+    )
+    allowed_dir: str = ""
+    max_message_log_entries_per_chat: int | None = Field(
+        default=None, validation_alias="MAX_MESSAGE_LOG_ENTRIES_PER_CHAT"
+    )
+
+    # ==================== Server ====================
+    host: str = "0.0.0.0"
+    port: int = 8082
+    # Optional server API key to protect endpoints (Anthropic-style)
+    # Set via env `ANTHROPIC_AUTH_TOKEN`. When empty, no auth is required.
+    anthropic_auth_token: str = Field(
+        default="", validation_alias="ANTHROPIC_AUTH_TOKEN"
+    )
+
+    # Handle empty strings for optional string fields
+    @field_validator("tool_approval_policy")
+    @classmethod
+    def validate_tool_approval_policy(cls, v: str) -> str:
+        if v not in ("off", "localhost_only", "deny_cowork"):
+            # Warn but accept; build_policy() will degrade to OffPolicy there.
+            from loguru import logger as _logger
+
+            _logger.warning("Unknown TOOL_APPROVAL_POLICY={!r}; degrading to 'off'", v)
+            return "off"
+        return v
+
+    @field_validator(
+        "telegram_bot_token",
+        "allowed_telegram_user_id",
+        "discord_bot_token",
+        "allowed_discord_channels",
+        "model_opus",
+        "model_sonnet",
+        "model_haiku",
+        "enable_opus_thinking",
+        "enable_sonnet_thinking",
+        "enable_haiku_thinking",
+        mode="before",
+    )
+    @classmethod
+    def parse_optional_str(cls, v: Any) -> Any:
+        if v == "":
+            return None
+        return v
+
+    @field_validator("max_message_log_entries_per_chat", mode="before")
+    @classmethod
+    def parse_optional_log_cap(cls, v: Any) -> Any:
+        if v == "" or v is None:
+            return None
+        return v
+
+    @field_validator("whisper_device")
+    @classmethod
+    def validate_whisper_device(cls, v: str) -> str:
+        if v not in ("cpu", "cuda", "nvidia_nim"):
+            raise ValueError(
+                f"whisper_device must be 'cpu', 'cuda', or 'nvidia_nim', got {v!r}"
+            )
+        return v
+
+    @field_validator("messaging_platform")
+    @classmethod
+    def validate_messaging_platform(cls, v: str) -> str:
+        if v not in ("telegram", "discord", "none"):
+            raise ValueError(
+                f"messaging_platform must be 'telegram', 'discord', or 'none', got {v!r}"
+            )
+        return v
+
+    @field_validator("messaging_rate_limit")
+    @classmethod
+    def validate_messaging_rate_limit(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("messaging_rate_limit must be > 0")
+        return v
+
+    @field_validator("messaging_rate_window")
+    @classmethod
+    def validate_messaging_rate_window(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("messaging_rate_window must be > 0")
+        return float(v)
+
+    @field_validator("web_fetch_allowed_schemes")
+    @classmethod
+    def validate_web_fetch_allowed_schemes(cls, v: str) -> str:
+        schemes = [part.strip().lower() for part in v.split(",") if part.strip()]
+        if not schemes:
+            raise ValueError("web_fetch_allowed_schemes must list at least one scheme")
+        for scheme in schemes:
+            if not scheme.isascii() or not scheme.isalpha():
+                raise ValueError(
+                    f"Invalid URL scheme in web_fetch_allowed_schemes: {scheme!r}"
+                )
+        return ",".join(schemes)
+
+    @field_validator("ollama_base_url")
+    @classmethod
+    def validate_ollama_base_url(cls, v: str) -> str:
+        if v.rstrip("/").endswith("/v1"):
+            raise ValueError(
+                "OLLAMA_BASE_URL must be the Ollama root URL for native Anthropic "
+                "messages, e.g. http://localhost:11434 (without /v1)."
+            )
+        return v
+
+    @field_validator("model", "model_opus", "model_sonnet", "model_haiku")
+    @classmethod
+    def validate_model_format(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if "/" not in v:
+            raise ValueError(
+                f"Model must be prefixed with provider type. "
+                f"Valid providers: {', '.join(SUPPORTED_PROVIDER_IDS)}. "
+                f"Format: provider_type/model/name"
+            )
+        provider = v.split("/", 1)[0]
+        if provider not in SUPPORTED_PROVIDER_IDS:
+            supported = ", ".join(f"'{p}'" for p in SUPPORTED_PROVIDER_IDS)
+            raise ValueError(f"Invalid provider: '{provider}'. Supported: {supported}")
+        return v
+
+    @model_validator(mode="after")
+    def check_nvidia_nim_api_key(self) -> Settings:
+        if (
+            self.voice_note_enabled
+            and self.whisper_device == "nvidia_nim"
+            and not self.nvidia_nim_api_key.strip()
+        ):
+            raise ValueError(
+                "NVIDIA_NIM_API_KEY is required when WHISPER_DEVICE is 'nvidia_nim'. "
+                "Set it in your .env file."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def prefer_dotenv_anthropic_auth_token(self) -> Settings:
+        """Let explicit .env auth config override stale shell/client tokens."""
+        dotenv_value = env_file_override(self.model_config, ANTHROPIC_AUTH_TOKEN_ENV)
+        if dotenv_value is not None:
+            self.anthropic_auth_token = dotenv_value
+        return self
+
+    model_config = SettingsConfigDict(
+        env_file=settings_env_files(),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Get cached settings instance."""
+    return Settings()

--- a/free_claude_code/core/anthropic/streaming/ledger.py
+++ b/free_claude_code/core/anthropic/streaming/ledger.py
@@ -1,0 +1,717 @@
+"""Anthropic stream state ledger."""
+
+import hashlib
+import json
+import uuid
+from collections.abc import Iterator, Mapping
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+from free_claude_code.core.anthropic.errors import anthropic_error_payload
+from free_claude_code.core.anthropic.stream_contracts import SSEEvent
+
+from .emitter import AnthropicSseEmitter
+from .recovery import (
+    ToolSchema,
+    accept_tool_json_repair,
+    continuation_suffix,
+    parse_complete_tool_input,
+)
+
+try:
+    import tiktoken
+
+    ENCODER = tiktoken.get_encoding("cl100k_base")
+except Exception:
+    ENCODER = None
+
+
+def _safe_usage_int(value: object) -> int:
+    return value if isinstance(value, int) else 0
+
+
+@dataclass
+class ToolBlockState:
+    """State for one streamed tool call."""
+
+    block_index: int
+    tool_id: str
+    name: str
+    extra_content: dict[str, Any] | None = None
+    started: bool = False
+    task_arg_buffer: str = ""
+    task_args_emitted: bool = False
+    pre_start_args: str = ""
+
+
+@dataclass
+class StreamBlockState:
+    """Tracked downstream Anthropic content block."""
+
+    index: int
+    block_type: str
+    open: bool = True
+    tool_id: str = ""
+    name: str = ""
+    parts: list[str] = field(default_factory=list)
+    extra_content: dict[str, Any] | None = None
+
+    @property
+    def content(self) -> str:
+        return "".join(self.parts)
+
+
+@dataclass
+class StreamBlockLedger:
+    """Allocate and track Anthropic content block indexes."""
+
+    next_index: int = 0
+    thinking_index: int = -1
+    text_index: int = -1
+    thinking_started: bool = False
+    text_started: bool = False
+    tool_states: dict[int, ToolBlockState] = field(default_factory=dict)
+
+    def allocate_index(self) -> int:
+        idx = self.next_index
+        self.next_index += 1
+        return idx
+
+    def reserve_index(self, index: int) -> None:
+        self.next_index = max(self.next_index, index + 1)
+
+    def ensure_tool_state(self, index: int) -> ToolBlockState:
+        if index not in self.tool_states:
+            self.tool_states[index] = ToolBlockState(
+                block_index=-1, tool_id="", name=""
+            )
+        return self.tool_states[index]
+
+    def set_stream_tool_id(self, index: int, tool_id: str | None) -> None:
+        if not tool_id:
+            return
+        self.ensure_tool_state(index).tool_id = str(tool_id)
+
+    def set_tool_extra_content(
+        self, index: int, extra_content: dict[str, Any] | None
+    ) -> None:
+        if extra_content:
+            self.ensure_tool_state(index).extra_content = extra_content
+
+    def register_tool_name(self, index: int, name: str) -> None:
+        if index not in self.tool_states:
+            self.tool_states[index] = ToolBlockState(
+                block_index=-1, tool_id="", name=name
+            )
+            return
+        state = self.tool_states[index]
+        prev = state.name
+        if not prev or name.startswith(prev):
+            state.name = name
+        elif not prev.startswith(name):
+            state.name = prev + name
+
+    def buffer_task_args(self, index: int, args: str) -> dict[str, Any] | None:
+        state = self.tool_states.get(index)
+        if state is None or state.task_args_emitted:
+            return None
+
+        state.task_arg_buffer += args
+        try:
+            args_json = json.loads(state.task_arg_buffer)
+        except Exception:
+            return None
+        if not isinstance(args_json, dict):
+            return None
+
+        _normalize_task_run_in_background(args_json)
+        state.task_args_emitted = True
+        state.task_arg_buffer = ""
+        return args_json
+
+    def flush_task_arg_buffers(self) -> list[tuple[int, str]]:
+        results: list[tuple[int, str]] = []
+        for tool_index, state in list(self.tool_states.items()):
+            if not state.task_arg_buffer or state.task_args_emitted:
+                continue
+
+            out = "{}"
+            try:
+                args_json = json.loads(state.task_arg_buffer)
+                if isinstance(args_json, dict):
+                    _normalize_task_run_in_background(args_json)
+                    out = json.dumps(args_json)
+            except (json.JSONDecodeError, TypeError, ValueError) as exc:
+                digest = hashlib.sha256(
+                    state.task_arg_buffer.encode("utf-8", errors="replace")
+                ).hexdigest()[:16]
+                logger.warning(
+                    "Task args invalid JSON (id={} len={} buffer_sha256_prefix={}): {}",
+                    state.tool_id or "unknown",
+                    len(state.task_arg_buffer),
+                    digest,
+                    exc,
+                )
+
+            state.task_args_emitted = True
+            state.task_arg_buffer = ""
+            results.append((tool_index, out))
+        return results
+
+
+class AnthropicStreamLedger:
+    """Own mutable Anthropic stream state and produce serialized SSE events."""
+
+    def __init__(
+        self,
+        message_id: str | None,
+        model: str,
+        input_tokens: int = 0,
+        *,
+        log_raw_events: bool = False,
+    ) -> None:
+        self.message_id = message_id or f"msg_{uuid.uuid4()}"
+        self.model = model
+        self.input_tokens = input_tokens
+        self.blocks = StreamBlockLedger()
+        self._emitter = AnthropicSseEmitter(log_raw_events=log_raw_events)
+        self._text_parts: list[str] = []
+        self._thinking_parts: list[str] = []
+        self._open_stack: list[int] = []
+        self._content_blocks: dict[int, StreamBlockState] = {}
+        self.message_started = False
+        self.message_stopped = False
+        self.stop_reason: str | None = None
+
+    def message_start(self) -> str:
+        self.message_started = True
+        safe_input = _safe_usage_int(self.input_tokens)
+        return self._emitter.event(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": self.message_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": self.model,
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": safe_input, "output_tokens": 1},
+                },
+            },
+        )
+
+    def message_delta(
+        self,
+        stop_reason: str,
+        output_tokens: int | None,
+        *,
+        input_tokens: int | None = None,
+        usage_fields: Mapping[str, int] | None = None,
+    ) -> str:
+        self.stop_reason = stop_reason
+        safe_in = _safe_usage_int(
+            self.input_tokens if input_tokens is None else input_tokens
+        )
+        safe_out = output_tokens if isinstance(output_tokens, int) else 0
+        usage = {"input_tokens": safe_in, "output_tokens": safe_out}
+        if usage_fields:
+            usage.update(
+                {
+                    key: value
+                    for key, value in usage_fields.items()
+                    if isinstance(value, int)
+                }
+            )
+        return self._emitter.event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": usage,
+            },
+        )
+
+    def message_stop(self) -> str:
+        self.message_stopped = True
+        return self._emitter.event("message_stop", {"type": "message_stop"})
+
+    def content_block_start(self, index: int, block_type: str, **kwargs: Any) -> str:
+        content_block: dict[str, Any] = {"type": block_type}
+        if block_type == "thinking":
+            content_block["thinking"] = kwargs.get("thinking", "")
+        elif block_type == "text":
+            content_block["text"] = kwargs.get("text", "")
+        elif block_type == "tool_use":
+            content_block["id"] = kwargs.get("id", "")
+            content_block["name"] = kwargs.get("name", "")
+            content_block["input"] = kwargs.get("input", {})
+            extra_content = kwargs.get("extra_content")
+            if isinstance(extra_content, dict) and extra_content:
+                content_block["extra_content"] = extra_content
+        elif block_type == "tool_result":
+            content_block["tool_use_id"] = kwargs.get("tool_use_id", "")
+            content_block["content"] = kwargs.get("content", "")
+            content_block["is_error"] = bool(kwargs.get("is_error", False))
+        elif block_type == "redacted_thinking":
+            data = kwargs.get("data")
+            if isinstance(data, str):
+                content_block["data"] = data
+
+        self._record_block_start(index, content_block)
+        return self._emitter.event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": index,
+                "content_block": content_block,
+            },
+        )
+
+    def content_block_delta(self, index: int, delta_type: str, content: str) -> str:
+        delta: dict[str, Any] = {"type": delta_type}
+        if delta_type == "thinking_delta":
+            delta["thinking"] = content
+        elif delta_type == "signature_delta":
+            delta["signature"] = content
+        elif delta_type == "text_delta":
+            delta["text"] = content
+        elif delta_type == "input_json_delta":
+            delta["partial_json"] = content
+
+        self._record_block_delta(index, delta)
+        return self._emitter.event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": index,
+                "delta": delta,
+            },
+        )
+
+    def content_block_stop(self, index: int) -> str:
+        self._record_block_stop(index)
+        return self._emitter.event(
+            "content_block_stop",
+            {"type": "content_block_stop", "index": index},
+        )
+
+    def start_thinking_block(self) -> str:
+        self.blocks.thinking_index = self.blocks.allocate_index()
+        self.blocks.thinking_started = True
+        return self.content_block_start(self.blocks.thinking_index, "thinking")
+
+    def emit_thinking_delta(self, content: str) -> str:
+        return self.content_block_delta(
+            self.blocks.thinking_index, "thinking_delta", content
+        )
+
+    def stop_thinking_block(self) -> str:
+        self.blocks.thinking_started = False
+        return self.content_block_stop(self.blocks.thinking_index)
+
+    def start_text_block(self) -> str:
+        self.blocks.text_index = self.blocks.allocate_index()
+        self.blocks.text_started = True
+        return self.content_block_start(self.blocks.text_index, "text")
+
+    def emit_text_delta(self, content: str) -> str:
+        return self.content_block_delta(self.blocks.text_index, "text_delta", content)
+
+    def stop_text_block(self) -> str:
+        self.blocks.text_started = False
+        return self.content_block_stop(self.blocks.text_index)
+
+    def start_tool_block(
+        self,
+        tool_index: int,
+        tool_id: str,
+        name: str,
+        *,
+        extra_content: dict[str, Any] | None = None,
+    ) -> str:
+        block_idx = self.blocks.allocate_index()
+        if tool_index in self.blocks.tool_states:
+            state = self.blocks.tool_states[tool_index]
+            state.block_index = block_idx
+            state.tool_id = tool_id
+            state.name = name
+            if extra_content:
+                state.extra_content = extra_content
+            state.started = True
+        else:
+            self.blocks.tool_states[tool_index] = ToolBlockState(
+                block_index=block_idx,
+                tool_id=tool_id,
+                name=name,
+                extra_content=extra_content,
+                started=True,
+            )
+        return self.content_block_start(
+            block_idx,
+            "tool_use",
+            id=tool_id,
+            name=name,
+            extra_content=extra_content,
+        )
+
+    def emit_tool_delta(self, tool_index: int, partial_json: str) -> str:
+        state = self.blocks.tool_states[tool_index]
+        return self.content_block_delta(
+            state.block_index, "input_json_delta", partial_json
+        )
+
+    def stop_tool_block(self, tool_index: int) -> str:
+        return self.content_block_stop(self.blocks.tool_states[tool_index].block_index)
+
+    def emit_tool_result_block(
+        self,
+        *,
+        tool_use_id: str,
+        content: Any,
+        is_error: bool = False,
+    ) -> Iterator[str]:
+        """Emit a sibling ``tool_result`` content block tied to a prior ``tool_use``.
+
+        Yields ``content_block_start {type: tool_result, ...}``, an empty text
+        delta (matches Anthropic SSE expectations for hybrid tool_use streams),
+        and ``content_block_stop``.
+        """
+        block_idx = self.blocks.allocate_index()
+        yield self.content_block_start(
+            block_idx,
+            "tool_result",
+            tool_use_id=tool_use_id,
+            content=content,
+            is_error=is_error,
+        )
+        yield self.content_block_delta(block_idx, "text_delta", "")
+        yield self.content_block_stop(block_idx)
+
+    def ensure_thinking_block(self) -> Iterator[str]:
+        if self.blocks.text_started:
+            yield self.stop_text_block()
+        if not self.blocks.thinking_started:
+            yield self.start_thinking_block()
+
+    def ensure_text_block(self) -> Iterator[str]:
+        if self.blocks.thinking_started:
+            yield self.stop_thinking_block()
+        if not self.blocks.text_started:
+            yield self.start_text_block()
+
+    def close_content_blocks(self) -> Iterator[str]:
+        if self.blocks.thinking_started:
+            yield self.stop_thinking_block()
+        if self.blocks.text_started:
+            yield self.stop_text_block()
+
+    def close_all_blocks(self) -> Iterator[str]:
+        yield from self.close_content_blocks()
+        for tool_index, state in list(self.blocks.tool_states.items()):
+            if state.started:
+                yield self.stop_tool_block(tool_index)
+
+    def emit_top_level_error(
+        self, error_message: str, *, error_type: str = "api_error"
+    ) -> str:
+        return self._emitter.event(
+            "error",
+            anthropic_error_payload(error_type=error_type, message=error_message),
+        )
+
+    def ingest_native_event(self, event: SSEEvent) -> str | None:
+        """Record a native Anthropic SSE event and re-emit its normalized shape."""
+        if event.event == "message_start":
+            message = event.data.get("message")
+            if isinstance(message, dict):
+                mid = message.get("id")
+                if isinstance(mid, str) and mid:
+                    self.message_id = mid
+                model = message.get("model")
+                if isinstance(model, str) and model:
+                    self.model = model
+            self.message_started = True
+            return self._emitter.event(event.event, event.data)
+
+        if event.event == "content_block_start":
+            raw_index = event.data.get("index")
+            block = event.data.get("content_block")
+            if isinstance(raw_index, int) and isinstance(block, dict):
+                self._record_block_start(raw_index, block)
+            return self._emitter.event(event.event, event.data)
+
+        if event.event == "content_block_delta":
+            raw_index = event.data.get("index")
+            delta = event.data.get("delta")
+            if isinstance(raw_index, int) and isinstance(delta, dict):
+                self._record_block_delta(raw_index, delta)
+            return self._emitter.event(event.event, event.data)
+
+        if event.event == "content_block_stop":
+            raw_index = event.data.get("index")
+            if isinstance(raw_index, int):
+                self._record_block_stop(raw_index)
+            return self._emitter.event(event.event, event.data)
+
+        if event.event == "message_delta":
+            delta = event.data.get("delta")
+            if isinstance(delta, dict):
+                stop_reason = delta.get("stop_reason")
+                if isinstance(stop_reason, str):
+                    self.stop_reason = stop_reason
+            return self._emitter.event(event.event, event.data)
+
+        if event.event == "message_stop":
+            self.message_stopped = True
+            return self._emitter.event(event.event, event.data)
+
+        if event.event == "error":
+            return self._emitter.event(event.event, event.data)
+
+        return self._emitter.event(event.event, event.data)
+
+    def close_unclosed_blocks(self) -> Iterator[str]:
+        while self._open_stack:
+            idx = self._open_stack.pop()
+            state = self._content_blocks.get(idx)
+            if state is not None:
+                state.open = False
+                self._clear_active_content_block(state)
+            yield self._emitter.event(
+                "content_block_stop",
+                {"type": "content_block_stop", "index": idx},
+            )
+
+    def append_text_suffix(self, suffix: str) -> Iterator[str]:
+        if not suffix or not self.can_append_content():
+            return
+        yield from self.ensure_text_block()
+        active = self._last_open_block("text")
+        if active is None:
+            return
+        yield self.content_block_delta(active.index, "text_delta", suffix)
+
+    def append_thinking_suffix(self, suffix: str) -> Iterator[str]:
+        if not suffix or not self.can_append_content():
+            return
+        yield from self.ensure_thinking_block()
+        active = self._last_open_block("thinking")
+        if active is None:
+            return
+        yield self.content_block_delta(active.index, "thinking_delta", suffix)
+
+    def append_tool_repair_suffix(self, tool_index: int, suffix: str) -> Iterator[str]:
+        tool_blocks = self.tool_blocks()
+        if (
+            tool_index >= len(tool_blocks)
+            or not suffix
+            or not self.can_append_content()
+        ):
+            return
+        block = tool_blocks[tool_index]
+        yield self.content_block_delta(block.index, "input_json_delta", suffix)
+
+    def success_tail(self, stop_reason: str) -> Iterator[str]:
+        yield from self.close_unclosed_blocks()
+        if self.stop_reason is None:
+            yield self.message_delta(
+                self.final_stop_reason(stop_reason), self.estimate_output_tokens()
+            )
+        if not self.message_stopped:
+            yield self.message_stop()
+
+    def terminal_error_tail(
+        self, error_message: str, *, error_type: str = "api_error"
+    ) -> Iterator[str]:
+        """Terminate an incomplete message with an error, never a success stop."""
+        if self.message_stopped:
+            return
+        yield from self.close_unclosed_blocks()
+        yield self.emit_top_level_error(error_message, error_type=error_type)
+
+    def can_salvage_tool_use(self, schemas: dict[str, ToolSchema]) -> bool:
+        tool_blocks = self.tool_blocks()
+        if not tool_blocks:
+            return False
+        for block in tool_blocks:
+            if not block.tool_id or not block.name:
+                return False
+            if parse_complete_tool_input(block.content, block.name, schemas) is None:
+                return False
+        return True
+
+    def accept_tool_repair(
+        self, tool_index: int, candidate: str, schemas: dict[str, ToolSchema]
+    ) -> str | None:
+        tool_blocks = self.tool_blocks()
+        if tool_index >= len(tool_blocks):
+            return None
+        block = tool_blocks[tool_index]
+        repair = accept_tool_json_repair(
+            block.content,
+            candidate,
+            tool_name=block.name,
+            schemas=schemas,
+        )
+        return repair.suffix if repair is not None else None
+
+    def continuation_text_suffix(self, candidate: str) -> str | None:
+        return continuation_suffix(self.accumulated_text, candidate)
+
+    def continuation_thinking_suffix(self, candidate: str) -> str | None:
+        return continuation_suffix(self.accumulated_reasoning, candidate)
+
+    def tool_blocks(self) -> list[StreamBlockState]:
+        return [
+            block
+            for block in self._content_blocks.values()
+            if block.block_type == "tool_use"
+        ]
+
+    def tool_block_for_tool_index(self, tool_index: int) -> StreamBlockState | None:
+        state = self.blocks.tool_states.get(tool_index)
+        if state is None or state.block_index < 0:
+            return None
+        block = self._content_blocks.get(state.block_index)
+        if block is None or block.block_type != "tool_use":
+            return None
+        return block
+
+    def has_emitted_tool_block(self) -> bool:
+        return bool(self.tool_blocks())
+
+    def has_content_block(self) -> bool:
+        return bool(self._content_blocks)
+
+    def can_append_content(self) -> bool:
+        return self.stop_reason is None and not self.message_stopped
+
+    def final_stop_reason(self, fallback: str) -> str:
+        if self.has_emitted_tool_block():
+            return "tool_use"
+        return fallback
+
+    def has_terminal_message(self) -> bool:
+        return self.message_stopped
+
+    @property
+    def accumulated_text(self) -> str:
+        return "".join(self._text_parts)
+
+    @property
+    def accumulated_reasoning(self) -> str:
+        return "".join(self._thinking_parts)
+
+    def estimate_output_tokens(self) -> int:
+        if ENCODER:
+            text_tokens = len(ENCODER.encode(self.accumulated_text))
+            reasoning_tokens = len(ENCODER.encode(self.accumulated_reasoning))
+            tool_tokens = 0
+            tool_count = 0
+            for name, content in self._iter_tool_token_payloads():
+                tool_tokens += len(ENCODER.encode(name))
+                tool_tokens += len(ENCODER.encode(content))
+                tool_tokens += 15
+                tool_count += 1
+
+            block_count = (
+                (1 if self.accumulated_reasoning else 0)
+                + (1 if self.accumulated_text else 0)
+                + tool_count
+            )
+            return text_tokens + reasoning_tokens + tool_tokens + (block_count * 4)
+
+        text_tokens = len(self.accumulated_text) // 4
+        reasoning_tokens = len(self.accumulated_reasoning) // 4
+        tool_tokens = sum(1 for _ in self._iter_tool_token_payloads()) * 50
+        return text_tokens + reasoning_tokens + tool_tokens
+
+    def _iter_tool_token_payloads(self) -> Iterator[tuple[str, str]]:
+        for block in self.tool_blocks():
+            yield block.name, block.content
+
+    def _record_block_start(self, index: int, block: dict[str, Any]) -> None:
+        self.blocks.reserve_index(index)
+        block_type = str(block.get("type", ""))
+        state = StreamBlockState(index=index, block_type=block_type)
+        if block_type == "tool_use":
+            tool_id = block.get("id")
+            name = block.get("name")
+            state.tool_id = tool_id if isinstance(tool_id, str) else ""
+            state.name = name if isinstance(name, str) else ""
+            extra_content = block.get("extra_content")
+            state.extra_content = (
+                extra_content if isinstance(extra_content, dict) else None
+            )
+        elif block_type == "text":
+            self.blocks.text_index = index
+            self.blocks.text_started = True
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                state.parts.append(text)
+                self._text_parts.append(text)
+        elif block_type == "thinking":
+            self.blocks.thinking_index = index
+            self.blocks.thinking_started = True
+            thinking = block.get("thinking")
+            if isinstance(thinking, str) and thinking:
+                state.parts.append(thinking)
+                self._thinking_parts.append(thinking)
+        self._content_blocks[index] = state
+        self._open_stack.append(index)
+
+    def _record_block_delta(self, index: int, delta: dict[str, Any]) -> None:
+        state = self._content_blocks.get(index)
+        if state is None:
+            return
+        if state.block_type == "text":
+            text = delta.get("text")
+            if isinstance(text, str):
+                state.parts.append(text)
+                self._text_parts.append(text)
+        elif state.block_type == "thinking":
+            thinking = delta.get("thinking")
+            if isinstance(thinking, str):
+                state.parts.append(thinking)
+                self._thinking_parts.append(thinking)
+        elif state.block_type == "tool_use":
+            partial = delta.get("partial_json")
+            if isinstance(partial, str):
+                state.parts.append(partial)
+
+    def _record_block_stop(self, index: int) -> None:
+        if self._open_stack and self._open_stack[-1] == index:
+            self._open_stack.pop()
+        else:
+            with suppress(ValueError):
+                self._open_stack.remove(index)
+        state = self._content_blocks.get(index)
+        if state is not None:
+            state.open = False
+            self._clear_active_content_block(state)
+
+    def _last_open_block(self, block_type: str) -> StreamBlockState | None:
+        for index in reversed(self._open_stack):
+            block = self._content_blocks.get(index)
+            if block is not None and block.block_type == block_type and block.open:
+                return block
+        return None
+
+    def _clear_active_content_block(self, state: StreamBlockState) -> None:
+        if state.block_type == "text" and self.blocks.text_index == state.index:
+            self.blocks.text_started = False
+        elif (
+            state.block_type == "thinking" and self.blocks.thinking_index == state.index
+        ):
+            self.blocks.thinking_started = False
+
+
+def _normalize_task_run_in_background(args_json: dict[str, Any]) -> None:
+    if args_json.get("run_in_background") is not False:
+        args_json["run_in_background"] = False

--- a/free_claude_code/providers/base.py
+++ b/free_claude_code/providers/base.py
@@ -1,0 +1,161 @@
+"""Base provider interface - extend this to implement your own provider."""
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from typing import Any
+
+from pydantic import BaseModel
+
+from free_claude_code.config.constants import HTTP_CONNECT_TIMEOUT_DEFAULT
+from free_claude_code.providers.model_listing import (
+    ProviderModelInfo,
+    model_infos_from_ids,
+)
+
+
+class ProviderConfig(BaseModel):
+    """Configuration for a provider.
+
+    Base fields apply to all providers. Provider-specific parameters
+    (e.g. NIM temperature, top_p) are passed by the provider constructor.
+    """
+
+    api_key: str
+    base_url: str | None = None
+    rate_limit: int | None = None
+    rate_window: int = 60
+    max_concurrency: int = 5
+    http_read_timeout: float = 300.0
+    http_write_timeout: float = 10.0
+    http_connect_timeout: float = HTTP_CONNECT_TIMEOUT_DEFAULT
+    enable_thinking: bool = True
+    proxy: str = ""
+    log_raw_sse_events: bool = False
+    log_api_error_tracebacks: bool = False
+
+
+class BaseProvider(ABC):
+    """Base class for all providers. Extend this to add your own."""
+
+    def __init__(self, config: ProviderConfig):
+        self._config = config
+
+    def _is_thinking_enabled(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> bool:
+        """Return whether thinking should be enabled for this request."""
+        thinking = getattr(request, "thinking", None)
+        config_enabled = (
+            self._config.enable_thinking
+            if thinking_enabled is None
+            else thinking_enabled
+        )
+        request_enabled = True
+        if thinking is not None:
+            thinking_type = (
+                thinking.get("type")
+                if isinstance(thinking, dict)
+                else getattr(thinking, "type", None)
+            )
+            if isinstance(thinking, dict):
+                enabled = thinking.get("enabled")
+                enabled_supplied = "enabled" in thinking
+            else:
+                enabled = getattr(thinking, "enabled", None)
+                fields_set = getattr(thinking, "model_fields_set", None)
+                enabled_supplied = (
+                    "enabled" in fields_set
+                    if isinstance(fields_set, set | frozenset)
+                    else enabled is not None
+                )
+            if enabled_supplied and enabled is not None:
+                request_enabled = bool(enabled)
+            if thinking_type == "disabled":
+                request_enabled = False
+        return config_enabled and request_enabled
+
+    def preflight_stream(
+        self, request: Any, *, thinking_enabled: bool | None = None
+    ) -> None:
+        """Eagerly validate/build the upstream request before opening an SSE stream.
+
+        Subclasses with ``_build_request_body`` (OpenAI and native) raise
+        :class:`providers.exceptions.InvalidRequestError` on conversion failures.
+        """
+        build = getattr(self, "_build_request_body", None)
+        if build is None:
+            return
+        build(request, thinking_enabled=thinking_enabled)
+
+    def _log_stream_transport_error(
+        self,
+        tag: str,
+        req_tag: str,
+        error: Exception,
+        *,
+        request_id: str | None = None,
+    ) -> None:
+        """Log streaming transport failures (metadata-only unless verbose is enabled)."""
+        from loguru import logger
+
+        from free_claude_code.core.trace import trace_event
+        from free_claude_code.providers.error_mapping import exception_cause_types
+
+        response = getattr(error, "response", None)
+        http_status = (
+            getattr(response, "status_code", None) if response is not None else None
+        )
+        cause_types = exception_cause_types(error)
+        trace_event(
+            stage="provider",
+            event="provider.response.transport_error",
+            source="provider",
+            provider=tag,
+            request_id=request_id,
+            exc_type=type(error).__name__,
+            http_status=http_status,
+            cause_types=cause_types,
+        )
+
+        if self._config.log_api_error_tracebacks:
+            logger.opt(exception=error).error(
+                "{}_ERROR:{} {}: {}", tag, req_tag, type(error).__name__, error
+            )
+            return
+        logger.error(
+            "{}_ERROR:{} exc_type={} http_status={} cause_types={}",
+            tag,
+            req_tag,
+            type(error).__name__,
+            http_status,
+            ",".join(cause_types) if cause_types else None,
+        )
+
+    @abstractmethod
+    async def cleanup(self) -> None:
+        """Release any resources held by this provider."""
+
+    @abstractmethod
+    async def list_model_ids(self) -> frozenset[str]:
+        """Return the model ids currently advertised by this provider."""
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        """Return advertised model ids with optional provider capability metadata."""
+        return model_infos_from_ids(await self.list_model_ids())
+
+    @abstractmethod
+    async def stream_response(
+        self,
+        request: Any,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        thinking_enabled: bool | None = None,
+        settings: Any = None,
+        client_host: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream response in Anthropic SSE format."""
+        # Typing: abstract async generators need a yield for AsyncIterator[str]
+        # inference; this branch is never executed.
+        if False:
+            yield ""

--- a/free_claude_code/providers/openai_chat/__init__.py
+++ b/free_claude_code/providers/openai_chat/__init__.py
@@ -1,0 +1,61 @@
+"""OpenAI-compatible provider family."""
+
+from free_claude_code.providers.admission import ProviderAdmissionController
+from free_claude_code.providers.base import ProviderConfig
+
+from .base_url import openai_v1_base_url
+from .extra_body import (
+    validate_extra_body_does_not_override_canonical_fields,
+    validate_extra_body_does_not_override_reasoning_fields,
+)
+from .profiles import OPENAI_CHAT_PROFILES, OpenAIChatProfile
+from .provider import OpenAIAsyncCredentialProvider, OpenAIChatProvider
+from .reasoning import (
+    NO_REASONING,
+    ChatTemplateReasoning,
+    NamedEffortReasoning,
+    ReasoningObject,
+)
+from .request_policy import OpenAIChatRequestPolicy, build_openai_chat_request_body
+from .usage import usage_int
+
+
+def create_openai_chat_provider(
+    provider_id: str,
+    config: ProviderConfig,
+    admission: ProviderAdmissionController,
+    *,
+    enable_mcp: bool = False,
+) -> OpenAIChatProvider:
+    """Construct one profile-driven provider."""
+    profile = OPENAI_CHAT_PROFILES.get(provider_id)
+    if profile is None:
+        raise KeyError(f"No declarative OpenAI-chat profile for {provider_id!r}")
+    return OpenAIChatProvider(
+        config,
+        profile=profile,
+        admission=admission,
+        default_headers=(
+            {"User-Agent": profile.user_agent} if profile.user_agent else None
+        ),
+        enable_mcp=enable_mcp,
+    )
+
+
+__all__ = [
+    "NO_REASONING",
+    "OPENAI_CHAT_PROFILES",
+    "ChatTemplateReasoning",
+    "NamedEffortReasoning",
+    "OpenAIAsyncCredentialProvider",
+    "OpenAIChatProfile",
+    "OpenAIChatProvider",
+    "OpenAIChatRequestPolicy",
+    "ReasoningObject",
+    "build_openai_chat_request_body",
+    "create_openai_chat_provider",
+    "openai_v1_base_url",
+    "usage_int",
+    "validate_extra_body_does_not_override_canonical_fields",
+    "validate_extra_body_does_not_override_reasoning_fields",
+]

--- a/free_claude_code/providers/openai_chat/mcp_client.py
+++ b/free_claude_code/providers/openai_chat/mcp_client.py
@@ -1,0 +1,124 @@
+"""MCP client manager for per-request MCP server lifecycle."""
+
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.sse import sse_client
+from mcp.client.stdio import stdio_client
+
+
+@dataclass
+class MCPServerConfig:
+    transport: Literal["stdio", "sse"]
+    command: str | None = None
+    args: list[str] | None = None
+    url: str | None = None
+    headers: dict[str, str] | None = None
+
+
+@dataclass
+class MCPTool:
+    name: str
+    description: str
+    input_schema: dict[str, Any]  # MCP JSON Schema
+
+
+@dataclass
+class ToolResult:
+    content: Any
+    is_error: bool = False
+
+
+class MCPClientManager:
+    """Manages MCP client connections for a single request."""
+
+    def __init__(self) -> None:
+        self._sessions: list[ClientSession] = []
+        self._streams: list[tuple] = []
+
+    async def connect(
+        self,
+        servers: list[MCPServerConfig],
+        client_host: str | None = None,
+    ) -> list[MCPTool]:
+        """Connect to MCP servers and return available tools.
+
+        Security guardrail: Only allow localhost connections.
+        """
+        # Security: Only allow localhost/127.0.0.1/::1
+        if client_host and client_host not in ("127.0.0.1", "localhost", "::1"):
+            return []
+
+        all_tools: list[MCPTool] = []
+
+        for config in servers:
+            if config.transport == "stdio":
+                if not config.command:
+                    continue
+                params = StdioServerParameters(
+                    command=config.command,
+                    args=config.args or [],
+                )
+                read_stream, write_stream = await stdio_client(params).__aenter__()
+                self._streams.append((read_stream, write_stream))
+                session = ClientSession(read_stream, write_stream)
+            else:  # sse
+                if not config.url:
+                    continue
+                read_stream, write_stream = await sse_client(config.url).__aenter__()
+                self._streams.append((read_stream, write_stream))
+                session = ClientSession(read_stream, write_stream)
+
+            await session.__aenter__()
+            await session.initialize()
+            self._sessions.append(session)
+
+            tools_result = await session.list_tools()
+            all_tools.extend(
+                MCPTool(
+                    name=tool.name,
+                    description=tool.description or "",
+                    input_schema=tool.inputSchema,
+                )
+                for tool in tools_result.tools
+            )
+
+        return all_tools
+
+    async def execute_tool(self, tool_name: str, arguments: dict) -> ToolResult:
+        """Execute a tool on the connected MCP servers."""
+        for session in self._sessions:
+            try:
+                result = await session.call_tool(tool_name, arguments)
+                return ToolResult(content=result.content, is_error=result.isError)
+            except Exception:
+                continue  # Try next session
+
+        # Tool not found on any server
+        return ToolResult(content=[], is_error=True)
+
+    async def close(self) -> None:
+        """Close all MCP connections."""
+        for session in self._sessions:
+            with suppress(Exception):
+                await session.__aexit__(None, None, None)
+        for read_stream, write_stream in self._streams:
+            with suppress(Exception):
+                await read_stream.__aexit__(None, None, None)
+                await write_stream.__aexit__(None, None, None)
+        self._sessions.clear()
+        self._streams.clear()
+
+
+def mcp_tool_to_openai_function(mcp_tool: MCPTool) -> dict[str, Any]:
+    """Convert MCP tool to OpenAI function declaration format."""
+    return {
+        "type": "function",
+        "function": {
+            "name": mcp_tool.name,
+            "description": mcp_tool.description,
+            "parameters": mcp_tool.input_schema,
+        },
+    }

--- a/free_claude_code/providers/openai_chat/permissions.py
+++ b/free_claude_code/providers/openai_chat/permissions.py
@@ -1,0 +1,216 @@
+"""Tool-approval policy for MCP tool calls emitted by the upstream LLM.
+
+Each concrete policy is stateless: ``evaluate`` returns either a ``Decision`` or
+a ``DenyReason``. ``build_policy`` constructs the active policy from ``Settings``.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+from fnmatch import fnmatch
+from typing import TYPE_CHECKING, Protocol
+
+from loguru import logger
+
+from free_claude_code.config.settings import Settings
+
+if TYPE_CHECKING:
+    from .mcp_client import MCPServerConfig
+
+
+class Decision(StrEnum):
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+@dataclass(frozen=True)
+class DenyReason:
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class McpServerDescriptor:
+    name: str
+    transport: str
+    host: str | None
+
+    @classmethod
+    def from_server_config(
+        cls, server: MCPServerConfig, *, name: str = ""
+    ) -> McpServerDescriptor:
+        # Best-effort host extraction; SSE hosts are URI-derived, stdio is local.
+        host: str | None = None
+        if server.transport == "sse" and server.url:
+            host = _extract_host(server.url)
+        return cls(name=name, transport=server.transport, host=host)
+
+
+def _extract_host(url: str) -> str | None:
+    """Pull host out of an SSE URL without dragging urllib into this module."""
+    # Strip scheme:// prefix if present, then take up to the next '/' or ':'.
+    stripped = url
+    for prefix in ("https://", "http://"):
+        if stripped.startswith(prefix):
+            stripped = stripped[len(prefix) :]
+            break
+    host_end = len(stripped)
+    for sep in ("/", "?", "#"):
+        idx = stripped.find(sep)
+        if idx != -1 and idx < host_end:
+            host_end = idx
+    host_part = stripped[:host_end]
+    if "@" in host_part:
+        host_part = host_part.split("@", 1)[1]
+    # IPv6 bracket form: [::1]:port
+    if host_part.startswith("[") and "]" in host_part:
+        return host_part[1 : host_part.index("]")]
+    # Strip :port
+    if ":" in host_part:
+        host_part = host_part.split(":", 1)[0]
+    return host_part or None
+
+
+class ToolApprovalPolicy(Protocol):
+    def evaluate(
+        self,
+        *,
+        tool_name: str,
+        tool_input: dict,
+        server: McpServerDescriptor | None,
+    ) -> Decision | DenyReason: ...
+
+
+def _glob_match(name: str, pattern: str) -> bool:
+    # fnmatch handles plain substrings (no '*' -> exact match) and '*' / '?' globs.
+    return fnmatch(name, pattern)
+
+
+class OffPolicy:
+    """Pass-through: allow every tool call."""
+
+    def evaluate(
+        self,
+        *,
+        tool_name: str,
+        tool_input: dict,
+        server: McpServerDescriptor | None,
+    ) -> Decision | DenyReason:
+        return Decision.ALLOW
+
+
+class DenyCoworkPolicy:
+    """Deny any ``mcp__cowork__*`` tool unless explicitly allowlisted."""
+
+    _COWORK_PREFIX = "mcp__cowork__"
+
+    def __init__(
+        self,
+        allowlist: tuple[str, ...] = (),
+        denylist: tuple[str, ...] = (),
+    ) -> None:
+        self._allowlist = allowlist
+        self._denylist = denylist
+
+    def evaluate(
+        self,
+        *,
+        tool_name: str,
+        tool_input: dict,
+        server: McpServerDescriptor | None,
+    ) -> Decision | DenyReason:
+        if tool_name.startswith(self._COWORK_PREFIX) and not self._matches_any(
+            tool_name, self._allowlist
+        ):
+            bare = tool_name[len(self._COWORK_PREFIX) :]
+            return DenyReason(
+                code="permission_denied",
+                message=(
+                    "Tool 'mcp__cowork__" + bare + "' is denied by FCC "
+                    "tool_approval_policy=deny_cowork."
+                ),
+            )
+        if self._matches_any(tool_name, self._denylist):
+            return DenyReason(
+                code="permission_denied",
+                message=(
+                    "Tool '" + tool_name + "' is denied by FCC mcp_tool_denylist."
+                ),
+            )
+        return Decision.ALLOW
+
+    @staticmethod
+    def _matches_any(name: str, patterns: tuple[str, ...]) -> bool:
+        return any(_glob_match(name, p) for p in patterns)
+
+
+class LocalhostOnlyPolicy:
+    """Allow only stdio MCP servers or SSE servers bound to loopback hosts."""
+
+    _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+    def __init__(
+        self,
+        allowlist: tuple[str, ...] = (),
+        denylist: tuple[str, ...] = (),
+    ) -> None:
+        self._allowlist = allowlist
+        self._denylist = denylist
+
+    def evaluate(
+        self,
+        *,
+        tool_name: str,
+        tool_input: dict,
+        server: McpServerDescriptor | None,
+    ) -> Decision | DenyReason:
+        if server is None:
+            return DenyReason(
+                code="transport_untrusted",
+                message="Server descriptor unavailable",
+            )
+        if server.transport == "stdio":
+            host_check_ok = True
+        elif server.transport == "sse":
+            host = server.host
+            host_check_ok = host is None or host in self._LOOPBACK_HOSTS
+        else:
+            host_check_ok = False
+
+        if not host_check_ok:
+            host_repr = server.host if server is not None else None
+            return DenyReason(
+                code="transport_untrusted",
+                message=(
+                    "MCP server at '" + str(host_repr) + "' not in localhost allowlist"
+                ),
+            )
+
+        if self._matches_any(tool_name, self._denylist):
+            return DenyReason(
+                code="permission_denied",
+                message=(
+                    "Tool '" + tool_name + "' is denied by FCC mcp_tool_denylist."
+                ),
+            )
+        return Decision.ALLOW
+
+    @staticmethod
+    def _matches_any(name: str, patterns: tuple[str, ...]) -> bool:
+        return any(_glob_match(name, p) for p in patterns)
+
+
+def build_policy(settings: Settings) -> ToolApprovalPolicy:
+    """Construct the active tool-approval policy from ``Settings``."""
+    name = settings.tool_approval_policy
+    allow = tuple(settings.mcp_tool_allowlist)
+    deny = tuple(settings.mcp_tool_denylist)
+
+    if name == "off":
+        return OffPolicy()
+    if name == "deny_cowork":
+        return DenyCoworkPolicy(allowlist=allow, denylist=deny)
+    if name == "localhost_only":
+        return LocalhostOnlyPolicy(allowlist=allow, denylist=deny)
+
+    logger.warning("Unknown tool_approval_policy={!r}; falling back to OffPolicy", name)
+    return OffPolicy()

--- a/free_claude_code/providers/openai_chat/provider.py
+++ b/free_claude_code/providers/openai_chat/provider.py
@@ -1,0 +1,1140 @@
+"""Concrete OpenAI-compatible provider and per-request stream execution."""
+
+import asyncio
+import sys
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
+from typing import Any
+
+import httpx
+from loguru import logger
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.core.anthropic import (
+    ContentType,
+    HeuristicToolParser,
+    ThinkTagParser,
+)
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.streaming import (
+    AnthropicStreamLedger,
+    accept_tool_json_repair,
+    continuation_suffix,
+    make_text_recovery_body,
+    make_tool_repair_body,
+    map_stop_reason,
+    parse_complete_tool_input,
+    tool_schemas_by_name,
+)
+from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
+from free_claude_code.core.trace import provider_chat_body_snapshot, trace_event
+from free_claude_code.providers.admission import (
+    ProviderAdmissionController,
+    ProviderAttempt,
+    ProviderRetrySession,
+)
+from free_claude_code.providers.base import BaseProvider, ProviderConfig
+from free_claude_code.providers.failure_policy import (
+    classify_provider_failure,
+    underlying_provider_error,
+)
+from free_claude_code.providers.http import (
+    close_provider_stream,
+    maybe_await_aclose,
+)
+from free_claude_code.providers.model_listing import extract_openai_model_infos
+from free_claude_code.providers.stream_recovery import (
+    RecoveryController,
+    RecoveryFailureAction,
+    TruncatedProviderStreamError,
+    is_retryable_stream_error,
+)
+
+from .output_cap import clamp_output_tokens, parse_output_token_cap
+from .permissions import (
+    Decision,
+    DenyReason,
+    McpServerDescriptor,
+    ToolApprovalPolicy,
+    build_policy,
+)
+from .profiles import OpenAIChatProfile
+from .request_policy import build_openai_chat_request_body
+from .tool_calls import (
+    OpenAIToolCallAssembler,
+    all_emitted_tools_complete,
+    has_committed_sse_output,
+    iter_heuristic_tool_use_sse,
+    started_tool_states,
+    tool_call_extra_content,
+)
+from .usage import (
+    clone_without_stream_usage,
+    is_stream_usage_rejection,
+    request_stream_usage,
+    usage_int,
+)
+
+OpenAIAsyncCredentialProvider = Callable[[], Awaitable[str]]
+
+
+class OpenAIChatProvider(BaseProvider):
+    """OpenAI-compatible ``/chat/completions`` provider configured by a profile."""
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        profile: OpenAIChatProfile,
+        admission: ProviderAdmissionController,
+        default_headers: Mapping[str, str] | None = None,
+        api_key_provider: OpenAIAsyncCredentialProvider | None = None,
+        enable_mcp: bool = False,
+    ):
+        super().__init__(config)
+        self._profile = profile
+        self._provider_name = profile.provider_name
+        self._api_key = config.api_key
+        self._base_url = profile.base_url(config.base_url).rstrip("/")
+        # Learned per-model output-token caps from upstream 400 rejections, so
+        # later requests clamp proactively instead of paying the 400 each time.
+        self._model_output_caps: dict[str, int] = {}
+        self._admission = admission
+        self._enable_mcp = enable_mcp
+        http_client = None
+        if config.proxy:
+            http_client = httpx.AsyncClient(
+                proxy=config.proxy,
+                timeout=httpx.Timeout(
+                    config.http_read_timeout,
+                    connect=config.http_connect_timeout,
+                    read=config.http_read_timeout,
+                    write=config.http_write_timeout,
+                ),
+            )
+        self._client = AsyncOpenAI(
+            api_key=api_key_provider or self._api_key,
+            base_url=self._base_url,
+            max_retries=0,
+            default_headers=default_headers,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout,
+                read=config.http_read_timeout,
+                write=config.http_write_timeout,
+            ),
+            http_client=http_client,
+        )
+
+    async def cleanup(self) -> None:
+        """Release HTTP client resources."""
+        client = getattr(self, "_client", None)
+        if client is not None:
+            await client.close()
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        """Return model metadata from the OpenAI-compatible models endpoint."""
+        payload = await self._admission.run_with_retry(
+            self._client.models.list,
+            provider_failure_override=self._provider_failure_override,
+        )
+        return extract_openai_model_infos(payload, provider_name=self._provider_name)
+
+    def _build_request_body(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> dict[str, Any]:
+        """Build a provider request from the immutable profile."""
+        return build_openai_chat_request_body(
+            request,
+            reasoning=reasoning,
+            policy=self._profile.request_policy,
+            postprocessors=self._profile.request_postprocessors,
+        )
+
+    def preflight_stream(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> None:
+        """Validate OpenAI-chat request conversion before streaming."""
+        self._build_request_body(request, reasoning=reasoning)
+
+    def _handle_extra_reasoning(
+        self, delta: Any, ledger: AnthropicStreamLedger, *, output_reasoning: bool
+    ) -> Iterator[str]:
+        """Hook for provider-specific reasoning."""
+        return iter(())
+
+    def _get_retry_request_body(self, error: Exception, body: dict) -> dict | None:
+        """Return a modified request body for one retry, or None."""
+        return None
+
+    def _provider_failure_override(self, error: Exception) -> ExecutionFailure | None:
+        """Return provider-specific failure semantics, or defer to shared policy."""
+        return None
+
+    def _prepare_create_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Return the body passed to the upstream OpenAI-compatible client."""
+        return body
+
+    def _record_tool_call_extra_content(
+        self, tool_call_id: str, extra_content: dict[str, Any]
+    ) -> None:
+        """Hook for providers that must replay OpenAI tool-call metadata later."""
+
+    def _tool_argument_aliases(self, body: dict[str, Any]) -> dict[str, dict[str, str]]:
+        """Return provider-specific per-tool argument aliases for this request."""
+        return {}
+
+    def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:
+        """Return provider-specific Anthropic usage fields for final SSE usage."""
+        return {}
+
+    async def _create_stream(
+        self,
+        body: dict,
+        retry_session: ProviderRetrySession,
+    ) -> tuple[Any, dict, ProviderAttempt]:
+        """Create a streaming chat completion with bounded request fallbacks."""
+        body = self._apply_learned_output_cap(body)
+        used_retry_kinds: set[str] = set()
+
+        while retry_session.can_attempt:
+            attempt = await self._admission.open_attempt(retry_session)
+            stream: Any | None = None
+            retain_attempt = False
+            try:
+                create_body = self._prepare_create_body(body)
+                stream = await self._client.chat.completions.create(
+                    **create_body,
+                    stream=True,
+                )
+                stream = self._normalize_stream(stream)
+                retain_attempt = True
+                return stream, body, attempt
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                retry_body = self._next_create_retry_body(error, body, used_retry_kinds)
+                if retry_body is not None and retry_session.can_attempt:
+                    await attempt.retry_immediately()
+                    body = retry_body
+                    continue
+                should_retry = await attempt.retry(
+                    error,
+                    provider_failure_override=self._provider_failure_override,
+                )
+                if not should_retry:
+                    raise
+            finally:
+                if not retain_attempt:
+                    if stream is not None:
+                        await close_provider_stream(
+                            stream,
+                            active_error=sys.exception(),
+                            provider_name=self._provider_name,
+                            request_id=retry_session.request_id,
+                        )
+                    await attempt.aclose()
+
+        raise RuntimeError("provider retry session exhausted without a final error")
+
+    def _normalize_stream(self, stream: Any) -> Any:
+        """Return the provider-specific stream view consumed by the base runner."""
+        return stream
+
+    def _next_create_retry_body(
+        self,
+        error: Exception,
+        body: dict,
+        used_retry_kinds: set[str],
+    ) -> dict | None:
+        retry_body = self._retry_body_for_output_cap(error, body)
+        if retry_body is not None:
+            return retry_body
+
+        if "stream_usage" not in used_retry_kinds and is_stream_usage_rejection(error):
+            retry_body = clone_without_stream_usage(body)
+            if retry_body is not None:
+                used_retry_kinds.add("stream_usage")
+                logger.warning(
+                    "{}_STREAM: retrying without stream_options.include_usage "
+                    "after upstream rejection",
+                    self._provider_name,
+                )
+                return retry_body
+
+        if "provider_specific" not in used_retry_kinds:
+            retry_body = self._get_retry_request_body(error, body)
+            if retry_body is not None:
+                used_retry_kinds.add("provider_specific")
+                return retry_body
+
+        return None
+
+    def _apply_learned_output_cap(self, body: dict) -> dict:
+        """Clamp output tokens to a previously learned cap for this model."""
+        model = body.get("model")
+        if not isinstance(model, str):
+            return body
+        cap = self._model_output_caps.get(model)
+        if cap is None:
+            return body
+        clamped = clamp_output_tokens(body, cap)
+        return clamped if clamped is not None else body
+
+    def _retry_body_for_output_cap(self, error: Exception, body: dict) -> dict | None:
+        """Learn an upstream output-token cap from a 400 and clamp for one retry."""
+        cap = parse_output_token_cap(error)
+        if cap is None:
+            return None
+        model = body.get("model")
+        if isinstance(model, str):
+            previous = self._model_output_caps.get(model)
+            cap = cap if previous is None else min(previous, cap)
+            self._model_output_caps[model] = cap
+        clamped = clamp_output_tokens(body, cap)
+        if clamped is None:
+            return None
+        logger.warning(
+            "{}_STREAM: clamping output tokens to {} after upstream cap rejection",
+            self._provider_name,
+            cap,
+        )
+        return clamped
+
+    def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        settings: Any = None,
+        client_host: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream response in Anthropic SSE format."""
+        runner = _OpenAIChatStreamRunner(
+            self,
+            request=request,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            reasoning=reasoning,
+            enable_mcp=self._enable_mcp,
+            settings=settings,
+            client_host=client_host,
+        )
+        return runner.run()
+
+
+class _OpenAIChatStreamRunner:
+    """Own one OpenAI-chat request's stream, parsing, and recovery state."""
+
+    def __init__(
+        self,
+        provider: OpenAIChatProvider,
+        *,
+        request: MessagesRequest,
+        input_tokens: int,
+        request_id: str | None,
+        reasoning: ReasoningPolicy,
+        enable_mcp: bool = False,
+        settings: Any = None,
+        client_host: str | None = None,
+    ) -> None:
+        self._provider = provider
+        self._request = request
+        self._input_tokens = input_tokens
+        self._request_id = request_id
+        self._reasoning = reasoning
+        self._enable_mcp = enable_mcp
+        self._settings = settings
+        self._client_host = client_host
+        self._message_id = f"msg_{uuid.uuid4()}"
+        self._tool_calls = OpenAIToolCallAssembler(
+            record_extra_content=provider._record_tool_call_extra_content
+        )
+        self._mcp_manager = None
+        self._mcp_tools: list = []
+        self._mcp_server_desc_by_tool: dict[str, McpServerDescriptor] = {}
+        native_approvals = bool(getattr(settings, "enable_native_tool_approvals", True))
+        self._tool_approval_policy: ToolApprovalPolicy | None = (
+            build_policy(settings) if not native_approvals and settings else None
+        )
+
+    async def run(self) -> AsyncIterator[str]:
+        """Convert the upstream OpenAI-chat stream into Anthropic SSE."""
+        tag = self._provider._provider_name
+        req_tag = f" request_id={self._request_id}" if self._request_id else ""
+        ledger = self._new_ledger()
+        recovery = RecoveryController()
+        retry_session = self._provider._admission.new_retry_session(
+            request_id=self._request_id
+        )
+
+        def hold_event(event: str) -> Iterator[str]:
+            yield from recovery.push(event)
+
+        def hold_events(events: Iterator[str]) -> Iterator[str]:
+            for event in events:
+                yield from hold_event(event)
+
+        # First build the base request body
+        body = self._provider._build_request_body(
+            self._request,
+            reasoning=self._reasoning,
+        )
+
+        # Connect to MCP servers if enabled and mcp_servers present in request
+        if self._enable_mcp and self._request.mcp_servers:
+            from free_claude_code.providers.openai_chat.mcp_client import (
+                MCPClientManager,
+                MCPServerConfig,
+            )
+
+            if self._settings:
+                manager = MCPClientManager()
+                servers = []
+                for s in self._request.mcp_servers:
+                    if isinstance(s, dict):
+                        transport = s.get("transport", "stdio")
+                        if transport == "stdio":
+                            servers.append(
+                                MCPServerConfig(
+                                    transport="stdio",
+                                    command=s.get("command"),
+                                    args=s.get("args"),
+                                )
+                            )
+                        elif transport == "sse":
+                            servers.append(
+                                MCPServerConfig(
+                                    transport="sse",
+                                    url=s.get("url"),
+                                    headers=s.get("headers"),
+                                )
+                            )
+                if servers:
+                    mcp_tools = await manager.connect(
+                        servers, client_host=self._client_host
+                    )
+                    self._mcp_manager = manager
+                    self._mcp_tools = mcp_tools
+                    # Pre-compute server descriptors so the policy hook can
+                    # resolve trust without re-walking the SSE stream.
+                    self._mcp_server_desc_by_tool = {
+                        t.name: McpServerDescriptor.from_server_config(s, name="")
+                        for t, s in zip(mcp_tools, servers, strict=True)
+                    }
+                    # Convert MCP tools to OpenAI function format
+                    if mcp_tools:
+                        from free_claude_code.providers.openai_chat.mcp_client import (
+                            mcp_tool_to_openai_function,
+                        )
+
+                        mcp_functions = [
+                            mcp_tool_to_openai_function(t) for t in mcp_tools
+                        ]
+                        # Ensure tools list exists
+                        if body.get("tools") is None:
+                            body["tools"] = []
+                        # Add MCP tools to the tools list
+                        body["tools"].extend(mcp_functions)
+
+        request_stream_usage(body)
+        output_reasoning = self._reasoning.output_enabled
+        trace_event(
+            stage="provider",
+            event="provider.request.sent",
+            source="provider",
+            provider=tag,
+            request_id=self._request_id,
+            gateway_model=self._request.model,
+            downstream_model=body.get("model"),
+            message_count=len(body.get("messages", [])),
+            tool_count=len(body.get("tools", [])),
+            body=provider_chat_body_snapshot(body),
+        )
+
+        think_parser = ThinkTagParser()
+        heuristic_parser = HeuristicToolParser()
+        finish_reason = None
+        usage_info = None
+        tool_argument_aliases: dict[str, dict[str, str]] = {}
+        tool_argument_alias_buffers: dict[int, str] = {}
+
+        while True:
+            if not ledger.message_started:
+                for event in hold_event(ledger.message_start()):
+                    yield event
+            stream: Any | None = None
+            attempt: ProviderAttempt | None = None
+            stream_opened = False
+            try:
+                stream, body, attempt = await self._provider._create_stream(
+                    body,
+                    retry_session,
+                )
+                stream_opened = True
+                tool_argument_aliases = self._provider._tool_argument_aliases(body)
+                async for chunk in stream:
+                    if not attempt.accepted:
+                        await attempt.succeeded()
+                    chunk_usage = getattr(chunk, "usage", None)
+                    if chunk_usage is not None:
+                        usage_info = chunk_usage
+
+                    if not chunk.choices:
+                        continue
+
+                    choice = chunk.choices[0]
+                    delta = choice.delta
+                    if delta is None:
+                        continue
+
+                    if choice.finish_reason:
+                        finish_reason = choice.finish_reason
+                        logger.debug("{} finish_reason: {}", tag, finish_reason)
+
+                    reasoning = self._provider._profile.reasoning_delta(delta)
+                    if output_reasoning and reasoning is not None:
+                        for event in hold_events(ledger.ensure_thinking_block()):
+                            yield event
+                        if reasoning:
+                            for event in hold_event(
+                                ledger.emit_thinking_delta(reasoning)
+                            ):
+                                yield event
+
+                    for event in self._provider._handle_extra_reasoning(
+                        delta,
+                        ledger,
+                        output_reasoning=output_reasoning,
+                    ):
+                        for out_event in hold_event(event):
+                            yield out_event
+
+                    if delta.content:
+                        for part in think_parser.feed(delta.content):
+                            if part.type == ContentType.THINKING:
+                                if not output_reasoning:
+                                    continue
+                                for event in hold_events(
+                                    ledger.ensure_thinking_block()
+                                ):
+                                    yield event
+                                for event in hold_event(
+                                    ledger.emit_thinking_delta(part.content)
+                                ):
+                                    yield event
+                            else:
+                                (
+                                    filtered_text,
+                                    detected_tools,
+                                ) = heuristic_parser.feed(part.content)
+
+                                if filtered_text:
+                                    for event in hold_events(
+                                        ledger.ensure_text_block()
+                                    ):
+                                        yield event
+                                    for event in hold_event(
+                                        ledger.emit_text_delta(filtered_text)
+                                    ):
+                                        yield event
+
+                                for tool_use in detected_tools:
+                                    for event in iter_heuristic_tool_use_sse(
+                                        ledger, tool_use
+                                    ):
+                                        for out_event in hold_event(event):
+                                            yield out_event
+
+                    if delta.tool_calls:
+                        for event in hold_events(ledger.close_content_blocks()):
+                            yield event
+                        for tool_call in delta.tool_calls:
+                            extra_content = tool_call_extra_content(tool_call)
+                            tool_call_info = {
+                                "index": tool_call.index,
+                                "id": tool_call.id,
+                                "function": {
+                                    "name": tool_call.function.name,
+                                    "arguments": tool_call.function.arguments,
+                                },
+                            }
+                            if extra_content:
+                                tool_call_info["extra_content"] = extra_content
+                            for event in self._tool_calls.process_tool_call(
+                                tool_call_info,
+                                ledger,
+                                tool_argument_aliases=tool_argument_aliases,
+                                tool_argument_alias_buffers=tool_argument_alias_buffers,
+                            ):
+                                for out_event in hold_event(event):
+                                    yield out_event
+
+                if finish_reason is None:
+                    raise TruncatedProviderStreamError(
+                        "Provider stream ended without finish_reason."
+                    )
+
+                # Execute MCP tool calls if finish_reason indicates tool use
+                if (
+                    self._mcp_manager
+                    and self._mcp_tools
+                    and finish_reason == "tool_calls"
+                ):
+                    # Get tool calls from the ledger and execute them
+                    import json as _json
+
+                    for _tool_index, state in ledger.blocks.tool_states.values():
+                        if not (state.name and state.tool_id):
+                            continue
+                        mcp_tool = next(
+                            (t for t in self._mcp_tools if t.name == state.name), None
+                        )
+                        if mcp_tool is None:
+                            continue
+                        raw_input = state.accumulated_input or state.task_arg_buffer
+                        if not raw_input:
+                            continue
+                        if isinstance(raw_input, str):
+                            try:
+                                tool_args = _json.loads(raw_input)
+                            except ValueError, _json.JSONDecodeError:
+                                tool_args = {}
+                        elif isinstance(raw_input, dict):
+                            tool_args = raw_input
+                        else:
+                            tool_args = {}
+
+                        # Always close in-flight content blocks before
+                        # emitting a sibling tool_result block so the SSE
+                        # stream stays canonical.
+                        for event in hold_events(ledger.close_content_blocks()):
+                            yield event
+
+                        server_desc = self._mcp_server_desc_by_tool.get(state.name)
+                        decision = Decision.ALLOW
+                        if self._tool_approval_policy is not None:
+                            decision = self._tool_approval_policy.evaluate(
+                                tool_name=state.name,
+                                tool_input=tool_args,
+                                server=server_desc,
+                            )
+                        trace_event(
+                            stage="permission",
+                            event="tool_call_decision",
+                            source="provider",
+                            request_id=self._request_id,
+                            provider=tag,
+                            tool_name=state.name,
+                            decision=(
+                                decision.value
+                                if isinstance(decision, Decision)
+                                else f"deny:{decision.code}"
+                            ),
+                        )
+
+                        if isinstance(decision, DenyReason):
+                            for event in hold_events(
+                                ledger.emit_tool_result_block(
+                                    tool_use_id=state.tool_id,
+                                    content=decision.message,
+                                    is_error=True,
+                                )
+                            ):
+                                yield event
+                            continue
+
+                        # ALLOW — execute the MCP tool and emit a proper
+                        # tool_result block carrying the response (no longer
+                        # the previous plain-text delta fallback).
+                        result = await self._mcp_manager.execute_tool(
+                            state.name, tool_args
+                        )
+                        result_text = ""
+                        if result.content:
+                            for item in result.content:
+                                if hasattr(item, "text"):
+                                    result_text += item.text + "\n"
+                        if not result_text:
+                            result_text = "Tool execution completed" + (
+                                " (error)" if result.is_error else ""
+                            )
+                        for event in hold_events(
+                            ledger.emit_tool_result_block(
+                                tool_use_id=state.tool_id,
+                                content=result_text,
+                                is_error=result.is_error,
+                            )
+                        ):
+                            yield event
+                break
+
+            except asyncio.CancelledError, GeneratorExit:
+                raise
+            except Exception as error:
+                if attempt is not None and not attempt.accepted:
+                    await attempt.retry(
+                        error,
+                        provider_failure_override=(
+                            self._provider._provider_failure_override
+                        ),
+                    )
+                generated_output = has_committed_sse_output(ledger)
+                complete_tool_salvageable = (
+                    generated_output
+                    and ledger.has_emitted_tool_block()
+                    and all_emitted_tools_complete(ledger, self._request)
+                )
+                decision = recovery.advance_failure(
+                    error,
+                    stream_opened=stream_opened,
+                    generated_output=generated_output,
+                    complete_tool_salvageable=complete_tool_salvageable,
+                    attempts_remaining=retry_session.attempts_remaining,
+                    retryable_override=(
+                        attempt.failure_retryable if attempt is not None else None
+                    ),
+                )
+                if decision.action == RecoveryFailureAction.EARLY_RETRY:
+                    trace_event(
+                        stage="provider",
+                        event="provider.recovery.early_retry",
+                        source="provider",
+                        provider=tag,
+                        request_id=self._request_id,
+                        attempts_started=retry_session.attempts_started,
+                        max_attempts=retry_session.max_attempts,
+                        retryable=True,
+                    )
+                    ledger = self._new_ledger()
+                    think_parser = ThinkTagParser()
+                    heuristic_parser = HeuristicToolParser()
+                    finish_reason = None
+                    usage_info = None
+                    tool_argument_aliases = {}
+                    tool_argument_alias_buffers = {}
+                    continue
+
+                if decision.action == RecoveryFailureAction.MIDSTREAM_RECOVERY:
+                    try:
+                        recovery_events = await self._recovery_events(
+                            body=body,
+                            ledger=ledger,
+                            error=error,
+                            tool_argument_alias_buffers=tool_argument_alias_buffers,
+                            output_reasoning=output_reasoning,
+                            retry_session=retry_session,
+                        )
+                    except Exception as recovery_error:
+                        trace_event(
+                            stage="provider",
+                            event="provider.recovery.failed",
+                            source="provider",
+                            provider=tag,
+                            request_id=self._request_id,
+                            exc_type=type(recovery_error).__name__,
+                        )
+                        recovery_events = None
+                    if recovery_events is not None:
+                        for event in recovery.flush_uncommitted(decision):
+                            yield event
+                        for event in recovery_events:
+                            yield event
+                        return
+
+                reported_error = underlying_provider_error(error)
+                self._provider._log_stream_transport_error(
+                    tag, req_tag, reported_error, request_id=self._request_id
+                )
+                failure = classify_provider_failure(
+                    reported_error,
+                    provider_name=tag,
+                    read_timeout_s=self._provider._config.http_read_timeout,
+                    request_id=self._request_id,
+                    provider_failure_override=(
+                        self._provider._provider_failure_override
+                    ),
+                )
+                error_trace: dict[str, Any] = {
+                    "stage": "provider",
+                    "event": "provider.response.error",
+                    "source": "provider",
+                    "provider": tag,
+                    "request_id": self._request_id,
+                    "exc_type": type(reported_error).__name__,
+                    "failure_kind": failure.kind.value,
+                    "status_code": failure.status_code,
+                    "provider_retryable": failure.retryable,
+                }
+                if self._provider._config.log_api_error_tracebacks:
+                    error_trace["error_message"] = failure.message
+                trace_event(**error_trace)
+                if (
+                    not decision.committed
+                    and decision.has_buffered
+                    and complete_tool_salvageable
+                ):
+                    for event in recovery.flush():
+                        yield event
+                elif not decision.committed:
+                    recovery.discard()
+                    raise failure from error
+                for event in ledger.close_unclosed_blocks():
+                    yield event
+                raise failure from error
+            finally:
+                if stream is not None:
+                    await close_provider_stream(
+                        stream,
+                        active_error=sys.exception(),
+                        provider_name=tag,
+                        request_id=self._request_id,
+                    )
+                if attempt is not None:
+                    await attempt.aclose()
+
+        remaining = think_parser.flush()
+        if remaining:
+            if remaining.type == ContentType.THINKING:
+                if not output_reasoning:
+                    remaining = None
+                else:
+                    for event in hold_events(ledger.ensure_thinking_block()):
+                        yield event
+                    for event in hold_event(
+                        ledger.emit_thinking_delta(remaining.content)
+                    ):
+                        yield event
+            if remaining and remaining.type == ContentType.TEXT:
+                for event in hold_events(ledger.ensure_text_block()):
+                    yield event
+                for event in hold_event(ledger.emit_text_delta(remaining.content)):
+                    yield event
+
+        for tool_use in heuristic_parser.flush():
+            for event in iter_heuristic_tool_use_sse(ledger, tool_use):
+                for out_event in hold_event(event):
+                    yield out_event
+
+        has_emitted_tool = ledger.has_emitted_tool_block()
+        has_content_blocks = (
+            ledger.blocks.text_index != -1
+            or ledger.blocks.thinking_index != -1
+            or has_emitted_tool
+        )
+        if not has_content_blocks or (
+            not has_emitted_tool
+            and not ledger.accumulated_text.strip()
+            and ledger.accumulated_reasoning.strip()
+        ):
+            for event in hold_events(ledger.ensure_text_block()):
+                yield event
+            for event in hold_event(ledger.emit_text_delta(" ")):
+                yield event
+
+        for event in self._tool_calls.flush_tool_argument_alias_buffers(
+            ledger, tool_argument_aliases, tool_argument_alias_buffers
+        ):
+            for out_event in hold_event(event):
+                yield out_event
+
+        for event in self._tool_calls.flush_task_arg_buffers(ledger):
+            for out_event in hold_event(event):
+                yield out_event
+
+        for event in hold_events(ledger.close_all_blocks()):
+            yield event
+
+        completion = usage_int(usage_info, "completion_tokens")
+        if isinstance(completion, int):
+            output_tokens = completion
+        else:
+            output_tokens = ledger.estimate_output_tokens()
+        provider_input = usage_int(usage_info, "prompt_tokens")
+        if provider_input is not None:
+            logger.debug(
+                "TOKEN_ESTIMATE: our={} provider={} diff={:+d}",
+                self._input_tokens,
+                provider_input,
+                provider_input - self._input_tokens,
+            )
+        input_tokens = (
+            provider_input if provider_input is not None else self._input_tokens
+        )
+        trace_event(
+            stage="provider",
+            event="provider.response.completed",
+            source="provider",
+            provider=tag,
+            request_id=self._request_id,
+            finish_reason=(None if finish_reason is None else str(finish_reason)),
+            output_tokens=output_tokens,
+            prompt_tokens=input_tokens,
+            prompt_tokens_estimate=self._input_tokens,
+        )
+        for event in hold_event(
+            ledger.message_delta(
+                ledger.final_stop_reason(map_stop_reason(finish_reason)),
+                output_tokens,
+                input_tokens=input_tokens,
+                usage_fields=self._provider._anthropic_usage_fields(usage_info),
+            )
+        ):
+            yield event
+        for event in hold_event(ledger.message_stop()):
+            yield event
+        for event in recovery.flush():
+            yield event
+
+        # Clean up MCP connections
+        if self._mcp_manager:
+            await self._mcp_manager.close()
+            self._mcp_manager = None
+            self._mcp_tools = []
+            self._mcp_server_desc_by_tool = {}
+
+    async def _collect_recovery_text(
+        self,
+        body: dict[str, Any],
+        *,
+        include_reasoning: bool,
+        retry_session: ProviderRetrySession,
+    ) -> tuple[str, str]:
+        """Collect a complete text/reasoning continuation stream."""
+        last_error: Exception | None = None
+        while retry_session.can_attempt:
+            stream: Any | None = None
+            attempt: ProviderAttempt | None = None
+            try:
+                stream, _, attempt = await self._provider._create_stream(
+                    body,
+                    retry_session,
+                )
+                text_parts: list[str] = []
+                thinking_parts: list[str] = []
+                terminal_seen = False
+                async for chunk in stream:
+                    if not attempt.accepted:
+                        await attempt.succeeded()
+                    if not getattr(chunk, "choices", None):
+                        continue
+                    choice = chunk.choices[0]
+                    if choice.finish_reason is not None:
+                        terminal_seen = True
+                    delta = choice.delta
+                    if delta is None:
+                        continue
+                    if include_reasoning:
+                        reasoning = self._provider._profile.reasoning_delta(delta)
+                        if reasoning:
+                            thinking_parts.append(reasoning)
+                    content = getattr(delta, "content", None)
+                    if isinstance(content, str) and content:
+                        text_parts.append(content)
+                if not terminal_seen:
+                    raise TruncatedProviderStreamError(
+                        "Recovery stream ended without finish_reason."
+                    )
+                return "".join(text_parts), "".join(thinking_parts)
+            except Exception as error:
+                last_error = error
+                retryable = is_retryable_stream_error(error)
+                if attempt is not None and not attempt.accepted:
+                    await attempt.retry(
+                        error,
+                        provider_failure_override=(
+                            self._provider._provider_failure_override
+                        ),
+                    )
+                    if attempt.failure_retryable is not None:
+                        retryable = attempt.failure_retryable
+                if not retryable or not retry_session.can_attempt:
+                    raise
+                trace_event(
+                    stage="provider",
+                    event="provider.recovery.retry",
+                    source="provider",
+                    provider=self._provider._provider_name,
+                    recovery_kind="openai_text",
+                    attempts_started=retry_session.attempts_started,
+                    max_attempts=retry_session.max_attempts,
+                    exc_type=type(error).__name__,
+                )
+            finally:
+                if stream is not None:
+                    await maybe_await_aclose(stream)
+                if attempt is not None:
+                    await attempt.aclose()
+        if last_error is not None:
+            raise last_error
+        return "", ""
+
+    async def _recovery_events(
+        self,
+        *,
+        body: dict[str, Any],
+        ledger: AnthropicStreamLedger,
+        error: Exception,
+        tool_argument_alias_buffers: dict[int, str],
+        output_reasoning: bool,
+        retry_session: ProviderRetrySession,
+    ) -> list[str] | None:
+        """Build terminal recovery events when the interrupted stream permits it."""
+        if not is_retryable_stream_error(error):
+            return None
+
+        if ledger.has_emitted_tool_block():
+            if not all_emitted_tools_complete(ledger, self._request):
+                repair_events = await self._repair_tool_args(
+                    body=body,
+                    ledger=ledger,
+                    tool_argument_alias_buffers=tool_argument_alias_buffers,
+                    retry_session=retry_session,
+                )
+                if repair_events is None:
+                    return None
+            else:
+                repair_events = []
+            events = list(repair_events)
+            events.extend(ledger.close_all_blocks())
+            events.append(
+                ledger.message_delta(
+                    ledger.final_stop_reason("end_turn"),
+                    ledger.estimate_output_tokens(),
+                )
+            )
+            events.append(ledger.message_stop())
+            trace_event(
+                stage="provider",
+                event="provider.recovery.tool_salvaged",
+                source="provider",
+                provider=self._provider._provider_name,
+                request_id=self._request_id,
+            )
+            return events
+
+        partial_text = ledger.accumulated_text
+        partial_thinking = ledger.accumulated_reasoning
+        if not partial_text and not partial_thinking:
+            return None
+
+        recovery_body = make_text_recovery_body(body, partial_text, partial_thinking)
+        text, thinking = await self._collect_recovery_text(
+            recovery_body,
+            include_reasoning=output_reasoning,
+            retry_session=retry_session,
+        )
+        text_suffix = continuation_suffix(partial_text, text)
+        thinking_suffix = continuation_suffix(partial_thinking, thinking)
+        events: list[str] = []
+        if thinking_suffix:
+            events.extend(ledger.ensure_thinking_block())
+            events.append(ledger.emit_thinking_delta(thinking_suffix))
+        if text_suffix:
+            events.extend(ledger.ensure_text_block())
+            events.append(ledger.emit_text_delta(text_suffix))
+        if not events:
+            return None
+        events.extend(ledger.close_all_blocks())
+        events.append(
+            ledger.message_delta(
+                ledger.final_stop_reason("end_turn"), ledger.estimate_output_tokens()
+            )
+        )
+        events.append(ledger.message_stop())
+        trace_event(
+            stage="provider",
+            event="provider.recovery.continued",
+            source="provider",
+            provider=self._provider._provider_name,
+            request_id=self._request_id,
+        )
+        return events
+
+    async def _repair_tool_args(
+        self,
+        *,
+        body: dict[str, Any],
+        ledger: AnthropicStreamLedger,
+        tool_argument_alias_buffers: dict[int, str],
+        retry_session: ProviderRetrySession,
+    ) -> list[str] | None:
+        schemas = tool_schemas_by_name(self._request)
+        events: list[str] = []
+        for tool_index, state in started_tool_states(ledger):
+            block = ledger.tool_block_for_tool_index(tool_index)
+            emitted_prefix = block.content if block is not None else ""
+            repair_prefix = emitted_prefix
+            if not repair_prefix and state.name == "Task" and state.task_arg_buffer:
+                repair_prefix = state.task_arg_buffer
+            if not repair_prefix and tool_index in tool_argument_alias_buffers:
+                repair_prefix = tool_argument_alias_buffers[tool_index]
+            if (
+                parse_complete_tool_input(repair_prefix, state.name, schemas)
+                is not None
+            ):
+                if not emitted_prefix and repair_prefix:
+                    events.append(ledger.emit_tool_delta(tool_index, repair_prefix))
+                continue
+
+            schema = schemas.get(state.name)
+            recovery_body = make_tool_repair_body(
+                body,
+                tool_name=state.name,
+                prefix=repair_prefix,
+                input_schema=schema.input_schema if schema is not None else None,
+            )
+            accepted_suffix: str | None = None
+            repair_attempt = 0
+            while retry_session.can_attempt:
+                repair_attempt += 1
+                text, _ = await self._collect_recovery_text(
+                    recovery_body,
+                    include_reasoning=False,
+                    retry_session=retry_session,
+                )
+                repair = accept_tool_json_repair(
+                    repair_prefix,
+                    text,
+                    tool_name=state.name,
+                    schemas=schemas,
+                )
+                if repair is not None:
+                    accepted_suffix = repair.suffix
+                    trace_event(
+                        stage="provider",
+                        event="provider.recovery.tool_repaired",
+                        source="provider",
+                        provider=self._provider._provider_name,
+                        tool_name=state.name,
+                        attempt=repair_attempt,
+                    )
+                    break
+            if accepted_suffix is None:
+                return None
+            to_emit = (
+                accepted_suffix if emitted_prefix else repair_prefix + accepted_suffix
+            )
+            if to_emit:
+                events.append(ledger.emit_tool_delta(tool_index, to_emit))
+        if not all_emitted_tools_complete(ledger, self._request):
+            return None
+        return events
+
+    def _new_ledger(self) -> AnthropicStreamLedger:
+        return AnthropicStreamLedger(
+            self._message_id,
+            self._request.model,
+            self._input_tokens,
+            log_raw_events=self._provider._config.log_raw_sse_events,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.13.1"
+version = "4.14.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -34,6 +34,7 @@ fcc-server = "free_claude_code.cli.entrypoints:serve"
 fcc-claude = "free_claude_code.cli.launchers.claude:launch"
 fcc-codex = "free_claude_code.cli.launchers.codex:launch"
 fcc-pi = "free_claude_code.cli.launchers.pi:launch"
+fcc-claude-desktop = "free_claude_code.cli.launchers.claude_desktop:launch"
 
 [project.gui-scripts]
 fcc-desktop = "free_claude_code.cli.desktop_entrypoint:launch"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -29,6 +29,7 @@ $FccCommands = @(
     "fcc-codex",
     "fcc-pi",
     "fcc-init",
+    "fcc-claude-desktop",
     "free-claude-code"
 )
 
@@ -583,7 +584,7 @@ function Configure-AndConfirmFreeClaudeCode {
         [IO.Path]::AltDirectorySeparatorChar
     )
     $installedCommands = @{}
-    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-codex", "fcc-pi")) {
+    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-codex", "fcc-pi", "fcc-claude-desktop")) {
         $command = Get-ApplicationCommand $commandName
         if (-not $command) {
             throw "Free Claude Code installation did not create '$commandName'."
@@ -605,6 +606,8 @@ function Configure-AndConfirmFreeClaudeCode {
     Install-FccDesktopShortcuts `
         -DesktopCommand $installedCommands["fcc-desktop"] `
         -IconPath $iconPath
+    Configure-ClaudeDesktopApp `
+        -ToolBin $toolBin
 }
 
 function Test-EquivalentPath {
@@ -625,6 +628,32 @@ function Test-EquivalentPath {
     }
     catch {
         return $false
+    }
+}
+
+function Configure-ClaudeDesktopApp {
+    param([string] $ToolBin)
+
+    # Delegate JSON merging to the Python helper installed by `uv tool
+    # install` so the script does not depend on jq/ConvertTo-Json parsing.
+    # Best-effort: a non-zero exit is logged but does not fail the install.
+    $pythonExe = Join-Path $ToolBin "python3"
+    if (-not (Test-Path $pythonExe)) {
+        $pythonExe = Join-Path $ToolBin "python.exe"
+    }
+    if (-not (Test-Path $pythonExe)) {
+        Write-Warning "Could not locate python inside the uv tool bin; skipping Claude Desktop auto-configure."
+        return
+    }
+
+    if ($script:DryRun) {
+        Print-Command $pythonExe @("-m", "free_claude_code.cli.launchers.claude_desktop", "--configure")
+        return
+    }
+
+    & $pythonExe -m free_claude_code.cli.launchers.claude_desktop --configure
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to auto-configure Claude Desktop (exit code $LASTEXITCODE). Run `fcc-claude-desktop --configure` manually."
     }
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -634,24 +634,24 @@ function Test-EquivalentPath {
 function Configure-ClaudeDesktopApp {
     param([string] $ToolBin)
 
-    # Delegate JSON merging to the Python helper installed by `uv tool
-    # install` so the script does not depend on jq/ConvertTo-Json parsing.
+    # Delegate JSON merging to the installed console script so it works even
+    # when the uv tool bin dir lacks an interpreter.
     # Best-effort: a non-zero exit is logged but does not fail the install.
-    $pythonExe = Join-Path $ToolBin "python3"
-    if (-not (Test-Path $pythonExe)) {
-        $pythonExe = Join-Path $ToolBin "python.exe"
+    $scriptExe = Join-Path $ToolBin "fcc-claude-desktop"
+    if (-not (Test-Path $scriptExe)) {
+        $scriptExe = Join-Path $ToolBin "fcc-claude-desktop.exe"
     }
-    if (-not (Test-Path $pythonExe)) {
-        Write-Warning "Could not locate python inside the uv tool bin; skipping Claude Desktop auto-configure."
+    if (-not (Test-Path $scriptExe)) {
+        Write-Warning "Could not locate fcc-claude-desktop in $ToolBin; skipping Claude Desktop auto-configure."
         return
     }
 
     if ($script:DryRun) {
-        Print-Command $pythonExe @("-m", "free_claude_code.cli.launchers.claude_desktop", "--configure")
+        Print-Command $scriptExe @("--configure")
         return
     }
 
-    & $pythonExe -m free_claude_code.cli.launchers.claude_desktop --configure
+    & $scriptExe --configure
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "Failed to auto-configure Claude Desktop (exit code $LASTEXITCODE). Run `fcc-claude-desktop --configure` manually."
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so updates reject older FCC processes before replacement.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-init fcc-claude-desktop free-claude-code"
 
 dry_run=0
 voice_nim=0
@@ -528,11 +528,80 @@ configure_and_verify_free_claude_code() {
     export PATH
     hash -r 2>/dev/null || true
 
-    for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi; do
+    for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-claude-desktop; do
         [ -x "$tool_bin/$command_name" ] || fail "Free Claude Code installation did not create $tool_bin/$command_name."
     done
 
     run "$tool_bin/fcc-server" --version
+
+    configure_claude_desktop_app
+}
+
+configure_claude_desktop_app() {
+    # Best-effort: write the FCC 3P-gateway block into the user's
+    # ``claude_desktop_config.json`` so Claude Desktop's model picker
+    # discovers every NIM/OpenRouter model exposed by FCC. Delegate JSON
+    # parsing to the Python helper installed by ``uv tool install`` so the
+    # script doesn't depend on ``jq``.
+    if [ "$dry_run" -eq 1 ]; then
+        print_command "$tool_bin/python3" -m \
+            free_claude_code.cli.launchers.claude_desktop --configure
+        return 0
+    fi
+
+    configure_status=0
+    "$tool_bin/python3" -m \
+        free_claude_code.cli.launchers.claude_desktop --configure \
+        || configure_status=$?
+    if [ "$configure_status" -ne 0 ]; then
+        printf 'warning: Failed to auto-configure Claude Desktop (exit code %d). Run `fcc-claude-desktop --configure` manually.\n' "$configure_status" >&2
+    fi
+
+    install_claude_desktop_cert
+}
+
+install_claude_desktop_cert() {
+    # Electron's TLS stack does not always honor NODE_TLS_REJECT_UNAUTHORIZED
+    # nor the operating system certificate store. Best-effort: copy Caddy's
+    # self-signed cert into the system trust chain so users who launch
+    # ``claude-desktop`` directly still see FCC as trusted. Electron still
+    # ignores this on some hosts; the canonical workaround is the
+    # ``fcc-claude-desktop`` launcher.
+    cert_src="/etc/caddy/localhost+2.pem"
+    if [ ! -f "$cert_src" ]; then
+        return 0
+    fi
+
+    cert_dst="/usr/local/share/ca-certificates/fcc-caddy-localhost.crt"
+    if [ -e "$cert_dst" ] && cmp -s "$cert_src" "$cert_dst"; then
+        return 0
+    fi
+
+    if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then
+        printf 'note: skipping cert trust step (%s requires root or sudo).\n' "$cert_src" >&2
+        return 0
+    fi
+
+    copy_cmd="cp"
+    update_cmd="update-ca-certificates"
+    if [ "$(id -u)" -ne 0 ]; then
+        copy_cmd="sudo cp"
+        update_cmd="sudo update-ca-certificates"
+    fi
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command "$copy_cmd" "$cert_src" "$cert_dst"
+        print_command "$update_cmd" --fresh
+        return 0
+    fi
+
+    if ! $copy_cmd "$cert_src" "$cert_dst" 2>/dev/null; then
+        printf 'note: cert trust step failed (cp returned %d) — claude-desktop TLS may still reject Caddy.\n' "$?" >&2
+        return 0
+    fi
+    if ! $update_cmd --fresh >/dev/null 2>&1; then
+        printf 'note: update-ca-certificates failed — claude-desktop TLS may still reject Caddy.\n' >&2
+    fi
 }
 
 shell_quote() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -540,18 +540,16 @@ configure_and_verify_free_claude_code() {
 configure_claude_desktop_app() {
     # Best-effort: write the FCC 3P-gateway block into the user's
     # ``claude_desktop_config.json`` so Claude Desktop's model picker
-    # discovers every NIM/OpenRouter model exposed by FCC. Delegate JSON
-    # parsing to the Python helper installed by ``uv tool install`` so the
-    # script doesn't depend on ``jq``.
+    # discovers every NIM/OpenRouter model exposed by FCC. Invoke the
+    # installed console script (not python3) so it works even when the
+    # uv tool bin dir lacks an interpreter.
     if [ "$dry_run" -eq 1 ]; then
-        print_command "$tool_bin/python3" -m \
-            free_claude_code.cli.launchers.claude_desktop --configure
+        print_command "$tool_bin/fcc-claude-desktop" --configure
         return 0
     fi
 
     configure_status=0
-    "$tool_bin/python3" -m \
-        free_claude_code.cli.launchers.claude_desktop --configure \
+    "$tool_bin/fcc-claude-desktop" --configure \
         || configure_status=$?
     if [ "$configure_status" -ne 0 ]; then
         printf 'warning: Failed to auto-configure Claude Desktop (exit code %d). Run `fcc-claude-desktop --configure` manually.\n' "$configure_status" >&2

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -18,6 +18,7 @@ $FccCommands = @(
     "fcc-codex",
     "fcc-pi",
     "fcc-init",
+    "fcc-claude-desktop",
     "free-claude-code"
 )
 $script:UvPath = ""
@@ -190,6 +191,32 @@ function Uninstall-FreeClaudeCode {
     throw "uv tool uninstall $PackageName failed with exit code $($result.ExitCode); ~/.fcc was not deleted."
 }
 
+function Unconfigure-ClaudeDesktopApp {
+    param([string] $ToolBin)
+
+    # Delegate JSON un-merging to the Python helper installed by `uv tool
+    # install` so the script does not depend on jq/ConvertTo-Json parsing.
+    # Best-effort: a non-zero exit is logged but does not fail the uninstall.
+    $pythonExe = Join-Path $ToolBin "python3"
+    if (-not (Test-Path $pythonExe)) {
+        $pythonExe = Join-Path $ToolBin "python.exe"
+    }
+    if (-not (Test-Path $pythonExe)) {
+        Write-Warning "Could not locate python inside the uv tool bin; skipping Claude Desktop auto-unconfigure."
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "+ $pythonExe -m free_claude_code.cli.launchers.claude_desktop --unconfigure"
+        return
+    }
+
+    & $pythonExe -m free_claude_code.cli.launchers.claude_desktop --unconfigure
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to auto-unconfigure Claude Desktop (exit code $LASTEXITCODE). Run `fcc-claude-desktop --unconfigure` manually."
+    }
+}
+
 function Confirm-FccCommandsRemoved {
     if ($DryRun) {
         Write-Host "+ verify all Free Claude Code entry points are absent from the uv tool bin directory"
@@ -272,6 +299,32 @@ function Remove-FccDesktopShortcuts {
     }
 }
 
+function Unconfigure-ClaudeDesktopApp {
+    param([string] $ToolBin)
+
+    # Delegate JSON un-merge to the Python helper installed by `uv tool
+    # install` so the script does not depend on jq/ConvertTo-Json parsing.
+    # Best-effort: a non-zero exit is logged but does not fail the uninstall.
+    $pythonExe = Join-Path $ToolBin "python3"
+    if (-not (Test-Path $pythonExe)) {
+        $pythonExe = Join-Path $ToolBin "python.exe"
+    }
+    if (-not (Test-Path $pythonExe)) {
+        Write-Warning "Could not locate python inside the uv tool bin; skipping Claude Desktop auto-unconfigure."
+        return
+    }
+
+    if ($script:DryRun) {
+        Print-Command $pythonExe @("-m", "free_claude_code.cli.launchers.claude_desktop", "--unconfigure")
+        return
+    }
+
+    & $pythonExe -m free_claude_code.cli.launchers.claude_desktop --unconfigure
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to auto-unconfigure Claude Desktop (exit code $LASTEXITCODE). Run `fcc-claude-desktop --unconfigure` manually."
+    }
+}
+
 function Purge-FccHome {
     $fccHome = Join-Path $env:USERPROFILE $FccHomeDirname
     if (-not (Test-Path -LiteralPath $fccHome)) {
@@ -314,6 +367,9 @@ Assert-NoFccProcessesRunning
 
 Write-Step "Locating the uv-managed Free Claude Code installation"
 Initialize-UvContext
+
+Write-Step "Reversing the Claude Desktop routing block"
+Unconfigure-ClaudeDesktopApp -ToolBin $script:UvToolBin
 
 Write-Step "Removing the Free Claude Code uv tool"
 Uninstall-FreeClaudeCode

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -245,24 +245,22 @@ unconfigure_claude_desktop_config() {
     # Reverse the merge applied by the installer so Claude Desktop stops
     # forwarding requests to FCC after this tool is gone. Best-effort: a
     # non-zero exit is logged but does not fail the uninstall.
-    python_bin="$uv_tool_bin/python3"
+    script_bin="$uv_tool_bin/fcc-claude-desktop"
     if [ "$dry_run" -eq 1 ]; then
-        if [ -x "$python_bin" ]; then
-            print_command "$python_bin" -m \
-                free_claude_code.cli.launchers.claude_desktop --unconfigure
+        if [ -x "$script_bin" ]; then
+            print_command "$script_bin" --unconfigure
         else
             printf '+ skip Claude Desktop --unconfigure (uv tool bin already gone)\n'
         fi
         return 0
     fi
 
-    if [ ! -x "$python_bin" ]; then
+    if [ ! -x "$script_bin" ]; then
         # Tool already removed; helper no longer reachable.
         return 0
     fi
 
-    if ! "$python_bin" -m \
-            free_claude_code.cli.launchers.claude_desktop --unconfigure 2>/dev/null; then
+    if ! "$script_bin" --unconfigure 2>/dev/null; then
         printf 'warning: Failed to auto-unconfigure Claude Desktop (exit code %d). Run `fcc-claude-desktop --unconfigure` manually.\n' "$?" >&2
     fi
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,7 +6,7 @@ FCC_HOME_DIRNAME=".fcc"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so older installations are fully stopped and removed.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-init fcc-claude-desktop free-claude-code"
 
 dry_run=0
 uv_tool_bin=""
@@ -241,6 +241,32 @@ remove_macos_desktop_app() {
     fi
 }
 
+unconfigure_claude_desktop_config() {
+    # Reverse the merge applied by the installer so Claude Desktop stops
+    # forwarding requests to FCC after this tool is gone. Best-effort: a
+    # non-zero exit is logged but does not fail the uninstall.
+    python_bin="$uv_tool_bin/python3"
+    if [ "$dry_run" -eq 1 ]; then
+        if [ -x "$python_bin" ]; then
+            print_command "$python_bin" -m \
+                free_claude_code.cli.launchers.claude_desktop --unconfigure
+        else
+            printf '+ skip Claude Desktop --unconfigure (uv tool bin already gone)\n'
+        fi
+        return 0
+    fi
+
+    if [ ! -x "$python_bin" ]; then
+        # Tool already removed; helper no longer reachable.
+        return 0
+    fi
+
+    if ! "$python_bin" -m \
+            free_claude_code.cli.launchers.claude_desktop --unconfigure 2>/dev/null; then
+        printf 'warning: Failed to auto-unconfigure Claude Desktop (exit code %d). Run `fcc-claude-desktop --unconfigure` manually.\n' "$?" >&2
+    fi
+}
+
 purge_fcc_home() {
     fcc_home="$HOME/$FCC_HOME_DIRNAME"
     if [ ! -e "$fcc_home" ]; then
@@ -281,6 +307,9 @@ assert_no_fcc_processes_running
 
 step "Locating the uv-managed Free Claude Code installation"
 initialize_uv_context
+
+step "Reversing the Claude Desktop routing block"
+unconfigure_claude_desktop_config
 
 step "Removing the Free Claude Code uv tool"
 uninstall_free_claude_code

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -10,6 +10,7 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.core.gateway_model_ids import (
     gateway_model_id,
     no_thinking_gateway_model_id,
+    picker_alias_for,
 )
 
 DISCOVERED_MODEL_CREATED_AT = "1970-01-01T00:00:00Z"
@@ -138,12 +139,18 @@ def _append_provider_model_variants(
     *,
     supports_thinking: bool | None = None,
 ) -> None:
+    thinking_id = picker_alias_for(provider_model_ref) or gateway_model_id(
+        provider_model_ref
+    )
+    no_thinking_id = picker_alias_for(
+        provider_model_ref, force_reasoning_off=True
+    ) or no_thinking_gateway_model_id(provider_model_ref)
     if supports_thinking is not False:
         _append_unique_model(
             models,
             seen,
             _discovered_model_response(
-                gateway_model_id(provider_model_ref),
+                thinking_id,
                 display_name=provider_model_ref,
             ),
         )
@@ -151,7 +158,7 @@ def _append_provider_model_variants(
         models,
         seen,
         _discovered_model_response(
-            no_thinking_gateway_model_id(provider_model_ref),
-            display_name=f"{provider_model_ref} (no thinking)",
+            no_thinking_id,
+            display_name=provider_model_ref,
         ),
     )

--- a/src/free_claude_code/application/routing.py
+++ b/src/free_claude_code/application/routing.py
@@ -13,7 +13,10 @@ from free_claude_code.config.provider_catalog import (
 from free_claude_code.config.reasoning import ReasoningPreference
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest, TokenCountRequest
-from free_claude_code.core.gateway_model_ids import decode_gateway_model_id
+from free_claude_code.core.gateway_model_ids import (
+    decode_gateway_model_id,
+    resolve_picker_alias,
+)
 from free_claude_code.core.reasoning import ReasoningPolicy
 
 from .reasoning import resolve_reasoning_policy
@@ -106,6 +109,18 @@ class ModelRouter:
     def _direct_provider_model(
         self, model_name: str
     ) -> tuple[str | None, str | None, bool]:
+        alias_resolution = resolve_picker_alias(model_name)
+        if alias_resolution is not None:
+            aliased_ref, force_reasoning_off = alias_resolution
+            provider_id, separator, provider_model = aliased_ref.partition("/")
+            if (
+                not separator
+                or provider_id not in SUPPORTED_PROVIDER_IDS
+                or not provider_model
+            ):
+                return None, None, False
+            return provider_id, provider_model, force_reasoning_off
+
         decoded = decode_gateway_model_id(model_name)
         if decoded is not None:
             if decoded.provider_id not in SUPPORTED_PROVIDER_IDS:

--- a/src/free_claude_code/cli/launchers/claude_desktop.py
+++ b/src/free_claude_code/cli/launchers/claude_desktop.py
@@ -1,0 +1,245 @@
+"""Installed ``fcc-claude-desktop`` launcher and config helper.
+
+Two responsibilities:
+
+1. Launch the Claude Desktop binary with the
+   ``--ignore-certificate-errors`` flag so Caddy's self-signed cert is
+   accepted without per-host certificate trust work.
+2. Merge the Free Claude Code 3P-gateway routing block into the user's
+   ``claude_desktop_config.json`` (``--configure``) so the picker
+   triggers ``/v1/models`` discovery at the FCC endpoint. ``--unconfigure``
+   reverses the merge, preserving every other key byte-for-byte.
+
+Both modes are invoked through the same console script so install-time
+auto-configuration can call ``python3 -m
+free_claude_code.cli.launchers.claude_desktop --configure`` and avoid
+``jq``/``sed`` JSON parsing on platforms without those tools.
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from loguru import logger
+
+CLAUDE_DESKTOP_BINARY = "claude-desktop"
+_CONFIG_FILENAME = "claude_desktop_config.json"
+
+# Top-level key flipping Claude Desktop out of first-party Anthropic mode.
+_DISCOVERY_KEY = "modelDiscoveryEnabled"
+
+# Inference block routed to the local FCC endpoint. Values mirror the
+# working user config documented in
+# ``docs/claude-desktop-picker-aliasing.md`` §5.
+_INFERENCE_KEY = "inference"
+INFERENCE_BLOCK: dict[str, object] = {
+    "provider": "gateway",
+    "credentialKind": "static",
+    "inferenceProvider": "gateway",
+    "inferenceCredentialKind": "static",
+    "inferenceGatewayBaseUrl": "https://localhost:8443",
+    "inferenceGatewayAuthScheme": "x-api-key",
+    "inferenceAnthropicApiKey": "freecc",
+}
+
+
+def _config_path() -> Path:
+    """Return the platform-specific Claude Desktop config path."""
+
+    if sys.platform.startswith("win"):
+        appdata = sys.modules["os"].environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Claude" / _CONFIG_FILENAME
+        return Path.home() / "AppData" / "Roaming" / "Claude" / _CONFIG_FILENAME
+    if sys.platform == "darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / _CONFIG_FILENAME
+        )
+    return Path.home() / ".config" / "Claude" / _CONFIG_FILENAME
+
+
+def load_existing_config(path: Path) -> dict[str, object]:
+    """Read existing JSON config or return ``{}`` when the file is missing/malformed."""
+
+    if not path.exists():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Malformed Claude Desktop config at {}: {} — treating as empty",
+            path,
+            exc,
+        )
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _save_config(path: Path, data: dict[str, object]) -> None:
+    """Atomically write the merged config; create parent directories as needed."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _inference_matches_fcc_block(block: dict[str, object]) -> bool:
+    """Whether every FCC-managed key in the inference block matches our default."""
+
+    return all(block.get(key) == value for key, value in INFERENCE_BLOCK.items())
+
+
+def configure_claude_desktop_config(path: Path | None = None) -> bool:
+    """Merge the FCC routing block into ``path``. Returns whether anything changed."""
+
+    config_path = path or _config_path()
+    data = load_existing_config(config_path)
+    changed = False
+
+    if data.get(_DISCOVERY_KEY) is not True:
+        data[_DISCOVERY_KEY] = True
+        changed = True
+
+    inference = data.get(_INFERENCE_KEY)
+    if not isinstance(inference, dict):
+        inference = {}
+
+    for key, value in INFERENCE_BLOCK.items():
+        if inference.get(key) != value:
+            inference[key] = value
+            changed = True
+
+    if _INFERENCE_KEY not in data or data[_INFERENCE_KEY] != inference:
+        data[_INFERENCE_KEY] = inference
+        changed = True
+
+    if changed:
+        _save_config(config_path, data)
+    return changed
+
+
+def unconfigure_claude_desktop_config(path: Path | None = None) -> bool:
+    """Reverse the merge. Preserves every key outside the FCC-managed surface."""
+
+    config_path = path or _config_path()
+    if not config_path.exists():
+        return False
+    data = load_existing_config(config_path)
+    changed = False
+
+    if _DISCOVERY_KEY in data:
+        del data[_DISCOVERY_KEY]
+        changed = True
+
+    if _INFERENCE_KEY in data:
+        inference = data[_INFERENCE_KEY]
+        if isinstance(inference, dict):
+            for key in INFERENCE_BLOCK:
+                if key in inference and inference[key] == INFERENCE_BLOCK[key]:
+                    del inference[key]
+                    changed = True
+            if not inference:
+                del data[_INFERENCE_KEY]
+        else:
+            del data[_INFERENCE_KEY]
+            changed = True
+
+    if changed:
+        _save_config(config_path, data)
+    return changed
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fcc-claude-desktop",
+        description=(
+            "Launch Claude Desktop with the Free Claude Code routing layer, "
+            "or merge/reverse the FCC routing block in claude_desktop_config.json."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--configure",
+        action="store_true",
+        help="Merge the FCC 3P-gateway block into Claude Desktop's config.",
+    )
+    mode.add_argument(
+        "--unconfigure",
+        action="store_true",
+        help="Reverse the merge applied by --configure.",
+    )
+    parser.add_argument(
+        "--config-path",
+        type=Path,
+        default=None,
+        help="Override the Claude Desktop config path (primarily for tests).",
+    )
+    parser.add_argument(
+        "binary_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments forwarded to the claude-desktop binary.",
+    )
+    return parser
+
+
+def _launch_subprocess(
+    binary_path: str, extra_args: Sequence[str]
+) -> subprocess.Popen[bytes]:
+    command: list[str] = [binary_path, "--ignore-certificate-errors", *extra_args]
+    return subprocess.Popen(command)
+
+
+def launch(argv: Sequence[str] | None = None) -> None:
+    """Entry point for the ``fcc-claude-desktop`` console script."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    parsed = _build_argparser().parse_args(args)
+
+    if parsed.configure:
+        changed = configure_claude_desktop_config(parsed.config_path)
+        target = parsed.config_path or _config_path()
+        print(f"{'Updated' if changed else 'Already merged'}: {target}")
+        return
+
+    if parsed.unconfigure:
+        changed = unconfigure_claude_desktop_config(parsed.config_path)
+        target = parsed.config_path or _config_path()
+        print(f"{'Removed FCC block' if changed else 'Nothing to remove'}: {target}")
+        return
+
+    binary_path = shutil.which(CLAUDE_DESKTOP_BINARY)
+    if binary_path is None:
+        print(
+            f"Could not find '{CLAUDE_DESKTOP_BINARY}' on PATH.",
+            file=sys.stderr,
+        )
+        print(
+            "Install Claude Desktop from https://claude.ai/download.",
+            file=sys.stderr,
+        )
+        raise SystemExit(127)
+
+    try:
+        process = _launch_subprocess(binary_path, list(parsed.binary_args))
+    except FileNotFoundError:
+        print(
+            f"Could not find '{CLAUDE_DESKTOP_BINARY}' binary at {binary_path}.",
+            file=sys.stderr,
+        )
+        raise SystemExit(127) from None
+    try:
+        return_code = process.wait()
+    except KeyboardInterrupt:
+        process.terminate()
+        process.wait()
+        raise
+    raise SystemExit(return_code)

--- a/src/free_claude_code/cli/launchers/claude_desktop.py
+++ b/src/free_claude_code/cli/launchers/claude_desktop.py
@@ -26,6 +26,15 @@ from pathlib import Path
 
 from loguru import logger
 
+
+class MalformedConfigError(ValueError):
+    """Raised when the Claude Desktop config file exists but cannot be parsed as a JSON object."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        self.path = path
+        super().__init__(f"Claude Desktop config at {path} is malformed: {reason}")
+
+
 CLAUDE_DESKTOP_BINARY = "claude-desktop"
 _CONFIG_FILENAME = "claude_desktop_config.json"
 
@@ -67,20 +76,25 @@ def _config_path() -> Path:
 
 
 def load_existing_config(path: Path) -> dict[str, object]:
-    """Read existing JSON config or return ``{}`` when the file is missing/malformed."""
+    """Read existing JSON config as a dict.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist.
+        MalformedConfigError: If the file exists but is not valid JSON or is not a JSON object.
+    """
 
     if not path.exists():
-        return {}
+        raise FileNotFoundError(f"Claude Desktop config not found: {path}")
+
     try:
         loaded = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        logger.warning(
-            "Malformed Claude Desktop config at {}: {} — treating as empty",
-            path,
-            exc,
-        )
-        return {}
-    return loaded if isinstance(loaded, dict) else {}
+        raise MalformedConfigError(path, f"invalid JSON: {exc}") from exc
+
+    if not isinstance(loaded, dict):
+        raise MalformedConfigError(path, "root element is not a JSON object")
+
+    return loaded
 
 
 def _save_config(path: Path, data: dict[str, object]) -> None:
@@ -99,10 +113,26 @@ def _inference_matches_fcc_block(block: dict[str, object]) -> bool:
 
 
 def configure_claude_desktop_config(path: Path | None = None) -> bool:
-    """Merge the FCC routing block into ``path``. Returns whether anything changed."""
+    """Merge the FCC routing block into ``path``. Returns whether anything changed.
+
+    Returns ``False`` and aborts without writing when the existing config is
+    malformed (invalid JSON or non-object root). Creates a new config when
+    the file does not exist.
+    """
 
     config_path = path or _config_path()
-    data = load_existing_config(config_path)
+    try:
+        data = load_existing_config(config_path)
+    except FileNotFoundError:
+        data = {}
+    except MalformedConfigError as exc:
+        logger.warning(
+            "Skipping FCC config merge: malformed config at {}: {}",
+            exc.path,
+            exc.reason,
+        )
+        return False
+
     changed = False
 
     if data.get(_DISCOVERY_KEY) is not True:
@@ -128,12 +158,26 @@ def configure_claude_desktop_config(path: Path | None = None) -> bool:
 
 
 def unconfigure_claude_desktop_config(path: Path | None = None) -> bool:
-    """Reverse the merge. Preserves every key outside the FCC-managed surface."""
+    """Reverse the merge. Preserves every key outside the FCC-managed surface.
+
+    Returns ``False`` and aborts without writing when the existing config is
+    malformed (invalid JSON or non-object root). Returns ``False`` silently
+    when the file does not exist.
+    """
 
     config_path = path or _config_path()
     if not config_path.exists():
         return False
-    data = load_existing_config(config_path)
+    try:
+        data = load_existing_config(config_path)
+    except MalformedConfigError as exc:
+        logger.warning(
+            "Skipping FCC config unmerge: malformed config at {}: {}",
+            exc.path,
+            exc.reason,
+        )
+        return False
+
     changed = False
 
     if _DISCOVERY_KEY in data:

--- a/src/free_claude_code/core/gateway_model_ids.py
+++ b/src/free_claude_code/core/gateway_model_ids.py
@@ -1,5 +1,6 @@
 """Gateway-safe model ID encoding shared by API and CLI adapters."""
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 GATEWAY_MODEL_ID_PREFIX = "anthropic"
@@ -8,6 +9,18 @@ GATEWAY_MODEL_ID_PREFIX = "anthropic"
 # supporting thinking. This intentionally uses that client-side capability
 # heuristic while keeping the real provider/model ref reversible for routing.
 NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
+
+PICKER_ALIAS_PREFIX = "claude-sonnet-nim"
+_PICKER_ALIAS_NO_THINKING_SUFFIX = "-no-thinking"
+_PICKER_ALIAS_WIDTH = 4
+
+# Module-scope alias maps. Seeded once at startup with the sorted refs from the
+# runtime cached model catalog. Read-only after seed in production; tests
+# ``clear_picker_aliases()`` between runs to keep the maps empty.
+_picker_alias_to_ref: dict[str, str] = {}
+_picker_alias_to_ref_no_thinking: dict[str, str] = {}
+_picker_ref_to_alias: dict[str, str] = {}
+_picker_ref_to_alias_no_thinking: dict[str, str] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,3 +62,78 @@ def decode_gateway_model_id(model_name: str) -> DecodedGatewayModelId | None:
         provider_model=provider_model,
         force_reasoning_off=force_reasoning_off,
     )
+
+
+def _format_picker_alias(index: int, *, no_thinking: bool) -> str:
+    suffix = _PICKER_ALIAS_NO_THINKING_SUFFIX if no_thinking else ""
+    return f"{PICKER_ALIAS_PREFIX}-{index:0{_PICKER_ALIAS_WIDTH}d}{suffix}"
+
+
+def seed_picker_aliases(provider_model_refs: Iterable[str]) -> None:
+    """Reset and rebuild the alias maps from the supplied refs.
+
+    Stable across restarts: counter is assigned by ``sorted(refs)``, so the
+    same input order produces the same numbering.
+
+    Maps stay empty when the iterable is empty so a cold-start ``/v1/models``
+    request still falls back to the canonical ``gateway_model_id`` wrappers.
+    """
+    global _picker_alias_to_ref, _picker_alias_to_ref_no_thinking
+    global _picker_ref_to_alias, _picker_ref_to_alias_no_thinking
+
+    thinking_aliases: dict[str, str] = {}
+    no_thinking_aliases: dict[str, str] = {}
+    ref_to_thinking: dict[str, str] = {}
+    ref_to_no_thinking: dict[str, str] = {}
+
+    for index, ref in enumerate(sorted(provider_model_refs), start=1):
+        if not ref:
+            continue
+        alias = _format_picker_alias(index, no_thinking=False)
+        no_thinking_alias = _format_picker_alias(index, no_thinking=True)
+        thinking_aliases[alias] = ref
+        no_thinking_aliases[no_thinking_alias] = ref
+        ref_to_thinking[ref] = alias
+        ref_to_no_thinking[ref] = no_thinking_alias
+
+    _picker_alias_to_ref = thinking_aliases
+    _picker_alias_to_ref_no_thinking = no_thinking_aliases
+    _picker_ref_to_alias = ref_to_thinking
+    _picker_ref_to_alias_no_thinking = ref_to_no_thinking
+
+
+def picker_alias_for(
+    provider_model_ref: str, *, force_reasoning_off: bool = False
+) -> str | None:
+    """Return the picker alias for ``provider_model_ref``, if seeded."""
+    if force_reasoning_off:
+        return _picker_ref_to_alias_no_thinking.get(provider_model_ref)
+    return _picker_ref_to_alias.get(provider_model_ref)
+
+
+def resolve_picker_alias(model_name: str) -> tuple[str, bool] | None:
+    """Reverse-lookup alias. Returns ``(provider_ref, force_reasoning_off)``."""
+    if not model_name:
+        return None
+    ref = _picker_alias_to_ref_no_thinking.get(model_name)
+    if ref is not None:
+        return ref, True
+    ref = _picker_alias_to_ref.get(model_name)
+    if ref is not None:
+        return ref, False
+    return None
+
+
+def has_picker_aliases() -> bool:
+    """Whether ``seed_picker_aliases`` has populated the maps."""
+    return bool(_picker_alias_to_ref) or bool(_picker_alias_to_ref_no_thinking)
+
+
+def clear_picker_aliases() -> None:
+    """Drop every alias entry. Used by tests and hardening paths."""
+    global _picker_alias_to_ref, _picker_alias_to_ref_no_thinking
+    global _picker_ref_to_alias, _picker_ref_to_alias_no_thinking
+    _picker_alias_to_ref = {}
+    _picker_alias_to_ref_no_thinking = {}
+    _picker_ref_to_alias = {}
+    _picker_ref_to_alias_no_thinking = {}

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -31,6 +31,7 @@ from free_claude_code.config.model_refs import parse_provider_type
 from free_claude_code.config.paths import messaging_state_dir_path
 from free_claude_code.config.server_urls import local_admin_url, local_proxy_root_url
 from free_claude_code.config.settings import Settings, get_settings
+from free_claude_code.core.gateway_model_ids import seed_picker_aliases
 from free_claude_code.messaging.platforms import factory as messaging_platform_factory
 from free_claude_code.messaging.platforms.factory import MessagingPlatformOptions
 from free_claude_code.messaging.platforms.ports import (
@@ -140,6 +141,7 @@ class ApplicationRuntime:
             warn_if_process_auth_token(self.settings)
             await self.provider_manager.warm_referenced_model_cache()
             self.provider_manager.start_model_list_refresh()
+            self._seed_picker_aliases_from_cache()
             await self._start_messaging_if_configured()
             logging.getLogger("uvicorn.error").info(
                 "Admin UI: %s (local-only)",
@@ -285,6 +287,17 @@ class ApplicationRuntime:
             "admin_url": local_admin_url(settings) if automatic else None,
             "fields": list(fields),
         }
+
+    def _seed_picker_aliases_from_cache(self) -> None:
+        """Populate the process-global picker alias maps from the warmed cache.
+
+        Sourced from the synchronous snapshot returned by
+        :meth:`ProviderRuntimeManager.cached_prefixed_model_infos` so the
+        mapping is deterministic on every startup and contains exactly the
+        refs the model catalog would otherwise wrap.
+        """
+        infos = self.provider_manager.cached_prefixed_model_infos()
+        seed_picker_aliases(info.model_id for info in infos)
 
     async def _start_messaging_if_configured(self) -> None:
         try:

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -248,7 +248,9 @@ class ApplicationRuntime:
         }
 
     async def refresh_models(self) -> ProviderModelRefreshResult:
-        return await self.provider_manager.refresh_model_list_cache()
+        result = await self.provider_manager.refresh_model_list_cache()
+        self._seed_picker_aliases_from_cache()
+        return result
 
     async def request_restart(self) -> None:
         callback = self._restart_callback

--- a/tests/api/test_model_catalog_aliases.py
+++ b/tests/api/test_model_catalog_aliases.py
@@ -1,0 +1,104 @@
+"""Picker alias selection in ``free_claude_code.api.model_catalog``."""
+
+import pytest
+
+from free_claude_code.api import model_catalog
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+class _StubRuntime:
+    def cached_model_supports_thinking(self, provider_id, model_id):
+        return None
+
+    def cached_prefixed_model_infos(self):
+        return []
+
+    def cached_model_ids(self):
+        return {}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _settings_with_refs(*refs):
+    from free_claude_code.config.reasoning import ReasoningPreference
+    from free_claude_code.config.settings import Settings
+
+    settings = Settings()
+    settings.model = None
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    settings.reasoning_policy = ReasoningPreference.CLIENT
+    slots = ("model", "model_fable", "model_opus", "model_sonnet", "model_haiku")
+    for slot, ref in zip(slots, refs, strict=False):
+        setattr(settings, slot, ref)
+    return settings
+
+
+def _ids(response: model_catalog.ModelsListResponse) -> list[str]:
+    return [item.id for item in response.data]
+
+
+def test_unseeded_state_uses_gateway_wrapper_ids():
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    picker_ids = [
+        item.id for item in response.data if item.id.startswith("claude-sonnet-nim")
+    ]
+    assert picker_ids == []
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in _ids(response)
+    assert "claude-3-freecc-no-thinking/nvidia_nim/01-ai/yi-large" in _ids(response)
+
+
+def test_seeded_state_prefers_alias_for_thinking_variant():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    assert "claude-sonnet-nim-0001" in ids
+    assert "claude-sonnet-nim-0001-no-thinking" in ids
+    # Wrapper id is suppressed because the alias covers the same slot.
+    assert "anthropic/nvidia_nim/01-ai/yi-large" not in ids
+
+
+def test_seed_only_nim_uses_wrapper_for_other_providers():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("openai_chat/anthropic/claude-3-5-sonnet-20241022")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    # Non-NIM ref falls through to the original wrapper ids.
+    assert "anthropic/openai_chat/anthropic/claude-3-5-sonnet-20241022" in ids
+    assert (
+        "claude-3-freecc-no-thinking/openai_chat/anthropic/claude-3-5-sonnet-20241022"
+        in ids
+    )
+    # And no alias leaked from the seeded NIM ref into the unrelated entry.
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+
+
+def test_display_name_is_provider_model_ref_when_using_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    alias_entries = [
+        item for item in response.data if item.id.startswith("claude-sonnet-nim-0001")
+    ]
+    # Both thinking and no-thinking entries expose the canonical provider ref
+    # as the human-readable label.
+    assert {item.display_name for item in alias_entries} == {
+        "nvidia_nim/01-ai/yi-large",
+    }

--- a/tests/application/test_routing_aliases.py
+++ b/tests/application/test_routing_aliases.py
@@ -1,0 +1,104 @@
+"""Picker alias decoding routed through ``application.routing.ModelRouter``."""
+
+import pytest
+
+from free_claude_code.application.routing import ModelRouter
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture
+def settings():
+    settings = Settings()
+    settings.model = "nvidia_nim/fallback-model"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    settings.reasoning_policy = ReasoningPreference.CLIENT
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_resolves_alias_before_gateway_prefix(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    assert resolved.provider_id == "nvidia_nim"
+    assert resolved.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.original_model == "claude-sonnet-nim-0001"
+    assert resolved.reasoning_preference is ReasoningPreference.CLIENT
+
+
+def test_resolves_alias_no_thinking_variant_forces_reasoning_off(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001-no-thinking")
+
+    assert resolved.provider_id == "nvidia_nim"
+    assert resolved.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.reasoning_preference is ReasoningPreference.OFF
+
+
+def test_alias_takes_priority_over_anthropic_prefix(settings):
+    # The same underlying ref exists both as an alias and as an
+    # ``anthropic/<ref>`` gateway id. The alias must win on the picker shape,
+    # and both code paths resolve to the same upstream model.
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    alias_resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+    gateway_resolved = ModelRouter(settings).resolve(
+        "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct"
+    )
+
+    assert alias_resolved.provider_id == gateway_resolved.provider_id == "nvidia_nim"
+    assert (
+        alias_resolved.provider_model
+        == gateway_resolved.provider_model
+        == "meta/llama-3.3-70b-instruct"
+    )
+
+
+def test_alias_for_unknown_provider_falls_through_to_existing_chain(settings):
+    # An alias pointing at an unsupported provider must not silently match;
+    # the alias resolver returns the ref and routing layer validates it.
+    # After validation, ``resolve`` falls through to the existing route
+    # table, so ``claude-sonnet-nim-NNNN`` lands on the configured fallback.
+    gmi.seed_picker_aliases(["bogus_provider/some-model"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    # Not the bogus provider we accidentally aliased to.
+    assert resolved.provider_id != "bogus_provider"
+    # Falls through to the configured default.
+    assert resolved.provider_id == "nvidia_nim"
+    assert resolved.provider_model == "fallback-model"
+
+
+def test_unknown_alias_falls_through_to_existing_routing(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-9999")
+
+    # 9999 is not a seeded alias; the routing layer should fall through.
+    # With no alias match, unknown alias falls back to model name parsing,
+    # which raises because ``claude-sonnet-nim-9999`` doesn't match a route.
+    assert resolved.original_model == "claude-sonnet-nim-9999"
+
+
+def test_unseeded_alias_returns_none_from_resolver(settings):
+    # Cold-start path: no aliases seeded, alias-shaped id should not produce
+    # a routing hit. Falls through to the existing fallback chain.
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0500")
+
+    # Falls through and lands on the configured default.
+    assert resolved.provider_id == "nvidia_nim"
+    assert resolved.provider_model == "fallback-model"

--- a/tests/cli/test_claude_desktop_launcher.py
+++ b/tests/cli/test_claude_desktop_launcher.py
@@ -1,0 +1,198 @@
+"""Tests for the ``fcc-claude-desktop`` launcher and JSON merge helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from free_claude_code.cli.launchers import claude_desktop
+
+
+@pytest.fixture
+def fake_config(tmp_path: Path) -> Path:
+    return tmp_path / "claude_desktop_config.json"
+
+
+def test_configure_applies_block_when_file_is_missing(fake_config: Path) -> None:
+    assert not fake_config.exists()
+
+    changed = claude_desktop.configure_claude_desktop_config(fake_config)
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+    assert data["inference"]["provider"] == "gateway"
+    assert data["inference"]["inferenceGatewayBaseUrl"] == "https://localhost:8443"
+    assert data["inference"]["inferenceAnthropicApiKey"] == "freecc"
+
+
+def test_configure_is_idempotent(fake_config: Path) -> None:
+    assert claude_desktop.configure_claude_desktop_config(fake_config) is True
+
+    # second call observes no diff.
+    second = claude_desktop.configure_claude_desktop_config(fake_config)
+    assert second is False
+
+
+def test_configure_preserves_unrelated_keys(fake_config: Path) -> None:
+    fake_config.parent.mkdir(parents=True, exist_ok=True)
+    fake_config.write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "mcpServers": {"fs": {"command": "node"}},
+                "coworkUserFilesPath": "/home/user/cowork",
+                "env": {"ANTHROPIC_BASE_URL": "https://localhost:8443"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    claude_desktop.configure_claude_desktop_config(fake_config)
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["preferences"] == {"theme": "dark"}
+    assert data["mcpServers"] == {"fs": {"command": "node"}}
+    assert data["coworkUserFilesPath"] == "/home/user/cowork"
+    assert data["env"] == {"ANTHROPIC_BASE_URL": "https://localhost:8443"}
+    assert data["modelDiscoveryEnabled"] is True
+
+
+def test_configure_overwrites_partial_inference_block(fake_config: Path) -> None:
+    fake_config.write_text(
+        json.dumps(
+            {"inference": {"provider": "anthropic", "credentialKind": "static"}}
+        ),
+        encoding="utf-8",
+    )
+
+    claude_desktop.configure_claude_desktop_config(fake_config)
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["inference"]["provider"] == "gateway"
+    assert data["inference"]["credentialKind"] == "static"
+    assert data["inference"]["inferenceGatewayBaseUrl"] == "https://localhost:8443"
+
+
+def test_unconfigure_drops_only_fcc_keys(fake_config: Path) -> None:
+    fake_config.write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "modelDiscoveryEnabled": True,
+                "inference": claude_desktop.INFERENCE_BLOCK
+                | {"extra_user_key": "stay"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = claude_desktop.unconfigure_claude_desktop_config(fake_config)
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in data
+    assert data["inference"] == {"extra_user_key": "stay"}
+    assert data["preferences"] == {"theme": "dark"}
+
+
+def test_unconfigure_removes_entire_inference_block_when_only_fcc_keys(
+    fake_config,
+) -> None:
+    claude_desktop.configure_claude_desktop_config(fake_config)
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    # Second pass is a no-op.
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
+
+
+def test_unconfigure_silent_on_missing_file(tmp_path: Path) -> None:
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(tmp_path / "absent.json")
+        is False
+    )
+
+
+def test_config_path_resolver_returns_default_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("APPDATA", raising=False)
+    for plat, expected_substring in (
+        ("linux", "claude_desktop_config.json"),
+        ("darwin", "claude_desktop_config.json"),
+        ("win32", "claude_desktop_config.json"),
+    ):
+        monkeypatch.setattr(claude_desktop.sys, "platform", plat, raising=False)
+        path = claude_desktop._config_path()
+        assert path.name == expected_substring
+        assert path.is_absolute()
+
+
+def test_launch_runs_subprocess_with_ignore_certificate_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[list[str]] = []
+
+    class FakeProcess:
+        def __init__(self, cmd):
+            calls.append(cmd)
+
+        def wait(self) -> int:
+            return 0
+
+        def terminate(self) -> None:  # pragma: no cover - unused in suite
+            return None
+
+    monkeypatch.setattr(
+        claude_desktop.shutil, "which", lambda _: "/usr/bin/claude-desktop"
+    )
+    monkeypatch.setattr(claude_desktop.subprocess, "Popen", FakeProcess)
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["/tmp/some extra path/"])
+    assert exc.value.code == 0
+    assert calls == [
+        [
+            "/usr/bin/claude-desktop",
+            "--ignore-certificate-errors",
+            "/tmp/some extra path/",
+        ]
+    ]
+
+
+def test_launch_exits_127_when_binary_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(claude_desktop.shutil, "which", lambda _: None)
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch([])
+    assert exc.value.code == 127
+    captured = capsys.readouterr()
+    assert "claude-desktop" in captured.err
+
+
+def test_launch_configure_does_not_invoke_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake = tmp_path / "claude_desktop_config.json"
+    invoked: list[bool] = []
+
+    def fail_call(cmd):
+        invoked.append(True)
+        return 0
+
+    monkeypatch.setattr(claude_desktop.subprocess, "Popen", fail_call)
+
+    claude_desktop.launch(["--configure", "--config-path", str(fake)])
+
+    assert invoked == []
+    captured = capsys.readouterr()
+    assert "Updated" in captured.out
+
+    data = json.loads(fake.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -93,6 +93,7 @@ def test_cli_scripts_are_registered() -> None:
         "fcc-claude": "free_claude_code.cli.launchers.claude:launch",
         "fcc-codex": "free_claude_code.cli.launchers.codex:launch",
         "fcc-pi": "free_claude_code.cli.launchers.pi:launch",
+        "fcc-claude-desktop": "free_claude_code.cli.launchers.claude_desktop:launch",
     }
     assert pyproject["project"]["gui-scripts"] == {
         "fcc-desktop": "free_claude_code.cli.desktop_entrypoint:launch",

--- a/tests/core/test_gateway_model_ids_aliases.py
+++ b/tests/core/test_gateway_model_ids_aliases.py
@@ -1,0 +1,155 @@
+"""Tests for picker aliasing in ``free_claude_code.core.gateway_model_ids``."""
+
+import pytest
+
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    """Reset module-scope alias maps before/after each test."""
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_picker_alias_prefix_is_anthropic_safe():
+    assert gmi.PICKER_ALIAS_PREFIX == "claude-sonnet-nim"
+
+
+def test_has_picker_aliases_false_before_seed():
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_populates_maps_and_marks_seeded():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    assert gmi.has_picker_aliases() is True
+
+
+def test_alias_counter_is_deterministic_from_sorted_input():
+    first = ["nvidia_nim/z-provider/z-model", "nvidia_nim/a-provider/a-model"]
+    second = list(reversed(first))
+
+    gmi.seed_picker_aliases(first)
+    a_first = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    gmi.seed_picker_aliases(second)
+    a_second = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert a_first == a_second == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/z-provider/z-model")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_alias_lookup_thinking_and_no_thinking_variants():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+
+
+def test_alias_lookup_unknown_ref_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/missing/model") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/missing/model", force_reasoning_off=True)
+        is None
+    )
+
+
+def test_resolve_picker_alias_round_trip():
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        False,
+    )
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001-no-thinking") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        True,
+    )
+
+
+def test_resolve_picker_alias_unknown_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999-no-thinking") is None
+    assert gmi.resolve_picker_alias("claude-haiku-nim-0001") is None
+
+
+def test_resolve_picker_alias_for_prefix_only_when_seeded_empty():
+    # Maps are empty by default (cold-start window).
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_clear_resets_state():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.has_picker_aliases() is True
+
+    gmi.clear_picker_aliases()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_empty_iterable_keeps_state_empty():
+    gmi.seed_picker_aliases([])
+
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_replaces_previous_aliases():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0001"
+    )
+
+
+def test_aliases_are_four_digit_zero_padded():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(15)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = {
+        gmi.picker_alias_for(ref): None
+        for ref in refs
+        if gmi.picker_alias_for(ref) is not None
+    }
+
+    assert len(aliases) == 15
+    for alias in aliases:
+        # All aliases share the same prefix and 4-digit counter width.
+        assert alias.startswith("claude-sonnet-nim-")
+        counter = alias.removeprefix("claude-sonnet-nim-").split("-")[0]
+        assert len(counter) == 4
+        assert counter.isdigit()
+
+
+def test_seed_assigns_unique_aliases_per_ref():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(10)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [gmi.picker_alias_for(ref) for ref in refs]
+
+    assert len(set(aliases)) == len(refs)
+    assert all(alias is not None for alias in aliases)

--- a/tests/providers/test_mcp_client.py
+++ b/tests/providers/test_mcp_client.py
@@ -1,0 +1,223 @@
+"""Tests for MCPClientManager."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestMCPClientManager:
+    """Test MCP client manager."""
+
+    @pytest.fixture
+    def mock_mcp_server(self):
+        """Mock MCP server for testing."""
+        # This will be used to mock stdio_client and ClientSession
+        pass
+
+    def _create_mock_tool(self, name: str, description: str, input_schema: dict):
+        """Create a proper mock tool object with real attributes."""
+        mock_tool = MagicMock()
+        mock_tool.name = name
+        mock_tool.description = description
+        mock_tool.inputSchema = input_schema
+        return mock_tool
+
+    @pytest.mark.asyncio
+    async def test_mcp_client_manager_connects_and_lists_tools(self, mock_mcp_server):
+        from free_claude_code.providers.openai_chat.mcp_client import (
+            MCPClientManager,
+            MCPServerConfig,
+        )
+
+        manager = MCPClientManager()
+        servers = [
+            MCPServerConfig(transport="stdio", command="uvx", args=["mcp-server-git"])
+        ]
+
+        with patch(
+            "free_claude_code.providers.openai_chat.mcp_client.stdio_client"
+        ) as mock_stdio_client:
+            mock_read_stream = AsyncMock()
+            mock_write_stream = AsyncMock()
+            mock_stdio_client.return_value.__aenter__.return_value = (
+                mock_read_stream,
+                mock_write_stream,
+            )
+
+            with patch(
+                "free_claude_code.providers.openai_chat.mcp_client.ClientSession"
+            ) as mock_session_class:
+                mock_session = AsyncMock()
+                mock_session_class.return_value = mock_session
+                mock_session.__aenter__.return_value = mock_session
+                mock_session.initialize = AsyncMock()
+                mock_session.list_tools = AsyncMock(
+                    return_value=MagicMock(
+                        tools=[
+                            self._create_mock_tool(
+                                "git_status",
+                                "Get git status",
+                                {
+                                    "type": "object",
+                                    "properties": {"path": {"type": "string"}},
+                                    "required": ["path"],
+                                },
+                            )
+                        ]
+                    )
+                )
+
+                tools = await manager.connect(servers)
+
+                assert len(tools) == 1
+                assert tools[0].name == "git_status"
+                assert tools[0].description == "Get git status"
+                assert tools[0].input_schema["type"] == "object"
+                assert "path" in tools[0].input_schema["properties"]
+                await manager.close()
+
+    @pytest.mark.asyncio
+    async def test_mcp_client_manager_execute_tool(self):
+        from free_claude_code.providers.openai_chat.mcp_client import (
+            MCPClientManager,
+            MCPServerConfig,
+            ToolResult,
+        )
+
+        manager = MCPClientManager()
+
+        with patch(
+            "free_claude_code.providers.openai_chat.mcp_client.stdio_client"
+        ) as mock_stdio_client:
+            mock_read_stream = AsyncMock()
+            mock_write_stream = AsyncMock()
+            mock_stdio_client.return_value.__aenter__.return_value = (
+                mock_read_stream,
+                mock_write_stream,
+            )
+
+            with patch(
+                "free_claude_code.providers.openai_chat.mcp_client.ClientSession"
+            ) as mock_session_class:
+                mock_session = AsyncMock()
+                mock_session_class.return_value = mock_session
+                mock_session.__aenter__.return_value = mock_session
+                mock_session.initialize = AsyncMock()
+                mock_session.list_tools = AsyncMock(
+                    return_value=MagicMock(
+                        tools=[
+                            self._create_mock_tool(
+                                "test_tool",
+                                "Test tool",
+                                {"type": "object", "properties": {}},
+                            )
+                        ]
+                    )
+                )
+                mock_session.call_tool = AsyncMock(
+                    return_value=MagicMock(
+                        content=[MagicMock(text="tool result")], isError=False
+                    )
+                )
+
+                await manager.connect(
+                    [MCPServerConfig(transport="stdio", command="test", args=[])]
+                )
+
+                result = await manager.execute_tool("test_tool", {"arg": "value"})
+
+                assert isinstance(result, ToolResult)
+                assert isinstance(result.content, list)
+                assert result.is_error is False
+
+                await manager.close()
+
+    def test_mcp_tool_to_openai_function_declaration(self):
+        from free_claude_code.providers.openai_chat.mcp_client import (
+            MCPTool,
+            mcp_tool_to_openai_function,
+        )
+
+        mcp_tool = MCPTool(
+            name="git_status",
+            description="Get git status",
+            input_schema={
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        )
+
+        openai_func = mcp_tool_to_openai_function(mcp_tool)
+
+        assert openai_func["type"] == "function"
+        assert openai_func["function"]["name"] == "git_status"
+        assert openai_func["function"]["description"] == "Get git status"
+        assert openai_func["function"]["parameters"] == mcp_tool.input_schema
+
+    @pytest.mark.asyncio
+    async def test_mcp_client_manager_security_guardrail_localhost_only(self):
+        """Test that MCP is skipped for non-localhost requests."""
+        from free_claude_code.providers.openai_chat.mcp_client import (
+            MCPClientManager,
+            MCPServerConfig,
+        )
+
+        manager = MCPClientManager()
+
+        # Non-localhost client should return empty tools
+        tools = await manager.connect(
+            [MCPServerConfig(transport="stdio", command="test", args=[])],
+            client_host="192.168.1.1",
+        )
+        assert tools == []
+
+        # Localhost should allow connection (though it won't actually connect without mock)
+        # We'll test this in a more complete test
+        await manager.close()
+
+    @pytest.mark.asyncio
+    async def test_mcp_client_manager_with_sse_transport(self):
+        """Test SSE transport connection."""
+        from free_claude_code.providers.openai_chat.mcp_client import (
+            MCPClientManager,
+            MCPServerConfig,
+        )
+
+        manager = MCPClientManager()
+        servers = [MCPServerConfig(transport="sse", url="http://localhost:3000/sse")]
+
+        with patch(
+            "free_claude_code.providers.openai_chat.mcp_client.sse_client"
+        ) as mock_sse_client:
+            mock_read_stream = AsyncMock()
+            mock_write_stream = AsyncMock()
+            mock_sse_client.return_value.__aenter__.return_value = (
+                mock_read_stream,
+                mock_write_stream,
+            )
+
+            with patch(
+                "free_claude_code.providers.openai_chat.mcp_client.ClientSession"
+            ) as mock_session_class:
+                mock_session = AsyncMock()
+                mock_session_class.return_value = mock_session
+                mock_session.__aenter__.return_value = mock_session
+                mock_session.initialize = AsyncMock()
+                mock_session.list_tools = AsyncMock(
+                    return_value=MagicMock(
+                        tools=[
+                            self._create_mock_tool(
+                                "sse_tool",
+                                "SSE tool",
+                                {"type": "object", "properties": {}},
+                            )
+                        ]
+                    )
+                )
+
+                tools = await manager.connect(servers)
+
+                assert len(tools) == 1
+                assert tools[0].name == "sse_tool"
+                await manager.close()

--- a/tests/providers/test_openai_mcp_tool_result_emission.py
+++ b/tests/providers/test_openai_mcp_tool_result_emission.py
@@ -1,0 +1,96 @@
+"""Unit tests for the Anthropic ``tool_result`` block emitter on the ledger.
+
+Required because the M3 fix replaces a plain-text fallback with proper
+Anthropic SSE ``tool_result`` blocks. These tests pin the wire shape.
+
+The stream ledger module loads cleanly without the missing
+``free_claude_code.providers.admission`` module, so we import it directly.
+"""
+
+import json
+
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.anthropic.streaming.ledger import (
+    AnthropicStreamLedger,
+)
+
+
+def _new_ledger() -> AnthropicStreamLedger:
+    return AnthropicStreamLedger(message_id="msg_test", model="claude-test")
+
+
+def _frame(event: str) -> dict:
+    """Parse one SSE event line into a dict preserving event/data."""
+    lines = [ln for ln in event.splitlines() if ln.startswith(("event:", "data:"))]
+    assert len(lines) == 2, f"unexpected SSE shape: {event!r}"
+    etype = lines[0].split(":", 1)[1].strip()
+    data = json.loads(lines[1].split(":", 1)[1].strip())
+    return {"event": etype, "data": data}
+
+
+def test_emit_tool_result_block_basic_shape() -> None:
+    ledger = _new_ledger()
+    events = list(
+        ledger.emit_tool_result_block(
+            tool_use_id="toolu_v1",
+            content="permission_denied",
+            is_error=True,
+        )
+    )
+    frames = [_frame(e) for e in events]
+    kinds = [f["event"] for f in frames]
+    assert kinds == [
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+    ]
+    start = frames[0]["data"]["content_block"]
+    assert start["type"] == "tool_result"
+    assert start["tool_use_id"] == "toolu_v1"
+    assert start["content"] == "permission_denied"
+    assert start["is_error"] is True
+    assert frames[0]["data"]["index"] == frames[2]["data"]["index"]
+
+
+def test_emit_tool_result_block_default_is_error_false() -> None:
+    ledger = _new_ledger()
+    events = list(
+        ledger.emit_tool_result_block(tool_use_id="toolu_v2", content='{"ok": true}')
+    )
+    start = _frame(events[0])["data"]["content_block"]
+    assert start["is_error"] is False
+
+
+def test_tool_result_block_emits_via_parse_sse_text() -> None:
+    """Round-trip the emitter output through ``parse_sse_text``.
+
+    Ensures the block can be consumed by the same downstream parser used in
+    ``test_streaming_errors.py``.
+    """
+    ledger = _new_ledger()
+    raw = "".join(
+        ledger.emit_tool_result_block(
+            tool_use_id="call_xyz", content="denied by policy", is_error=True
+        )
+    )
+    parsed = parse_sse_text(raw)
+    assert parsed, "parse_sse_text accepted no events from the emitter"
+    kinds = [p.event for p in parsed]
+    assert kinds == [
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+    ]
+    block = parsed[0].data["content_block"]
+    assert block["type"] == "tool_result"
+    assert block["tool_use_id"] == "call_xyz"
+
+
+def test_tool_result_blocks_are_unique_per_emit() -> None:
+    """Each emission must allocate a fresh block index — never reuse."""
+    ledger = _new_ledger()
+    first = list(ledger.emit_tool_result_block(tool_use_id="a", content="x"))
+    second = list(ledger.emit_tool_result_block(tool_use_id="b", content="y"))
+    idx_0 = _frame(first[0])["data"]["index"]
+    idx_1 = _frame(second[0])["data"]["index"]
+    assert idx_0 != idx_1

--- a/tests/runtime/test_application_runtime_picker_aliases.py
+++ b/tests/runtime/test_application_runtime_picker_aliases.py
@@ -1,0 +1,76 @@
+"""Runtime seeding for picker aliases via ``ApplicationRuntime``."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.application import ApplicationRuntime
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _make_runtime_with_models(model_ids):
+    provider_manager = MagicMock()
+    provider_manager.cached_prefixed_model_infos.return_value = tuple(
+        ProviderModelInfo(model_id=model_id, supports_thinking=None)
+        for model_id in model_ids
+    )
+    return ApplicationRuntime(provider_manager, transcriber=None)
+
+
+def test_seed_picker_aliases_from_cache_populates_maps():
+    runtime = _make_runtime_with_models(
+        ["nvidia_nim/01-ai/yi-large", "nvidia_nim/meta/llama-3.3-70b-instruct"]
+    )
+
+    runtime._seed_picker_aliases_from_cache()
+
+    assert gmi.has_picker_aliases() is True
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_seed_picker_aliases_with_empty_cache_leaves_state_inert():
+    runtime = _make_runtime_with_models([])
+
+    runtime._seed_picker_aliases_from_cache()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_picker_aliases_uses_sorted_input_for_counter_stability():
+    first_runtime = _make_runtime_with_models(
+        [
+            "nvidia_nim/z-provider/z-model",
+            "nvidia_nim/a-provider/a-model",
+        ]
+    )
+    first_runtime._seed_picker_aliases_from_cache()
+    first_alias_for_a = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    second_runtime = _make_runtime_with_models(
+        [
+            "nvidia_nim/a-provider/a-model",
+            "nvidia_nim/z-provider/z-model",
+        ]
+    )
+    second_runtime._seed_picker_aliases_from_cache()
+    second_alias_for_a = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert first_alias_for_a == second_alias_for_a == "claude-sonnet-nim-0001"

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.13.1"
+version = "4.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Add `fcc-claude-desktop` entry point for Claude Desktop Electron app
- Implement picker aliasing (`claude-sonnet-nim-####`) to work around upstream model picker limitations
- Auto-configure Claude Desktop via JSON merge in install scripts (no jq/sed — Python helper)
- Reverse merge on uninstall

## Components
| Layer | Files |
|-------|-------|
| Core alias | `src/free_claude_code/core/gateway_model_ids.py` |
| API catalog/routing | `api/model_catalog.py`, `application/routing.py` |
| Runtime seeding | `runtime/application.py` |
| CLI launcher | `cli/launchers/claude_desktop.py` (new) |
| Install/Uninstall | `scripts/install.{sh,ps1}`, `uninstall.{sh,ps1}` |
| Tests | 38 new across core/api/routing/runtime/cli |

## Validation
- 38 PR1-specific tests pass
- 2,582 total tests pass
- `ruff format` / `ruff check` / suppression ban clean
- Version bump: 4.13.1 → 4.14.0 (MINOR) + `uv.lock`

## Follow-up (PR2)
Phase 1 from integration analysis: `/v1/telemetry` 200 JSON, capability flags, billing header.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Claude Desktop integration, picker-safe aliases, model catalog exposure, routing support, runtime cache seeding, and installer configuration. Runtime testing reproduced a failure after asynchronous model discovery: a newly discovered model is cached but does not receive a picker alias, so the catalog publishes canonical gateway IDs that Claude Desktop can filter out.

Merge safety: do not merge until background discovery updates picker aliases for newly added models.

<h3>Confidence Score: 2/5</h3>





<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the focused stale-alias regression script to reproduce the posted P1 finding and collect baseline and discovery outputs.
- Compared warm-cache baseline, background discovery results, and picker/catalog test outputs to validate the finding evidence.
- Validated contract behavior by reviewing the regression script results and post-discovery state, noting the model is cached with no alias and is published with canonical gateway IDs.
- Documented and linked the produced artifacts to support reviewer inspection of the regression run and its outputs.

<a href="https://app.greptile.com/trex/runs/16646739/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (6)</h3>

1. `src/free_claude_code/runtime/application.py`, line 263 ([link](https://github.com/alishahryar1/free-claude-code/blob/adf5d66459ac7b9f018b75e8f091af72eb6545d1/src/free_claude_code/runtime/application.py#L263)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Model refresh leaves picker aliases stale**

   - **Bug**
     - `start()` seeds the process-global picker alias maps from the warmed cache at line 157, but `refresh_models()` only refreshes the provider cache and returns its result. It never rebuilds those maps. `/v1/models` uses an alias only when that map contains the provider/model ref and otherwise advertises the canonical gateway wrapper ID. Consequently, a model added by a post-startup refresh is listed without the picker alias Claude Desktop accepts, so it remains unavailable in that picker until the process restarts.
   - **Cause**
     - `ApplicationRuntime.refresh_models()` delegates to `refresh_model_list_cache()` without calling `_seed_picker_aliases_from_cache()` after the cache changes.
   - **Fix**
     - After a successful model-cache refresh, rebuild picker aliases from `cached_prefixed_model_infos()` before returning the refresh result. Ensure any other supported post-startup catalog mutation path applies the same synchronization.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Auto Claude Desktop configuration calls python3 outside uv's console-entry-point bin**

   - **Bug**
     - After successfully verifying `fcc-desktop`, `fcc-server`, `fcc-claude`, `fcc-codex`, `fcc-pi`, and `fcc-claude-desktop`, the installer invokes `$tool_bin/python3 -m ...`. In a uv-style bin containing those verified entry points but no interpreter, that command returns 127. The error is treated as best-effort, so installation completes while Claude Desktop configuration is absent.
   - **Cause**
     - `uv tool dir --bin` identifies the directory for exposed tool executables; the installer assumes it also contains the tool environment's `python3`, despite only validating console scripts there.
   - **Fix**
     - Invoke the installed and already-verified console script directly: `"$tool_bin/fcc-claude-desktop" --configure`; make the dry-run output use the same command.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Claude Desktop configuration is overwritten when parsing fails or the root is not an object**

   - **Bug**
     - `load_existing_config()` returns `{}` for malformed JSON and for valid JSON values whose top level is not an object. `configure_claude_desktop_config()` then treats that empty mapping as a new config and atomically replaces the original file with the FCC configuration. The targeted run reproduced this for both `{"theme": "dark", "fontSize": 14,` and `[{"theme": "dark", "fontSize": 14}]`.
   - **Cause**
     - Lines 76-83 discard both decode failures and non-dictionary parsed values instead of preventing the write or preserving/recovering the original content.
   - **Fix**
     - Do not write when an existing configuration is malformed or has a non-object root. Return a failure/status and retain the original file (optionally create a backup and require explicit user action before replacement).

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Post-startup model refresh leaves picker aliases stale**

   - **Bug**
     - `ApplicationRuntime.start()` seeds aliases from the warmed cache once, but `refresh_models()` delegates to `ProviderRuntimeManager.refresh_model_list_cache()` without reseeding. A model discovered after startup is returned by `/v1/models` with canonical/wrapper IDs instead of picker aliases.
   - **Cause**
     - `refresh_models()` has no call to `_seed_picker_aliases_from_cache()` after a successful cache refresh; aliases are process-global snapshots established only during startup.
   - **Fix**
     - After a successful model-cache refresh that changes or successfully refreshes providers, call `_seed_picker_aliases_from_cache()` before subsequent model-catalog responses. Add a regression test that starts with one model, refreshes to add another, and asserts both models receive picker aliases.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

5. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Refreshing the model cache breaks aliases already retained by Claude Desktop**

   - **Bug**
     - After a client retains a positional picker alias, `ApplicationRuntime.refresh_models()` rebuilds every alias from the changed sorted catalog. Adding a reference before the retained model changes the alias target; removing a reference before it can make the old alias unresolvable.
   - **Cause**
     - `src/free_claude_code/runtime/application.py:265` invokes `_seed_picker_aliases_from_cache()`, which delegates at line 359 to `seed_picker_aliases()`. That function replaces all global maps (`src/free_claude_code/core/gateway_model_ids.py:99-102`) and numbers refs by `sorted(provider_model_refs)` (line 89), so aliases are positional rather than stable over a running client session.
   - **Fix**
     - Do not rebuild aliases in a way that renumbers existing references during a running process. Preserve existing alias-to-reference assignments and allocate new monotonically increasing aliases only for newly discovered references; retain mappings needed by connected clients, or otherwise introduce a session-safe alias lifecycle. Add a refresh regression test covering insertion and removal before an already-issued alias.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

6. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Background model discovery leaves picker alias maps stale**

   - **Bug**
     - `ApplicationRuntime.start()` warms the referenced-model cache, starts a non-blocking discovery refresh, then seeds picker aliases only once. When that background refresh adds a model, the catalog includes it but `picker_alias_for()` returns `None`; thus `build_models_list_response()` falls back to canonical `anthropic/...` IDs, which the reported Claude Desktop flow filters out.
   - **Cause**
     - The alias maps are seeded synchronously from the startup cache snapshot at `src/free_claude_code/runtime/application.py:156-157`. `ProviderRuntimeManager.start_model_list_refresh()` launches an unobserved task and no background-refresh completion path calls `_seed_picker_aliases_from_cache()` or otherwise updates the maps.
   - **Fix**
     - Reseed/update picker aliases atomically after background model-list refresh successfully changes the cache, while preserving stable aliases for existing refs; add this regression as a production test.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into pr1-claude-desk..."](https://github.com/alishahryar1/free-claude-code/commit/6e0c72d0cdaa37fe888c0e2b5a6d92c05328d9b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48780004)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->