### PR TITLE
Feature Add Tokenrouter Provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,11 @@ GITHUB_MODELS_TOKEN=""
 ZAI_API_KEY=""
 
 
+# TokenRouter Config (OpenAI-compatible Chat Completions gateway at api.tokenrouter.com/v1)
+TOKENROUTER_API_KEY=""
+TOKENROUTER_BASE_URL="https://api.tokenrouter.com/v1"
+
+
 # Fireworks AI Config (OpenAI-compatible Chat Completions at api.fireworks.ai/inference/v1)
 FIREWORKS_API_KEY=""
 
@@ -121,7 +126,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -155,6 +160,7 @@ FCC_SMOKE_MODEL_HUGGINGFACE=
 FCC_SMOKE_MODEL_COHERE=
 FCC_SMOKE_MODEL_GITHUB_MODELS=
 FCC_SMOKE_MODEL_ZAI=
+FCC_SMOKE_MODEL_TOKENROUTER=
 FCC_SMOKE_MODEL_FIREWORKS=
 FCC_SMOKE_MODEL_CLOUDFLARE=
 FCC_SMOKE_MODEL_GEMINI=
@@ -202,6 +208,7 @@ HUGGINGFACE_PROXY=""
 COHERE_PROXY=""
 GITHUB_MODELS_PROXY=""
 ZAI_PROXY=""
