### PR TITLE
Add MiniMax speech synthesis endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,8 +35,10 @@ KIMI_CODE_API_KEY=""
 WAFER_API_KEY=""
 
 
-# MiniMax Config (OpenAI-compatible Chat Completions at api.minimax.io/v1)
+# MiniMax Config (chat plus global/China text-to-speech endpoints)
 MINIMAX_API_KEY=""
+# "global" uses api.minimax.io; "china" uses api.minimaxi.com.
+MINIMAX_TTS_REGION="global"
 
 
 # OpenCode Zen (opencode.ai/zen/v1) and OpenCode Go (opencode.ai/zen/go/v1) share OPENCODE_API_KEY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.20.0"
+version = "4.21.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.21.0"
+version = "4.21.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/ports.py
+++ b/src/free_claude_code/api/ports.py
@@ -10,6 +10,17 @@ from free_claude_code.application.connected_accounts import (
 )
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
 from free_claude_code.application.ports import RequestRuntimePort, TaskController
+from free_claude_code.config.settings import Settings
+
+
+class SpeechSynthesisPort(Protocol):
+    """Synthesize audio through the runtime-selected speech provider."""
+
+    async def synthesize(
+        self,
+        payload: Mapping[str, Any],
+        settings: Settings,
+    ) -> bytes: ...
 
 
 class AdminRuntimePort(Protocol):
@@ -53,3 +64,4 @@ class ApiServices:
     requests: RequestRuntimePort
     admin: AdminRuntimePort
     tasks: TaskController
+    speech: SpeechSynthesisPort

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -1,5 +1,6 @@
 """FastAPI route handlers."""
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from loguru import logger
 
