### PR TITLE
Negotiate Groq reasoning vocabularies per model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -649,6 +649,17 @@ owns the exactly typed private per-request runner, recovery operations, tool-cal
 assembly, and streamed usage handling. No obsolete generic transport namespace
 or untyped provider backchannel remains.
 
+[providers/groq/](src/free_claude_code/providers/groq/) is a specialized
+`OpenAIChatProvider` because Groq exposes incompatible `reasoning_effort`
+vocabularies without publishing that capability in model metadata. The Groq
+adapter owns a generation-local vocabulary cache keyed by the exact opaque model
+ID; model names and versions are never parsed to select behavior. A narrowly
+recognized pre-stream 400 can teach the adapter the accepted known vocabulary
+and trigger one request-body correction through the shared provider attempt
+budget. Later requests apply the same pure rewrite proactively. Unknown values
+are never echoed, unrelated errors retain their normal failure path, and no
+separate retry loop or persisted capability registry exists.
+
 [providers/openai_codex/](src/free_claude_code/providers/openai_codex/) owns
 ChatGPT subscription authentication and the Codex backend's OpenAI Responses
 transport. Its process-lifetime auth manager owns FCC's credential file,
@@ -706,9 +717,10 @@ remain unchanged, while deterministic aliases keep retries, replay, and
 append-only prompt prefixes stable. This is target-protocol conversion, never a
 provider or model capability switch.
 Specialized provider packages remain only for true upstream quirks such as