+TOKENROUTER_PROXY=""
 FIREWORKS_PROXY=""
 CLOUDFLARE_PROXY=""
 GEMINI_PROXY=""

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ fcc-codex exec "hello"
 | [Fireworks AI](https://fireworks.ai/account/api-keys) | `FIREWORKS_API_KEY` | `fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct` |
 | [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` | `cloudflare/@cf/moonshotai/kimi-k2.6` |
 | [Z.ai](https://z.ai/manage-apikey/apikey-list) | `ZAI_API_KEY` | `zai/glm-5.2` |
+| [TokenRouter](https://www.tokenrouter.com/) | `TOKENROUTER_API_KEY` | `tokenrouter/moonshotai/kimi-k3-free` |
 | [Ollama Cloud](https://ollama.com/settings/keys) | `OLLAMA_API_KEY` | `ollama_cloud/qwen3-coder:480b` |
 | [LM Studio](https://lmstudio.ai/) | `LM_STUDIO_BASE_URL` | `lmstudio/<model-id>` |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | `LLAMACPP_BASE_URL` | `llamacpp/<model-id>` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.17.8"
+version = "4.18.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -74,6 +74,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",
     "cloudflare": "cloudflare/@cf/moonshotai/kimi-k2.6",
+    "tokenrouter": "tokenrouter/moonshotai/kimi-k3-free",
 }
 MISTRAL_REASONING_SMOKE_DEFAULT_MODEL = "mistral/mistral-medium-3-5"
 

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -724,6 +724,12 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         advanced=True,
     ),
     ConfigFieldSpec(
+        "FCC_SMOKE_MODEL_TOKENROUTER",
+        "Smoke TokenRouter Model",
+        "smoke",
+        advanced=True,
+    ),
+    ConfigFieldSpec(
         "FCC_SMOKE_NIM_MODELS",
         "Smoke NIM Models",
         "smoke",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -150,6 +150,18 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "Ollama API key for direct OpenAI-compatible Cloud access at ollama.com/v1."
         ),
     },
+    "TOKENROUTER_API_KEY": {
+        "label": "TokenRouter API Key",
+        "description": (
+            "TokenRouter OpenAI-compatible gateway API key for api.tokenrouter.com/v1."
+        ),
+    },
+    "TOKENROUTER_BASE_URL": {
+        "description": (
+            "TokenRouter OpenAI-compatible Chat Completions base URL. "
+            "Defaults to https://api.tokenrouter.com/v1."
+        ),
+    },
 }
 
 

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -49,6 +49,8 @@ SAMBANOVA_DEFAULT_BASE = "https://api.sambanova.ai/v1"
 # Kilo.ai gateway OpenAI-compatible Chat Completions API.
 KILO_DEFAULT_BASE = "https://api.kilo.ai/api/gateway"
 OPENAI_CODEX_DEFAULT_BASE = "https://chatgpt.com/backend-api/codex"
+# TokenRouter OpenAI-compatible Chat Completions gateway.
+TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 
 
 class ProviderAuthKind(StrEnum):
@@ -336,6 +338,16 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="zai_api_key",
         default_base_url=ZAI_DEFAULT_BASE,
         proxy_attr="zai_proxy",
+    ),
+    "tokenrouter": ProviderDescriptor(
+        provider_id="tokenrouter",
+        display_name="TokenRouter",
+        credential_env="TOKENROUTER_API_KEY",
+        credential_url="https://www.tokenrouter.com/",
+        credential_attr="tokenrouter_api_key",
+        default_base_url=TOKENROUTER_DEFAULT_BASE,
+        base_url_attr="tokenrouter_base_url",
+        proxy_attr="tokenrouter_proxy",
     ),
     "ollama_cloud": ProviderDescriptor(
         provider_id="ollama_cloud",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -13,7 +13,11 @@ from .env_files import (
     settings_env_files,
 )
 from .nim import NimSettings
-from .provider_catalog import BEDROCK_DEFAULT_BASE, SUPPORTED_PROVIDER_IDS
+from .provider_catalog import (
+    BEDROCK_DEFAULT_BASE,
+    SUPPORTED_PROVIDER_IDS,
+    TOKENROUTER_DEFAULT_BASE,
+)
 from .reasoning import ReasoningPreference
 
 
@@ -87,6 +91,13 @@ class Settings(BaseSettings):
 
     # ==================== Z.ai Config ====================
     zai_api_key: str = Field(default="", validation_alias="ZAI_API_KEY")
+
+    # ==================== TokenRouter Config ====================
+    tokenrouter_api_key: str = Field(default="", validation_alias="TOKENROUTER_API_KEY")
+    tokenrouter_base_url: str = Field(
+        default=TOKENROUTER_DEFAULT_BASE,
+        validation_alias="TOKENROUTER_BASE_URL",
+    )
 
     # ==================== Fireworks AI Config ====================
     fireworks_api_key: str = Field(default="", validation_alias="FIREWORKS_API_KEY")
@@ -185,6 +196,7 @@ class Settings(BaseSettings):
     sambanova_proxy: str = Field(default="", validation_alias="SAMBANOVA_PROXY")
     kilo_proxy: str = Field(default="", validation_alias="KILO_PROXY")
     zai_proxy: str = Field(default="", validation_alias="ZAI_PROXY")
+    tokenrouter_proxy: str = Field(default="", validation_alias="TOKENROUTER_PROXY")
     fireworks_proxy: str = Field(default="", validation_alias="FIREWORKS_PROXY")
     cloudflare_proxy: str = Field(default="", validation_alias="CLOUDFLARE_PROXY")
     gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -342,6 +342,13 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         ),
         reasoning_delta_field="reasoning",
     ),
+    "tokenrouter": OpenAIChatProfile(
+        _policy(
+            "TOKENROUTER",
+            ReasoningReplayMode.DISABLED,
+        ),
+        NO_REASONING,
+    ),
     "llamacpp": OpenAIChatProfile(
         _policy(
             "LLAMACPP",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -33,6 +33,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "fireworks",
     "cloudflare",
     "zai",
+    "tokenrouter",
     "ollama_cloud",
     "lmstudio",
     "llamacpp",

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -20,6 +20,7 @@ from free_claude_code.config.provider_catalog import (
     OLLAMA_CLOUD_DEFAULT_BASE,
     PROVIDER_CATALOG,
     SUPPORTED_PROVIDER_IDS,
+    TOKENROUTER_DEFAULT_BASE,
     VERCEL_AI_GATEWAY_DEFAULT_BASE,
     ZAI_DEFAULT_BASE,
 )
@@ -71,6 +72,8 @@ def _make_settings(**overrides):
     mock.cohere_api_key = "test_cohere_key"
     mock.github_models_token = "test_github_models_token"
     mock.zai_api_key = "test_zai_key"
+    mock.tokenrouter_api_key = "test_tokenrouter_key"
+    mock.tokenrouter_base_url = TOKENROUTER_DEFAULT_BASE
     mock.lm_studio_base_url = "http://localhost:1234/v1"
     mock.llamacpp_base_url = "http://localhost:8080/v1"
     mock.ollama_base_url = "http://localhost:11434"
@@ -95,6 +98,7 @@ def _make_settings(**overrides):
     mock.cohere_proxy = ""
     mock.github_models_proxy = ""
     mock.zai_proxy = ""
+    mock.tokenrouter_proxy = ""
     mock.fireworks_proxy = ""
     mock.fireworks_api_key = "test_fireworks_key"
     mock.cloudflare_api_token = "test_cloudflare_token"
@@ -495,6 +499,7 @@ def test_create_provider_instantiates_each_builtin():
         "cohere": OpenAIChatProvider,
         "github_models": GitHubModelsProvider,
         "zai": OpenAIChatProvider,
+        "tokenrouter": OpenAIChatProvider,
         "gemini": GeminiProvider,
         "vertex": VertexProvider,
         "groq": GroqProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.17.8"
+version = "4.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Adds [TokenRouter](https://www.tokenrouter.com/) as a new provider. TokenRouter is an OpenAI-compatible Chat Completions gateway (`api.tokenrouter.com/v1`), so it's wired in through the existing `openai_chat` profile infrastructure — no new protocol code.

## Changes

- **Provider catalog** (`config/provider_catalog.py`): registered `tokenrouter` descriptor with `TOKENROUTER_API_KEY` credential, default base URL `https://api.tokenrouter.com/v1`, and optional base-URL/proxy overrides.
- **Settings** (`config/settings.py`): added `tokenrouter_api_key`, `tokenrouter_base_url`, and `tokenrouter_proxy` env-backed fields.
- **OpenAI chat profile** (`providers/openai_chat/profiles.py`): added the `tokenrouter` profile.
- **Admin UI** (`config/admin/provider_manifest.py`, `config/admin/manifest.py`): added the TokenRouter API key / base URL fields and smoke-model entry so it renders in the Providers grid and settings form.
- **Docs & examples**: `.env.example` and `README.md` provider table.
- **Smoke config** (`smoke/lib/config.py`): default smoke model `tokenrouter/moonshotai/kimi-k3-free`.
- **Tests**: updated `test_provider_catalog_order.py` and `test_provider_runtime.py` to cover the new provider.
- **Version bump**: `4.17.8` → `4.18.0` in `pyproject.toml` + matching `uv.lock` (runtime + packaging change, per CONTRIBUTING.md).

## Configuration

```env
TOKENROUTER_API_KEY=your_key_here
# optional overrides
TOKENROUTER_BASE_URL=https://api.tokenrouter.com/v1
TOKENROUTER_PROXY=

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds TokenRouter as an OpenAI-compatible provider, with API key, endpoint, proxy, Admin configuration, documentation, and a smoke-model default.

Focused execution verified that `tokenrouter/moonshotai/kimi-k3-free` resolves to the shared OpenAI-compatible provider while preserving the nested model ID after removing the provider prefix once. The configured TokenRouter key, endpoint, and proxy were applied to the request path, the Admin configuration exposes all required settings, and the smoke default is selectable. The focused provider-runtime, smoke-config, and Admin tests passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised TokenRouter routing, configuration, request, Admin, and smoke-model paths.

No defects remain after the focused checks confirmed the intended provider behavior and the related test suite passed.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The tokenrouter-validation script ran and finished with exit code 0, reporting a PASS status.
- A mocked OpenAI SDK wire request was recorded during validation, showing a POST to a redacted internal URL with Bearer tokenrouter-test-key and model moonshotai/kimi-k3-free, after routing tokenrouter/moonshotai/kimi-k3-free to the same nested model ID, and it noted four Admin keys and the smoke default mapping.
- The separate Pytest run completed successfully with 142 passing tests across the listed test files.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Feature Add Tokenrouter Provider"](https://github.com/alishahryar1/free-claude-code/commit/2e8c4f341e2c859c7d3b32051e2c1ce432d93a13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51714058)</sub>

<!-- /greptile_comment -->