### PR TITLE
Add TokenRouter as an OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,13 +115,17 @@ LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 LLAMACPP_BASE_URL="http://localhost:8080/v1"
 
 
+# TokenRouter Config (OpenAI-compatible Chat Completions gateway at api.tokenrouter.com/v1)
+TOKENROUTER_API_KEY=""
+
+
 # Ollama Config (local provider, no API key required)
 OLLAMA_BASE_URL="http://localhost:11434"
 
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -163,6 +167,7 @@ FCC_SMOKE_MODEL_GROQ=
 FCC_SMOKE_MODEL_SAMBANOVA=
 FCC_SMOKE_MODEL_KILO=
 FCC_SMOKE_MODEL_CEREBRAS=
+FCC_SMOKE_MODEL_TOKENROUTER=
 FCC_SMOKE_NIM_MODELS=
 FCC_SMOKE_NIM_EXTRA_MODELS=
 FCC_SMOKE_OPENROUTER_FREE_MODELS=
@@ -211,6 +216,7 @@ SAMBANOVA_PROXY=""
 KILO_PROXY=""
 CEREBRAS_PROXY=""
 OLLAMA_CLOUD_PROXY=""
+TOKENROUTER_PROXY=""
 
 PROVIDER_RATE_LIMIT=1
 PROVIDER_RATE_WINDOW=3

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.
 - Run FCC in the background from a desktop launcher on Windows or macOS.
-- Switch among 31 cloud and local providers from the Admin UI.
+- Switch among 32 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
 - Route Fable, Opus, Sonnet, Haiku, and fallback traffic to different models.
 - Keep streaming, tool use, reasoning, and image input across compatible models.
@@ -198,6 +198,7 @@ fcc-codex exec "hello"
 | [LM Studio](https://lmstudio.ai/) | `LM_STUDIO_BASE_URL` | `lmstudio/<model-id>` |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | `LLAMACPP_BASE_URL` | `llamacpp/<model-id>` |
 | [Ollama](https://ollama.com/) | `OLLAMA_BASE_URL` | `ollama/<model-tag>` |
+| [TokenRouter](https://www.tokenrouter.com/docs) | `TOKENROUTER_API_KEY` | `tokenrouter/quimera-3-free` |
 
 Important provider notes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.0"
+version = "4.17.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -74,6 +74,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",
     "cloudflare": "cloudflare/@cf/moonshotai/kimi-k2.6",
+    "tokenrouter": "tokenrouter/quimera-3-free",
 }
 MISTRAL_REASONING_SMOKE_DEFAULT_MODEL = "mistral/mistral-medium-3-5"
 

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -747,6 +747,12 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         "smoke",
         advanced=True,
     ),
+    ConfigFieldSpec(
+        "FCC_SMOKE_MODEL_TOKENROUTER",
+        "Smoke TokenRouter Model",
+        "smoke",
+        advanced=True,
+    ),
 )
 
 

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -150,6 +150,13 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "Ollama API key for direct OpenAI-compatible Cloud access at ollama.com/v1."
         ),
     },
+    "TOKENROUTER_API_KEY": {
+        "label": "TokenRouter API Key",
+        "description": (
+            "TokenRouter API key for the OpenAI-compatible Chat Completions API "
+            "gateway at api.tokenrouter.com/v1."
+        ),
+    },
 }
 
 

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -50,6 +50,9 @@ SAMBANOVA_DEFAULT_BASE = "https://api.sambanova.ai/v1"
 KILO_DEFAULT_BASE = "https://api.kilo.ai/api/gateway"
 OPENAI_CODEX_DEFAULT_BASE = "https://chatgpt.com/backend-api/codex"
 
+# TokenRouter OpenAI-compatible Chat Completions API gateway (api.tokenrouter.com/v1).
+TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
+
 
 class ProviderAuthKind(StrEnum):
     """How a customer makes one provider available."""
@@ -371,6 +374,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=OLLAMA_DEFAULT_BASE,
         base_url_attr="ollama_base_url",
         local=True,
