### PR TITLE
Restore Claude Code client controls for OpenAI Responses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -990,6 +990,16 @@ policy. The adapter preserves `reasoning.effort` in Anthropic `output_config`;
 the application reasoning boundary then interprets `none` as off and preserves
 all other named efforts. It never translates OpenAI effort names into Anthropic
 token budgets.
+Application-resolved source controls remain on the immutable canonical request;
+provider adapters consume the resolved `ReasoningPolicy` rather than parsing
+those controls again. A target converter validates only the unrepresented
+semantic remainder: it may omit an application-consumed control or an exact
+no-op, but must reject active or unknown behavior before upstream I/O. For the
+connected OpenAI Responses transport, `output_config.effort` is already
+represented by the policy and an empty context edit or exact
+`clear_thinking_20251015` edit with `keep: "all"` is inert. Structured-output
+configuration and any active, malformed, or extended context edit remain
+unsupported and fail preflight rather than being silently discarded.
 Prior Responses `reasoning` input items replay plaintext `reasoning_text`, or
 fallback `summary_text`, into assistant `reasoning_content`. Encrypted reasoning
 input is ignored because the proxy cannot decrypt it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.1"
+version = "4.16.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/openai_responses/provider_input.py
+++ b/src/free_claude_code/core/openai_responses/provider_input.py
@@ -100,10 +100,9 @@ def _validate_supported_request(request: MessagesRequest) -> None:
         unsupported.append("stop_sequences")
     if request.top_k is not None:
         unsupported.append("top_k")
-    if request.context_management:
+    if not _is_noop_context_management(request.context_management):
         unsupported.append("context_management")
-    if request.output_config:
-        unsupported.append("output_config")
+    unsupported.extend(_unsupported_output_config_paths(request.output_config))
     if request.mcp_servers:
         unsupported.append("mcp_servers")
     if request.extra_body:
@@ -113,6 +112,33 @@ def _validate_supported_request(request: MessagesRequest) -> None:
             "OpenAI Responses cannot represent these fields without data loss: "
             f"{unsupported}."
         )
+
+
+def _unsupported_output_config_paths(
+    output_config: dict[str, Any] | None,
+) -> list[str]:
+    if not output_config:
+        return []
+    return [f"output_config.{key}" for key in sorted(output_config) if key != "effort"]
+
+
+def _is_noop_context_management(
+    context_management: dict[str, Any] | None,
+) -> bool:
+    if not context_management:
+        return True
+    if set(context_management) != {"edits"}:
+        return False
+    edits = context_management["edits"]
+    return isinstance(edits, list) and all(
+        isinstance(edit, dict)
+        and edit
+        == {
+            "type": "clear_thinking_20251015",
+            "keep": "all",
+        }
+        for edit in edits
+    )
 
 
 def _system_text(request: MessagesRequest) -> list[str]:

--- a/tests/api/test_openai_codex_compatibility.py
+++ b/tests/api/test_openai_codex_compatibility.py
@@ -1,0 +1,130 @@
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from free_claude_code.core.anthropic.stream_contracts import (
+    assert_anthropic_stream_contract,
+    parse_sse_text,
+    text_content,
+)
+from free_claude_code.providers.admission import ProviderAdmissionController
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_codex.auth import (
+    OpenAIAccess,
+    OpenAIAuthManager,
+)
+from free_claude_code.providers.openai_codex.provider import OpenAICodexProvider
+from tests.api.support import create_test_app
+
+
+class _FakeOpenAIAuth(OpenAIAuthManager):
+    async def access(self, *, force_refresh: bool = False) -> OpenAIAccess:
+        return OpenAIAccess("access", "account", False)
+
+    async def recover_unauthorized(self, rejected_token: str) -> OpenAIAccess:
+        raise AssertionError("The compatibility request must not require auth recovery")
+
+
+def _complete_stream(text: str) -> str:
+    events = [
+        (
+            "response.created",
+            {"type": "response.created", "response": {"id": "resp_1"}},
+        ),
+        (
+            "response.output_text.delta",
+            {"type": "response.output_text.delta", "delta": text},
+        ),
+        (
+            "response.completed",
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_1",
+                    "usage": {"input_tokens": 3, "output_tokens": 2},
+                },
+            },
+        ),
+    ]
+    return "".join(
+        f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+        for event_type, payload in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_messages_accepts_current_claude_controls_for_openai_provider() -> None:
+    upstream_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        upstream_requests.append(request)
+        return httpx.Response(
+            200,
+            text=_complete_stream("hello"),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    upstream_client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        ProviderConfig(
+            api_key="",
+            base_url="https://chatgpt.com/backend-api/codex",
+            rate_limit=100,
+            rate_window=1,
+            max_concurrency=2,
+        ),
+        auth=_FakeOpenAIAuth(),
+        admission=ProviderAdmissionController(
+            provider_name="openai",
+            rate_limit=100,
+            rate_window=1,
+            max_concurrency=2,
+            base_delay=0,
+            max_delay=0,
+            jitter=0,
+        ),
+        client=upstream_client,
+    )
+    app = create_test_app(providers={"openai": provider})
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/messages",
+                json={
+                    "model": "openai/gpt-test",
+                    "max_tokens": 1024,
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "thinking": {"type": "adaptive", "display": "omitted"},
+                    "context_management": {
+                        "edits": [
+                            {
+                                "type": "clear_thinking_20251015",
+                                "keep": "all",
+                            }
+                        ]
+                    },
+                    "output_config": {"effort": "high"},
+                    "stream": True,
+                },
+            )
+    finally:
+        await upstream_client.aclose()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    events = parse_sse_text(response.text)
+    assert_anthropic_stream_contract(events)
+    assert text_content(events) == "hello"
+    assert len(upstream_requests) == 1
+    payload = json.loads(upstream_requests[0].content)
+    assert payload["model"] == "gpt-test"
+    assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert "context_management" not in payload
+    assert "output_config" not in payload