@@ -14,6 +15,11 @@ from free_claude_code.core.anthropic import (
 )
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.trace import trace_event
+from free_claude_code.providers.minimax import (
+    MiniMaxSpeechClient,
+    MiniMaxSpeechError,
+    MiniMaxSpeechRequest,
+)
 
 from .dependencies import (
     get_services,
@@ -139,6 +145,42 @@ async def create_response(
 
 @router.api_route("/v1/responses", methods=["HEAD", "OPTIONS"])
 async def probe_responses(_auth=Depends(require_proxy_auth)):
+    return _probe_response("POST, HEAD, OPTIONS")
+
+
+@router.post("/v1/audio/speech")
+async def create_speech(
+    request_data: MiniMaxSpeechRequest,
+    settings: Settings = Depends(get_settings),
+    _auth=Depends(require_proxy_auth),
+):
+    """Synthesize speech with MiniMax and return the requested audio format."""
+    if not settings.minimax_api_key.strip():
+        raise HTTPException(
+            status_code=503,
+            detail="MINIMAX_API_KEY is required for speech synthesis.",
+        )
+    timeout = httpx.Timeout(
+        connect=settings.http_connect_timeout,
+        read=settings.http_read_timeout,
+        write=settings.http_write_timeout,
+        pool=settings.http_connect_timeout,
+    )
+    client = MiniMaxSpeechClient(
+        api_key=settings.minimax_api_key,
+        region=settings.minimax_tts_region,
+        proxy=settings.minimax_proxy,
+        timeout=timeout,
+    )
+    try:
+        audio = await client.synthesize(request_data)
+    except MiniMaxSpeechError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return Response(content=audio, media_type=request_data.media_type)
+
+
+@router.api_route("/v1/audio/speech", methods=["HEAD", "OPTIONS"])
+async def probe_speech(_auth=Depends(require_proxy_auth)):
     return _probe_response("POST, HEAD, OPTIONS")
 
 

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -1,10 +1,9 @@
 """FastAPI route handlers."""
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from loguru import logger
 
-from free_claude_code.application.errors import ApplicationError
+from free_claude_code.application.errors import ApplicationError, SpeechSynthesisError
 from free_claude_code.application.ports import ProviderResolver, RequestRuntimeLease
 from free_claude_code.config.model_refs import parse_provider_type
 from free_claude_code.config.settings import Settings
@@ -15,11 +14,6 @@ from free_claude_code.core.anthropic import (
 )
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.trace import trace_event
-from free_claude_code.providers.minimax import (
-    MiniMaxSpeechClient,
-    MiniMaxSpeechError,
-    MiniMaxSpeechRequest,
-)
 
 from .dependencies import (
     get_services,
@@ -33,6 +27,7 @@ from .ports import ApiServices
 from .request_errors import ordinary_application_error_response
 from .request_ids import get_request_id
 from .response_streams import bind_response_lifetime
+from .speech import MiniMaxSpeechRequest
 
 router = APIRouter()
 
@@ -151,6 +146,7 @@ async def probe_responses(_auth=Depends(require_proxy_auth)):
 @router.post("/v1/audio/speech")
 async def create_speech(
     request_data: MiniMaxSpeechRequest,
+    services: ApiServices = Depends(get_services),
     settings: Settings = Depends(get_settings),
     _auth=Depends(require_proxy_auth),
 ):
@@ -160,21 +156,12 @@ async def create_speech(
             status_code=503,
             detail="MINIMAX_API_KEY is required for speech synthesis.",
         )
-    timeout = httpx.Timeout(
-        connect=settings.http_connect_timeout,
-        read=settings.http_read_timeout,
-        write=settings.http_write_timeout,
-        pool=settings.http_connect_timeout,
-    )
-    client = MiniMaxSpeechClient(
-        api_key=settings.minimax_api_key,
-        region=settings.minimax_tts_region,
-        proxy=settings.minimax_proxy,
-        timeout=timeout,
-    )
     try:
-        audio = await client.synthesize(request_data)
-    except MiniMaxSpeechError as exc:
+        audio = await services.speech.synthesize(
+            request_data.upstream_payload(),
+            settings,
+        )
+    except SpeechSynthesisError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     return Response(content=audio, media_type=request_data.media_type)
 

--- a/src/free_claude_code/api/speech.py
+++ b/src/free_claude_code/api/speech.py
@@ -1,0 +1,56 @@
+"""HTTP request models for speech synthesis."""
+
+from typing import Any, Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_AUDIO_MEDIA_TYPES: Final = {
+    "mp3": "audio/mpeg",
+    "wav": "audio/wav",
+    "flac": "audio/flac",
+    "pcm": "audio/L16",
+}
+
+
+class MiniMaxAudioSetting(BaseModel):
+    """Audio settings with a constrained output format."""
+
+    model_config = ConfigDict(extra="allow")
+
+    format: Literal["mp3", "wav", "flac", "pcm"] = "mp3"
+
+
+class MiniMaxSpeechRequest(BaseModel):
+    """Supported request fields for the synchronous MiniMax T2A operation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: Literal[
+        "speech-2.8-hd",
+        "speech-2.8-turbo",
+        "speech-2.6-hd",
+        "speech-2.6-turbo",
+        "speech-02-hd",
+        "speech-02-turbo",
+        "speech-01-hd",
+        "speech-01-turbo",
+    ] = "speech-2.8-hd"
+    text: str = Field(min_length=1, max_length=10_000)
+    stream: bool = False
+    language_boost: str | None = None
+    output_format: Literal["hex"] = "hex"
+    voice_setting: dict[str, Any] | None = None
+    pronunciation_dict: dict[str, Any] | None = None
+    audio_setting: MiniMaxAudioSetting | None = None
+    voice_modify: dict[str, Any] | None = None
+    subtitle_enable: bool | None = None
+
+    @property
+    def media_type(self) -> str:
+        """Return the response media type requested through ``audio_setting``."""
+        audio_format = self.audio_setting.format if self.audio_setting else "mp3"
+        return _AUDIO_MEDIA_TYPES[audio_format]
+
+    def upstream_payload(self) -> dict[str, Any]:
+        """Serialize only documented request fields for the upstream API."""
+        return self.model_dump(exclude_none=True)

--- a/src/free_claude_code/application/errors.py
+++ b/src/free_claude_code/application/errors.py
@@ -39,3 +39,10 @@ class ApplicationUnavailableError(ApplicationError):
 
     kind = FailureKind.UNAVAILABLE
     status_code = 503
+
+
+class SpeechSynthesisError(ApplicationError):
+    """An upstream speech request failed without exposing response contents."""
+
+    kind = FailureKind.UPSTREAM
+    status_code = 502

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -133,6 +133,20 @@ SECTIONS: tuple[ConfigSectionSpec, ...] = (
 
 _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
     ConfigFieldSpec(
+        "MINIMAX_TTS_REGION",
+        "MiniMax Speech Region",
+        "voice",
+        "select",
+        settings_attr="minimax_tts_region",
+        default="global",
+        options=(
+            ConfigOptionSpec("global", "Global"),
+            ConfigOptionSpec("china", "China"),
+        ),
+        restart_required=True,
+        description="Regional MiniMax endpoint used by /v1/audio/speech.",
+    ),
+    ConfigFieldSpec(
         "MODEL",
         "Default Model",
         "models",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -101,10 +101,7 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
     },
     "MINIMAX_API_KEY": {
         "label": "MiniMax API Key",
-        "description": (
-            "MiniMax API key for the OpenAI-compatible Chat Completions API at "
-            "free_claude_code.api.minimax.io/v1."
-        ),
+        "description": ("MiniMax API key for chat and text-to-speech requests."),
     },
     "KIMI_CODE_API_KEY": {
         "label": "Kimi Code API Key",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -1,7 +1,7 @@
 """Flat application settings schema loaded by Pydantic Settings."""
 
 from functools import lru_cache
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -56,6 +56,9 @@ class Settings(BaseSettings):
 
     # ==================== MiniMax Config ====================
     minimax_api_key: str = Field(default="", validation_alias="MINIMAX_API_KEY")
+    minimax_tts_region: Literal["global", "china"] = Field(
+        default="global", validation_alias="MINIMAX_TTS_REGION"
+    )
 
     # ==================== OpenCode Zen / OpenCode Go ====================
     # Same key from opencode.ai/auth; Zen uses ``opencode_zen/``, Go uses ``opencode_go/``.

--- a/src/free_claude_code/providers/minimax/__init__.py
+++ b/src/free_claude_code/providers/minimax/__init__.py
@@ -4,12 +4,12 @@ from .speech import (
     MINIMAX_TTS_ENDPOINTS,
     MiniMaxSpeechClient,
     MiniMaxSpeechError,
-    MiniMaxSpeechRequest,
+    MiniMaxSpeechService,
 )
 
 __all__ = [
     "MINIMAX_TTS_ENDPOINTS",
     "MiniMaxSpeechClient",
     "MiniMaxSpeechError",
-    "MiniMaxSpeechRequest",
+    "MiniMaxSpeechService",
 ]

--- a/src/free_claude_code/providers/minimax/__init__.py
+++ b/src/free_claude_code/providers/minimax/__init__.py
@@ -1,0 +1,15 @@
+"""MiniMax-specific multimodal clients."""
+
+from .speech import (
+    MINIMAX_TTS_ENDPOINTS,
+    MiniMaxSpeechClient,
+    MiniMaxSpeechError,
+    MiniMaxSpeechRequest,
+)
+
+__all__ = [
+    "MINIMAX_TTS_ENDPOINTS",
+    "MiniMaxSpeechClient",
+    "MiniMaxSpeechError",
+    "MiniMaxSpeechRequest",
+]

--- a/src/free_claude_code/providers/minimax/speech.py
+++ b/src/free_claude_code/providers/minimax/speech.py
@@ -1,0 +1,174 @@
+"""MiniMax synchronous text-to-speech transport and response parsing."""
+
+import json
+from typing import Any, Final, Literal
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+MINIMAX_TTS_ENDPOINTS: Final = {
+    "global": "https://api.minimax.io/v1/t2a_v2",
+    "china": "https://api.minimaxi.com/v1/t2a_v2",
+}
+MINIMAX_SPEECH_MODELS: Final = (
+    "speech-2.8-hd",
+    "speech-2.8-turbo",
+    "speech-2.6-hd",
+    "speech-2.6-turbo",
+    "speech-02-hd",
+    "speech-02-turbo",
+    "speech-01-hd",
+    "speech-01-turbo",
+)
+_AUDIO_MEDIA_TYPES: Final = {
+    "mp3": "audio/mpeg",
+    "wav": "audio/wav",
+    "flac": "audio/flac",
+    "pcm": "audio/L16",
+}
+
+
+class MiniMaxSpeechError(RuntimeError):
+    """A safe speech synthesis failure without upstream response contents."""
+
+
+class MiniMaxSpeechRequest(BaseModel):
+    """Supported request fields for the synchronous MiniMax T2A operation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: Literal[
+        "speech-2.8-hd",
+        "speech-2.8-turbo",
+        "speech-2.6-hd",
+        "speech-2.6-turbo",
+        "speech-02-hd",
+        "speech-02-turbo",
+        "speech-01-hd",
+        "speech-01-turbo",
+    ] = "speech-2.8-hd"
+    text: str = Field(min_length=1, max_length=10_000)
+    stream: bool = False
+    language_boost: str | None = None
+    output_format: Literal["hex"] = "hex"
+    voice_setting: dict[str, Any] | None = None
+    pronunciation_dict: dict[str, Any] | None = None
+    audio_setting: dict[str, Any] | None = None
+    voice_modify: dict[str, Any] | None = None
+    subtitle_enable: bool | None = None
+
+    @property
+    def media_type(self) -> str:
+        """Return the response media type requested through ``audio_setting``."""
+        audio_format = (self.audio_setting or {}).get("format", "mp3")
+        return _AUDIO_MEDIA_TYPES.get(str(audio_format), "application/octet-stream")
+
+    def upstream_payload(self) -> dict[str, Any]:
+        """Serialize only documented request fields for the upstream API."""
+        return self.model_dump(exclude_none=True)
+
+
+class MiniMaxSpeechClient:
+    """Call the regional MiniMax T2A endpoint and return decoded audio bytes."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        region: Literal["global", "china"] = "global",
+        proxy: str = "",
+        timeout: httpx.Timeout | float = 60.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        if not api_key.strip():
+            raise ValueError("MiniMax speech synthesis requires MINIMAX_API_KEY.")
+        self._api_key = api_key
+        self._endpoint = MINIMAX_TTS_ENDPOINTS[region]
+        self._proxy = proxy or None
+        self._timeout = timeout
+        self._transport = transport
+
+    @property
+    def endpoint(self) -> str:
+        """Return the selected regional endpoint."""
+        return self._endpoint
+
+    async def synthesize(self, request: MiniMaxSpeechRequest) -> bytes:
+        """Generate audio and decode non-streaming JSON or streaming SSE chunks."""
+        try:
+            async with httpx.AsyncClient(
+                proxy=self._proxy,
+                timeout=self._timeout,
+                transport=self._transport,
+            ) as client:
+                response = await client.post(
+                    self._endpoint,
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=request.upstream_payload(),
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise MiniMaxSpeechError("MiniMax speech request failed.") from exc
+
+        payloads = _response_payloads(response)
+        audio_parts: list[bytes] = []
+        terminal = False
+        for payload in payloads:
+            _raise_for_upstream_error(payload)
+            data = payload.get("data")
+            if not isinstance(data, dict):
+                continue
+            audio = data.get("audio")
+            if audio:
+                if not isinstance(audio, str):
+                    raise MiniMaxSpeechError("MiniMax returned invalid audio data.")
+                try:
+                    audio_parts.append(bytes.fromhex(audio))
+                except ValueError as exc:
+                    raise MiniMaxSpeechError(
+                        "MiniMax returned invalid hex audio data."
+                    ) from exc
+            terminal = terminal or data.get("status") == 2
+
+        if not terminal or not audio_parts:
+            raise MiniMaxSpeechError("MiniMax returned an incomplete speech response.")
+        return b"".join(audio_parts)
+
+
+def _response_payloads(response: httpx.Response) -> list[dict[str, Any]]:
+    content_type = response.headers.get("content-type", "").lower()
+    try:
+        if "text/event-stream" not in content_type:
+            parsed = response.json()
+            if isinstance(parsed, dict):
+                return [parsed]
+            if isinstance(parsed, list) and all(
+                isinstance(item, dict) for item in parsed
+            ):
+                return parsed
+            raise MiniMaxSpeechError("MiniMax returned an invalid JSON response.")
+
+        payloads: list[dict[str, Any]] = []
+        for line in response.text.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            raw = line.removeprefix("data:").strip()
+            if not raw or raw == "[DONE]":
+                continue
+            item = json.loads(raw)
+            if not isinstance(item, dict):
+                raise MiniMaxSpeechError("MiniMax returned an invalid stream event.")
+            payloads.append(item)
+        return payloads
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise MiniMaxSpeechError("MiniMax returned malformed speech data.") from exc
+
+
+def _raise_for_upstream_error(payload: dict[str, Any]) -> None:
+    base_response = payload.get("base_resp")
+    if not isinstance(base_response, dict) or base_response.get("status_code") != 0:
+        raise MiniMaxSpeechError("MiniMax rejected the speech request.")

--- a/src/free_claude_code/providers/minimax/speech.py
+++ b/src/free_claude_code/providers/minimax/speech.py
@@ -1,10 +1,13 @@
 """MiniMax synchronous text-to-speech transport and response parsing."""
 
 import json
+from collections.abc import Mapping
 from typing import Any, Final, Literal
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field
+
+from free_claude_code.application.errors import SpeechSynthesisError
+from free_claude_code.config.settings import Settings
 
 MINIMAX_TTS_ENDPOINTS: Final = {
     "global": "https://api.minimax.io/v1/t2a_v2",
@@ -20,52 +23,10 @@ MINIMAX_SPEECH_MODELS: Final = (
     "speech-01-hd",
     "speech-01-turbo",
 )
-_AUDIO_MEDIA_TYPES: Final = {
-    "mp3": "audio/mpeg",
-    "wav": "audio/wav",
-    "flac": "audio/flac",
-    "pcm": "audio/L16",
-}
 
 
-class MiniMaxSpeechError(RuntimeError):
+class MiniMaxSpeechError(SpeechSynthesisError):
     """A safe speech synthesis failure without upstream response contents."""
-
-
-class MiniMaxSpeechRequest(BaseModel):
-    """Supported request fields for the synchronous MiniMax T2A operation."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    model: Literal[
-        "speech-2.8-hd",
-        "speech-2.8-turbo",
-        "speech-2.6-hd",
-        "speech-2.6-turbo",
-        "speech-02-hd",
-        "speech-02-turbo",
-        "speech-01-hd",
-        "speech-01-turbo",
-    ] = "speech-2.8-hd"
-    text: str = Field(min_length=1, max_length=10_000)
-    stream: bool = False
-    language_boost: str | None = None
-    output_format: Literal["hex"] = "hex"
-    voice_setting: dict[str, Any] | None = None
-    pronunciation_dict: dict[str, Any] | None = None
-    audio_setting: dict[str, Any] | None = None
-    voice_modify: dict[str, Any] | None = None
-    subtitle_enable: bool | None = None
-
-    @property
-    def media_type(self) -> str:
-        """Return the response media type requested through ``audio_setting``."""
-        audio_format = (self.audio_setting or {}).get("format", "mp3")
-        return _AUDIO_MEDIA_TYPES.get(str(audio_format), "application/octet-stream")
-
-    def upstream_payload(self) -> dict[str, Any]:
-        """Serialize only documented request fields for the upstream API."""
-        return self.model_dump(exclude_none=True)
 
 
 class MiniMaxSpeechClient:
@@ -93,7 +54,7 @@ class MiniMaxSpeechClient:
         """Return the selected regional endpoint."""
         return self._endpoint
 
-    async def synthesize(self, request: MiniMaxSpeechRequest) -> bytes:
+    async def synthesize(self, payload: Mapping[str, Any]) -> bytes:
         """Generate audio and decode non-streaming JSON or streaming SSE chunks."""
         try:
             async with httpx.AsyncClient(
@@ -107,7 +68,7 @@ class MiniMaxSpeechClient:
                         "Authorization": f"Bearer {self._api_key}",
                         "Content-Type": "application/json",
                     },
-                    json=request.upstream_payload(),
+                    json=dict(payload),
                 )
                 response.raise_for_status()
         except httpx.HTTPError as exc:
@@ -136,6 +97,29 @@ class MiniMaxSpeechClient:
         if not terminal or not audio_parts:
             raise MiniMaxSpeechError("MiniMax returned an incomplete speech response.")
         return b"".join(audio_parts)
+
+
+class MiniMaxSpeechService:
+    """Construct request-scoped MiniMax clients from the current settings."""
+
+    async def synthesize(
+        self,
+        payload: Mapping[str, Any],
+        settings: Settings,
+    ) -> bytes:
+        timeout = httpx.Timeout(
+            connect=settings.http_connect_timeout,
+            read=settings.http_read_timeout,
+            write=settings.http_write_timeout,
+            pool=settings.http_connect_timeout,
+        )
+        client = MiniMaxSpeechClient(
+            api_key=settings.minimax_api_key,
+            region=settings.minimax_tts_region,
+            proxy=settings.minimax_proxy,
+            timeout=timeout,
+        )
+        return await client.synthesize(payload)
 
 
 def _response_payloads(response: httpx.Response) -> list[dict[str, Any]]:

--- a/src/free_claude_code/runtime/bootstrap.py
+++ b/src/free_claude_code/runtime/bootstrap.py
@@ -13,6 +13,7 @@ from free_claude_code.messaging.transcription import TranscriptionService
 from free_claude_code.messaging.voice import Transcriber
 from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.base import BaseProvider, ProviderConfig
+from free_claude_code.providers.minimax import MiniMaxSpeechService
 from free_claude_code.providers.nvidia_nim.voice import NvidiaNimTranscriber
 from free_claude_code.providers.openai_codex import (
     OpenAIAuthManager,
@@ -64,6 +65,7 @@ def build_asgi_app(
         requests=provider_manager,
         admin=runtime,
         tasks=runtime,
+        speech=MiniMaxSpeechService(),
     )
     return RuntimeASGIApp(create_app(services), runtime)
 

--- a/tests/api/support.py
+++ b/tests/api/support.py
@@ -5,10 +5,11 @@ from collections.abc import Mapping, MutableMapping
 from fastapi import FastAPI
 
 from free_claude_code.api.app import create_app
-from free_claude_code.api.ports import ApiServices
+from free_claude_code.api.ports import ApiServices, SpeechSynthesisPort
 from free_claude_code.application.connected_accounts import ConnectedAccountPort
 from free_claude_code.config.settings import Settings
 from free_claude_code.providers.base import BaseProvider
+from free_claude_code.providers.minimax import MiniMaxSpeechService
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime, RestartCallback
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
@@ -20,6 +21,7 @@ def create_test_app(
     providers: MutableMapping[str, BaseProvider] | None = None,
     restart_callback: RestartCallback | None = None,
     connected_accounts: Mapping[str, ConnectedAccountPort] | None = None,
+    speech: SpeechSynthesisPort | None = None,
 ) -> FastAPI:
     """Build an API app with explicit in-memory runtime services."""
     settings = settings or Settings()
@@ -57,6 +59,7 @@ def create_test_app(
             requests=manager,
             admin=runtime,
             tasks=runtime,
+            speech=speech or MiniMaxSpeechService(),
         )
     )
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,8 +1,9 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from free_claude_code.config.settings import Settings
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.reasoning import ReasoningPolicy
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
@@ -81,6 +82,49 @@ def test_health(client: TestClient):
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
     assert response.headers["request-id"].startswith("req_")
+
+
+def test_speech_requires_minimax_api_key():
+    speech_app = create_test_app(Settings(MINIMAX_API_KEY=""))
+    with TestClient(speech_app) as speech_client:
+        response = speech_client.post(
+            "/v1/audio/speech",
+            json={"model": "speech-2.8-hd", "text": "Hello"},
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "MINIMAX_API_KEY is required for speech synthesis."
+    )
+
+
+def test_speech_returns_decoded_audio_from_selected_region():
+    speech_app = create_test_app(
+        Settings(MINIMAX_API_KEY="test-key", MINIMAX_TTS_REGION="china")
+    )
+    speech_client = MagicMock()
+    speech_client.synthesize = AsyncMock(return_value=b"RIFF")
+
+    with (
+        patch(
+            "free_claude_code.api.routes.MiniMaxSpeechClient",
+            return_value=speech_client,
+        ) as client_type,
+        TestClient(speech_app) as test_client,
+    ):
+        response = test_client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "speech-2.8-hd",
+                "text": "Hello",
+                "audio_setting": {"format": "wav"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"RIFF"
+    assert response.headers["content-type"] == "audio/wav"
+    assert client_type.call_args.kwargs["region"] == "china"
 
 
 def test_models_list(client: TestClient):

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -99,19 +99,14 @@ def test_speech_requires_minimax_api_key():
 
 
 def test_speech_returns_decoded_audio_from_selected_region():
+    speech_service = MagicMock()
+    speech_service.synthesize = AsyncMock(return_value=b"RIFF")
     speech_app = create_test_app(
-        Settings(MINIMAX_API_KEY="test-key", MINIMAX_TTS_REGION="china")
+        Settings(MINIMAX_API_KEY="test-key", MINIMAX_TTS_REGION="china"),
+        speech=speech_service,
     )
-    speech_client = MagicMock()
-    speech_client.synthesize = AsyncMock(return_value=b"RIFF")
 
-    with (
-        patch(
-            "free_claude_code.api.routes.MiniMaxSpeechClient",
-            return_value=speech_client,
-        ) as client_type,
-        TestClient(speech_app) as test_client,
-    ):
+    with TestClient(speech_app) as test_client:
         response = test_client.post(
             "/v1/audio/speech",
             json={
@@ -124,7 +119,30 @@ def test_speech_returns_decoded_audio_from_selected_region():
     assert response.status_code == 200
     assert response.content == b"RIFF"
     assert response.headers["content-type"] == "audio/wav"
-    assert client_type.call_args.kwargs["region"] == "china"
+    request, settings = speech_service.synthesize.call_args.args
+    assert request["audio_setting"]["format"] == "wav"
+    assert settings.minimax_tts_region == "china"
+
+
+def test_speech_rejects_unsupported_audio_format():
+    speech_service = MagicMock()
+    speech_app = create_test_app(
+        Settings(MINIMAX_API_KEY="test-key"),
+        speech=speech_service,
+    )
+
+    with TestClient(speech_app) as speech_client:
+        response = speech_client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "speech-2.8-hd",
+                "text": "Hello",
+                "audio_setting": {"format": "not-a-real-audio-format"},
+            },
+        )
+
+    assert response.status_code == 422
+    speech_service.synthesize.assert_not_called()
 
 
 def test_models_list(client: TestClient):

--- a/tests/api/test_routes_optimizations.py
+++ b/tests/api/test_routes_optimizations.py
@@ -160,6 +160,7 @@ def test_stop_cli_with_messaging_workflow(client):
         requests=services.requests,
         admin=services.admin,
         tasks=session_control,
+        speech=services.speech,
     )
 
     response = client.post("/stop")
@@ -177,6 +178,7 @@ def test_stop_cli_fallback_to_manager(client):
         requests=services.requests,
         admin=services.admin,
         tasks=session_control,
+        speech=services.speech,
     )
 
     response = client.post("/stop")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -323,9 +323,11 @@ class TestSettings:
 
         monkeypatch.setenv("MINIMAX_API_KEY", "minimax-key")
         monkeypatch.setenv("MINIMAX_PROXY", "http://proxy.test:8080")
