### PR TITLE
Recover from quoted output-token caps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.17.3"
+version = "4.17.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/openai_chat/output_cap.py
+++ b/src/free_claude_code/providers/openai_chat/output_cap.py
@@ -24,14 +24,15 @@ _OUTPUT_TOKEN_FIELDS = ("max_completion_tokens", "max_tokens")
 _OUTPUT_TOKEN_KEYWORDS = ("max_completion_tokens", "max_tokens")
 
 # Comparator phrases that precede the allowed maximum in provider error text.
+_CAP_VALUE_PATTERN = r"[`'\"]?(\d+)[`'\"]?"
 _CAP_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"less than or equal to\s+(\d+)"),
-    re.compile(r"smaller than or equal to\s+(\d+)"),
-    re.compile(r"<=\s*(\d+)"),
-    re.compile(r"at most\s+(\d+)"),
-    re.compile(r"must not exceed\s+(\d+)"),
-    re.compile(r"maximum(?:\s+value)?(?:\s+for\s+\S+)?\s+is\s+(\d+)"),
-    re.compile(r"maximum(?:\s+allowed)?(?:\s+value)?\s+of\s+(\d+)"),
+    re.compile(rf"less than or equal to\s+{_CAP_VALUE_PATTERN}"),
+    re.compile(rf"smaller than or equal to\s+{_CAP_VALUE_PATTERN}"),
+    re.compile(rf"<=\s*{_CAP_VALUE_PATTERN}"),
+    re.compile(rf"at most\s+{_CAP_VALUE_PATTERN}"),
+    re.compile(rf"must not exceed\s+{_CAP_VALUE_PATTERN}"),
+    re.compile(rf"maximum(?:\s+value)?(?:\s+for\s+\S+)?\s+is\s+{_CAP_VALUE_PATTERN}"),
+    re.compile(rf"maximum(?:\s+allowed)?(?:\s+value)?\s+of\s+{_CAP_VALUE_PATTERN}"),
 )
 
 

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -36,10 +36,11 @@ class _BadRequest(Exception):
 
 def test_parse_cap_from_groq_message():
     error = _BadRequest(
-        "max_completion_tokens must be less than or equal to 40960, the maximum "
-        "value for max_completion_tokens is less than the context_window for this model"
+        "`max_completion_tokens` must be less than or equal to `16384`, the maximum "
+        "value for `max_completion_tokens` is less than the `context_window` for this "
+        "model"
     )
-    assert parse_output_token_cap(error) == 40960
+    assert parse_output_token_cap(error) == 16384
 
 
 @pytest.mark.parametrize(
@@ -136,7 +137,18 @@ async def test_create_stream_clamps_and_learns_on_cap_rejection(groq_provider):
     assert body["max_completion_tokens"] == 64000
     model = body["model"]
 
-    error = _BadRequest("max_completion_tokens must be less than or equal to 40960")
+    error = _BadRequest(
+        "invalid request",
+        body={
+            "message": (
+                "`max_completion_tokens` must be less than or equal to `16384`, "
+                "the maximum value for `max_completion_tokens` is less than the "
+                "`context_window` for this model"
+            ),
+            "type": "invalid_request_error",
+            "param": "max_completion_tokens",
+        },
+    )
     create = AsyncMock(side_effect=[error, object()])
 
     with patch.object(groq_provider._client.chat.completions, "create", create):
@@ -147,9 +159,9 @@ async def test_create_stream_clamps_and_learns_on_cap_rejection(groq_provider):
         await attempt.aclose()
 
     assert create.call_count == 2
-    assert create.call_args_list[1].kwargs["max_completion_tokens"] == 40960
-    assert used_body["max_completion_tokens"] == 40960
-    assert groq_provider._model_output_caps[model] == 40960
+    assert create.call_args_list[1].kwargs["max_completion_tokens"] == 16384
+    assert used_body["max_completion_tokens"] == 16384
+    assert groq_provider._model_output_caps[model] == 16384
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.17.3"
+version = "4.17.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Groq wraps output-token limits in backticks. The shared cap parser ignored the quoted number, so FCC returned the upstream 400 instead of clamping and retrying. Fixes #1354.

## Changes

| Before | After |
| --- | --- |
| Output-cap recovery accepted only bare numeric limits. | Output-cap recovery accepts numeric limits wrapped in backticks or quotes. |
| Groq's exact structured error escaped the shared retry path. | Groq's exact structured error clamps to `16384`, retries, and caches the learned cap. |
| Regression coverage used an easier unquoted approximation. | Regression coverage uses the reporter's exact upstream error body. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update allows output-token limits enclosed in backticks or quotes to be recovered from OpenAI-compatible provider errors, including Groq’s structured 400 response. The quoted-error flow was exercised with a real OpenAI client against a mocked upstream response: the request retried with 16,384 output tokens, stored that cap for the model, and applied it proactively to the next request. The focused output-cap test suite passed with 18 tests. No defects were found, and the change is safe to merge.
</details>

<h3>Confidence Score: 5/5</h3>

The provider correctly recovers from Groq’s quoted output-cap error and preserves the existing retry and learned-cap behavior.

The complete request path was exercised before and after the change using a real OpenAI client and a mocked OpenAI-format Groq error response. The updated implementation retried at the parsed cap and proactively reused it, while the focused regression suite passed.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a real OpenAI client request through GroqProvider.\_create\_stream against a mocked OpenAI 400 response with quoted max\_completion\_tokens, first on the parent commit and then on the change; observed the token sequence of 64,000 on the initial call, followed by 16,384 tokens on the retry and 16,384 tokens on the proactive call.
- Executed the test suite with uv run pytest -q tests/providers/test\_openai\_chat\_output\_cap.py; all 18 focused parser, retry, and learned-cap tests passed, confirming quoted provider limits now enter the existing recovery path.
- Completed the requested verification; noted that the local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/17920881/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix quoted output token cap recovery"](https://github.com/alishahryar1/free-claude-code/commit/d6601b440060d7f540da6203119223aee89e9962) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51419367)</sub>

<!-- /greptile_comment -->