### PR TITLE
Restore OpenCode reasoning replay for tool turns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.5"
+version = "4.16.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -157,11 +157,11 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         NO_REASONING,
     ),
     "opencode": OpenAIChatProfile(
-        _policy("OPENCODE", ReasoningReplayMode.THINK_TAGS),
+        _policy("OPENCODE", ReasoningReplayMode.REASONING_CONTENT),
         NO_REASONING,
     ),
     "opencode_go": OpenAIChatProfile(
-        _policy("OPENCODE_GO", ReasoningReplayMode.THINK_TAGS),
+        _policy("OPENCODE_GO", ReasoningReplayMode.REASONING_CONTENT),
         NO_REASONING,
     ),
     "vercel": OpenAIChatProfile(

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -1,5 +1,7 @@
 """Tests for the OpenCode OpenAI-compatible provider."""
 
+import pytest
+
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.support import (
@@ -9,9 +11,12 @@ from tests.providers.support import (
 )
 
 
-def test_build_request_body_omits_empty_reasoning_content() -> None:
+@pytest.mark.parametrize("provider_id", ["opencode", "opencode_go"])
+def test_build_request_body_preserves_empty_reasoning_content(
+    provider_id: str,
+) -> None:
     provider = profiled_provider(
-        "opencode",
+        provider_id,
         ProviderConfig(
             api_key="test_opencode_key",
             base_url="https://example.invalid/v1",
@@ -39,4 +44,68 @@ def test_build_request_body_omits_empty_reasoning_content() -> None:
     assert body["messages"][0] == {
         "role": "assistant",
         "content": "visible",
+        "reasoning_content": "",
+    }
+
+
+@pytest.mark.parametrize("provider_id", ["opencode", "opencode_go"])
+def test_build_request_body_replays_tool_reasoning_natively(
+    provider_id: str,
+) -> None:
+    provider = profiled_provider(
+        provider_id,
+        ProviderConfig(
+            api_key="test_opencode_key",
+            base_url="https://example.invalid/v1",
+            rate_limit=1,
+            rate_window=1,
+        ),
+        admission=immediate_admission(),
+    )
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "I should inspect the file.",
+                            "signature": "sig",
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "call_1",
+                            "name": "Read",
+                            "input": {"path": "README.md"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_1",
+                            "content": "file contents",
+                        }
+                    ],
+                },
+            ],
+            "thinking": {"type": "enabled"},
+        }
+    )
+
+    body = provider._build_request_body(request, reasoning=reasoning_for(request))
+
+    assistant = body["messages"][0]
+    assert assistant["content"] == ""
+    assert assistant["reasoning_content"] == "I should inspect the file."
+    assert "<think>" not in assistant["content"]
+    assert assistant["tool_calls"][0]["id"] == "call_1"
+    assert body["messages"][1] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": "file contents",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.5"
+version = "4.16.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

OpenCode replayed reasoning tool turns as visible `<think>` tags instead of native `reasoning_content`. DeepSeek thinking models rejected the following tool-result request with HTTP 400. Fixes #1327.

## Changes

| Before | After |
| --- | --- |
| OpenCode Zen and Go replayed prior reasoning through `<think>` tags. | OpenCode Zen and Go replay prior reasoning through native `reasoning_content`. |
| Tool-follow-up coverage did not enforce OpenCode's native replay contract. | Zen and Go coverage verifies non-empty tool reasoning and explicit empty reasoning state. |
| The package version was `4.16.5`. | The package version is `4.16.6`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change restores native reasoning replay for the OpenCode and OpenCode Go provider profiles and updates the package version to 4.16.6.

The reasoning replay path was exercised for both profiles with empty reasoning and assistant thinking followed by a tool call. The resulting request bodies preserve `reasoning_content`, valid tool-call data, and matching tool results. The focused OpenCode provider suite completed successfully with four passing tests.
</details>

<h3>Confidence Score: 5/5</h3>

The changed OpenCode request-construction behavior is safe to merge based on focused execution of both affected profiles.

No defects remain. The exercised empty-reasoning and reasoning-plus-tool-call flows produced compatible request bodies, and the focused regression suite passed.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the review-authored request-construction harness against the parent and changed commits for both opencode and opencode\_go, covering empty reasoning and a tool call.
- Verified that the changed implementation emitted native reasoning\_content, kept an empty assistant content field with a valid tool call, and preserved the matching tool-result sequence.
- Ran the OpenCode provider regression tests and all four tests passed, confirming the request-construction flows remained internally consistent.
- Observed that the changed OpenCode implementation builds internally consistent OpenAI-chat request bodies for the two edge cases, with no malformed assistant/tool sequences.

<a href="https://app.greptile.com/trex/runs/17154913/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Restore OpenCode native reasoning replay"](https://github.com/alishahryar1/free-claude-code/commit/c2a5ee218b4a1504574562860dce82f9c6a92243) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49867899)</sub>

<!-- /greptile_comment -->