-Gemini thought signatures, NIM tool-schema aliases, retry downgrades, and NVCF
-deployment-failure classification, or DeepSeek attachment/tool/thinking
-compatibility. Local Ollama, Ollama Cloud, llama.cpp, and LM Studio all use the
+Gemini thought signatures, Groq reasoning-vocabulary negotiation, NIM
+tool-schema aliases, retry downgrades, and NVCF deployment-failure
+classification, or DeepSeek attachment/tool/thinking compatibility. Local
+Ollama, Ollama Cloud, llama.cpp, and LM Studio all use the
 same OpenAI-compatible Chat Completions provider family;
 Ollama's standard `reasoning` delta and history field are profile data rather
 than a specialized adapter. DeepSeek intentionally uses its

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.17.0"
+version = "4.17.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/groq/__init__.py
+++ b/src/free_claude_code/providers/groq/__init__.py
@@ -1,0 +1,5 @@
+"""Groq provider package."""
+
+from .client import GroqProvider
+
+__all__ = ["GroqProvider"]

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -1,0 +1,273 @@
+"""Groq chat-completions provider with per-model reasoning negotiation."""
+
+import re
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import openai
+from loguru import logger
+
+from free_claude_code.core.anthropic import ReasoningReplayMode
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import (
+    DEFAULT_REASONING_POLICY,
+    ReasoningEffort,
+    ReasoningPolicy,
+)
+from free_claude_code.providers.admission import ProviderAdmissionController
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_chat import (
+    NamedEffortReasoning,
+    OpenAIChatProfile,
+    OpenAIChatProvider,
+    OpenAIChatRequestPolicy,
+    validate_extra_body_does_not_override_reasoning_fields,
+)
+
+_GROQ_EFFORTS = (
+    (ReasoningEffort.MINIMAL, "low"),
+    (ReasoningEffort.LOW, "low"),
+    (ReasoningEffort.MEDIUM, "medium"),
+    (ReasoningEffort.HIGH, "high"),
+    (ReasoningEffort.XHIGH, "high"),
+    (ReasoningEffort.MAX, "high"),
+)
+_REQUEST_POLICY = OpenAIChatRequestPolicy(
+    provider_name="GROQ",
+    reasoning_replay=ReasoningReplayMode.REASONING_CONTENT,
+    include_extra_body=True,
+    extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+    max_tokens_field="max_completion_tokens",
+    strip_message_names=True,
+    unsupported_body_keys=frozenset({"logprobs", "logit_bias", "top_logprobs"}),
+    normalize_n_to_one=True,
+)
+_PROFILE = OpenAIChatProfile(
+    _REQUEST_POLICY,
+    NamedEffortReasoning(
+        _GROQ_EFFORTS,
+        disabled_value="none",
+        enabled_value="medium",
+    ),
+)
+
+_REASONING_FIELD = "reasoning_effort"
+_KNOWN_VALUES = frozenset({"none", "default", "low", "medium", "high"})
+_FIELD_PATTERN = re.compile(r"(?<![a-z0-9_])reasoning_effort(?![a-z0-9_])", re.I)
+_VALUE_PATTERN = re.compile(
+    r"(?<![a-z0-9_])(none|default|low|medium|high)(?![a-z0-9_])",
+    re.I,
+)
+_ALLOWED_MARKER = re.compile(
+    r"(?:"
+    r"(?:must|should|needs?\s+to)\s+be\s+one\s+of"
+    r"|expected(?:\s+to\s+be)?\s+one\s+of"
+    r"|(?:allowed|valid|accepted)\s+(?:values?|options?)"
+    r")",
+    re.I,
+)
+_CLAUSE_END = re.compile(r"(?:\r?\n|;|[.!?](?:\s|$))")
+_UNSUPPORTED_PHRASE = re.compile(
+    r"(?:"
+    r"unsupported\s+(?:parameter|field)"
+    r"|(?:parameter|field)(?:\s+\S+){0,3}\s+is\s+not\s+supported"
+    r"|unknown\s+(?:parameter|field)"
+    r"|unrecognized\s+(?:parameter|field)"
+    r"|does\s+not\s+support"
+    r")",
+    re.I,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ErrorCandidate:
+    text: str
+    field_context: bool = False
+
+
+class GroqProvider(OpenAIChatProvider):
+    """Groq API with model-agnostic reasoning-vocabulary learning."""
+
+    def __init__(
+        self, config: ProviderConfig, *, admission: ProviderAdmissionController
+    ) -> None:
+        super().__init__(config, profile=_PROFILE, admission=admission)
+        self._model_reasoning_vocabularies: dict[str, frozenset[str]] = {}
+
+    def _build_request_body(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> dict[str, Any]:
+        body = super()._build_request_body(request, reasoning=reasoning)
+        model = body.get("model")
+        if not isinstance(model, str):
+            return body
+        accepted = self._model_reasoning_vocabularies.get(model)
+        if accepted is None:
+            return body
+        return _rewrite_reasoning_effort(body, accepted) or body
+
+    def _get_retry_request_body(
+        self, error: Exception, body: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        accepted = _parse_reasoning_vocabulary(error)
+        model = body.get("model")
+        if accepted is None or not isinstance(model, str):
+            return None
+
+        retry_body = _rewrite_reasoning_effort(body, accepted)
+        if retry_body is None:
+            return None
+
+        self._model_reasoning_vocabularies[model] = accepted
+        action = (
+            "omitting reasoning_effort"
+            if _REASONING_FIELD not in retry_body
+            else "adjusting reasoning_effort"
+        )
+        logger.warning("GROQ_STREAM: {} after upstream rejection", action)
+        return retry_body
+
+
+def _parse_reasoning_vocabulary(error: Exception) -> frozenset[str] | None:
+    """Return Groq's accepted known values, or an understood empty vocabulary."""
+    if not _is_bad_request(error):
+        return None
+
+    candidates = _error_candidates(error)
+    for candidate in candidates:
+        for marker in _ALLOWED_MARKER.finditer(candidate.text):
+            if not _marker_targets_reasoning(candidate, marker):
+                continue
+            tail = candidate.text[marker.end() : marker.end() + 512]
+            clause = _CLAUSE_END.split(tail, maxsplit=1)[0]
+            return frozenset(
+                match.group(1).lower()
+                for match in _VALUE_PATTERN.finditer(clause)
+                if match.group(1).lower() in _KNOWN_VALUES
+            )
+
+    for candidate in candidates:
+        for phrase in _UNSUPPORTED_PHRASE.finditer(candidate.text):
+            if _marker_targets_reasoning(candidate, phrase):
+                return frozenset()
+
+    return None
+
+
+def _rewrite_reasoning_effort(
+    body: dict[str, Any], accepted: frozenset[str]
+) -> dict[str, Any] | None:
+    """Clone ``body`` with a compatible known effort, or omit the field."""
+    current = body.get(_REASONING_FIELD)
+    if not isinstance(current, str):
+        return None
+
+    normalized = current.lower()
+    if normalized in accepted:
+        return None
+
+    rewritten = dict(body)
+    if normalized in {"low", "medium", "high"} and "default" in accepted:
+        rewritten[_REASONING_FIELD] = "default"
+    else:
+        rewritten.pop(_REASONING_FIELD, None)
+    return rewritten
+
+
+def _is_bad_request(error: Exception) -> bool:
+    if isinstance(error, openai.BadRequestError):
+        return True
+    if getattr(error, "status_code", None) == 400:
+        return True
+    response = getattr(error, "response", None)
+    return getattr(response, "status_code", None) == 400
+
+
+def _error_candidates(error: Exception) -> tuple[_ErrorCandidate, ...]:
+    candidates: list[_ErrorCandidate] = []
+    positions: dict[str, int] = {}
+
+    def add(candidate: _ErrorCandidate) -> None:
+        text = candidate.text.strip()
+        if not text:
+            return
+        normalized = _ErrorCandidate(text, candidate.field_context)
+        position = positions.get(text)
+        if position is None:
+            positions[text] = len(candidates)
+            candidates.append(normalized)
+        elif candidate.field_context and not candidates[position].field_context:
+            candidates[position] = normalized
+
+    body = getattr(error, "body", None)
+    for candidate in _body_error_candidates(body):
+        add(candidate)
+
+    response = getattr(error, "response", None)
+    try:
+        response_text = getattr(response, "text", None)
+    except Exception:
+        response_text = None
+    if isinstance(response_text, str):
+        add(_ErrorCandidate(response_text))
+
+    try:
+        error_text = str(error)
+    except Exception:
+        error_text = ""
+    add(_ErrorCandidate(error_text))
+    return tuple(candidates)
+
+
+def _body_error_candidates(
+    value: Any, *, field_context: bool = False
+) -> Iterator[_ErrorCandidate]:
+    if isinstance(value, str):
+        yield _ErrorCandidate(value, field_context)
+        return
+
+    if isinstance(value, Mapping):
+        local_context = field_context or _mapping_names_reasoning_field(value)
+        for key, child in value.items():
+            if str(key).lower() in {"message", "detail"} and isinstance(child, str):
+                yield _ErrorCandidate(child, local_context)
+        for child in value.values():
+            if isinstance(child, (Mapping, list, tuple)):
+                yield from _body_error_candidates(
+                    child,
+                    field_context=local_context,
+                )
+        return
+
+    if isinstance(value, (list, tuple)):
+        for child in value:
+            yield from _body_error_candidates(child, field_context=field_context)
+
+
+def _mapping_names_reasoning_field(value: Mapping[Any, Any]) -> bool:
+    for key, parameter in value.items():
+        if (
+            str(key).lower() in {"param", "parameter"}
+            and isinstance(parameter, str)
+            and parameter.strip().lower() == _REASONING_FIELD
+        ):
+            return True
+    return False
+
+
+def _marker_targets_reasoning(
+    candidate: _ErrorCandidate, marker: re.Match[str]
+) -> bool:
+    if candidate.field_context:
+        return True
+    for field in _FIELD_PATTERN.finditer(candidate.text):
+        start = min(field.start(), marker.start())
+        end = max(field.end(), marker.end())
+        between = candidate.text[start:end]
+        if len(between) <= 128 and _CLAUSE_END.search(between) is None:
+            return True
+    return False

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -1,5 +1,6 @@
 """Groq chat-completions provider with per-model reasoning negotiation."""
 
+import json
 import re
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
@@ -188,64 +189,78 @@ def _is_bad_request(error: Exception) -> bool:
 
 
 def _error_candidates(error: Exception) -> tuple[_ErrorCandidate, ...]:
-    candidates: list[_ErrorCandidate] = []
-    positions: dict[str, int] = {}
-
-    def add(candidate: _ErrorCandidate) -> None:
-        text = candidate.text.strip()
-        if not text:
-            return
-        normalized = _ErrorCandidate(text, candidate.field_context)
-        position = positions.get(text)
-        if position is None:
-            positions[text] = len(candidates)
-            candidates.append(normalized)
-        elif candidate.field_context and not candidates[position].field_context:
-            candidates[position] = normalized
-
     body = getattr(error, "body", None)
-    for candidate in _body_error_candidates(body):
-        add(candidate)
+    if body is not None:
+        return _payload_error_candidates(body)
 
     response = getattr(error, "response", None)
     try:
         response_text = getattr(response, "text", None)
     except Exception:
         response_text = None
-    if isinstance(response_text, str):
-        add(_ErrorCandidate(response_text))
+    if isinstance(response_text, str) and response_text.strip():
+        return _payload_error_candidates(response_text)
 
     try:
         error_text = str(error)
     except Exception:
         error_text = ""
-    add(_ErrorCandidate(error_text))
-    return tuple(candidates)
+    return _payload_error_candidates(error_text)
 
 
-def _body_error_candidates(
-    value: Any, *, field_context: bool = False
-) -> Iterator[_ErrorCandidate]:
+def _payload_error_candidates(value: Any) -> tuple[_ErrorCandidate, ...]:
     if isinstance(value, str):
-        yield _ErrorCandidate(value, field_context)
+        parsed = _parse_json_container(value)
+        if parsed is not None:
+            value = parsed
+    return _deduplicate_candidates(_body_error_candidates(value))
+
+
+def _deduplicate_candidates(
+    candidates: Iterator[_ErrorCandidate],
+) -> tuple[_ErrorCandidate, ...]:
+    result: list[_ErrorCandidate] = []
+    positions: dict[str, int] = {}
+    for candidate in candidates:
+        text = candidate.text.strip()
+        if not text:
+            continue
+        normalized = _ErrorCandidate(text, candidate.field_context)
+        position = positions.get(text)
+        if position is None:
+            positions[text] = len(result)
+            result.append(normalized)
+        elif candidate.field_context and not result[position].field_context:
+            result[position] = normalized
+    return tuple(result)
+
+
+def _parse_json_container(text: str) -> Mapping[Any, Any] | list[Any] | None:
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, (Mapping, list)) else None
+
+
+def _body_error_candidates(value: Any) -> Iterator[_ErrorCandidate]:
+    if isinstance(value, str):
+        yield _ErrorCandidate(value)
         return
 
     if isinstance(value, Mapping):
-        local_context = field_context or _mapping_names_reasoning_field(value)
+        local_context = _mapping_names_reasoning_field(value)
         for key, child in value.items():
             if str(key).lower() in {"message", "detail"} and isinstance(child, str):
                 yield _ErrorCandidate(child, local_context)
         for child in value.values():
             if isinstance(child, (Mapping, list, tuple)):
-                yield from _body_error_candidates(
-                    child,
-                    field_context=local_context,
-                )
+                yield from _body_error_candidates(child)
         return
 
     if isinstance(value, (list, tuple)):
         for child in value:
-            yield from _body_error_candidates(child, field_context=field_context)
+            yield from _body_error_candidates(child)
 
 
 def _mapping_names_reasoning_field(value: Mapping[Any, Any]) -> bool:

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -281,23 +281,6 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         ),
         reasoning_delta_field="reasoning",
     ),
