### PR TITLE
Fix Codex App authentication for signed-in users

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1117,6 +1117,12 @@ instead of stopping at its login gate.
 - It stores the proxy auth token in `FCC_CODEX_API_KEY` for Codex's provider
   `env_key` to read. This process-local variable is a client credential carrier,
   not a second FCC setting.
+- Persistent Codex App and IDE configuration uses Codex's command-backed provider
+  authentication. Codex invokes `fcc-codex --print-proxy-auth-token`, which reads
+  the canonical FCC settings, prints only the shared proxy-auth token (or the
+  no-auth sentinel), and exits without a proxy preflight, model request, or client
+  process. This makes the FCC provider own its bearer credential instead of
+  competing with Codex's signed-in OpenAI authorization.
 
 [cli/launchers/pi.py](src/free_claude_code/cli/launchers/pi.py) owns the installed
 `fcc-pi` launcher and [cli/launchers/pi_extension.ts](src/free_claude_code/cli/launchers/pi_extension.ts)

--- a/README.md
+++ b/README.md
@@ -322,12 +322,16 @@ model = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 [model_providers.fcc]
 name = "Free Claude Code"
 base_url = "http://127.0.0.1:8082/v1"
-http_headers = { Authorization = "Bearer freecc" }
 wire_api = "responses"
+
+[model_providers.fcc.auth]
+command = "fcc-codex"
+args = ["--print-proxy-auth-token"]
 ```
 
-Match the model, port, and bearer token to the Admin UI. Restart the Codex App
-after setup or model changes, then select an FCC model from its model picker.
+Match the model and port to the Admin UI. The auth command reads FCC's current
+proxy token automatically. Restart the Codex App after setup or model changes,
+then select an FCC model from its model picker.
 
 </details>
 
@@ -343,11 +347,16 @@ model = "nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 [model_providers.fcc]
 name = "Free Claude Code"
 base_url = "http://127.0.0.1:8082/v1"
-http_headers = { Authorization = "Bearer freecc" }
 wire_api = "responses"
+
+[model_providers.fcc.auth]
+command = "fcc-codex"
+args = ["--print-proxy-auth-token"]
 ```
 
-Match `model`, the port, and bearer token to the Admin UI, then restart VS Code. For WSL-backed Codex, edit the file inside WSL.
+Match `model` and the port to the Admin UI. The auth command reads FCC's current
+proxy token automatically. Restart VS Code after setup or model changes. For
+WSL-backed Codex, edit the file inside WSL.
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.17.4"
+version = "4.17.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/codex.py
+++ b/src/free_claude_code/cli/launchers/codex.py
@@ -24,6 +24,7 @@ from .common import (
 )
 
 _CODEX_AUTH_ENV_KEY = "FCC_CODEX_API_KEY"
+_PRINT_PROXY_AUTH_TOKEN_FLAG = "--print-proxy-auth-token"
 _DISPLAY_NAME = "Codex CLI"
 _DEFAULT_BINARY = "codex"
 _INSTALL_HINT = "Install Codex with: npm install -g @openai/codex"
