### PR TITLE
Run CI only before merges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,8 @@ env:
   UV_PREVIEW_FEATURES: "malware-check"
 
 on:
-  push:
-    branches: [main, master]
   pull_request:
-    branches: [main, master]
-  merge_group:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@
 - Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
-- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced in `tests.yml` on push/merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- GitHub CI runs on `push`, `pull_request`, and `merge_group` so required checks validate merge queue candidates before they land.
-- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
+- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
+- GitHub CI runs only for pull requests targeting `main`. Strict required checks keep each PR current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
+- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests and strict required checks, keeps branches current, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
 - Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 
 ## IDENTITY & CONTEXT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@
 - Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
-- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced in `tests.yml` on push/merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- GitHub CI runs on `push`, `pull_request`, and `merge_group` so required checks validate merge queue candidates before they land.
-- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
+- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
+- GitHub CI runs only for pull requests targeting `main`. Strict required checks keep each PR current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
+- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests and strict required checks, keeps branches current, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
 - Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 
 ## IDENTITY & CONTEXT


### PR DESCRIPTION
## Problem

Strict pull-request checks already validate the exact tree that squash-merges into `main`. The push workflow reran the same five jobs after merging without protecting the branch.

## Changes

| Before | After |
| --- | --- |
| CI ran for pushes, pull requests, and an unused merge-queue event across `main` and `master`. | CI runs only for pull requests targeting `main`. |
| Agent guidance described duplicate post-merge checks and merge-queue protection. | Agent guidance describes the active strict, up-to-date pull-request protection. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change limits the test workflow to pull requests targeting `main` and updates the contributor guidance to describe the corresponding branch-protection model. The workflow contract was checked against both the prior and updated versions: the updated configuration accepts only pull requests into `main`, removes `push` and merge-queue triggers, and preserves all five required checks. No defects were found.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the verified workflow trigger and required-check contract.

The updated workflow passed an executable configuration check that also confirmed the prior configuration differed exactly where intended; no review findings remain.

**Files Needing Attention:** No files need changes. `.github/workflows/tests.yml` was verified directly, and `AGENTS.md` plus `CLAUDE.md` accurately describe the new policy.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the CI contract validator against the PR workflow file and verified it exited with code 0, confirming the trigger is exactly pull\_request restricted to main and that push and merge\_group are absent.
- Verified that all five CI checks are preserved: Ban suppressions and legacy annotations, ruff-format, ruff-check, ty, and pytest.
- The validator output includes explicit PASS lines and the CONTRACT CONFIRMED verdict, and the validator source and both outputs were saved for review.

<a href="https://app.greptile.com/trex/runs/18041895/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Run CI only before merges"](https://github.com/alishahryar1/free-claude-code/commit/693b595ef13588e5834acc5afc6ef0da17da1900) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51669330)</sub>

<!-- /greptile_comment -->