-    "groq": OpenAIChatProfile(
-        _policy(
-            "GROQ",
-            ReasoningReplayMode.REASONING_CONTENT,
-            include_extra_body=True,
-            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
-            max_tokens_field="max_completion_tokens",
-            strip_message_names=True,
-            unsupported_body_keys=frozenset({"logprobs", "logit_bias", "top_logprobs"}),
-            normalize_n_to_one=True,
-        ),
-        NamedEffortReasoning(
-            _LOW_MEDIUM_HIGH,
-            disabled_value="none",
-            enabled_value="medium",
-        ),
-    ),
     "sambanova": OpenAIChatProfile(
         _policy(
             "SAMBANOVA",

--- a/src/free_claude_code/providers/runtime/factory.py
+++ b/src/free_claude_code/providers/runtime/factory.py
@@ -135,6 +135,16 @@ def _create_github_models(
     return GitHubModelsProvider(config, admission=admission)
 
 
+def _create_groq(
+    config: ProviderConfig,
+    _settings: Settings,
+    admission: ProviderAdmissionController,
+) -> BaseProvider:
+    from free_claude_code.providers.groq import GroqProvider
+
+    return GroqProvider(config, admission=admission)
+
+
 _SPECIAL_PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
@@ -146,6 +156,7 @@ _SPECIAL_PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "gemini": _create_gemini,
     "vertex": _create_vertex,
     "github_models": _create_github_models,
+    "groq": _create_groq,
 }
 _INJECTED_PROVIDER_IDS = {"openai"}
 

--- a/tests/contracts/test_feature_manifest.py
+++ b/tests/contracts/test_feature_manifest.py
@@ -8,6 +8,7 @@ from free_claude_code.providers.cloudflare import CloudflareProvider
 from free_claude_code.providers.deepseek import DeepSeekProvider
 from free_claude_code.providers.gemini import GeminiProvider
 from free_claude_code.providers.github_models import GitHubModelsProvider
+from free_claude_code.providers.groq import GroqProvider
 from free_claude_code.providers.kilo import KiloProvider
 from free_claude_code.providers.lmstudio import LMStudioProvider
 from free_claude_code.providers.mistral import MistralProvider
@@ -72,6 +73,7 @@ def test_provider_and_platform_registries_include_builtins() -> None:
         "cloudflare": CloudflareProvider,
         "lmstudio": LMStudioProvider,
         "github_models": GitHubModelsProvider,
+        "groq": GroqProvider,
         "gemini": GeminiProvider,
         "vertex": VertexProvider,
     }

--- a/tests/providers/test_groq.py
+++ b/tests/providers/test_groq.py
@@ -6,8 +6,9 @@ import pytest
 
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.groq import GroqProvider
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import immediate_admission, profiled_provider
+from tests.providers.support import immediate_admission
 
 
 def make_request(**overrides):
@@ -26,7 +27,7 @@ def groq_config():
 
 @pytest.fixture
 def groq_provider(groq_config):
-    return profiled_provider("groq", groq_config, admission=immediate_admission())
+    return GroqProvider(groq_config, admission=immediate_admission())
 
 
 def test_init(groq_config):
@@ -34,9 +35,7 @@ def test_init(groq_config):
     with patch(
         "free_claude_code.providers.openai_chat.provider.AsyncOpenAI"
     ) as mock_openai:
-        provider = profiled_provider(
-            "groq", groq_config, admission=immediate_admission()
-        )
+        provider = GroqProvider(groq_config, admission=immediate_admission())
         assert provider._api_key == "test_groq_key"
         assert provider._base_url == GROQ_DEFAULT_BASE
         mock_openai.assert_called_once()
@@ -57,8 +56,7 @@ def test_build_request_body_basic(groq_provider):
 
 
 def test_build_request_body_global_disable_blocks_reasoning_mapping():
-    provider = profiled_provider(
-        "groq",
+    provider = GroqProvider(
         ProviderConfig(
             api_key="test_groq_key",
             base_url=GROQ_DEFAULT_BASE,

--- a/tests/providers/test_groq_reasoning.py
+++ b/tests/providers/test_groq_reasoning.py
@@ -121,6 +121,18 @@ def test_parse_structured_error_shapes(body: object) -> None:
     )
 
 
+def test_parse_does_not_inherit_reasoning_param_into_unrelated_descendant() -> None:
+    error = _BadRequest(
+        "invalid request",
+        body={
+            "param": "reasoning_effort",
+            "details": [{"message": "temperature must be one of low, medium, or high"}],
+        },
+    )
+
+    assert _parse_reasoning_vocabulary(error) is None
+
+
 def test_parse_actual_openai_bad_request() -> None:
     request = httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions")
     response = httpx.Response(400, request=request)
@@ -140,6 +152,32 @@ def test_parse_response_text_fallback() -> None:
         status_code=None,
         response=response,
     )
+
+    assert _parse_reasoning_vocabulary(error) == frozenset({"none", "default"})
+
+
+def test_parse_json_response_text_preserves_structured_field_scope() -> None:
+    response = SimpleNamespace(
+        status_code=400,
+        text=(
+            '{"param":"reasoning_effort","details":['
+            '{"message":"temperature must be one of low, medium, or high"}]}'
+        ),
+    )
+    error = _BadRequest("invalid request", status_code=None, response=response)
+
+    assert _parse_reasoning_vocabulary(error) is None
+
+
+def test_parse_json_response_text_accepts_direct_reasoning_message() -> None:
+    response = SimpleNamespace(
+        status_code=400,
+        text=(
+            '{"error":{"param":"reasoning_effort",'
+            '"message":"must be one of none or default"}}'
+        ),
+    )
+    error = _BadRequest("invalid request", status_code=None, response=response)
 
     assert _parse_reasoning_vocabulary(error) == frozenset({"none", "default"})
 
@@ -509,6 +547,33 @@ async def test_unrelated_400_propagates_without_cache_poisoning() -> None:
         await provider._create_stream(body, provider._admission.new_retry_session())
 
     assert create.await_count == 1
+    assert provider._model_reasoning_vocabularies == {}
+
+
+@pytest.mark.asyncio
+async def test_nested_unrelated_allow_list_cannot_retry_or_poison_cache() -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.off(),
+    )
+    error = _BadRequest(
+        "invalid request",
+        body={
+            "param": "reasoning_effort",
+            "details": [{"message": "temperature must be one of low, medium, or high"}],
+        },
+    )
+    create = AsyncMock(side_effect=error)
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(_BadRequest),
+    ):
+        await provider._create_stream(body, provider._admission.new_retry_session())
+
+    assert create.await_count == 1
+    assert create.await_args_list[0].kwargs["reasoning_effort"] == "none"
     assert provider._model_reasoning_vocabularies == {}
 
 