+    ),
+    "tokenrouter": ProviderDescriptor(
+        provider_id="tokenrouter",
+        display_name="TokenRouter",
+        credential_env="TOKENROUTER_API_KEY",
+        credential_url="https://www.tokenrouter.com/docs",
+        credential_attr="tokenrouter_api_key",
+        default_base_url=TOKENROUTER_DEFAULT_BASE,
+        proxy_attr="tokenrouter_proxy",
     ),
 }
 

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -82,6 +82,9 @@ class Settings(BaseSettings):
     # ==================== SambaNova Cloud ====================
     sambanova_api_key: str = Field(default="", validation_alias="SAMBANOVA_API_KEY")
 
+    # ==================== TokenRouter ====================
+    tokenrouter_api_key: str = Field(default="", validation_alias="TOKENROUTER_API_KEY")
+
     # ==================== Kilo.ai Config ====================
     kilo_api_key: str = Field(default="", validation_alias="KILO_API_KEY")
 
@@ -192,6 +195,7 @@ class Settings(BaseSettings):
     groq_proxy: str = Field(default="", validation_alias="GROQ_PROXY")
     cerebras_proxy: str = Field(default="", validation_alias="CEREBRAS_PROXY")
     ollama_cloud_proxy: str = Field(default="", validation_alias="OLLAMA_CLOUD_PROXY")
+    tokenrouter_proxy: str = Field(default="", validation_alias="TOKENROUTER_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -382,4 +382,18 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         normalize_base_url=True,
         reasoning_delta_field="reasoning",
     ),
+    "tokenrouter": OpenAIChatProfile(
+        _policy(
+            "TOKENROUTER",
+            ReasoningReplayMode.THINK_TAGS,
+            include_extra_body=True,
+            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+            max_tokens_field="max_completion_tokens",
+        ),
+        NamedEffortReasoning(
+            _LOW_MEDIUM_HIGH,
+            disabled_value="none",
+            enabled_value="medium",
+        ),
+    ),
 }

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -37,6 +37,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "lmstudio",
     "llamacpp",
     "ollama",
+    "tokenrouter",
 )
 
 

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -109,6 +109,8 @@ def _make_settings(**overrides):
     mock.cerebras_api_key = ""
     mock.cerebras_proxy = ""
     mock.ollama_cloud_proxy = ""
+    mock.tokenrouter_api_key = "test_tokenrouter_key"
+    mock.tokenrouter_proxy = ""
     mock.kilo_api_key = "test_kilo_key"
     mock.kilo_proxy = ""
     mock.openai_proxy = ""
@@ -457,6 +459,7 @@ def test_create_provider_instantiates_each_builtin():
         provider_rate_window=11,
         provider_max_concurrency=3,
         sambanova_api_key="test_sambanova_key",
+        tokenrouter_api_key="test_tokenrouter_key",
     )
     cases = {
         "nvidia_nim": NvidiaNimProvider,
@@ -490,6 +493,7 @@ def test_create_provider_instantiates_each_builtin():
         "sambanova": OpenAIChatProvider,
         "kilo": KiloProvider,
         "cerebras": OpenAIChatProvider,
+        "tokenrouter": OpenAIChatProvider,
     }
     sentinel_admission = MagicMock(spec=ProviderAdmissionController)
     auth = MagicMock()
@@ -672,3 +676,28 @@ async def test_provider_runtime_cleanup_exceptiongroup_on_multiple_failures() ->
 
     assert not runtime.is_cached("x")
     assert not runtime.is_cached("y")