+        monkeypatch.setenv("MINIMAX_TTS_REGION", "china")
         settings = Settings()
         assert settings.minimax_api_key == "minimax-key"
         assert settings.minimax_proxy == "http://proxy.test:8080"
+        assert settings.minimax_tts_region == "china"
 
     def test_cloudflare_settings_from_env(self, monkeypatch):
         """Cloudflare token, account, and proxy env vars load into settings."""

--- a/tests/providers/test_minimax_speech.py
+++ b/tests/providers/test_minimax_speech.py
@@ -1,0 +1,121 @@
+import json
+
+import httpx
+import pytest
+
+from free_claude_code.providers.minimax import (
+    MINIMAX_TTS_ENDPOINTS,
+    MiniMaxSpeechClient,
+    MiniMaxSpeechError,
+    MiniMaxSpeechRequest,
+)
+
+
+@pytest.mark.asyncio
+async def test_speech_request_uses_china_endpoint_and_decodes_hex_audio() -> None:
+    seen_request: httpx.Request | None = None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen_request
+        seen_request = request
+        return httpx.Response(
+            200,
+            json={
+                "data": {"audio": "494433", "status": 2},
+                "base_resp": {"status_code": 0},
+            },
+        )
+
+    client = MiniMaxSpeechClient(
+        api_key="test-key",
+        region="china",
+        transport=httpx.MockTransport(handler),
+    )
+    request = MiniMaxSpeechRequest(
+        text="Hello",
+        audio_setting={"format": "mp3", "sample_rate": 32000},
+        voice_setting={"voice_id": "English_expressive_narrator"},
+    )
+
+    assert await client.synthesize(request) == b"ID3"
+    assert seen_request is not None
+    assert str(seen_request.url) == MINIMAX_TTS_ENDPOINTS["china"]
+    assert seen_request.headers["authorization"] == "Bearer test-key"
+    payload = json.loads(seen_request.content)
+    assert payload["model"] == "speech-2.8-hd"
+    assert payload["text"] == "Hello"
+    assert payload["stream"] is False
+    assert request.media_type == "audio/mpeg"
+
+
+def test_speech_request_preserves_all_supported_optional_fields() -> None:
+    request = MiniMaxSpeechRequest(
+        text="Hello",
+        stream=True,
+        language_boost="English",
+        output_format="hex",
+        voice_setting={"voice_id": "English_expressive_narrator"},
+        pronunciation_dict={"tone": ["FCC/F C C"]},
+        audio_setting={"format": "flac"},
+        voice_modify={"pitch": 1},
+        subtitle_enable=True,
+    )
+
+    assert request.upstream_payload() == {
+        "model": "speech-2.8-hd",
+        "text": "Hello",
+        "stream": True,
+        "language_boost": "English",
+        "output_format": "hex",
+        "voice_setting": {"voice_id": "English_expressive_narrator"},
+        "pronunciation_dict": {"tone": ["FCC/F C C"]},
+        "audio_setting": {"format": "flac"},
+        "voice_modify": {"pitch": 1},
+        "subtitle_enable": True,
+    }
+    assert request.media_type == "audio/flac"
+
+
+@pytest.mark.asyncio
+async def test_speech_stream_collects_chunks_until_terminal_status() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=(
+                'data: {"data":{"audio":"4944","status":1},'
+                '"base_resp":{"status_code":0}}\n\n'
+                'data: {"data":{"audio":"33","status":2},'
+                '"base_resp":{"status_code":0}}\n\n'
+                "data: [DONE]\n\n"
+            ),
+        )
+
+    client = MiniMaxSpeechClient(
+        api_key="test-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    audio = await client.synthesize(MiniMaxSpeechRequest(text="Hello", stream=True))
+
+    assert audio == b"ID3"
+
+
+@pytest.mark.asyncio
+async def test_speech_response_rejects_upstream_status_error() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": {"audio": "494433", "status": 2},
+                "base_resp": {"status_code": 1004},
+            },
+        )
+
+    client = MiniMaxSpeechClient(
+        api_key="test-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(MiniMaxSpeechError, match="rejected"):
+        await client.synthesize(MiniMaxSpeechRequest(text="Hello"))

--- a/tests/providers/test_minimax_speech.py
+++ b/tests/providers/test_minimax_speech.py
@@ -3,11 +3,11 @@ import json
 import httpx
 import pytest
 
+from free_claude_code.api.speech import MiniMaxSpeechRequest
 from free_claude_code.providers.minimax import (
     MINIMAX_TTS_ENDPOINTS,
     MiniMaxSpeechClient,
     MiniMaxSpeechError,
-    MiniMaxSpeechRequest,
 )
 
 
@@ -37,7 +37,7 @@ async def test_speech_request_uses_china_endpoint_and_decodes_hex_audio() -> Non
         voice_setting={"voice_id": "English_expressive_narrator"},
     )
 
