### PR TITLE
Rewrite CLAUDE.md and AGENTS.md with project overview and commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,107 @@
-# AGENTIC DIRECTIVE
+# CLAUDE.md
 
-> Keep AGENTS.md and CLAUDE.md identical.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## CODING ENVIRONMENT
+> Keep AGENTS.md and CLAUDE.md identical: apply every change to this file to both.
 
-- Install astral uv using "curl -LsSf https://astral.sh/uv/install.sh | sh" if not already installed and if already installed then update it to the latest version
-- Install Python 3.14.0 stable using `uv python install 3.14.0` if not already installed (requires uv >=0.9; see `[tool.uv] required-version` in `pyproject.toml`)
-- Always use `uv run` to run files instead of the global `python` command.
-- Current uv ruff formatter is set to py314 which has supports multiple exception types without paranthesis (except TypeError, ValueError:)
-- Read `.env.example` for environment variables.
-- All CI checks must pass; failing checks block merge.
-- Add tests for new changes (including edge cases).
-- Before pushing, prefer `./scripts/ci.sh` (macOS/Linux) or `.\scripts\ci.ps1` (Windows) to run the local CI sequence; requires `uv` on PATH. The local scripts run Ruff in repair mode (`ruff format`, then `ruff check --fix`) before type checking and tests.
-- Use `--only` / `--skip` (PowerShell: `-Only` / `-Skip`) to run a subset when iterating; use `--dry-run` to print commands without running them.
-- GitHub CI remains check-only for Ruff (`ruff format --check`, `ruff check`) so branch protection verifies committed code.
-- Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
-- Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
-- Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
-- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced in `tests.yml` on push/merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- GitHub CI runs on `push`, `pull_request`, and `merge_group` so required checks validate merge queue candidates before they land.
-- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
-- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
+## Project Overview
 
-## IDENTITY & CONTEXT
+Free Claude Code (FCC) is a local proxy that connects coding agents to AI providers. It accepts Anthropic Messages traffic from Claude Code and Pi, and OpenAI Responses traffic from Codex, routes each request to a configured upstream provider (30+ hosted APIs plus local Ollama / LM Studio / llama.cpp), and preserves the caller's wire protocol.
 
-- You are an expert Software Architect and Systems Engineer.
-- Goal: Zero-defect, root-cause-oriented engineering for bugs; test-driven engineering for new features. Think carefully; no need to rush.
-- Code: Write the simplest code possible. Keep the codebase minimal and modular.
+Three runtime surfaces:
 
-## ARCHITECTURE PRINCIPLES
+- **HTTP proxy** — FastAPI app in `src/free_claude_code/api/`: `/v1/messages`, `/v1/responses`, `/v1/messages/count_tokens`, `/v1/models`, `/health`, `/stop`, plus the local-only Admin UI at `http://127.0.0.1:8082/admin`.
+- **CLI launchers** — `fcc-server`, `fcc-claude`, `fcc-codex`, `fcc-pi`, `fcc-desktop` (entrypoints declared in `pyproject.toml`).
+- **Messaging bridge** — optional Discord/Telegram adapters that turn chat messages into managed Claude CLI sessions.
 
-- **Shared utilities**: Put shared Anthropic protocol logic in neutral `src/free_claude_code/core/anthropic/` modules. Do not have one provider import from another provider's utils.
-- **Failure ownership**: Keep canonical failure semantics and redaction SDK-free in `core/`; providers alone classify SDK/HTTP failures and own retries; protocol/API adapters alone choose wire error types and commit-boundary serialization.
-- **DRY**: Extract shared base classes to eliminate duplication. Prefer composition over copy-paste.
-- **Encapsulation**: Use accessor methods for internal state (e.g. `set_current_task()`), not direct `_attribute` assignment from outside.
-- **Provider-specific config**: Keep provider-specific fields (e.g. `nim_settings`) in provider constructors, not in the base `ProviderConfig`.
-- **Model-independent reasoning**: Resolve client reasoning intent once at the application boundary; provider adapters translate documented provider capabilities. Never branch on upstream model names or versions to choose reasoning behavior.
-- **Dead code**: Remove unused code, legacy systems, and hardcoded values. Use settings/config instead of literals (e.g. `settings.provider_type` not `"nvidia_nim"`).
-- **Performance**: Use list accumulation for strings (not `+=` in loops), cache env vars at init, prefer iterative over recursive when stack depth matters.
-- **Platform-agnostic naming**: Use generic names (e.g. `PLATFORM_EDIT`) not platform-specific ones (e.g. `TELEGRAM_EDIT`) in shared code.
-- **No type ignores**: Do not add `# type: ignore` or `# ty: ignore`. Fix the underlying type issue.
-- **Python 3.14 annotations**: Do not use `from __future__ import annotations`; rely on native lazy annotations and fix circular import boundaries instead of hiding them with annotation stringization.
-- **Imports**: Prefer top-level imports. Avoid `TYPE_CHECKING` and local imports for first-party or required dependencies; if a top-level import creates a cycle, move shared types/protocols to a neutral owner.
-- **Complete migrations**: When moving modules, update imports to the new owner and remove old compatibility shims in the same change unless preserving a published interface is explicitly required.
-- **Maximum Test Coverage**: There should be maximum test coverage for everything, preferably live smoke test coverage to catch bugs early
+## Commands
 
