### PR TITLE
Add NaraRoute provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,11 @@ TOKENROUTER_API_KEY=""
 TOKENROUTER_BASE_URL="https://api.tokenrouter.com/v1"
 
 
+# NaraRoute Config (OpenAI-compatible Chat Completions gateway at router.bynara.id/v1)
+NARAROUTE_API_KEY=""
+NARAROUTE_BASE_URL="https://router.bynara.id/v1"
+
+
 # Fireworks AI Config (OpenAI-compatible Chat Completions at api.fireworks.ai/inference/v1)
 FIREWORKS_API_KEY=""
 
@@ -126,7 +131,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -161,6 +166,7 @@ FCC_SMOKE_MODEL_COHERE=
 FCC_SMOKE_MODEL_GITHUB_MODELS=
 FCC_SMOKE_MODEL_ZAI=
 FCC_SMOKE_MODEL_TOKENROUTER=
+FCC_SMOKE_MODEL_NARAROUTE=
 FCC_SMOKE_MODEL_FIREWORKS=
 FCC_SMOKE_MODEL_CLOUDFLARE=
 FCC_SMOKE_MODEL_GEMINI=
@@ -209,6 +215,7 @@ COHERE_PROXY=""
 GITHUB_MODELS_PROXY=""
 ZAI_PROXY=""
 TOKENROUTER_PROXY=""