-    assert await client.synthesize(request) == b"ID3"
+    assert await client.synthesize(request.upstream_payload()) == b"ID3"
     assert seen_request is not None
     assert str(seen_request.url) == MINIMAX_TTS_ENDPOINTS["china"]
     assert seen_request.headers["authorization"] == "Bearer test-key"
@@ -96,7 +96,8 @@ async def test_speech_stream_collects_chunks_until_terminal_status() -> None:
         transport=httpx.MockTransport(handler),
     )
 
-    audio = await client.synthesize(MiniMaxSpeechRequest(text="Hello", stream=True))
+    request = MiniMaxSpeechRequest(text="Hello", stream=True)
+    audio = await client.synthesize(request.upstream_payload())
 
     assert audio == b"ID3"
 
@@ -118,4 +119,5 @@ async def test_speech_response_rejects_upstream_status_error() -> None:
     )
 
     with pytest.raises(MiniMaxSpeechError, match="rejected"):
-        await client.synthesize(MiniMaxSpeechRequest(text="Hello"))
+        request = MiniMaxSpeechRequest(text="Hello")
+        await client.synthesize(request.upstream_payload())

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.20.0"
+version = "4.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.21.0"
+version = "4.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Reason: Add MiniMax text-to-speech to the existing audio-capable HTTP service.

