### PR TITLE
Fix Codex auth configuration conflicts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1113,16 +1113,15 @@ instead of stopping at its login gate.
   fail-open: launch continues with a warning if the catalog cannot be prepared.
 - The server lifecycle independently keeps that same file synchronized for
   Codex App and IDE processes that are not launched through `fcc-codex`.
-- Catalog discovery and inference both authenticate with HTTP bearer authorization.
-- It stores the proxy auth token in `FCC_CODEX_API_KEY` for Codex's provider
-  `env_key` to read. This process-local variable is a client credential carrier,
-  not a second FCC setting.
-- Persistent Codex App and IDE configuration uses Codex's command-backed provider
-  authentication. Codex invokes `fcc-codex --print-proxy-auth-token`, which reads
-  the canonical FCC settings, prints only the shared proxy-auth token (or the
-  no-auth sentinel), and exits without a proxy preflight, model request, or client
-  process. This makes the FCC provider own its bearer credential instead of
-  competing with Codex's signed-in OpenAI authorization.
+- Launcher-side catalog discovery authenticates directly with the canonical proxy
+  token.
+- Inference through `fcc-codex`, Codex App, and IDE integrations uses the same
+  command-backed provider authentication. Codex invokes
+  `fcc-codex --print-proxy-auth-token`, which reads the canonical FCC settings,
+  prints only the shared proxy-auth token (or the no-auth sentinel), and exits
+  without a proxy preflight, model request, or client process. This gives every
+  Codex surface one credential owner instead of competing with Codex's signed-in
+  OpenAI authorization.
 
 [cli/launchers/pi.py](src/free_claude_code/cli/launchers/pi.py) owns the installed
 `fcc-pi` launcher and [cli/launchers/pi_extension.ts](src/free_claude_code/cli/launchers/pi_extension.ts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.17.5"
+version = "4.17.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/codex.py
+++ b/src/free_claude_code/cli/launchers/codex.py
@@ -23,7 +23,6 @@ from .common import (
     run_client_process,
 )
 
-_CODEX_AUTH_ENV_KEY = "FCC_CODEX_API_KEY"
 _PRINT_PROXY_AUTH_TOKEN_FLAG = "--print-proxy-auth-token"
 _DISPLAY_NAME = "Codex CLI"
 _DEFAULT_BINARY = "codex"
@@ -41,7 +40,6 @@ _STRIPPED_CODEX_ENV_KEYS = frozenset(
         "CODEX_PERMISSION_PROFILE",
         "CODEX_SHELL",
         "CODEX_THREAD_ID",
-        _CODEX_AUTH_ENV_KEY,
     }
 )
 
@@ -81,7 +79,6 @@ def launch(argv: Sequence[str] | None = None) -> None:
         ),
         env=build_codex_launcher_env(
             proxy_root_url=proxy_root_url,
-            auth_token=settings.anthropic_auth_token,
             base_env=os.environ,
         ),
         binary_name=binary_name,
@@ -120,7 +117,6 @@ def build_codex_launcher_command(
 def build_codex_launcher_env(
     *,
     proxy_root_url: str,
-    auth_token: str,
     base_env: Mapping[str, str],
 ) -> dict[str, str]:
     """Return a Codex environment that targets the local proxy provider."""
@@ -133,7 +129,6 @@ def build_codex_launcher_env(
         },
         proxy_root_url=proxy_root_url,
     )
-    env[_CODEX_AUTH_ENV_KEY] = proxy_auth_token(auth_token)
     return env
 
 
@@ -206,7 +201,11 @@ def codex_config_args(*, api_url: str, model: str | None = None) -> list[str]:
         "-c",
         _toml_assignment("model_providers.fcc.base_url", _ensure_v1_url(api_url)),
         "-c",
-        _toml_assignment("model_providers.fcc.env_key", _CODEX_AUTH_ENV_KEY),
+        _toml_assignment("model_providers.fcc.auth.command", "fcc-codex"),
+        "-c",
+        _toml_assignment(
+            "model_providers.fcc.auth.args", [_PRINT_PROXY_AUTH_TOKEN_FLAG]
+        ),
         "-c",
         _toml_assignment("model_providers.fcc.wire_api", "responses"),
     ]
@@ -220,5 +219,5 @@ def _ensure_v1_url(url: str) -> str:
     return stripped if stripped.endswith("/v1") else f"{stripped}/v1"
 
 
-def _toml_assignment(key: str, value: str) -> str:
+def _toml_assignment(key: str, value: str | list[str]) -> str:
     return f"{key}={json.dumps(value)}"

