### PR TITLE
add per-provider model allowlist filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,13 @@ MODEL_HAIKU=
 MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 
 
+# Per-provider model allowlists (optional). Comma-separated "provider/model" pairs.
+# When set, model pickers only show the listed models for each provider. A provider
+# without an entry falls back to all its models (or FCC_MODEL_ALLOWLIST when set).
+# Example: "open_router/anthropic/claude-3-opus,open_router/google/gemini-pro"
+FCC_PROVIDER_MODEL_ALLOWLIST=
+
+
 # Optional live smoke model overrides. Provider smoke runs once per configured
 # provider even when MODEL/MODEL_* route to a different provider.
 FCC_SMOKE_MODEL_NVIDIA_NIM=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.7"
+version = "4.17.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -48,6 +48,13 @@ class ConnectedAccountLoginPayload(BaseModel):
     mode: ConnectedAccountLoginMode = ConnectedAccountLoginMode.BROWSER
 
 
+class ProviderAllowlistPayload(BaseModel):
+    """Per-provider model allowlist submitted by the admin UI."""
+
+    models: list[str] = Field(default_factory=list)
+    restricted: bool = True
+
+
 def _is_loopback_host(host: str | None) -> bool:
     if host is None:
         return False
@@ -156,6 +163,33 @@ async def test_provider(
 ):
     require_loopback_admin(request)
     return await services.admin.test_provider(provider_id)
+
+
+@router.get("/admin/api/providers/{provider_id}/allowlist")
+async def get_provider_allowlist(
+    provider_id: str,
+    request: Request,
+    services: ApiServices = Depends(get_services),
+):
+    require_loopback_admin(request)
+    return {
+        "provider_id": provider_id,
+        "models": services.admin.get_provider_allowlist(provider_id),
+        "restricted": services.admin.is_provider_allowlist_restricted(provider_id),
+    }
+
+
+@router.post("/admin/api/providers/{provider_id}/allowlist")
+async def set_provider_allowlist(
+    provider_id: str,
+    payload: ProviderAllowlistPayload,
+    request: Request,
+    services: ApiServices = Depends(get_services),
+):
+    require_loopback_admin(request)
+    return await services.admin.set_provider_allowlist(
+        provider_id, payload.models, restricted=payload.restricted
+    )
 
 
 @router.get("/admin/api/providers/{provider_id}/auth")

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -187,9 +187,12 @@ async def set_provider_allowlist(
     services: ApiServices = Depends(get_services),
 ):
     require_loopback_admin(request)
-    return await services.admin.set_provider_allowlist(
-        provider_id, payload.models, restricted=payload.restricted
-    )
+    try:
+        return await services.admin.set_provider_allowlist(
+            provider_id, payload.models, restricted=payload.restricted
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/admin/api/providers/{provider_id}/auth")

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -393,6 +393,18 @@ textarea:focus-visible,
   border-color: var(--text);
 }
 
+.provider-allowlist-trigger {
+  margin-top: 8px;
+  align-self: flex-start;
+}
+
+.provider-allowlist-meta {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
 .primary-button {
   border-color: var(--accent);
   background: var(--accent);
@@ -777,6 +789,187 @@ textarea:focus-visible,
     flex: 1;
     min-height: 44px; /* Better touch target on mobile */
   }
+}
+
+/* Model Selector Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+
+.modal-dialog {
+  position: relative;
+  width: min(640px, 100%);
+  max-height: min(80vh, 720px);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.modal-close {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--muted);
+  font-size: 20px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.modal-close:hover {
+  background: var(--panel-strong);
+  border-color: var(--line-strong);
+  color: var(--text-strong);
+}
+
+.modal-body {
+  flex: 1;
+  overflow: hidden;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.provider-enabled-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-strong);
+  cursor: pointer;
+  user-select: none;
+}
+
+.provider-enabled-toggle input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.model-selector-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.model-selector-search {
+  flex: 1;
+  min-height: 40px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-md);
+  background: var(--input);
+  color: var(--text-strong);
+  padding: 10px 14px;
+  font-size: 14px;
+  transition: all var(--transition-fast);
+}
+
+.model-selector-search:focus {
+  border-color: var(--accent);
+  background: var(--input-focus);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+  outline: none;
+}
+
+.model-selector-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.model-selector-list {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--input);
+  padding: 8px;
+}
+
+.model-selector-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.model-selector-item:hover {
+  background: var(--panel-strong);
+}
+
+.model-selector-item input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.model-selector-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.model-selector-empty {
+  padding: 16px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--line);
 }
 
 /* Mobile Layout Optimization */

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1020,13 +1020,24 @@ function modelsForProvider(providerId) {
   );
 }
 
+function rawModelsForProvider(providerId, refs) {
+  const prefix = `${providerId}/`;
+  return refs.map((ref) =>
+    ref.toLocaleLowerCase().startsWith(prefix) ? ref.slice(prefix.length) : ref,
+  );
+}
+
 function openProviderAllowlistModal(providerId) {
   state.providerAllowlistProviderId = providerId;
   state.providerAllowlistAvailable = modelsForProvider(providerId);
   const restricted = state.providerAllowlistRestricted.get(providerId) || false;
   const allowed = state.providerAllowlists.get(providerId) || [];
+  const prefix = `${providerId}/`;
+  const allowedRefs = allowed.map((model) =>
+    model.toLocaleLowerCase().startsWith(prefix) ? model : `${prefix}${model}`,
+  );
   state.providerAllowlistSelected = new Set(
-    restricted ? allowed : state.providerAllowlistAvailable,
+    restricted ? allowedRefs : state.providerAllowlistAvailable,
   );
   state.providerAllowlistOpen = true;
   renderProviderAllowlistList();
@@ -1110,11 +1121,12 @@ async function saveProviderAllowlist() {
     const selected = restricted
       ? Array.from(selectedSet).sort((a, b) => a.localeCompare(b))
       : [];
+    const rawSelected = rawModelsForProvider(providerId, selected);
     await api(`/admin/api/providers/${providerId}/allowlist`, {
       method: "POST",
-      body: JSON.stringify({ models: selected, restricted }),
+      body: JSON.stringify({ models: rawSelected, restricted }),
     });
-    state.providerAllowlists.set(providerId, selected);
+    state.providerAllowlists.set(providerId, rawSelected);
     state.providerAllowlistRestricted.set(providerId, restricted);
     showMessage(`${providerDisplayName(providerId)} allowlist saved`, "ok");
     closeProviderAllowlistModal();

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -6,6 +6,12 @@ const state = {
   modelComboboxes: new Set(),
   authPollers: new Map(),
   activeView: "providers",
+  providerAllowlists: new Map(),
+  providerAllowlistRestricted: new Map(),
+  providerAllowlistOpen: false,
+  providerAllowlistProviderId: null,
+  providerAllowlistSelected: new Set(),
+  providerAllowlistAvailable: [],
 };
 
 const MASKED_SECRET = "********";
@@ -96,8 +102,10 @@ async function load() {
   byId("configPath").textContent = config.paths.managed;
   await refreshConnectedAccounts();
   await hydrateModelOptions();
+  await loadProviderAllowlists(config.provider_status);
   await validate(false);
   await refreshLocalStatus();
+  await refreshProviderAllowlistMeta(config.provider_status);
   updateDirtyState();
   showMessage("");
 }
@@ -189,7 +197,33 @@ function renderProviders(providerStatus) {
     button.textContent = provider.kind === "local" ? "Test" : "Refresh models";
     button.addEventListener("click", () => testProvider(provider.provider_id, button));
 
-    card.append(title, meta, button);
+    const allowlistButton = document.createElement("button");
+    allowlistButton.type = "button";
+    allowlistButton.className = "test-button provider-allowlist-trigger";
+    allowlistButton.textContent = "Select models";
+    allowlistButton.addEventListener("click", () =>
+      openProviderAllowlistModal(provider.provider_id),
+    );
+
+    const enabledToggle = document.createElement("label");
+    enabledToggle.className = "provider-enabled-toggle";
+    enabledToggle.dataset.provider = provider.provider_id;
+    const enabledCheckbox = document.createElement("input");
+    enabledCheckbox.type = "checkbox";
+    enabledCheckbox.checked = true;
+    enabledCheckbox.addEventListener("click", (event) => event.stopPropagation());
+    enabledCheckbox.addEventListener("change", () => {
+      toggleProviderEnabled(provider.provider_id, enabledCheckbox.checked);
+    });
+    const enabledText = document.createElement("span");
+    enabledText.textContent = "Enabled";
+    enabledToggle.append(enabledCheckbox, enabledText);
+
+    const allowlistMeta = document.createElement("div");
+    allowlistMeta.className = "provider-allowlist-meta";
+    allowlistMeta.dataset.provider = provider.provider_id;
+
+    card.append(title, meta, button, allowlistButton, enabledToggle, allowlistMeta);
     grid.appendChild(card);
   });
 }