--- a/tests/core/openai_responses/test_provider_input.py
+++ b/tests/core/openai_responses/test_provider_input.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from free_claude_code.application.reasoning import client_reasoning_policy
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.openai_responses import (
     OpenAIResponsesAdapter,
@@ -12,6 +13,11 @@ from free_claude_code.core.openai_responses.provider_input import (
     build_responses_provider_request,
 )
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+
+_KEEP_ALL_THINKING_EDIT = {
+    "type": "clear_thinking_20251015",
+    "keep": "all",
+}
 
 
 def test_build_responses_provider_request_preserves_multiturn_protocol() -> None:
@@ -105,6 +111,182 @@ def test_build_responses_provider_request_preserves_multiturn_protocol() -> None
         "type": "input_image",
         "image_url": "data:image/png;base64,aGVsbG8=",
     }
+
+
+def test_build_responses_provider_request_accepts_claude_client_controls() -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "thinking": {"type": "adaptive", "display": "omitted"},
+            "context_management": {"edits": [_KEEP_ALL_THINKING_EDIT]},
+            "output_config": {"effort": "high"},
+        }
+    )
+    snapshot = request.model_dump()
+
+    body = build_responses_provider_request(
+        request,
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+
+    assert body["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert "context_management" not in body
+    assert "output_config" not in body
+    assert request.model_dump() == snapshot
+
+
+def test_build_responses_provider_request_uses_resolved_reasoning_policy() -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "output_config": {"effort": "low"},
+        }
+    )
+
+    body = build_responses_provider_request(
+        request,
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.MAX),
+    )
+
+    assert body["reasoning"] == {"effort": "max", "summary": "auto"}
+
+
+@pytest.mark.parametrize(
+    "context_management",
+    [
+        None,
+        {},
+        {"edits": []},
+        {"edits": [_KEEP_ALL_THINKING_EDIT]},
+        {"edits": [_KEEP_ALL_THINKING_EDIT, _KEEP_ALL_THINKING_EDIT]},
+    ],
+)
+def test_build_responses_provider_request_accepts_noop_context_management(
+    context_management: dict[str, object] | None,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "context_management": context_management,
+        }
+    )
+
+    body = build_responses_provider_request(
+        request,
+        reasoning=ReasoningPolicy.provider_default(),
+    )
+
+    assert "context_management" not in body
+
+
+@pytest.mark.parametrize(
+    "context_management",
+    [
+        {"edits": [{"type": "clear_thinking_20251015"}]},
+        {
+            "edits": [
+                {
+                    "type": "clear_thinking_20251015",
+                    "keep": {"type": "thinking_turns", "value": 2},
+                }
+            ]
+        },
+        {"edits": [{"type": "clear_tool_uses_20250919"}]},
+        {"edits": [{"type": "unknown_edit", "keep": "all"}]},
+        {
+            "edits": [
+                {
+                    **_KEEP_ALL_THINKING_EDIT,
+                    "extra": True,
+                }
+            ]
+        },
+        {"edits": [], "extra": True},
+        {"edits": None},
+        {"edits": {}},
+        {"edits": "not-a-list"},
+    ],
+)
+def test_build_responses_provider_request_rejects_active_or_malformed_context(
+    context_management: dict[str, object],
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "context_management": context_management,
+        }
+    )
+
+    with pytest.raises(ResponsesConversionError, match="context_management"):
+        build_responses_provider_request(
+            request,
+            reasoning=ReasoningPolicy.provider_default(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("effort", "reasoning", "expected"),
+    [
+        (
+            "high",
+            ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+            {"effort": "high", "summary": "auto"},
+        ),
+        ("none", ReasoningPolicy.off(), {"effort": "none"}),
+        ("future", ReasoningPolicy.provider_default(), None),
+    ],
+)
+def test_build_responses_provider_request_accepts_application_owned_effort(
+    effort: str,
+    reasoning: ReasoningPolicy,
+    expected: dict[str, str] | None,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "output_config": {"effort": effort},
+        }
+    )
+
+    body = build_responses_provider_request(request, reasoning=reasoning)
+
+    assert body.get("reasoning") == expected
+    assert "output_config" not in body
+
+
+@pytest.mark.parametrize(
+    ("output_config", "unsupported_path"),
+    [
+        ({"format": {"type": "json_schema"}}, "output_config.format"),
+        (
+            {"effort": "high", "format": {"type": "json_schema"}},
+            "output_config.format",
+        ),
+        ({"future_control": True}, "output_config.future_control"),
+    ],
+)
+def test_build_responses_provider_request_rejects_unconsumed_output_config(
+    output_config: dict[str, object],
+    unsupported_path: str,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "output_config": output_config,
+        }
+    )
+
+    with pytest.raises(ResponsesConversionError, match=unsupported_path):
+        build_responses_provider_request(
+            request,
+            reasoning=ReasoningPolicy.provider_default(),
+        )
 
 
 def test_responses_provider_request_uses_one_portable_tool_alias() -> None:
@@ -219,13 +401,31 @@ def test_responses_round_trip_preserves_encrypted_reasoning_and_tool_ids() -> No
     ]
 
 
+def test_responses_reasoning_round_trip_reaches_provider_request() -> None:
+    adapter = OpenAIResponsesAdapter()
+    ingress = OpenAIResponsesRequest.model_validate(
+        {
+            "model": "openai/gpt-test",
+            "input": "hello",
+            "reasoning": {"effort": "high"},
+        }
+    )
+    anthropic = MessagesRequest.model_validate(adapter.to_anthropic_payload(ingress))
+
+    body = build_responses_provider_request(
+        anthropic,
+        reasoning=client_reasoning_policy(anthropic),
+    )
+
+    assert body["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert "output_config" not in body
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
         ("stop_sequences", ["stop"]),
         ("top_k", 4),
-        ("context_management", {"edits": []}),
-        ("output_config", {"effort": "high"}),
         ("mcp_servers", [{"name": "server"}]),
         ("extra_body", {"unknown": True}),
     ],
@@ -262,6 +462,22 @@ def test_build_responses_provider_request_rejects_provider_managed_tools() -> No
     )
 
     with pytest.raises(ResponsesConversionError, match="web_search_20250305"):
+        build_responses_provider_request(
+            request,
+            reasoning=ReasoningPolicy.provider_default(),
+        )
+
+
+def test_build_responses_provider_request_rejects_unknown_request_fields() -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hello"}],
+            "future_field": True,
+        }
+    )
+
+    with pytest.raises(ResponsesConversionError, match="future_field"):
         build_responses_provider_request(
             request,
             reasoning=ReasoningPolicy.provider_default(),

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -5,6 +5,7 @@ from typing import Any
 import httpx
 import pytest
 
+from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.stream_contracts import (
     assert_anthropic_stream_contract,
@@ -12,7 +13,7 @@ from free_claude_code.core.anthropic.stream_contracts import (
     text_content,
 )
 from free_claude_code.core.failures import ExecutionFailure
-from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_codex.auth import (
@@ -67,6 +68,27 @@ def _request() -> MessagesRequest:
         max_tokens=1024,
         messages=[{"role": "user", "content": "hello"}],
         stream=True,
+    )
+
+
+def _client_control_request() -> MessagesRequest:
+    return MessagesRequest.model_validate(
+        {
+            "model": "gpt-test",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "hello"}],
+            "thinking": {"type": "adaptive", "display": "omitted"},
+            "context_management": {
+                "edits": [
+                    {
+                        "type": "clear_thinking_20251015",
+                        "keep": "all",
+                    }
+                ]
+            },
+            "output_config": {"effort": "high"},
+            "stream": True,
+        }
     )
 
 