+NARAROUTE_PROXY=""
 FIREWORKS_PROXY=""
 CLOUDFLARE_PROXY=""
 GEMINI_PROXY=""

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ fcc-codex exec "hello"
 | [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` | `cloudflare/@cf/moonshotai/kimi-k2.6` |
 | [Z.ai](https://z.ai/manage-apikey/apikey-list) | `ZAI_API_KEY` | `zai/glm-5.2` |
 | [TokenRouter](https://www.tokenrouter.com/) | `TOKENROUTER_API_KEY` | `tokenrouter/moonshotai/kimi-k3-free` |
+| [NaraRoute](https://router.bynara.id/) | `NARAROUTE_API_KEY` | `nararoute/kimi-k3-free` |
 | [Ollama Cloud](https://ollama.com/settings/keys) | `OLLAMA_API_KEY` | `ollama_cloud/qwen3-coder:480b` |
 | [LM Studio](https://lmstudio.ai/) | `LM_STUDIO_BASE_URL` | `lmstudio/<model-id>` |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | `LLAMACPP_BASE_URL` | `llamacpp/<model-id>` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.18.0"
+version = "4.19.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -75,6 +75,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "cerebras": "cerebras/llama3.1-8b",
     "cloudflare": "cloudflare/@cf/moonshotai/kimi-k2.6",
     "tokenrouter": "tokenrouter/moonshotai/kimi-k3-free",
+    "nararoute": "nararoute/kimi-k3-free",
 }
 MISTRAL_REASONING_SMOKE_DEFAULT_MODEL = "mistral/mistral-medium-3-5"
 

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -688,6 +688,12 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         advanced=True,
     ),
     ConfigFieldSpec(
+        "FCC_SMOKE_MODEL_NARAROUTE",
+        "Smoke NaraRoute Model",
+        "smoke",
+        advanced=True,
+    ),
+    ConfigFieldSpec(
         "FCC_SMOKE_MODEL_FIREWORKS",
         "Smoke Fireworks Model",
         "smoke",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -162,6 +162,19 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "Defaults to https://api.tokenrouter.com/v1."
         ),
     },
+    "NARAROUTE_API_KEY": {
+        "label": "NaraRoute API Key",
+        "description": (
+            "NaraRoute OpenAI-compatible gateway API key for router.bynara.id/v1. "
+            "Keys begin with sk-nry-; create one at router.bynara.id/keys."
+        ),
+    },
+    "NARAROUTE_BASE_URL": {
+        "description": (
+            "NaraRoute OpenAI-compatible Chat Completions base URL. "
+            "Defaults to https://router.bynara.id/v1."
+        ),
+    },
 }
 
 

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -51,6 +51,8 @@ KILO_DEFAULT_BASE = "https://api.kilo.ai/api/gateway"
 OPENAI_CODEX_DEFAULT_BASE = "https://chatgpt.com/backend-api/codex"
 # TokenRouter OpenAI-compatible Chat Completions gateway.
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
+# NaraRoute OpenAI-compatible Chat Completions gateway.
+NARAROUTE_DEFAULT_BASE = "https://router.bynara.id/v1"
 
 
 class ProviderAuthKind(StrEnum):
@@ -348,6 +350,16 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=TOKENROUTER_DEFAULT_BASE,
         base_url_attr="tokenrouter_base_url",
         proxy_attr="tokenrouter_proxy",
+    ),
+    "nararoute": ProviderDescriptor(
+        provider_id="nararoute",
+        display_name="NaraRoute",
+        credential_env="NARAROUTE_API_KEY",
+        credential_url="https://router.bynara.id/keys",
+        credential_attr="nararoute_api_key",
+        default_base_url=NARAROUTE_DEFAULT_BASE,
+        base_url_attr="nararoute_base_url",
+        proxy_attr="nararoute_proxy",
     ),
     "ollama_cloud": ProviderDescriptor(
         provider_id="ollama_cloud",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -15,6 +15,7 @@ from .env_files import (
 from .nim import NimSettings
 from .provider_catalog import (
     BEDROCK_DEFAULT_BASE,
+    NARAROUTE_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
     TOKENROUTER_DEFAULT_BASE,
 )
@@ -97,6 +98,13 @@ class Settings(BaseSettings):
     tokenrouter_base_url: str = Field(
         default=TOKENROUTER_DEFAULT_BASE,
         validation_alias="TOKENROUTER_BASE_URL",
+    )
+
+    # ==================== NaraRoute Config ====================
+    nararoute_api_key: str = Field(default="", validation_alias="NARAROUTE_API_KEY")
+    nararoute_base_url: str = Field(
+        default=NARAROUTE_DEFAULT_BASE,
+        validation_alias="NARAROUTE_BASE_URL",
     )
 
     # ==================== Fireworks AI Config ====================
@@ -197,6 +205,7 @@ class Settings(BaseSettings):
     kilo_proxy: str = Field(default="", validation_alias="KILO_PROXY")
     zai_proxy: str = Field(default="", validation_alias="ZAI_PROXY")
     tokenrouter_proxy: str = Field(default="", validation_alias="TOKENROUTER_PROXY")
+    nararoute_proxy: str = Field(default="", validation_alias="NARAROUTE_PROXY")
     fireworks_proxy: str = Field(default="", validation_alias="FIREWORKS_PROXY")
     cloudflare_proxy: str = Field(default="", validation_alias="CLOUDFLARE_PROXY")
     gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -329,6 +329,17 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             disabled={"type": "disabled"},
         ),
     ),
+    "nararoute": OpenAIChatProfile(
+        _policy(
+            "NARAROUTE",
+            ReasoningReplayMode.DISABLED,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NamedEffortReasoning(
+            _LOW_MEDIUM_HIGH,
+            enabled_value="medium",
+        ),
+    ),
     "ollama_cloud": OpenAIChatProfile(
         _policy(
             "OLLAMA_CLOUD",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -34,6 +34,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "cloudflare",
     "zai",
     "tokenrouter",
+    "nararoute",
     "ollama_cloud",
     "lmstudio",
     "llamacpp",

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -17,6 +17,7 @@ from free_claude_code.config.provider_catalog import (
     HUGGINGFACE_DEFAULT_BASE,
     KIMI_CODE_DEFAULT_BASE,
     MINIMAX_DEFAULT_BASE,
+    NARAROUTE_DEFAULT_BASE,
     OLLAMA_CLOUD_DEFAULT_BASE,
     PROVIDER_CATALOG,
     SUPPORTED_PROVIDER_IDS,
@@ -74,6 +75,8 @@ def _make_settings(**overrides):
     mock.zai_api_key = "test_zai_key"
     mock.tokenrouter_api_key = "test_tokenrouter_key"
     mock.tokenrouter_base_url = TOKENROUTER_DEFAULT_BASE
+    mock.nararoute_api_key = "test_nararoute_key"
+    mock.nararoute_base_url = NARAROUTE_DEFAULT_BASE
     mock.lm_studio_base_url = "http://localhost:1234/v1"
     mock.llamacpp_base_url = "http://localhost:8080/v1"
     mock.ollama_base_url = "http://localhost:11434"
@@ -99,6 +102,7 @@ def _make_settings(**overrides):
     mock.github_models_proxy = ""
     mock.zai_proxy = ""
     mock.tokenrouter_proxy = ""
+    mock.nararoute_proxy = ""
     mock.fireworks_proxy = ""
     mock.fireworks_api_key = "test_fireworks_key"
     mock.cloudflare_api_token = "test_cloudflare_token"
@@ -500,6 +504,7 @@ def test_create_provider_instantiates_each_builtin():
         "github_models": GitHubModelsProvider,
         "zai": OpenAIChatProvider,
         "tokenrouter": OpenAIChatProvider,
+        "nararoute": OpenAIChatProvider,
         "gemini": GeminiProvider,
         "vertex": VertexProvider,
         "groq": GroqProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.18.0"
+version = "4.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Adds [NaraRoute](https://router.bynara.id/) as a new OpenAI-compatible provider, closing #1370. NaraRoute is an OpenAI-compatible Chat Completions gateway (`https://router.bynara.id/v1`) with Bearer auth and per-key model discovery, so it plugs into the existing `OpenAIChatProvider` + catalog-driven wiring with no new protocol code.

## Changes

- **`config/provider_catalog.py`** — Added `NARAROUTE_DEFAULT_BASE` (`https://router.bynara.id/v1`) and the `nararoute` `ProviderDescriptor` (display name, `NARAROUTE_API_KEY` credential env, key URL, base-url/proxy attrs).
- **`config/settings.py`** — Added `nararoute_api_key`, `nararoute_base_url` (defaults to the gateway), and `nararoute_proxy` settings with env aliases.
- **`providers/openai_chat/profiles.py`** — Added the `nararoute` `OpenAIChatProfile` with `NamedEffortReasoning` (`_LOW_MEDIUM_HIGH`, default `medium`) mapping to `reasoning_effort` low/medium/high; `ReasoningReplayMode.DISABLED`. Reasoning effort is a safe no-op on non-reasoning models.
- **`config/admin/provider_manifest.py`** — Admin UI field overrides for `NARAROUTE_API_KEY` (label + description noting the `sk-nry-` key prefix) and `NARAROUTE_BASE_URL`.
- **`config/admin/manifest.py`** — Added `FCC_SMOKE_MODEL_NARAROUTE` smoke field.
- **`tests/contracts/test_provider_catalog_order.py`** — Added `nararoute` to the expected provider order.
- **`tests/providers/test_provider_runtime.py`** — Added nararoute settings mocks and the `nararoute → OpenAIChatProvider` instantiation case.
- **`.env.example`** — `NARAROUTE_API_KEY`, `NARAROUTE_BASE_URL`, `NARAROUTE_PROXY`, `FCC_SMOKE_MODEL_NARAROUTE`, and added `nararoute` to the valid-providers list.
- **`README.md`** — Provider table row with example slug `nararoute/kimi-k3-free`.
- **`smoke/lib/config.py`** — Default smoke model `nararoute/kimi-k3-free`.
- **`pyproject.toml` / `uv.lock`** — Version bump `4.17.8 → 4.18.0`.

## Configuration

```bash
NARAROUTE_API_KEY="sk-nry-..."
# optional overrides
NARAROUTE_BASE_URL="https://router.bynara.id/v1"
NARAROUTE_PROXY=""

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds NaraRoute as an OpenAI-compatible provider. Users can configure its API key, optional base URL, and proxy through environment variables or the Admin UI, then select `nararoute/<model>` routes. Hermetic coverage confirmed settings parsing, Admin configuration, provider construction, request generation, and related provider contracts.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The configured NaraRoute route completed settings, Admin manifest, runtime, proxy, and OpenAI-compatible request assertions, and the related contract tests passed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a hermetic NaraRoute validation with uv run using synthetic configuration values and mocked HTTP/OpenAI clients, with no real credentials or network calls.
- Verified that an empty key leaves NaraRoute unavailable, then confirmed that configured API key, base URL, and proxy values populate Settings and Admin fields, construct the provider, and emit the expected OpenAI-compatible request body for kimi-k3-free.
- Ran the provider runtime, generated the Admin manifest, and executed the provider catalog-order test modules; all 48 tests passed in 2.75 seconds.
- Validated the repository environment; before the run, empty key yielded nararoute configured: False, and after the hermetic script, the run completed with exit code 0 and produced the expected OpenAI body for kimi-k3-free.

<a href="https://app.greptile.com/trex/runs/18094455/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Add NaraRoute provider"](https://github.com/alishahryar1/free-claude-code/commit/2ad968e6e9f067185bbacd0640be0bc7fed43df7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51773789)</sub>

<!-- /greptile_comment -->