### PR TITLE
Add Novita AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,10 @@ NARAROUTE_BASE_URL="https://router.bynara.id/v1"
 FIREWORKS_API_KEY=""
 
 
+# Novita AI (OpenAI-compatible Chat Completions at api.novita.ai/openai/v1)
+NOVITA_API_KEY=""
+
+
 # Cloudflare Workers AI Config (OpenAI-compatible Chat Completions at api.cloudflare.com/client/v4/accounts/<id>/ai/v1)
 CLOUDFLARE_API_TOKEN=""
 CLOUDFLARE_ACCOUNT_ID=""
@@ -131,7 +135,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -168,6 +172,7 @@ FCC_SMOKE_MODEL_ZAI=
 FCC_SMOKE_MODEL_TOKENROUTER=
 FCC_SMOKE_MODEL_NARAROUTE=
 FCC_SMOKE_MODEL_FIREWORKS=
+FCC_SMOKE_MODEL_NOVITA=
 FCC_SMOKE_MODEL_CLOUDFLARE=
 FCC_SMOKE_MODEL_GEMINI=
 FCC_SMOKE_MODEL_VERTEX=
@@ -217,6 +222,7 @@ ZAI_PROXY=""
 TOKENROUTER_PROXY=""
 NARAROUTE_PROXY=""
 FIREWORKS_PROXY=""