@@ -169,6 +191,107 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
     events = parse_sse_text(body)
     assert_anthropic_stream_contract(events)
     assert text_content(events) == "hello"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_accepts_claude_client_controls_before_upstream_io() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=_complete_stream("hello"),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+    request = _client_control_request()
+    reasoning = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
+
+    provider.preflight_stream(request, reasoning=reasoning)
+    assert requests == []
+
+    body = await _collect(
+        provider.stream_response(
+            request,
+            request_id="req_client_controls",
+            response_model="claude-opus-4",
+            reasoning=reasoning,
+        )
+    )
+
+    assert len(requests) == 1
+    upstream = requests[0]
+    assert upstream.url.path.endswith("/responses")
+    payload = json.loads(upstream.content)
+    assert payload["model"] == "gpt-test"
+    assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert "context_management" not in payload
+    assert "output_config" not in payload
+    assert_anthropic_stream_contract(parse_sse_text(body))
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value", "error_path"),
+    [
+        (
+            "context_management",
+            {
+                "edits": [
+                    {
+                        "type": "clear_thinking_20251015",
+                        "keep": {"type": "thinking_turns", "value": 2},
+                    }
+                ]
+            },
+            "context_management",
+        ),
+        (
+            "output_config",
+            {"format": {"type": "json_schema"}},
+            "output_config.format",
+        ),
+    ],
+)
+async def test_provider_preflight_rejects_unrepresentable_client_controls(
+    field: str,
+    value: object,
+    error_path: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(500, request=request)
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+    payload = {
+        "model": "gpt-test",
+        "messages": [{"role": "user", "content": "hello"}],
+        field: value,
+    }
+
+    with pytest.raises(InvalidRequestError, match=error_path):
+        provider.preflight_stream(MessagesRequest.model_validate(payload))
+
+    assert requests == []
     await client.aclose()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.1"
+version = "4.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Claude Code sends effort and keep-all context controls that the connected OpenAI provider rejected before upstream I/O. The Responses converter revalidated application-owned effort and could not distinguish inert context edits from active unsupported behavior. Fixes #1310.

## Changes

| Before | After |
| --- | --- |
| Every non-empty `output_config` failed OpenAI Responses preflight. | Application-consumed `output_config.effort` reaches one policy-derived OpenAI `reasoning` object. |
| Every non-empty `context_management` failed OpenAI Responses preflight. | Empty edits and exact keep-all thinking edits are omitted as semantic no-ops. |
| Structured output, active edits, and unknown controls shared coarse top-level diagnostics. | Unrepresentable controls still fail before I/O with precise nested output paths. |
| The current Claude request shape had no end-to-end regression contract. | Core, real-provider, and `/v1/messages` tests lock conversion, immutability, wire payload, and zero-I/O rejection. |
| The reasoning boundary did not document consumed controls versus residual semantics. | Architecture now assigns reasoning intent to the application and representability to the target converter. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update restores compatibility with current Claude Code controls when routing requests through OpenAI Responses. Focused mocked-upstream checks verified that effort is converted into the resolved OpenAI reasoning policy, inert keep-all thinking edits are omitted, and active context edits or structured-output settings are rejected before an upstream request is made.
</details>

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused OpenAI responses controls runtime test against the PR, and it passed with 4 tests in 1.47 seconds.
- Compared the same test against the parent commit c36c97f; the run exited with code 2 because the new reasoning module was absent, highlighting the PR-specific change.
- Validated the new control-resolution path by inspecting the changed source at provider\_input.py:103-122 and reasoning.py:38-90.
- Post-PR test run again passed with 4 tests in 1.47 seconds.

<a href="https://app.greptile.com/trex/runs/16880858/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix OpenAI Responses client control vali..."](https://github.com/alishahryar1/free-claude-code/commit/25a79de0147366945117a0ea24f0107955fbaff1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49303265)</sub>

<!-- /greptile_comment -->