### PR TITLE
Add optional RTK token optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@
 - **Use your preferred coding agent.** Run Claude Code, Codex, or Pi with FCC.
 - **Choose your own models.** Connect free, paid, or local providers and search their models from one Admin UI.
 - **Route work your way.** Set one default model or map Fable, Opus, Sonnet, and Haiku separately.
-- **Save time and tokens.** Five built-in optimizations handle quota probes, command-prefix detection, title generation, suggestion mode, and filepath extraction locally instead of calling your provider.
-- **Reduce command-output noise.** Optionally enable [RTK](https://github.com/rtk-ai/rtk) to filter noisy terminal output before it reaches the model.
+- **Save time and tokens.** Five built-in optimizations handle quota probes, command-prefix detection, title generation, suggestion mode, and filepath extraction locally instead of calling your provider; optionally enable [RTK](https://github.com/rtk-ai/rtk) to filter noisy terminal output before it reaches the model.
 - **Keep coding-agent capabilities.** Use streaming, tools, reasoning, and image input with compatible models.
 - **Work where you want.** Launch from your desktop, connect supported IDEs, or use optional Discord and Telegram bots with voice notes.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **Choose your own models.** Connect free, paid, or local providers and search their models from one Admin UI.
 - **Route work your way.** Set one default model or map Fable, Opus, Sonnet, and Haiku separately.
 - **Save time and tokens.** Five built-in optimizations handle quota probes, command-prefix detection, title generation, suggestion mode, and filepath extraction locally instead of calling your provider.
+- **Reduce command-output noise.** Optionally enable [RTK](https://github.com/rtk-ai/rtk) to filter noisy terminal output before it reaches the model.
 - **Keep coding-agent capabilities.** Use streaming, tools, reasoning, and image input with compatible models.
 - **Work where you want.** Launch from your desktop, connect supported IDEs, or use optional Discord and Telegram bots with voice notes.
 
@@ -53,7 +54,7 @@ Windows PowerShell:
 
 Re-run the same command whenever you want to update. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
 
-The installer asks which coding agents to install or verify. Choose at least one; skipped agents are left unchanged.
+The installer asks which coding agents to install or verify. Choose at least one; skipped agents are left unchanged. It can also install and configure RTK globally for the selected agents; RTK is off by default.
 
 ### 2. Start FCC
 
@@ -493,7 +494,7 @@ Stop every running FCC command before uninstalling.
 **Keeps**
 
 - uv and Python
-- Claude Code, Codex, and Pi
+- Claude Code, Codex, Pi, and RTK
 - Shared PATH entries
 
 macOS/Linux:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.16.8"
+version = "4.17.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -469,6 +469,20 @@ function Invoke-RtkCommand {
     }
 }
 
+function Ensure-RtkClaudeConfigDirectory {
+    $claudeConfigDirectory = $env:CLAUDE_CONFIG_DIR
+    if ([string]::IsNullOrWhiteSpace($claudeConfigDirectory)) {
+        $claudeConfigDirectory = Join-Path $env:USERPROFILE ".claude"
+    }
+
+    if ($DryRun) {
+        Write-Host "+ mkdir $(Format-Argument $claudeConfigDirectory)"
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path $claudeConfigDirectory | Out-Null
+}
+
 function Confirm-RtkApplication {
     if ($DryRun) {
         Invoke-RtkCommand -Arguments @("--version")
@@ -511,6 +525,7 @@ function Configure-RtkForSelectedAgents {
     Ensure-Rtk
 
     if ($script:InstallClaudeCode) {
+        Ensure-RtkClaudeConfigDirectory
         Invoke-RtkCommand -Arguments @("init", "--global", "--auto-patch")
     }
     if ($script:InstallCodex) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,6 +3,7 @@ param(
     [switch] $VoiceLocal,
     [switch] $VoiceAll,
     [string] $TorchBackend = "",
+    [switch] $Rtk,
     [switch] $DryRun,
     [switch] $Help,
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -20,11 +21,14 @@ $MinUvVersion = "0.11.16"
 $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"
+$RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/latest/download"
+$RtkWindowsAssetName = "rtk-x86_64-pc-windows-msvc.zip"
 $UvInstallUrl = "https://astral.sh/uv/install.ps1"
 $script:InstallClaudeCode = $true
 $script:InstallCodex = $true
 $script:InstallPi = $true
 $script:PiAvailable = $false
+$script:EnableRtk = $Rtk.IsPresent
 $FccCommands = @(
     # Include retired entry points so updates reject older FCC processes before replacement.
     "fcc-desktop",
@@ -47,6 +51,7 @@ Options:
   -VoiceLocal            Install local Whisper voice transcription support.
   -VoiceAll              Install all voice transcription backends.
   -TorchBackend VALUE    Use a uv PyTorch backend, such as cu130. Requires local voice.
+  -Rtk                   Install and configure RTK for the selected coding agents.
   -DryRun                Print commands without running them.
   -Help                  Show this help text.
 "@
@@ -64,11 +69,18 @@ function Test-InteractiveInstaller {
 }
 
 function Read-YesNo {
-    param([string] $Prompt)
+    param(
+        [string] $Prompt,
+        [bool] $DefaultYes = $true
+    )
 
     while ($true) {
-        $answer = ([string] (Read-Host "$Prompt [Y/n]")).Trim().ToLowerInvariant()
-        if ($answer -in @("", "y", "yes")) {
+        $hint = if ($DefaultYes) { "[Y/n]" } else { "[y/N]" }
+        $answer = ([string] (Read-Host "$Prompt $hint")).Trim().ToLowerInvariant()
+        if ($answer -eq "") {
+            return $DefaultYes
+        }
+        if ($answer -in @("y", "yes")) {
             return $true
         }
         if ($answer -in @("n", "no")) {
@@ -85,10 +97,16 @@ function Select-CodingAgents {
         $script:InstallPi = Read-YesNo "Install or verify Pi for fcc-pi?"
 
         if ($script:InstallClaudeCode -or $script:InstallCodex -or $script:InstallPi) {
-            return
+            break
         }
         Write-Host "Select at least one coding agent."
         Write-Host ""
+    }
+
+    if (-not $script:EnableRtk) {
+        $script:EnableRtk = Read-YesNo `
+            -Prompt "Enable RTK token optimization globally for the selected coding agents?" `
+            -DefaultYes $false
     }
 }
 
@@ -367,6 +385,158 @@ function Confirm-PiApplication {
         throw "The 'pi' command at '$($command.Source)' is not a compatible Pi Coding Agent."
     }
     Invoke-NativeCommand -FilePath $command.Source -Arguments @("--version")
+}
+
+function Install-Rtk {
+    $archiveUrl = "$RtkReleaseBaseUrl/$RtkWindowsAssetName"
+    $checksumsUrl = "$RtkReleaseBaseUrl/checksums.txt"
+    if ($DryRun) {
+        Write-Host "+ irm $archiveUrl -OutFile <temporary-archive>"
+        Write-Host "+ irm $checksumsUrl -OutFile <temporary-checksums>"
+        Write-Host "+ verify SHA-256 checksum for $RtkWindowsAssetName"
+        Write-Host "+ extract and install rtk.exe to ~/.local/bin"
+        return
+    }
+
+    $temporaryRoot = Join-Path ([IO.Path]::GetTempPath()) ("fcc-rtk-" + [guid]::NewGuid().ToString("N"))
+    $archivePath = Join-Path $temporaryRoot $RtkWindowsAssetName
+    $checksumsPath = Join-Path $temporaryRoot "checksums.txt"
+    $extractPath = Join-Path $temporaryRoot "extracted"
+    try {
+        New-Item -ItemType Directory -Path $temporaryRoot | Out-Null
+
+        Write-Host "+ irm $archiveUrl -OutFile $(Format-Argument $archivePath)"
+        Invoke-RestMethod -Uri $archiveUrl -OutFile $archivePath -ErrorAction Stop
+        Write-Host "+ irm $checksumsUrl -OutFile $(Format-Argument $checksumsPath)"
+        Invoke-RestMethod -Uri $checksumsUrl -OutFile $checksumsPath -ErrorAction Stop
+
+        foreach ($download in @($archivePath, $checksumsPath)) {
+            if ((-not (Test-Path -LiteralPath $download -PathType Leaf)) -or ((Get-Item -LiteralPath $download).Length -eq 0)) {
+                throw "The RTK release download '$download' was empty."
+            }
+        }
+
+        $assetPattern = "^([0-9A-Fa-f]{64})\s+\*?$([regex]::Escape($RtkWindowsAssetName))$"
+        $expectedHashes = @(
+            foreach ($line in Get-Content -LiteralPath $checksumsPath) {
+                if ($line -match $assetPattern) {
+                    $Matches[1].ToLowerInvariant()
+                }
+            }
+        )
+        if ($expectedHashes.Count -ne 1) {
+            throw "RTK checksums.txt did not contain exactly one checksum for $RtkWindowsAssetName."
+        }
+
+        $sha256 = [Security.Cryptography.SHA256]::Create()
+        $archiveStream = [IO.File]::OpenRead($archivePath)
+        try {
+            $actualHash = [BitConverter]::ToString($sha256.ComputeHash($archiveStream)).Replace("-", "").ToLowerInvariant()
+        }
+        finally {
+            $archiveStream.Dispose()
+            $sha256.Dispose()
+        }
+        if ($actualHash -ne $expectedHashes[0]) {
+            throw "RTK checksum verification failed for $RtkWindowsAssetName."
+        }
+
+        Expand-Archive -LiteralPath $archivePath -DestinationPath $extractPath
+        $extractedExecutable = Join-Path $extractPath "rtk.exe"
+        if (-not (Test-Path -LiteralPath $extractedExecutable -PathType Leaf)) {
+            throw "The verified RTK archive did not contain rtk.exe."
+        }
+
+        $installDirectory = Join-Path $env:USERPROFILE ".local\bin"
+        New-Item -ItemType Directory -Force -Path $installDirectory | Out-Null
+        Copy-Item -LiteralPath $extractedExecutable -Destination (Join-Path $installDirectory "rtk.exe") -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporaryRoot) {
+            Remove-Item -LiteralPath $temporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Invoke-RtkCommand {
+    param([string[]] $Arguments)
+
+    if ($DryRun) {
+        Write-Host "+ RTK_TELEMETRY_DISABLED=1 $(Format-Command -FilePath 'rtk' -Arguments $Arguments)"
+        return
+    }
+
+    $command = Get-ApplicationCommand "rtk"
+    if (-not $command) {
+        throw "RTK was installed, but 'rtk' is not available on PATH."
+    }
+
+    $hadTelemetryDisabled = Test-Path Env:RTK_TELEMETRY_DISABLED
+    $previousTelemetryDisabled = $env:RTK_TELEMETRY_DISABLED
+    try {
+        $env:RTK_TELEMETRY_DISABLED = "1"
+        Invoke-NativeCommand -FilePath $command.Source -Arguments $Arguments
+    }
+    finally {
+        if ($hadTelemetryDisabled) {
+            $env:RTK_TELEMETRY_DISABLED = $previousTelemetryDisabled
+        }
+        else {
+            Remove-Item Env:RTK_TELEMETRY_DISABLED -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Confirm-RtkApplication {
+    if ($DryRun) {
+        Invoke-RtkCommand -Arguments @("--version")
+        Invoke-RtkCommand -Arguments @("gain")
+        return
+    }
+
+    $command = Get-ApplicationCommand "rtk"
+    if (-not $command) {
+        throw "RTK was installed, but 'rtk' is not available on PATH."
+    }
+
+    try {
+        Invoke-RtkCommand -Arguments @("--version")
+        Invoke-RtkCommand -Arguments @("gain")
+    }
+    catch {
+        throw "The 'rtk' command at '$($command.Source)' is not a compatible Rust Token Killer installation. Remove the conflicting command from PATH, then rerun the installer. $($_.Exception.Message)"
+    }
+}
+
+function Ensure-Rtk {
+    if (Get-ApplicationCommand "rtk") {
+        Write-Host "RTK already found on PATH; verifying it without updating it."
+    }
+    else {
+        Install-Rtk
+        Add-KnownBinDirectories
+    }
+
+    Confirm-RtkApplication
+}
+
+function Configure-RtkForSelectedAgents {
+    if (-not $script:EnableRtk) {
+        return
+    }
+
+    Write-Step "Installing and configuring RTK token optimization"
+    Ensure-Rtk
+
+    if ($script:InstallClaudeCode) {
+        Invoke-RtkCommand -Arguments @("init", "--global", "--auto-patch")
+    }
+    if ($script:InstallCodex) {
+        Invoke-RtkCommand -Arguments @("init", "--global", "--codex")
+    }
+    if ($script:InstallPi -and $script:PiAvailable) {
+        Invoke-RtkCommand -Arguments @("init", "--global", "--agent", "pi")
+    }
 }
 
 function Ensure-ClaudeCode {
@@ -772,6 +942,7 @@ if (Test-InteractiveInstaller) {
 }
 
 Ensure-SelectedCodingAgents
+Configure-RtkForSelectedAgents
 
 Write-Step "Ensuring uv $MinUvVersion or newer is installed"
 Ensure-Uv

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,8 +21,10 @@ $MinUvVersion = "0.11.16"
 $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"
-$RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/latest/download"
+$RtkVersion = "0.44.2"
+$RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/download/v$RtkVersion"
 $RtkWindowsAssetName = "rtk-x86_64-pc-windows-msvc.zip"
+$RtkWindowsAssetSha256 = "3a1e114edce9080f8a10663e9c87488363a82f14a5ca8aab2ad416817f89d47c"
 $UvInstallUrl = "https://astral.sh/uv/install.ps1"
 $script:InstallClaudeCode = $true
 $script:InstallCodex = $true
@@ -389,43 +391,23 @@ function Confirm-PiApplication {
 
 function Install-Rtk {
     $archiveUrl = "$RtkReleaseBaseUrl/$RtkWindowsAssetName"
-    $checksumsUrl = "$RtkReleaseBaseUrl/checksums.txt"
     if ($DryRun) {
         Write-Host "+ irm $archiveUrl -OutFile <temporary-archive>"
-        Write-Host "+ irm $checksumsUrl -OutFile <temporary-checksums>"
-        Write-Host "+ verify SHA-256 checksum for $RtkWindowsAssetName"
+        Write-Host "+ verify pinned SHA-256 for $RtkWindowsAssetName"
         Write-Host "+ extract and install rtk.exe to ~/.local/bin"
         return
     }
 
     $temporaryRoot = Join-Path ([IO.Path]::GetTempPath()) ("fcc-rtk-" + [guid]::NewGuid().ToString("N"))
     $archivePath = Join-Path $temporaryRoot $RtkWindowsAssetName
-    $checksumsPath = Join-Path $temporaryRoot "checksums.txt"
     $extractPath = Join-Path $temporaryRoot "extracted"
     try {
         New-Item -ItemType Directory -Path $temporaryRoot | Out-Null
 
         Write-Host "+ irm $archiveUrl -OutFile $(Format-Argument $archivePath)"
         Invoke-RestMethod -Uri $archiveUrl -OutFile $archivePath -ErrorAction Stop
-        Write-Host "+ irm $checksumsUrl -OutFile $(Format-Argument $checksumsPath)"
-        Invoke-RestMethod -Uri $checksumsUrl -OutFile $checksumsPath -ErrorAction Stop
-
-        foreach ($download in @($archivePath, $checksumsPath)) {
-            if ((-not (Test-Path -LiteralPath $download -PathType Leaf)) -or ((Get-Item -LiteralPath $download).Length -eq 0)) {
-                throw "The RTK release download '$download' was empty."
-            }
-        }
-
-        $assetPattern = "^([0-9A-Fa-f]{64})\s+\*?$([regex]::Escape($RtkWindowsAssetName))$"
-        $expectedHashes = @(
-            foreach ($line in Get-Content -LiteralPath $checksumsPath) {
-                if ($line -match $assetPattern) {
-                    $Matches[1].ToLowerInvariant()
-                }
-            }
-        )
-        if ($expectedHashes.Count -ne 1) {
-            throw "RTK checksums.txt did not contain exactly one checksum for $RtkWindowsAssetName."
+        if ((-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) -or ((Get-Item -LiteralPath $archivePath).Length -eq 0)) {
+            throw "The RTK release archive was empty."
         }
 
         $sha256 = [Security.Cryptography.SHA256]::Create()
@@ -437,7 +419,7 @@ function Install-Rtk {
             $archiveStream.Dispose()
             $sha256.Dispose()
         }
-        if ($actualHash -ne $expectedHashes[0]) {
+        if ($actualHash -ne $RtkWindowsAssetSha256) {
             throw "RTK checksum verification failed for $RtkWindowsAssetName."
         }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -487,6 +487,16 @@ run_rtk_init() {
     fail "RTK configuration failed with exit code $status. Correct the reported RTK error, then rerun the installer."
 }
 
+ensure_rtk_claude_config_directory() {
+    if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+        rtk_claude_config_directory=$CLAUDE_CONFIG_DIR
+    else
+        [ -n "${HOME:-}" ] || fail "HOME is required to configure RTK for Claude Code."
+        rtk_claude_config_directory="$HOME/.claude"
+    fi
+    run mkdir -p "$rtk_claude_config_directory"
+}
+
 configure_rtk_for_selected_agents() {
     [ "$enable_rtk" -eq 1 ] || return 0
 
@@ -494,6 +504,7 @@ configure_rtk_for_selected_agents() {
     ensure_rtk
 
     if [ "$install_claude" -eq 1 ]; then
+        ensure_rtk_claude_config_directory
         run_rtk_init init --global --auto-patch
     fi
     if [ "$install_codex" -eq 1 ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@ MIN_UV_VERSION="0.11.16"
 CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
 CODEX_INSTALL_URL="https://chatgpt.com/codex/install.sh"
 PI_INSTALL_URL="https://pi.dev/install.sh"
+RTK_INSTALL_URL="https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
@@ -20,10 +21,12 @@ voice_all=0
 install_claude=1
 install_codex=1
 install_pi=1
+enable_rtk=0
 torch_backend=""
 temporary_script=""
 tool_bin=""
 pi_available=0
+rtk_path=""
 
 show_usage() {
     cat <<'USAGE'
@@ -36,6 +39,7 @@ Options:
   --voice-local            Install local Whisper voice transcription support.
   --voice-all              Install all voice transcription backends.
   --torch-backend VALUE    Use a uv PyTorch backend, such as cu130. Requires local voice.
+  --rtk                    Install and configure RTK for the selected coding agents.
   --dry-run                Print commands without running them.
   --help                   Show this help text.
 USAGE
@@ -52,13 +56,26 @@ installer_is_interactive() {
 
 prompt_yes_no() {
     question=$1
+    default_answer=${2:-yes}
+    case "$default_answer" in
+        yes) prompt='[Y/n]' ;;
+        no) prompt='[y/N]' ;;
+        *) fail "Unsupported prompt default: $default_answer" ;;
+    esac
+
     while :; do
-        printf '%s [Y/n] ' "$question" >&4
+        printf '%s %s ' "$question" "$prompt" >&4
         if ! IFS= read -r answer <&3; then
-            fail "Could not read the coding agent selection."
+            fail "Could not read the installer selection."
         fi
         case "$answer" in
-            ""|[Yy]|[Yy][Ee][Ss]) return 0 ;;
+            '')
+                if [ "$default_answer" = "yes" ]; then
+                    return 0
+                fi
+                return 1
+                ;;
+            [Yy]|[Yy][Ee][Ss]) return 0 ;;
             [Nn]|[Nn][Oo]) return 1 ;;
             *) printf 'Please answer Y or N.\n' >&4 ;;
         esac
@@ -93,6 +110,11 @@ choose_coding_agents() {
         fi
         printf 'Select at least one coding agent.\n\n' >&4
     done
+
+    if [ "$enable_rtk" -eq 0 ] &&
+        prompt_yes_no "Enable RTK token optimization globally for the selected coding agents?" no; then
+        enable_rtk=1
+    fi
 
     exec 3<&-
     exec 4>&-
@@ -332,6 +354,68 @@ verify_pi_command() {
     run "$pi_command_path" --version
 }
 
+verify_rtk_command() {
+    if [ "$dry_run" -eq 1 ]; then
+        print_command env RTK_TELEMETRY_DISABLED=1 rtk --version
+        print_command env RTK_TELEMETRY_DISABLED=1 rtk gain
+        return 0
+    fi
+
+    rtk_path=$(command -v rtk 2>/dev/null) || fail "RTK was installed, but 'rtk' is not available on PATH."
+    print_command env RTK_TELEMETRY_DISABLED=1 "$rtk_path" --version
+    if ! RTK_TELEMETRY_DISABLED=1 "$rtk_path" --version; then
+        fail "The 'rtk' command at $rtk_path is not a compatible Rust Token Killer installation. Remove the conflicting command from PATH, then rerun the installer."
+    fi
+
+    print_command env RTK_TELEMETRY_DISABLED=1 "$rtk_path" gain
+    if ! RTK_TELEMETRY_DISABLED=1 "$rtk_path" gain; then
+        fail "The 'rtk' command at $rtk_path is not a compatible Rust Token Killer installation. Remove the conflicting command from PATH, then rerun the installer."
+    fi
+}
+
+ensure_rtk() {
+    if command -v rtk >/dev/null 2>&1; then
+        printf 'RTK already found on PATH; verifying it without updating it.\n'
+    else
+        download_and_run "$RTK_INSTALL_URL" sh "RTK"
+        add_known_bin_directories
+    fi
+
+    verify_rtk_command
+}
+
+run_rtk_init() {
+    print_command env RTK_TELEMETRY_DISABLED=1 rtk "$@"
+    if [ "$dry_run" -eq 1 ]; then
+        return 0
+    fi
+
+    if RTK_TELEMETRY_DISABLED=1 "$rtk_path" "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+
+    fail "RTK configuration failed with exit code $status. Correct the reported RTK error, then rerun the installer."
+}
+
+configure_rtk_for_selected_agents() {
+    [ "$enable_rtk" -eq 1 ] || return 0
+
+    step "Installing and configuring RTK token optimization"
+    ensure_rtk
+
+    if [ "$install_claude" -eq 1 ]; then
+        run_rtk_init init --global --auto-patch
+    fi
+    if [ "$install_codex" -eq 1 ]; then
+        run_rtk_init init --global --codex
+    fi
+    if [ "$install_pi" -eq 1 ] && [ "$pi_available" -eq 1 ]; then
+        run_rtk_init init --global --agent pi
+    fi
+}
+
 ensure_claude() {
     if command -v claude >/dev/null 2>&1; then
         printf 'Claude Code already found on PATH; verifying it.\n'
@@ -522,6 +606,9 @@ parse_args() {
             --torch-backend=*)
                 torch_backend=${1#*=}
                 [ -n "$torch_backend" ] || fail "--torch-backend requires a non-empty value."
+                ;;
+            --rtk)
+                enable_rtk=1
                 ;;
             --dry-run)
                 dry_run=1
@@ -719,8 +806,17 @@ if [ "$install_claude" -eq 1 ]; then
 fi
 require_command sh
 require_command mktemp
+if [ "$enable_rtk" -eq 1 ] && ! command -v rtk >/dev/null 2>&1; then
+    require_command tar
+    if [ "$dry_run" -eq 0 ] &&
+        ! command -v sha256sum >/dev/null 2>&1 &&
+        ! command -v shasum >/dev/null 2>&1; then
+        fail "RTK installation requires sha256sum or shasum for checksum verification."
+    fi
+fi
 
 ensure_selected_coding_agents
+configure_rtk_for_selected_agents
 
 step "Ensuring uv $MIN_UV_VERSION or newer is installed"
 ensure_uv

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,8 @@ MIN_UV_VERSION="0.11.16"
 CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
 CODEX_INSTALL_URL="https://chatgpt.com/codex/install.sh"
 PI_INSTALL_URL="https://pi.dev/install.sh"
-RTK_INSTALL_URL="https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh"
+RTK_VERSION="0.44.2"
+RTK_RELEASE_BASE_URL="https://github.com/rtk-ai/rtk/releases/download/v$RTK_VERSION"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
@@ -23,7 +24,8 @@ install_codex=1
 install_pi=1
 enable_rtk=0
 torch_backend=""
-temporary_script=""
+temporary_file=""
+temporary_binary=""
 tool_bin=""
 pi_available=0
 rtk_path=""
@@ -161,8 +163,11 @@ run() {
 }
 
 cleanup() {
-    if [ -n "$temporary_script" ] && [ -e "$temporary_script" ]; then
-        rm -f "$temporary_script"
+    if [ -n "$temporary_file" ] && [ -e "$temporary_file" ]; then
+        rm -f "$temporary_file"
+    fi
+    if [ -n "$temporary_binary" ] && [ -e "$temporary_binary" ]; then
+        rm -f "$temporary_binary"
     fi
 }
 
@@ -277,16 +282,16 @@ download_and_run() {
         return 0
     fi
 
-    temporary_script=$(mktemp "${TMPDIR:-/tmp}/fcc-install.XXXXXX") || fail "Unable to create a temporary file for $label."
-    print_command curl -fsSL "$url" -o "$temporary_script"
-    if curl -fsSL "$url" -o "$temporary_script"; then
+    temporary_file=$(mktemp "${TMPDIR:-/tmp}/fcc-install.XXXXXX") || fail "Unable to create a temporary file for $label."
+    print_command curl -fsSL "$url" -o "$temporary_file"
+    if curl -fsSL "$url" -o "$temporary_file"; then
         :
     else
         status=$?
         fail "Could not download the $label installer (curl exit code $status)."
     fi
 
-    if [ ! -s "$temporary_script" ]; then
+    if [ ! -s "$temporary_file" ]; then
         fail "The downloaded $label installer was empty."
     fi
 
@@ -294,17 +299,17 @@ download_and_run() {
         printf '+ CODEX_NON_INTERACTIVE=1 '
         quote_arg "$interpreter"
         printf ' '
-        quote_arg "$temporary_script"
+        quote_arg "$temporary_file"
         printf '\n'
-        if CODEX_NON_INTERACTIVE=1 "$interpreter" "$temporary_script"; then
+        if CODEX_NON_INTERACTIVE=1 "$interpreter" "$temporary_file"; then
             :
         else
             status=$?
             fail "$label installation failed with exit code $status."
         fi
     else
-        print_command "$interpreter" "$temporary_script"
-        if "$interpreter" "$temporary_script"; then
+        print_command "$interpreter" "$temporary_file"
+        if "$interpreter" "$temporary_file"; then
             :
         else
             status=$?
@@ -312,8 +317,8 @@ download_and_run() {
         fi
     fi
 
-    rm -f "$temporary_script"
-    temporary_script=""
+    rm -f "$temporary_file"
+    temporary_file=""
 }
 
 verify_command() {
@@ -373,11 +378,94 @@ verify_rtk_command() {
     fi
 }
 
+select_rtk_release() {
+    rtk_platform=$(uname -s)
+    rtk_architecture=$(uname -m)
+    case "$rtk_platform:$rtk_architecture" in
+        Linux:x86_64|Linux:amd64)
+            rtk_asset_name="rtk-x86_64-unknown-linux-musl.tar.gz"
+            rtk_asset_sha256="d94cc2a3e57fa534892b5235a726e7eeb7523f205a5f8f48f853bfcae7be7e33"
+            ;;
+        Linux:aarch64|Linux:arm64)
+            rtk_asset_name="rtk-aarch64-unknown-linux-gnu.tar.gz"
+            rtk_asset_sha256="5cd3f7fa2697faf9e5b77a10ce4e699006e02d4752d792f06550697eb4b8e8a9"
+            ;;
+        Darwin:x86_64|Darwin:amd64)
+            rtk_asset_name="rtk-x86_64-apple-darwin.tar.gz"
+            rtk_asset_sha256="636f808db86b2cefab7db7dd9393da8b6e4721bb2ffaa0644e3ffa52d3420d81"
+            ;;
+        Darwin:aarch64|Darwin:arm64)
+            rtk_asset_name="rtk-aarch64-apple-darwin.tar.gz"
+            rtk_asset_sha256="b7c2218eca538b54e63fa594a8ce58bd3716851b01b3b0dc026515323baf6393"
+            ;;
+        *)
+            fail "RTK $RTK_VERSION does not provide a release for $rtk_platform $rtk_architecture."
+            ;;
+    esac
+}
+
+install_rtk() {
+    select_rtk_release
+    rtk_archive_url="$RTK_RELEASE_BASE_URL/$rtk_asset_name"
+    if [ "$dry_run" -eq 1 ]; then
+        print_command curl -fsSL "$rtk_archive_url" -o "<temporary-archive>"
+        printf '+ verify pinned SHA-256 for %s\n' "$rtk_asset_name"
+        printf '+ extract rtk to %s\n' "${HOME:-~}/.local/bin/rtk"
+        return 0
+    fi
+
+    [ -n "${HOME:-}" ] || fail "HOME is required to install RTK."
+    temporary_file=$(mktemp "${TMPDIR:-/tmp}/fcc-rtk.XXXXXX") || fail "Unable to create a temporary RTK archive."
+    print_command curl -fsSL "$rtk_archive_url" -o "$temporary_file"
+    if curl -fsSL "$rtk_archive_url" -o "$temporary_file"; then
+        :
+    else
+        status=$?
+        fail "Could not download RTK $RTK_VERSION (curl exit code $status)."
+    fi
+    [ -s "$temporary_file" ] || fail "The downloaded RTK archive was empty."
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        print_command sha256sum "$temporary_file"
+        rtk_actual_sha256=$(sha256sum "$temporary_file") || fail "Could not hash the downloaded RTK archive."
+    elif command -v shasum >/dev/null 2>&1; then
+        print_command shasum -a 256 "$temporary_file"
+        rtk_actual_sha256=$(shasum -a 256 "$temporary_file") || fail "Could not hash the downloaded RTK archive."
+    else
+        fail "RTK installation requires sha256sum or shasum for checksum verification."
+    fi
+    rtk_actual_sha256=${rtk_actual_sha256%% *}
+    [ "$rtk_actual_sha256" = "$rtk_asset_sha256" ] || fail "RTK checksum verification failed for $rtk_asset_name."
+
+    if rtk_archive_entries=$(tar -tzf "$temporary_file"); then
+        :
+    else
+        fail "The verified RTK archive could not be inspected."
+    fi
+    [ "$rtk_archive_entries" = "rtk" ] || fail "The verified RTK archive did not contain exactly one root rtk executable."
+
+    rtk_install_directory="$HOME/.local/bin"
+    run mkdir -p "$rtk_install_directory"
+    temporary_binary=$(mktemp "$rtk_install_directory/.rtk.XXXXXX") || fail "Unable to create a temporary RTK executable."
+    print_command tar -xOzf "$temporary_file" rtk
+    if tar -xOzf "$temporary_file" rtk >"$temporary_binary"; then
+        :
+    else
+        fail "The verified RTK archive could not be extracted."
+    fi
+    [ -s "$temporary_binary" ] || fail "The verified RTK executable was empty."
+    run chmod +x "$temporary_binary"
+    run mv "$temporary_binary" "$rtk_install_directory/rtk"
+    temporary_binary=""
+    rm -f "$temporary_file"
+    temporary_file=""
+}
+
 ensure_rtk() {
     if command -v rtk >/dev/null 2>&1; then
         printf 'RTK already found on PATH; verifying it without updating it.\n'
     else
-        download_and_run "$RTK_INSTALL_URL" sh "RTK"
+        install_rtk
         add_known_bin_directories
     fi
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1,8 +1,10 @@
 import hashlib
+import io
 import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -332,7 +334,13 @@ case "$url" in
     *claude.ai*) source="$FAKE_FIXTURES/claude-installer.sh" ;;
     *chatgpt.com*) source="$FAKE_FIXTURES/codex-installer.sh" ;;
     *pi.dev*) source="$FAKE_FIXTURES/pi-installer.sh" ;;
-    *rtk-ai*) source="$FAKE_FIXTURES/rtk-installer.sh" ;;
+    *rtk-ai*)
+        if [ "$FAIL_STEP" = "rtk-install" ]; then
+            printf 'invalid archive\n' > "$output"
+            exit 0
+        fi
+        source="$FAKE_FIXTURES/rtk-x86_64-unknown-linux-musl.tar.gz"
+        ;;
     *astral.sh*) source="$FAKE_FIXTURES/uv-installer.sh" ;;
     *) exit 42 ;;
 esac
@@ -376,16 +384,6 @@ chmod +x "$pi_bin/pi"
 """,
     )
     _write_executable(
-        fixtures / "rtk-installer.sh",
-        """#!/bin/sh
-echo "rtk-install" >> "$CALL_LOG"
-[ "$FAIL_STEP" = "rtk-install" ] && exit 25
-mkdir -p "$HOME/.local/bin"
-cp "$FAKE_FIXTURES/rtk-command.sh" "$HOME/.local/bin/rtk"
-chmod +x "$HOME/.local/bin/rtk"
-""",
-    )
-    _write_executable(
         fixtures / "uv-installer.sh",
         """#!/bin/sh
 echo "uv-install" >> "$CALL_LOG"
@@ -398,7 +396,14 @@ chmod +x "$HOME/.local/bin/uv"
     _write_executable(fixtures / "claude-command.sh", _posix_command("claude"))
     _write_executable(fixtures / "codex-command.sh", _posix_command("codex"))
     _write_executable(fixtures / "pi-command.sh", _posix_command("pi"))
-    _write_executable(fixtures / "rtk-command.sh", _posix_rtk_command())
+    rtk_command = _posix_rtk_command().encode()
+    with tarfile.open(
+        fixtures / "rtk-x86_64-unknown-linux-musl.tar.gz", "w:gz"
+    ) as archive:
+        metadata = tarfile.TarInfo("rtk")
+        metadata.mode = 0o755
+        metadata.size = len(rtk_command)
+        archive.addfile(metadata, io.BytesIO(rtk_command))
     _write_executable(fixtures / "uv-command.sh", _posix_uv_command("0.11.28"))
     _write_executable(
         fixtures / "fcc-command.sh",
@@ -421,7 +426,22 @@ fi
     _write_executable(
         bin_dir / "uname",
         """#!/bin/sh
-printf '%s\n' "${FAKE_UNAME:-Linux}"
+case "${1:-}" in
+    -m) printf '%s\n' "${FAKE_UNAME_MACHINE:-x86_64}" ;;
+    *) printf '%s\n' "${FAKE_UNAME:-Linux}" ;;
+esac
+""",
+    )
+    _write_executable(
+        bin_dir / "sha256sum",
+        """#!/bin/sh
+echo "sha256sum:$*" >> "$CALL_LOG"
+if [ "$FAIL_STEP" = "rtk-checksum" ]; then
+    checksum="0000000000000000000000000000000000000000000000000000000000000000"
+else
+    checksum="d94cc2a3e57fa534892b5235a726e7eeb7523f205a5f8f48f853bfcae7be7e33"
+fi
+printf '%s  %s\n' "$checksum" "$1"
 """,
     )
 
@@ -478,10 +498,13 @@ def test_install_sh_installs_and_configures_rtk_for_selected_agents(
     assert result.returncode == 0, result.stderr
     calls = posix_harness.calls()
     assert (
-        "download:https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh"
+        "download:https://github.com/rtk-ai/rtk/releases/download/v0.44.2/rtk-x86_64-unknown-linux-musl.tar.gz"
         in calls
     )
-    assert calls.index("rtk-install") < calls.index("rtk:--version:telemetry=1")
+    assert any(call.startswith("sha256sum:") for call in calls)
+    assert calls.index("rtk:--version:telemetry=1") > next(
+        index for index, call in enumerate(calls) if call.startswith("sha256sum:")
+    )
     assert calls.index("rtk:--version:telemetry=1") < calls.index(
         "rtk:gain:telemetry=1"
     )
@@ -493,6 +516,43 @@ def test_install_sh_installs_and_configures_rtk_for_selected_agents(
     assert calls.index("rtk:init --global --agent pi:telemetry=1") < calls.index(
         "uv-install"
     )
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "asset"),
+    [
+        ("Linux", "x86_64", "rtk-x86_64-unknown-linux-musl.tar.gz"),
+        ("Linux", "aarch64", "rtk-aarch64-unknown-linux-gnu.tar.gz"),
+        ("Darwin", "x86_64", "rtk-x86_64-apple-darwin.tar.gz"),
+        ("Darwin", "arm64", "rtk-aarch64-apple-darwin.tar.gz"),
+    ],
+)
+def test_install_sh_selects_pinned_rtk_release_for_platform(
+    posix_harness: PosixHarness,
+    system: str,
+    machine: str,
+    asset: str,
+) -> None:
+    posix_harness.env["FAKE_UNAME"] = system
+    posix_harness.env["FAKE_UNAME_MACHINE"] = machine
+
+    result = posix_harness.run("--rtk", "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert f"rtk-ai/rtk/releases/download/v0.44.2/{asset}" in result.stdout
+    assert "raw.githubusercontent.com/rtk-ai/rtk" not in result.stdout
+
+
+def test_install_sh_rejects_unsupported_rtk_platform(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.env["FAKE_UNAME"] = "FreeBSD"
+    posix_harness.env["FAKE_UNAME_MACHINE"] = "riscv64"
+
+    result = posix_harness.run("--rtk", "--dry-run")
+
+    assert result.returncode != 0
+    assert "does not provide a release for FreeBSD riscv64" in result.stderr
 
 
 def test_install_sh_preserves_existing_rtk_and_configures_only_selected_agent(
@@ -525,7 +585,13 @@ def test_install_sh_rejects_conflicting_rtk_command(
 
 @pytest.mark.parametrize(
     "failure",
-    ["rtk-download", "rtk-install", "rtk-verify", "rtk-init-claude"],
+    [
+        "rtk-download",
+        "rtk-checksum",
+        "rtk-install",
+        "rtk-verify",
+        "rtk-init-claude",
+    ],
 )
 def test_install_sh_stops_when_rtk_setup_fails(
     posix_harness: PosixHarness,
@@ -1304,11 +1370,6 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "uv-install"
     rtk_archive = fixtures / "rtk-x86_64-pc-windows-msvc.zip"
     with zipfile.ZipFile(rtk_archive, "w") as archive:
         archive.writestr("rtk.exe", b"fake RTK executable")
-    rtk_hash = hashlib.sha256(rtk_archive.read_bytes()).hexdigest()
-    (fixtures / "rtk-checksums.txt").write_text(
-        f"{rtk_hash}  {rtk_archive.name}\n",
-        encoding="utf-8",
-    )
 
     wrapper = tmp_path / "run-installer.ps1"
     wrapper.write_text(
@@ -1339,9 +1400,6 @@ function Invoke-RestMethod {
     }
     elseif ($Uri.EndsWith("rtk-x86_64-pc-windows-msvc.zip")) {
         $source = Join-Path $env:FAKE_FIXTURES "rtk-x86_64-pc-windows-msvc.zip"
-    }
-    elseif ($Uri.Contains("rtk-ai/rtk") -and $Uri.EndsWith("checksums.txt")) {
-        $source = Join-Path $env:FAKE_FIXTURES "rtk-checksums.txt"
     }
     elseif ($Uri.Contains("astral.sh")) {
         $source = Join-Path $env:FAKE_FIXTURES "uv-installer.ps1"
@@ -1493,7 +1551,7 @@ def test_install_ps1_rtk_dry_run_prints_install_and_agent_setup(
 
     assert result.returncode == 0, result.stderr
     assert powershell_harness.calls() == []
-    assert "releases/latest/download/rtk-x86_64-pc-windows-msvc.zip" in result.stdout
+    assert "releases/download/v0.44.2/rtk-x86_64-pc-windows-msvc.zip" in result.stdout
     assert "RTK_TELEMETRY_DISABLED=1 rtk init --global --auto-patch" in result.stdout
     assert "RTK_TELEMETRY_DISABLED=1 rtk init --global --codex" in result.stdout
     assert "RTK_TELEMETRY_DISABLED=1 rtk init --global --agent pi" in result.stdout
@@ -1520,8 +1578,6 @@ def test_install_ps1_installs_only_checksum_verified_rtk_archive(
     checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
     if not valid_checksum:
         checksum = "0" * 64
-    checksums_path = tmp_path / "checksums.txt"
-    checksums_path.write_text(f"{checksum}  {asset_name}\n", encoding="utf-8")
 
     installer = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
     format_argument = _braced_body(installer, "function Format-Argument")
@@ -1529,18 +1585,14 @@ def test_install_ps1_installs_only_checksum_verified_rtk_archive(
     script = f"""Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $DryRun = $false
-$RtkReleaseBaseUrl = "https://example.test/releases/latest/download"
+$RtkReleaseBaseUrl = "https://example.test/releases/download/v0.44.2"
 $RtkWindowsAssetName = "{asset_name}"
+$RtkWindowsAssetSha256 = "{checksum}"
 function Format-Argument {{{format_argument}}}
 function Invoke-RestMethod {{
     [CmdletBinding()]
     param([string] $Uri, [string] $OutFile)
-    if ($Uri.EndsWith("checksums.txt")) {{
-        Copy-Item -LiteralPath $env:RTK_TEST_CHECKSUMS -Destination $OutFile
-    }}
-    else {{
-        Copy-Item -LiteralPath $env:RTK_TEST_ARCHIVE -Destination $OutFile
-    }}
+    Copy-Item -LiteralPath $env:RTK_TEST_ARCHIVE -Destination $OutFile
 }}
 function Install-Rtk {{{install_rtk}}}
 Install-Rtk
@@ -1550,7 +1602,6 @@ Install-Rtk
     env = os.environ | {
         "USERPROFILE": str(home),
         "RTK_TEST_ARCHIVE": str(archive_path),
-        "RTK_TEST_CHECKSUMS": str(checksums_path),
     }
     result = subprocess.run(
         [powershell, "-NoProfile", "-Command", script],

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -127,6 +127,10 @@ exit 35
 def _posix_rtk_command() -> str:
     return """#!/bin/sh
 echo "rtk:$*:telemetry=${RTK_TELEMETRY_DISABLED:-}" >> "$CALL_LOG"
+if [ "$*" = "init --global --auto-patch" ]; then
+    claude_config_directory=${CLAUDE_CONFIG_DIR:-$HOME/.claude}
+    [ -d "$claude_config_directory" ] || exit 77
+fi
 case "${1:-}:$FAIL_STEP" in
     --version:rtk-verify|gain:rtk-verify) exit 72 ;;
 esac
@@ -457,6 +461,7 @@ printf '%s  %s\n' "$checksum" "$1"
             "FCC_RUNNING_COMMAND": "",
             "FCC_RUNNING_PHASE": "early",
             "FAKE_UNAME": "Linux",
+            "CLAUDE_CONFIG_DIR": "",
             "FAIL_STEP": "",
         }
     )
@@ -516,6 +521,21 @@ def test_install_sh_installs_and_configures_rtk_for_selected_agents(
     assert calls.index("rtk:init --global --agent pi:telemetry=1") < calls.index(
         "uv-install"
     )
+    assert (Path(posix_harness.env["HOME"]) / ".claude").is_dir()
+
+
+def test_install_sh_prepares_custom_claude_config_directory_for_rtk(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_rtk()
+    custom_config = posix_harness.root / "custom-claude"
+    posix_harness.env["CLAUDE_CONFIG_DIR"] = str(custom_config)
+
+    result = posix_harness.run("--rtk")
+
+    assert result.returncode == 0, result.stderr
+    assert custom_config.is_dir()
+    assert not (Path(posix_harness.env["HOME"]) / ".claude").exists()
 
 
 @pytest.mark.parametrize(
@@ -1206,6 +1226,8 @@ exit /b 0
 def _batch_rtk() -> str:
     return r"""@echo off
 >>"%CALL_LOG%" echo rtk:%*:telemetry=%RTK_TELEMETRY_DISABLED%
+if "%*"=="init --global --auto-patch" if defined CLAUDE_CONFIG_DIR if not exist "%CLAUDE_CONFIG_DIR%" exit /b 77
+if "%*"=="init --global --auto-patch" if not defined CLAUDE_CONFIG_DIR if not exist "%USERPROFILE%\.claude" exit /b 77
 if "%FAIL_STEP%"=="rtk-verify" if "%1"=="--version" exit /b 72
 if "%FAIL_STEP%"=="rtk-verify" if "%1"=="gain" exit /b 72
 if "%FAIL_STEP%"=="rtk-init-claude" if "%*"=="init --global --auto-patch" exit /b 73
@@ -1446,6 +1468,7 @@ $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_INSTALLER))
             "LOCALAPPDATA": str(local_app_data),
             "APPDATA": str(app_data),
             "CALL_LOG": str(log),
+            "CLAUDE_CONFIG_DIR": "",
             "FAKE_FIXTURES": str(fixtures),
             "FAKE_TOOL_BIN": str(tool_bin),
             "FCC_INSTALLER": str(_repo_root() / "scripts" / "install.ps1"),
@@ -1529,6 +1552,21 @@ def test_install_ps1_preserves_existing_rtk_and_configures_selected_agents(
         "rtk:init --global --codex:telemetry=1",
         "rtk:init --global --agent pi:telemetry=1",
     ]
+    assert (Path(powershell_harness.env["USERPROFILE"]) / ".claude").is_dir()
+
+
+def test_install_ps1_prepares_custom_claude_config_directory_for_rtk(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_rtk()
+    custom_config = powershell_harness.root / "custom-claude"
+    powershell_harness.env["CLAUDE_CONFIG_DIR"] = str(custom_config)
+
+    result = powershell_harness.run("-Rtk")
+
+    assert result.returncode == 0, result.stderr
+    assert custom_config.is_dir()
+    assert not (Path(powershell_harness.env["USERPROFILE"]) / ".claude").exists()
 
 
 def test_install_ps1_rejects_conflicting_rtk_command(

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1,7 +1,9 @@
+import hashlib
 import os
 import shutil
 import subprocess
 import sys
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -120,6 +122,24 @@ exit 35
 """
 
 
+def _posix_rtk_command() -> str:
+    return """#!/bin/sh
+echo "rtk:$*:telemetry=${RTK_TELEMETRY_DISABLED:-}" >> "$CALL_LOG"
+case "${1:-}:$FAIL_STEP" in
+    --version:rtk-verify|gain:rtk-verify) exit 72 ;;
+esac
+case "$*:$FAIL_STEP" in
+    "init --global --auto-patch:rtk-init-claude") exit 73 ;;
+    "init --global --codex:rtk-init-codex") exit 74 ;;
+    "init --global --agent pi:rtk-init-pi") exit 75 ;;
+esac
+if [ "${1:-}" = "--version" ]; then
+    echo "rtk 0.44.2"
+fi
+exit 0
+"""
+
+
 @dataclass
 class PosixHarness:
     root: Path
@@ -142,6 +162,19 @@ class PosixHarness:
 
     def add_uv(self, version: str) -> None:
         _write_executable(self.bin_dir / "uv", _posix_uv_command(version))
+
+    def add_rtk(self) -> None:
+        _write_executable(self.bin_dir / "rtk", _posix_rtk_command())
+
+    def add_unrelated_rtk(self) -> None:
+        _write_executable(
+            self.bin_dir / "rtk",
+            """#!/bin/sh
+echo "unrelated-rtk:$*" >> "$CALL_LOG"
+[ "${1:-}" = "--version" ] && echo "rtk 1.0.0" && exit 0
+exit 76
+""",
+        )
 
     def use_process_list_fallback(self, process_line: str) -> None:
         fallback_bin = self.root / "fallback-bin"
@@ -291,7 +324,7 @@ while [ "$#" -gt 0 ]; do
 done
 echo "download:$url" >> "$CALL_LOG"
 case "$url:$FAIL_STEP" in
-    *claude.ai*:claude-download|*chatgpt.com*:codex-download|*pi.dev*:pi-download|*astral.sh*:uv-download)
+    *claude.ai*:claude-download|*chatgpt.com*:codex-download|*pi.dev*:pi-download|*rtk-ai*:rtk-download|*astral.sh*:uv-download)
         exit 41
         ;;
 esac
@@ -299,6 +332,7 @@ case "$url" in
     *claude.ai*) source="$FAKE_FIXTURES/claude-installer.sh" ;;
     *chatgpt.com*) source="$FAKE_FIXTURES/codex-installer.sh" ;;
     *pi.dev*) source="$FAKE_FIXTURES/pi-installer.sh" ;;
+    *rtk-ai*) source="$FAKE_FIXTURES/rtk-installer.sh" ;;
     *astral.sh*) source="$FAKE_FIXTURES/uv-installer.sh" ;;
     *) exit 42 ;;
 esac
@@ -342,6 +376,16 @@ chmod +x "$pi_bin/pi"
 """,
     )
     _write_executable(
+        fixtures / "rtk-installer.sh",
+        """#!/bin/sh
+echo "rtk-install" >> "$CALL_LOG"
+[ "$FAIL_STEP" = "rtk-install" ] && exit 25
+mkdir -p "$HOME/.local/bin"
+cp "$FAKE_FIXTURES/rtk-command.sh" "$HOME/.local/bin/rtk"
+chmod +x "$HOME/.local/bin/rtk"
+""",
+    )
+    _write_executable(
         fixtures / "uv-installer.sh",
         """#!/bin/sh
 echo "uv-install" >> "$CALL_LOG"
@@ -354,6 +398,7 @@ chmod +x "$HOME/.local/bin/uv"
     _write_executable(fixtures / "claude-command.sh", _posix_command("claude"))
     _write_executable(fixtures / "codex-command.sh", _posix_command("codex"))
     _write_executable(fixtures / "pi-command.sh", _posix_command("pi"))
+    _write_executable(fixtures / "rtk-command.sh", _posix_rtk_command())
     _write_executable(fixtures / "uv-command.sh", _posix_uv_command("0.11.28"))
     _write_executable(
         fixtures / "fcc-command.sh",
@@ -425,10 +470,78 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
     ]
 
 
+def test_install_sh_installs_and_configures_rtk_for_selected_agents(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run("--rtk")
+
+    assert result.returncode == 0, result.stderr
+    calls = posix_harness.calls()
+    assert (
+        "download:https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh"
+        in calls
+    )
+    assert calls.index("rtk-install") < calls.index("rtk:--version:telemetry=1")
+    assert calls.index("rtk:--version:telemetry=1") < calls.index(
+        "rtk:gain:telemetry=1"
+    )
+    assert [call for call in calls if call.startswith("rtk:init")] == [
+        "rtk:init --global --auto-patch:telemetry=1",
+        "rtk:init --global --codex:telemetry=1",
+        "rtk:init --global --agent pi:telemetry=1",
+    ]
+    assert calls.index("rtk:init --global --agent pi:telemetry=1") < calls.index(
+        "uv-install"
+    )
+
+
+def test_install_sh_preserves_existing_rtk_and_configures_only_selected_agent(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_rtk()
+
+    result = posix_harness.run_interactive("n\ny\nn\ny\n")
+
+    assert result.returncode == 0, result.stdout
+    assert "verifying it without updating it" in result.stdout
+    assert not any("rtk-ai/rtk" in call for call in posix_harness.calls())
+    assert [call for call in posix_harness.calls() if call.startswith("rtk:init")] == [
+        "rtk:init --global --codex:telemetry=1"
+    ]
+
+
+def test_install_sh_rejects_conflicting_rtk_command(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_unrelated_rtk()
+
+    result = posix_harness.run("--rtk")
+
+    assert result.returncode != 0
+    assert "not a compatible Rust Token Killer installation" in result.stderr
+    assert not any("rtk-ai/rtk" in call for call in posix_harness.calls())
+    assert not any("astral.sh" in call for call in posix_harness.calls())
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ["rtk-download", "rtk-install", "rtk-verify", "rtk-init-claude"],
+)
+def test_install_sh_stops_when_rtk_setup_fails(
+    posix_harness: PosixHarness,
+    failure: str,
+) -> None:
+    result = posix_harness.run("--rtk", fail_step=failure)
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    assert not any("astral.sh" in call for call in posix_harness.calls())
+
+
 def test_install_sh_reprompts_then_installs_only_selected_agent(
     posix_harness: PosixHarness,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\nn\nn\ny\nn\n")
+    result = posix_harness.run_interactive("n\nn\nn\nn\ny\nn\nn\n")
 
     assert result.returncode == 0, result.stdout
     assert "Select at least one coding agent." in result.stdout
@@ -439,12 +552,13 @@ def test_install_sh_reprompts_then_installs_only_selected_agent(
     assert "codex-install:1" in calls
     assert not any("claude.ai" in call for call in calls)
     assert not any("pi.dev" in call for call in calls)
+    assert not any("rtk-ai/rtk" in call for call in calls)
 
 
 def test_install_sh_rejects_uninstalled_only_selection(
     posix_harness: PosixHarness,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\ny\n", fail_step="pi-skip")
+    result = posix_harness.run_interactive("n\nn\ny\nn\n", fail_step="pi-skip")
 
     assert result.returncode != 0
     assert "No selected coding agent was installed." in result.stdout
@@ -1023,6 +1137,19 @@ exit /b 0
 """
 
 
+def _batch_rtk() -> str:
+    return r"""@echo off
+>>"%CALL_LOG%" echo rtk:%*:telemetry=%RTK_TELEMETRY_DISABLED%
+if "%FAIL_STEP%"=="rtk-verify" if "%1"=="--version" exit /b 72
+if "%FAIL_STEP%"=="rtk-verify" if "%1"=="gain" exit /b 72
+if "%FAIL_STEP%"=="rtk-init-claude" if "%*"=="init --global --auto-patch" exit /b 73
+if "%FAIL_STEP%"=="rtk-init-codex" if "%*"=="init --global --codex" exit /b 74
+if "%FAIL_STEP%"=="rtk-init-pi" if "%*"=="init --global --agent pi" exit /b 75
+if "%1"=="--version" echo rtk 0.44.2
+exit /b 0
+"""
+
+
 @dataclass
 class PowerShellHarness:
     root: Path
@@ -1047,6 +1174,22 @@ class PowerShellHarness:
 
     def add_uv(self, version: str) -> None:
         _write_executable(self.bin_dir / "uv.cmd", _batch_uv(version))
+
+    def add_rtk(self) -> None:
+        _write_executable(self.bin_dir / "rtk.cmd", _batch_rtk())
+
+    def add_unrelated_rtk(self) -> None:
+        _write_executable(
+            self.bin_dir / "rtk.cmd",
+            r"""@echo off
+echo unrelated-rtk:%*>>"%CALL_LOG%"
+if "%1"=="--version" (
+    echo rtk 1.0.0
+    exit /b 0
+)
+exit /b 76
+""",
+        )
 
     def run(self, *args: str, fail_step: str = "") -> subprocess.CompletedProcess[str]:
         env = self.env | {"FAIL_STEP": fail_step}
@@ -1101,6 +1244,7 @@ def powershell_harness(
         _batch_client("codex"), encoding="utf-8"
     )
     (fixtures / "pi-command.cmd").write_text(_batch_client("pi"), encoding="utf-8")
+    (fixtures / "rtk-command.cmd").write_text(_batch_rtk(), encoding="utf-8")
     (fixtures / "uv-command.cmd").write_text(_batch_uv("0.11.28"), encoding="utf-8")
     (fixtures / "fcc-command.cmd").write_text(
         """@echo off
@@ -1157,6 +1301,14 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "uv-install"
 """,
         encoding="utf-8",
     )
+    rtk_archive = fixtures / "rtk-x86_64-pc-windows-msvc.zip"
+    with zipfile.ZipFile(rtk_archive, "w") as archive:
+        archive.writestr("rtk.exe", b"fake RTK executable")
+    rtk_hash = hashlib.sha256(rtk_archive.read_bytes()).hexdigest()
+    (fixtures / "rtk-checksums.txt").write_text(
+        f"{rtk_hash}  {rtk_archive.name}\n",
+        encoding="utf-8",
+    )
 
     wrapper = tmp_path / "run-installer.ps1"
     wrapper.write_text(
@@ -1171,6 +1323,7 @@ function Invoke-RestMethod {
         ($env:FAIL_STEP -eq "claude-download" -and $Uri.Contains("claude.ai")) -or
         ($env:FAIL_STEP -eq "codex-download" -and $Uri.Contains("chatgpt.com")) -or
         ($env:FAIL_STEP -eq "pi-download" -and $Uri.Contains("pi.dev")) -or
+        ($env:FAIL_STEP -eq "rtk-download" -and $Uri.Contains("rtk-ai/rtk")) -or
         ($env:FAIL_STEP -eq "uv-download" -and $Uri.Contains("astral.sh"))
     ) {
         throw "simulated download failure"
@@ -1183,6 +1336,12 @@ function Invoke-RestMethod {
     }
     elseif ($Uri.Contains("pi.dev")) {
         $source = Join-Path $env:FAKE_FIXTURES "pi-installer.ps1"
+    }
+    elseif ($Uri.EndsWith("rtk-x86_64-pc-windows-msvc.zip")) {
+        $source = Join-Path $env:FAKE_FIXTURES "rtk-x86_64-pc-windows-msvc.zip"
+    }
+    elseif ($Uri.Contains("rtk-ai/rtk") -and $Uri.EndsWith("checksums.txt")) {
+        $source = Join-Path $env:FAKE_FIXTURES "rtk-checksums.txt"
     }
     elseif ($Uri.Contains("astral.sh")) {
         $source = Join-Path $env:FAKE_FIXTURES "uv-installer.ps1"
@@ -1292,6 +1451,123 @@ def test_install_ps1_fresh_install_is_verified(
         / "Programs"
         / "Free Claude Code.lnk"
     ).is_file()
+
+
+def test_install_ps1_preserves_existing_rtk_and_configures_selected_agents(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_rtk()
+
+    result = powershell_harness.run("-Rtk")
+
+    assert result.returncode == 0, result.stderr
+    assert "verifying it without updating it" in result.stdout
+    calls = powershell_harness.calls()
+    assert not any("rtk-ai/rtk" in call for call in calls)
+    assert "rtk:--version:telemetry=1" in calls
+    assert "rtk:gain:telemetry=1" in calls
+    assert [call for call in calls if call.startswith("rtk:init")] == [
+        "rtk:init --global --auto-patch:telemetry=1",
+        "rtk:init --global --codex:telemetry=1",
+        "rtk:init --global --agent pi:telemetry=1",
+    ]
+
+
+def test_install_ps1_rejects_conflicting_rtk_command(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_unrelated_rtk()
+
+    result = powershell_harness.run("-Rtk")
+
+    assert result.returncode != 0
+    assert "not a compatible Rust Token Killer installation" in result.stderr
+    assert not any("rtk-ai/rtk" in call for call in powershell_harness.calls())
+    assert not any("astral.sh" in call for call in powershell_harness.calls())
+
+
+def test_install_ps1_rtk_dry_run_prints_install_and_agent_setup(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    result = powershell_harness.run("-Rtk", "-DryRun")
+
+    assert result.returncode == 0, result.stderr
+    assert powershell_harness.calls() == []
+    assert "releases/latest/download/rtk-x86_64-pc-windows-msvc.zip" in result.stdout
+    assert "RTK_TELEMETRY_DISABLED=1 rtk init --global --auto-patch" in result.stdout
+    assert "RTK_TELEMETRY_DISABLED=1 rtk init --global --codex" in result.stdout
+    assert "RTK_TELEMETRY_DISABLED=1 rtk init --global --agent pi" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "powershell",
+    _powershells() or (None,),
+    ids=lambda path: Path(path).name if path is not None else "unavailable",
+)
+@pytest.mark.parametrize("valid_checksum", [True, False])
+def test_install_ps1_installs_only_checksum_verified_rtk_archive(
+    powershell: str | None,
+    tmp_path: Path,
+    valid_checksum: bool,
+) -> None:
+    if powershell is None or os.name != "nt":
+        pytest.skip("PowerShell RTK archive installation runs on Windows hosts")
+
+    asset_name = "rtk-x86_64-pc-windows-msvc.zip"
+    archive_path = tmp_path / asset_name
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("rtk.exe", b"verified RTK executable")
+    checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    if not valid_checksum:
+        checksum = "0" * 64
+    checksums_path = tmp_path / "checksums.txt"
+    checksums_path.write_text(f"{checksum}  {asset_name}\n", encoding="utf-8")
+
+    installer = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    format_argument = _braced_body(installer, "function Format-Argument")
+    install_rtk = _braced_body(installer, "function Install-Rtk")
+    script = f"""Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$DryRun = $false
+$RtkReleaseBaseUrl = "https://example.test/releases/latest/download"
+$RtkWindowsAssetName = "{asset_name}"
+function Format-Argument {{{format_argument}}}
+function Invoke-RestMethod {{
+    [CmdletBinding()]
+    param([string] $Uri, [string] $OutFile)
+    if ($Uri.EndsWith("checksums.txt")) {{
+        Copy-Item -LiteralPath $env:RTK_TEST_CHECKSUMS -Destination $OutFile
+    }}
+    else {{
+        Copy-Item -LiteralPath $env:RTK_TEST_ARCHIVE -Destination $OutFile
+    }}
+}}
+function Install-Rtk {{{install_rtk}}}
+Install-Rtk
+"""
+    home = tmp_path / "home"
+    home.mkdir()
+    env = os.environ | {
+        "USERPROFILE": str(home),
+        "RTK_TEST_ARCHIVE": str(archive_path),
+        "RTK_TEST_CHECKSUMS": str(checksums_path),
+    }
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-Command", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    installed = home / ".local" / "bin" / "rtk.exe"
+    if valid_checksum:
+        assert result.returncode == 0, result.stderr
+        assert installed.read_bytes() == b"verified RTK executable"
+    else:
+        assert result.returncode != 0
+        assert "checksum verification failed" in result.stderr
+        assert not installed.exists()
 
 
 def test_install_ps1_stops_if_windows_icon_export_fails(
@@ -1691,10 +1967,10 @@ Invoke-DownloadedPowerShellInstaller `
 @pytest.mark.parametrize(
     ("answers", "expected", "expected_messages"),
     [
-        (("", "", ""), "True,True,True", ()),
+        (("", "", "", ""), "True,True,True,False", ()),
         (
-            ("maybe", "n", "n", "n", "n", "y", "n"),
-            "False,True,False",
+            ("maybe", "n", "n", "n", "n", "y", "n", "y"),
+            "False,True,False,True",
             ("Please answer Y or N.", "Select at least one coding agent."),
         ),
     ],
@@ -1716,6 +1992,7 @@ $script:AnswerIndex = 0
 $script:InstallClaudeCode = $true
 $script:InstallCodex = $true
 $script:InstallPi = $true
+$script:EnableRtk = $false
 function Read-Host {{
     param([string] $Prompt)
     $answer = $script:Answers[$script:AnswerIndex]
@@ -1725,7 +2002,7 @@ function Read-Host {{
 function Read-YesNo {{{read_yes_no}}}
 function Select-CodingAgents {{{select_agents}}}
 Select-CodingAgents
-Write-Output "selection:$($script:InstallClaudeCode),$($script:InstallCodex),$($script:InstallPi)"
+Write-Output "selection:$($script:InstallClaudeCode),$($script:InstallCodex),$($script:InstallPi),$($script:EnableRtk)"
 """
 
     result = subprocess.run(
@@ -1770,6 +2047,42 @@ Write-Output "calls:$($script:Calls -join ',')"
 
     assert result.returncode == 0, result.stderr
     assert "calls:codex" in result.stdout
+
+
+@pytest.mark.parametrize("powershell", _powershells())
+def test_install_ps1_configures_rtk_only_for_available_selected_agents(
+    powershell: str,
+) -> None:
+    text = (_repo_root() / "scripts" / "install.ps1").read_text(encoding="utf-8")
+    body = _braced_body(text, "function Configure-RtkForSelectedAgents")
+    script = f"""Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$script:EnableRtk = $true
+$script:InstallClaudeCode = $false
+$script:InstallCodex = $true
+$script:InstallPi = $true
+$script:PiAvailable = $false
+$script:Calls = @()
+function Write-Step {{ param([string] $Message) }}
+function Ensure-Rtk {{ $script:Calls += "ensure" }}
+function Invoke-RtkCommand {{
+    param([string[]] $Arguments)
+    $script:Calls += ($Arguments -join " ")
+}}
+function Configure-RtkForSelectedAgents {{{body}}}
+Configure-RtkForSelectedAgents
+Write-Output "calls:$($script:Calls -join ',')"
+"""
+
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-Command", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "calls:ensure,init --global --codex" in result.stdout
 
 
 @pytest.mark.parametrize("powershell", _powershells())

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.16.8"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC users cannot enable RTK while installing their selected coding agents. Configuring RTK separately adds platform-specific setup and can accidentally overwrite an existing installation.

## Changes

| Before | After |
| --- | --- |
| Installers configure Claude Code, Codex, and Pi without command-output filtering. | Installers offer opt-in global RTK setup for the selected coding agents. |
| Missing RTK requires a separate manual installation. | Missing RTK is installed from official checksum-verified releases on macOS, Linux, and Windows. |
| Existing `rtk` commands are outside installer validation. | Existing RTK is verified without being updated, while conflicting commands stop with a clear error. |
| RTK setup can prompt for telemetry independently. | FCC setup suppresses RTK telemetry without changing an existing user preference. |
| Installer behavior lacks RTK failure-path coverage. | Installer tests cover selection, verification, checksums, conflicts, dry runs, and setup failures across platforms. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

RTK setup now prepares the Claude configuration directory before applying the global patch. A clean-home installation was exercised with RTK configured to reject Claude initialization when that directory is absent; the current installer created the directory first and completed Claude, Codex, and Pi RTK configuration successfully.
</details>

<h3>Confidence Score: 5/5</h3>

The installer’s clean-home RTK configuration path completes successfully.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The clean-home installer now creates the .claude directory before Claude patch, and Claude, Codex, and Pi initialization proceeds with the directory in place.
- The implementation creates the Claude config directory in scripts/install.sh at the ensure\_rtk\_claude\_config\_directory location before running the RTK init, as verified by the code and logs.
- Post-change, the run exits 0 and the RTK init commands proceed because the directory exists, demonstrating the validated flow.

<a href="https://app.greptile.com/trex/runs/17726825/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["Trigger CI"](https://github.com/alishahryar1/free-claude-code/commit/a31b7459c76f4da812f7a0e515201966ce48540a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50893642)</sub>

<!-- /greptile_comment -->