Changes:
- Add an authenticated `/v1/audio/speech` endpoint backed by the synchronous T2A API.
- Support the global and China endpoints, all current speech model IDs, documented request fields, and MP3, WAV, FLAC, and PCM output formats.
- Decode both JSON and server-sent event responses, validate terminal status, and return safe upstream errors.
- Add Admin and environment configuration for regional endpoint selection, focused tests, and a minor package version bump.

Checks:
- `uv run ruff check src/free_claude_code/providers/minimax src/free_claude_code/api/routes.py src/free_claude_code/config/settings.py src/free_claude_code/config/admin/manifest.py src/free_claude_code/config/admin/provider_manifest.py tests/providers/test_minimax_speech.py tests/api/test_api.py tests/config/test_config.py`
- `uv run ty check`
- `uv run pytest -q tests/providers/test_minimax_speech.py tests/config/test_config.py::TestSettings::test_minimax_settings_from_env tests/api/test_api.py::test_speech_requires_minimax_api_key tests/api/test_api.py::test_speech_returns_decoded_audio_from_selected_region`
- `git diff --check`
- Secret scan

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

MiniMax text-to-speech requests now reject unsupported output formats before an upstream request is made. The endpoint also enforces proxy authentication and returns the expected media type for supported audio responses.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The exercised invalid-format path returns HTTP 422 without invoking the speech service, while authentication and supported WAV response behavior also passed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The speech endpoint request model enforces allowed audio formats (mp3, wav, flac, or pcm).
- Runtime validation confirmed that FastAPI enforces the format constraint before create\_speech calls services.synthesize.
- The authentication guard was exercised and an absent Authorization header yielded a 401 Unauthorized with Missing proxy authentication token.
- The WAV media type was mapped to a 200 OK response with Content-Type: audio/wav.
- Artifacts were uploaded for review, including the MiniMax speech endpoint runtime probe source and related test logs.

<a href="https://app.greptile.com/trex/runs/18508692/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix MiniMax speech request validation"](https://github.com/alishahryar1/free-claude-code/commit/4612027e23ea0232da1c2ebf8b3c952c5aa1f3ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52541328)</sub>

<!-- /greptile_comment -->