@@ -878,15 +912,17 @@ async function testProvider(providerId, button) {
       body: "{}",
     });
     if (result.ok) {
+      const models = result.models;
+
       updateProviderCard(
         providerId,
         "reachable",
-        `${result.models.length} models`,
-        result.models.slice(0, 3).join(", ") || "No models returned",
+        `${models.length} models`,
+        models.slice(0, 3).join(", ") || "No models returned",
       );
       setModelOptions([
         ...state.modelOptions,
-        ...result.models.map((model) => `${providerId}/${model}`),
+        ...models.map((model) => `${providerId}/${model}`),
       ]);
     } else {
       updateProviderCard(providerId, "offline", result.error_type, result.error_type);
@@ -959,12 +995,218 @@ function showMessage(message, kind = "") {
   area.className = `message-area ${kind}`.trim();
 }
 
+async function loadProviderAllowlists(providerStatus) {
+  for (const provider of providerStatus) {
+    try {
+      const result = await api(
+        `/admin/api/providers/${provider.provider_id}/allowlist`,
+      );
+      state.providerAllowlists.set(provider.provider_id, result.models || []);
+      state.providerAllowlistRestricted.set(
+        provider.provider_id,
+        Boolean(result.restricted),
+      );
+    } catch {
+      state.providerAllowlists.set(provider.provider_id, []);
+      state.providerAllowlistRestricted.set(provider.provider_id, false);
+    }
+  }
+}
+
+function modelsForProvider(providerId) {
+  const prefix = `${providerId}/`;
+  return state.modelOptions.filter((model) =>
+    model.toLocaleLowerCase().startsWith(prefix),
+  );
+}
+
+function openProviderAllowlistModal(providerId) {
+  state.providerAllowlistProviderId = providerId;
+  state.providerAllowlistAvailable = modelsForProvider(providerId);
+  const restricted = state.providerAllowlistRestricted.get(providerId) || false;
+  const allowed = state.providerAllowlists.get(providerId) || [];
+  state.providerAllowlistSelected = new Set(
+    restricted ? allowed : state.providerAllowlistAvailable,
+  );
+  state.providerAllowlistOpen = true;
+  renderProviderAllowlistList();
+  byId("providerAllowlistTitle").textContent =
+    `Select Models — ${providerDisplayName(providerId)}`;
+  byId("providerAllowlistModal").hidden = false;
+  byId("providerAllowlistSearch").value = "";
+  byId("providerAllowlistSearch").focus();
+}
+
+function closeProviderAllowlistModal() {
+  state.providerAllowlistOpen = false;
+  state.providerAllowlistProviderId = null;
+  state.providerAllowlistSelected = new Set();
+  state.providerAllowlistAvailable = [];
+  byId("providerAllowlistModal").hidden = true;
+}
+
+function renderProviderAllowlistList(query = "") {
+  const list = byId("providerAllowlistList");
+  list.innerHTML = "";
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const models = normalizedQuery
+    ? state.providerAllowlistAvailable.filter((model) =>
+        model.toLocaleLowerCase().includes(normalizedQuery),
+      )
+    : state.providerAllowlistAvailable;
+
+  if (models.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "model-selector-empty";
+    empty.textContent = normalizedQuery
+      ? "No matching models."
+      : "No models available. Refresh models first.";
+    list.appendChild(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  models.forEach((model) => {
+    const item = document.createElement("div");
+    item.className = "model-selector-item";
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = state.providerAllowlistSelected.has(model);
+    checkbox.addEventListener("change", () => {
+      if (checkbox.checked) {
+        state.providerAllowlistSelected.add(model);
+      } else {
+        state.providerAllowlistSelected.delete(model);
+      }
+    });
+
+    const label = document.createElement("span");
+    label.className = "model-selector-label";
+    label.textContent = model;
+
+    item.appendChild(checkbox);
+    item.appendChild(label);
+    fragment.appendChild(item);
+  });
+  list.appendChild(fragment);
+}
+
+async function saveProviderAllowlist() {
+  const providerId = state.providerAllowlistProviderId;
+  if (!providerId) return;
+  const button = byId("providerAllowlistSave");
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = "Saving";
+  try {
+    const available = state.providerAllowlistAvailable;
+    const selectedSet = state.providerAllowlistSelected;
+    const allSelected =
+      available.length > 0 &&
+      available.length === selectedSet.size &&
+      available.every((model) => selectedSet.has(model));
+    const restricted = !allSelected;
+    const selected = restricted
+      ? Array.from(selectedSet).sort((a, b) => a.localeCompare(b))
+      : [];
+    await api(`/admin/api/providers/${providerId}/allowlist`, {
+      method: "POST",
+      body: JSON.stringify({ models: selected, restricted }),
+    });
+    state.providerAllowlists.set(providerId, selected);
+    state.providerAllowlistRestricted.set(providerId, restricted);
+    showMessage(`${providerDisplayName(providerId)} allowlist saved`, "ok");
+    closeProviderAllowlistModal();
+    refreshProviderAllowlistMeta([{ provider_id: providerId }]);
+  } catch (error) {
+    showMessage(`Could not save allowlist: ${error.message}`, "error");
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+}
+
+async function toggleProviderEnabled(providerId, enabled) {
+  try {
+    await api(`/admin/api/providers/${providerId}/allowlist`, {
+      method: "POST",
+      body: JSON.stringify({ models: [], restricted: !enabled }),
+    });
+    state.providerAllowlistRestricted.set(providerId, !enabled);
+    state.providerAllowlists.set(providerId, []);
+    refreshProviderAllowlistMeta([{ provider_id: providerId }]);
+    showMessage(
+      `${providerDisplayName(providerId)} ${enabled ? "enabled" : "disabled"}`,
+      "ok",
+    );
+  } catch (error) {
+    showMessage(`Could not update provider: ${error.message}`, "error");
+  }
+}
+
+function refreshProviderAllowlistMeta(providerStatus) {
+  providerStatus.forEach((provider) => {
+    const allowed = state.providerAllowlists.get(provider.provider_id) || [];
+    const restricted =
+      state.providerAllowlistRestricted.get(provider.provider_id) || false;
+    const disabled = restricted && allowed.length === 0;
+    const meta = document.querySelector(
+      `[data-provider="${provider.provider_id}"].provider-allowlist-meta`,
+    );
+    if (meta) {
+      meta.textContent = disabled
+        ? "No models allowed"
+        : allowed.length > 0
+          ? `${allowed.length} allowed: ${allowed.slice(0, 3).join(", ")}${allowed.length > 3 ? "…" : ""}`
+          : "All models allowed";
+    }
+    const toggle = document.querySelector(
+      `[data-provider="${provider.provider_id}"].provider-enabled-toggle input`,
+    );
+    if (toggle) toggle.checked = !disabled;
+  });
+}
+
 byId("validateButton").addEventListener("click", () => validate(true));
 byId("applyButton").addEventListener("click", apply);
 document.addEventListener("pointerdown", (event) => {
   state.modelComboboxes.forEach((combobox) => {
     if (combobox.isOpen && !combobox.element.contains(event.target)) combobox.close();
   });
+  if (state.providerAllowlistOpen) {
+    const modal = byId("providerAllowlistModal");
+    if (!modal.contains(event.target)) closeProviderAllowlistModal();
+  }
+});
+
+byId("providerAllowlistSearch").addEventListener("input", (event) => {
+  renderProviderAllowlistList(event.target.value);
+});
+byId("providerAllowlistSelectAll").addEventListener("click", () => {
+  state.providerAllowlistSelected = new Set(state.providerAllowlistAvailable);
+  renderProviderAllowlistList(byId("providerAllowlistSearch").value);
+});
+byId("providerAllowlistSelectFiltered").addEventListener("click", () => {
+  const query = byId("providerAllowlistSearch").value;
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const models = normalizedQuery
+    ? state.providerAllowlistAvailable.filter((model) =>
+        model.toLocaleLowerCase().includes(normalizedQuery),
+      )
+    : state.providerAllowlistAvailable;
+  state.providerAllowlistSelected = new Set(models);
+  renderProviderAllowlistList(query);
+});
+byId("providerAllowlistDeselectAll").addEventListener("click", () => {
+  state.providerAllowlistSelected = new Set();
+  renderProviderAllowlistList(byId("providerAllowlistSearch").value);
+});
+byId("providerAllowlistSave").addEventListener("click", saveProviderAllowlist);
+byId("providerAllowlistCancel").addEventListener("click", closeProviderAllowlistModal);
+byId("providerAllowlistModal").addEventListener("click", (event) => {
+  const closer = event.target.closest("[data-close]");
+  if (closer) closeProviderAllowlistModal();
 });
 
 load().catch((error) => {

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1113,11 +1113,13 @@ async function saveProviderAllowlist() {
   try {
     const available = state.providerAllowlistAvailable;
     const selectedSet = state.providerAllowlistSelected;
-    const allSelected =
-      available.length > 0 &&
-      available.length === selectedSet.size &&
-      available.every((model) => selectedSet.has(model));
-    const restricted = !allSelected;
+    const restricted =
+      available.length === 0
+        ? Boolean(state.providerAllowlistRestricted.get(providerId))
+        : !(
+            available.length === selectedSet.size &&
+            available.every((model) => selectedSet.has(model))
+          );
     const selected = restricted
       ? Array.from(selectedSet).sort((a, b) => a.localeCompare(b))
       : [];

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -85,6 +85,37 @@
           <button id="applyButton" class="primary-button" type="button" disabled>Apply</button>
         </div>
       </footer>
+
+      <div id="providerAllowlistModal" class="modal" hidden>
+        <div class="modal-backdrop" data-close="providerAllowlistModal"></div>
+        <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="providerAllowlistTitle">
+          <div class="modal-header">
+            <h3 id="providerAllowlistTitle">Select Models</h3>
+            <button class="modal-close" data-close="providerAllowlistModal" aria-label="Close">×</button>
+          </div>
+          <div class="modal-body">
+            <div class="model-selector-toolbar">
+              <input
+                id="providerAllowlistSearch"
+                class="model-selector-search"
+                type="text"
+                placeholder="Search models..."
+                autocomplete="off"
+              />
+              <div class="model-selector-actions">
+                <button id="providerAllowlistSelectAll" class="ghost-button" type="button">Select all</button>
+                <button id="providerAllowlistSelectFiltered" class="ghost-button" type="button">Select filtered</button>
+                <button id="providerAllowlistDeselectAll" class="ghost-button" type="button">Deselect all</button>
+              </div>
+            </div>
+            <div id="providerAllowlistList" class="model-selector-list"></div>
+          </div>
+          <div class="modal-footer">
+            <button id="providerAllowlistCancel" class="secondary-button" type="button">Cancel</button>
+            <button id="providerAllowlistSave" class="primary-button" type="button">Save selection</button>
+          </div>
+        </div>
+      </div>
     </div>
     <script src="/admin/assets/admin.js"></script>
   </body>

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -5,7 +5,10 @@ from typing import Literal
 from pydantic import BaseModel
 
 from free_claude_code.application.ports import RequestRuntimePort
-from free_claude_code.config.model_refs import configured_chat_model_refs
+from free_claude_code.config.model_refs import (
+    configured_chat_model_refs,
+    model_ref_allowed,
+)
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.gateway_model_ids import (
     gateway_model_id,
@@ -85,6 +88,8 @@ def build_models_list_response(
     seen: set[str] = set()
 
     for ref in configured_chat_model_refs(settings):
+        if not model_ref_allowed(settings, ref.model_ref):
+            continue
         supports_thinking = runtime.cached_model_supports_thinking(
             ref.provider_id, ref.model_id
         )
@@ -96,6 +101,8 @@ def build_models_list_response(
         )
 
     for model_info in runtime.cached_prefixed_model_infos():
+        if not model_ref_allowed(settings, model_info.model_id):
+            continue
         _append_provider_model_variants(
             models,
             seen,

--- a/src/free_claude_code/api/ports.py
+++ b/src/free_claude_code/api/ports.py
@@ -45,6 +45,14 @@ class AdminRuntimePort(Protocol):
         self, provider_id: str
     ) -> ConnectedAccountStatus: ...
 
+    def get_provider_allowlist(self, provider_id: str) -> list[str]: ...
+
+    def is_provider_allowlist_restricted(self, provider_id: str) -> bool: ...
+
+    async def set_provider_allowlist(
+        self, provider_id: str, models: list[str], *, restricted: bool = True
+    ) -> dict[str, Any]: ...
+
 
 @dataclass(frozen=True, slots=True)
 class ApiServices:

--- a/src/free_claude_code/cli/launchers/codex_model_catalog.py
+++ b/src/free_claude_code/cli/launchers/codex_model_catalog.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from free_claude_code.config.model_refs import model_ref_allowed
 from free_claude_code.config.provider_catalog import SUPPORTED_PROVIDER_IDS
+from free_claude_code.config.settings import get_settings
 from free_claude_code.core.gateway_model_ids import (
     GATEWAY_MODEL_ID_PREFIX,
     NO_THINKING_GATEWAY_MODEL_ID_PREFIX,
@@ -44,6 +46,8 @@ class _CatalogCandidate:
 def build_codex_model_catalog(models_response: Mapping[str, Any]) -> dict[str, Any]:
     """Convert FCC `/v1/models` data into Codex `model_catalog_json` payload."""
 
+    settings = get_settings()
+
     candidates = list(_catalog_candidates(models_response))
     normal_provider_refs = {
         candidate.provider_model_ref
@@ -61,10 +65,20 @@ def build_codex_model_catalog(models_response: Mapping[str, Any]) -> dict[str, A
             continue
         if candidate.slug in seen_slugs:
             continue
+        # Apply per-provider allowlist when configured; otherwise global.
+        if not _model_is_allowed(settings, candidate):
+            continue
         seen_slugs.add(candidate.slug)
         models.append(_codex_catalog_entry(candidate, priority=len(models)))
 
     return {"models": models}
+
+
+def _model_is_allowed(settings: Any, candidate: _CatalogCandidate) -> bool:
+    """Return whether a catalog candidate passes allowlist filtering."""
+    return model_ref_allowed(
+        settings, candidate.provider_model_ref, alt_ids=(candidate.slug,)
+    )
 
 
 def write_codex_model_catalog(catalog_path: Path, catalog: Mapping[str, Any]) -> bool:

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -48,6 +48,7 @@ class ConfigFieldSpec:
     options: tuple[str | ConfigOptionSpec, ...] = ()
     secret: bool = False
     advanced: bool = False
+    hidden: bool = False
     restart_required: bool = False
     session_sensitive: bool = False
     description: str = ""
@@ -172,6 +173,12 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         "optional_model",
         settings_attr="model_haiku",
         description="Select None to use the Default Model for Haiku requests.",
+    ),
+    ConfigFieldSpec(
+        "FCC_PROVIDER_MODEL_ALLOWLIST",
+        "Per-Provider Model Allowlists",
+        "models",
+        hidden=True,
     ),
     ConfigFieldSpec(
         "REASONING_POLICY",

--- a/src/free_claude_code/config/admin/persistence.py
+++ b/src/free_claude_code/config/admin/persistence.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from free_claude_code.config.model_refs import RESTRICTED_EMPTY_MARKER
 from free_claude_code.config.paths import managed_env_path
 from free_claude_code.config.settings import Settings
 
@@ -178,6 +179,92 @@ def commit_prepared_admin_update(prepared: PreparedAdminUpdate) -> dict[str, Any
     finally:
         temp_path.unlink(missing_ok=True)
     return prepared.applied_response()
+
+
+ALLOWLIST_ENV_KEY = "FCC_PROVIDER_MODEL_ALLOWLIST"
+
+
+def render_provider_allowlists(allowlists: Mapping[str, list[str]]) -> str:
+    """Render per-provider allowlists into the FCC_PROVIDER_MODEL_ALLOWLIST value."""
+
+    parts: list[str] = []
+    for provider_id in sorted(allowlists):
+        models = sorted(allowlists[provider_id])
+        if models:
+            parts.extend(f"{provider_id}/{model}" for model in models)
+        else:
+            parts.append(f"{provider_id}/{RESTRICTED_EMPTY_MARKER}")
+    return ",".join(parts)
+
+
+def parse_provider_allowlists(value: str) -> dict[str, list[str]]:
+    """Parse the FCC_PROVIDER_MODEL_ALLOWLIST value into provider -> models.
+
+    A provider restricted to zero models is stored with the internal
+    RESTRICTED_EMPTY_MARKER and parsed back as an empty list so the restriction
+    survives a managed-env round-trip.
+    """
+
+    result: dict[str, list[str]] = {}
+    for item in value.split(","):
+        item = item.strip()
+        if not item or "/" not in item:
+            continue
+        provider_id, model = item.split("/", 1)
+        provider_id = provider_id.strip()
+        model = model.strip()
+        if model == RESTRICTED_EMPTY_MARKER:
+            result.setdefault(provider_id, [])
+        else:
+            result.setdefault(provider_id, []).append(model)
+    return result
+
+
+def load_provider_allowlists() -> dict[str, list[str]]:
+    """Return per-provider allowlists persisted in the managed env file."""
+
+    managed = dotenv_values_from_file(managed_env_path())
+    return parse_provider_allowlists(managed.get(ALLOWLIST_ENV_KEY, ""))
+
+
+def commit_provider_allowlist(
+    provider_id: str,
+    models: list[str],
+    *,
+    restricted: bool = True,
+) -> dict[str, Any]:
+    """Persist one provider's allowlist into the managed env file.
+
+    When ``restricted`` is True the provider is limited to ``models`` (an empty
+    list disables the provider). When False the provider entry is removed so all
+    of its models are allowed again.
+    """
+
+    allowlists = load_provider_allowlists()
+    if restricted:
+        allowlists[provider_id] = sorted(
+            model.strip() for model in models if model.strip()
+        )
+    else:
+        allowlists.pop(provider_id, None)
+
+    path = managed_env_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    managed = dotenv_values_from_file(path)
+    managed[ALLOWLIST_ENV_KEY] = render_provider_allowlists(allowlists)
+
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temp_path.write_text(render_env_file(managed), encoding="utf-8")
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return {
+        "applied": True,
+        "provider_id": provider_id,
+        "models": allowlists.get(provider_id, []),
+        "restricted": provider_id in allowlists,
+    }
 
 
 def quote_env_value(value: str) -> str:

--- a/src/free_claude_code/config/admin/persistence.py
+++ b/src/free_claude_code/config/admin/persistence.py
@@ -227,6 +227,12 @@ def load_provider_allowlists() -> dict[str, list[str]]:
     return parse_provider_allowlists(managed.get(ALLOWLIST_ENV_KEY, ""))
 
 
+def provider_allowlists_are_locked() -> bool:
+    """Return whether the allowlist env key is locked by a higher-precedence source."""
+
+    return is_locked_source(load_value_state()[ALLOWLIST_ENV_KEY]["source"])
+
+
 def _normalize_allowlist_model(provider_id: str, model: str) -> str:
     """Strip a redundant leading ``{provider_id}/`` prefix from a model id.
 

--- a/src/free_claude_code/config/admin/persistence.py
+++ b/src/free_claude_code/config/admin/persistence.py
@@ -227,6 +227,23 @@ def load_provider_allowlists() -> dict[str, list[str]]:
     return parse_provider_allowlists(managed.get(ALLOWLIST_ENV_KEY, ""))
 
 
+def _normalize_allowlist_model(provider_id: str, model: str) -> str:
+    """Strip a redundant leading ``{provider_id}/`` prefix from a model id.
+
+    The admin UI lists model refs already prefixed with the provider id, while
+    the persistence layer always prepends ``provider_id/`` itself. Stripping a
+    single leading prefix keeps stored values canonical even when a client
+    sends an already-prefixed ref, and repairs double-prefixed entries when
+    they are re-saved.
+    """
+
+    model = model.strip()
+    prefix = f"{provider_id}/"
+    if model.startswith(prefix):
+        return model[len(prefix) :]
+    return model
+
+
 def commit_provider_allowlist(
     provider_id: str,
     models: list[str],
@@ -243,7 +260,11 @@ def commit_provider_allowlist(
     allowlists = load_provider_allowlists()
     if restricted:
         allowlists[provider_id] = sorted(
-            model.strip() for model in models if model.strip()
+            dict.fromkeys(
+                _normalize_allowlist_model(provider_id, model)
+                for model in models
+                if model.strip()
+            )
         )
     else:
         allowlists.pop(provider_id, None)

--- a/src/free_claude_code/config/admin/values.py
+++ b/src/free_claude_code/config/admin/values.py
@@ -77,6 +77,8 @@ def load_config_response() -> dict[str, Any]:
     state = load_value_state()
     fields: list[dict[str, Any]] = []
     for field in FIELDS:
+        if field.hidden:
+            continue
         entry = state[field.key]
         source = entry["source"]
         raw_value = entry["value"]

--- a/src/free_claude_code/config/model_refs.py
+++ b/src/free_claude_code/config/model_refs.py
@@ -1,7 +1,13 @@
 """Provider-prefixed model reference helpers."""
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
+
+# Internal marker used to persist a provider that is restricted to zero models
+# (i.e. disabled) in the FCC_PROVIDER_MODEL_ALLOWLIST env value without colliding
+# with the "all models allowed" absent state.
+RESTRICTED_EMPTY_MARKER = "__fcc_no_models__"
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,3 +64,29 @@ def configured_chat_model_refs(
         )
         for model_ref in model_refs
     )
+
+
+def model_ref_allowed(
+    settings: Any,
+    provider_model_ref: str,
+    *,
+    alt_ids: Iterable[str] = (),
+) -> bool:
+    """Return whether a provider model reference passes allowlist filtering.
+
+    Semantics:
+    - If the provider_id has a per-provider allowlist, the model_name must be in it.
+    - Otherwise, if the global model_allowlist is empty, all models are allowed.
+    - Otherwise, the provider_model_ref or any alt_id must be in the global allowlist.
+    """
+    provider_id, separator, model_name = provider_model_ref.partition("/")
+    provider_allowlists = settings.provider_model_allowlists
+    if provider_id in provider_allowlists:
+        if not separator:
+            return False
+        return model_name in provider_allowlists[provider_id]
+
+    allowlist = settings.model_allowlist
+    if not allowlist:
+        return True
+    return provider_model_ref in allowlist or any(alt in allowlist for alt in alt_ids)

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -1,10 +1,10 @@
 """Flat application settings schema loaded by Pydantic Settings."""
 
 from functools import lru_cache
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import Field, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from .constants import HTTP_CONNECT_TIMEOUT_DEFAULT
 from .env_files import (
@@ -12,6 +12,7 @@ from .env_files import (
     env_file_override,
     settings_env_files,
 )
+from .model_refs import RESTRICTED_EMPTY_MARKER
 from .nim import NimSettings
 from .provider_catalog import BEDROCK_DEFAULT_BASE, SUPPORTED_PROVIDER_IDS
 from .reasoning import ReasoningPreference
@@ -159,6 +160,72 @@ class Settings(BaseSettings):
     model_opus: str | None = Field(default=None, validation_alias="MODEL_OPUS")
     model_sonnet: str | None = Field(default=None, validation_alias="MODEL_SONNET")
     model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
+
+    # ==================== Model Filtering ====================
+    # Comma-separated list of model IDs to display in model pickers.
+    # When empty, all discovered models are shown.
+    # Example: "open_router/anthropic/claude-3-opus,open_router/google/gemini-pro"
+    model_allowlist: list[str] = Field(
+        default_factory=list,
+        validation_alias="FCC_MODEL_ALLOWLIST",
+    )
+
+    @field_validator("model_allowlist", mode="before")
+    @classmethod
+    def parse_model_allowlist(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if isinstance(value, str):
+            if not value.strip():
+                return []
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return []
+
+    # Per-provider model allowlists. Maps provider_id -> list of model IDs
+    # (without the provider prefix). When a provider has no entry, the global
+    # model_allowlist (or all discovered models) applies.
+    # Env format: comma-separated "provider/model" pairs, e.g.
+    # "open_router/anthropic/claude-3-opus,nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
+    provider_model_allowlists: Annotated[dict[str, list[str]], NoDecode] = Field(
+        default_factory=dict,
+        validation_alias="FCC_PROVIDER_MODEL_ALLOWLIST",
+    )
+
+    @field_validator("provider_model_allowlists", mode="before")
+    @classmethod
+    def parse_provider_model_allowlists(cls, value: Any) -> dict[str, list[str]]:
+        if value is None:
+            return {}
+        if isinstance(value, dict):
+            return {
+                str(provider).strip(): [
+                    str(model).strip() for model in models if str(model).strip()
+                ]
+                for provider, models in value.items()
+                if str(provider).strip()
+            }
+        if isinstance(value, str):
+            if not value.strip():
+                return {}
+            result: dict[str, list[str]] = {}
+            for item in value.split(","):
+                item = item.strip()
+                if not item:
+                    continue
+                if "/" in item:
+                    provider, model = item.split("/", 1)
+                    provider = provider.strip()
+                    model = model.strip()
+                    if model == RESTRICTED_EMPTY_MARKER:
+                        result.setdefault(provider, [])
+                    else:
+                        result.setdefault(provider, []).append(model)
+                else:
+                    result.setdefault("", []).append(item)
+            return result
+        return {}
 
     # ==================== Per-Provider Proxy ====================
     openai_proxy: str = Field(default="", validation_alias="OPENAI_PROXY")

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -28,6 +28,7 @@ from free_claude_code.config.admin.persistence import (
     commit_provider_allowlist,
     load_provider_allowlists,
     prepare_admin_update,
+    provider_allowlists_are_locked,
 )
 from free_claude_code.config.admin.status import provider_config_status
 from free_claude_code.config.admin.values import load_value_state
@@ -308,10 +309,17 @@ class ApplicationRuntime:
         return status
 
     def get_provider_allowlist(self, provider_id: str) -> list[str]:
-        return list(load_provider_allowlists().get(provider_id, []))
+        return list(
+            self.provider_manager.current_settings().provider_model_allowlists.get(
+                provider_id, []
+            )
+        )
 
     def is_provider_allowlist_restricted(self, provider_id: str) -> bool:
-        return provider_id in load_provider_allowlists()
+        return (
+            provider_id
+            in self.provider_manager.current_settings().provider_model_allowlists
+        )
 
     async def set_provider_allowlist(
         self,
@@ -320,6 +328,12 @@ class ApplicationRuntime:
         *,
         restricted: bool = True,
     ) -> dict[str, Any]:
+        if provider_allowlists_are_locked():
+            raise ValueError(
+                "FCC_PROVIDER_MODEL_ALLOWLIST is locked by the process "
+                "environment or FCC_ENV_FILE and cannot be edited from the "
+                "admin UI."
+            )
         async with self._config_lock:
             result = commit_provider_allowlist(
                 provider_id, models, restricted=restricted

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -325,6 +325,17 @@ class ApplicationRuntime:
                 provider_id, models, restricted=restricted
             )
             get_settings.cache_clear()
+            # Refresh the running generation's allowlist from the committed
+            # managed env so model lists, the Codex catalog, and cache scope
+            # update live without a server restart. Copy the current generation
+            # settings so every other value stays untouched.
+            committed = load_provider_allowlists()
+            updated = self.provider_manager.current_settings().model_copy(
+                update={"provider_model_allowlists": committed}
+            )
+            await self.provider_manager.replace(
+                updated, commit=lambda: None, reason="admin_allowlist"
+            )
             return result
 
     async def request_restart(self) -> None:

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -25,6 +25,8 @@ from free_claude_code.application.ports import StopResult
 from free_claude_code.config.admin.persistence import (
     PreparedAdminUpdate,
     commit_prepared_admin_update,
+    commit_provider_allowlist,
+    load_provider_allowlists,
     prepare_admin_update,
 )
 from free_claude_code.config.admin.status import provider_config_status
@@ -304,6 +306,26 @@ class ApplicationRuntime:
         )
         self._connected_account_revisions[provider_id] = status.revision
         return status
+
+    def get_provider_allowlist(self, provider_id: str) -> list[str]:
+        return list(load_provider_allowlists().get(provider_id, []))
+
+    def is_provider_allowlist_restricted(self, provider_id: str) -> bool:
+        return provider_id in load_provider_allowlists()
+
+    async def set_provider_allowlist(
+        self,
+        provider_id: str,
+        models: list[str],
+        *,
+        restricted: bool = True,
+    ) -> dict[str, Any]:
+        async with self._config_lock:
+            result = commit_provider_allowlist(
+                provider_id, models, restricted=restricted
+            )
+            get_settings.cache_clear()
+            return result
 
     async def request_restart(self) -> None:
         callback = self._restart_callback

--- a/src/free_claude_code/runtime/codex_catalog.py
+++ b/src/free_claude_code/runtime/codex_catalog.py
@@ -41,8 +41,8 @@ class CodexModelCatalogPublisher:
         )
         catalog = build_codex_model_catalog(models_response.model_dump())
         models = catalog.get("models")
-        if not isinstance(models, list) or not models:
-            raise ValueError("Codex model catalog contains no routable models.")
+        if not isinstance(models, list):
+            raise ValueError("Codex model catalog is not a list of models.")
         write_codex_model_catalog(catalog_path, catalog)
 
     def _resolved_catalog_path(self) -> Path:

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -415,6 +415,34 @@ def test_admin_allowlist_post_restricted_empty_disables_provider(monkeypatch, tm
     }
 
 
+def test_admin_allowlist_post_applies_to_running_runtime_without_restart(
+    monkeypatch, tmp_path
+):
+    """Allowlist saves propagate live to the runtime generation snapshot."""
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+    manager = provider_manager_for_app(app)
+
+    assert "nvidia_nim" not in manager.current_settings().provider_model_allowlists
+
+    response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": ["nvidia/nemotron-3-super"]},
+    )
+    assert response.status_code == 200
+    assert manager.current_settings().provider_model_allowlists == {
+        "nvidia_nim": ["nvidia/nemotron-3-super"]
+    }
+
+    clear_response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": [], "restricted": False},
+    )
+    assert clear_response.status_code == 200
+    assert "nvidia_nim" not in manager.current_settings().provider_model_allowlists
+
+
 def test_admin_allowlist_preserves_other_managed_values(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -322,6 +322,39 @@ def test_admin_allowlist_post_persists_and_get_reads_back(monkeypatch, tmp_path)
     }
 
 
+def test_admin_allowlist_post_normalizes_prefixed_models(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={
+            "models": [
+                "nvidia_nim/meta/llama3-70b",
+                "meta/llama3-70b",
+                "nvidia/nemotron-3-super",
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "applied": True,
+        "provider_id": "nvidia_nim",
+        "models": ["meta/llama3-70b", "nvidia/nemotron-3-super"],
+        "restricted": True,
+    }
+
+    env_file = tmp_path / ".fcc" / ".env"
+    text = env_file.read_text(encoding="utf-8")
+    assert (
+        "FCC_PROVIDER_MODEL_ALLOWLIST="
+        "nvidia_nim/meta/llama3-70b,nvidia_nim/nvidia/nemotron-3-super" in text
+    )
+    assert "nvidia_nim/nvidia_nim/" not in text
+
+
 def test_admin_allowlist_post_with_empty_models_clears_entry(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -273,6 +273,148 @@ def test_admin_provider_cards_support_non_key_configuration():
     assert ": provider.configuration;" in script
 
 
+def test_admin_allowlist_get_returns_empty_when_unset(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    response = _local_client(app).get("/admin/api/providers/nvidia_nim/allowlist")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "provider_id": "nvidia_nim",
+        "models": [],
+        "restricted": False,
+    }
+
+
+def test_admin_allowlist_post_persists_and_get_reads_back(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": ["nvidia/nemotron-3-super", "meta/llama3-70b"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "applied": True,
+        "provider_id": "nvidia_nim",
+        "models": ["meta/llama3-70b", "nvidia/nemotron-3-super"],
+        "restricted": True,
+    }
+
+    env_file = tmp_path / ".fcc" / ".env"
+    text = env_file.read_text(encoding="utf-8")
+    assert (
+        "FCC_PROVIDER_MODEL_ALLOWLIST="
+        "nvidia_nim/meta/llama3-70b,nvidia_nim/nvidia/nemotron-3-super" in text
+    )
+
+    get_response = _local_client(app).get("/admin/api/providers/nvidia_nim/allowlist")
+    assert get_response.status_code == 200
+    assert get_response.json() == {
+        "provider_id": "nvidia_nim",
+        "models": ["meta/llama3-70b", "nvidia/nemotron-3-super"],
+        "restricted": True,
+    }
+
+
+def test_admin_allowlist_post_with_empty_models_clears_entry(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": ["nvidia/nemotron-3-super"]},
+    )
+    response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": [], "restricted": False},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "applied": True,
+        "provider_id": "nvidia_nim",
+        "models": [],
+        "restricted": False,
+    }
+    env_file = tmp_path / ".fcc" / ".env"
+    text = env_file.read_text(encoding="utf-8")
+    assert "FCC_PROVIDER_MODEL_ALLOWLIST=nvidia_nim/" not in text
+    assert "FCC_PROVIDER_MODEL_ALLOWLIST=" not in text or (
+        text.split("FCC_PROVIDER_MODEL_ALLOWLIST=")[1].splitlines()[0] == ""
+    )
+
+
+def test_admin_allowlist_post_restricted_empty_disables_provider(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": [], "restrict": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "applied": True,
+        "provider_id": "nvidia_nim",
+        "models": [],
+        "restricted": True,
+    }
+
+    env_file = tmp_path / ".fcc" / ".env"
+    text = env_file.read_text(encoding="utf-8")
+    assert "FCC_PROVIDER_MODEL_ALLOWLIST=nvidia_nim/__fcc_no_models__" in text
+
+    get_response = _local_client(app).get("/admin/api/providers/nvidia_nim/allowlist")
+    assert get_response.status_code == 200
+    assert get_response.json() == {
+        "provider_id": "nvidia_nim",
+        "models": [],
+        "restricted": True,
+    }
+
+
+def test_admin_allowlist_preserves_other_managed_values(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"MODEL": "open_router/test-model"}},
+    )
+    response = _local_client(app).post(
+        "/admin/api/providers/open_router/allowlist",
+        json={"models": ["google/gemini-pro"]},
+    )
+
+    assert response.status_code == 200
+    env_file = tmp_path / ".fcc" / ".env"
+    text = env_file.read_text(encoding="utf-8")
+    assert "MODEL=open_router/test-model" in text
+    assert "FCC_PROVIDER_MODEL_ALLOWLIST=open_router/google/gemini-pro" in text
+
+
+def test_admin_allowlist_hidden_from_config_response(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    response = _local_client(app).get("/admin/api/config")
+
+    assert response.status_code == 200
+    keys = [field["key"] for field in response.json()["fields"]]
+    assert "FCC_PROVIDER_MODEL_ALLOWLIST" not in keys
+
+
 def test_admin_page_no_longer_renders_generated_env_panel(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     app = create_test_app()

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -476,6 +476,60 @@ def test_admin_allowlist_hidden_from_config_response(monkeypatch, tmp_path):
     assert "FCC_PROVIDER_MODEL_ALLOWLIST" not in keys
 
 
+def test_admin_allowlist_post_rejected_when_locked_by_process_env(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    monkeypatch.setenv("FCC_PROVIDER_MODEL_ALLOWLIST", "nvidia_nim/locked-model")
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": ["admin-model"]},
+    )
+
+    assert response.status_code == 400
+    assert "locked" in response.json()["detail"]
+
+
+def test_admin_allowlist_post_rejected_when_locked_by_explicit_env_file(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    env_file = tmp_path / "locked.env"
+    env_file.write_text(
+        "FCC_PROVIDER_MODEL_ALLOWLIST=nvidia_nim/locked-model\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("FCC_ENV_FILE", str(env_file))
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": ["admin-model"]},
+    )
+
+    assert response.status_code == 400
+    assert "locked" in response.json()["detail"]
+
+
+def test_admin_allowlist_get_reflects_locked_process_env(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    monkeypatch.setenv("FCC_PROVIDER_MODEL_ALLOWLIST", "nvidia_nim/locked-model")
+    app = create_test_app()
+
+    response = _local_client(app).get("/admin/api/providers/nvidia_nim/allowlist")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "provider_id": "nvidia_nim",
+        "models": ["locked-model"],
+        "restricted": True,
+    }
+
+
 def test_admin_page_no_longer_renders_generated_env_panel(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     app = create_test_app()

--- a/tests/api/test_model_catalog.py
+++ b/tests/api/test_model_catalog.py
@@ -1,0 +1,319 @@
+"""Tests for gateway /v1/models allowlist filtering."""
+
+from fastapi.testclient import TestClient
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from tests.api.support import create_test_app, provider_manager_for_app
+
+
+def _settings(
+    *,
+    model: str = "deepseek/deepseek-chat",
+    model_fable: str | None = None,
+    model_opus: str | None = "open_router/anthropic/claude-opus",
+    model_haiku: str | None = "deepseek/deepseek-chat",
+    model_allowlist: list[str] | None = None,
+    provider_model_allowlists: dict[str, list[str]] | None = None,
+    nvidia_nim_api_key: str = "",
+) -> Settings:
+    return Settings.model_construct(
+        model=model,
+        model_fable=model_fable,
+        model_opus=model_opus,
+        model_sonnet=None,
+        model_haiku=model_haiku,
+        anthropic_auth_token="",
+        deepseek_api_key="deepseek-key",
+        open_router_api_key="open-router-key",
+        wafer_api_key="wafer-key",
+        nvidia_nim_api_key=nvidia_nim_api_key,
+        model_allowlist=model_allowlist or [],
+        provider_model_allowlists=provider_model_allowlists or {},
+    )
+
+
+def _cache_models(app, provider_id: str, *model_ids: str) -> None:
+    provider_manager_for_app(app).cache_model_infos(
+        provider_id,
+        {ProviderModelInfo(model_id) for model_id in model_ids},
+    )
+
+
+def _get_model_ids(response) -> list[str]:
+    return [item["id"] for item in response.json()["data"]]
+
+
+def test_gateway_models_list_respects_per_provider_allowlists():
+    """Models from a provider with a restriction that are NOT in its allowlist are absent."""
+    settings = _settings(
+        model="nvidia_nim/nvidia/nemotron-3-super",
+        model_opus=None,
+        provider_model_allowlists={
+            "nvidia_nim": ["nvidia/nemotron-3-super"],
+        },
+    )
+    app = create_test_app(settings)
+    _cache_models(app, "nvidia_nim", "nvidia/nemotron-3-super", "nvidia/other-model")
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # Allowed model should be present (both normal and no-thinking variants)
+    assert "anthropic/nvidia_nim/nvidia/nemotron-3-super" in ids
+    assert "claude-3-freecc-no-thinking/nvidia_nim/nvidia/nemotron-3-super" in ids
+
+    # Disallowed model should be absent
+    assert "anthropic/nvidia_nim/nvidia/other-model" not in ids
+    assert "claude-3-freecc-no-thinking/nvidia_nim/nvidia/other-model" not in ids
+
+
+def test_gateway_models_list_per_provider_allowlist_allows_specific_models():
+    """Models IN the allowlist are present with both variants."""
+    settings = _settings(
+        model_opus=None,
+        provider_model_allowlists={
+            "open_router": ["anthropic/claude-opus", "meta/llama-3.3"],
+        },
+    )
+    app = create_test_app(settings)
+    _cache_models(
+        app,
+        "open_router",
+        "anthropic/claude-opus",
+        "meta/llama-3.3",
+        "google/gemini-pro",
+    )
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # Allowed models should be present
+    assert "anthropic/open_router/anthropic/claude-opus" in ids
+    assert "claude-3-freecc-no-thinking/open_router/anthropic/claude-opus" in ids
+    assert "anthropic/open_router/meta/llama-3.3" in ids
+    assert "claude-3-freecc-no-thinking/open_router/meta/llama-3.3" in ids
+
+    # Disallowed model should be absent
+    assert "anthropic/open_router/google/gemini-pro" not in ids
+    assert "claude-3-freecc-no-thinking/open_router/google/gemini-pro" not in ids
+
+
+def test_gateway_models_list_falls_back_to_global_allowlist():
+    """Providers with no per-provider entry fall back to global model_allowlist."""
+    settings = _settings(
+        model_opus=None,
+        model_allowlist=["open_router/anthropic/claude-opus"],
+    )
+    app = create_test_app(settings)
+    _cache_models(app, "open_router", "anthropic/claude-opus", "meta/llama-3.3")
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # Only globally allowed model should be present
+    assert "anthropic/open_router/anthropic/claude-opus" in ids
+    assert "claude-3-freecc-no-thinking/open_router/anthropic/claude-opus" in ids
+
+    # Model not in global allowlist should be absent
+    assert "anthropic/open_router/meta/llama-3.3" not in ids
+    assert "claude-3-freecc-no-thinking/open_router/meta/llama-3.3" not in ids
+
+
+def test_gateway_models_list_empty_allowlists_shows_all():
+    """Empty allowlists => all models still listed (unchanged behavior)."""
+    settings = _settings(model_opus=None)
+    app = create_test_app(settings)
+    _cache_models(app, "open_router", "anthropic/claude-opus", "meta/llama-3.3")
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # All models should be present
+    assert "anthropic/open_router/anthropic/claude-opus" in ids
+    assert "claude-3-freecc-no-thinking/open_router/anthropic/claude-opus" in ids
+    assert "anthropic/open_router/meta/llama-3.3" in ids
+    assert "claude-3-freecc-no-thinking/open_router/meta/llama-3.3" in ids
+
+
+def test_gateway_models_list_supported_claude_models_always_present():
+    """SUPPORTED_CLAUDE_MODELS still always present even with a restrictive allowlist."""
+    settings = _settings(
+        model_opus=None,
+        model_allowlist=["open_router/anthropic/claude-opus"],
+    )
+    app = create_test_app(settings)
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # Claude compatibility models should always be present
+    assert "claude-opus-4-20250514" in ids
+    assert "claude-sonnet-4-20250514" in ids
+    assert "claude-haiku-4-20250514" in ids
+    assert "claude-3-opus-20240229" in ids
+
+
+def test_gateway_models_list_configured_refs_respect_allowlist():
+    """Configured model refs also respect allowlist filtering."""
+    settings = _settings(
+        model="nvidia_nim/nvidia/nemotron-3-super",
+        model_opus=None,
+        provider_model_allowlists={
+            "nvidia_nim": [
+                "nvidia/other-model"
+            ],  # nemotron-3-super is NOT in the allowlist
+        },
+    )
+    app = create_test_app(settings)
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # Configured model should be filtered out because it's not in the allowlist
+    assert "anthropic/nvidia_nim/nvidia/nemotron-3-super" not in ids
+    assert "claude-3-freecc-no-thinking/nvidia_nim/nvidia/nemotron-3-super" not in ids
+
+
+def test_gateway_models_list_mixed_allowlist_scenarios():
+    """Test complex scenario with both per-provider and global allowlists."""
+    settings = _settings(
+        model="deepseek/deepseek-chat",
+        model_opus=None,
+        model_allowlist=["deepseek/deepseek-chat"],
+        provider_model_allowlists={
+            "open_router": ["anthropic/claude-opus"],
+        },
+    )
+    app = create_test_app(settings)
+    _cache_models(app, "open_router", "anthropic/claude-opus", "meta/llama-3.3")
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # deepseek model should be present (in global allowlist)
+    assert "anthropic/deepseek/deepseek-chat" in ids
+    assert "claude-3-freecc-no-thinking/deepseek/deepseek-chat" in ids
+
+    # open_router: claude-opus should be present (in per-provider allowlist)
+    assert "anthropic/open_router/anthropic/claude-opus" in ids
+    assert "claude-3-freecc-no-thinking/open_router/anthropic/claude-opus" in ids
+
+    # open_router: llama-3.3 should be absent (not in per-provider allowlist, and open_router has per-provider entry)
+    assert "anthropic/open_router/meta/llama-3.3" not in ids
+    assert "claude-3-freecc-no-thinking/open_router/meta/llama-3.3" not in ids
+
+    # Claude compatibility models should always be present
+    assert "claude-opus-4-20250514" in ids
+
+
+def test_gateway_models_list_disabled_via_admin_api(monkeypatch, tmp_path):
+    """Disabling a provider via the admin API removes its models from /v1/models."""
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    settings = _settings(
+        model="nvidia_nim/nvidia/nemotron-3-super",
+        model_opus=None,
+        nvidia_nim_api_key="test-key",
+    )
+    app = create_test_app(settings)
+    _cache_models(
+        app,
+        "nvidia_nim",
+        "nvidia/nemotron-3-super",
+        "nvidia/other-model",
+    )
+
+    client = TestClient(app, client=("127.0.0.1", 50000))
+
+    # Verify nvidia_nim models are present before disabling
+    response = client.get("/v1/models")
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+    assert "anthropic/nvidia_nim/nvidia/nemotron-3-super" in ids
+    assert "anthropic/nvidia_nim/nvidia/other-model" in ids
+
+    # Disable nvidia_nim via admin API
+    response = client.post(
+        "/admin/api/providers/nvidia_nim/allowlist",
+        json={"models": [], "restricted": True},
+    )
+    assert response.status_code == 200
+    assert response.json()["restricted"] is True
+
+    # The admin API persists the allowlist to the managed env file.
+    from free_claude_code.config.admin.persistence import load_provider_allowlists
+
+    allowlists = load_provider_allowlists()
+    assert allowlists.get("nvidia_nim") == []
+
+    # A restarted app that reloads settings with the updated allowlist
+    # must exclude the disabled provider's models from /v1/models.
+    restarted_settings = _settings(
+        model="nvidia_nim/nvidia/nemotron-3-super",
+        model_opus=None,
+        nvidia_nim_api_key="test-key",
+        provider_model_allowlists={"nvidia_nim": []},
+    )
+    restarted_app = create_test_app(restarted_settings)
+    _cache_models(
+        restarted_app,
+        "nvidia_nim",
+        "nvidia/nemotron-3-super",
+        "nvidia/other-model",
+    )
+
+    response = TestClient(restarted_app).get("/v1/models")
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+    assert "anthropic/nvidia_nim/nvidia/nemotron-3-super" not in ids
+    assert "anthropic/nvidia_nim/nvidia/other-model" not in ids
+    assert "claude-opus-4-20250514" in ids
+
+
+def test_gateway_models_list_disabled_provider_shows_no_models():
+    """A provider restricted to zero models exposes no models via /v1/models."""
+    settings = _settings(
+        model="nvidia_nim/nvidia/nemotron-3-super",
+        model_opus=None,
+        provider_model_allowlists={
+            "nvidia_nim": [],  # restricted to nothing => provider disabled
+        },
+    )
+    app = create_test_app(settings)
+    _cache_models(
+        app,
+        "nvidia_nim",
+        "nvidia/nemotron-3-super",
+        "nvidia/other-model",
+    )
+
+    response = TestClient(app).get("/v1/models")
+
+    assert response.status_code == 200
+    ids = _get_model_ids(response)
+
+    # No nvidia_nim variants should appear (provider disabled)
+    assert "anthropic/nvidia_nim/nvidia/nemotron-3-super" not in ids
+    assert "claude-3-freecc-no-thinking/nvidia_nim/nvidia/nemotron-3-super" not in ids
+    assert "anthropic/nvidia_nim/nvidia/other-model" not in ids
+    assert "claude-3-freecc-no-thinking/nvidia_nim/nvidia/other-model" not in ids
+
+    # Claude compatibility models remain present
+    assert "claude-opus-4-20250514" in ids

--- a/tests/cli/test_codex_model_catalog.py
+++ b/tests/cli/test_codex_model_catalog.py
@@ -5,6 +5,7 @@ import subprocess
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -233,3 +234,167 @@ def test_catalog_writer_cleans_temporary_file_after_replace_failure(
 
     assert catalog_path.read_text(encoding="utf-8") == "previous\n"
     assert list(tmp_path.glob(".codex-model-catalog.json.*.tmp")) == []
+
+
+def test_codex_catalog_allowlist_filters_models() -> None:
+    settings = MagicMock()
+    settings.model_allowlist = [
+        "nvidia_nim/nvidia/nemotron-3-super",
+        "open_router/meta-llama/llama-3.3-70b",
+    ]
+
+    with patch(
+        "free_claude_code.cli.launchers.codex_model_catalog.get_settings",
+        return_value=settings,
+    ):
+        catalog = build_codex_model_catalog(
+            _models_payload(
+                "anthropic/nvidia_nim/nvidia/nemotron-3-super",
+                "anthropic/open_router/meta-llama/llama-3.3-70b",
+                "anthropic/open_router/google/gemini-pro",
+            )
+        )
+
+    assert _slugs(catalog) == [
+        "nvidia_nim/nvidia/nemotron-3-super",
+        "open_router/meta-llama/llama-3.3-70b",
+    ]
+
+
+def test_codex_catalog_empty_allowlist_shows_all() -> None:
+    settings = MagicMock()
+    settings.model_allowlist = []
+
+    with patch(
+        "free_claude_code.cli.launchers.codex_model_catalog.get_settings",
+        return_value=settings,
+    ):
+        catalog = build_codex_model_catalog(
+            _models_payload(
+                "anthropic/nvidia_nim/nvidia/nemotron-3-super",
+                "anthropic/open_router/google/gemini-pro",
+            )
+        )
+
+    assert _slugs(catalog) == [
+        "nvidia_nim/nvidia/nemotron-3-super",
+        "open_router/google/gemini-pro",
+    ]
+
+
+def test_codex_catalog_allowlist_excludes_non_matching_models() -> None:
+    settings = MagicMock()
+    settings.model_allowlist = ["open_router/google/gemini-pro"]
+
+    with patch(
+        "free_claude_code.cli.launchers.codex_model_catalog.get_settings",
+        return_value=settings,
+    ):
+        catalog = build_codex_model_catalog(
+            _models_payload(
+                "anthropic/nvidia_nim/nvidia/nemotron-3-super",
+                "anthropic/open_router/google/gemini-pro",
+                "anthropic/open_router/meta-llama/llama-3.3-70b",
+            )
+        )
+
+    assert _slugs(catalog) == ["open_router/google/gemini-pro"]
+
+
+def test_codex_catalog_allowlist_with_no_thinking_prefix() -> None:
+    settings = MagicMock()
+    settings.model_allowlist = [
+        "claude-3-freecc-no-thinking/open_router/google/gemini-pro"
+    ]
+
+    with patch(
+        "free_claude_code.cli.launchers.codex_model_catalog.get_settings",
+        return_value=settings,
+    ):
+        catalog = build_codex_model_catalog(
+            _models_payload(
+                "claude-3-freecc-no-thinking/open_router/google/gemini-pro",
+            )
+        )
+
+    assert _slugs(catalog) == [
+        "claude-3-freecc-no-thinking/open_router/google/gemini-pro"
+    ]
+
+
+def test_codex_catalog_provider_allowlist_filters_that_provider_only() -> None:
+    settings = MagicMock()
+    settings.provider_model_allowlists = {
+        "nvidia_nim": ["nvidia/nemotron-3-super"],
+    }
+    settings.model_allowlist = []
+
+    with patch(
+        "free_claude_code.cli.launchers.codex_model_catalog.get_settings",
+        return_value=settings,
+    ):
+        catalog = build_codex_model_catalog(
+            _models_payload(
+                "anthropic/nvidia_nim/nvidia/nemotron-3-super",
+                "anthropic/nvidia_nim/nvidia/other-model",
+                "anthropic/open_router/google/gemini-pro",
+                "anthropic/open_router/meta-llama/llama-3.3-70b",
+            )
+        )
+
+    # nvidia_nim is restricted to nemotron-3-super; open_router is untouched.
+    assert _slugs(catalog) == [
+        "nvidia_nim/nvidia/nemotron-3-super",
+        "open_router/google/gemini-pro",
+        "open_router/meta-llama/llama-3.3-70b",
+    ]
+
+
+def test_codex_catalog_provider_allowlist_takes_precedence_over_global() -> None:
+    settings = MagicMock()
+    settings.provider_model_allowlists = {
+        "open_router": ["google/gemini-pro"],
+    }
+    settings.model_allowlist = ["open_router/meta-llama/llama-3.3-70b"]
+
+    with patch(
+        "free_claude_code.cli.launchers.codex_model_catalog.get_settings",
+        return_value=settings,
+    ):
+        catalog = build_codex_model_catalog(
+            _models_payload(
+                "anthropic/open_router/google/gemini-pro",
+                "anthropic/open_router/meta-llama/llama-3.3-70b",
+                "anthropic/nvidia_nim/nvidia/nemotron-3-super",
+            )
+        )
+
+    # open_router follows its per-provider list, not the global allowlist.
+    # nvidia_nim has no per-provider entry, so the global allowlist applies
+    # and excludes nemotron-3-super.
+    assert _slugs(catalog) == [
+        "open_router/google/gemini-pro",
+    ]
+
+
+def test_codex_catalog_provider_allowlist_restricts_no_thinking_entries() -> None:
+    settings = MagicMock()
+    settings.provider_model_allowlists = {
+        "open_router": ["google/gemini-pro"],
+    }
+    settings.model_allowlist = []
+
+    with patch(
+        "free_claude_code.cli.launchers.codex_model_catalog.get_settings",
+        return_value=settings,
+    ):
+        catalog = build_codex_model_catalog(
+            _models_payload(
+                "claude-3-freecc-no-thinking/open_router/google/gemini-pro",
+                "claude-3-freecc-no-thinking/open_router/meta-llama/llama-3.3-70b",
+            )
+        )
+
+    assert _slugs(catalog) == [
+        "claude-3-freecc-no-thinking/open_router/google/gemini-pro"
+    ]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -942,6 +942,29 @@ class TestPerModelMapping:
         with pytest.raises(ValidationError, match="Invalid provider"):
             Settings()
 
+    def test_provider_model_allowlists_from_env(self, monkeypatch):
+        """FCC_PROVIDER_MODEL_ALLOWLIST env var is parsed into per-provider lists."""
+        from free_claude_code.config.settings import Settings
+
+        monkeypatch.setenv(
+            "FCC_PROVIDER_MODEL_ALLOWLIST",
+            "open_router/anthropic/claude-3-opus,open_router/google/gemini-pro,"
+            "nvidia_nim/nvidia/nemotron-3-super",
+        )
+        s = Settings()
+        assert s.provider_model_allowlists == {
+            "open_router": ["anthropic/claude-3-opus", "google/gemini-pro"],
+            "nvidia_nim": ["nvidia/nemotron-3-super"],
+        }
+
+    def test_provider_model_allowlists_empty_env(self, monkeypatch):
+        """Empty FCC_PROVIDER_MODEL_ALLOWLIST yields an empty dict."""
+        from free_claude_code.config.settings import Settings
+
+        monkeypatch.setenv("FCC_PROVIDER_MODEL_ALLOWLIST", "")
+        s = Settings()
+        assert s.provider_model_allowlists == {}
+
     def test_model_fable_invalid_provider_raises(self, monkeypatch):
         """MODEL_FABLE with invalid provider prefix raises ValidationError."""
         from free_claude_code.config.settings import Settings

--- a/tests/runtime/test_codex_catalog.py
+++ b/tests/runtime/test_codex_catalog.py
@@ -2,8 +2,6 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.application.ports import (
     RequestRuntimeLease,
@@ -83,18 +81,15 @@ def test_startup_publication_creates_missing_catalog_and_preserves_existing(
     assert catalog_path.read_text(encoding="utf-8") == "complete prior catalog\n"
 
 
-def test_empty_projection_preserves_existing_catalog(tmp_path: Path) -> None:
+def test_empty_projection_publishes_empty_catalog(tmp_path: Path) -> None:
     catalog_path = tmp_path / "codex-model-catalog.json"
     catalog_path.write_text("last known good\n", encoding="utf-8")
     publisher = CodexModelCatalogPublisher(catalog_path)
 
-    with (
-        patch(
-            "free_claude_code.runtime.codex_catalog.build_codex_model_catalog",
-            return_value={"models": []},
-        ),
-        pytest.raises(ValueError, match="no routable models"),
+    with patch(
+        "free_claude_code.runtime.codex_catalog.build_codex_model_catalog",
+        return_value={"models": []},
     ):
         publisher.publish(_runtime())
 
-    assert catalog_path.read_text(encoding="utf-8") == "last known good\n"
+    assert json.loads(catalog_path.read_text(encoding="utf-8")) == {"models": []}

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.7"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Adds per-provider model allowlists so users can restrict which models each provider advertises.
- FCC_PROVIDER_MODEL_ALLOWLIST: comma-separated provider/model pairs; empty list or provider/__fcc_no_models__ disables a provider
- Admin API + UI: POST /admin/api/providers/{id}/allowlist to restrict or clear
- Changes apply live — no server restart needed
- Redundant provider prefixes normalized on save
- Version bumped to 4.17.0
Tested in claude, codex, and pi clients. Not sure about some edge cases (e.g. allowlisted models the provider doesn't advertise)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds provider-specific model allowlists across configuration, the Admin interface, gateway model discovery, and Codex catalog publication. Browser verification reproduced a failure in the Admin selector: if a provider allowlist request fails while no models are discovered, saving the empty selector persists that provider as unrestricted.

<h3>Confidence Score: 4/5</h3>

<details open><summary><h3>Security Review</h3></summary>

Provider allowlists control which models may be exposed through each provider. The Admin interface currently converts a failed allowlist read into an unrestricted saved state, so an administrator can unintentionally re-enable a provider that was previously restricted or disabled.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a P1 finding proof for the posted issue, with visuals showing the allowlist read failure and the safe-fallback selector behavior.
- A second P1 finding proof was produced to broaden coverage of the same issue.
- General-contract-validation confirmed the exact candidate request POST /admin/api/providers/restricted\_provider/allowlist and located the code path in src/free\_claude\_code/api/admin\_static/admin.js, highlighting the risk of silent re-enabling a restricted provider.
- Artifacts from the proofs were organized and linked, including repro videos, UI state images, and browser logs to support the findings.
- The evidence set includes a reproducible Chromium allowlist repro source and browser repro outputs to aid review.

<a href="https://app.greptile.com/trex/runs/17508075/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: reject locked allowlist edits and p..."](https://github.com/alishahryar1/free-claude-code/commit/b06fe014918cedb0cc84dd6907a055bb35ca2d86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50509860)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->