-## COGNITIVE WORKFLOW
+Everything runs through [uv](https://docs.astral.sh/uv/) with Python 3.14 — never a global interpreter. Requires uv >= 0.11.16 (`[tool.uv] required-version` in pyproject.toml); install or update uv with `curl -LsSf https://astral.sh/uv/install.sh | sh` and run `uv python install 3.14.0` if that interpreter is missing. See `.env.example` for environment variables.
+
+```bash
+uv run fcc-server                  # run the proxy + Admin UI from a checkout
+
+./scripts/ci.sh                    # full local CI before pushing (Windows: .\scripts\ci.ps1)
+./scripts/ci.sh --only pytest      # subset; also --skip, --dry-run (PowerShell: -Only, -Skip, -DryRun)
+```
+
+`scripts/ci.sh` runs, in order: suppression grep → `uv run ruff format` → `uv run ruff check --fix` → `uv run ty check` → `uv run pytest -v --tb=short`. Ruff runs in repair mode locally; GitHub CI is check-only (`ruff format --check`, `ruff check`) and enforces the same 5 check IDs as parallel jobs on push, pull_request, and merge_group. Use the individual repair commands above when debugging local failures; use the `--check` variants only when verifying GitHub-style enforcement.
+
+```bash
+uv run pytest                                             # deterministic tests; addopts "-n auto" (parallel xdist)
+uv run pytest tests/core/test_failures.py -v              # one file
+uv run pytest tests/core/test_failures.py::test_name -v   # one test (add -n 0 to serialize while debugging)
+```
+
+`tests/` mirrors the `src/` package layout and must stay hermetic. Live product smoke lives in `smoke/` and does nothing without opt-in (target catalog, env vars, and failure classes are in `smoke/README.md`):
+
+```bash
+FCC_LIVE_SMOKE=1 uv run pytest smoke -n 0 -s --tb=short
+FCC_LIVE_SMOKE=1 FCC_SMOKE_TARGETS=api,providers uv run pytest smoke -n 0 -s --tb=short
+```
+
+## Architecture
+
+[ARCHITECTURE.md](ARCHITECTURE.md) is the authoritative map — read it before changing package boundaries, providers, protocol conversion, launchers, or messaging. It also has step-by-step extension checklists (add a provider, admin setting, messaging platform, or protocol behavior). The essentials:
+
+**Import policy (test-enforced).** Production code lives under `src/free_claude_code/`. An AST-scanner contract test derives every static production edge and enforces this exact direct-dependency matrix; the first-party module graph must stay acyclic. New packages or cross-package edges are added to the policy deliberately:
+
+| Package | Owns | May import |
+| --- | --- | --- |
+| `config` | pydantic-settings schema, provider catalog, paths, Admin config | — |
+| `core` | protocol-neutral logic: Anthropic + OpenAI Responses wire models and conversion, SSE, canonical `ExecutionFailure` semantics, credential-redacting diagnostics, token counting | — |
+| `application` | dependency leaf: `ModelRouter`, `ProviderExecutor`, reasoning resolution, consumer-owned ports | config, core |
+| `providers` | provider runtime/construction, OpenAI-chat profiles, specialized adapters, SDK/HTTP failure classification, retry/recovery, admission | application, config, core |
+| `api` | FastAPI app, routes, product handlers, local optimizations, web tools, model-catalog responses | application, config, core |
+| `messaging` | Discord/Telegram runtimes, tree queues, transcripts, persistence, voice flow | core |
+| `cli` | entrypoints, client launchers, managed Claude subprocesses | config, core |
+| `runtime` | process composition root: bootstrap, provider generations, ordered lifecycle shutdown | everything |
+
+The single sanctioned exception: `cli.entrypoints` → `runtime.bootstrap`.
+
+**Request flow.** Route → provider-generation lease (`runtime/provider_manager.py`) → product handler (`api/handlers/`) → `ModelRouter` resolves model + reasoning intent → `ProviderExecutor` (`application/execution.py`) preflights and streams → provider adapter → Anthropic SSE. Codex Responses traffic goes through `core/openai_responses/`, which converts Responses ⇄ Anthropic Messages at the adapter boundary. Failures cross boundaries as canonical `core/failures.py` values; each protocol package maps them to its wire error type, and the HTTP commit boundary (first chunk sent) decides between a non-2xx JSON error and a terminal stream event.
+
+**Provider model.** Neutral provider metadata is centralized in `config/provider_catalog.py`. Most upstreams are declarative `OpenAIChatProfile` data on the shared `OpenAIChatProvider` (`providers/openai_chat/`) — configuration differences stay data, not subclasses. Only a true upstream quirk (own state, model-list behavior, stream events, retry algorithms) justifies a specialized package plus sparse factory entry, and the union of construction owners must exactly equal the neutral catalog.
+
+**Configuration.** Flat schema in `config/settings.py`. Dotenv precedence: repo `.env` → `~/.fcc/.env` → optional `FCC_ENV_FILE` (later files override earlier ones). `.env.example` is the Admin UI template source (force-included into the wheel), not a live config file. Model refs are `<provider_id>/<model-id>`; `MODEL` is the fallback and `MODEL_FABLE` / `MODEL_OPUS` / `MODEL_SONNET` / `MODEL_HAIKU` are Claude-tier overrides. Reasoning is resolved once at the application boundary into an immutable `core/reasoning.py` policy; provider adapters translate only the subset their documented wire API can express, and never branch on upstream model names or versions.
+
+**Stable contract.** The customer-facing surfaces are the contract: `fcc-server`/Admin UI, `fcc-claude`/Claude proxy behavior, `fcc-codex`/Responses behavior, `fcc-pi`, the messaging bridges, and the install scripts. Internal modules, class designs, helper APIs, and tests are not stable — refactor them freely when it simplifies the system, and update tests that encode obsolete internal shapes to assert customer-facing behavior instead.
+
+## Invariants (CI-enforced — never suppress)
+
+- Never add `# type: ignore`, `# ty: ignore`, or `from __future__ import annotations` — a CI grep fails on all three. Fix the underlying type issue or import cycle instead (move shared types/protocols to a neutral owner).
+- Python 3.14 native lazy annotations are the standard; the py314 ruff target allows multiple exception types in `except` without parentheses (`except TypeError, ValueError:`).
+- Prefer top-level imports; avoid `TYPE_CHECKING` and local imports for first-party or required dependencies.
+- Optional voice imports are lazy at their exact owners, below a function boundary: `torch` / `transformers` / `librosa` in `messaging.transcription`; `riva.client` in `providers.nvidia_nim.voice`.
+- Shared Anthropic protocol logic belongs in `core/anthropic/`; no provider imports from another provider.
+- Provider-specific config fields (e.g. `nim_settings`) stay in provider constructors, not the base `ProviderConfig`.
+
+## Engineering Principles
+
+- Zero-defect, root-cause-oriented engineering for bugs; test-driven engineering for new features. Write the simplest code possible; keep the codebase minimal and modular.
+- DRY: extract shared base classes to eliminate duplication; prefer composition over copy-paste.
+- Encapsulation: use accessor methods for internal state (e.g. `set_current_task()`), not direct `_attribute` assignment from outside.
+- Dead code: remove unused code, legacy systems, and hardcoded values; use settings/config instead of literals (e.g. `settings.provider_type`, not `"nvidia_nim"`).
+- Performance: list accumulation for strings (not `+=` in loops), cache env vars at init, prefer iterative over recursive when stack depth matters.
+- Platform-agnostic naming in shared code (e.g. `PLATFORM_EDIT`, not `TELEGRAM_EDIT`).
+- Complete migrations: when moving modules, update imports to the new owner and remove old compatibility shims in the same change unless preserving a published interface is explicitly required.
+- Maximum test coverage for everything, preferably including live smoke coverage to catch bugs early.
+
+## Workflow
 
 1. **ANALYZE**: Read relevant files. Do not guess.
 2. **PLAN**: Map out the logic. Identify root cause or required changes. Order changes by dependency.
-3. **EXECUTE**: Fix the cause, not the symptom. Execute incrementally with clear commits.
-4. **VERIFY**: Run `./scripts/ci.sh` or `.\scripts\ci.ps1`, plus relevant smoke tests when needed. Confirm the fix via logs or output.
-5. **SPECIFICITY**: Do exactly as much as asked; nothing more, nothing less.
-6. **PROPAGATION**: Changes impact multiple files; propagate updates correctly.
-7. **VERSION**: If the commit touches production files on `main`, bump semver in the same commit (see [Versioning](#versioning-main)).
+3. **EXECUTE**: Fix the cause, not the symptom. Execute incrementally with clear commits. Do exactly as much as asked; nothing more, nothing less. Changes impact multiple files — propagate updates correctly.
+4. **VERIFY**: Run `./scripts/ci.sh` (or `.\scripts\ci.ps1`), plus relevant smoke tests when needed. Confirm the fix via logs or output.
+5. **VERSION**: If the commit touches production files on `main`, bump semver in the same commit (see below).
 
-## VERSIONING (MAIN)
+## Versioning (MAIN)
 
 Every commit on `main` that changes a **production file** must include a semver bump in **`pyproject.toml`** in the **same commit**. Do not merge or push prod changes without updating the version.
 
-### Production files
+**Production files** (runtime, packaging, or install surface):
 
-These paths count as production (runtime, packaging, or install surface):
-
-- `src/free_claude_code/api/`, `src/free_claude_code/cli/`, `src/free_claude_code/config/`, `src/free_claude_code/core/`, `src/free_claude_code/messaging/`, `src/free_claude_code/providers/`
-- `src/free_claude_code/application/`
+- `src/free_claude_code/api/`, `application/`, `cli/`, `config/`, `core/`, `messaging/`, `providers/`
 - `.env.example`
 - `pyproject.toml` (dependencies, scripts, packaging)
 - `scripts/install.sh`, `scripts/install.ps1`, `scripts/uninstall.sh`, `scripts/uninstall.ps1`, `scripts/ci.sh`, `scripts/ci.ps1`
@@ -72,35 +109,26 @@ These paths count as production (runtime, packaging, or install surface):
 These do **not** require a version bump on their own:
 
 - `tests/`, `smoke/`
-- Docs and assets: `README.md`, `assets/`, `AGENTS.md`, `CLAUDE.md`
+- Docs and assets: `README.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `assets/`, `AGENTS.md`, `CLAUDE.md`
 - CI and repo config: `.github/`, `.gitignore`
 
 If a single commit mixes production and non-production edits, still bump the version.
 
-### Semver rules
-
-Use `[project].version` as `MAJOR.MINOR.PATCH`:
+**Semver rules** (`MAJOR.MINOR.PATCH` in `[project].version`):
 
 - **PATCH** (`x.y.Z+1`): bug fixes, refactors with no user-visible behavior change, dependency updates, packaging/install fixes.
-- **MINOR** (`x.Y+1.0`): backward-compatible features—new providers, admin fields, CLI commands, config options, or behavior additions.
-- **MAJOR** (`X+1.0.0`): breaking changes—removed or renamed env vars, incompatible API/CLI/default changes, or migrations users must act on.
+- **MINOR** (`x.Y+1.0`): backward-compatible features — new providers, admin fields, CLI commands, config options, or behavior additions.
+- **MAJOR** (`X+1.0.0`): breaking changes — removed or renamed env vars, incompatible API/CLI/default changes, or migrations users must act on.
 
 When unsure between PATCH and MINOR, prefer PATCH for fixes and MINOR for new capability.
 
-### Required steps
+**Required steps**: classify the change → update `version` in `pyproject.toml` → run `uv lock` so `uv.lock` reflects the new package version → include the version and lockfile updates in the same commit as the production change. Example: after a packaging fix, bump `1.2.38` → `1.2.39`, run `uv lock`, commit together with the fix.
 
-1. Classify the change and choose the bump level.
-2. Update `version` in `pyproject.toml`.
-3. Run `uv lock` so `uv.lock` reflects the new package version.
-4. Include the version and lockfile updates in the same commit as the production change.
+## CI Notes
 
-Example commit on `main` after a packaging fix: bump `1.2.38` → `1.2.39`, run `uv lock`, commit together with the fix.
+- Required status checks are exactly the 5 check IDs (possibly prefixed with `CI /`): **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**. Remove **ci** from required checks if it was previously added for the old gate job.
+- Repository protection uses rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, and required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
 
-## SUMMARY STANDARDS
+## Summary Standards
 
-- Summaries must be technical and granular.
-- Include: [Files Changed], [Logic Altered], [Verification Method], [Residual Risks] (if no residual risks then say none).
-
-## TOOLS
-
-- Prefer built-in tools (grep, read_file, etc.) over manual workflows. Check tool availability before use.
+Summaries must be technical and granular. Include: [Files Changed], [Logic Altered], [Verification Method], [Residual Risks] (if no residual risks then say none).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,70 +1,107 @@
-# AGENTIC DIRECTIVE
+# CLAUDE.md
 
-> Keep AGENTS.md and CLAUDE.md identical.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## CODING ENVIRONMENT
+> Keep AGENTS.md and CLAUDE.md identical: apply every change to this file to both.
 
-- Install astral uv using "curl -LsSf https://astral.sh/uv/install.sh | sh" if not already installed and if already installed then update it to the latest version
-- Install Python 3.14.0 stable using `uv python install 3.14.0` if not already installed (requires uv >=0.9; see `[tool.uv] required-version` in `pyproject.toml`)
-- Always use `uv run` to run files instead of the global `python` command.
-- Current uv ruff formatter is set to py314 which has supports multiple exception types without paranthesis (except TypeError, ValueError:)
-- Read `.env.example` for environment variables.
-- All CI checks must pass; failing checks block merge.
-- Add tests for new changes (including edge cases).
-- Before pushing, prefer `./scripts/ci.sh` (macOS/Linux) or `.\scripts\ci.ps1` (Windows) to run the local CI sequence; requires `uv` on PATH. The local scripts run Ruff in repair mode (`ruff format`, then `ruff check --fix`) before type checking and tests.
-- Use `--only` / `--skip` (PowerShell: `-Only` / `-Skip`) to run a subset when iterating; use `--dry-run` to print commands without running them.
-- GitHub CI remains check-only for Ruff (`ruff format --check`, `ruff check`) so branch protection verifies committed code.
-- Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
-- Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
-- Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
-- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced in `tests.yml` on push/merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- GitHub CI runs on `push`, `pull_request`, and `merge_group` so required checks validate merge queue candidates before they land.
-- Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
-- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
+## Project Overview
 
-## IDENTITY & CONTEXT
+Free Claude Code (FCC) is a local proxy that connects coding agents to AI providers. It accepts Anthropic Messages traffic from Claude Code and Pi, and OpenAI Responses traffic from Codex, routes each request to a configured upstream provider (30+ hosted APIs plus local Ollama / LM Studio / llama.cpp), and preserves the caller's wire protocol.
 
-- You are an expert Software Architect and Systems Engineer.
-- Goal: Zero-defect, root-cause-oriented engineering for bugs; test-driven engineering for new features. Think carefully; no need to rush.
-- Code: Write the simplest code possible. Keep the codebase minimal and modular.
+Three runtime surfaces:
 
-## ARCHITECTURE PRINCIPLES
+- **HTTP proxy** — FastAPI app in `src/free_claude_code/api/`: `/v1/messages`, `/v1/responses`, `/v1/messages/count_tokens`, `/v1/models`, `/health`, `/stop`, plus the local-only Admin UI at `http://127.0.0.1:8082/admin`.
+- **CLI launchers** — `fcc-server`, `fcc-claude`, `fcc-codex`, `fcc-pi`, `fcc-desktop` (entrypoints declared in `pyproject.toml`).
+- **Messaging bridge** — optional Discord/Telegram adapters that turn chat messages into managed Claude CLI sessions.
 
-- **Shared utilities**: Put shared Anthropic protocol logic in neutral `src/free_claude_code/core/anthropic/` modules. Do not have one provider import from another provider's utils.
-- **Failure ownership**: Keep canonical failure semantics and redaction SDK-free in `core/`; providers alone classify SDK/HTTP failures and own retries; protocol/API adapters alone choose wire error types and commit-boundary serialization.
-- **DRY**: Extract shared base classes to eliminate duplication. Prefer composition over copy-paste.
-- **Encapsulation**: Use accessor methods for internal state (e.g. `set_current_task()`), not direct `_attribute` assignment from outside.
-- **Provider-specific config**: Keep provider-specific fields (e.g. `nim_settings`) in provider constructors, not in the base `ProviderConfig`.
-- **Model-independent reasoning**: Resolve client reasoning intent once at the application boundary; provider adapters translate documented provider capabilities. Never branch on upstream model names or versions to choose reasoning behavior.
-- **Dead code**: Remove unused code, legacy systems, and hardcoded values. Use settings/config instead of literals (e.g. `settings.provider_type` not `"nvidia_nim"`).
-- **Performance**: Use list accumulation for strings (not `+=` in loops), cache env vars at init, prefer iterative over recursive when stack depth matters.
-- **Platform-agnostic naming**: Use generic names (e.g. `PLATFORM_EDIT`) not platform-specific ones (e.g. `TELEGRAM_EDIT`) in shared code.
-- **No type ignores**: Do not add `# type: ignore` or `# ty: ignore`. Fix the underlying type issue.
-- **Python 3.14 annotations**: Do not use `from __future__ import annotations`; rely on native lazy annotations and fix circular import boundaries instead of hiding them with annotation stringization.
-- **Imports**: Prefer top-level imports. Avoid `TYPE_CHECKING` and local imports for first-party or required dependencies; if a top-level import creates a cycle, move shared types/protocols to a neutral owner.
-- **Complete migrations**: When moving modules, update imports to the new owner and remove old compatibility shims in the same change unless preserving a published interface is explicitly required.
-- **Maximum Test Coverage**: There should be maximum test coverage for everything, preferably live smoke test coverage to catch bugs early
+## Commands
 
-## COGNITIVE WORKFLOW
+Everything runs through [uv](https://docs.astral.sh/uv/) with Python 3.14 — never a global interpreter. Requires uv >= 0.11.16 (`[tool.uv] required-version` in pyproject.toml); install or update uv with `curl -LsSf https://astral.sh/uv/install.sh | sh` and run `uv python install 3.14.0` if that interpreter is missing. See `.env.example` for environment variables.
+
+```bash
+uv run fcc-server                  # run the proxy + Admin UI from a checkout
+
+./scripts/ci.sh                    # full local CI before pushing (Windows: .\scripts\ci.ps1)
+./scripts/ci.sh --only pytest      # subset; also --skip, --dry-run (PowerShell: -Only, -Skip, -DryRun)
+```
+
+`scripts/ci.sh` runs, in order: suppression grep → `uv run ruff format` → `uv run ruff check --fix` → `uv run ty check` → `uv run pytest -v --tb=short`. Ruff runs in repair mode locally; GitHub CI is check-only (`ruff format --check`, `ruff check`) and enforces the same 5 check IDs as parallel jobs on push, pull_request, and merge_group. Use the individual repair commands above when debugging local failures; use the `--check` variants only when verifying GitHub-style enforcement.
+
+```bash
+uv run pytest                                             # deterministic tests; addopts "-n auto" (parallel xdist)
+uv run pytest tests/core/test_failures.py -v              # one file
+uv run pytest tests/core/test_failures.py::test_name -v   # one test (add -n 0 to serialize while debugging)
+```
+
+`tests/` mirrors the `src/` package layout and must stay hermetic. Live product smoke lives in `smoke/` and does nothing without opt-in (target catalog, env vars, and failure classes are in `smoke/README.md`):
+
+```bash
+FCC_LIVE_SMOKE=1 uv run pytest smoke -n 0 -s --tb=short
+FCC_LIVE_SMOKE=1 FCC_SMOKE_TARGETS=api,providers uv run pytest smoke -n 0 -s --tb=short
+```
+
+## Architecture
+
+[ARCHITECTURE.md](ARCHITECTURE.md) is the authoritative map — read it before changing package boundaries, providers, protocol conversion, launchers, or messaging. It also has step-by-step extension checklists (add a provider, admin setting, messaging platform, or protocol behavior). The essentials:
+
+**Import policy (test-enforced).** Production code lives under `src/free_claude_code/`. An AST-scanner contract test derives every static production edge and enforces this exact direct-dependency matrix; the first-party module graph must stay acyclic. New packages or cross-package edges are added to the policy deliberately:
+
+| Package | Owns | May import |
+| --- | --- | --- |
+| `config` | pydantic-settings schema, provider catalog, paths, Admin config | — |
+| `core` | protocol-neutral logic: Anthropic + OpenAI Responses wire models and conversion, SSE, canonical `ExecutionFailure` semantics, credential-redacting diagnostics, token counting | — |
+| `application` | dependency leaf: `ModelRouter`, `ProviderExecutor`, reasoning resolution, consumer-owned ports | config, core |
+| `providers` | provider runtime/construction, OpenAI-chat profiles, specialized adapters, SDK/HTTP failure classification, retry/recovery, admission | application, config, core |
+| `api` | FastAPI app, routes, product handlers, local optimizations, web tools, model-catalog responses | application, config, core |
+| `messaging` | Discord/Telegram runtimes, tree queues, transcripts, persistence, voice flow | core |
+| `cli` | entrypoints, client launchers, managed Claude subprocesses | config, core |
+| `runtime` | process composition root: bootstrap, provider generations, ordered lifecycle shutdown | everything |
+
+The single sanctioned exception: `cli.entrypoints` → `runtime.bootstrap`.
+
+**Request flow.** Route → provider-generation lease (`runtime/provider_manager.py`) → product handler (`api/handlers/`) → `ModelRouter` resolves model + reasoning intent → `ProviderExecutor` (`application/execution.py`) preflights and streams → provider adapter → Anthropic SSE. Codex Responses traffic goes through `core/openai_responses/`, which converts Responses ⇄ Anthropic Messages at the adapter boundary. Failures cross boundaries as canonical `core/failures.py` values; each protocol package maps them to its wire error type, and the HTTP commit boundary (first chunk sent) decides between a non-2xx JSON error and a terminal stream event.
+
+**Provider model.** Neutral provider metadata is centralized in `config/provider_catalog.py`. Most upstreams are declarative `OpenAIChatProfile` data on the shared `OpenAIChatProvider` (`providers/openai_chat/`) — configuration differences stay data, not subclasses. Only a true upstream quirk (own state, model-list behavior, stream events, retry algorithms) justifies a specialized package plus sparse factory entry, and the union of construction owners must exactly equal the neutral catalog.
+
+**Configuration.** Flat schema in `config/settings.py`. Dotenv precedence: repo `.env` → `~/.fcc/.env` → optional `FCC_ENV_FILE` (later files override earlier ones). `.env.example` is the Admin UI template source (force-included into the wheel), not a live config file. Model refs are `<provider_id>/<model-id>`; `MODEL` is the fallback and `MODEL_FABLE` / `MODEL_OPUS` / `MODEL_SONNET` / `MODEL_HAIKU` are Claude-tier overrides. Reasoning is resolved once at the application boundary into an immutable `core/reasoning.py` policy; provider adapters translate only the subset their documented wire API can express, and never branch on upstream model names or versions.
+
+**Stable contract.** The customer-facing surfaces are the contract: `fcc-server`/Admin UI, `fcc-claude`/Claude proxy behavior, `fcc-codex`/Responses behavior, `fcc-pi`, the messaging bridges, and the install scripts. Internal modules, class designs, helper APIs, and tests are not stable — refactor them freely when it simplifies the system, and update tests that encode obsolete internal shapes to assert customer-facing behavior instead.
+
+## Invariants (CI-enforced — never suppress)
+
+- Never add `# type: ignore`, `# ty: ignore`, or `from __future__ import annotations` — a CI grep fails on all three. Fix the underlying type issue or import cycle instead (move shared types/protocols to a neutral owner).
+- Python 3.14 native lazy annotations are the standard; the py314 ruff target allows multiple exception types in `except` without parentheses (`except TypeError, ValueError:`).
+- Prefer top-level imports; avoid `TYPE_CHECKING` and local imports for first-party or required dependencies.
+- Optional voice imports are lazy at their exact owners, below a function boundary: `torch` / `transformers` / `librosa` in `messaging.transcription`; `riva.client` in `providers.nvidia_nim.voice`.
+- Shared Anthropic protocol logic belongs in `core/anthropic/`; no provider imports from another provider.
+- Provider-specific config fields (e.g. `nim_settings`) stay in provider constructors, not the base `ProviderConfig`.
+
+## Engineering Principles
+
+- Zero-defect, root-cause-oriented engineering for bugs; test-driven engineering for new features. Write the simplest code possible; keep the codebase minimal and modular.
+- DRY: extract shared base classes to eliminate duplication; prefer composition over copy-paste.
+- Encapsulation: use accessor methods for internal state (e.g. `set_current_task()`), not direct `_attribute` assignment from outside.
+- Dead code: remove unused code, legacy systems, and hardcoded values; use settings/config instead of literals (e.g. `settings.provider_type`, not `"nvidia_nim"`).
+- Performance: list accumulation for strings (not `+=` in loops), cache env vars at init, prefer iterative over recursive when stack depth matters.
+- Platform-agnostic naming in shared code (e.g. `PLATFORM_EDIT`, not `TELEGRAM_EDIT`).
+- Complete migrations: when moving modules, update imports to the new owner and remove old compatibility shims in the same change unless preserving a published interface is explicitly required.
+- Maximum test coverage for everything, preferably including live smoke coverage to catch bugs early.
+
+## Workflow
 
 1. **ANALYZE**: Read relevant files. Do not guess.
 2. **PLAN**: Map out the logic. Identify root cause or required changes. Order changes by dependency.
-3. **EXECUTE**: Fix the cause, not the symptom. Execute incrementally with clear commits.
-4. **VERIFY**: Run `./scripts/ci.sh` or `.\scripts\ci.ps1`, plus relevant smoke tests when needed. Confirm the fix via logs or output.
-5. **SPECIFICITY**: Do exactly as much as asked; nothing more, nothing less.
-6. **PROPAGATION**: Changes impact multiple files; propagate updates correctly.
-7. **VERSION**: If the commit touches production files on `main`, bump semver in the same commit (see [Versioning](#versioning-main)).
+3. **EXECUTE**: Fix the cause, not the symptom. Execute incrementally with clear commits. Do exactly as much as asked; nothing more, nothing less. Changes impact multiple files — propagate updates correctly.
+4. **VERIFY**: Run `./scripts/ci.sh` (or `.\scripts\ci.ps1`), plus relevant smoke tests when needed. Confirm the fix via logs or output.
+5. **VERSION**: If the commit touches production files on `main`, bump semver in the same commit (see below).
 
-## VERSIONING (MAIN)
+## Versioning (MAIN)
 
 Every commit on `main` that changes a **production file** must include a semver bump in **`pyproject.toml`** in the **same commit**. Do not merge or push prod changes without updating the version.
 
-### Production files
+**Production files** (runtime, packaging, or install surface):
 
-These paths count as production (runtime, packaging, or install surface):
-
-- `src/free_claude_code/api/`, `src/free_claude_code/cli/`, `src/free_claude_code/config/`, `src/free_claude_code/core/`, `src/free_claude_code/messaging/`, `src/free_claude_code/providers/`
-- `src/free_claude_code/application/`
+- `src/free_claude_code/api/`, `application/`, `cli/`, `config/`, `core/`, `messaging/`, `providers/`
 - `.env.example`
 - `pyproject.toml` (dependencies, scripts, packaging)
 - `scripts/install.sh`, `scripts/install.ps1`, `scripts/uninstall.sh`, `scripts/uninstall.ps1`, `scripts/ci.sh`, `scripts/ci.ps1`
@@ -72,35 +109,26 @@ These paths count as production (runtime, packaging, or install surface):
 These do **not** require a version bump on their own:
 
 - `tests/`, `smoke/`
-- Docs and assets: `README.md`, `assets/`, `AGENTS.md`, `CLAUDE.md`
+- Docs and assets: `README.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `assets/`, `AGENTS.md`, `CLAUDE.md`
 - CI and repo config: `.github/`, `.gitignore`
 
 If a single commit mixes production and non-production edits, still bump the version.
 
-### Semver rules
-
-Use `[project].version` as `MAJOR.MINOR.PATCH`:
+**Semver rules** (`MAJOR.MINOR.PATCH` in `[project].version`):
 
 - **PATCH** (`x.y.Z+1`): bug fixes, refactors with no user-visible behavior change, dependency updates, packaging/install fixes.
-- **MINOR** (`x.Y+1.0`): backward-compatible features—new providers, admin fields, CLI commands, config options, or behavior additions.
-- **MAJOR** (`X+1.0.0`): breaking changes—removed or renamed env vars, incompatible API/CLI/default changes, or migrations users must act on.
+- **MINOR** (`x.Y+1.0`): backward-compatible features — new providers, admin fields, CLI commands, config options, or behavior additions.
+- **MAJOR** (`X+1.0.0`): breaking changes — removed or renamed env vars, incompatible API/CLI/default changes, or migrations users must act on.
 
 When unsure between PATCH and MINOR, prefer PATCH for fixes and MINOR for new capability.
 
-### Required steps
+**Required steps**: classify the change → update `version` in `pyproject.toml` → run `uv lock` so `uv.lock` reflects the new package version → include the version and lockfile updates in the same commit as the production change. Example: after a packaging fix, bump `1.2.38` → `1.2.39`, run `uv lock`, commit together with the fix.
 
-1. Classify the change and choose the bump level.
-2. Update `version` in `pyproject.toml`.
-3. Run `uv lock` so `uv.lock` reflects the new package version.
-4. Include the version and lockfile updates in the same commit as the production change.
+## CI Notes
 
-Example commit on `main` after a packaging fix: bump `1.2.38` → `1.2.39`, run `uv lock`, commit together with the fix.
+- Required status checks are exactly the 5 check IDs (possibly prefixed with `CI /`): **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**. Remove **ci** from required checks if it was previously added for the old gate job.
+- Repository protection uses rulesets: a non-bypassable main integrity ruleset requires pull requests, merge queue, and required checks, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
 
-## SUMMARY STANDARDS
+## Summary Standards
 
-- Summaries must be technical and granular.
-- Include: [Files Changed], [Logic Altered], [Verification Method], [Residual Risks] (if no residual risks then say none).
-
-## TOOLS
-
-- Prefer built-in tools (grep, read_file, etc.) over manual workflows. Check tool availability before use.
+Summaries must be technical and granular. Include: [Files Changed], [Logic Altered], [Verification Method], [Residual Risks] (if no residual risks then say none).


### PR DESCRIPTION
Documentation-only update to the agent guidance files (kept identical per the repo directive).

**Added**
- Project overview: what FCC is and its three runtime surfaces (HTTP proxy, CLI launchers, messaging bridge)
- Common commands: running the server from a checkout, running a single test file/test, live smoke test invocations, xdist notes
- Compact architecture map: package/import-policy matrix, request flow, provider model, configuration model — pointing to ARCHITECTURE.md for depth

**Fixed**
- Stale uv minimum version (claimed `>=0.9`; pyproject.toml pins `>=0.11.16`)
- Typo in the py314 exception-syntax note
- Version-bump exemption list now explicitly includes ARCHITECTURE.md and CONTRIBUTING.md (both docs already state they are bump-exempt)

**Kept intact**
- CI-enforced invariants, engineering principles, workflow, semver policy, summary standards, branch-protection notes — reorganized only

No production code changed; no version bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change rewrites the synchronized contributor-guidance files with project architecture, development workflow, and release-versioning instructions. Two documentation failures were reproduced: the documented CLI-to-runtime exception identifies the wrong direct import edge, and the production-file list excludes the shipped runtime package. Correct both `CLAUDE.md` and `AGENTS.md` before merging so contributors follow the enforced architecture and apply version updates to runtime changes.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until the synchronized guidance correctly names the sanctioned import edge and includes the runtime package in release-versioning scope.

Focused source and contract checks reproduced both documentation failures: the direct import and enforced exception are on `cli.commands`, and the omitted runtime package is shipped and constructs the served ASGI application.

**Files Needing Attention:** `CLAUDE.md` and `AGENTS.md` require matching corrections at the architecture exception and production-file list.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P2 finding about the import boundary review script.
- T-Rex produced proof for a posted P2 finding about the focused runtime versioning check.
- The review-authored AST inspection ran for both modules and confirmed the direct\_runtime\_bootstrap\_import statuses as described.
- T-Rex produced proof for another posted P2 finding.
- The contract-validation proof identified exact affected lines in CLAUDE.md and AGENTS.md and notes a packaging omission in the runtime surface.

<a href="https://app.greptile.com/trex/runs/18212904/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Versioning policy omits shipped production runtime path**

   - **Bug**
     - The production-file list omits `src/free_claude_code/runtime/`, despite that package being included in the wheel and invoked by the server command to construct the served ASGI application. A runtime-only change is therefore incorrectly not explicitly classified as requiring the mandated semver bump.
   - **Cause**
     - The exhaustive production-path enumeration at line 104 lists sibling source packages but leaves out the runtime package.
   - **Fix**
     - Add `runtime/` to the `src/free_claude_code/` production-path list in both identical documents, so runtime code changes require the same-commit semver bump on `main`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Rewrite CLAUDE.md and AGENTS.md with pro..."](https://github.com/alishahryar1/free-claude-code/commit/761e404a250ae5d670868d71008270194f415cec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52014160)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->