### PR TITLE
Restore OpenAI subscription generation compatibility

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -657,8 +657,14 @@ failure classification, model discovery, admission, and commit-boundary retry.
 Neutral Anthropic-to-Responses input and Responses-to-Anthropic stream
 conversion remain in
 [core/openai_responses/](src/free_claude_code/core/openai_responses/), which
-never imports OAuth, account IDs, or provider endpoints. The Admin API exposes
-only safe connected-account state and never serializes token objects.
+never imports OAuth, account IDs, or provider endpoints. That neutral converter
+preserves the public Responses contract; the subscription provider owns the
+private Codex request projection and omits fields that backend does not accept,
+such as the public `max_output_tokens` cap and `metadata`. Successful private
+responses are recognized from their SSE framing rather than their media type
+because the backend can omit `Content-Type`; a bounded pre-event prefix is
+retained only for diagnosing genuine non-SSE HTTP 2xx responses. The Admin API
+exposes only safe connected-account state and never serializes token objects.
 
 [providers/google_openai/](src/free_claude_code/providers/google_openai/) owns the
 Google-specific protocol behavior shared by AI Studio and Vertex AI: literal

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -661,11 +661,11 @@ never imports OAuth, account IDs, or provider endpoints. That neutral converter
 preserves the public Responses contract; the subscription provider owns the
 private Codex request projection and omits fields that backend does not accept,
 such as the public `max_output_tokens` cap and `metadata`. Successful private
-responses are recognized from their SSE framing rather than their media type
-because the backend can omit `Content-Type`. Before framing is established,
-parsing stops at the diagnostic byte cap and retains only that bounded prefix
-for genuine non-SSE HTTP 2xx responses. The Admin API exposes only safe
-connected-account state and never serializes token objects.
+responses can omit `Content-Type`, so the provider accepts an absent media type
+for its always-streaming request and parses the body as SSE. An explicitly
+declared non-SSE media type retains the bounded diagnostic failure path. The
+Admin API exposes only safe connected-account state and never serializes token
+objects.
 
 [providers/google_openai/](src/free_claude_code/providers/google_openai/) owns the
 Google-specific protocol behavior shared by AI Studio and Vertex AI: literal

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -662,9 +662,10 @@ preserves the public Responses contract; the subscription provider owns the
 private Codex request projection and omits fields that backend does not accept,
 such as the public `max_output_tokens` cap and `metadata`. Successful private
 responses are recognized from their SSE framing rather than their media type
-because the backend can omit `Content-Type`; a bounded pre-event prefix is
-retained only for diagnosing genuine non-SSE HTTP 2xx responses. The Admin API
-exposes only safe connected-account state and never serializes token objects.
+because the backend can omit `Content-Type`. Before framing is established,
+parsing stops at the diagnostic byte cap and retains only that bounded prefix
+for genuine non-SSE HTTP 2xx responses. The Admin API exposes only safe
+connected-account state and never serializes token objects.
 
 [providers/google_openai/](src/free_claude_code/providers/google_openai/) owns the
 Google-specific protocol behavior shared by AI Studio and Vertex AI: literal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.4"
+version = "4.16.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -237,6 +237,18 @@ class OpenAICodexProvider(BaseProvider):
                             truncated=body_truncated,
                         )
                         raise
+                content_type = response.headers.get("content-type")
+                if content_type and "text/event-stream" not in content_type.lower():
+                    body_bytes, body_truncated = await _read_bounded_body(response)
+                    error = _TruncatedResponsesStream(
+                        "OpenAI returned a non-streaming Responses payload."
+                    )
+                    attach_upstream_error_body(
+                        error,
+                        body_bytes,
+                        truncated=body_truncated,
+                    )
+                    raise error
                 stream_opened = True
 
                 async for event_type, payload in _iter_sse(response):
