### PR TITLE
Preserve empty reasoning state across native tool turns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.6"
+version = "4.16.7"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -574,6 +574,8 @@ class AnthropicToOpenAIConverter:
                 reasoning_replay=reasoning_replay,
             )[0]
         pre_msg["tool_calls"] = tool_calls
+        if reasoning_replay is ReasoningReplayMode.REASONING_CONTENT:
+            pre_msg.setdefault("reasoning_content", "")
         if tool_calls and pre_msg.get("content") == " ":
             pre_msg["content"] = ""
         return _ToolTurnSegment(

--- a/tests/providers/support.py
+++ b/tests/providers/support.py
@@ -1,5 +1,10 @@
 """Provider test helpers with explicit admission ownership."""
 
+import json
+
+import httpx
+from openai import AsyncOpenAI
+
 from free_claude_code.application.reasoning import client_reasoning_policy
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.reasoning import ReasoningPolicy
@@ -13,6 +18,36 @@ from free_claude_code.providers.openai_chat import (
 REASONING_DEFAULT = ReasoningPolicy.provider_default()
 REASONING_ON = ReasoningPolicy.on()
 REASONING_OFF = ReasoningPolicy.off()
+
+
+async def capture_openai_chat_wire_body(body: dict) -> dict:
+    """Return the JSON body serialized by the OpenAI chat client."""
+    captured: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert isinstance(payload, dict)
+        captured.append(payload)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text="data: [DONE]\n\n",
+        )
+
+    client = AsyncOpenAI(
+        api_key="test",
+        base_url="https://provider.invalid/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_retries=0,
+    )
+    try:
+        stream = await client.chat.completions.create(**body, stream=True)
+        await stream.close()
+    finally:
+        await client.close()
+
+    assert len(captured) == 1
+    return captured[0]
 
 
 def immediate_admission(

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -641,6 +641,99 @@ def test_convert_assistant_tool_use_replays_empty_reasoning_content():
     assert result[0]["tool_calls"][0]["id"] == "call_empty"
 
 
+def _convert_tool_turn(
+    assistant_content: list[MockBlock],
+    reasoning_replay: ReasoningReplayMode = ReasoningReplayMode.REASONING_CONTENT,
+) -> list[dict]:
+    tool_ids = [
+        block.get("id")
+        for block in assistant_content
+        if block.get("type") == "tool_use"
+    ]
+    return AnthropicToOpenAIConverter.convert_messages(
+        [
+            MockMessage("assistant", assistant_content),
+            MockMessage(
+                "user",
+                [
+                    MockBlock(
+                        type="tool_result",
+                        tool_use_id=tool_id,
+                        content="result",
+                    )
+                    for tool_id in tool_ids
+                ],
+            ),
+        ],
+        reasoning_replay=reasoning_replay,
+    )
+
+
+def test_convert_assistant_tool_use_without_thinking_replays_empty_reasoning_content():
+    result = _convert_tool_turn(
+        [MockBlock(type="tool_use", id="call_missing", name="Read", input={})]
+    )
+
+    assert result[0]["content"] == ""
+    assert result[0]["reasoning_content"] == ""
+    assert result[0]["tool_calls"][0]["id"] == "call_missing"
+
+
+def test_convert_parallel_tool_use_without_thinking_replays_one_empty_reasoning_field():
+    result = _convert_tool_turn(
+        [
+            MockBlock(type="tool_use", id="call_1", name="Read", input={}),
+            MockBlock(type="tool_use", id="call_2", name="Glob", input={}),
+        ]
+    )
+
+    assert result[0]["reasoning_content"] == ""
+    assert [tool_call["id"] for tool_call in result[0]["tool_calls"]] == [
+        "call_1",
+        "call_2",
+    ]
+
+
+def test_convert_redacted_thinking_tool_use_replays_empty_reasoning_without_data():
+    result = _convert_tool_turn(
+        [
+            MockBlock(type="redacted_thinking", data="opaque-secret"),
+            MockBlock(type="tool_use", id="call_redacted", name="Read", input={}),
+        ]
+    )
+
+    assert result[0]["reasoning_content"] == ""
+    assert "opaque-secret" not in json.dumps(result)
+
+
+def test_convert_text_only_assistant_without_thinking_omits_reasoning_content():
+    result = AnthropicToOpenAIConverter.convert_messages(
+        [MockMessage("assistant", "Visible answer")],
+        reasoning_replay=ReasoningReplayMode.REASONING_CONTENT,
+    )
+
+    assert result == [{"role": "assistant", "content": "Visible answer"}]
+
+
+@pytest.mark.parametrize(
+    "reasoning_replay",
+    [
+        ReasoningReplayMode.THINK_TAGS,
+        ReasoningReplayMode.REASONING,
+        ReasoningReplayMode.DISABLED,
+    ],
+)
+def test_convert_tool_use_without_thinking_does_not_change_other_replay_modes(
+    reasoning_replay: ReasoningReplayMode,
+) -> None:
+    result = _convert_tool_turn(
+        [MockBlock(type="tool_use", id="call_other", name="Read", input={})],
+        reasoning_replay,
+    )
+
+    assert "reasoning_content" not in result[0]
+
+
 def test_convert_assistant_message_thinking_removed_when_disabled():
     content = [
         MockBlock(type="thinking", thinking="I need to calculate this."),

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -1,13 +1,10 @@
 """Tests for DeepSeek OpenAI-compatible Chat Completions provider."""
 
-import json
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
-from openai import AsyncOpenAI
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
@@ -24,6 +21,7 @@ from free_claude_code.providers.deepseek import DeepSeekProvider
 from tests.providers.support import (
     REASONING_OFF,
     REASONING_ON,
+    capture_openai_chat_wire_body,
     immediate_admission,
     reasoning_for,
 )
@@ -42,36 +40,6 @@ def deepseek_config():
 @pytest.fixture
 def deepseek_provider(deepseek_config):
     return DeepSeekProvider(deepseek_config, admission=immediate_admission())
-
-
-async def _capture_openai_wire_body(body: dict) -> dict:
-    captured: list[dict] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        payload = json.loads(request.content)
-        assert isinstance(payload, dict)
-        captured.append(payload)
-        return httpx.Response(
-            200,
-            headers={"content-type": "text/event-stream"},
-            text="data: [DONE]\n\n",
-        )
-
-    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
-    client = AsyncOpenAI(
-        api_key="test",
-        base_url="https://deepseek.invalid",
-        http_client=http_client,
-        max_retries=0,
-    )
-    try:
-        stream = await client.chat.completions.create(**body, stream=True)
-        await stream.close()
-    finally:
-        await client.close()
-
-    assert len(captured) == 1
-    return captured[0]
 
 
 def test_default_base_url_alias():
@@ -866,8 +834,8 @@ async def test_wire_messages_keep_prefix_across_tool_thinking_fallback(
             request, reasoning=reasoning_for(request)
         )
 
-    first_wire = await _capture_openai_wire_body(build(prefix_messages))
-    continued_wire = await _capture_openai_wire_body(build(continued_messages))
+    first_wire = await capture_openai_chat_wire_body(build(prefix_messages))
+    continued_wire = await capture_openai_chat_wire_body(build(continued_messages))
     first_messages = first_wire["messages"]
     continued = continued_wire["messages"]
 

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -5,47 +5,11 @@ import pytest
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.providers.base import ProviderConfig
 from tests.providers.support import (
+    capture_openai_chat_wire_body,
     immediate_admission,
     profiled_provider,
     reasoning_for,
 )
-
-
-@pytest.mark.parametrize("provider_id", ["opencode", "opencode_go"])
-def test_build_request_body_preserves_empty_reasoning_content(
-    provider_id: str,
-) -> None:
-    provider = profiled_provider(
-        provider_id,
-        ProviderConfig(
-            api_key="test_opencode_key",
-            base_url="https://example.invalid/v1",
-            rate_limit=1,
-            rate_window=1,
-        ),
-        admission=immediate_admission(),
-    )
-    request = MessagesRequest.model_validate(
-        {
-            "model": "m",
-            "messages": [
-                {
-                    "role": "assistant",
-                    "content": "visible",
-                    "reasoning_content": "",
-                }
-            ],
-            "thinking": {"type": "enabled"},
-        }
-    )
-
-    body = provider._build_request_body(request, reasoning=reasoning_for(request))
-
-    assert body["messages"][0] == {
-        "role": "assistant",
-        "content": "visible",
-        "reasoning_content": "",
-    }
 
 
 @pytest.mark.parametrize("provider_id", ["opencode", "opencode_go"])
@@ -107,5 +71,64 @@ def test_build_request_body_replays_tool_reasoning_natively(
     assert body["messages"][1] == {
         "role": "tool",
         "tool_call_id": "call_1",
+        "content": "file contents",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_id", ["opencode", "opencode_go"])
+async def test_tool_only_history_sends_empty_reasoning_content_on_wire(
+    provider_id: str,
+) -> None:
+    provider = profiled_provider(
+        provider_id,
+        ProviderConfig(
+            api_key="test_opencode_key",
+            base_url="https://example.invalid/v1",
+            rate_limit=1,
+            rate_window=1,
+        ),
+        admission=immediate_admission(),
+    )
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_missing",
+                            "name": "Read",
+                            "input": {"path": "README.md"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_missing",
+                            "content": "file contents",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    body = provider._build_request_body(request, reasoning=reasoning_for(request))
+    wire = await capture_openai_chat_wire_body(body)
+
+    assistant = wire["messages"][0]
+    assert assistant["content"] == ""
+    assert assistant["reasoning_content"] == ""
+    assert assistant["tool_calls"][0]["id"] == "call_missing"
+    assert assistant["tool_calls"][0]["function"]["name"] == "Read"
+    assert wire["messages"][1] == {
+        "role": "tool",
+        "tool_call_id": "call_missing",
         "content": "file contents",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.6"
+version = "4.16.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Claude tool-only assistant turns omitted `reasoning_content` when a provider used native reasoning replay. DeepSeek V4 requires that field to remain present—even as an empty string—so OpenCode Zen and Go continuations could fail despite valid Claude history.

Fixes #1336
Fixes #1338

## Changes

| Before | After |
| --- | --- |
| Native tool turns without thinking omitted `reasoning_content`. | Native `reasoning_content` tool turns send `""` when no replayable reasoning exists. |
| OpenCode coverage injected an internal empty field before conversion. | Zen and Go coverage starts from real tool-only Anthropic history and asserts the final SDK wire JSON. |
| DeepSeek owned a private wire-capture helper. | Provider tests share one OpenAI Chat wire-capture helper. |
| The behavior was only simulated. | The exact tool-only continuation passed against the real DeepSeek V4 Flash endpoint. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change preserves an explicit empty `reasoning_content` field for Anthropic assistant messages that contain tool calls but no replayable thinking, so OpenCode-compatible providers can accept the continuation history.

A Python 3.14 wire-level check exercised single and parallel tool-only histories for both OpenCode profiles through the production request builder and OpenAI client serialization. The resulting requests included empty `content` and `reasoning_content` fields while retaining matching tool-call and tool-result identifiers. The focused converter and OpenCode provider tests passed (98 tests).

The prior behavior was also checked against `origin/main`: those tool-only assistant messages omitted `reasoning_content`. The updated behavior corrects that omission.
</details>

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the MockTransport wire probe on origin/main and on the updated code using Python 3.14.
- I observed that before the change the tool-only assistant history omitted reasoning\_content, and after the change the four provider/scenario calls serialized explicit empty content and reasoning\_content with matching tool-call and tool-result IDs.
- I executed the validation workflow described for the PR, including the wire probe script and the test suite, and all 98 tests passed.
- I captured and linked artifacts that support reviewer inspection, including the focused wire probe source, the before and after wire JSON, the post-PR tests, and the OpenCode reasoning replay profile.

<a href="https://app.greptile.com/trex/runs/17309680/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Preserve empty reasoning on tool turns"](https://github.com/alishahryar1/free-claude-code/commit/3141fadcca12d8993b0678b6a24cc48170f4ed5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50197140)</sub>

<!-- /greptile_comment -->