### PR TITLE
feat: add FPT AI Factory provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,11 @@ GROQ_API_KEY=""
 SAMBANOVA_API_KEY=""
 
 
+# FPT AI Factory (OpenAI-compatible Chat Completions gateway at mkp-api.fptcloud.com/v1)
+# Verified accounts get $100 in free credit: https://marketplace.fptcloud.com/
+FPT_AI_FACTORY_API_KEY=""
+
+
 # Kilo.ai Config (OpenAI-compatible Chat Completions gateway at api.kilo.ai/api/gateway)
 KILO_API_KEY=""
 
@@ -121,7 +126,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "fpt_ai_factory" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -208,6 +213,7 @@ GEMINI_PROXY=""
 VERTEX_PROXY=""
 GROQ_PROXY=""
 SAMBANOVA_PROXY=""
+FPT_AI_FACTORY_PROXY=""
 KILO_PROXY=""
 CEREBRAS_PROXY=""
 OLLAMA_CLOUD_PROXY=""

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run your coding agents with free, paid, or local models. Choose and validate pro
 
 - Launch Claude Code with `fcc-claude`, Codex with `fcc-codex`, or Pi with `fcc-pi`.
 - Run FCC in the background from a desktop launcher on Windows or macOS.
-- Switch among 31 cloud and local providers from the Admin UI.
+- Switch among 32 cloud and local providers from the Admin UI.
 - Use each coding agent's native model picker.
 - Route Fable, Opus, Sonnet, Haiku, and fallback traffic to different models.
 - Keep streaming, tool use, reasoning, and image input across compatible models.
