### PR TITLE
Make OpenCode Zen mappings explicit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,7 +121,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -147,7 +147,7 @@ FCC_SMOKE_MODEL_KIMI=
 FCC_SMOKE_MODEL_KIMI_CODE=
 FCC_SMOKE_MODEL_WAFER=
 FCC_SMOKE_MODEL_MINIMAX=
-FCC_SMOKE_MODEL_OPENCODE=
+FCC_SMOKE_MODEL_OPENCODE_ZEN=
 FCC_SMOKE_MODEL_OPENCODE_GO=
 FCC_SMOKE_MODEL_VERCEL=
 FCC_SMOKE_MODEL_BEDROCK=
@@ -194,7 +194,7 @@ KIMI_PROXY=""
 KIMI_CODE_PROXY=""
 WAFER_PROXY=""
 MINIMAX_PROXY=""
-OPENCODE_PROXY=""
+OPENCODE_ZEN_PROXY=""
 OPENCODE_GO_PROXY=""
 VERCEL_AI_GATEWAY_PROXY=""
 BEDROCK_PROXY=""

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -342,9 +342,10 @@ Model routing configuration is tiered:
   `REASONING_HAIKU` accept the same values plus `inherit`.
 
 [config/reasoning.py](src/free_claude_code/config/reasoning.py) owns the typed