@@ -327,141 +339,38 @@ async def _iter_sse(
 ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
     event_type = ""
     data_lines: list[str] = []
-    body_prefix = bytearray()
-    saw_sse_framing = False
-    saw_sse_event = False
-    pending_line = bytearray()
-    suppress_lf = False
-    done = False
-
-    def decode_lines(chunk: bytes, *, flush: bool = False) -> list[str]:
-        nonlocal saw_sse_framing, suppress_lf
-        lines: list[str] = []
-        for byte in chunk:
-            if suppress_lf:
-                suppress_lf = False
-                if byte == 0x0A:
-                    continue
-            if byte == 0x0D:
-                lines.append(pending_line.decode("utf-8", errors="replace"))
-                pending_line.clear()
-                suppress_lf = True
-            elif byte == 0x0A:
-                lines.append(pending_line.decode("utf-8", errors="replace"))
-                pending_line.clear()
-            else:
-                pending_line.append(byte)
-                # A valid first Codex event can exceed the diagnostic cap.
-                # Field syntax, not complete event size, ends the non-SSE guard.
-                if pending_line in (b"event:", b"data:"):
-                    saw_sse_framing = True
-        if flush and pending_line:
-            lines.append(pending_line.decode("utf-8", errors="replace"))
-            pending_line.clear()
-        return lines
-
-    def process_line(line: str) -> tuple[str, dict[str, Any]] | None:
-        nonlocal data_lines, done, event_type, saw_sse_event
+    async for line in response.aiter_lines():
         if not line:
             if not data_lines:
                 event_type = ""
-                return None
+                continue
             raw_data = "\n".join(data_lines)
             data_lines = []
             if raw_data == "[DONE]":
-                done = True
-                return None
+                return
             try:
                 payload = json.loads(raw_data)
             except json.JSONDecodeError as exc:
-                error = _TruncatedResponsesStream(
+                raise _TruncatedResponsesStream(
                     "OpenAI returned malformed Responses SSE."
-                )
-                body_bytes = raw_data.encode("utf-8", errors="replace")
-                attach_upstream_error_body(
-                    error,
-                    body_bytes[:ERROR_DETAIL_DISPLAY_CAP_BYTES],
-                    truncated=len(body_bytes) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
-                )
-                raise error from exc
+                ) from exc
             if not isinstance(payload, dict):
-                error = _TruncatedResponsesStream(
+                raise _TruncatedResponsesStream(
                     "OpenAI returned a non-object Responses event."
                 )
-                body_bytes = raw_data.encode("utf-8", errors="replace")
-                attach_upstream_error_body(
-                    error,
-                    body_bytes[:ERROR_DETAIL_DISPLAY_CAP_BYTES],
-                    truncated=len(body_bytes) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
-                )
-                raise error
-            saw_sse_event = True
-            body_prefix.clear()
             resolved_type = event_type or payload.get("type")
             event_type = ""
             if isinstance(resolved_type, str) and resolved_type:
-                return resolved_type, payload
-            return None
+                yield resolved_type, payload
+            continue
         if line.startswith("event:"):
             event_type = line[6:].strip()
         elif line.startswith("data:"):
             data_lines.append(line[5:].lstrip())
-        return None
-
-    def non_streaming_error() -> _TruncatedResponsesStream:
-        error = _TruncatedResponsesStream(
-            "OpenAI returned a non-streaming Responses payload."
-        )
-        attach_upstream_error_body(
-            error,
-            bytes(body_prefix[:ERROR_DETAIL_DISPLAY_CAP_BYTES]),
-            truncated=len(body_prefix) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
-        )
-        return error
-
-    async for chunk in response.aiter_bytes():
-        offset = 0
-        while offset < len(chunk):
-            if saw_sse_framing:
-                segment = chunk[offset:]
-                offset = len(chunk)
-            else:
-                remaining = ERROR_DETAIL_DISPLAY_CAP_BYTES + 1 - len(body_prefix)
-                segment = chunk[offset : offset + remaining]
-                body_prefix.extend(segment)
-                offset += len(segment)
-
-            for line in decode_lines(segment):
-                event = process_line(line)
-                if done:
-                    return
-                if event is not None:
-                    yield event
-
-            if not saw_sse_framing and (
-                len(body_prefix) > ERROR_DETAIL_DISPLAY_CAP_BYTES
-            ):
-                raise non_streaming_error()
-
-    for line in decode_lines(b"", flush=True):
-        event = process_line(line)
-        if done:
-            return
-        if event is not None:
-            yield event
     if data_lines:
-        error = _TruncatedResponsesStream(
+        raise _TruncatedResponsesStream(
             "OpenAI Responses stream ended during an SSE event."
         )
-        body_bytes = "\n".join(data_lines).encode("utf-8", errors="replace")
-        attach_upstream_error_body(
-            error,
-            body_bytes[:ERROR_DETAIL_DISPLAY_CAP_BYTES],
-            truncated=len(body_bytes) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
-        )
-        raise error
-    if not saw_sse_event:
-        raise non_streaming_error()
 
 
 async def _read_bounded_body(

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -91,7 +91,7 @@ class OpenAICodexProvider(BaseProvider):
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
     ) -> None:
-        """Validate lossless request conversion before any upstream I/O."""
+        """Validate and adapt the private Codex request before upstream I/O."""
 
         self._build_body(request, reasoning=reasoning)
 
@@ -152,9 +152,14 @@ class OpenAICodexProvider(BaseProvider):
         reasoning: ReasoningPolicy,
     ) -> dict[str, Any]:
         try:
-            return build_responses_provider_request(request, reasoning=reasoning)
+            body = build_responses_provider_request(request, reasoning=reasoning)
         except ResponsesConversionError as exc:
             raise InvalidRequestError(str(exc)) from exc
+        # The private Codex backend rejects these public Responses fields.
+        # Codex itself omits the output cap and uses separate internal metadata.
+        body.pop("max_output_tokens", None)
+        body.pop("metadata", None)
+        return body
 
     async def _run_stream(
         self,
@@ -232,18 +237,6 @@ class OpenAICodexProvider(BaseProvider):
                             truncated=body_truncated,
                         )
                         raise
-                content_type = response.headers.get("content-type", "")
-                if "text/event-stream" not in content_type.lower():
-                    body_bytes, body_truncated = await _read_bounded_body(response)
-                    error = _TruncatedResponsesStream(
-                        "OpenAI returned a non-streaming Responses payload."
-                    )
-                    attach_upstream_error_body(
-                        error,
-                        body_bytes,
-                        truncated=body_truncated,
-                    )
-                    raise error
                 stream_opened = True
 
                 async for event_type, payload in _iter_sse(response):
@@ -334,7 +327,14 @@ async def _iter_sse(
 ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
     event_type = ""
     data_lines: list[str] = []
+    body_prefix = bytearray()
+    saw_sse_event = False
     async for line in response.aiter_lines():
+        if not saw_sse_event:
+            encoded_line = f"{line}\n".encode("utf-8", errors="replace")
+            remaining = ERROR_DETAIL_DISPLAY_CAP_BYTES + 1 - len(body_prefix)
+            if remaining > 0:
+                body_prefix.extend(encoded_line[:remaining])
         if not line:
             if not data_lines:
                 event_type = ""
@@ -346,13 +346,29 @@ async def _iter_sse(
             try:
                 payload = json.loads(raw_data)
             except json.JSONDecodeError as exc:
-                raise _TruncatedResponsesStream(
+                error = _TruncatedResponsesStream(
                     "OpenAI returned malformed Responses SSE."
-                ) from exc
+                )
+                body_bytes = raw_data.encode("utf-8", errors="replace")
+                attach_upstream_error_body(
+                    error,
+                    body_bytes[:ERROR_DETAIL_DISPLAY_CAP_BYTES],
+                    truncated=len(body_bytes) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
+                )
+                raise error from exc
             if not isinstance(payload, dict):
-                raise _TruncatedResponsesStream(
+                error = _TruncatedResponsesStream(
                     "OpenAI returned a non-object Responses event."
                 )
+                body_bytes = raw_data.encode("utf-8", errors="replace")
+                attach_upstream_error_body(
+                    error,
+                    body_bytes[:ERROR_DETAIL_DISPLAY_CAP_BYTES],
+                    truncated=len(body_bytes) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
+                )
+                raise error
+            saw_sse_event = True
+            body_prefix.clear()
             resolved_type = event_type or payload.get("type")
             event_type = ""
             if isinstance(resolved_type, str) and resolved_type:
@@ -363,9 +379,26 @@ async def _iter_sse(
         elif line.startswith("data:"):
             data_lines.append(line[5:].lstrip())
     if data_lines:
-        raise _TruncatedResponsesStream(
+        error = _TruncatedResponsesStream(
             "OpenAI Responses stream ended during an SSE event."
         )
+        body_bytes = "\n".join(data_lines).encode("utf-8", errors="replace")
+        attach_upstream_error_body(
+            error,
+            body_bytes[:ERROR_DETAIL_DISPLAY_CAP_BYTES],
+            truncated=len(body_bytes) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
+        )
+        raise error
+    if not saw_sse_event:
+        error = _TruncatedResponsesStream(
+            "OpenAI returned a non-streaming Responses payload."
+        )
+        attach_upstream_error_body(
+            error,
+            bytes(body_prefix[:ERROR_DETAIL_DISPLAY_CAP_BYTES]),
+            truncated=len(body_prefix) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
+        )
+        raise error
 
 
 async def _read_bounded_body(

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -328,21 +328,49 @@ async def _iter_sse(
     event_type = ""
     data_lines: list[str] = []
     body_prefix = bytearray()
+    saw_sse_framing = False
     saw_sse_event = False
-    async for line in response.aiter_lines():
-        if not saw_sse_event:
-            encoded_line = f"{line}\n".encode("utf-8", errors="replace")
-            remaining = ERROR_DETAIL_DISPLAY_CAP_BYTES + 1 - len(body_prefix)
-            if remaining > 0:
-                body_prefix.extend(encoded_line[:remaining])
+    pending_line = bytearray()
+    suppress_lf = False
+    done = False
+
+    def decode_lines(chunk: bytes, *, flush: bool = False) -> list[str]:
+        nonlocal saw_sse_framing, suppress_lf
+        lines: list[str] = []
+        for byte in chunk:
+            if suppress_lf:
+                suppress_lf = False
+                if byte == 0x0A:
+                    continue
+            if byte == 0x0D:
+                lines.append(pending_line.decode("utf-8", errors="replace"))
+                pending_line.clear()
+                suppress_lf = True
+            elif byte == 0x0A:
+                lines.append(pending_line.decode("utf-8", errors="replace"))
+                pending_line.clear()
+            else:
+                pending_line.append(byte)
+                # A valid first Codex event can exceed the diagnostic cap.
+                # Field syntax, not complete event size, ends the non-SSE guard.
+                if pending_line in (b"event:", b"data:"):
+                    saw_sse_framing = True
+        if flush and pending_line:
+            lines.append(pending_line.decode("utf-8", errors="replace"))
+            pending_line.clear()
+        return lines
+
+    def process_line(line: str) -> tuple[str, dict[str, Any]] | None:
+        nonlocal data_lines, done, event_type, saw_sse_event
         if not line:
             if not data_lines:
                 event_type = ""
-                continue
+                return None
             raw_data = "\n".join(data_lines)
             data_lines = []
             if raw_data == "[DONE]":
-                return
+                done = True
+                return None
             try:
                 payload = json.loads(raw_data)
             except json.JSONDecodeError as exc:
@@ -372,12 +400,55 @@ async def _iter_sse(
             resolved_type = event_type or payload.get("type")
             event_type = ""
             if isinstance(resolved_type, str) and resolved_type:
-                yield resolved_type, payload
-            continue
+                return resolved_type, payload
+            return None
         if line.startswith("event:"):
             event_type = line[6:].strip()
         elif line.startswith("data:"):
             data_lines.append(line[5:].lstrip())
+        return None
+
+    def non_streaming_error() -> _TruncatedResponsesStream:
+        error = _TruncatedResponsesStream(
+            "OpenAI returned a non-streaming Responses payload."
+        )
+        attach_upstream_error_body(
+            error,
+            bytes(body_prefix[:ERROR_DETAIL_DISPLAY_CAP_BYTES]),
+            truncated=len(body_prefix) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
+        )
+        return error
+
+    async for chunk in response.aiter_bytes():
+        offset = 0
+        while offset < len(chunk):
+            if saw_sse_framing:
+                segment = chunk[offset:]
+                offset = len(chunk)
+            else:
+                remaining = ERROR_DETAIL_DISPLAY_CAP_BYTES + 1 - len(body_prefix)
+                segment = chunk[offset : offset + remaining]
+                body_prefix.extend(segment)
+                offset += len(segment)
+
+            for line in decode_lines(segment):
+                event = process_line(line)
+                if done:
+                    return
+                if event is not None:
+                    yield event
+
+            if not saw_sse_framing and (
+                len(body_prefix) > ERROR_DETAIL_DISPLAY_CAP_BYTES
+            ):
+                raise non_streaming_error()
+
+    for line in decode_lines(b"", flush=True):
+        event = process_line(line)
+        if done:
+            return
+        if event is not None:
+            yield event
     if data_lines:
         error = _TruncatedResponsesStream(
             "OpenAI Responses stream ended during an SSE event."
@@ -390,15 +461,7 @@ async def _iter_sse(
         )
         raise error
     if not saw_sse_event:
-        error = _TruncatedResponsesStream(
-            "OpenAI returned a non-streaming Responses payload."
-        )
-        attach_upstream_error_body(
-            error,
-            bytes(body_prefix[:ERROR_DETAIL_DISPLAY_CAP_BYTES]),
-            truncated=len(body_prefix) > ERROR_DETAIL_DISPLAY_CAP_BYTES,
-        )
-        raise error
+        raise non_streaming_error()
 
 
 async def _read_bounded_body(

--- a/tests/api/test_openai_codex_compatibility.py
+++ b/tests/api/test_openai_codex_compatibility.py
@@ -63,7 +63,6 @@ async def test_messages_accepts_current_claude_controls_for_openai_provider() ->
         return httpx.Response(
             200,
             text=_complete_stream("hello"),
-            headers={"content-type": "text/event-stream"},
             request=request,
         )
 
@@ -101,6 +100,7 @@ async def test_messages_accepts_current_claude_controls_for_openai_provider() ->
                     "model": "openai/gpt-test",
                     "max_tokens": 1024,
                     "messages": [{"role": "user", "content": "hello"}],
+                    "metadata": {"user_id": "example-user"},
                     "thinking": {"type": "adaptive", "display": "omitted"},
                     "context_management": {
                         "edits": [
@@ -126,5 +126,7 @@ async def test_messages_accepts_current_claude_controls_for_openai_provider() ->
     payload = json.loads(upstream_requests[0].content)
     assert payload["model"] == "gpt-test"
     assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert "max_output_tokens" not in payload
+    assert "metadata" not in payload
     assert "context_management" not in payload
     assert "output_config" not in payload

--- a/tests/api/test_openai_codex_compatibility.py
+++ b/tests/api/test_openai_codex_compatibility.py
@@ -62,7 +62,7 @@ async def test_messages_accepts_current_claude_controls_for_openai_provider() ->
         upstream_requests.append(request)
         return httpx.Response(
             200,
-            text=_complete_stream("hello"),
+            content=_complete_stream("hello").encode(),
             request=request,
         )
 

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -12,6 +12,7 @@ from free_claude_code.core.anthropic.stream_contracts import (
     parse_sse_text,
     text_content,
 )
+from free_claude_code.core.diagnostics import ERROR_DETAIL_DISPLAY_CAP_BYTES
 from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.admission import ProviderAdmissionController
@@ -77,6 +78,7 @@ def _client_control_request() -> MessagesRequest:
             "model": "gpt-test",
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "hello"}],
+            "metadata": {"user_id": "example-user"},
             "thinking": {"type": "adaptive", "display": "omitted"},
             "context_management": {
                 "edits": [
@@ -152,7 +154,7 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
         return httpx.Response(
             200,
             text=_complete_stream("hello"),
-            headers={"content-type": "text/event-stream"},
+            headers={"content-type": "application/json"},
             request=request,
         )
 
@@ -215,6 +217,7 @@ async def test_provider_accepts_claude_client_controls_before_upstream_io() -> N
         _config(), auth=_FakeAuth(), admission=_admission(), client=client
     )
     request = _client_control_request()
+    original_request = request.model_dump()
     reasoning = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
 
     provider.preflight_stream(request, reasoning=reasoning)
@@ -235,8 +238,11 @@ async def test_provider_accepts_claude_client_controls_before_upstream_io() -> N
     payload = json.loads(upstream.content)
     assert payload["model"] == "gpt-test"
     assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert "max_output_tokens" not in payload
+    assert "metadata" not in payload
     assert "context_management" not in payload
     assert "output_config" not in payload
+    assert request.model_dump() == original_request
     assert_anthropic_stream_contract(parse_sse_text(body))
     await client.aclose()
 
@@ -487,13 +493,19 @@ async def test_pre_stream_retry_discards_held_message_start() -> None:
 @pytest.mark.asyncio
 async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> None:
     attempts = 0
+    tail_sentinel = "must-not-escape-the-diagnostic-cap"
+    upstream_body = (
+        "upstream contract changed\n"
+        + "x" * ERROR_DETAIL_DISPLAY_CAP_BYTES
+        + tail_sentinel
+    ).encode()
 
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal attempts
         attempts += 1
         return httpx.Response(
             200,
-            json={"error": {"message": "upstream contract changed"}},
+            content=upstream_body,
             request=request,
         )
 
@@ -516,6 +528,10 @@ async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> N
 
     assert attempts > 1
     assert "upstream contract changed" in exc_info.value.message
+    assert f"truncated after {ERROR_DETAIL_DISPLAY_CAP_BYTES} bytes" in (
+        exc_info.value.message
+    )
+    assert tail_sentinel not in exc_info.value.message
     assert "Request ID: req_non_stream" in exc_info.value.message
     await client.aclose()
 

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -128,6 +128,38 @@ async def _collect(stream: AsyncIterator[str]) -> str:
     return "".join([chunk async for chunk in stream])
 
 
+class _ChunkedAsyncStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _GuardedNonStreamingBody(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        prefix = b"upstream contract changed "
+        self._first_chunk = prefix + b"x" * (
+            ERROR_DETAIL_DISPLAY_CAP_BYTES + 1 - len(prefix)
+        )
+        self.reads = 0
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.reads += 1
+        yield self._first_chunk
+        self.reads += 1
+        raise AssertionError("FCC requested bytes beyond the diagnostic cap")
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
 @pytest.mark.asyncio
 async def test_provider_uses_subscription_headers_and_visible_model_catalog() -> None:
     requests: list[httpx.Request] = []
@@ -533,6 +565,136 @@ async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> N
     )
     assert tail_sentinel not in exc_info.value.message
     assert "Request ID: req_non_stream" in exc_info.value.message
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_success_stops_reading_at_diagnostic_cap() -> None:
+    streams: list[_GuardedNonStreamingBody] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        stream = _GuardedNonStreamingBody()
+        streams.append(stream)
+        return httpx.Response(200, stream=stream, request=request)
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await _collect(
+            provider.stream_response(
+                _request(),
+                request_id="req_bounded_stream",
+                response_model="claude-opus-4",
+            )
+        )
+
+    assert len(streams) > 1
+    assert all(stream.reads == 1 for stream in streams)
+    assert all(stream.closed for stream in streams)
+    assert "upstream contract changed" in exc_info.value.message
+    assert "requested bytes beyond" not in exc_info.value.message
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_parser_preserves_chunked_sse_line_boundaries() -> None:
+    text = "héllo"
+    created = json.dumps(
+        {
+            "type": "response.created",
+            "response": {
+                "id": "resp_1",
+                "instructions": "x" * (ERROR_DETAIL_DISPLAY_CAP_BYTES + 1),
+            },
+        }
+    )
+    delta = json.dumps(
+        {"type": "response.output_text.delta", "delta": text},
+        ensure_ascii=False,
+    )
+    completed = json.dumps(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_1",
+                "usage": {"input_tokens": 3, "output_tokens": 2},
+            },
+        }
+    )
+    body = (
+        f"event: response.created\r\ndata: {created}\r\r"
+        f"event: response.output_text.delta\ndata: {delta}\n\n"
+        f"event: response.completed\r\ndata: {completed}\r\n\r\n"
+    ).encode()
+    crlf_split = body.index(b"\r\n") + 1
+    utf8_split = body.index("é".encode()) + 1
+    split_points = sorted((crlf_split, utf8_split))
+    chunks = [
+        body[: split_points[0]],
+        body[split_points[0] : split_points[1]],
+        body[split_points[1] :],
+    ]
+    streams: list[_ChunkedAsyncStream] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        stream = _ChunkedAsyncStream(chunks)
+        streams.append(stream)
+        return httpx.Response(200, stream=stream, request=request)
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    result = await _collect(provider.stream_response(_request()))
+
+    events = parse_sse_text(result)
+    assert_anthropic_stream_contract(events)
+    assert text_content(events) == text
+    assert len(streams) == 1
+    assert streams[0].closed
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("body", "expected_detail"),
+    [
+        (b"data: {\n\n", "malformed Responses SSE"),
+        (b"data: []\n\n", "non-object Responses event"),
+        (
+            b'data: {"type":"response.created"}',
+            "stream ended during an SSE event",
+        ),
+    ],
+)
+async def test_invalid_sse_event_diagnostics_are_preserved(
+    body: bytes,
+    expected_detail: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body, request=request)
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    with pytest.raises(ExecutionFailure, match=expected_detail):
+        await _collect(provider.stream_response(_request()))
+
     await client.aclose()
 
 

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -128,38 +128,6 @@ async def _collect(stream: AsyncIterator[str]) -> str:
     return "".join([chunk async for chunk in stream])
 
 
-class _ChunkedAsyncStream(httpx.AsyncByteStream):
-    def __init__(self, chunks: list[bytes]) -> None:
-        self._chunks = chunks
-        self.closed = False
-
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        for chunk in self._chunks:
-            yield chunk
-
-    async def aclose(self) -> None:
-        self.closed = True
-
-
-class _GuardedNonStreamingBody(httpx.AsyncByteStream):
-    def __init__(self) -> None:
-        prefix = b"upstream contract changed "
-        self._first_chunk = prefix + b"x" * (
-            ERROR_DETAIL_DISPLAY_CAP_BYTES + 1 - len(prefix)
-        )
-        self.reads = 0
-        self.closed = False
-
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        self.reads += 1
-        yield self._first_chunk
-        self.reads += 1
-        raise AssertionError("FCC requested bytes beyond the diagnostic cap")
-
-    async def aclose(self) -> None:
-        self.closed = True
-
-
 @pytest.mark.asyncio
 async def test_provider_uses_subscription_headers_and_visible_model_catalog() -> None:
     requests: list[httpx.Request] = []
@@ -185,8 +153,7 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
         assert request.url.path.endswith("/responses")
         return httpx.Response(
             200,
-            text=_complete_stream("hello"),
-            headers={"content-type": "application/json"},
+            content=_complete_stream("hello").encode(),
             request=request,
         )
 
@@ -538,6 +505,7 @@ async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> N
         return httpx.Response(
             200,
             content=upstream_body,
+            headers={"content-type": "application/json"},
             request=request,
         )
 
@@ -565,136 +533,6 @@ async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> N
     )
     assert tail_sentinel not in exc_info.value.message
     assert "Request ID: req_non_stream" in exc_info.value.message
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-async def test_non_streaming_success_stops_reading_at_diagnostic_cap() -> None:
-    streams: list[_GuardedNonStreamingBody] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        stream = _GuardedNonStreamingBody()
-        streams.append(stream)
-        return httpx.Response(200, stream=stream, request=request)
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await _collect(
-            provider.stream_response(
-                _request(),
-                request_id="req_bounded_stream",
-                response_model="claude-opus-4",
-            )
-        )
-
-    assert len(streams) > 1
-    assert all(stream.reads == 1 for stream in streams)
-    assert all(stream.closed for stream in streams)
-    assert "upstream contract changed" in exc_info.value.message
-    assert "requested bytes beyond" not in exc_info.value.message
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-async def test_stream_parser_preserves_chunked_sse_line_boundaries() -> None:
-    text = "héllo"
-    created = json.dumps(
-        {
-            "type": "response.created",
-            "response": {
-                "id": "resp_1",
-                "instructions": "x" * (ERROR_DETAIL_DISPLAY_CAP_BYTES + 1),
-            },
-        }
-    )
-    delta = json.dumps(
-        {"type": "response.output_text.delta", "delta": text},
-        ensure_ascii=False,
-    )
-    completed = json.dumps(
-        {
-            "type": "response.completed",
-            "response": {
-                "id": "resp_1",
-                "usage": {"input_tokens": 3, "output_tokens": 2},
-            },
-        }
-    )
-    body = (
-        f"event: response.created\r\ndata: {created}\r\r"
-        f"event: response.output_text.delta\ndata: {delta}\n\n"
-        f"event: response.completed\r\ndata: {completed}\r\n\r\n"
-    ).encode()
-    crlf_split = body.index(b"\r\n") + 1
-    utf8_split = body.index("é".encode()) + 1
-    split_points = sorted((crlf_split, utf8_split))
-    chunks = [
-        body[: split_points[0]],
-        body[split_points[0] : split_points[1]],
-        body[split_points[1] :],
-    ]
-    streams: list[_ChunkedAsyncStream] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        stream = _ChunkedAsyncStream(chunks)
-        streams.append(stream)
-        return httpx.Response(200, stream=stream, request=request)
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    result = await _collect(provider.stream_response(_request()))
-
-    events = parse_sse_text(result)
-    assert_anthropic_stream_contract(events)
-    assert text_content(events) == text
-    assert len(streams) == 1
-    assert streams[0].closed
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("body", "expected_detail"),
-    [
-        (b"data: {\n\n", "malformed Responses SSE"),
-        (b"data: []\n\n", "non-object Responses event"),
-        (
-            b'data: {"type":"response.created"}',
-            "stream ended during an SSE event",
-        ),
-    ],
-)
-async def test_invalid_sse_event_diagnostics_are_preserved(
-    body: bytes,
-    expected_detail: str,
-) -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=body, request=request)
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    with pytest.raises(ExecutionFailure, match=expected_detail):
-        await _collect(provider.stream_response(_request()))
-
     await client.aclose()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.4"
+version = "4.16.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

OpenAI subscription generations failed because FCC sent public Responses fields that the private Codex backend rejects. Valid backend SSE without a `Content-Type` header was then misclassified as non-streaming. Fixes #1320.

## Changes

| Before | After |
| --- | --- |
| Private Codex requests forwarded `max_output_tokens` and `metadata`. | Private Codex requests omit those unsupported public fields while leaving the neutral Responses contract unchanged. |
| Successful streams required `text/event-stream`. | Successful streams may omit `Content-Type`; explicitly declared non-SSE responses retain the bounded failure path. |
| Non-SSE HTTP 2xx diagnostics depended on the header gate. | Non-SSE HTTP 2xx bodies remain retryable failures with bounded, redacted diagnostics. |
| Compatibility coverage assumed canonical response headers. | Provider and API tests cover private projection, immutable input, headerless SSE success, explicit non-SSE failures, bounded diagnostics, and duplicate-free retries. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adapts OpenAI Codex requests for the private Responses backend by removing unsupported fields and allowing SSE streams whose response omits `Content-Type`. A successful headerless JSON response is also accepted as a stream, so its useful upstream error detail is discarded and the user receives a generic terminal-stream failure after repeated retries.

### T-Rex validation blocked
The focused provider scenario executed successfully, but the artifact upload tool was unavailable. The captured reproducer and execution output could not be uploaded as review artifacts, so no proof attachment is included.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge until headerless non-SSE success responses retain their upstream diagnostic instead of being retried as malformed streams.

The final defect set contains one P1 provider compatibility failure on the Codex streaming path. A deterministic provider run reproduced the behavior: a headerless HTTP 200 JSON error was retried five times and surfaced as a generic 502 without the JSON error detail.

**Files Needing Attention:** src/free_claude_code/providers/openai_codex/provider.py

<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (3)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Non-SSE 2xx stream is consumed beyond the diagnostic cap**

   - **Bug**
     - `_iter_sse()` continues `response.aiter_lines()` after the capped prefix is full, delaying its non-streaming protocol error and retry until EOF or transport timeout.
   - **Cause**
     - Lines 332-337 cap `body_prefix` storage only; the no-SSE error is raised only after the iterator ends at lines 392-401.
   - **Fix**
     - Raise `_TruncatedResponsesStream` immediately once a non-SSE response exceeds the diagnostic cap, attaching the capped body detail as truncated.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unterminated data: prefix bypasses the SSE diagnostic cap**

   - **Bug**
     - An unterminated streamed line beginning with `data:` consumed 17,413 bytes—1,029 bytes beyond the 16,384-byte diagnostic cap—and every supplied chunk before `_iter_sse` raised its EOF error.
   - **Cause**
     - Lines 353-357 set `saw_sse_framing` as soon as `pending_line == b"data:"` or `b"event:"`, even though no line terminator has established a complete SSE field. Lines 425-444 stop extending and enforcing `body_prefix` once that flag is set, while `pending_line` has no size bound.
   - **Fix**
     - Only recognize SSE framing after a complete newline-terminated SSE field has been decoded, or independently bound `pending_line` and raise the retryable protocol error once it exceeds `ERROR_DETAIL_DISPLAY_CAP_BYTES` before a completed SSE line/event is established.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. `src/free_claude_code/providers/openai_codex/provider.py`, line 241-252 ([link](https://github.com/alishahryar1/free-claude-code/blob/2a5458ff1612a027112e23e69e433d7b62c03c3b/src/free_claude_code/providers/openai_codex/provider.py#L241-L252)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Headerless JSON responses lose upstream diagnostics**

   A successful Codex response with no `Content-Type` header is accepted as SSE even when its body is a non-streaming JSON error. `_iter_sse()` consumes that JSON as an inert non-SSE line, then the provider retries and ultimately surfaces only “stream ended without a terminal event,” dropping the upstream error details that would explain the incompatibility. Require a positive SSE media-type check, or read and attach the bounded body when the header is absent, before entering the SSE parser.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-openai-subscription-generation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-openai-subscription-generation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffree_claude_code%2Fproviders%2Fopenai_codex%2Fprovider.py%0ALine%3A%20241-252%0A%0AComment%3A%0A**Headerless%20JSON%20responses%20lose%20upstream%20diagnostics**%0A%0AA%20successful%20Codex%20response%20with%20no%20%60Content-Type%60%20header%20is%20accepted%20as%20SSE%20even%20when%20its%20body%20is%20a%20non-streaming%20JSON%20error.%20%60_iter_sse%28%29%60%20consumes%20that%20JSON%20as%20an%20inert%20non-SSE%20line%2C%20then%20the%20provider%20retries%20and%20ultimately%20surfaces%20only%20%E2%80%9Cstream%20ended%20without%20a%20terminal%20event%2C%E2%80%9D%20dropping%20the%20upstream%20error%20details%20that%20would%20explain%20the%20incompatibility.%20Require%20a%20positive%20SSE%20media-type%20check%2C%20or%20read%20and%20attach%20the%20bounded%20body%20when%20the%20header%20is%20absent%2C%20before%20entering%20the%20SSE%20parser.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1326&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-openai-subscription-generation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-openai-subscription-generation%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fproviders%2Fopenai_codex%2Fprovider.py%3A241-252%0A**Headerless%20JSON%20responses%20lose%20upstream%20diagnostics**%0A%0AA%20successful%20Codex%20response%20with%20no%20%60Content-Type%60%20header%20is%20accepted%20as%20SSE%20even%20when%20its%20body%20is%20a%20non-streaming%20JSON%20error.%20%60_iter_sse%28%29%60%20consumes%20that%20JSON%20as%20an%20inert%20non-SSE%20line%2C%20then%20the%20provider%20retries%20and%20ultimately%20surfaces%20only%20%E2%80%9Cstream%20ended%20without%20a%20terminal%20event%2C%E2%80%9D%20dropping%20the%20upstream%20error%20details%20that%20would%20explain%20the%20incompatibility.%20Require%20a%20positive%20SSE%20media-type%20check%2C%20or%20read%20and%20attach%20the%20bounded%20body%20when%20the%20header%20is%20absent%2C%20before%20entering%20the%20SSE%20parser.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1326&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Simplify OpenAI headerless stream handli..."](https://github.com/alishahryar1/free-claude-code/commit/2a5458ff1612a027112e23e69e433d7b62c03c3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49602945)</sub>

<!-- /greptile_comment -->