@@ -190,6 +190,7 @@ fcc-codex exec "hello"
 | [Cerebras Inference](https://cloud.cerebras.ai/) | `CEREBRAS_API_KEY` | `cerebras/gpt-oss-120b` |
 | [Groq](https://console.groq.com/keys) | `GROQ_API_KEY` | `groq/llama-3.3-70b-versatile` |
 | [SambaNova](https://cloud.sambanova.ai/apis) | `SAMBANOVA_API_KEY` | `sambanova/Meta-Llama-3.3-70B-Instruct` |
+| [FPT AI Factory](https://marketplace.fptcloud.com/) ($100 free credit for verified accounts) | `FPT_AI_FACTORY_API_KEY` | `fpt_ai_factory/gpt-oss-120b` |
 | [Kilo.ai](https://kilo.ai) | `KILO_API_KEY` | `kilo/kilo-auto/free` |
 | [Fireworks AI](https://fireworks.ai/account/api-keys) | `FIREWORKS_API_KEY` | `fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct` |
 | [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` | `cloudflare/@cf/moonshotai/kimi-k2.6` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.6"
+version = "4.17.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -46,6 +46,8 @@ VERTEX_AI_API_ROOT = "https://aiplatform.googleapis.com"
 GROQ_DEFAULT_BASE = "https://api.groq.com/openai/v1"
 CEREBRAS_DEFAULT_BASE = "https://api.cerebras.ai/v1"
 SAMBANOVA_DEFAULT_BASE = "https://api.sambanova.ai/v1"
+# FPT AI Factory OpenAI-compatible Chat Completions gateway (mkp-api.fptcloud.com).
+FPT_AI_FACTORY_DEFAULT_BASE = "https://mkp-api.fptcloud.com/v1"
 # Kilo.ai gateway OpenAI-compatible Chat Completions API.
 KILO_DEFAULT_BASE = "https://api.kilo.ai/api/gateway"
 OPENAI_CODEX_DEFAULT_BASE = "https://chatgpt.com/backend-api/codex"
@@ -306,6 +308,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="sambanova_api_key",
         default_base_url=SAMBANOVA_DEFAULT_BASE,
         proxy_attr="sambanova_proxy",
+    ),
+    "fpt_ai_factory": ProviderDescriptor(
+        provider_id="fpt_ai_factory",
+        display_name="FPT AI Factory",
+        credential_env="FPT_AI_FACTORY_API_KEY",
+        credential_url="https://marketplace.fptcloud.com/",
+        credential_attr="fpt_ai_factory_api_key",
+        default_base_url=FPT_AI_FACTORY_DEFAULT_BASE,
+        proxy_attr="fpt_ai_factory_proxy",
     ),
     "fireworks": ProviderDescriptor(
         provider_id="fireworks",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -82,6 +82,11 @@ class Settings(BaseSettings):
     # ==================== SambaNova Cloud ====================
     sambanova_api_key: str = Field(default="", validation_alias="SAMBANOVA_API_KEY")
 
+    # ==================== FPT AI Factory Config ====================
+    fpt_ai_factory_api_key: str = Field(
+        default="", validation_alias="FPT_AI_FACTORY_API_KEY"
+    )
+
     # ==================== Kilo.ai Config ====================
     kilo_api_key: str = Field(default="", validation_alias="KILO_API_KEY")
 
@@ -183,6 +188,9 @@ class Settings(BaseSettings):
     cohere_proxy: str = Field(default="", validation_alias="COHERE_PROXY")
     github_models_proxy: str = Field(default="", validation_alias="GITHUB_MODELS_PROXY")
     sambanova_proxy: str = Field(default="", validation_alias="SAMBANOVA_PROXY")
+    fpt_ai_factory_proxy: str = Field(
+        default="", validation_alias="FPT_AI_FACTORY_PROXY"
+    )
     kilo_proxy: str = Field(default="", validation_alias="KILO_PROXY")
     zai_proxy: str = Field(default="", validation_alias="ZAI_PROXY")
     fireworks_proxy: str = Field(default="", validation_alias="FIREWORKS_PROXY")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -310,6 +310,10 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             enabled_value="medium",
         ),
     ),
+    "fpt_ai_factory": OpenAIChatProfile(
+        _policy("FPT_AI_FACTORY", ReasoningReplayMode.REASONING_CONTENT),
+        NO_REASONING,
+    ),
     "fireworks": OpenAIChatProfile(
         _policy(
             "FIREWORKS",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -30,6 +30,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "cerebras",
     "groq",
     "sambanova",
+    "fpt_ai_factory",
     "fireworks",
     "cloudflare",
     "zai",

--- a/tests/providers/test_fpt_ai_factory.py
+++ b/tests/providers/test_fpt_ai_factory.py
@@ -1,0 +1,111 @@
+"""Tests for the FPT AI Factory OpenAI-chat provider."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import FPT_AI_FACTORY_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import Message, MessagesRequest
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+@pytest.fixture
+def fpt_config():
+    return ProviderConfig(
+        api_key="test_fpt_key",
+        base_url=FPT_AI_FACTORY_DEFAULT_BASE,
+        rate_limit=10,
+        rate_window=60,
+    )
+
+
+@pytest.fixture
+def fpt_provider(fpt_config):
+    return profiled_provider(
+        "fpt_ai_factory",
+        fpt_config,
+        admission=immediate_admission(),
+    )
+
+
+def test_default_base_url():
+    assert FPT_AI_FACTORY_DEFAULT_BASE == "https://mkp-api.fptcloud.com/v1"
+
+
+def test_init_uses_openai_chat_provider(fpt_provider):
+    assert isinstance(fpt_provider, OpenAIChatProvider)
+    assert fpt_provider._api_key == "test_fpt_key"
+    assert fpt_provider._base_url == FPT_AI_FACTORY_DEFAULT_BASE
+    assert fpt_provider._provider_name == "FPT_AI_FACTORY"
+
+
+def test_build_request_body_openai_shape(fpt_provider):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-oss-120b",
+            "messages": [Message(role="user", content="Hello")],
+            "max_tokens": 100,
+        }
+    )
+
+    body = fpt_provider._build_request_body(request, reasoning=reasoning_for(request))
+
+    assert body["model"] == "gpt-oss-120b"
+    assert body["messages"][0] == {"role": "user", "content": "Hello"}
+    assert body["max_tokens"] == 100
+
+
+def test_build_request_body_omits_reasoning_controls(fpt_provider):
+    # FPT's OpenAI-compatible gateway exposes no reasoning control parameter
+    # (supported_parameters carries none), so the profile must never emit one.
+    request = MessagesRequest.model_validate(
+        {
+            "model": "gpt-oss-120b",
+            "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "enabled", "budget_tokens": 2048},
+        }
+    )
+
+    body = fpt_provider._build_request_body(request, reasoning=reasoning_for(request))
+
+    assert "reasoning" not in body
+    assert "reasoning_effort" not in body
+    assert "reasoning" not in body.get("extra_body", {})
+
+
+@pytest.mark.asyncio
+async def test_model_list_uses_openai_client_models_endpoint(fpt_provider):
+    fpt_provider._client.models.list = AsyncMock(
+        return_value=MagicMock(
+            data=[
+                MagicMock(id="gpt-oss-120b"),
+                MagicMock(id="DeepSeek-V4-Flash"),
+            ]
+        )
+    )
+
+    assert await fpt_provider.list_model_infos() == frozenset(
+        {
+            ProviderModelInfo("gpt-oss-120b"),
+            ProviderModelInfo("DeepSeek-V4-Flash"),
+        }
+    )
+
+    fpt_provider._client.models.list.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_closes_openai_client(fpt_provider):
+    fpt_provider._client = MagicMock()
+    fpt_provider._client.close = AsyncMock()
+
+    await fpt_provider.cleanup()
+
+    fpt_provider._client.close.assert_awaited_once()

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -111,6 +111,8 @@ def _make_settings(**overrides):
     mock.ollama_cloud_proxy = ""
     mock.kilo_api_key = "test_kilo_key"
     mock.kilo_proxy = ""
+    mock.fpt_ai_factory_api_key = "test_fpt_ai_factory_key"
+    mock.fpt_ai_factory_proxy = ""
     mock.openai_proxy = ""
     mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
@@ -457,6 +459,7 @@ def test_create_provider_instantiates_each_builtin():
         provider_rate_window=11,
         provider_max_concurrency=3,
         sambanova_api_key="test_sambanova_key",
+        fpt_ai_factory_api_key="test_fpt_ai_factory_key",
     )
     cases = {
         "nvidia_nim": NvidiaNimProvider,
@@ -488,6 +491,7 @@ def test_create_provider_instantiates_each_builtin():
         "vertex": VertexProvider,
         "groq": OpenAIChatProvider,
         "sambanova": OpenAIChatProvider,
+        "fpt_ai_factory": OpenAIChatProvider,
         "kilo": KiloProvider,
         "cerebras": OpenAIChatProvider,
     }

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.6"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Declarative OpenAI-compatible profile for the **FPT AI Factory** gateway (`https://mkp-api.fptcloud.com/v1`). One entry in the provider catalog, one `OpenAIChatProfile`, following the same shape as the Kilo.ai provider (#1273).

**FPT AI Factory** is a first-party Vietnamese cloud AI marketplace serving open models on NVIDIA GB300 nodes — DeepSeek-V4-Flash, Qwen3.6-27B, GLM-5.2, gpt-oss-120b/20b, gemma-4-26B/31B, and Llama-3.3-70B.

> 💰 **Verified accounts get $100 in free credit** — https://marketplace.fptcloud.com/

## Design notes

- **`provider_id = "fpt_ai_factory"`**, env `FPT_AI_FACTORY_API_KEY` (mirrors the `nvidia_nim` multi-word naming convention).
- **`NO_REASONING` profile.** FPT's live catalog (`GET /v1/models`) reports `supported_parameters` as exactly `["temperature","top_p","max_tokens","tools","tool_choice","response_format","stream"]` for every served model — no `reasoning`/`reasoning_effort`/`thinking` field. So the profile never emits a reasoning-control parameter (verified by `test_build_request_body_omits_reasoning_controls`).
- Placed as an OpenAI-compatible gateway right after `sambanova` in the catalog order.

## Verified live

`GET https://mkp-api.fptcloud.com/v1/models` (public, no auth) returns the model IDs above with pricing and `top_provider` limits.

## Changes

- `provider_catalog.py` — `FPT_AI_FACTORY_DEFAULT_BASE` + `ProviderDescriptor`
- `settings.py` — `fpt_ai_factory_api_key` / `fpt_ai_factory_proxy`
- `profiles.py` — `fpt_ai_factory` `OpenAIChatProfile` (`NO_REASONING`)
- `.env.example`, `README.md` (+ provider count 31→32)
- `pyproject.toml` / `uv.lock` — 4.16.6 → 4.17.0
- Tests: new `tests/providers/test_fpt_ai_factory.py`, plus catalog-order and provider-runtime coverage

## Tests

`uv run pytest tests/providers/ tests/contracts/` → **1042 passed**. `ruff check`, `ruff format --check`, and `ty check` all clean. (The 8 pre-existing `tests/scripts/test_uninstallers.py` failures are unrelated to this change and also fail on `main`.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds FPT AI Factory as an OpenAI-compatible provider, with API-key and proxy configuration, catalog metadata, documentation, and focused runtime coverage.

A credential-free integration check exercised configuration through provider creation and a mocked upstream streaming request. The provider sent `POST https://mkp-api.fptcloud.com/v1/chat/completions` with bearer authentication, the expected OpenAI Chat Completions payload, and no unsupported reasoning controls. The focused provider tests passed.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a credential-free integration check against the parent and PR revisions, exercising settings, provider resolution, OpenAI client request serialization, and a mocked streaming upstream response, which showed the parent revision did not register FPT AI Factory and the PR revision posted a POST to https://mkp-api.fptcloud.com/v1/chat/completions with bearer authentication, model, messages, max-token, and streaming fields, and no reasoning controls.
- Before the PR, the pre-PR revision reported catalog\_contains\_fpt\_ai\_factory: false, with no runtime provider or request that could be constructed.
- After the PR, the mock captured POST https://mkp-api.fptcloud.com/v1/chat/completions with Authorization: Bearer \[REDACTED\], model/messages/max\_tokens/stream fields, and no unsupported reasoning controls, and the focused provider tests also passed: 6 passed in 2.15s.

<a href="https://app.greptile.com/trex/runs/17214387/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add FPT AI Factory provider"](https://github.com/alishahryar1/free-claude-code/commit/627456ea3c52a9b693428366324a84480c52559b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50003881)</sub>

<!-- /greptile_comment -->