-configuration vocabulary. FCC-owned dotenv files receive a one-time rename and
-value migration from the retired boolean settings; explicit `FCC_ENV_FILE`
-files are never rewritten and instead receive an actionable startup warning.
+configuration vocabulary. FCC-owned dotenv files receive one-time migrations
+for retired configuration keys and values before Settings loads them. Explicit
+`FCC_ENV_FILE` files are never rewritten and instead receive an actionable
+startup warning.
 
 [config/model_refs.py](src/free_claude_code/config/model_refs.py) owns provider-prefixed model ref
 parsing and configured `MODEL*` inventory. API routing and provider validation

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ fcc-codex exec "hello"
 | [DeepSeek](https://platform.deepseek.com/api_keys) | `DEEPSEEK_API_KEY` | `deepseek/deepseek-chat` |
 | [Mistral La Plateforme](https://console.mistral.ai/) | `MISTRAL_API_KEY` | `mistral/devstral-small-latest` |
 | [Mistral Codestral](https://console.mistral.ai/) | `CODESTRAL_API_KEY` | `mistral_codestral/codestral-latest` |
-| [OpenCode Zen](https://opencode.ai/auth) | `OPENCODE_API_KEY` | `opencode/gpt-5.3-codex` |
+| [OpenCode Zen](https://opencode.ai/auth) | `OPENCODE_API_KEY` | `opencode_zen/gpt-5.3-codex` |
 | [OpenCode Go](https://opencode.ai/auth) | `OPENCODE_API_KEY` | `opencode_go/minimax-m2.7` |
 | [Vercel AI Gateway](https://vercel.com/docs/ai-gateway/models-and-providers) | `AI_GATEWAY_API_KEY` | `vercel/openai/gpt-5.5` |
 | [Amazon Bedrock](https://console.aws.amazon.com/bedrock/) | `AWS_BEARER_TOKEN_BEDROCK` | `bedrock/openai.gpt-oss-120b` |
@@ -216,7 +216,8 @@ Important provider notes:
 - Kimi Code subscription keys use `kimi_code/`; Kimi API credit keys use
   `kimi/`. Kimi Code plans are for personal interactive coding-agent use under
   [Kimi's community guidelines](https://www.kimi.com/code/docs/en/kimi-code/community-guidelines.html).
-- OpenCode Zen and OpenCode Go share `OPENCODE_API_KEY` but use different model prefixes.
+- OpenCode Zen and OpenCode Go share `OPENCODE_API_KEY` but use the explicit
+  `opencode_zen/` and `opencode_go/` model prefixes.
 - Amazon Bedrock uses its Mantle OpenAI-compatible endpoint. Set
   `BEDROCK_BASE_URL` to the endpoint for the same region as the API key and
   select one of the models returned by FCC's model picker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.7"
+version = "4.16.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -59,7 +59,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "kimi_code": "kimi_code/k3",
     "wafer": "wafer/DeepSeek-V4-Pro",
     "minimax": "minimax/MiniMax-M3",
-    "opencode": "opencode/gpt-5.3-codex",
+    "opencode_zen": "opencode_zen/gpt-5.3-codex",
     "opencode_go": "opencode_go/minimax-m2.7",
     "vercel": "vercel/openai/gpt-5.5",
     "bedrock": "bedrock/openai.gpt-oss-120b",

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -192,7 +192,7 @@ def load_server_settings() -> Settings:
     """Apply owned config migrations before returning the cached settings."""
 
     _migrate_legacy_env_if_missing()
-    _migrate_config_env_keys()
+    _migrate_config_env()
     return get_settings()
 
 
@@ -238,8 +238,8 @@ def _migrate_legacy_env_if_missing() -> Path | None:
     return None
 
 
-def _migrate_config_env_keys() -> tuple[Path, ...]:
-    """Apply dotenv key migrations before Settings loads config."""
+def _migrate_config_env() -> tuple[Path, ...]:
+    """Apply dotenv migrations before Settings loads config."""
 
     migrated = migrate_owned_env_files()
     if warning := explicit_env_file_migration_warning(os.environ):

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -640,7 +640,7 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         advanced=True,
     ),
     ConfigFieldSpec(
-        "FCC_SMOKE_MODEL_OPENCODE",
+        "FCC_SMOKE_MODEL_OPENCODE_ZEN",
         "Smoke OpenCode Zen Model",
         "smoke",
         advanced=True,

--- a/src/free_claude_code/config/env_migrations.py
+++ b/src/free_claude_code/config/env_migrations.py
@@ -1,4 +1,4 @@
-"""One-time dotenv key migrations for FCC-owned config files."""
+"""One-time dotenv migrations for FCC-owned config files."""
 
 import re
 from collections.abc import Mapping
@@ -10,6 +10,10 @@ from .paths import managed_env_path
 
 LEGACY_HUGGINGFACE_TOKEN_ENV = "HF_TOKEN"
 HUGGINGFACE_API_KEY_ENV = "HUGGINGFACE_API_KEY"
+LEGACY_OPENCODE_PROXY_ENV = "OPENCODE_PROXY"
+OPENCODE_ZEN_PROXY_ENV = "OPENCODE_ZEN_PROXY"
+LEGACY_OPENCODE_SMOKE_MODEL_ENV = "FCC_SMOKE_MODEL_OPENCODE"
+OPENCODE_ZEN_SMOKE_MODEL_ENV = "FCC_SMOKE_MODEL_OPENCODE_ZEN"
 
 _DOTENV_ASSIGNMENT_RE = re.compile(
     r"^(?P<prefix>\s*(?:export\s+)?)(?P<key>[A-Za-z_][A-Za-z0-9_]*)(?P<suffix>\s*(?:=|$))"
@@ -17,15 +21,16 @@ _DOTENV_ASSIGNMENT_RE = re.compile(
 
 
 @dataclass(frozen=True, slots=True)
-class EnvKeyMigration:
-    """A dotenv key rename migration."""
+class EnvMigration:
+    """A migration for one dotenv setting."""
 
     old_key: str
     new_key: str
     value_map: tuple[tuple[str, str], ...] = ()
+    value_prefix_map: tuple[tuple[str, str], ...] = ()
 
 
-HUGGINGFACE_TOKEN_MIGRATION = EnvKeyMigration(
+HUGGINGFACE_TOKEN_MIGRATION = EnvMigration(
     old_key=LEGACY_HUGGINGFACE_TOKEN_ENV,
     new_key=HUGGINGFACE_API_KEY_ENV,
 )
@@ -38,13 +43,13 @@ _LEGACY_REASONING_BOOLEAN_MAP = (
 )
 
 REASONING_MIGRATIONS = (
-    EnvKeyMigration(
+    EnvMigration(
         "ENABLE_MODEL_THINKING",
         "REASONING_POLICY",
         _LEGACY_REASONING_BOOLEAN_MAP,
     ),
     *(
-        EnvKeyMigration(
+        EnvMigration(
             f"ENABLE_{route}_THINKING",
             f"REASONING_{route}",
             (("", "inherit"), *_LEGACY_REASONING_BOOLEAN_MAP),
@@ -53,17 +58,47 @@ REASONING_MIGRATIONS = (
     ),
 )
 
-ENV_MIGRATIONS = (HUGGINGFACE_TOKEN_MIGRATION, *REASONING_MIGRATIONS)
+OPENCODE_ZEN_KEY_MIGRATIONS = (
+    EnvMigration(LEGACY_OPENCODE_PROXY_ENV, OPENCODE_ZEN_PROXY_ENV),
+    EnvMigration(
+        LEGACY_OPENCODE_SMOKE_MODEL_ENV,
+        OPENCODE_ZEN_SMOKE_MODEL_ENV,
+        value_prefix_map=(("opencode/", "opencode_zen/"),),
+    ),
+)
+
+OPENCODE_ZEN_MODEL_REF_MIGRATIONS = tuple(
+    EnvMigration(
+        key,
+        key,
+        value_prefix_map=(("opencode/", "opencode_zen/"),),
+    )
+    for key in (
+        "MODEL",
+        "MODEL_FABLE",
+        "MODEL_OPUS",
+        "MODEL_SONNET",
+        "MODEL_HAIKU",
+        OPENCODE_ZEN_SMOKE_MODEL_ENV,
+    )
+)
+
+ENV_MIGRATIONS = (
+    HUGGINGFACE_TOKEN_MIGRATION,
+    *REASONING_MIGRATIONS,
+    *OPENCODE_ZEN_KEY_MIGRATIONS,
+    *OPENCODE_ZEN_MODEL_REF_MIGRATIONS,
+)
 
 
 def migrate_owned_env_files() -> tuple[Path, ...]:
-    """Apply key migrations to repo and managed dotenv files."""
+    """Apply config migrations to repo and managed dotenv files."""
 
     changed_paths: list[Path] = []
     for path in _unique_paths((repo_env_path(), managed_env_path())):
         changed = False
         for migration in ENV_MIGRATIONS:
-            changed = migrate_env_key_in_file(path, migration) or changed
+            changed = migrate_env_setting_in_file(path, migration) or changed
         if changed:
             changed_paths.append(path.resolve())
     return tuple(changed_paths)
@@ -85,35 +120,41 @@ def explicit_env_file_migration_warning(
     )
     if not pending:
         return None
-    renames = ", ".join(
-        f"{migration.old_key} to {migration.new_key}" for migration in pending
-    )
+    actions: list[str] = []
+    for migration in pending:
+        if migration.old_key != migration.new_key:
+            actions.append(f"rename {migration.old_key} to {migration.new_key}")
+        actions.extend(
+            f"replace {old_prefix} with {new_prefix} in {migration.new_key}"
+            for old_prefix, new_prefix in migration.value_prefix_map
+        )
     return (
-        f"Explicit FCC_ENV_FILE {path} uses retired settings. Rename {renames}; "
+        f"Explicit FCC_ENV_FILE {path} uses retired settings. "
+        f"{'; '.join(actions)}; "
         "explicit env files are not rewritten automatically."
     )
 
 
-def migrate_env_key_in_file(path: Path, migration: EnvKeyMigration) -> bool:
-    """Rename a dotenv key in ``path`` when the new key is absent."""
+def migrate_env_setting_in_file(path: Path, migration: EnvMigration) -> bool:
+    """Apply one setting migration to ``path``."""
 
     if not path.is_file():
         return False
     original = path.read_text(encoding="utf-8")
-    migrated, changed = migrate_env_key_in_text(original, migration)
+    migrated, changed = migrate_env_setting_in_text(original, migration)
     if not changed:
         return False
     path.write_text(migrated, encoding="utf-8")
     return True
 
 
-def migrate_env_key_in_text(
+def migrate_env_setting_in_text(
     text: str,
-    migration: EnvKeyMigration,
+    migration: EnvMigration,
 ) -> tuple[str, bool]:
-    """Return text with ``old_key`` renamed to ``new_key`` when safe."""
+    """Return text with one setting migration applied when safe."""
 
-    if _defines_key(text, migration.new_key):
+    if migration.old_key != migration.new_key and _defines_key(text, migration.new_key):
         return text, False
 
     lines = text.splitlines(keepends=True)
@@ -125,22 +166,25 @@ def migrate_env_key_in_text(
         remainder = line[match.end() :]
         if migration.value_map:
             remainder = _mapped_value(remainder, migration.value_map)
-        lines[index] = (
+        for old_prefix, new_prefix in migration.value_prefix_map:
+            remainder = _mapped_prefix_value(remainder, old_prefix, new_prefix)
+        migrated_line = (
             f"{match.group('prefix')}{migration.new_key}{match.group('suffix')}"
             f"{remainder}"
         )
+        if migrated_line == line:
+            continue
+        lines[index] = migrated_line
         changed = True
     if not changed:
         return text, False
     return "".join(lines), True
 
 
-def env_text_needs_migration(text: str, migration: EnvKeyMigration) -> bool:
-    """Return whether text defines old key without new key."""
+def env_text_needs_migration(text: str, migration: EnvMigration) -> bool:
+    """Return whether one setting migration would change text."""
 
-    return _defines_key(text, migration.old_key) and not _defines_key(
-        text, migration.new_key
-    )
+    return migrate_env_setting_in_text(text, migration)[1]
 
 
 def _defines_key(text: str, key: str) -> bool:
@@ -165,6 +209,18 @@ def _mapped_value(value: str, mapping: tuple[tuple[str, str], ...]) -> str:
         return value
     suffix = f" #{comment}" if separator else ""
     return f"{replacement}{suffix}{newline}"
+
+
+def _mapped_prefix_value(value: str, old_prefix: str, new_prefix: str) -> str:
+    """Rewrite one simple dotenv value while preserving its original syntax."""
+
+    pattern = rf"^(?P<leading>\s*['\"]?){re.escape(old_prefix)}"
+    return re.sub(
+        pattern,
+        lambda match: f"{match.group('leading')}{new_prefix}",
+        value,
+        count=1,
+    )
 
 
 def _unique_paths(paths: tuple[Path, ...]) -> tuple[Path, ...]:

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -28,7 +28,7 @@ LMSTUDIO_DEFAULT_BASE = "http://localhost:1234/v1"
 LLAMACPP_DEFAULT_BASE = "http://localhost:8080/v1"
 OLLAMA_DEFAULT_BASE = "http://localhost:11434"
 OLLAMA_CLOUD_DEFAULT_BASE = "https://ollama.com/v1"
-OPENCODE_DEFAULT_BASE = "https://opencode.ai/zen/v1"
+OPENCODE_ZEN_DEFAULT_BASE = "https://opencode.ai/zen/v1"
 OPENCODE_GO_DEFAULT_BASE = "https://opencode.ai/zen/go/v1"
 VERCEL_AI_GATEWAY_DEFAULT_BASE = "https://ai-gateway.vercel.sh/v1"
 # Amazon Bedrock Mantle OpenAI-compatible endpoint. The base URL remains
@@ -171,14 +171,14 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=CODESTRAL_DEFAULT_BASE,
         proxy_attr="codestral_proxy",
     ),
-    "opencode": ProviderDescriptor(
-        provider_id="opencode",
+    "opencode_zen": ProviderDescriptor(
+        provider_id="opencode_zen",
         display_name="OpenCode Zen",
         credential_env="OPENCODE_API_KEY",
         credential_url="https://opencode.ai/auth",
         credential_attr="opencode_api_key",
-        default_base_url=OPENCODE_DEFAULT_BASE,
-        proxy_attr="opencode_proxy",
+        default_base_url=OPENCODE_ZEN_DEFAULT_BASE,
+        proxy_attr="opencode_zen_proxy",
     ),
     "opencode_go": ProviderDescriptor(
         provider_id="opencode_go",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -53,7 +53,7 @@ class Settings(BaseSettings):
     minimax_api_key: str = Field(default="", validation_alias="MINIMAX_API_KEY")
 
     # ==================== OpenCode Zen / OpenCode Go ====================
-    # Same key from opencode.ai/auth; zen uses prefix ``opencode/``, Go uses ``opencode_go/``.
+    # Same key from opencode.ai/auth; Zen uses ``opencode_zen/``, Go uses ``opencode_go/``.
     opencode_api_key: str = Field(default="", validation_alias="OPENCODE_API_KEY")
 
     # ==================== Vercel AI Gateway ====================
@@ -173,7 +173,7 @@ class Settings(BaseSettings):
     kimi_code_proxy: str = Field(default="", validation_alias="KIMI_CODE_PROXY")
     wafer_proxy: str = Field(default="", validation_alias="WAFER_PROXY")
     minimax_proxy: str = Field(default="", validation_alias="MINIMAX_PROXY")
-    opencode_proxy: str = Field(default="", validation_alias="OPENCODE_PROXY")
+    opencode_zen_proxy: str = Field(default="", validation_alias="OPENCODE_ZEN_PROXY")
     opencode_go_proxy: str = Field(default="", validation_alias="OPENCODE_GO_PROXY")
     vercel_ai_gateway_proxy: str = Field(
         default="", validation_alias="VERCEL_AI_GATEWAY_PROXY"

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -156,8 +156,8 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         _policy("CODESTRAL", ReasoningReplayMode.THINK_TAGS),
         NO_REASONING,
     ),
-    "opencode": OpenAIChatProfile(
-        _policy("OPENCODE", ReasoningReplayMode.REASONING_CONTENT),
+    "opencode_zen": OpenAIChatProfile(
+        _policy("OPENCODE_ZEN", ReasoningReplayMode.REASONING_CONTENT),
         NO_REASONING,
     ),
     "opencode_go": OpenAIChatProfile(

--- a/tests/application/test_routing.py
+++ b/tests/application/test_routing.py
@@ -149,6 +149,20 @@ def test_model_router_routes_prefixed_provider_model_directly(settings):
     assert routed.resolved.provider_model_ref == "deepseek/deepseek-chat"
 
 
+def test_model_router_routes_explicit_opencode_zen_prefix(settings):
+    routed = ModelRouter(settings).resolve_messages_request(
+        MessagesRequest(
+            model="opencode_zen/kimi-k2.6",
+            max_tokens=100,
+            messages=[Message(role="user", content="hello")],
+        )
+    )
+
+    assert routed.request.model == "kimi-k2.6"
+    assert routed.resolved.provider_id == "opencode_zen"
+    assert routed.resolved.provider_model_ref == "opencode_zen/kimi-k2.6"
+
+
 def test_model_router_routes_wafer_provider_model_directly(settings):
     routed = ModelRouter(settings).resolve_messages_request(
         MessagesRequest(

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -346,7 +346,39 @@ def test_serve_migrates_hf_token_before_loading_settings(
     get_settings.assert_called_once_with()
 
 
-def test_config_env_key_migration_warns_for_explicit_env_file(
+def test_serve_migrates_opencode_zen_prefix_before_loading_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from free_claude_code.cli import commands
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env_file = repo / ".env"
+    env_file.write_text("MODEL=opencode/model\n", encoding="utf-8")
+    settings = _launcher_settings()
+
+    def load_settings() -> Settings:
+        assert env_file.read_text(encoding="utf-8") == ("MODEL=opencode_zen/model\n")
+        return settings
+
+    get_settings = MagicMock(side_effect=load_settings)
+    get_settings.cache_clear = MagicMock()
+    monkeypatch.chdir(repo)
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch.object(commands, "get_settings", get_settings),
+        patch.object(commands.ServerSupervisor, "_run_once", return_value=False),
+        patch.object(commands, "kill_all_best_effort"),
+        patch.object(commands, "explicit_env_file_migration_warning"),
+    ):
+        commands.serve()
+
+    get_settings.assert_called_once_with()
+
+
+def test_config_env_migration_warns_for_explicit_env_file(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -356,7 +388,7 @@ def test_config_env_key_migration_warns_for_explicit_env_file(
     explicit.write_text("HF_TOKEN=legacy-hf\n", encoding="utf-8")
 
     with patch.dict(commands.os.environ, {"FCC_ENV_FILE": str(explicit)}):
-        migrated = commands._migrate_config_env_keys()
+        migrated = commands._migrate_config_env()
 
     assert migrated == ()
     assert "HF_TOKEN" in capsys.readouterr().err

--- a/tests/config/test_env_migrations.py
+++ b/tests/config/test_env_migrations.py
@@ -6,11 +6,14 @@ from free_claude_code.config.env_migrations import (
     HUGGINGFACE_API_KEY_ENV,
     HUGGINGFACE_TOKEN_MIGRATION,
     LEGACY_HUGGINGFACE_TOKEN_ENV,
+    LEGACY_OPENCODE_PROXY_ENV,
+    OPENCODE_ZEN_MODEL_REF_MIGRATIONS,
+    OPENCODE_ZEN_PROXY_ENV,
     REASONING_MIGRATIONS,
     env_text_needs_migration,
     explicit_env_file_migration_warning,
-    migrate_env_key_in_file,
-    migrate_env_key_in_text,
+    migrate_env_setting_in_file,
+    migrate_env_setting_in_text,
     migrate_owned_env_files,
 )
 
@@ -18,7 +21,7 @@ from free_claude_code.config.env_migrations import (
 def test_migrate_env_key_in_text_renames_legacy_hf_token() -> None:
     text = "# comment\nHF_TOKEN=old-token\nMODEL=nvidia_nim/model\n"
 
-    migrated, changed = migrate_env_key_in_text(text, HUGGINGFACE_TOKEN_MIGRATION)
+    migrated, changed = migrate_env_setting_in_text(text, HUGGINGFACE_TOKEN_MIGRATION)
 
     assert changed is True
     assert migrated == (
@@ -29,7 +32,7 @@ def test_migrate_env_key_in_text_renames_legacy_hf_token() -> None:
 def test_migrate_env_key_in_text_preserves_existing_huggingface_api_key() -> None:
     text = "HF_TOKEN=old-token\nHUGGINGFACE_API_KEY=new-token\n"
 
-    migrated, changed = migrate_env_key_in_text(text, HUGGINGFACE_TOKEN_MIGRATION)
+    migrated, changed = migrate_env_setting_in_text(text, HUGGINGFACE_TOKEN_MIGRATION)
 
     assert changed is False
     assert migrated == text
@@ -38,7 +41,7 @@ def test_migrate_env_key_in_text_preserves_existing_huggingface_api_key() -> Non
 def test_migrate_env_key_in_text_ignores_comments() -> None:
     text = "# HF_TOKEN=old-token\n"
 
-    migrated, changed = migrate_env_key_in_text(text, HUGGINGFACE_TOKEN_MIGRATION)
+    migrated, changed = migrate_env_setting_in_text(text, HUGGINGFACE_TOKEN_MIGRATION)
 
     assert changed is False
     assert migrated == text
@@ -49,7 +52,7 @@ def test_migrate_env_key_in_file_rewrites_dotenv(tmp_path: Path) -> None:
     env_file = tmp_path / ".env"
     env_file.write_text("export HF_TOKEN = quoted-token\n", encoding="utf-8")
 
-    assert migrate_env_key_in_file(env_file, HUGGINGFACE_TOKEN_MIGRATION) is True
+    assert migrate_env_setting_in_file(env_file, HUGGINGFACE_TOKEN_MIGRATION) is True
 
     assert env_file.read_text(encoding="utf-8") == (
         "export HUGGINGFACE_API_KEY = quoted-token\n"
@@ -95,6 +98,85 @@ def test_explicit_env_file_migration_warning_does_not_rewrite(
     assert explicit.read_text(encoding="utf-8") == "HF_TOKEN=explicit-token\n"
 
 
+def test_opencode_zen_migration_rewrites_owned_model_refs_and_keys(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env_file = repo / ".env"
+    env_file.write_text(
+        "MODEL=opencode/kimi-k2.6\n"
+        'MODEL_FABLE = "opencode/model-a" # keep\n'
+        "MODEL_OPUS='opencode/model-b'\n"
+        "MODEL_SONNET=opencode_go/model-c\n"
+        "MODEL_HAIKU=open_router/opencode/model-d\n"
+        "FCC_SMOKE_MODEL_OPENCODE=opencode/smoke\n"
+        "OPENCODE_PROXY=http://proxy.example\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    assert migrate_owned_env_files() == (env_file,)
+    assert env_file.read_text(encoding="utf-8") == (
+        "MODEL=opencode_zen/kimi-k2.6\n"
+        'MODEL_FABLE = "opencode_zen/model-a" # keep\n'
+        "MODEL_OPUS='opencode_zen/model-b'\n"
+        "MODEL_SONNET=opencode_go/model-c\n"
+        "MODEL_HAIKU=open_router/opencode/model-d\n"
+        "FCC_SMOKE_MODEL_OPENCODE_ZEN=opencode_zen/smoke\n"
+        "OPENCODE_ZEN_PROXY=http://proxy.example\n"
+    )
+    assert migrate_owned_env_files() == ()
+
+
+def test_opencode_zen_value_migration_ignores_comments_and_other_values() -> None:
+    text = (
+        "# MODEL=opencode/commented\n"
+        "MODEL=opencode_go/model\n"
+        "MODEL_OPUS=open_router/opencode/model\n"
+    )
+
+    migrated = text
+    changed = False
+    for migration in OPENCODE_ZEN_MODEL_REF_MIGRATIONS:
+        migrated, migration_changed = migrate_env_setting_in_text(
+            migrated,
+            migration,
+        )
+        changed = changed or migration_changed
+
+    assert changed is False
+    assert migrated == text
+    assert not any(
+        env_text_needs_migration(text, migration)
+        for migration in OPENCODE_ZEN_MODEL_REF_MIGRATIONS
+    )
+
+
+def test_explicit_env_file_warns_for_opencode_zen_migrations(
+    tmp_path: Path,
+) -> None:
+    explicit = tmp_path / "custom.env"
+    explicit.write_text(
+        "MODEL=opencode/model\nOPENCODE_PROXY=http://proxy.example\n",
+        encoding="utf-8",
+    )
+
+    warning = explicit_env_file_migration_warning({"FCC_ENV_FILE": str(explicit)})
+
+    assert warning is not None
+    assert LEGACY_OPENCODE_PROXY_ENV in warning
+    assert OPENCODE_ZEN_PROXY_ENV in warning
+    assert "opencode/" in warning
+    assert "opencode_zen/" in warning
+    assert explicit.read_text(encoding="utf-8") == (
+        "MODEL=opencode/model\nOPENCODE_PROXY=http://proxy.example\n"
+    )
+
+
 def test_reasoning_migrations_rename_and_map_boolean_values() -> None:
     text = (
         "ENABLE_MODEL_THINKING=false\n"
@@ -103,7 +185,7 @@ def test_reasoning_migrations_rename_and_map_boolean_values() -> None:
     )
 
     for migration in REASONING_MIGRATIONS:
-        text, _ = migrate_env_key_in_text(text, migration)
+        text, _ = migrate_env_setting_in_text(text, migration)
 
     assert text == (
         "REASONING_POLICY=off\nREASONING_FABLE=client\nREASONING_OPUS=inherit\n"
@@ -133,7 +215,7 @@ def test_reasoning_migration_accepts_every_legacy_boolean_spelling(
 ) -> None:
     text = f"ENABLE_MODEL_THINKING={legacy_value}\n"
 
-    migrated, changed = migrate_env_key_in_text(text, REASONING_MIGRATIONS[0])
+    migrated, changed = migrate_env_setting_in_text(text, REASONING_MIGRATIONS[0])
 
     assert changed is True
     assert migrated == f"REASONING_POLICY={expected}\n"

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -15,7 +15,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "deepseek",
     "mistral",
     "mistral_codestral",
-    "opencode",
+    "opencode_zen",
     "opencode_go",
     "vercel",
     "bedrock",

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -12,7 +12,7 @@ from tests.providers.support import (
 )
 
 
-@pytest.mark.parametrize("provider_id", ["opencode", "opencode_go"])
+@pytest.mark.parametrize("provider_id", ["opencode_zen", "opencode_go"])
 def test_build_request_body_replays_tool_reasoning_natively(
     provider_id: str,
 ) -> None:
@@ -76,7 +76,7 @@ def test_build_request_body_replays_tool_reasoning_natively(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider_id", ["opencode", "opencode_go"])
+@pytest.mark.parametrize("provider_id", ["opencode_zen", "opencode_go"])
 async def test_tool_only_history_sends_empty_reasoning_content_on_wire(
     provider_id: str,
 ) -> None:

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -86,7 +86,7 @@ def _make_settings(**overrides):
     mock.kimi_code_api_key = "test_kimi_code_key"
     mock.wafer_proxy = ""
     mock.minimax_proxy = ""
-    mock.opencode_proxy = ""
+    mock.opencode_zen_proxy = ""
     mock.opencode_go_proxy = ""
     mock.vercel_ai_gateway_proxy = ""
     mock.bedrock_proxy = ""
@@ -320,6 +320,16 @@ def test_create_cloudflare_provider_uses_account_scoped_base_url():
     )
 
 
+def test_opencode_zen_provider_config_uses_explicit_id_and_name():
+    with patch("httpx.AsyncClient"):
+        provider = create_provider("opencode_zen", _make_settings())
+
+    assert isinstance(provider, OpenAIChatProvider)
+    assert provider._base_url == "https://opencode.ai/zen/v1"
+    assert provider._provider_name == "OPENCODE_ZEN"
+    assert provider._api_key == "test_opencode_key"
+
+
 def test_opencode_go_provider_config_uses_correct_base_url_and_name():
     with patch("httpx.AsyncClient"):
         provider = create_provider("opencode_go", _make_settings())
@@ -476,7 +486,7 @@ def test_create_provider_instantiates_each_builtin():
         "ollama": OpenAIChatProvider,
         "ollama_cloud": OpenAIChatProvider,
         "wafer": OpenAIChatProvider,
-        "opencode": OpenAIChatProvider,
+        "opencode_zen": OpenAIChatProvider,
         "opencode_go": OpenAIChatProvider,
         "vercel": OpenAIChatProvider,
         "bedrock": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.7"
+version = "4.16.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

OpenCode Zen uses the ambiguous `opencode/` identifier while OpenCode Go uses `opencode_go/`. Renaming Zen without migrating saved configuration would break existing installations.

## Changes

| Before | After |
| --- | --- |
| OpenCode Zen used `opencode/` in model mappings and `OPENCODE` in diagnostics. | OpenCode Zen uses `opencode_zen/` and `OPENCODE_ZEN` throughout FCC. |
| Existing FCC-owned environment files retained legacy Zen model references. | Server startup rewrites legacy Zen model references before settings validation. |
| Zen used `OPENCODE_PROXY` and `FCC_SMOKE_MODEL_OPENCODE`. | Zen uses `OPENCODE_ZEN_PROXY` and `FCC_SMOKE_MODEL_OPENCODE_ZEN`. |
| The package version was `4.16.7`. | The package version is `4.16.8`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change renames the OpenCode Zen provider and related environment settings, adds migration for legacy FCC-owned dotenv configuration on the server path, and updates the package metadata. The server correctly migrates legacy model and proxy settings before validation, but the Claude, Codex, and Pi launchers still validate settings before running that migration, so upgraded users with legacy managed configuration cannot start those launchers. The package version also does not meet the repository rule for a breaking provider and configuration rename.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge until the launchers use the same migration-before-validation behavior as the server and the release version complies with the repository rule.

An isolated execution reproduced the legacy-configuration startup failure in all three affected launchers while confirming that the server path migrates the same configuration successfully. The versioning policy issue is explicitly tied to the package metadata change.

**Files Needing Attention:** src/free_claude_code/cli/launchers/claude.py, src/free_claude_code/cli/launchers/codex.py, src/free_claude_code/cli/launchers/pi.py, the shared configuration-loading path in src/free_claude_code/cli/commands.py, and pyproject.toml.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for two posted P1 findings and referenced the corresponding review comments.
- General contract validation showed server path migrations occur before validation and identified the root cause that migrations are invoked by load\_server\_settings and not by direct get\_settings calls.
- Focused tests for dotenv migration and CLI entrypoint regression were run.
- The server path migrated legacy OpenCode dotenv settings and all three launcher paths rejected unchanged legacy OpenCode dotenv settings.
- An isolated dotenv reproduction source was produced to assist debugging and verification.

<a href="https://app.greptile.com/trex/runs/17568907/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (2)</h3>

1. `src/free_claude_code/cli/launchers/claude.py`, line 23 ([link](https://github.com/alishahryar1/free-claude-code/blob/d94b10c3a6c927c9b78dde4f5131cef8c10fedbb/src/free_claude_code/cli/launchers/claude.py#L23)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **CLI launchers skip dotenv migration**

   `fcc-claude`, `fcc-codex`, and `fcc-pi` load settings directly before the FCC-owned dotenv migration runs. An upgraded `~/.fcc/.env` containing `MODEL=opencode/...` therefore raises settings validation during launcher startup; its `OPENCODE_PROXY` value also remains unmigrated and is not applied. Route these launchers through the same migration-before-settings helper used by the server path.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Isolated launcher dotenv reproduction source](https://app.greptile.com/trex/artifacts/8a5c91f2-104e-4984-9f65-7e97b368d3b4)**

   - Synthetic HOME/workdir harness writes only a temporary FCC-owned dotenv file and invokes server plus all launcher paths; the takeaway is that the check is deterministic and does not access user configuration.

   **[Server path migrates legacy OpenCode dotenv settings](https://app.greptile.com/trex/artifacts/af92a4f1-5589-4f07-acdf-0ea487f0fe73)**

   - The executed server settings path rewrites both legacy settings and loads their migrated values; the takeaway is that migration before Settings validation works on the server path.

   **[All three launcher paths reject unchanged legacy OpenCode dotenv settings](https://app.greptile.com/trex/artifacts/d7bb3b43-e523-485d-aaa4-288c602f8781)**

   - The executed fcc-claude, fcc-codex, and fcc-pi paths each fail validation and leave the owned dotenv unchanged; the takeaway is that launchers skip the required migration.

   **[Focused dotenv migration and CLI entrypoint regression tests](https://app.greptile.com/trex/artifacts/7e2765b1-33d6-4391-a865-2bce3c1efd6c)**

   - The executed focused pytest suite reports 65 passing tests; the takeaway is that existing tests pass despite the uncovered launcher integration gap.

   <a href="https://app.greptile.com/trex/runs/17568907/artifacts?artifact=8a5c91f2-104e-4984-9f65-7e97b368d3b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Frename-opencode-zen%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Frename-opencode-zen%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffree_claude_code%2Fcli%2Flaunchers%2Fclaude.py%0ALine%3A%2023%0A%0AComment%3A%0A**CLI%20launchers%20skip%20dotenv%20migration**%0A%0A%60fcc-claude%60%2C%20%60fcc-codex%60%2C%20and%20%60fcc-pi%60%20load%20settings%20directly%20before%20the%20FCC-owned%20dotenv%20migration%20runs.%20An%20upgraded%20%60~%2F.fcc%2F.env%60%20containing%20%60MODEL%3Dopencode%2F...%60%20therefore%20raises%20settings%20validation%20during%20launcher%20startup%3B%20its%20%60OPENCODE_PROXY%60%20value%20also%20remains%20unmigrated%20and%20is%20not%20applied.%20Route%20these%20launchers%20through%20the%20same%20migration-before-settings%20helper%20used%20by%20the%20server%20path.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1342&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **CLI launchers skip FCC-owned dotenv migrations before Settings validation**

   - **Bug**
     - With an FCC-owned `~/.fcc/.env` containing `MODEL=opencode/kimi-k2.6` and `OPENCODE_PROXY=https://legacy-proxy.invalid`, each launcher (`fcc-claude`, `fcc-codex`, and `fcc-pi`) raises a Settings ValidationError because `opencode` is no longer supported. The file remains unchanged, so `OPENCODE_PROXY` is not renamed to recognized `OPENCODE_ZEN_PROXY` either.
   - **Cause**
     - `src/free_claude_code/cli/launchers/claude.py:23`, `codex.py:51`, and `pi.py:57` invoke `get_settings()` directly. The migration sequence `_migrate_legacy_env_if_missing()` and `_migrate_config_env()` runs only in `src/free_claude_code/cli/commands.py:191-196` through `load_server_settings()`, before that path calls `get_settings()`.
   - **Fix**
     - Route launcher configuration loading through the same migration-before-settings helper (or a shared equivalent) before any call to `get_settings()`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Frename-opencode-zen%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Frename-opencode-zen%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fcli%2Flaunchers%2Fclaude.py%3A23%0A**CLI%20launchers%20skip%20dotenv%20migration**%0A%0A%60fcc-claude%60%2C%20%60fcc-codex%60%2C%20and%20%60fcc-pi%60%20load%20settings%20directly%20before%20the%20FCC-owned%20dotenv%20migration%20runs.%20An%20upgraded%20%60~%2F.fcc%2F.env%60%20containing%20%60MODEL%3Dopencode%2F...%60%20therefore%20raises%20settings%20validation%20during%20launcher%20startup%3B%20its%20%60OPENCODE_PROXY%60%20value%20also%20remains%20unmigrated%20and%20is%20not%20applied.%20Route%20these%20launchers%20through%20the%20same%20migration-before-settings%20helper%20used%20by%20the%20server%20path.%0A%0A%23%23%23%20Issue%202%0Apyproject.toml%3A7%0A**Patch%20version%20hides%20breaking%20renames**%0A%0AVersion%20%604.16.8%60%20presents%20the%20renamed%20provider%20identifier%20and%20environment%20variables%20as%20a%20backward-compatible%20patch%2C%20contrary%20to%20the%20repository%20policy%20requiring%20a%20major%20release%20for%20these%20changes%20and%20preventing%20consumers%20from%20reliably%20recognizing%20the%20compatibility%20impact.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1342&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Make OpenCode Zen naming explicit"](https://github.com/alishahryar1/free-claude-code/commit/d94b10c3a6c927c9b78dde4f5131cef8c10fedbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50703372)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->