### PR TITLE
Add Codex App model catalog support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,8 +12,8 @@ and how contributors should extend it.
 
 Free Claude Code is a local proxy for agent clients. It accepts Anthropic
 Messages traffic from Claude Code and Pi clients and OpenAI Responses traffic
-from Codex clients, routes the request to a configured upstream provider, and
-preserves the wire protocol expected by the caller.
+from Codex CLI, IDE, and App clients, routes the request to a configured
+upstream provider, and preserves the wire protocol expected by the caller.
 
 There are three runtime surfaces:
 
@@ -27,7 +27,7 @@ There are three runtime surfaces:
 ```mermaid
 flowchart LR
     ClaudeCode[Claude Code CLI and Extensions] --> ProxyAPI[FastAPI Proxy]
-    Codex[Codex CLI and Extensions] --> ProxyAPI
+    Codex[Codex CLI, IDE, and App] --> ProxyAPI
     Pi[Pi Coding Agent] --> ProxyAPI
     AdminUI[Local Admin UI] --> ProxyAPI
     Bots[Discord or Telegram Bots] --> Messaging[Messaging Bridge]
@@ -301,8 +301,11 @@ Settings-configured providers and currently connected accounts contribute to
 the same availability set. Account connect/disconnect performs a targeted model
 refresh or eviction; it does not mutate settings or replace a provider
 generation.
-This keeps the server model inventory stable without extra synchronization;
-Claude clients may independently retain the list they fetched at startup.
+Runtime integrations may observe those lifecycle events through one neutral
+catalog publisher supplied by the composition root. Publication is fail-open
+and occurs only after settings or cache changes; provider adapters remain the
+sole owners of upstream discovery. Claude and Codex clients may independently
+retain the model list they loaded at startup.
 
 ## Configuration Model
 
@@ -539,11 +542,26 @@ translate reasoning. The catalog is not part of an individual provider
 generation, so a hot replacement does not erase the last useful model list.
 Discovery failures retain prior entries.
 
-Codex-specific model picker shaping stays out of this route. `fcc-codex` fetches
-the same `/v1/models` response at launch, converts FCC gateway IDs into
-provider-selectable Codex slugs, writes `~/.fcc/codex-model-catalog.json`, and
-passes it as `model_catalog_json`. Codex users open the native picker with
-`/model`; FCC does not implement a proxy-level `/models` alias.
+Codex-specific model picker shaping stays out of this route.
+[runtime/codex_catalog.py](src/free_claude_code/runtime/codex_catalog.py) is the
+composition bridge: it asks this route's pure builder for the exact application
+inventory, passes that response to the existing Codex adapter, and writes
+`~/.fcc/codex-model-catalog.json` without making a loopback HTTP request.
+`ProviderRuntimeManager` invokes the bridge after authoritative settings,
+discovery, provider-test, or connected-account changes. Startup creates a
+missing file after routed-provider warming but preserves an existing
+last-known-good catalog until the background discovery pass publishes the
+complete accumulated inventory. Writes are atomic and identical bytes are not
+rewritten. Projection or filesystem failures emit only a concise warning and do
+not fail server startup, Admin operations, discovery, or inference. Shutdown
+never publishes the cleared in-memory cache.
+
+The Codex App reads `model_catalog_json` at startup, so it must restart to see a
+later catalog publication. `fcc-codex` remains an additional launch-time
+synchronizer: it fetches the same `/v1/models` response, uses the same adapter
+and writer, and passes the path as an ephemeral override. Codex users open the
+native picker with `/model`; FCC does not implement a proxy-level `/models`
+alias.
 
 ## Provider Architecture
 
@@ -1047,6 +1065,8 @@ instead of stopping at its login gate.
   `model_catalog_json` file under `~/.fcc/`, and injects that path so Codex's
   native `/model` picker lists FCC provider slugs. Catalog generation is
   fail-open: launch continues with a warning if the catalog cannot be prepared.
+- The server lifecycle independently keeps that same file synchronized for
+  Codex App and IDE processes that are not launched through `fcc-codex`.
 - Catalog discovery and inference both authenticate with HTTP bearer authorization.
 - It stores the proxy auth token in `FCC_CODEX_API_KEY` for Codex's provider
   `env_key` to read. This process-local variable is a client credential carrier,

--- a/README.md
+++ b/README.md
@@ -301,6 +301,43 @@ Match the port and authentication token to the Admin UI, then reload the extensi
 </details>
 
 <details>
+<summary><strong>Codex App</strong></summary>
+
+Start FCC, then add its provider and generated model catalog to your user-level Codex configuration.
+
+**Windows** — edit `%USERPROFILE%\.codex\config.toml` and replace `YOUR_USERNAME`:
+
+```toml
+model_provider = "fcc"
+model = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
+model_catalog_json = "C:/Users/YOUR_USERNAME/.fcc/codex-model-catalog.json"
+
+[model_providers.fcc]
+name = "Free Claude Code"
+base_url = "http://127.0.0.1:8082/v1"
+http_headers = { Authorization = "Bearer freecc" }
+wire_api = "responses"
+```
+
+**macOS** — edit `~/.codex/config.toml` and replace `YOUR_USERNAME`:
+
+```toml
+model_provider = "fcc"
+model = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
+model_catalog_json = "/Users/YOUR_USERNAME/.fcc/codex-model-catalog.json"
+
+[model_providers.fcc]
+name = "Free Claude Code"
+base_url = "http://127.0.0.1:8082/v1"
+http_headers = { Authorization = "Bearer freecc" }
+wire_api = "responses"
+```
+
+Match the model, port, and bearer token to the Admin UI. Restart the Codex App after setup or model changes, then use its model picker to select any FCC provider/model slug.
+
+</details>
+
+<details>
 <summary><strong>Codex in VS Code</strong></summary>
 
 Install the [Codex extension](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt). Create or edit `~/.codex/config.toml` (`%USERPROFILE%\.codex\config.toml` on Windows):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.15.1"
+version = "4.16.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/codex_model_catalog.py
+++ b/src/free_claude_code/cli/launchers/codex_model_catalog.py
@@ -67,16 +67,24 @@ def build_codex_model_catalog(models_response: Mapping[str, Any]) -> dict[str, A
     return {"models": models}
 
 
-def write_codex_model_catalog(catalog_path: Path, catalog: Mapping[str, Any]) -> None:
-    """Atomically write a Codex model catalog JSON file."""
+def write_codex_model_catalog(catalog_path: Path, catalog: Mapping[str, Any]) -> bool:
+    """Atomically write changed Codex model catalog JSON."""
+
+    content = (json.dumps(catalog, ensure_ascii=True, indent=2) + "\n").encode()
+    try:
+        if catalog_path.read_bytes() == content:
+            return False
+    except FileNotFoundError:
+        pass
 
     catalog_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = catalog_path.with_name(f".{catalog_path.name}.{uuid.uuid4().hex}.tmp")
-    temp_path.write_text(
-        json.dumps(catalog, ensure_ascii=True, indent=2) + "\n",
-        encoding="utf-8",
-    )
-    temp_path.replace(catalog_path)
+    try:
+        temp_path.write_bytes(content)
+        temp_path.replace(catalog_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return True
 
 
 def _catalog_candidates(

--- a/src/free_claude_code/runtime/bootstrap.py
+++ b/src/free_claude_code/runtime/bootstrap.py
@@ -23,6 +23,7 @@ from free_claude_code.providers.runtime.factory import create_provider
 
 from .application import ApplicationRuntime, RestartCallback
 from .asgi import RuntimeASGIApp
+from .codex_catalog import CodexModelCatalogPublisher
 from .provider_manager import ProviderRuntimeManager
 
 
@@ -51,6 +52,7 @@ def build_asgi_app(
         settings,
         runtime_factory=runtime_factory,
         connected_provider_ids=openai_auth.connected_provider_ids,
+        model_catalog_publisher=CodexModelCatalogPublisher(),
     )
     runtime = ApplicationRuntime(
         provider_manager,

--- a/src/free_claude_code/runtime/codex_catalog.py
+++ b/src/free_claude_code/runtime/codex_catalog.py
@@ -1,0 +1,49 @@
+"""Publish the application model inventory for Codex clients."""
+
+from pathlib import Path
+
+from free_claude_code.api.model_catalog import build_models_list_response
+from free_claude_code.application.ports import RequestRuntimePort
+from free_claude_code.cli.launchers.codex_model_catalog import (
+    build_codex_model_catalog,
+    write_codex_model_catalog,
+)
+from free_claude_code.config.paths import codex_model_catalog_path
+
+
+class CodexModelCatalogPublisher:
+    """Own synchronization of the stable Codex model catalog file."""
+
+    def __init__(self, catalog_path: Path | None = None) -> None:
+        self._catalog_path = catalog_path
+
+    def ensure_exists(self, runtime: RequestRuntimePort) -> None:
+        """Publish a startup catalog only when no prior catalog exists."""
+
+        catalog_path = self._resolved_catalog_path()
+        if catalog_path.exists():
+            return
+        self._publish(runtime, catalog_path)
+
+    def publish(self, runtime: RequestRuntimePort) -> None:
+        """Publish the complete current application model inventory."""
+
+        self._publish(runtime, self._resolved_catalog_path())
+
+    def _publish(
+        self,
+        runtime: RequestRuntimePort,
+        catalog_path: Path,
+    ) -> None:
+        models_response = build_models_list_response(
+            runtime.current_settings(),
+            runtime,
+        )
+        catalog = build_codex_model_catalog(models_response.model_dump())
+        models = catalog.get("models")
+        if not isinstance(models, list) or not models:
+            raise ValueError("Codex model catalog contains no routable models.")
+        write_codex_model_catalog(catalog_path, catalog)
+
+    def _resolved_catalog_path(self) -> Path:
+        return self._catalog_path or codex_model_catalog_path()

--- a/src/free_claude_code/runtime/provider_manager.py
+++ b/src/free_claude_code/runtime/provider_manager.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from typing import Protocol
 
 from loguru import logger
 
@@ -11,6 +12,7 @@ from free_claude_code.application.model_metadata import (
     ProviderModelInfo,
     ProviderModelRefreshResult,
 )
+from free_claude_code.application.ports import RequestRuntimePort
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.base import BaseProvider
@@ -24,6 +26,14 @@ from free_claude_code.providers.runtime.model_cache import ProviderModelCache
 ProviderRuntimeFactory = Callable[[Settings], ProviderRuntime]
 ConnectedProviderIds = Callable[[], tuple[str, ...]]
 CommitConfig = Callable[[], None]
+
+
+class ModelCatalogPublisher(Protocol):
+    """Synchronize an external view of the application model inventory."""
+
+    def ensure_exists(self, runtime: RequestRuntimePort) -> None: ...
+
+    def publish(self, runtime: RequestRuntimePort) -> None: ...
 
 
 @dataclass(slots=True, eq=False)
@@ -89,9 +99,11 @@ class ProviderRuntimeManager:
         *,
         runtime_factory: ProviderRuntimeFactory = ProviderRuntime,
         connected_provider_ids: ConnectedProviderIds = tuple,
+        model_catalog_publisher: ModelCatalogPublisher | None = None,
     ) -> None:
         self._runtime_factory = runtime_factory
         self._connected_provider_ids = connected_provider_ids
+        self._model_catalog_publisher = model_catalog_publisher
         self._replace_lock = asyncio.Lock()
         self._close_lock = asyncio.Lock()
         self._model_cache = ProviderModelCache(
@@ -145,6 +157,7 @@ class ProviderRuntimeManager:
         model_infos: Iterable[ProviderModelInfo],
     ) -> None:
         self._model_cache.cache_model_infos(provider_id, model_infos)
+        self._publish_model_catalog()
 
     async def warm_referenced_model_cache(self) -> ProviderModelRefreshResult:
         """Warm routed provider catalogs before clients perform model discovery."""
@@ -156,7 +169,9 @@ class ProviderRuntimeManager:
                 self._model_cache,
                 self._connected_provider_ids(),
             )
-            return await discovery.warm_referenced_model_cache()
+            result = await discovery.warm_referenced_model_cache()
+            self._ensure_model_catalog()
+            return result
         finally:
             await lease.release()
 
@@ -189,6 +204,7 @@ class ProviderRuntimeManager:
                 raise ApplicationUnavailableError("Provider runtime is shutting down.")
             if not connected:
                 self._model_cache.remove_provider(provider_id)
+                self._publish_model_catalog()
                 return ProviderModelRefreshResult()
             self._model_cache.add_provider(provider_id)
             discovery = ProviderModelDiscovery(
@@ -197,7 +213,9 @@ class ProviderRuntimeManager:
                 self._model_cache,
                 self._connected_provider_ids(),
             )
-            return await discovery.refresh_provider(provider_id)
+            result = await discovery.refresh_provider(provider_id)
+            self._publish_model_catalog()
+            return result
 
     def _synchronize_model_cache_scope(self) -> None:
         """Drop metadata whose settings or connected account is no longer usable."""
@@ -254,6 +272,7 @@ class ProviderRuntimeManager:
                     settings, self._connected_provider_ids()
                 )
             )
+            self._publish_model_catalog()
             previous.retired = True
             self._retired[previous.generation_id] = previous
             self._trace_published(candidate, previous=previous, reason=reason)
@@ -323,9 +342,35 @@ class ProviderRuntimeManager:
                 self._model_cache,
                 self._connected_provider_ids(),
             )
-            return await discovery.refresh_model_list_cache(only_missing=only_missing)
+            result = await discovery.refresh_model_list_cache(only_missing=only_missing)
+            self._publish_model_catalog()
+            return result
         finally:
             await self._release(generation)
+
+    def _ensure_model_catalog(self) -> None:
+        publisher = self._model_catalog_publisher
+        if publisher is None:
+            return
+        self._run_model_catalog_publication(publisher.ensure_exists)
+
+    def _publish_model_catalog(self) -> None:
+        publisher = self._model_catalog_publisher
+        if publisher is None:
+            return
+        self._run_model_catalog_publication(publisher.publish)
+
+    def _run_model_catalog_publication(
+        self,
+        publication: Callable[[RequestRuntimePort], None],
+    ) -> None:
+        try:
+            publication(self)
+        except Exception as exc:
+            logger.warning(
+                "Model catalog publication failed: exc_type={}",
+                type(exc).__name__,
+            )
 
     async def _refresh_generation_in_background(
         self,

--- a/tests/api/test_app_lifespan_and_errors.py
+++ b/tests/api/test_app_lifespan_and_errors.py
@@ -11,6 +11,7 @@ from free_claude_code.application.errors import (
     ApplicationUnavailableError,
     InvalidRequestError,
 )
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.settings import Settings
 from free_claude_code.messaging.transcription import TranscriptionService
 from free_claude_code.providers.nvidia_nim.client import NvidiaNimProvider
@@ -333,6 +334,28 @@ def test_bootstrap_configures_default_log_and_publishes_only_services(tmp_path):
     )
     api_app = cast(FastAPI, asgi_app.app)
     assert set(api_app.state._state) == {"services"}
+
+
+def test_bootstrap_wires_the_codex_catalog_publisher() -> None:
+    publisher = MagicMock()
+
+    with (
+        patch("free_claude_code.runtime.bootstrap.configure_logging"),
+        patch(
+            "free_claude_code.runtime.bootstrap.CodexModelCatalogPublisher",
+            return_value=publisher,
+        ) as publisher_type,
+    ):
+        asgi_app = build_asgi_app(_settings())
+
+    manager = asgi_app.runtime.provider_manager
+    manager.cache_model_infos(
+        "nvidia_nim",
+        {ProviderModelInfo("published-model")},
+    )
+
+    publisher_type.assert_called_once_with()
+    publisher.publish.assert_called_once_with(manager)
 
 
 def test_bootstrap_honors_process_log_file_override(monkeypatch, tmp_path):

--- a/tests/cli/test_codex_model_catalog.py
+++ b/tests/cli/test_codex_model_catalog.py
@@ -153,6 +153,23 @@ def test_generated_catalog_schema_is_accepted_by_installed_codex(
     )
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "\n".join(
+            (
+                'model_provider = "fcc"',
+                'model = "nvidia_nim/test-model"',
+                f"model_catalog_json = {json.dumps(str(catalog_path))}",
+                "",
+                "[model_providers.fcc]",
+                'name = "Free Claude Code"',
+                'base_url = "http://127.0.0.1:8082/v1"',
+                'http_headers = { Authorization = "Bearer freecc" }',
+                'wire_api = "responses"',
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
     codex_env = os.environ.copy()
     for key in (
         "CODEX_THREAD_ID",
@@ -164,13 +181,7 @@ def test_generated_catalog_schema_is_accepted_by_installed_codex(
     codex_env["CODEX_HOME"] = str(codex_home)
 
     result = subprocess.run(
-        [
-            codex_binary,
-            "debug",
-            "models",
-            "-c",
-            f"model_catalog_json={json.dumps(str(catalog_path))}",
-        ],
+        [codex_binary, "debug", "models"],
         capture_output=True,
         check=False,
         encoding="utf-8",
@@ -182,3 +193,43 @@ def test_generated_catalog_schema_is_accepted_by_installed_codex(
 
     assert result.returncode == 0, result.stderr
     assert "nvidia_nim/test-model" in result.stdout
+
+
+def test_catalog_writer_skips_identical_content_and_replaces_changes(
+    tmp_path: Path,
+) -> None:
+    catalog_path = tmp_path / "codex-model-catalog.json"
+    first = build_codex_model_catalog(_models_payload("anthropic/nvidia_nim/first"))
+    second = build_codex_model_catalog(_models_payload("anthropic/nvidia_nim/second"))
+
+    assert write_codex_model_catalog(catalog_path, first) is True
+    assert write_codex_model_catalog(catalog_path, first) is False
+    assert list(tmp_path.glob(".codex-model-catalog.json.*.tmp")) == []
+
+    assert write_codex_model_catalog(catalog_path, second) is True
+    assert json.loads(catalog_path.read_text(encoding="utf-8")) == second
+    assert list(tmp_path.glob(".codex-model-catalog.json.*.tmp")) == []
+
+
+def test_catalog_writer_cleans_temporary_file_after_replace_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    catalog_path = tmp_path / "codex-model-catalog.json"
+    catalog_path.write_text("previous\n", encoding="utf-8")
+
+    def fail_replace(_source: Path, _destination: Path) -> Path:
+        raise PermissionError("destination is locked")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    with pytest.raises(PermissionError, match="locked"):
+        write_codex_model_catalog(
+            catalog_path,
+            build_codex_model_catalog(
+                _models_payload("anthropic/nvidia_nim/replacement")
+            ),
+        )
+
+    assert catalog_path.read_text(encoding="utf-8") == "previous\n"
+    assert list(tmp_path.glob(".codex-model-catalog.json.*.tmp")) == []

--- a/tests/runtime/test_codex_catalog.py
+++ b/tests/runtime/test_codex_catalog.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.ports import (
+    RequestRuntimeLease,
+    RequestRuntimePort,
+)
+from free_claude_code.config.settings import Settings
+from free_claude_code.runtime.codex_catalog import CodexModelCatalogPublisher
+
+
+class FakeRequestRuntime(RequestRuntimePort):
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        cached_infos: tuple[ProviderModelInfo, ...] = (),
+    ) -> None:
+        self._settings = settings
+        self._cached_infos = cached_infos
+
+    async def acquire(self) -> RequestRuntimeLease:
+        raise AssertionError("Catalog publication must not acquire a provider lease.")
+
+    def current_settings(self) -> Settings:
+        return self._settings
+
+    def cached_model_supports_thinking(
+        self, provider_id: str, model_id: str
+    ) -> bool | None:
+        return None
+
+    def cached_prefixed_model_infos(self) -> tuple[ProviderModelInfo, ...]:
+        return self._cached_infos
+
+
+def _runtime() -> FakeRequestRuntime:
+    settings = Settings().model_copy(update={"model": "nvidia_nim/configured"})
+    return FakeRequestRuntime(
+        settings=settings,
+        cached_infos=(ProviderModelInfo("open_router/discovered"),),
+    )
+
+
+def _catalog_slugs(path: Path) -> list[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return [model["slug"] for model in payload["models"]]
+
+
+def test_publisher_projects_the_application_catalog_without_compatibility_ids(
+    tmp_path: Path,
+) -> None:
+    catalog_path = tmp_path / "codex-model-catalog.json"
+    publisher = CodexModelCatalogPublisher(catalog_path)
+
+    publisher.publish(_runtime())
+
+    assert _catalog_slugs(catalog_path) == [
+        "nvidia_nim/configured",
+        "open_router/discovered",
+    ]
+
+
+def test_startup_publication_creates_missing_catalog_and_preserves_existing(
+    tmp_path: Path,
+) -> None:
+    catalog_path = tmp_path / "codex-model-catalog.json"
+    publisher = CodexModelCatalogPublisher(catalog_path)
+
+    publisher.ensure_exists(_runtime())
+    assert _catalog_slugs(catalog_path) == [
+        "nvidia_nim/configured",
+        "open_router/discovered",
+    ]
+
+    catalog_path.write_text("complete prior catalog\n", encoding="utf-8")
+    publisher.ensure_exists(_runtime())
+
+    assert catalog_path.read_text(encoding="utf-8") == "complete prior catalog\n"
+
+
+def test_empty_projection_preserves_existing_catalog(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "codex-model-catalog.json"
+    catalog_path.write_text("last known good\n", encoding="utf-8")
+    publisher = CodexModelCatalogPublisher(catalog_path)
+
+    with (
+        patch(
+            "free_claude_code.runtime.codex_catalog.build_codex_model_catalog",
+            return_value={"models": []},
+        ),
+        pytest.raises(ValueError, match="no routable models"),
+    ):
+        publisher.publish(_runtime())
+
+    assert catalog_path.read_text(encoding="utf-8") == "last known good\n"

--- a/tests/runtime/test_provider_manager.py
+++ b/tests/runtime/test_provider_manager.py
@@ -6,6 +6,7 @@ import pytest
 
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.ports import RequestRuntimePort
 from free_claude_code.config.settings import Settings
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
@@ -50,6 +51,27 @@ class RuntimeFactory:
         runtime = FakeRuntime(settings)
         self.runtimes.append(runtime)
         return runtime
+
+
+class RecordingModelCatalogPublisher:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.snapshots: list[tuple[str, tuple[str, ...]]] = []
+
+    def ensure_exists(self, runtime: RequestRuntimePort) -> None:
+        self._record("ensure_exists", runtime)
+
+    def publish(self, runtime: RequestRuntimePort) -> None:
+        self._record("publish", runtime)
+
+    def _record(self, event: str, runtime: RequestRuntimePort) -> None:
+        self.events.append(event)
+        self.snapshots.append(
+            (
+                runtime.current_settings().model,
+                tuple(info.model_id for info in runtime.cached_prefixed_model_infos()),
+            )
+        )
 
 
 def _settings(model: str) -> Settings:
@@ -105,6 +127,146 @@ async def test_connected_provider_refresh_and_eviction_are_targeted() -> None:
     await manager.connected_provider_changed("openai", connected=False)
 
     assert "openai" not in manager.cached_model_ids()
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_catalog_publication_tracks_warm_refresh_and_direct_cache() -> None:
+    factory = RuntimeFactory()
+    publisher = RecordingModelCatalogPublisher()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/one"),
+        runtime_factory=factory,
+        model_catalog_publisher=publisher,
+    )
+    factory.runtimes[0].provider.list_model_infos = AsyncMock(
+        return_value=frozenset({ProviderModelInfo("warm-model")})
+    )
+
+    await manager.warm_referenced_model_cache()
+    manager.start_model_list_refresh()
+    refresh_task = manager._refresh_task
+    assert refresh_task is not None
+    await refresh_task
+    manager.cache_model_infos(
+        "nvidia_nim",
+        {ProviderModelInfo("tested-model")},
+    )
+
+    assert publisher.events == ["ensure_exists", "publish", "publish"]
+    assert publisher.snapshots == [
+        ("nvidia_nim/one", ("nvidia_nim/warm-model",)),
+        ("nvidia_nim/one", ("nvidia_nim/warm-model",)),
+        ("nvidia_nim/one", ("nvidia_nim/tested-model",)),
+    ]
+
+    await manager.close()
+    assert publisher.events == ["ensure_exists", "publish", "publish"]
+
+
+@pytest.mark.asyncio
+async def test_failed_startup_discovery_still_ensures_a_fresh_catalog() -> None:
+    factory = RuntimeFactory()
+    publisher = RecordingModelCatalogPublisher()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/configured"),
+        runtime_factory=factory,
+        model_catalog_publisher=publisher,
+    )
+    factory.runtimes[0].provider.list_model_infos = AsyncMock(
+        side_effect=RuntimeError("upstream unavailable")
+    )
+
+    result = await manager.warm_referenced_model_cache()
+
+    assert result.failed_provider_ids == ("nvidia_nim",)
+    assert publisher.events == ["ensure_exists"]
+    assert publisher.snapshots == [("nvidia_nim/configured", ())]
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_catalog_publication_tracks_connected_account_changes() -> None:
+    factory = RuntimeFactory()
+    publisher = RecordingModelCatalogPublisher()
+    connected: set[str] = set()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/one"),
+        runtime_factory=factory,
+        connected_provider_ids=lambda: tuple(connected),
+        model_catalog_publisher=publisher,
+    )
+    factory.runtimes[0].provider.list_model_infos = AsyncMock(
+        return_value=frozenset({ProviderModelInfo("gpt-connected")})
+    )
+
+    connected.add("openai")
+    await manager.connected_provider_changed("openai", connected=True)
+    connected.clear()
+    await manager.connected_provider_changed("openai", connected=False)
+
+    assert publisher.events == ["publish", "publish"]
+    assert publisher.snapshots == [
+        ("nvidia_nim/one", ("openai/gpt-connected",)),
+        ("nvidia_nim/one", ()),
+    ]
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_catalog_publication_tracks_replacement_and_its_refresh() -> None:
+    factory = RuntimeFactory()
+    publisher = RecordingModelCatalogPublisher()
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/one"),
+        runtime_factory=factory,
+        model_catalog_publisher=publisher,
+    )
+
+    await manager.replace(
+        _settings("nvidia_nim/two"),
+        commit=lambda: None,
+    )
+    refresh_task = manager._refresh_task
+    assert refresh_task is not None
+    await refresh_task
+
+    assert publisher.events == ["publish", "publish"]
+    assert publisher.snapshots == [
+        ("nvidia_nim/two", ()),
+        ("nvidia_nim/two", ()),
+    ]
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_catalog_publication_failure_is_warning_only_and_secret_safe() -> None:
+    factory = RuntimeFactory()
+    secret = "private-catalog-write-detail"
+    publisher = MagicMock()
+    publisher.ensure_exists.side_effect = PermissionError(secret)
+    publisher.publish.side_effect = PermissionError(secret)
+    manager = ProviderRuntimeManager(
+        _settings("nvidia_nim/one"),
+        runtime_factory=factory,
+        model_catalog_publisher=publisher,
+    )
+
+    with patch("free_claude_code.runtime.provider_manager.logger.warning") as warning:
+        await manager.warm_referenced_model_cache()
+        manager.cache_model_infos(
+            "nvidia_nim",
+            {ProviderModelInfo("tested-model")},
+        )
+
+    assert warning.call_count == 2
+    log_blob = " ".join(
+        str(value)
+        for call in warning.call_args_list
+        for value in (*call.args, *call.kwargs.values())
+    )
+    assert "PermissionError" in log_blob
+    assert secret not in log_blob
     await manager.close()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.15.1"
+version = "4.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Codex App cannot discover FCC provider/model slugs because it loads a local model catalog at startup instead of querying FCC's `/v1/models` endpoint. Users can configure FCC as a Responses provider, but its native model picker remains incomplete. Fixes #1260.

## Changes

| Before | After |
| --- | --- |
| FCC generated the Codex catalog only when `fcc-codex` launched. | FCC synchronizes the catalog from its canonical model lifecycle for independently launched Codex clients. |
| Startup could leave a configured Codex App without a catalog file. | Startup creates a missing catalog after routed-provider warming and preserves an existing last-known-good catalog. |
| Every catalog publication replaced the file. | Identical content is skipped and changed content is replaced atomically. |
| Catalog filesystem failures could escape a direct writer call. | Runtime publication is fail-open and logs only the exception type. |
| Codex App setup was undocumented. | The README documents user-level Windows and macOS configuration, model selection, and restart behavior. |
| The package version was `4.15.1`. | The package version is `4.16.0`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds runtime-managed Codex App model catalog synchronization, publishing FCC’s current model inventory through atomic, content-aware catalog writes as provider state changes. A reproduced failure shows that a successful provider refresh returning no models can remove previously discovered models from the Codex picker by replacing the last-known-good catalog with one containing only configured fallback models.
</details>


<h3>Confidence Score: 3/5</h3>

Not safe to merge until T-Rex findings are addressed.

The catalog update path was exercised with the real manager, cache, discovery flow, and publisher. It reproducibly removes a previously published discovered model after a successful empty refresh, which can make valid Codex model selections disappear for users.

T-Rex reproduced 2 failing behaviors at runtime in src/free_claude_code/runtime/provider_manager.py; the change needs fixes before it is safe to merge.

**Files Needing Attention:** src/free_claude_code/runtime/provider_manager.py, src/free_claude_code/providers/runtime/model_cache.py, and src/free_claude_code/runtime/codex_catalog.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for a posted P1 finding and captured a deterministic Codex catalog repro, including the before-discovery state, the after-empty-discovery state, and the focused runtime test output.
- Validation of the general contract confirmed the before and after catalog states and the focused test results, noting 27 tests passed and 1 unrelated failure due to the default model-list scope, which did not block the deterministic repro.

<a href="https://app.greptile.com/trex/runs/16701253/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (2)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Replacement overwrites the last-known-good Codex model catalog before discovery succeeds**

   - **Bug**
     - Admin replacement scopes the shared model cache to the new settings and immediately publishes the Codex catalog. When the previous provider is no longer in scope, its complete discovered catalog is discarded. The replacement catalog is then published with only the configured model before the background task starts; a delayed or failed discovery leaves users without the previously available models.
   - **Cause**
     - `replace()` assigns the candidate generation, calls `set_available_providers()` (which drops cache entries outside the new scope), and calls `_publish_model_catalog()` before scheduling `_refresh_generation_in_background()`.
   - **Fix**
     - Preserve and publish the last-known-good catalog until replacement discovery has produced a successful usable catalog, or defer catalog publication from replacement until discovery succeeds while retaining the old catalog on failure.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Empty successful provider discovery overwrites the last-known-good Codex catalog**

   - **Bug**
     - After the catalog contains a discovered model, a later successful refresh that returns an empty model collection replaces the provider cache entry with an empty mapping and republishes the Codex catalog. The resulting catalog removes previously selectable discovered models, leaving only configured-model entries.
   - **Cause**
     - `ProviderModelCache.cache_model_infos()` stores an empty result as the full cache value for that provider (`src/free_claude_code/providers/runtime/model_cache.py:25-28`). `ProviderRuntimeManager._refresh_generation()` then unconditionally calls `_publish_model_catalog()` (`src/free_claude_code/runtime/provider_manager.py:345-347`). The publisher only rejects a wholly empty Codex projection, so a configured model keeps the projection nonempty and permits the incomplete overwrite (`src/free_claude_code/runtime/codex_catalog.py:42-46`).
   - **Fix**
     - Treat an empty discovery result as non-authoritative when a provider already has cached model metadata, retaining its last-known-good cache/catalog; alternatively, pass refresh completeness into publication and skip publication when it would remove previously discovered models without an explicit provider-disconnect or configuration-removal event. Add an integration test beginning with a populated catalog and asserting an empty refresh cannot remove the discovered slug.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22feat%2Fcodex-app-model-catalog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcodex-app-model-catalog%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fruntime%2Fprovider_manager.py%3A346%0A**Empty%20discovery%20replaces%20the%20last-known-good%20picker%20catalog**%0A%0AA%20successful%20discovery%20response%20with%20no%20models%20clears%20that%20provider's%20cached%20model%20metadata%20and%20this%20unconditional%20publication%20immediately%20rewrites%20the%20Codex%20catalog.%20If%20the%20catalog%20previously%20contained%20discovered%20models%2C%20Codex%20App%20users%20lose%20those%20selectable%20entries%20and%20are%20left%20only%20with%20configured%20fallback%20models%20after%20a%20transient%20or%20partial%20upstream%20response.%20Retain%20existing%20discovered%20metadata%20when%20an%20otherwise%20successful%20refresh%20is%20empty%2C%20or%20skip%20publication%20when%20that%20response%20would%20discard%20last-known-good%20entries%20without%20an%20explicit%20disconnect%20or%20configuration%20removal.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Credit Codex for the Codex App integrati..."](https://github.com/alishahryar1/free-claude-code/commit/be9672ac5132a3d483fc2f61038007aa9a451250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48910848)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->