### PR TITLE
Add coding-agent selection and validate PowerShell downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Windows PowerShell:
 
 Re-run the same command whenever you want to update. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
 
-Pi is optional. If you decline Pi's installer, FCC continues installing with Claude Code and Codex.
+The installer asks which coding agents to install or verify. Choose at least one; skipped agents are left unchanged.
 
 ### 2. Start FCC
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.3"
+version = "4.16.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.4"
+version = "4.17.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.17.0"
+version = "4.16.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,6 +21,9 @@ $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"
 $UvInstallUrl = "https://astral.sh/uv/install.ps1"
+$script:InstallClaudeCode = $true
+$script:InstallCodex = $true
+$script:InstallPi = $true
 $script:PiAvailable = $false
 $FccCommands = @(
     # Include retired entry points so updates reject older FCC processes before replacement.
@@ -37,7 +40,7 @@ function Show-Usage {
     @"
 Usage: install.ps1 [options]
 
-Installs Claude Code and Codex, offers to install Pi, ensures a compatible uv, and installs or updates Free Claude Code.
+Installs or updates Free Claude Code and lets you choose which coding agents to install or verify.
 
 Options:
   -VoiceNim              Install NVIDIA NIM voice transcription support.
@@ -54,6 +57,39 @@ function Write-Step {
 
     Write-Host ""
     Write-Host "==> $Message"
+}
+
+function Test-InteractiveInstaller {
+    return (-not [Console]::IsInputRedirected) -and (-not [Console]::IsOutputRedirected)
+}
+
+function Read-YesNo {
+    param([string] $Prompt)
+
+    while ($true) {
+        $answer = ([string] (Read-Host "$Prompt [Y/n]")).Trim().ToLowerInvariant()
+        if ($answer -in @("", "y", "yes")) {
+            return $true
+        }
+        if ($answer -in @("n", "no")) {
+            return $false
+        }
+        Write-Host "Please answer Y or N."
+    }
+}
+
+function Select-CodingAgents {
+    while ($true) {
+        $script:InstallClaudeCode = Read-YesNo "Install or verify Claude Code for fcc-claude?"
+        $script:InstallCodex = Read-YesNo "Install or verify Codex for fcc-codex?"
+        $script:InstallPi = Read-YesNo "Install or verify Pi for fcc-pi?"
+
+        if ($script:InstallClaudeCode -or $script:InstallCodex -or $script:InstallPi) {
+            return
+        }
+        Write-Host "Select at least one coding agent."
+        Write-Host ""
+    }
 }
 
 function Format-Argument {
@@ -390,6 +426,27 @@ function Ensure-Pi {
     $script:PiAvailable = $true
 }
 
+function Ensure-SelectedCodingAgents {
+    if ($script:InstallClaudeCode) {
+        Write-Step "Ensuring Claude Code is installed"
+        Ensure-ClaudeCode
+    }
+
+    if ($script:InstallCodex) {
+        Write-Step "Ensuring Codex is installed"
+        Ensure-Codex
+    }
+
+    if ($script:InstallPi) {
+        Write-Step "Checking or installing Pi"
+        Ensure-Pi
+    }
+
+    if ((-not $script:InstallClaudeCode) -and (-not $script:InstallCodex) -and (-not $script:PiAvailable)) {
+        throw "No selected coding agent was installed. Re-run the installer and choose at least one."
+    }
+}
+
 function Convert-UvVersionOutput {
     param([string] $Output)
 
@@ -709,14 +766,12 @@ Add-KnownBinDirectories
 Write-Step "Checking for running Free Claude Code processes"
 Assert-NoFccProcessesRunning
 
-Write-Step "Ensuring Claude Code is installed"
-Ensure-ClaudeCode
+if (Test-InteractiveInstaller) {
+    Write-Step "Choosing coding agents"
+    Select-CodingAgents
+}
 
-Write-Step "Ensuring Codex is installed"
-Ensure-Codex
-
-Write-Step "Checking or installing Pi"
-Ensure-Pi
+Ensure-SelectedCodingAgents
 
 Write-Step "Ensuring uv $MinUvVersion or newer is installed"
 Ensure-Uv
@@ -734,8 +789,12 @@ if ($DryRun) {
 else {
     Write-Host "Free Claude Code is installed and verified. Open the Free Claude Code desktop shortcut to run it in the background."
     Write-Host "For terminal use, start the proxy with: fcc-server"
-    Write-Host "Run Claude Code with: fcc-claude"
-    Write-Host "Run Codex with: fcc-codex"
+    if ($script:InstallClaudeCode) {
+        Write-Host "Run Claude Code with: fcc-claude"
+    }
+    if ($script:InstallCodex) {
+        Write-Host "Run Codex with: fcc-codex"
+    }
     if ($script:PiAvailable) {
         Write-Host "Run Pi with: fcc-pi"
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -241,6 +241,17 @@ function Invoke-DownloadedPowerShellInstaller {
             throw "The downloaded $Name installer was empty."
         }
 
+        $tokens = $null
+        $parseErrors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile(
+            $temporaryScript,
+            [ref] $tokens,
+            [ref] $parseErrors
+        ) | Out-Null
+        if ($parseErrors.Count -gt 0) {
+            throw "The downloaded $Name installer from '$Url' is not valid PowerShell. A network proxy or filter may have replaced it with an HTML response."
+        }
+
         $powerShellPath = Get-PowerShellExecutable
 
         $hadNonInteractive = Test-Path Env:CODEX_NON_INTERACTIVE

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,9 @@ dry_run=0
 voice_nim=0
 voice_local=0
 voice_all=0
+install_claude=1
+install_codex=1
+install_pi=1
 torch_backend=""
 temporary_script=""
 tool_bin=""
@@ -26,7 +29,7 @@ show_usage() {
     cat <<'USAGE'
 Usage: install.sh [options]
 
-Installs Claude Code and Codex, offers to install Pi, ensures a compatible uv, and installs or updates Free Claude Code.
+Installs or updates Free Claude Code and lets you choose which coding agents to install or verify.
 
 Options:
   --voice-nim              Install NVIDIA NIM voice transcription support.
@@ -41,6 +44,58 @@ USAGE
 fail() {
     printf 'error: %s\n' "$*" >&2
     exit 1
+}
+
+installer_is_interactive() {
+    [ -t 1 ] && ( : </dev/tty ) 2>/dev/null
+}
+
+prompt_yes_no() {
+    question=$1
+    while :; do
+        printf '%s [Y/n] ' "$question" >&4
+        if ! IFS= read -r answer <&3; then
+            fail "Could not read the coding agent selection."
+        fi
+        case "$answer" in
+            ""|[Yy]|[Yy][Ee][Ss]) return 0 ;;
+            [Nn]|[Nn][Oo]) return 1 ;;
+            *) printf 'Please answer Y or N.\n' >&4 ;;
+        esac
+    done
+}
+
+choose_coding_agents() {
+    selection_input=$1
+    selection_output=$2
+    exec 3<"$selection_input"
+    exec 4>"$selection_output"
+
+    while :; do
+        if prompt_yes_no "Install or verify Claude Code for fcc-claude?"; then
+            install_claude=1
+        else
+            install_claude=0
+        fi
+        if prompt_yes_no "Install or verify Codex for fcc-codex?"; then
+            install_codex=1
+        else
+            install_codex=0
+        fi
+        if prompt_yes_no "Install or verify Pi for fcc-pi?"; then
+            install_pi=1
+        else
+            install_pi=0
+        fi
+
+        if [ "$install_claude" -eq 1 ] || [ "$install_codex" -eq 1 ] || [ "$install_pi" -eq 1 ]; then
+            break
+        fi
+        printf 'Select at least one coding agent.\n\n' >&4
+    done
+
+    exec 3<&-
+    exec 4>&-
 }
 
 step() {
@@ -329,6 +384,27 @@ ensure_pi() {
 
     verify_pi_command
     pi_available=1
+}
+
+ensure_selected_coding_agents() {
+    if [ "$install_claude" -eq 1 ]; then
+        step "Ensuring Claude Code is installed"
+        ensure_claude
+    fi
+
+    if [ "$install_codex" -eq 1 ]; then
+        step "Ensuring Codex is installed"
+        ensure_codex
+    fi
+
+    if [ "$install_pi" -eq 1 ]; then
+        step "Checking or installing Pi"
+        ensure_pi
+    fi
+
+    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ] && [ "$pi_available" -eq 0 ]; then
+        fail "No selected coding agent was installed. Re-run the installer and choose at least one."
+    fi
 }
 
 current_uv_version() {
@@ -631,20 +707,20 @@ add_known_bin_directories
 step "Checking for running Free Claude Code processes"
 assert_no_fcc_processes_running
 
+if installer_is_interactive; then
+    step "Choosing coding agents"
+    choose_coding_agents /dev/tty /dev/tty
+fi
+
 step "Checking installation prerequisites"
 require_command curl
-require_command bash
+if [ "$install_claude" -eq 1 ]; then
+    require_command bash
+fi
 require_command sh
 require_command mktemp
 
-step "Ensuring Claude Code is installed"
-ensure_claude
-
-step "Ensuring Codex is installed"
-ensure_codex
-
-step "Checking or installing Pi"
-ensure_pi
+ensure_selected_coding_agents
 
 step "Ensuring uv $MIN_UV_VERSION or newer is installed"
 ensure_uv
@@ -669,8 +745,12 @@ else
     else
         printf '\nFree Claude Code is installed and verified. Start the proxy with: fcc-server\n'
     fi
-    printf 'Run Claude Code with: fcc-claude\n'
-    printf 'Run Codex with: fcc-codex\n'
+    if [ "$install_claude" -eq 1 ]; then
+        printf 'Run Claude Code with: fcc-claude\n'
+    fi
+    if [ "$install_codex" -eq 1 ]; then
+        printf 'Run Codex with: fcc-codex\n'
+    fi
     if [ "$pi_available" -eq 1 ]; then
         printf 'Run Pi with: fcc-pi\n'
     fi

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -169,6 +169,77 @@ printf '%s\n' "$FCC_PS_OUTPUT"
             env=env,
         )
 
+    def run_interactive(
+        self,
+        answers: str,
+        *args: str,
+        fail_step: str = "",
+    ) -> subprocess.CompletedProcess[str]:
+        import errno
+        import pty
+        import select
+        import time
+
+        env = self.env | {
+            "FAIL_STEP": fail_step,
+            "FCC_INSTALLER": str(_repo_root() / "scripts" / "install.sh"),
+        }
+        command = [
+            "/bin/sh",
+            "-c",
+            'cat "$FCC_INSTALLER" | /bin/sh -s -- "$@"',
+            "fcc-installer",
+            *args,
+        ]
+        fork = vars(pty)["fork"]
+        wait_without_blocking = vars(os)["WNOHANG"]
+        child_pid, master_fd = fork()
+        if child_pid == 0:
+            os.execve(command[0], command, env)
+
+        output = bytearray()
+        status: int | None = None
+        deadline = time.monotonic() + 30
+        try:
+            os.write(master_fd, answers.encode())
+            while status is None:
+                readable, _, _ = select.select([master_fd], [], [], 0.1)
+                if readable:
+                    try:
+                        output.extend(os.read(master_fd, 65536))
+                    except OSError as error:
+                        if error.errno != errno.EIO:
+                            raise
+
+                waited_pid, wait_status = os.waitpid(child_pid, wait_without_blocking)
+                if waited_pid == child_pid:
+                    status = wait_status
+                elif time.monotonic() >= deadline:
+                    os.kill(child_pid, 9)
+                    os.waitpid(child_pid, 0)
+                    raise AssertionError("Interactive installer did not finish")
+
+            while True:
+                readable, _, _ = select.select([master_fd], [], [], 0)
+                if not readable:
+                    break
+                try:
+                    output.extend(os.read(master_fd, 65536))
+                except OSError as error:
+                    if error.errno == errno.EIO:
+                        break
+                    raise
+        finally:
+            os.close(master_fd)
+
+        assert status is not None
+        return subprocess.CompletedProcess(
+            command,
+            os.waitstatus_to_exitcode(status),
+            output.decode(errors="replace"),
+            "",
+        )
+
     def calls(self) -> list[str]:
         if not self.log.exists():
             return []
@@ -352,6 +423,32 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
         "uv:tool dir --bin",
         "fcc-server:--version",
     ]
+
+
+def test_install_sh_reprompts_then_installs_only_selected_agent(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run_interactive("n\nn\nn\nn\ny\nn\n")
+
+    assert result.returncode == 0, result.stdout
+    assert "Select at least one coding agent." in result.stdout
+    assert "Run Codex with: fcc-codex" in result.stdout
+    assert "Run Claude Code with: fcc-claude" not in result.stdout
+    assert "Run Pi with: fcc-pi" not in result.stdout
+    calls = posix_harness.calls()
+    assert "codex-install:1" in calls
+    assert not any("claude.ai" in call for call in calls)
+    assert not any("pi.dev" in call for call in calls)
+
+
+def test_install_sh_rejects_uninstalled_only_selection(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run_interactive("n\nn\ny\n", fail_step="pi-skip")
+
+    assert result.returncode != 0
+    assert "No selected coding agent was installed." in result.stdout
+    assert not any("astral.sh" in call for call in posix_harness.calls())
 
 
 def test_install_sh_creates_native_macos_app_and_desktop_link(
@@ -1598,6 +1695,120 @@ Invoke-DownloadedPowerShellInstaller `
     )
     assert "network proxy or filter" in result.stderr
     assert "invalid installer reached execution" not in result.stderr
+
+
+@pytest.mark.parametrize("powershell", _powershells())
+@pytest.mark.parametrize(
+    ("answers", "expected", "expected_messages"),
+    [
+        (("", "", ""), "True,True,True", ()),
+        (
+            ("maybe", "n", "n", "n", "n", "y", "n"),
+            "False,True,False",
+            ("Please answer Y or N.", "Select at least one coding agent."),
+        ),
+    ],
+)
+def test_install_ps1_selects_at_least_one_coding_agent(
+    powershell: str,
+    answers: tuple[str, ...],
+    expected: str,
+    expected_messages: tuple[str, ...],
+) -> None:
+    text = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    read_yes_no = _braced_body(text, "function Read-YesNo")
+    select_agents = _braced_body(text, "function Select-CodingAgents")
+    answer_array = ", ".join(repr(answer) for answer in answers)
+    script = f"""Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$script:Answers = @({answer_array})
+$script:AnswerIndex = 0
+$script:InstallClaudeCode = $true
+$script:InstallCodex = $true
+$script:InstallPi = $true
+function Read-Host {{
+    param([string] $Prompt)
+    $answer = $script:Answers[$script:AnswerIndex]
+    $script:AnswerIndex += 1
+    return $answer
+}}
+function Read-YesNo {{{read_yes_no}}}
+function Select-CodingAgents {{{select_agents}}}
+Select-CodingAgents
+Write-Output "selection:$($script:InstallClaudeCode),$($script:InstallCodex),$($script:InstallPi)"
+"""
+
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-Command", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"selection:{expected}" in result.stdout
+    for message in expected_messages:
+        assert message in result.stdout
+
+
+@pytest.mark.parametrize("powershell", _powershells())
+def test_install_ps1_runs_only_selected_coding_agents(powershell: str) -> None:
+    text = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    body = _braced_body(text, "function Ensure-SelectedCodingAgents")
+    script = f"""Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$script:InstallClaudeCode = $false
+$script:InstallCodex = $true
+$script:InstallPi = $false
+$script:PiAvailable = $false
+$script:Calls = @()
+function Write-Step {{ param([string] $Message) }}
+function Ensure-ClaudeCode {{ $script:Calls += "claude" }}
+function Ensure-Codex {{ $script:Calls += "codex" }}
+function Ensure-Pi {{ $script:Calls += "pi"; $script:PiAvailable = $true }}
+function Ensure-SelectedCodingAgents {{{body}}}
+Ensure-SelectedCodingAgents
+Write-Output "calls:$($script:Calls -join ',')"
+"""
+
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-Command", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "calls:codex" in result.stdout
+
+
+@pytest.mark.parametrize("powershell", _powershells())
+def test_install_ps1_rejects_uninstalled_only_selection(powershell: str) -> None:
+    text = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    body = _braced_body(text, "function Ensure-SelectedCodingAgents")
+    script = f"""Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$script:InstallClaudeCode = $false
+$script:InstallCodex = $false
+$script:InstallPi = $true
+$script:PiAvailable = $false
+function Write-Step {{ param([string] $Message) }}
+function Ensure-ClaudeCode {{ }}
+function Ensure-Codex {{ }}
+function Ensure-Pi {{ }}
+function Ensure-SelectedCodingAgents {{{body}}}
+Ensure-SelectedCodingAgents
+"""
+
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-Command", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "No selected coding agent was installed." in result.stderr
 
 
 @pytest.mark.parametrize("powershell", _powershells())

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1563,6 +1563,44 @@ def test_readme_install_section_has_no_manual_git_prerequisite() -> None:
 
 
 @pytest.mark.parametrize("powershell", _powershells())
+def test_install_ps1_rejects_invalid_download_before_execution(
+    powershell: str,
+) -> None:
+    text = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    body = _braced_body(text, "function Invoke-DownloadedPowerShellInstaller")
+    script = f"""Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$DryRun = $false
+function Format-Argument {{ param([string] $Value) return $Value }}
+function Invoke-RestMethod {{
+    [CmdletBinding()]
+    param([string] $Uri, [string] $OutFile)
+    [IO.File]::WriteAllText($OutFile, "<style>div#box {{")
+}}
+function Get-PowerShellExecutable {{ throw "invalid installer reached execution" }}
+function Invoke-DownloadedPowerShellInstaller {{{body}}}
+Invoke-DownloadedPowerShellInstaller `
+    -Url "https://example.test/install.ps1" `
+    -Name "Example"
+"""
+
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-Command", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert (
+        "Example installer from 'https://example.test/install.ps1' is not valid PowerShell"
+        in result.stderr
+    )
+    assert "network proxy or filter" in result.stderr
+    assert "invalid installer reached execution" not in result.stderr
+
+
+@pytest.mark.parametrize("powershell", _powershells())
 def test_install_ps1_falls_back_when_pshome_executable_is_unavailable(
     tmp_path: Path,
     powershell: str,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.3"
+version = "4.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.17.0"
+version = "4.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.4"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Installers always installed or verified every coding agent, so users could not choose only Claude Code, Codex, or Pi. Windows could also execute an intercepted HTML response as PowerShell. Fixes #1322.

## Changes

| Before | After |
| --- | --- |
| Interactive installs processed all three coding agents. | Interactive installs ask about Claude Code, Codex, and Pi with Yes defaults. |
| Users could not skip individual agents. | No skips installation and verification while leaving an existing agent unchanged. |
| Selecting no agents had no defined contract. | All-No re-prompts, and installation requires at least one selected agent to be available. |
| Automation depended on the unconditional client flow. | Non-interactive installs preserve the existing all-selected behavior. |
| Completion output advertised every required wrapper. | Completion output advertises only selected and available coding agents. |
| Every nonempty downloaded file was executed as PowerShell. | Every downloaded PowerShell installer must parse before execution. |
| The package version was 4.16.3. | The package version is 4.16.4. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds interactive coding-agent selection to both installers, keeps non-interactive installs configured for all agents, and validates downloaded PowerShell installer syntax before execution.

The POSIX installer was exercised through an interactive terminal flow. Declining every option re-prompts without invoking an installer; selecting only Codex installs and verifies Codex and FCC without calling the Claude or Pi installers; and selecting only an unavailable Pi stops before FCC installation. The focused POSIX selection regression tests also passed.

### T-Rex validation blocked
Windows runtime validation is blocked by a missing tool: neither `pwsh` nor `powershell` is installed in this Linux environment. The Windows selection and downloaded-script parsing paths require execution on a Windows-capable host with PowerShell available.
</details>

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains.

The POSIX installer behavior was verified end to end, including empty selection handling, selected-agent isolation, and rejection when the only selected agent is unusable. Windows-only runtime execution remains unavailable here because PowerShell is not installed, but this did not reveal a defect.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused POSIX agent-selection harness against scripts/install.sh with mocked agent installers and FCC tooling; observed that declining Claude, Codex, and Pi produced the required re-prompt and made no external installer calls.
- Installed only Codex with CODEX\_NON\_INTERACTIVE=1 and completed FCC verification through fcc-server --version, with no Claude or Pi installer activity.
- Selected only Pi; the installer produced no usable Pi command and stopped before uv or FCC installation.
- Ran the focused installer regression tests; two tests passed and one was skipped.
- PowerShell availability checks on the Linux host showed pwsh and powershell were not on PATH, blocking the focused harness; the focused PowerShell pytest run reported 1 passed, 5 skipped, and 96 deselected.

<a href="https://app.greptile.com/trex/runs/17001367/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Use a patch version for installer update..."](https://github.com/alishahryar1/free-claude-code/commit/15b827255a4fbc876ca2f195a56aa86e521ebc87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49549360)</sub>

<!-- /greptile_comment -->