### PR TITLE
Fix Windows ARM64 installation without source builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.15.0"
+version = "4.15.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,7 +14,8 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 $RepoArchiveUrl = "https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
-$PythonVersion = "3.14.0"
+# Windows on ARM emulates x64, whose Python package ecosystem has broader wheel support.
+$PythonRequest = "cpython-3.14.0-windows-x86_64-none"
 $MinUvVersion = "0.11.16"
 $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
@@ -499,7 +500,7 @@ function Install-FreeClaudeCode {
         "--refresh-package",
         "free-claude-code",
         "--python",
-        $PythonVersion
+        $PythonRequest
     )
     if (-not [string]::IsNullOrWhiteSpace($TorchBackend)) {
         $arguments += @("--torch-backend", $TorchBackend)

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1161,7 +1161,8 @@ def test_install_ps1_fresh_install_is_verified(
     assert any(
         call.startswith(
             "uv:tool install --force --refresh-package free-claude-code "
-            '--python 3.14.0 "free-claude-code @ '
+            "--python cpython-3.14.0-windows-x86_64-none "
+            '"free-claude-code @ '
             'https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"'
         )
         for call in calls
@@ -1543,6 +1544,12 @@ def test_installers_use_native_clients_and_single_python_selection() -> None:
 
     assert "https://pi.dev/install.sh" in shell
     assert "https://pi.dev/install.ps1" in powershell
+
+
+def test_install_ps1_uses_x64_python_for_windows_arm_compatibility() -> None:
+    powershell = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+
+    assert '$PythonRequest = "cpython-3.14.0-windows-x86_64-none"' in powershell
 
 
 def test_readme_install_section_has_no_manual_git_prerequisite() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.15.0"
+version = "4.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Windows ARM64 installations selected native Python and attempted to compile `cryptography` because current releases provide no ARM64 Windows wheel. Fresh FCC installation therefore failed without a local Rust and C build environment. Fixes #1289.

## Changes

| Before | After |
| --- | --- |
| The PowerShell installer requested architecture-neutral Python 3.14.0. | The PowerShell installer requests x64 CPython 3.14.0, which Windows on ARM runs through transparent emulation. |
| ARM64 dependency resolution selected unsupported native source builds. | ARM64 dependency resolution consumes the supported Windows x64 wheels. |
| Installer contracts checked only the Python version. | Installer contracts preserve the complete x64 interpreter request. |
| The package version was 4.15.0. | The package version and lockfile are 4.15.1. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Windows installer now requests CPython 3.14.0 for Windows x64, its command contract is covered by tests, and the release metadata is updated to 4.15.1.

The reported Windows ARM64 installation failure was disproved. The installer passes the explicit x64 request to uv, which resolves the expected x64 Windows archive. Current Windows on ARM provides transparent x64 emulation, so that interpreter remains executable on supported ARM64 Windows systems. The installer test suite completed with 51 passing tests and 44 skipped tests.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised Windows interpreter-selection behavior and passing installer contract tests.

The reported installation failure was disproved by resolving the exact interpreter request and confirming that supported Windows ARM64 systems execute x64 applications through built-in emulation. No remaining defects were found.

**Files Needing Attention:** No files require follow-up changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused before-and-after harness against the parent revision and the PR, which showed the PR sets PythonRequest and uses uv tool install to fetch a Windows x64 interpreter.
- Verified uv returns the exact proposed interpreter for x86\_64 (cpython-3.14.0+20251120-x86\_64-pc-windows-msvc-install\_only\_stripped.tar.gz) and a separate ARM64 request resolves to aarch64, confirming correct target selection.
- Ran the installer test suite via pytest, obtaining 51 passing tests and 44 skipped tests, which demonstrates the tests' coverage and behavior after the change.
- Validated with before/after execution records that uv selects the same x86\_64 tarball for both parent and PR, and noted Windows-on-ARM x64 emulation is transparent, supporting the PR's compatibility rationale.

<a href="https://app.greptile.com/trex/runs/16634110/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Windows ARM64 installation"](https://github.com/alishahryar1/free-claude-code/commit/05f9160b2c580fa12127ada71495d0cd158cd9dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48792036)</sub>

<!-- /greptile_comment -->