@@ -48,7 +49,12 @@ _STRIPPED_CODEX_ENV_KEYS = frozenset(
 def launch(argv: Sequence[str] | None = None) -> None:
     """Launch Codex CLI with Free Claude Code proxy configuration."""
 
+    args = list(sys.argv[1:] if argv is None else argv)
     settings = get_settings()
+    if args == [_PRINT_PROXY_AUTH_TOKEN_FLAG]:
+        print(proxy_auth_token(settings.anthropic_auth_token))
+        return
+
     proxy_root_url = local_proxy_root_url(settings)
     if error := preflight_proxy(proxy_root_url):
         print(
@@ -65,7 +71,6 @@ def launch(argv: Sequence[str] | None = None) -> None:
         install_hint=_INSTALL_HINT,
     )
     catalog_args = codex_model_catalog_config_args(proxy_root_url, settings)
-    args = list(sys.argv[1:] if argv is None else argv)
     run_client_process(
         command=build_codex_launcher_command(
             binary_path=binary_path,

--- a/tests/cli/test_codex_model_catalog.py
+++ b/tests/cli/test_codex_model_catalog.py
@@ -163,8 +163,11 @@ def test_generated_catalog_schema_is_accepted_by_installed_codex(
                 "[model_providers.fcc]",
                 'name = "Free Claude Code"',
                 'base_url = "http://127.0.0.1:8082/v1"',
-                'http_headers = { Authorization = "Bearer freecc" }',
                 'wire_api = "responses"',
+                "",
+                "[model_providers.fcc.auth]",
+                'command = "fcc-codex"',
+                'args = ["--print-proxy-auth-token"]',
                 "",
             )
         ),

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -623,6 +623,38 @@ def test_launch_codex_passes_responses_config_and_child_env(
     unregister_pid.assert_called_once_with(12345)
 
 
+@pytest.mark.parametrize(
+    ("configured_token", "expected_token"),
+    [
+        (" proxy-token ", "proxy-token"),
+        ("", "fcc-no-auth"),
+    ],
+)
+def test_codex_proxy_auth_command_prints_only_current_token(
+    configured_token: str,
+    expected_token: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from free_claude_code.cli.launchers import codex
+
+    settings = _launcher_settings(token=configured_token)
+    with (
+        patch.object(codex, "get_settings", return_value=settings) as get_settings,
+        patch.object(codex, "preflight_proxy") as preflight_proxy,
+        patch.object(codex, "resolve_client_binary") as resolve_client_binary,
+        patch.object(codex, "open_local_request") as open_local_request,
+        patch.object(codex, "run_client_process") as run_client_process,
+    ):
+        codex.launch(["--print-proxy-auth-token"])
+
+    assert capsys.readouterr() == (f"{expected_token}\n", "")
+    get_settings.assert_called_once_with()
+    preflight_proxy.assert_not_called()
+    resolve_client_binary.assert_not_called()
+    open_local_request.assert_not_called()
+    run_client_process.assert_not_called()
+
+
 def test_launch_codex_catalog_failure_warns_and_continues(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.17.4"
+version = "4.17.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Codex App and VS Code replace FCC's documented static authorization header with the signed-in OpenAI JWT, causing valid FCC requests to fail proxy authentication. Fixes #1360.

## Changes

| Before | After |
| --- | --- |
| Persistent Codex configuration supplied FCC authentication as a static header. | Persistent Codex configuration uses Codex's command-backed provider authentication. |
| Users duplicated the FCC bearer token in Codex configuration. | `fcc-codex --print-proxy-auth-token` reads the canonical FCC setting and prints only the current credential. |
| Credential lookup shared the normal launcher lifecycle. | Credential lookup exits before proxy preflight, model discovery, binary resolution, or Codex launch. |
| Codex compatibility coverage retained the static-header configuration. | Codex 0.147 compatibility verifies model discovery and inference with the FCC-owned bearer credential. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change replaces persistent Codex authorization headers with a command-backed FCC credential flow and updates the Codex App and VS Code setup examples. The credential command was exercised with configured and blank tokens, an unreachable proxy, and no Codex executable on `PATH`; it returned the current trimmed proxy token or the no-auth sentinel without launching a client. A real Codex 0.147.0 provider flow also invoked the documented command and sent its result as the Bearer credential for model and response requests. No defects were found.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised command path and real Codex provider request flow.

The new credential command was verified for configured and blank-token settings, without a reachable proxy or installed Codex binary, and through a real Codex 0.147.0 request path. No publishable defects remain.

**Files Needing Attention:** No files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the parent behavior with no proxy running and observed that the proxy-auth command enters the normal launcher flow while the proxy preflight fails.
- Verified the updated fcc-codex prints only the trimmed configured token or the fcc-no-auth sentinel, with exit code 0, even when no proxy is reachable and Codex is not on PATH.
- Ran the focused proxy-auth tests and confirmed the Codex 0.147.0 harness exercises the auth command path and uses the returned value as the Bearer credential for model and responses requests.
- Validated after installation that the outputs are canonical-proxy-token or fcc-no-auth and that the documented model\_providers.fcc.auth path executes within a real provider request flow using a local provider capture server.

<a href="https://app.greptile.com/trex/runs/17957916/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Codex App proxy authentication"](https://github.com/alishahryar1/free-claude-code/commit/3a65a37eaa6181425663d6d9b761024d5f7b311c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51495606)</sub>

<!-- /greptile_comment -->