+
+
+def test_tokenrouter_descriptor_uses_openai_chat_gateway():
+    descriptor = PROVIDER_CATALOG["tokenrouter"]
+
+    assert descriptor.default_base_url == "https://api.tokenrouter.com/v1"
+    assert descriptor.credential_env == "TOKENROUTER_API_KEY"
+    assert descriptor.credential_attr == "tokenrouter_api_key"
+    assert descriptor.proxy_attr == "tokenrouter_proxy"
+    assert descriptor.base_url_attr is None
+    assert descriptor.local is False
+
+
+def test_tokenrouter_provider_config_uses_key_and_proxy():
+    descriptor = PROVIDER_CATALOG["tokenrouter"]
+    settings = _make_settings(
+        tokenrouter_api_key="tokenrouter-token",
+        tokenrouter_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+
+    assert config.api_key == "tokenrouter-token"
+    assert config.base_url == "https://api.tokenrouter.com/v1"
+    assert config.proxy == "http://proxy.test:8080"

--- a/tests/providers/test_tokenrouter.py
+++ b/tests/providers/test_tokenrouter.py
@@ -1,0 +1,241 @@
+"""Tests for TokenRouter (OpenAI-compatible Chat Completions gateway)."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from free_claude_code.config.provider_catalog import TOKENROUTER_DEFAULT_BASE
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_chat import OPENAI_CHAT_PROFILES
+from tests.providers.request_factory import make_messages_request
+from tests.providers.support import (
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+def make_request(model="quimera-3-free", **overrides):
+    return make_messages_request(model, **overrides)
+
+
+@pytest.fixture
+def tokenrouter_config():
+    return ProviderConfig(
+        api_key="test_tokenrouter_key",
+        base_url=TOKENROUTER_DEFAULT_BASE,
+        rate_limit=10,
+        rate_window=60,
+    )
+
+
+@pytest.fixture
+def tokenrouter_provider(tokenrouter_config):
+    return profiled_provider(
+        "tokenrouter", tokenrouter_config, admission=immediate_admission()
+    )
+
+
+def test_default_base_url_constant():
+    assert TOKENROUTER_DEFAULT_BASE == "https://api.tokenrouter.com/v1"
+
+
+def test_profile_in_openai_chat_profiles():
+    """The tokenrouter profile must be wired into OPENAI_CHAT_PROFILES."""
+    assert "tokenrouter" in OPENAI_CHAT_PROFILES
+    profile = OPENAI_CHAT_PROFILES["tokenrouter"]
+    assert profile.provider_name == "TOKENROUTER"
+    assert profile.request_policy.max_tokens_field == "max_completion_tokens"
+    assert profile.request_policy.include_extra_body is True
+
+
+def test_init_uses_default_base_url_and_api_key(tokenrouter_config):
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI"
+    ) as mock_openai:
+        provider = profiled_provider(
+            "tokenrouter", tokenrouter_config, admission=immediate_admission()
+        )
+
+    assert provider._api_key == "test_tokenrouter_key"
+    assert provider._base_url == TOKENROUTER_DEFAULT_BASE
+    mock_openai.assert_called_once()
+
+
+def test_init_strips_trailing_slash(tokenrouter_config):
+    config = replace(tokenrouter_config, base_url=f"{TOKENROUTER_DEFAULT_BASE}/")
+
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = profiled_provider(
+            "tokenrouter", config, admission=immediate_admission()
+        )
+
+    assert provider._base_url == TOKENROUTER_DEFAULT_BASE
+
+
+def test_build_request_body_basic(tokenrouter_provider):
+    """Basic request body conversion attaches system message and uses max_completion_tokens."""
+    req = make_request()
+    body = tokenrouter_provider._build_request_body(req, reasoning=reasoning_for(req))
+
+    assert body["model"] == "quimera-3-free"
+    assert body["messages"][0]["role"] == "system"
+    assert "max_completion_tokens" in body
+    assert "max_tokens" not in body
+
+
+def test_build_request_body_preserves_caller_extra_body(tokenrouter_provider):
+    req = make_request(extra_body={"metadata": {"user": "u1"}})
+
+    body = tokenrouter_provider._build_request_body(req, reasoning=reasoning_for(req))
+
+    eb = body.get("extra_body")
+    assert isinstance(eb, dict)
+    assert eb.get("metadata") == {"user": "u1"}
+
+
+def test_build_request_body_rejects_reasoning_in_extra_body(tokenrouter_provider):
+    from free_claude_code.application.errors import InvalidRequestError
+
+    req = make_request(extra_body={"reasoning_effort": "high"})
+
+    with pytest.raises(InvalidRequestError, match="reasoning"):
+        tokenrouter_provider._build_request_body(req, reasoning=reasoning_for(req))
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "expected"),
+    (
+        (ReasoningPolicy.provider_default(), None),
+        (ReasoningPolicy.off(), "none"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.LOW), "low"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.HIGH), "high"),
+        (ReasoningPolicy.on(), "medium"),
+    ),
+)
+def test_build_request_body_uses_only_documented_reasoning_efforts(
+    tokenrouter_provider, reasoning, expected
+):
+    body = tokenrouter_provider._build_request_body(make_request(), reasoning=reasoning)
+
+    assert body.get("reasoning_effort") == expected
+
+
+@pytest.mark.asyncio
+async def test_stream_response_text(tokenrouter_provider):
+    """Text content deltas are emitted as text blocks."""
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(
+                content="Hello from TokenRouter",
+                reasoning_content=None,
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=5, prompt_tokens=10)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        tokenrouter_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [
+            event
+            async for event in tokenrouter_provider.stream_response(make_request())
+        ]
+
+    assert any(
+        '"text_delta"' in event and "Hello from TokenRouter" in event
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_response_tool_call(tokenrouter_provider):
+    mock_tc = MagicMock()
+    mock_tc.index = 0
+    mock_tc.id = "call_1"
+    mock_tc.function = MagicMock()
+    mock_tc.function.name = "Read"
+    mock_tc.function.arguments = '{"file_path":"a.py"}'
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content=None, reasoning_content=None, tool_calls=[mock_tc]),
+            finish_reason="tool_calls",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=5, prompt_tokens=10)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        tokenrouter_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [
+            event
+            async for event in tokenrouter_provider.stream_response(make_request())
+        ]
+
+    assert any(
+        '"content_block_start"' in event and '"tool_use"' in event for event in events
+    )
+    assert any(
+        '"input_json_delta"' in event and "file_path" in event for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_response_reasoning_content(tokenrouter_provider):
+    """reasoning_content deltas are emitted as thinking blocks (THINK_TAGS replay)."""
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(
+                content=None,
+                reasoning_content="Thinking via TokenRouter",
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=2, prompt_tokens=10)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        tokenrouter_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [
+            event
+            async for event in tokenrouter_provider.stream_response(make_request())
+        ]
+
+    assert any(
+        '"thinking_delta"' in event and "Thinking via TokenRouter" in event
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup(tokenrouter_provider):
+    tokenrouter_provider._client = AsyncMock()
+
+    await tokenrouter_provider.cleanup()
+
+    tokenrouter_provider._client.close.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Adds TokenRouter as the 32nd supported provider through the existing declarative OpenAI-compatible provider path.

## Changes
- Add `tokenrouter` to the provider catalog at the end of the canonical order.
- Configure `https://api.tokenrouter.com/v1` and `TOKENROUTER_API_KEY`.
- Add proxy, admin manifest, smoke configuration, and `.env.example` entries.
- Add OpenAI Chat profile with reasoning-effort mapping and protected `extra_body` passthrough.
- Add focused provider/runtime tests and update the provider-order contract.
- Document the provider and default `quimera-3-free` smoke model.
- Bump version from `4.16.0` to `4.17.0` and update `uv.lock`.

## Verification
- `./scripts/ci.sh --skip pytest` passes: suppressions, Ruff format/check, and ty.
- `uv run pytest --ignore=tests/scripts/test_uninstallers.py`: 2645 passed, 48 skipped.
- 8 uninstall-script tests remain environment-blocked when `fcc-server`/`fcc-codex` are running; they are unrelated to this change.

Closes #1302

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds TokenRouter through the OpenAI-compatible provider path, including credentials, endpoint configuration, Admin UI fields, a smoke model, canonical provider ordering, and request/reasoning behavior. A hermetic request capture confirmed that TokenRouter currently lets caller-provided `extra_body` replace FCC-owned request fields in the final upstream payload.

<h3>Confidence Score: 4/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P2 finding and linked it to the review comment.
- A hermetic Python source file that captures the TokenRouter SDK payload was prepared.
- A hermetic capture output log for the TokenRouter payload was generated and logged for review.
- The proof was validated by cross-checking the capture details against the P2 finding described in the review comment.
- The artifacts, including the capture source and the capture output, are made available to reviewers for inspection.

<a href="https://app.greptile.com/trex/runs/16777950/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add TokenRouter as new OpenAI-compatible..."](https://github.com/alishahryar1/free-claude-code/commit/5fbbf3d198c315cf12b5a758e3eb265ce6e2a542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49066215)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->