--- a/tests/providers/test_groq_reasoning.py
+++ b/tests/providers/test_groq_reasoning.py
@@ -1,0 +1,628 @@
+"""Groq model-agnostic reasoning-vocabulary negotiation tests."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import openai
+import pytest
+
+from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.groq import GroqProvider
+from free_claude_code.providers.groq.client import (
+    _parse_reasoning_vocabulary,
+    _rewrite_reasoning_effort,
+)
+from tests.providers.request_factory import make_messages_request
+from tests.providers.support import capture_openai_chat_wire_body, immediate_admission
+
+_MODEL = "opaque-model-a"
+_ISSUE_MESSAGE = "`reasoning_effort` must be one of `none` or `default`"
+
+
+class _BadRequest(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = 400,
+        body: object | None = None,
+        response: object | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+        self.response = response
+
+
+def _provider(*, max_attempts: int = 5) -> GroqProvider:
+    return GroqProvider(
+        ProviderConfig(
+            api_key="test_groq_key",
+            base_url=GROQ_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(
+            provider_name="GROQ",
+            max_attempts=max_attempts,
+        ),
+    )
+
+
+def _request(model: str = _MODEL):
+    return make_messages_request(model)
+
+
+def _vocabulary_error(
+    values: str = "`none` or `default`",
+    *,
+    current: str = "high",
+) -> _BadRequest:
+    message = f"`reasoning_effort` value `{current}` must be one of {values}"
+    return _BadRequest(
+        message,
+        body={"message": message, "type": "invalid_request_error"},
+    )
+
+
+def _chunk(*, content: str | None = None, finish_reason: str | None = None):
+    delta = MagicMock(
+        content=content,
+        reasoning_content=None,
+        tool_calls=None,
+    )
+    return MagicMock(
+        choices=[MagicMock(delta=delta, finish_reason=finish_reason)],
+        usage=None,
+    )
+
+
+async def _successful_stream(text: str = "visible"):
+    yield _chunk(content=text)
+    yield _chunk(finish_reason="stop")
+
+
+def test_parse_exact_issue_vocabulary_excludes_rejected_value() -> None:
+    error = _BadRequest(
+        _ISSUE_MESSAGE,
+        body={"message": _ISSUE_MESSAGE, "type": "invalid_request_error"},
+    )
+
+    assert _parse_reasoning_vocabulary(error) == frozenset({"none", "default"})
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"error": {"message": _ISSUE_MESSAGE}},
+        {"detail": _ISSUE_MESSAGE},
+        {
+            "error": {
+                "param": "reasoning_effort",
+                "message": "must be one of 'none', 'default'",
+            }
+        },
+        [
+            {
+                "parameter": "reasoning_effort",
+                "detail": "allowed values are NONE or DEFAULT",
+            }
+        ],
+    ],
+)
+def test_parse_structured_error_shapes(body: object) -> None:
+    assert _parse_reasoning_vocabulary(_BadRequest("invalid", body=body)) == (
+        frozenset({"none", "default"})
+    )
+
+
+def test_parse_actual_openai_bad_request() -> None:
+    request = httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions")
+    response = httpx.Response(400, request=request)
+    error = openai.BadRequestError(
+        _ISSUE_MESSAGE,
+        response=response,
+        body={"message": _ISSUE_MESSAGE},
+    )
+
+    assert _parse_reasoning_vocabulary(error) == frozenset({"none", "default"})
+
+
+def test_parse_response_text_fallback() -> None:
+    response = SimpleNamespace(status_code=400, text=_ISSUE_MESSAGE)
+    error = _BadRequest(
+        "invalid request",
+        status_code=None,
+        response=response,
+    )
+
+    assert _parse_reasoning_vocabulary(error) == frozenset({"none", "default"})
+
+
+def test_parse_exception_string_fallback() -> None:
+    assert _parse_reasoning_vocabulary(_BadRequest(_ISSUE_MESSAGE)) == frozenset(
+        {"none", "default"}
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "reasoning_effort should be one of low, medium, or high",
+        "reasoning_effort is expected to be one of low / medium / high",
+        "allowed values for reasoning_effort are low, medium and high",
+        "reasoning_effort valid values: `low`, `medium`, `high`",
+        "accepted options for reasoning_effort include low, medium, high",
+        "reasoning_effort valid option is low",
+    ],
+)
+def test_parse_supported_allow_list_phrasings(message: str) -> None:
+    assert _parse_reasoning_vocabulary(_BadRequest(message)) == frozenset(
+        {"low", "medium", "high"} if "medium" in message else {"low"}
+    )
+
+
+def test_parse_unknown_only_values_returns_understood_empty_vocabulary() -> None:
+    error = _BadRequest("reasoning_effort must be one of `balanced` or `extreme`")
+
+    assert _parse_reasoning_vocabulary(error) == frozenset()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Unsupported parameter: reasoning_effort",
+        "reasoning_effort field is not supported",
+        "Unknown field `reasoning_effort`",
+        "Unrecognized parameter reasoning_effort",
+        "This model does not support reasoning_effort",
+    ],
+)
+def test_parse_explicit_unsupported_phrasings(message: str) -> None:
+    assert _parse_reasoning_vocabulary(_BadRequest(message)) == frozenset()
+
+
+def test_parse_prefers_structured_allow_list_over_fallback_text() -> None:
+    error = _BadRequest(
+        "Unsupported parameter: reasoning_effort",
+        body={"message": _ISSUE_MESSAGE},
+    )
+
+    assert _parse_reasoning_vocabulary(error) == frozenset({"none", "default"})
+
+
+def test_parse_finds_reasoning_allow_list_after_unrelated_clause() -> None:
+    error = _BadRequest(
+        "temperature must be one of 0 or 1; "
+        "reasoning_effort must be one of none or default"
+    )
+
+    assert _parse_reasoning_vocabulary(error) == frozenset({"none", "default"})
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _BadRequest(_ISSUE_MESSAGE, status_code=500),
+        _BadRequest("temperature must be one of low or high"),
+        _BadRequest("reasoning_effort is invalid"),
+        _BadRequest("temperature must be one of low or high; reasoning_effort is set"),
+        _BadRequest(
+            "must be one of low or high",
+            body={"param": "temperature", "message": "must be one of low or high"},
+        ),
+        _BadRequest("Unsupported parameter: temperature; reasoning_effort is set"),
+    ],
+)
+def test_parse_rejects_unrelated_or_ambiguous_errors(error: Exception) -> None:
+    assert _parse_reasoning_vocabulary(error) is None
+
+
+def test_parse_ignores_non_string_response_text() -> None:
+    error = _BadRequest(
+        "invalid",
+        status_code=None,
+        response=SimpleNamespace(status_code=400, text=object()),
+    )
+
+    assert _parse_reasoning_vocabulary(error) is None
+
+
+@pytest.mark.parametrize(
+    "current,accepted,expected",
+    [
+        (None, frozenset({"none", "default"}), None),
+        ("none", frozenset({"none", "default"}), None),
+        ("default", frozenset({"none", "default"}), None),
+        ("low", frozenset({"none", "default"}), "default"),
+        ("medium", frozenset({"none", "default"}), "default"),
+        ("high", frozenset({"none", "default"}), "default"),
+        ("none", frozenset({"low", "medium", "high"}), None),
+        ("low", frozenset({"low", "medium", "high"}), "low"),
+        ("medium", frozenset({"low", "medium", "high"}), "medium"),
+        ("high", frozenset({"low", "medium", "high"}), "high"),
+        ("default", frozenset({"low", "medium", "high"}), None),
+        ("high", frozenset({"low"}), None),
+        ("high", frozenset(), None),
+    ],
+)
+def test_rewrite_reasoning_effort_total_mapping(
+    current: str | None,
+    accepted: frozenset[str],
+    expected: str | None,
+) -> None:
+    body = {"model": _MODEL, "messages": [{"role": "user", "content": "x"}]}
+    if current is not None:
+        body["reasoning_effort"] = current
+    original = {**body, "messages": list(body["messages"])}
+
+    rewritten = _rewrite_reasoning_effort(body, accepted)
+
+    if current is None or current in accepted:
+        assert rewritten is None
+    else:
+        assert rewritten is not None
+        assert rewritten.get("reasoning_effort") == expected
+        assert rewritten["messages"] is body["messages"]
+    assert body == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "policy,expected",
+    [
+        (ReasoningPolicy.provider_default(), None),
+        (ReasoningPolicy.off(), "none"),
+        (ReasoningPolicy.on(), "medium"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.LOW), "low"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.MEDIUM), "medium"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.XHIGH), "high"),
+    ],
+)
+async def test_initial_reasoning_policy_reaches_sdk_wire(
+    policy: ReasoningPolicy,
+    expected: str | None,
+) -> None:
+    body = _provider()._build_request_body(_request(), reasoning=policy)
+
+    wire = await capture_openai_chat_wire_body(body)
+
+    assert wire.get("reasoning_effort") == expected
+
+
+@pytest.mark.asyncio
+async def test_exact_issue_retries_with_default_and_learns_model() -> None:
+    provider = _provider()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
+    body = provider._build_request_body(_request(), reasoning=policy)
+    create = AsyncMock(side_effect=[_vocabulary_error(), object()])
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        _stream, used_body, attempt = await provider._create_stream(
+            body,
+            provider._admission.new_retry_session(),
+        )
+        await attempt.aclose()
+
+    assert create.await_count == 2
+    assert create.await_args_list[0].kwargs["reasoning_effort"] == "high"
+    assert create.await_args_list[1].kwargs["reasoning_effort"] == "default"
+    assert used_body["reasoning_effort"] == "default"
+    assert provider._model_reasoning_vocabularies == {
+        _MODEL: frozenset({"none", "default"})
+    }
+
+    next_body = provider._build_request_body(_request(), reasoning=policy)
+    assert next_body["reasoning_effort"] == "default"
+    next_create = AsyncMock(return_value=object())
+    with patch.object(provider._client.chat.completions, "create", next_create):
+        _stream, next_used_body, next_attempt = await provider._create_stream(
+            next_body,
+            provider._admission.new_retry_session(),
+        )
+        await next_attempt.aclose()
+    assert next_create.await_count == 1
+    assert next_used_body["reasoning_effort"] == "default"
+
+
+def test_cached_none_default_preserves_off() -> None:
+    provider = _provider()
+    provider._model_reasoning_vocabularies[_MODEL] = frozenset({"none", "default"})
+
+    body = provider._build_request_body(_request(), reasoning=ReasoningPolicy.off())
+
+    assert body["reasoning_effort"] == "none"
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        (ReasoningEffort.LOW, "low"),
+        (ReasoningEffort.MEDIUM, "medium"),
+        (ReasoningEffort.HIGH, "high"),
+    ],
+)
+def test_cached_named_vocabulary_preserves_enabled_efforts(
+    effort: ReasoningEffort,
+    expected: str,
+) -> None:
+    provider = _provider()
+    provider._model_reasoning_vocabularies[_MODEL] = frozenset(
+        {"low", "medium", "high"}
+    )
+
+    body = provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(effort=effort),
+    )
+
+    assert body["reasoning_effort"] == expected
+
+
+def test_cached_named_vocabulary_omits_unrepresentable_off() -> None:
+    provider = _provider()
+    provider._model_reasoning_vocabularies[_MODEL] = frozenset(
+        {"low", "medium", "high"}
+    )
+
+    body = provider._build_request_body(_request(), reasoning=ReasoningPolicy.off())
+
+    assert "reasoning_effort" not in body
+
+
+@pytest.mark.asyncio
+async def test_unknown_vocabulary_retries_without_effort_and_negative_caches() -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+    create = AsyncMock(
+        side_effect=[
+            _vocabulary_error("`balanced` or `extreme`"),
+            object(),
+        ]
+    )
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        _stream, used_body, attempt = await provider._create_stream(
+            body,
+            provider._admission.new_retry_session(),
+        )
+        await attempt.aclose()
+
+    assert "reasoning_effort" not in create.await_args_list[1].kwargs
+    assert "reasoning_effort" not in used_body
+    assert provider._model_reasoning_vocabularies[_MODEL] == frozenset()
+    assert "reasoning_effort" not in provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+
+
+def test_reasoning_cache_isolated_by_opaque_model_id() -> None:
+    provider = _provider()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
+    provider._model_reasoning_vocabularies[_MODEL] = frozenset({"none", "default"})
+
+    learned = provider._build_request_body(_request(_MODEL), reasoning=policy)
+    unlearned = provider._build_request_body(
+        _request("opaque-model-b"), reasoning=policy
+    )
+
+    assert learned["reasoning_effort"] == "default"
+    assert unlearned["reasoning_effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_requests_can_learn_without_state_corruption() -> None:
+    provider = _provider()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
+    bodies = [
+        provider._build_request_body(_request(), reasoning=policy),
+        provider._build_request_body(_request(), reasoning=policy),
+    ]
+    initial_calls = 0
+    release_initial_errors = asyncio.Event()
+    sent_efforts: list[str | None] = []
+
+    async def create(**kwargs: object):
+        nonlocal initial_calls
+        effort = kwargs.get("reasoning_effort")
+        sent_efforts.append(effort if isinstance(effort, str) else None)
+        if effort == "high":
+            initial_calls += 1
+            if initial_calls == 2:
+                release_initial_errors.set()
+            await release_initial_errors.wait()
+            raise _vocabulary_error()
+        return object()
+
+    async def execute(body: dict):
+        _stream, used_body, attempt = await provider._create_stream(
+            body,
+            provider._admission.new_retry_session(),
+        )
+        await attempt.aclose()
+        return used_body
+
+    mock_create = AsyncMock(side_effect=create)
+    with patch.object(provider._client.chat.completions, "create", mock_create):
+        used_bodies = await asyncio.gather(*(execute(body) for body in bodies))
+
+    assert mock_create.await_count == 4
+    assert sent_efforts.count("high") == 2
+    assert sent_efforts.count("default") == 2
+    assert all(body["reasoning_effort"] == "default" for body in used_bodies)
+    assert provider._model_reasoning_vocabularies == {
+        _MODEL: frozenset({"none", "default"})
+    }
+
+
+@pytest.mark.asyncio
+async def test_stale_cache_self_heals_without_guessing_original_effort() -> None:
+    provider = _provider()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
+    provider._model_reasoning_vocabularies[_MODEL] = frozenset({"none", "default"})
+    cached_body = provider._build_request_body(_request(), reasoning=policy)
+    assert cached_body["reasoning_effort"] == "default"
+    create = AsyncMock(
+        side_effect=[
+            _vocabulary_error("`low`, `medium`, or `high`", current="default"),
+            object(),
+        ]
+    )
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        _stream, corrected_body, attempt = await provider._create_stream(
+            cached_body,
+            provider._admission.new_retry_session(),
+        )
+        await attempt.aclose()
+
+    assert "reasoning_effort" not in corrected_body
+    assert provider._model_reasoning_vocabularies[_MODEL] == frozenset(
+        {"low", "medium", "high"}
+    )
+    rebuilt = provider._build_request_body(_request(), reasoning=policy)
+    assert rebuilt["reasoning_effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_400_propagates_without_cache_poisoning() -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+    create = AsyncMock(side_effect=_BadRequest("messages: invalid role 'wizard'"))
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(_BadRequest, match="wizard"),
+    ):
+        await provider._create_stream(body, provider._admission.new_retry_session())
+
+    assert create.await_count == 1
+    assert provider._model_reasoning_vocabularies == {}
+
+
+@pytest.mark.asyncio
+async def test_advertised_current_value_does_not_retry_or_cache() -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+    create = AsyncMock(side_effect=_vocabulary_error("`low`, `medium`, or `high`"))
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(_BadRequest),
+    ):
+        await provider._create_stream(body, provider._admission.new_retry_session())
+
+    assert create.await_count == 1
+    assert provider._model_reasoning_vocabularies == {}
+
+
+@pytest.mark.asyncio
+async def test_last_attempt_learns_but_does_not_exceed_budget() -> None:
+    provider = _provider(max_attempts=1)
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
+    body = provider._build_request_body(_request(), reasoning=policy)
+    create = AsyncMock(side_effect=_vocabulary_error())
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(_BadRequest),
+    ):
+        await provider._create_stream(body, provider._admission.new_retry_session())
+
+    assert create.await_count == 1
+    assert provider._model_reasoning_vocabularies[_MODEL] == frozenset(
+        {"none", "default"}
+    )
+    assert (
+        provider._build_request_body(_request(), reasoning=policy)["reasoning_effort"]
+        == "default"
+    )
+
+
+@pytest.mark.asyncio
+async def test_output_cap_and_reasoning_corrections_share_one_session() -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        make_messages_request(_MODEL, max_tokens=64_000),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+    cap_error = _BadRequest("max_completion_tokens must be less than or equal to 40960")
+    create = AsyncMock(side_effect=[cap_error, _vocabulary_error(), object()])
+    session = provider._admission.new_retry_session()
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        _stream, used_body, attempt = await provider._create_stream(body, session)
+        await attempt.aclose()
+
+    assert create.await_count == 3
+    assert session.attempts_started == 3
+    assert create.await_args_list[1].kwargs["max_completion_tokens"] == 40_960
+    assert create.await_args_list[1].kwargs["reasoning_effort"] == "high"
+    assert create.await_args_list[2].kwargs["max_completion_tokens"] == 40_960
+    assert create.await_args_list[2].kwargs["reasoning_effort"] == "default"
+    assert used_body["max_completion_tokens"] == 40_960
+    assert used_body["reasoning_effort"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_corrected_request_cannot_enter_vocabulary_retry_loop() -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+    create = AsyncMock(side_effect=[_vocabulary_error(), _vocabulary_error()])
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(_BadRequest),
+    ):
+        await provider._create_stream(body, provider._admission.new_retry_session())
+
+    assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reasoning_correction_emits_one_downstream_lifecycle() -> None:
+    provider = _provider()
+    request = _request()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
+    create = AsyncMock(side_effect=[_vocabulary_error(), _successful_stream()])
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        raw = "".join(
+            [
+                event
+                async for event in provider.stream_response(
+                    request,
+                    reasoning=policy,
+                )
+            ]
+        )
+
+    events = parse_sse_text(raw)
+    assert create.await_count == 2
+    assert create.await_args_list[0].kwargs["reasoning_effort"] == "high"
+    assert create.await_args_list[1].kwargs["reasoning_effort"] == "default"
+    assert "visible" in raw
+    assert "event: error" not in raw
+    assert sum(event.event == "message_start" for event in events) == 1
+    assert sum(event.event == "content_block_start" for event in events) == 1
+    assert sum(event.event == "content_block_stop" for event in events) == 1
+    assert sum(event.event == "message_delta" for event in events) == 1
+    assert sum(event.event == "message_stop" for event in events) == 1

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -11,12 +11,13 @@ import pytest
 
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
 from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.groq import GroqProvider
 from free_claude_code.providers.openai_chat.output_cap import (
     clamp_output_tokens,
     parse_output_token_cap,
 )
 from tests.providers.request_factory import make_messages_request
-from tests.providers.support import immediate_admission, profiled_provider
+from tests.providers.support import immediate_admission
 
 
 class _BadRequest(Exception):
@@ -112,8 +113,7 @@ def test_clamp_ignores_bool_values():
 
 @pytest.fixture
 def groq_provider():
-    return profiled_provider(
-        "groq",
+    return GroqProvider(
         ProviderConfig(
             api_key="test_groq_key",
             base_url=GROQ_DEFAULT_BASE,

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -28,6 +28,7 @@ from free_claude_code.providers.cloudflare import CloudflareProvider
 from free_claude_code.providers.deepseek import DeepSeekProvider
 from free_claude_code.providers.gemini import GeminiProvider
 from free_claude_code.providers.github_models import GitHubModelsProvider
+from free_claude_code.providers.groq import GroqProvider
 from free_claude_code.providers.kilo import KiloProvider
 from free_claude_code.providers.lmstudio import LMStudioProvider
 from free_claude_code.providers.mistral import MistralProvider
@@ -496,7 +497,7 @@ def test_create_provider_instantiates_each_builtin():
         "zai": OpenAIChatProvider,
         "gemini": GeminiProvider,
         "vertex": VertexProvider,
-        "groq": OpenAIChatProvider,
+        "groq": GroqProvider,
         "sambanova": OpenAIChatProvider,
         "kilo": KiloProvider,
         "cerebras": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.17.0"
+version = "4.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Groq models accept incompatible `reasoning_effort` vocabularies, but FCC encoded every Groq request with one static `low`/`medium`/`high` profile. Models that accept only `none`/`default` therefore rejected client-controlled reasoning with HTTP 400. Fixes #1348.

## Changes

| Before | After |
| --- | --- |
| Groq was an ordinary immutable OpenAI-chat profile with one provider-wide reasoning vocabulary. | Groq is a specialized OpenAI-chat adapter that keeps the shared transport while owning model-agnostic reasoning negotiation. |
| A recognized vocabulary rejection escaped directly to the client. | FCC parses only narrowly identified pre-stream 400s, rewrites once within the existing attempt budget, and learns the accepted known vocabulary per opaque model ID for later requests. |
| Unknown values, stale learned state, concurrent first requests, stacked fallbacks, and duplicate downstream lifecycle behavior were unguarded. | Closed-vocabulary parsing never echoes unknown tokens, cache state self-heals without model-name branches, and focused SDK-wire/retry/concurrency/lifecycle coverage protects the full behavior. |
| The package remained at 4.17.0. | The bug fix ships as 4.17.1 with the lockfile synchronized. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Groq now uses a dedicated provider that learns compatible reasoning-effort values per model while preserving the OpenAI-compatible request flow. The nested error-detail path was exercised with a reasoning field declaration alongside an unrelated temperature validation message; it made one upstream request and left the model vocabulary cache empty, confirming unrelated nested details do not alter later requests.
</details>

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The exercised reasoning-vocabulary error path preserves model capability data when an unrelated nested validation detail is returned.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Created and prepared the focused Groq nested-context validation script to drive the validation workflow.
- Executed the focused Groq retry and cache test for a 400 response with param: reasoning\_effort and a nested temperature allow-list message; the test passed under CPython 3.14 with exit code 0, showing one upstream call with reasoning\_effort="none" and an empty model vocabulary cache.
- Inspected the passing output log for Groq nested-context retry and cache validation.
- Reviewed the contract validation approach and code behavior that field context is derived only for direct message/detail strings and not inherited by descendants, and that retry/cache mutation is declined when parsing returns None; the related test passed.

<a href="https://app.greptile.com/trex/runs/17763928/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Scope Groq reasoning error parsing"](https://github.com/alishahryar1/free-claude-code/commit/656bd5f27cabad85115d90217e58826ebbb995d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51088225)</sub>

<!-- /greptile_comment -->