### PR TITLE
Add QwenCloud Token Plan provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,10 @@ GROQ_API_KEY=""
 XAI_API_KEY=""
 
 
+# QwenCloud Token Plan (dedicated sk-sp- key; OpenAI-compatible Chat Completions)
+QWENCLOUD_API_KEY=""
+
+
 # SambaNova Cloud (OpenAI-compatible Chat Completions at api.sambanova.ai/v1)
 SAMBANOVA_API_KEY=""
 
@@ -139,7 +143,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -181,6 +185,7 @@ FCC_SMOKE_MODEL_CLOUDFLARE=
 FCC_SMOKE_MODEL_GEMINI=
 FCC_SMOKE_MODEL_VERTEX=
 FCC_SMOKE_MODEL_GROQ=
+FCC_SMOKE_MODEL_QWENCLOUD=
 FCC_SMOKE_MODEL_SAMBANOVA=
 FCC_SMOKE_MODEL_KILO=
 FCC_SMOKE_MODEL_CEREBRAS=
@@ -205,6 +210,7 @@ REASONING_HAIKU=inherit
 # Per-provider proxy support: http and socks5, example: "http://username:password@host:port"
 OPENAI_PROXY=""
 XAI_PROXY=""
+QWENCLOUD_PROXY=""
 AZURE_OPENAI_PROXY=""
 NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ fcc-codex exec "hello"
 | [Groq](https://console.groq.com/keys) | `GROQ_API_KEY` | `groq/llama-3.3-70b-versatile` |
 | [OpenAI / ChatGPT](https://learn.chatgpt.com/docs/auth) | Connect ChatGPT in the Admin UI | `openai/<model-id>` |
 | [xAI (Grok)](https://console.x.ai/team/default/api-keys) | `XAI_API_KEY` | `xai/grok-4.5` |
+| [QwenCloud Token Plan](https://home.qwencloud.com/api-keys) | `QWENCLOUD_API_KEY` | `qwencloud/qwen3.7-plus` |
 | [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |
 | [Google AI Studio (Gemini)](https://aistudio.google.com/apikey) | `GEMINI_API_KEY` | `gemini/models/gemini-3.1-flash-lite` |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/start/openai) | `VERTEX_PROJECT_ID` + ADC | `vertex/google/gemini-3.5-flash` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.21.0"
+version = "4.22.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -71,6 +71,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "vertex": "vertex/google/gemini-3.5-flash",
     "groq": "groq/llama-3.3-70b-versatile",
     "xai": "xai/grok-4.5",
+    "qwencloud": "qwencloud/qwen3.7-plus",
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -144,6 +144,14 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "models."
         ),
     },
+    "QWENCLOUD_API_KEY": {
+        "label": "QwenCloud Token Plan API Key",
+        "description": (
+            "Dedicated QwenCloud Token Plan key (sk-sp-...). Token Plan, Coding "
+            "Plan, and pay-as-you-go keys use separate endpoints and cannot be "
+            "mixed."
+        ),
+    },
     "SAMBANOVA_API_KEY": {
         "label": "SambaNova API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -52,6 +52,10 @@ KILO_DEFAULT_BASE = "https://api.kilo.ai/api/gateway"
 OPENAI_CODEX_DEFAULT_BASE = "https://chatgpt.com/backend-api/codex"
 # xAI OpenAI-compatible Chat Completions API.
 XAI_DEFAULT_BASE = "https://api.x.ai/v1"
+# QwenCloud Token Plan OpenAI-compatible Chat Completions API.
+QWENCLOUD_DEFAULT_BASE = (
+    "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+)
 # TokenRouter OpenAI-compatible Chat Completions gateway.
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 # NaraRoute OpenAI-compatible Chat Completions gateway.
@@ -136,6 +140,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="xai_api_key",
         default_base_url=XAI_DEFAULT_BASE,
         proxy_attr="xai_proxy",
+    ),
+    "qwencloud": ProviderDescriptor(
+        provider_id="qwencloud",
+        display_name="QwenCloud Token Plan",
+        credential_env="QWENCLOUD_API_KEY",
+        credential_url="https://home.qwencloud.com/api-keys",
+        credential_attr="qwencloud_api_key",
+        default_base_url=QWENCLOUD_DEFAULT_BASE,
+        proxy_attr="qwencloud_proxy",
     ),
     "azure_openai": ProviderDescriptor(
         provider_id="azure_openai",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -134,6 +134,9 @@ class Settings(BaseSettings):
     # ==================== xAI / Grok (OpenAI-compatible) ====================
     xai_api_key: str = Field(default="", validation_alias="XAI_API_KEY")
 
+    # ==================== QwenCloud Token Plan (OpenAI-compatible) ====================
+    qwencloud_api_key: str = Field(default="", validation_alias="QWENCLOUD_API_KEY")
+
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
 
@@ -188,6 +191,7 @@ class Settings(BaseSettings):
     # ==================== Per-Provider Proxy ====================
     openai_proxy: str = Field(default="", validation_alias="OPENAI_PROXY")
     xai_proxy: str = Field(default="", validation_alias="XAI_PROXY")
+    qwencloud_proxy: str = Field(default="", validation_alias="QWENCLOUD_PROXY")
     azure_openai_proxy: str = Field(default="", validation_alias="AZURE_OPENAI_PROXY")
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -162,6 +162,14 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             aliases_field="aliases",
         ),
     ),
+    "qwencloud": OpenAIChatProfile(
+        _policy(
+            "QWENCLOUD",
+            ReasoningReplayMode.REASONING_CONTENT,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NO_REASONING,
+    ),
     "azure_openai": OpenAIChatProfile(
         _policy(
             "AZURE_OPENAI",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -11,6 +11,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "groq",
     "openai",
     "xai",
+    "qwencloud",
     "azure_openai",
     "gemini",
     "vertex",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -54,6 +54,7 @@ def _settings(**overrides):
         "vertex_location": "global",
         "groq_api_key": "",
         "xai_api_key": "",
+        "qwencloud_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
         "ollama_api_key": "",
@@ -166,6 +167,23 @@ def test_xai_provider_smoke_uses_current_grok_model(monkeypatch) -> None:
 
     assert [model.provider for model in models] == ["xai"]
     assert models[0].full_model == "xai/grok-4.5"
+    assert models[0].source == "provider_default"
+
+
+def test_qwencloud_provider_smoke_uses_current_coding_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_QWENCLOUD", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            qwencloud_api_key="qwencloud-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["qwencloud"]
+    assert models[0].full_model == "qwencloud/qwen3.7-plus"
     assert models[0].source == "provider_default"
 
 

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -20,6 +20,7 @@ from free_claude_code.config.provider_catalog import (
     NARAROUTE_DEFAULT_BASE,
     OLLAMA_CLOUD_DEFAULT_BASE,
     PROVIDER_CATALOG,
+    QWENCLOUD_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
     TOKENROUTER_DEFAULT_BASE,
     VERCEL_AI_GATEWAY_DEFAULT_BASE,
@@ -62,6 +63,7 @@ def _make_settings(**overrides):
     mock.nvidia_nim_api_key = "test_key"
     mock.open_router_api_key = "test_openrouter_key"
     mock.xai_api_key = "test_xai_key"
+    mock.qwencloud_api_key = "test_qwencloud_key"
     mock.mistral_api_key = "test_mistral_key"
     mock.codestral_api_key = "test_codestral_key"
     mock.deepseek_api_key = "test_deepseek_key"
@@ -126,6 +128,7 @@ def _make_settings(**overrides):
     mock.kilo_proxy = ""
     mock.openai_proxy = ""
     mock.xai_proxy = ""
+    mock.qwencloud_proxy = ""
     mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
@@ -210,6 +213,25 @@ def test_xai_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.credential_env == "XAI_API_KEY"
     assert config.api_key == "xai-token"
     assert config.base_url == XAI_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_qwencloud_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["qwencloud"]
+    settings = _make_settings(
+        qwencloud_api_key="qwencloud-token",
+        qwencloud_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("qwencloud", settings)
+
+    assert descriptor.display_name == "QwenCloud Token Plan"
+    assert descriptor.credential_env == "QWENCLOUD_API_KEY"
+    assert config.api_key == "qwencloud-token"
+    assert config.base_url == QWENCLOUD_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -506,6 +528,7 @@ def test_create_provider_instantiates_each_builtin():
         "nvidia_nim": NvidiaNimProvider,
         "openai": OpenAICodexProvider,
         "xai": OpenAIChatProvider,
+        "qwencloud": OpenAIChatProvider,
         "azure_openai": OpenAIChatProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,

--- a/tests/providers/test_qwencloud.py
+++ b/tests/providers/test_qwencloud.py
@@ -1,0 +1,228 @@
+"""Tests for the QwenCloud Token Plan OpenAI-chat provider profile."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import QWENCLOUD_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+@pytest.fixture
+def qwencloud_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "qwencloud",
+        ProviderConfig(
+            api_key="test-qwencloud-key",
+            base_url=QWENCLOUD_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="qwencloud"),
+    )
+
+
+def test_init_uses_openai_chat_provider(
+    qwencloud_provider: OpenAIChatProvider,
+) -> None:
+    assert qwencloud_provider._api_key == "test-qwencloud-key"
+    assert qwencloud_provider._base_url == QWENCLOUD_DEFAULT_BASE
+    assert qwencloud_provider._provider_name == "QWENCLOUD"
+
+
+def test_build_request_body_preserves_common_chat_tools_and_images(
+    qwencloud_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "qwen3.7-plus",
+            "system": "Be concise.",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Inspect this image."},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "aW1hZ2U=",
+                            },
+                        },
+                    ],
+                }
+            ],
+            "tools": [
+                {
+                    "name": "inspect_image",
+                    "description": "Inspect an image",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                    },
+                }
+            ],
+        }
+    )
+
+    body = qwencloud_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["model"] == "qwen3.7-plus"
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["messages"][0] == {"role": "system", "content": "Be concise."}
+    assert body["messages"][1]["content"] == [
+        {"type": "text", "text": "Inspect this image."},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aW1hZ2U="},
+        },
+    ]
+    assert body["tools"][0]["function"]["name"] == "inspect_image"
+
+
+@pytest.mark.parametrize("reasoning", [REASONING_OFF, REASONING_ON])
+def test_build_request_body_does_not_invent_catalog_wide_reasoning_control(
+    qwencloud_provider: OpenAIChatProvider,
+    reasoning,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "qwen3.7-plus",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+    )
+
+    body = qwencloud_provider._build_request_body(request, reasoning=reasoning)
+    extra_body = body.get("extra_body", {})
+
+    for field in (
+        "enable_thinking",
+        "preserve_thinking",
+        "reasoning_effort",
+        "thinking_budget",
+    ):
+        assert field not in body
+        assert field not in extra_body
+
+
+def test_build_request_body_replays_prior_reasoning_content(
+    qwencloud_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "qwen3.7-plus",
+            "messages": [
+                {"role": "user", "content": "Solve it."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Work through it."},
+                        {"type": "text", "text": "The answer is 42."},
+                    ],
+                },
+                {"role": "user", "content": "Continue."},
+            ],
+        }
+    )
+
+    body = qwencloud_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "The answer is 42.",
+        "reasoning_content": "Work through it.",
+    }
+    assert (
+        qwencloud_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning_content="next thought")
+        )
+        == "next thought"
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_standard_endpoint_base_url_and_auth(
+    qwencloud_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": "qwen3.7-plus",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "qwencloud",
+                    },
+                    {
+                        "id": "deepseek-v4-pro",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "qwencloud",
+                    },
+                ],
+            },
+        )
+
+    await qwencloud_provider._client.close()
+    qwencloud_provider._client = AsyncOpenAI(
+        api_key="wire-qwencloud-key",
+        base_url=QWENCLOUD_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        model_infos = await qwencloud_provider.list_model_infos()
+    finally:
+        await qwencloud_provider.cleanup()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("qwen3.7-plus"),
+            ProviderModelInfo("deepseek-v4-pro"),
+        }
+    )
+    assert len(requests) == 1
+    assert str(requests[0].url) == (
+        "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models"
+    )
+    assert requests[0].headers["authorization"] == "Bearer wire-qwencloud-key"
+
+
+@pytest.mark.asyncio
+async def test_empty_model_catalog_fails_instead_of_publishing_partial_state(
+    qwencloud_provider: OpenAIChatProvider,
+) -> None:
+    qwencloud_provider._client.models.list = AsyncMock(
+        return_value=SimpleNamespace(data=[])
+    )
+
+    with pytest.raises(ModelListResponseError, match="did not include any model ids"):
+        await qwencloud_provider.list_model_infos()

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.21.0"
+version = "4.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

QwenCloud Token Plan subscribers cannot configure or select their models in FCC, despite the plan exposing an OpenAI-compatible coding endpoint.

## Changes

| Before | After |
| --- | --- |
| QwenCloud had no provider identity or Admin configuration. | `qwencloud/`, `QWENCLOUD_API_KEY`, and `QWENCLOUD_PROXY` configure the international Token Plan endpoint. |
| QwenCloud models could not appear in FCC selectors. | The existing strict OpenAI `/models` discovery path publishes the current text catalog dynamically. |
| QwenCloud requests had no owned reasoning policy. | The ordinary OpenAI-chat profile replays `reasoning_content` and avoids unsafe catalog-wide thinking controls. |
| QwenCloud had no reliability or smoke contracts. | Provider, discovery, Admin, routing, and smoke tests cover the integration; the default smoke model is `qwen3.7-plus`. |
| The authenticated upstream contract was untracked. | The official `/models` route is confirmed, while the credentialed inference and tool smoke remain explicitly pending because no local Token Plan key is configured. |
| FCC was version 4.21.0. | FCC is version 4.22.0 with an updated lockfile. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds QwenCloud Token Plan and xAI provider support, including credentials, proxy configuration, Admin settings metadata, provider catalog entries, model discovery, smoke defaults, and version metadata.

The QwenCloud flow was exercised with deterministic HTTP requests: configuration loading, provider routing, default endpoint selection, Bearer authentication, chat request serialization, `reasoning_content` replay, and `/models` parsing all behaved as expected. Focused QwenCloud provider, runtime, catalog, and smoke-configuration tests passed. No defects were found.

## T-Rex validation blocked

A live QwenCloud inference smoke could not run because `QWENCLOUD_API_KEY` is not configured in this environment. No credential value was accessed or exposed.
</details>

<h3>Confidence Score: 5/5</h3>

The reviewed QwenCloud integration is safe to merge based on the exercised configuration, routing, request, response, and model-listing behavior.

Deterministic wire-level validation covered the changed provider path from settings through runtime construction and outbound requests, including reasoning replay and model discovery. Focused provider and contract tests also passed, and no defects were reproduced.

**Files Needing Attention:** No files need author action. A live upstream check of `src/free_claude_code/providers/openai_chat/provider.py` remains unavailable until a QwenCloud Token Plan credential is configured.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified that no real QWENCLOUD\_API\_KEY or QWENCLOUD\_PROXY were configured before starting the QwenCloud validation.
- Executed a deterministic MockTransport end-to-end validation that exercises settings resolution, model routing, runtime factory construction, OpenAI-compatible POST requests, reasoning replay, and model listing.
- Ran focused QwenCloud contract, provider, and smoke-configuration tests; all selected tests passed.
- Concluded that live upstream inference remains unavailable due to the missing API key, while the deterministic capture confirms the complete route/factory/client serialization flow with captured requests and shows no new defects.

<a href="https://app.greptile.com/trex/runs/18559380/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add QwenCloud Token Plan provider"](https://github.com/alishahryar1/free-claude-code/commit/27102bc618d445f449cc594f5f60e98ad4b4f0d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52696160)</sub>

<!-- /greptile_comment -->