+NOVITA_PROXY=""
 CLOUDFLARE_PROXY=""
 GEMINI_PROXY=""
 VERTEX_PROXY=""

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ fcc-codex exec "hello"
 | [SambaNova](https://cloud.sambanova.ai/apis) | `SAMBANOVA_API_KEY` | `sambanova/Meta-Llama-3.3-70B-Instruct` |
 | [Kilo.ai](https://kilo.ai) | `KILO_API_KEY` | `kilo/kilo-auto/free` |
 | [Fireworks AI](https://fireworks.ai/account/api-keys) | `FIREWORKS_API_KEY` | `fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct` |
-| [Novita AI](https://novita.ai/settings/key-management) | `NOVITA_API_KEY` | `novita/qwen/qwen3-coder-next` |
+| [Novita AI](https://novita.ai/settings/key-management) | `NOVITA_API_KEY` | `novita/deepseek/deepseek-v4-flash-0731` |
 | [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` | `cloudflare/@cf/moonshotai/kimi-k2.6` |
 | [Z.ai](https://z.ai/manage-apikey/apikey-list) | `ZAI_API_KEY` | `zai/glm-5.2` |
 | [TokenRouter](https://www.tokenrouter.com/) | `TOKENROUTER_API_KEY` | `tokenrouter/moonshotai/kimi-k3-free` |

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ fcc-codex exec "hello"
 | [SambaNova](https://cloud.sambanova.ai/apis) | `SAMBANOVA_API_KEY` | `sambanova/Meta-Llama-3.3-70B-Instruct` |
 | [Kilo.ai](https://kilo.ai) | `KILO_API_KEY` | `kilo/kilo-auto/free` |
 | [Fireworks AI](https://fireworks.ai/account/api-keys) | `FIREWORKS_API_KEY` | `fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct` |
+| [Novita AI](https://novita.ai/settings/key-management) | `NOVITA_API_KEY` | `novita/qwen/qwen3-coder-next` |
 | [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` | `cloudflare/@cf/moonshotai/kimi-k2.6` |
 | [Z.ai](https://z.ai/manage-apikey/apikey-list) | `ZAI_API_KEY` | `zai/glm-5.2` |
 | [TokenRouter](https://www.tokenrouter.com/) | `TOKENROUTER_API_KEY` | `tokenrouter/moonshotai/kimi-k3-free` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.19.0"
+version = "4.20.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -73,7 +73,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",
-    "novita": "novita/qwen/qwen3-coder-next",
+    "novita": "novita/deepseek/deepseek-v4-flash-0731",
     "cloudflare": "cloudflare/@cf/moonshotai/kimi-k2.6",
     "tokenrouter": "tokenrouter/moonshotai/kimi-k3-free",
     "nararoute": "nararoute/kimi-k3-free",

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -73,6 +73,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",
+    "novita": "novita/qwen/qwen3-coder-next",
     "cloudflare": "cloudflare/@cf/moonshotai/kimi-k2.6",
     "tokenrouter": "tokenrouter/moonshotai/kimi-k3-free",
     "nararoute": "nararoute/kimi-k3-free",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -92,6 +92,13 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
         "label": "Fireworks API Key",
         "description": "Fireworks AI inference API key.",
     },
+    "NOVITA_API_KEY": {
+        "label": "Novita AI API Key",
+        "description": (
+            "Novita AI OpenAI-compatible API key (create at "
+            "[novita.ai/settings/key-management](https://novita.ai/settings/key-management))."
+        ),
+    },
     "MINIMAX_API_KEY": {
         "label": "MiniMax API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -18,6 +18,7 @@ MINIMAX_DEFAULT_BASE = "https://api.minimax.io/v1"
 # DeepSeek Chat Completions API; cache usage is reported on this endpoint.
 DEEPSEEK_DEFAULT_BASE = "https://api.deepseek.com"
 FIREWORKS_DEFAULT_BASE = "https://api.fireworks.ai/inference/v1"
+NOVITA_DEFAULT_BASE = "https://api.novita.ai/openai/v1"
 # Cloudflare account-scoped AI REST root; provider appends /accounts/{id}/ai/v1.
 CLOUDFLARE_AI_REST_ROOT = "https://api.cloudflare.com/client/v4"
 OPENROUTER_DEFAULT_BASE = "https://openrouter.ai/api/v1"
@@ -319,6 +320,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="fireworks_api_key",
         default_base_url=FIREWORKS_DEFAULT_BASE,
         proxy_attr="fireworks_proxy",
+    ),
+    "novita": ProviderDescriptor(
+        provider_id="novita",
+        display_name="Novita AI",
+        credential_env="NOVITA_API_KEY",
+        credential_url="https://novita.ai/settings/key-management",
+        credential_attr="novita_api_key",
+        default_base_url=NOVITA_DEFAULT_BASE,
+        proxy_attr="novita_proxy",
     ),
     "cloudflare": ProviderDescriptor(
         provider_id="cloudflare",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -110,6 +110,9 @@ class Settings(BaseSettings):
     # ==================== Fireworks AI Config ====================
     fireworks_api_key: str = Field(default="", validation_alias="FIREWORKS_API_KEY")
 
+    # ==================== Novita AI Config ====================
+    novita_api_key: str = Field(default="", validation_alias="NOVITA_API_KEY")
+
     # ==================== Cloudflare Workers AI Config ====================
     cloudflare_api_token: str = Field(
         default="", validation_alias="CLOUDFLARE_API_TOKEN"
@@ -207,6 +210,7 @@ class Settings(BaseSettings):
     tokenrouter_proxy: str = Field(default="", validation_alias="TOKENROUTER_PROXY")
     nararoute_proxy: str = Field(default="", validation_alias="NARAROUTE_PROXY")
     fireworks_proxy: str = Field(default="", validation_alias="FIREWORKS_PROXY")
+    novita_proxy: str = Field(default="", validation_alias="NOVITA_PROXY")
     cloudflare_proxy: str = Field(default="", validation_alias="CLOUDFLARE_PROXY")
     gemini_proxy: str = Field(default="", validation_alias="GEMINI_PROXY")
     vertex_proxy: str = Field(default="", validation_alias="VERTEX_PROXY")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -315,6 +315,22 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             budget_field="reasoning_effort",
         ),
     ),
+    "novita": OpenAIChatProfile(
+        _policy(
+            "NOVITA",
+            ReasoningReplayMode.REASONING_CONTENT,
+            include_extra_body=True,
+            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NamedEffortReasoning(
+            (),
+            disabled_value=False,
+            enabled_value=True,
+            field="enable_thinking",
+            use_extra_body=True,
+        ),
+    ),
     "zai": OpenAIChatProfile(
         _policy(
             "ZAI",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -31,6 +31,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "cerebras",
     "sambanova",
     "fireworks",
+    "novita",
     "cloudflare",
     "zai",
     "tokenrouter",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -57,6 +57,7 @@ def _settings(**overrides):
         "cerebras_api_key": "",
         "ollama_api_key": "",
         "fireworks_api_key": "",
+        "novita_api_key": "",
         "cloudflare_api_token": "",
         "cloudflare_account_id": "",
         "lm_studio_base_url": "",

--- a/tests/providers/test_novita.py
+++ b/tests/providers/test_novita.py
@@ -1,0 +1,153 @@
+"""Tests for the Novita AI OpenAI-chat provider."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import NOVITA_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import Message, MessagesRequest
+from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+@pytest.fixture
+def novita_provider():
+    return profiled_provider(
+        "novita",
+        ProviderConfig(
+            api_key="test_novita_key",
+            base_url=NOVITA_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(),
+    )
+
+
+def test_init_uses_openai_chat_provider(novita_provider):
+    assert isinstance(novita_provider, OpenAIChatProvider)
+    assert novita_provider._api_key == "test_novita_key"
+    assert novita_provider._base_url == NOVITA_DEFAULT_BASE
+
+
+def test_base_url_constant():
+    assert NOVITA_DEFAULT_BASE == "https://api.novita.ai/openai/v1"
+
+
+def test_build_request_body_openai_chat_shape(novita_provider):
+    request = MessagesRequest(
+        model="qwen/qwen3-coder-next",
+        max_tokens=100,
+        messages=[Message(role="user", content="Hello")],
+        system="System prompt",
+    )
+
+    body = novita_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assert body["model"] == "qwen/qwen3-coder-next"
+    assert body["max_tokens"] == 100
+    assert body["messages"] == [
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "Hello"},
+    ]
+
+
+def test_build_request_body_default_max_tokens(novita_provider):
+    request = MessagesRequest(
+        model="m",
+        messages=[Message(role="user", content="x")],
+    )
+
+    body = novita_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_build_request_body_preserves_validated_extra_body(novita_provider):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "x"}],
+            "extra_body": {"custom_param": "value"},
+        }
+    )
+
+    body = novita_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assert body["extra_body"]["custom_param"] == "value"
+
+
+def test_build_request_body_rejects_reserved_reasoning_extra_body_keys(
+    novita_provider,
+):
+    request = MessagesRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "x"}],
+            "extra_body": {"reasoning_effort": "high"},
+        }
+    )
+
+    with pytest.raises(InvalidRequestError, match="extra_body must not override"):
+        novita_provider._build_request_body(request, reasoning=reasoning_for(request))
+
+
+def test_build_request_body_disables_thinking_when_reasoning_off(novita_provider):
+    request = MessagesRequest(
+        model="zai-org/glm-5.2",
+        messages=[Message(role="user", content="x")],
+    )
+
+    body = novita_provider._build_request_body(request, reasoning=REASONING_OFF)
+
+    assert body["extra_body"]["enable_thinking"] is False
+
+
+def test_build_request_body_enables_thinking_when_reasoning_on(novita_provider):
+    request = MessagesRequest(
+        model="zai-org/glm-5.2",
+        messages=[Message(role="user", content="x")],
+    )
+
+    body = novita_provider._build_request_body(request, reasoning=REASONING_ON)
+
+    assert body["extra_body"]["enable_thinking"] is True
+
+
+def test_build_request_body_omits_thinking_field_by_default(novita_provider):
+    request = MessagesRequest(
+        model="zai-org/glm-5.2",
+        messages=[Message(role="user", content="x")],
+    )
+
+    body = novita_provider._build_request_body(
+        request, reasoning=ReasoningPolicy.provider_default()
+    )
+
+    assert "enable_thinking" not in body.get("extra_body", {})
+
+
+@pytest.mark.asyncio
+async def test_cleanup_closes_openai_client(novita_provider):
+    novita_provider._client = MagicMock()
+    novita_provider._client.close = AsyncMock()
+
+    await novita_provider.cleanup()
+
+    novita_provider._client.close.assert_awaited_once()

--- a/tests/providers/test_novita.py
+++ b/tests/providers/test_novita.py
@@ -46,7 +46,7 @@ def test_base_url_constant():
 
 def test_build_request_body_openai_chat_shape(novita_provider):
     request = MessagesRequest(
-        model="qwen/qwen3-coder-next",
+        model="deepseek/deepseek-v4-flash-0731",
         max_tokens=100,
         messages=[Message(role="user", content="Hello")],
         system="System prompt",
@@ -56,7 +56,7 @@ def test_build_request_body_openai_chat_shape(novita_provider):
         request, reasoning=reasoning_for(request)
     )
 
-    assert body["model"] == "qwen/qwen3-coder-next"
+    assert body["model"] == "deepseek/deepseek-v4-flash-0731"
     assert body["max_tokens"] == 100
     assert body["messages"] == [
         {"role": "system", "content": "System prompt"},

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -105,6 +105,8 @@ def _make_settings(**overrides):
     mock.nararoute_proxy = ""
     mock.fireworks_proxy = ""
     mock.fireworks_api_key = "test_fireworks_key"
+    mock.novita_proxy = ""
+    mock.novita_api_key = "test_novita_key"
     mock.cloudflare_api_token = "test_cloudflare_token"
     mock.cloudflare_account_id = "test_cloudflare_account"
     mock.cloudflare_proxy = ""
@@ -463,6 +465,7 @@ def test_create_provider_instantiates_each_builtin():
         groq_api_key="test_groq_key",
         cerebras_api_key="test_cerebras_key",
         fireworks_api_key="test_fireworks_key",
+        novita_api_key="test_novita_key",
         cloudflare_api_token="test_cloudflare_token",
         cloudflare_account_id="test_cloudflare_account",
         vercel_ai_gateway_api_key="test_vercel_key",
@@ -489,6 +492,7 @@ def test_create_provider_instantiates_each_builtin():
         "kimi_code": OpenAIChatProvider,
         "minimax": OpenAIChatProvider,
         "fireworks": OpenAIChatProvider,
+        "novita": OpenAIChatProvider,
         "cloudflare": CloudflareProvider,
         "lmstudio": LMStudioProvider,
         "llamacpp": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.19.0"
+version = "4.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Adds Novita AI as a supported OpenAI-compatible provider, following the same declarative-profile pattern already used for Fireworks.

## Changes

- Registered `novita` in `PROVIDER_CATALOG` (`src/free_claude_code/config/provider_catalog.py`), pointing at `https://api.novita.ai/openai/v1`, with credential env `NOVITA_API_KEY` and optional `NOVITA_PROXY`.
- Added `novita_api_key` / `novita_proxy` settings fields (`src/free_claude_code/config/settings.py`).
- Added a declarative `OpenAIChatProfile` for `novita` (`src/free_claude_code/providers/openai_chat/profiles.py`), reusing `NamedEffortReasoning` for the `enable_thinking` toggle — no dedicated provider package needed.
- Documented the provider in `README.md` and `.env.example` (including the `novita` entry in the `MODEL_*` provider list and a `FCC_SMOKE_MODEL_NOVITA` smoke var).
- Added Admin UI help text for the new provider (`src/free_claude_code/config/admin/provider_manifest.py`).
- Added `tests/providers/test_novita.py` covering initialization/base URL, request body shape, default `max_tokens`, `extra_body` passthrough and reserved-field rejection, and the three `enable_thinking` states.
- Extended the existing all-provider contract tests (`test_provider_catalog_order.py`, `test_smoke_config.py`, `test_provider_runtime.py`) and smoke config to cover `novita`.
- Bumped `pyproject.toml` to `4.18.0` (backwards-compatible addition) with a matching `uv.lock` regeneration.

## Verification

- `./scripts/ci.sh` (ruff format, ruff check, ty check, pytest): `2796 passed, 69 skipped`.
- `uv run pytest tests/providers/test_novita.py tests/contracts/test_provider_catalog_order.py tests/contracts/test_smoke_config.py tests/providers/test_provider_runtime.py -q`: `93 passed`.
- Live smoke run against the real Novita API (`FCC_LIVE_SMOKE=1 FCC_SMOKE_TARGETS=providers FCC_SMOKE_PROVIDER_MATRIX=novita`) using `novita/deepseek/deepseek-v4-flash-0731`: text, adaptive/interleaved thinking, tool calls, tool continuation, disconnect, and error scenarios all passed, plus Codex Responses coverage.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Novita AI as an OpenAI-compatible provider, including credential configuration, provider metadata, documentation, smoke defaults, and reasoning support. The Novita reasoning request path was exercised with a local HTTP capture: the OpenAI SDK correctly flattens the profile’s `extra_body.enable_thinking` value into Novita’s supported top-level request field.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted P0 or P1 findings remain.

<sub>Reviews (2): Last reviewed commit: ["Use deepseek-v4-flash-0731 as Novita def..."](https://github.com/alishahryar1/free-claude-code/commit/f83c91b79bca948849c093ca782c04df6e538bb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51903526)</sub>

<!-- /greptile_comment -->