### PR TITLE
Stop recommending unavailable NVIDIA Kimi endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Use the tag shown by `ollama list` with the `ollama/` prefix. `OLLAMA_BASE_URL` 
 
 `MODEL` is the fallback for every request. Select a model for `MODEL_FABLE`, `MODEL_OPUS`, `MODEL_SONNET`, or `MODEL_HAIKU` to override an individual Claude Code tier; select **None** to use `MODEL`.
 
-For example, route Opus to `nvidia_nim/moonshotai/kimi-k2.6`, Sonnet to `open_router/openrouter/free`, Haiku to `lmstudio/qwen3.5-coder`, and keep `MODEL` on `zai/glm-5.2`.
+For example, route Opus to `nvidia_nim/nvidia/nemotron-3-super-120b-a12b`, Sonnet to `open_router/openrouter/free`, Haiku to `lmstudio/qwen3.5-coder`, and keep `MODEL` on `zai/glm-5.2`.
 
 ### Reasoning Control
 


### PR DESCRIPTION
## Problem

The model-routing example recommends NVIDIA NIM's hosted Kimi K2.6 endpoint, which NVIDIA currently lists but returns HTTP 404 when invoked. This sends users toward an unavailable model, as reported in #1314.

## Changes

| Before | After |
| --- | --- |
| The Opus example used `nvidia_nim/moonshotai/kimi-k2.6`. | The Opus example uses the verified working default `nvidia_nim/nvidia/nemotron-3-super-120b-a12b`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the README’s optional model-tier routing example to replace the unavailable Kimi NVIDIA NIM identifier with NVIDIA Nemotron.

The documentation-to-routing failure hypothesis was disproved: the documented `MODEL_OPUS` value is accepted by configuration and resolves Opus requests through NVIDIA NIM using the expected upstream model identifier. Focused configuration and routing regressions also passed (14 passed).
</details>

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the routing check script with PYTHONPATH=src to validate configuration and routing; the run exited with CHECK=PASS, MODEL\_OPUS accepted, and the routed provider set to nvidia\_nim with upstream model nvidia/nemotron-3-super-120b-a12b.
- Compared the README before and after the change to confirm the updated example uses the model accepted by the configuration and routing path.
- Executed focused routing and configuration regression tests; fourteen tests passed, confirming the related established behavior remains intact.
- Artifact references were uploaded for review, including the before/after routing logs, the routing check script, and the routing regression log.

<a href="https://app.greptile.com/trex/runs/16915498/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Replace unavailable NIM model in README ..."](https://github.com/alishahryar1/free-claude-code/commit/bb9b41c8ec92981151b078fd02714bb26649f3c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49380397)</sub>

<!-- /greptile_comment -->