--- a/tests/cli/test_codex_model_catalog.py
+++ b/tests/cli/test_codex_model_catalog.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import pytest
 
+from free_claude_code.cli.launchers.codex import codex_config_args
 from free_claude_code.cli.launchers.codex_model_catalog import (
     build_codex_model_catalog,
     write_codex_model_catalog,
@@ -139,7 +140,7 @@ def test_codex_catalog_accepts_future_direct_provider_slugs() -> None:
     ]
 
 
-def test_generated_catalog_schema_is_accepted_by_installed_codex(
+def test_launcher_config_composes_with_persistent_codex_config(
     tmp_path: Path,
 ) -> None:
     codex_binary = shutil.which("codex")
@@ -184,7 +185,12 @@ def test_generated_catalog_schema_is_accepted_by_installed_codex(
     codex_env["CODEX_HOME"] = str(codex_home)
 
     result = subprocess.run(
-        [codex_binary, "debug", "models"],
+        [
+            codex_binary,
+            *codex_config_args(api_url="http://127.0.0.1:8082/v1"),
+            "debug",
+            "models",
+        ],
         capture_output=True,
         check=False,
         encoding="utf-8",

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -595,7 +595,10 @@ def test_launch_codex_passes_responses_config_and_child_env(
     assert command[0] == "resolved-codex.cmd"
     assert 'model_provider="fcc"' in command
     assert 'model_providers.fcc.base_url="http://127.0.0.1:9191/v1"' in command
+    assert 'model_providers.fcc.auth.command="fcc-codex"' in command
+    assert 'model_providers.fcc.auth.args=["--print-proxy-auth-token"]' in command
     assert 'model_providers.fcc.wire_api="responses"' in command
+    assert not any("model_providers.fcc.env_key" in arg for arg in command)
     assert f"model_catalog_json={json.dumps(str(catalog_path))}" in command
     assert command[-2:] == ["exec", "hello"]
     assert len(requests) == 1
@@ -609,7 +612,7 @@ def test_launch_codex_passes_responses_config_and_child_env(
         "nvidia_nim/provider-model"
     ]
     child_env = popen.call_args.kwargs["env"]
-    assert child_env["FCC_CODEX_API_KEY"] == "proxy-token"
+    assert "FCC_CODEX_API_KEY" not in child_env
     assert child_env["CODEX_HOME"] == "keep-home"
     assert child_env["NO_PROXY"] == "127.0.0.1,localhost,::1"
     assert child_env["no_proxy"] == child_env["NO_PROXY"]

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.17.5"
+version = "4.17.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Codex rejected `fcc-codex` startup when persistent App or IDE configuration used command authentication because the launcher added a mutually exclusive environment-key credential to the same provider. Fixes #1367.

## Changes

| Before | After |
| --- | --- |
| `fcc-codex` carried the proxy token in `FCC_CODEX_API_KEY`. | Every Codex surface obtains the proxy token through `fcc-codex --print-proxy-auth-token`. |
| Persistent and ephemeral provider configuration could merge two authentication mechanisms. | Persistent and ephemeral provider configuration share one command-backed authentication owner. |
| Codex configuration tests exercised the two authentication paths separately. | The installed-Codex regression test layers the exact launcher arguments over persistent App configuration. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change moves Codex proxy authentication from a launcher-injected environment variable to the command-backed token provider. The tested authentication failure path did not occur: `fcc-codex --print-proxy-auth-token` returned the configured token without recursively invoking Codex, and Codex CLI 0.147.0 accepted the generated provider configuration and loaded the generated model catalog.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised Codex token-command and provider-configuration flows.

No defects remain in the final review. The focused runtime check exercised exact token output, prevented recursive Codex execution with a shadowed executable, and confirmed that an installed Codex CLI accepts the generated configuration.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused authentication harness was run with a whitespace-padded token and a fake failing Codex on PATH, and the fcc-codex --print-proxy-auth-token output the canonical token followed by a newline without invoking the fake Codex.
- The same harness was run against Codex CLI 0.147.0; codex debug models accepted the generated model\_providers.fcc.auth.command and model\_providers.fcc.auth.args, exited successfully, returned nvidia\_nim/test-model, and did not invoke the fake executable.
- Validation showed the previously proposed failure path did not occur; the token command produced the canonical token and did not trigger the shadowed Codex binary, and Codex accepted the command-backed provider configuration.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Codex provider auth composition"](https://github.com/alishahryar1/free-claude-code/commit/5601f55308bb64005b725d1438d78e602ec5ef3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51562529)</sub>

<!-- /greptile_comment -->