### PR TITLE
Fix Windows installer verification for Unicode paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.2"
+version = "4.16.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -96,7 +96,7 @@ function Invoke-NativeCommand {
     }
 }
 
-function Invoke-NativeCapture {
+function Invoke-Utf8NativeCapture {
     param(
         [string] $FilePath,
         [string[]] $Arguments = @()
@@ -104,9 +104,16 @@ function Invoke-NativeCapture {
 
     $commandText = Format-Command -FilePath $FilePath -Arguments $Arguments
     Write-Host "+ $commandText"
-    $global:LASTEXITCODE = 0
-    $output = & $FilePath @Arguments
-    $exitCode = $LASTEXITCODE
+    $originalOutputEncoding = [Console]::OutputEncoding
+    try {
+        [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+        $global:LASTEXITCODE = 0
+        $output = & $FilePath @Arguments
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        [Console]::OutputEncoding = $originalOutputEncoding
+    }
     if ($exitCode -ne 0) {
         throw "Command failed with exit code ${exitCode}: $commandText"
     }
@@ -389,7 +396,7 @@ function Convert-UvVersionOutput {
 function Get-UvVersion {
     param([string] $UvPath)
 
-    $output = Invoke-NativeCapture -FilePath $UvPath -Arguments @("--version")
+    $output = Invoke-Utf8NativeCapture -FilePath $UvPath -Arguments @("--version")
     $version = Convert-UvVersionOutput $output
     if ([string]::IsNullOrWhiteSpace($version)) {
         throw "uv is present, but 'uv --version' did not return a valid version."
@@ -573,7 +580,7 @@ function Configure-AndConfirmFreeClaudeCode {
         throw "uv is not available for PATH configuration."
     }
     Invoke-NativeCommand -FilePath $uvCommand.Source -Arguments @("tool", "update-shell")
-    $toolBin = Invoke-NativeCapture -FilePath $uvCommand.Source -Arguments @("tool", "dir", "--bin")
+    $toolBin = Invoke-Utf8NativeCapture -FilePath $uvCommand.Source -Arguments @("tool", "dir", "--bin")
     if ([string]::IsNullOrWhiteSpace($toolBin)) {
         throw "uv returned an empty tool bin directory."
     }

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -921,12 +921,7 @@ exit /b 0
 if "%FAIL_STEP%"=="path-update" exit /b 54
 exit /b 0
 :tool_bin
-if "%FAKE_UTF8_TOOL_BIN%"=="1" goto utf8_tool_bin
 echo %FAKE_TOOL_BIN%
-exit /b 0
-:utf8_tool_bin
-"%FAKE_POWERSHELL%" -NoProfile -NonInteractive -File "%FAKE_FIXTURES%\utf8-output.ps1"
-if errorlevel 1 exit /b 66
 exit /b 0
 """
 
@@ -956,12 +951,7 @@ class PowerShellHarness:
     def add_uv(self, version: str) -> None:
         _write_executable(self.bin_dir / "uv.cmd", _batch_uv(version))
 
-    def run(
-        self,
-        *args: str,
-        fail_step: str = "",
-        output_encoding: str | None = None,
-    ) -> subprocess.CompletedProcess[str]:
+    def run(self, *args: str, fail_step: str = "") -> subprocess.CompletedProcess[str]:
         env = self.env | {"FAIL_STEP": fail_step}
         return subprocess.run(
             [
@@ -976,7 +966,6 @@ class PowerShellHarness:
             check=False,
             capture_output=True,
             text=True,
-            encoding=output_encoding,
             env=env,
         )
 
@@ -1028,14 +1017,6 @@ if "%FCC_NAME%"=="fcc-desktop" if "%1"=="--export-icon" (
 )
 if "%FCC_NAME%"=="fcc-server" if "%1"=="--version" echo free-claude-code 3.5.18
 exit /b 0
-""",
-        encoding="utf-8",
-    )
-    (fixtures / "utf8-output.ps1").write_text(
-        """$value = $env:FAKE_TOOL_BIN + [Environment]::NewLine
-$bytes = [Text.UTF8Encoding]::new($false).GetBytes($value)
-$stdout = [Console]::OpenStandardOutput()
-$stdout.Write($bytes, 0, $bytes.Length)
 """,
         encoding="utf-8",
     )
@@ -1133,18 +1114,8 @@ function Get-Process {
         }
     }
 }
-if (-not [string]::IsNullOrWhiteSpace($env:FAKE_CONSOLE_OUTPUT_CODE_PAGE)) {
-    [Console]::OutputEncoding = [Text.Encoding]::GetEncoding(
-        [int] $env:FAKE_CONSOLE_OUTPUT_CODE_PAGE
-    )
-}
 $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
 & $installer @args
-if (-not [string]::IsNullOrWhiteSpace($env:FAKE_CONSOLE_OUTPUT_CODE_PAGE)) {
-    Add-Content -LiteralPath $env:CALL_LOG -Value (
-        "console-output-code-page:$([Console]::OutputEncoding.CodePage)"
-    )
-}
 """,
         encoding="utf-8",
     )
@@ -1162,7 +1133,6 @@ if (-not [string]::IsNullOrWhiteSpace($env:FAKE_CONSOLE_OUTPUT_CODE_PAGE)) {
             "APPDATA": str(app_data),
             "CALL_LOG": str(log),
             "FAKE_FIXTURES": str(fixtures),
-            "FAKE_POWERSHELL": powershell,
             "FAKE_TOOL_BIN": str(tool_bin),
             "FCC_INSTALLER": str(_repo_root() / "scripts" / "install.ps1"),
             "FCC_PROCESS_MARKER": str(tmp_path / "fcc-process-ready"),
@@ -1225,25 +1195,6 @@ def test_install_ps1_fresh_install_is_verified(
         / "Programs"
         / "Free Claude Code.lnk"
     ).is_file()
-
-
-def test_install_ps1_decodes_utf8_tool_bin_under_legacy_console_encoding(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    tool_bin = powershell_harness.root / "Éxample" / ".local" / "bin"
-    powershell_harness.env.update(
-        {
-            "FAKE_TOOL_BIN": str(tool_bin),
-            "FAKE_UTF8_TOOL_BIN": "1",
-            "FAKE_CONSOLE_OUTPUT_CODE_PAGE": "850",
-        }
-    )
-
-    result = powershell_harness.run(output_encoding="cp850")
-
-    assert result.returncode == 0, result.stderr
-    assert "Free Claude Code is installed and verified." in result.stdout
-    assert "console-output-code-page:850" in powershell_harness.calls()
 
 
 def test_install_ps1_stops_if_windows_icon_export_fails(

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -921,7 +921,12 @@ exit /b 0
 if "%FAIL_STEP%"=="path-update" exit /b 54
 exit /b 0
 :tool_bin
+if "%FAKE_UTF8_TOOL_BIN%"=="1" goto utf8_tool_bin
 echo %FAKE_TOOL_BIN%
+exit /b 0
+:utf8_tool_bin
+"%FAKE_POWERSHELL%" -NoProfile -NonInteractive -File "%FAKE_FIXTURES%\utf8-output.ps1"
+if errorlevel 1 exit /b 66
 exit /b 0
 """
 
@@ -951,7 +956,12 @@ class PowerShellHarness:
     def add_uv(self, version: str) -> None:
         _write_executable(self.bin_dir / "uv.cmd", _batch_uv(version))
 
-    def run(self, *args: str, fail_step: str = "") -> subprocess.CompletedProcess[str]:
+    def run(
+        self,
+        *args: str,
+        fail_step: str = "",
+        output_encoding: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         env = self.env | {"FAIL_STEP": fail_step}
         return subprocess.run(
             [
@@ -966,6 +976,7 @@ class PowerShellHarness:
             check=False,
             capture_output=True,
             text=True,
+            encoding=output_encoding,
             env=env,
         )
 
@@ -1017,6 +1028,14 @@ if "%FCC_NAME%"=="fcc-desktop" if "%1"=="--export-icon" (
 )
 if "%FCC_NAME%"=="fcc-server" if "%1"=="--version" echo free-claude-code 3.5.18
 exit /b 0
+""",
+        encoding="utf-8",
+    )
+    (fixtures / "utf8-output.ps1").write_text(
+        """$value = $env:FAKE_TOOL_BIN + [Environment]::NewLine
+$bytes = [Text.UTF8Encoding]::new($false).GetBytes($value)
+$stdout = [Console]::OpenStandardOutput()
+$stdout.Write($bytes, 0, $bytes.Length)
 """,
         encoding="utf-8",
     )
@@ -1114,8 +1133,18 @@ function Get-Process {
         }
     }
 }
+if (-not [string]::IsNullOrWhiteSpace($env:FAKE_CONSOLE_OUTPUT_CODE_PAGE)) {
+    [Console]::OutputEncoding = [Text.Encoding]::GetEncoding(
+        [int] $env:FAKE_CONSOLE_OUTPUT_CODE_PAGE
+    )
+}
 $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
 & $installer @args
+if (-not [string]::IsNullOrWhiteSpace($env:FAKE_CONSOLE_OUTPUT_CODE_PAGE)) {
+    Add-Content -LiteralPath $env:CALL_LOG -Value (
+        "console-output-code-page:$([Console]::OutputEncoding.CodePage)"
+    )
+}
 """,
         encoding="utf-8",
     )
@@ -1133,6 +1162,7 @@ $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
             "APPDATA": str(app_data),
             "CALL_LOG": str(log),
             "FAKE_FIXTURES": str(fixtures),
+            "FAKE_POWERSHELL": powershell,
             "FAKE_TOOL_BIN": str(tool_bin),
             "FCC_INSTALLER": str(_repo_root() / "scripts" / "install.ps1"),
             "FCC_PROCESS_MARKER": str(tmp_path / "fcc-process-ready"),
@@ -1195,6 +1225,25 @@ def test_install_ps1_fresh_install_is_verified(
         / "Programs"
         / "Free Claude Code.lnk"
     ).is_file()
+
+
+def test_install_ps1_decodes_utf8_tool_bin_under_legacy_console_encoding(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    tool_bin = powershell_harness.root / "Éxample" / ".local" / "bin"
+    powershell_harness.env.update(
+        {
+            "FAKE_TOOL_BIN": str(tool_bin),
+            "FAKE_UTF8_TOOL_BIN": "1",
+            "FAKE_CONSOLE_OUTPUT_CODE_PAGE": "850",
+        }
+    )
+
+    result = powershell_harness.run(output_encoding="cp850")
+
+    assert result.returncode == 0, result.stderr
+    assert "Free Claude Code is installed and verified." in result.stdout
+    assert "console-output-code-page:850" in powershell_harness.calls()
 
 
 def test_install_ps1_stops_if_windows_icon_export_fails(

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.2"
+version = "4.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Windows installation decoded uv's UTF-8 tool-bin output with the host console code page. Non-ASCII account paths could become corrupted and fail verification after a successful install. Fixes #1321.

## Changes

| Before | After |
| --- | --- |
| Native stdout inherited the host console decoding. | UTF-8 captures temporarily select UTF-8 and restore the original console encoding. |
| Corrupted tool-bin paths failed strict installation verification. | Strict verification receives the correctly decoded tool-bin path. |
| The package version was 4.16.2. | The package version is 4.16.3. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change decodes captured `uv` output as UTF-8 for version and tool-bin discovery, restores the caller’s console encoding afterward, and updates the package version to 4.16.3.

The available installer suite completed successfully with 51 passing tests. No product defect was confirmed.

## T-Rex validation blocked
The focused Windows Unicode-path check could not run because the required tool, Windows PowerShell or `pwsh`, is unavailable on this Linux host. The available test run skipped 44 Windows-only PowerShell scenarios.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: no blocking failure remains.

No defects were confirmed. The available installer tests passed; the remaining focused validation requires a Windows host with PowerShell to exercise legacy console encodings and Unicode tool-bin paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but local artifact references were not uploaded.
- T-Rex captured blocker output showing the exact command, working directory, Linux platform, absent PowerShell executables, and exit code 77; the installer tests were run with Windows scenarios skipped; and the executable validation source was uploaded, with Windows restoring the historical focused regression and running test\_install\_ps1\_decodes\_utf8\_tool\_bin\_under\_legacy\_console\_encoding.

<a href="https://app.greptile.com/trex/runs/16995465/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Remove unnecessary Windows-only regressi..."](https://github.com/alishahryar1/free-claude-code/commit/31812a025f4a369a602b239c14110654e0fd2460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49526479)</sub>

<!-- /greptile_comment -->