### PR TITLE
Add Together AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,10 @@ XAI_API_KEY=""
 QWENCLOUD_API_KEY=""
 
 
+# Together AI (OpenAI-compatible Chat Completions at api.together.ai/v1)
+TOGETHER_API_KEY=""
+
+
 # SambaNova Cloud (OpenAI-compatible Chat Completions at api.sambanova.ai/v1)
 SAMBANOVA_API_KEY=""
 
@@ -143,7 +147,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -186,6 +190,7 @@ FCC_SMOKE_MODEL_GEMINI=
 FCC_SMOKE_MODEL_VERTEX=
 FCC_SMOKE_MODEL_GROQ=
 FCC_SMOKE_MODEL_QWENCLOUD=
+FCC_SMOKE_MODEL_TOGETHER=
 FCC_SMOKE_MODEL_SAMBANOVA=
 FCC_SMOKE_MODEL_KILO=
 FCC_SMOKE_MODEL_CEREBRAS=
@@ -211,6 +216,7 @@ REASONING_HAIKU=inherit
 OPENAI_PROXY=""
 XAI_PROXY=""
 QWENCLOUD_PROXY=""
+TOGETHER_PROXY=""
 AZURE_OPENAI_PROXY=""
 NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ fcc-codex exec "hello"
 | [OpenAI / ChatGPT](https://learn.chatgpt.com/docs/auth) | Connect ChatGPT in the Admin UI | `openai/<model-id>` |
 | [xAI (Grok)](https://console.x.ai/team/default/api-keys) | `XAI_API_KEY` | `xai/grok-4.5` |
 | [QwenCloud Token Plan](https://home.qwencloud.com/api-keys) | `QWENCLOUD_API_KEY` | `qwencloud/qwen3.7-plus` |
+| [Together AI](https://api.together.ai/settings/api-keys) | `TOGETHER_API_KEY` | `together/zai-org/GLM-5.2` |
 | [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |
 | [Google AI Studio (Gemini)](https://aistudio.google.com/apikey) | `GEMINI_API_KEY` | `gemini/models/gemini-3.1-flash-lite` |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/start/openai) | `VERTEX_PROJECT_ID` + ADC | `vertex/google/gemini-3.5-flash` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.22.0"
+version = "4.23.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -72,6 +72,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "groq": "groq/llama-3.3-70b-versatile",
     "xai": "xai/grok-4.5",
     "qwencloud": "qwencloud/qwen3.7-plus",
+    "together": "together/zai-org/GLM-5.2",
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -152,6 +152,13 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "mixed."
         ),
     },
+    "TOGETHER_API_KEY": {
+        "label": "Together AI API Key",
+        "description": (
+            "Together AI OpenAI-compatible API key for serverless and dedicated "
+            "chat models."
+        ),
+    },
     "SAMBANOVA_API_KEY": {
         "label": "SambaNova API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -56,6 +56,8 @@ XAI_DEFAULT_BASE = "https://api.x.ai/v1"
 QWENCLOUD_DEFAULT_BASE = (
     "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
 )
+# Together AI OpenAI-compatible Chat Completions API.
+TOGETHER_DEFAULT_BASE = "https://api.together.ai/v1"
 # TokenRouter OpenAI-compatible Chat Completions gateway.
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 # NaraRoute OpenAI-compatible Chat Completions gateway.
@@ -149,6 +151,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="qwencloud_api_key",
         default_base_url=QWENCLOUD_DEFAULT_BASE,
         proxy_attr="qwencloud_proxy",
+    ),
+    "together": ProviderDescriptor(
+        provider_id="together",
+        display_name="Together AI",
+        credential_env="TOGETHER_API_KEY",
+        credential_url="https://api.together.ai/settings/api-keys",
+        credential_attr="together_api_key",
+        default_base_url=TOGETHER_DEFAULT_BASE,
+        proxy_attr="together_proxy",
     ),
     "azure_openai": ProviderDescriptor(
         provider_id="azure_openai",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -137,6 +137,9 @@ class Settings(BaseSettings):
     # ==================== QwenCloud Token Plan (OpenAI-compatible) ====================
     qwencloud_api_key: str = Field(default="", validation_alias="QWENCLOUD_API_KEY")
 
+    # ==================== Together AI (OpenAI-compatible) ====================
+    together_api_key: str = Field(default="", validation_alias="TOGETHER_API_KEY")
+
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
 
@@ -192,6 +195,7 @@ class Settings(BaseSettings):
     openai_proxy: str = Field(default="", validation_alias="OPENAI_PROXY")
     xai_proxy: str = Field(default="", validation_alias="XAI_PROXY")
     qwencloud_proxy: str = Field(default="", validation_alias="QWENCLOUD_PROXY")
+    together_proxy: str = Field(default="", validation_alias="TOGETHER_PROXY")
     azure_openai_proxy: str = Field(default="", validation_alias="AZURE_OPENAI_PROXY")
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")

--- a/src/free_claude_code/providers/model_listing.py
+++ b/src/free_claude_code/providers/model_listing.py
@@ -31,11 +31,13 @@ def extract_openai_model_infos(
     payload: Any,
     *,
     provider_name: str,
-    collection_field: str = "data",
+    collection_field: str | None = "data",
     aliases_field: str | None = None,
+    field_equals: tuple[str, str] | None = None,
 ) -> frozenset[_ProviderModelInfo]:
     """Extract routable IDs from an OpenAI-compatible model-list response."""
     model_ids: set[str] = set()
+    item_location = collection_field or "root-array"
     for item in model_list_items(
         payload,
         provider_name=provider_name,
@@ -45,15 +47,26 @@ def extract_openai_model_infos(
         if not isinstance(model_id, str) or not model_id.strip():
             raise _malformed(
                 provider_name,
-                f"expected every {collection_field} item to include id",
+                f"expected every {item_location} item to include id",
             )
+        if field_equals is not None:
+            field_name, expected_value = field_equals
+            field_value = _field(item, field_name)
+            if not isinstance(field_value, str):
+                raise _malformed(
+                    provider_name,
+                    f"expected every {item_location} item to include "
+                    f"string {field_name}",
+                )
+            if field_value != expected_value:
+                continue
         model_ids.add(model_id)
         if aliases_field is not None:
             aliases = _field(item, aliases_field)
             if not _is_sequence(aliases):
                 raise _malformed(
                     provider_name,
-                    f"expected every {collection_field} item to include "
+                    f"expected every {item_location} item to include "
                     f"{aliases_field} array",
                 )
             for alias in aliases:
@@ -103,14 +116,19 @@ def model_list_items(
     payload: Any,
     *,
     provider_name: str,
-    collection_field: str = "data",
+    collection_field: str | None = "data",
 ) -> tuple[Any, ...]:
     """Return a validated OpenAI-shaped model-list data array."""
-    data = _field(payload, collection_field)
+    data = payload if collection_field is None else _field(payload, collection_field)
     if not _is_sequence(data):
+        location = (
+            "root array"
+            if collection_field is None
+            else (f"top-level {collection_field} array")
+        )
         raise _malformed(
             provider_name,
-            f"expected top-level {collection_field} array",
+            f"expected {location}",
         )
     return tuple(data)
 

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -59,8 +59,9 @@ class OpenAIModelListing:
     """Declarative model-list endpoint and response shape."""
 
     path: str | None = None
-    collection_field: str = "data"
+    collection_field: str | None = "data"
     aliases_field: str | None = None
+    field_equals: tuple[str, str] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,6 +170,20 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
         NO_REASONING,
+    ),
+    "together": OpenAIChatProfile(
+        _policy(
+            "TOGETHER",
+            ReasoningReplayMode.REASONING,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NO_REASONING,
+        model_listing=OpenAIModelListing(
+            path="/models",
+            collection_field=None,
+            field_equals=("type", "chat"),
+        ),
+        reasoning_delta_field="reasoning",
     ),
     "azure_openai": OpenAIChatProfile(
         _policy(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -149,6 +149,7 @@ class OpenAIChatProvider(BaseProvider):
             provider_name=self._provider_name,
             collection_field=listing.collection_field,
             aliases_field=listing.aliases_field,
+            field_equals=listing.field_equals,
         )
 
     async def _list_models_payload(self) -> Any:

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -12,6 +12,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "openai",
     "xai",
     "qwencloud",
+    "together",
     "azure_openai",
     "gemini",
     "vertex",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -55,6 +55,7 @@ def _settings(**overrides):
         "groq_api_key": "",
         "xai_api_key": "",
         "qwencloud_api_key": "",
+        "together_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
         "ollama_api_key": "",
@@ -184,6 +185,23 @@ def test_qwencloud_provider_smoke_uses_current_coding_model(monkeypatch) -> None
 
     assert [model.provider for model in models] == ["qwencloud"]
     assert models[0].full_model == "qwencloud/qwen3.7-plus"
+    assert models[0].source == "provider_default"
+
+
+def test_together_provider_smoke_uses_current_coding_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_TOGETHER", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            together_api_key="together-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["together"]
+    assert models[0].full_model == "together/zai-org/GLM-5.2"
     assert models[0].source == "provider_default"
 
 

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -22,6 +22,7 @@ from free_claude_code.config.provider_catalog import (
     PROVIDER_CATALOG,
     QWENCLOUD_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
+    TOGETHER_DEFAULT_BASE,
     TOKENROUTER_DEFAULT_BASE,
     VERCEL_AI_GATEWAY_DEFAULT_BASE,
     XAI_DEFAULT_BASE,
@@ -64,6 +65,7 @@ def _make_settings(**overrides):
     mock.open_router_api_key = "test_openrouter_key"
     mock.xai_api_key = "test_xai_key"
     mock.qwencloud_api_key = "test_qwencloud_key"
+    mock.together_api_key = "test_together_key"
     mock.mistral_api_key = "test_mistral_key"
     mock.codestral_api_key = "test_codestral_key"
     mock.deepseek_api_key = "test_deepseek_key"
@@ -129,6 +131,7 @@ def _make_settings(**overrides):
     mock.openai_proxy = ""
     mock.xai_proxy = ""
     mock.qwencloud_proxy = ""
+    mock.together_proxy = ""
     mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
@@ -232,6 +235,25 @@ def test_qwencloud_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.credential_env == "QWENCLOUD_API_KEY"
     assert config.api_key == "qwencloud-token"
     assert config.base_url == QWENCLOUD_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_together_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["together"]
+    settings = _make_settings(
+        together_api_key="together-token",
+        together_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("together", settings)
+
+    assert descriptor.display_name == "Together AI"
+    assert descriptor.credential_env == "TOGETHER_API_KEY"
+    assert config.api_key == "together-token"
+    assert config.base_url == TOGETHER_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -529,6 +551,7 @@ def test_create_provider_instantiates_each_builtin():
         "openai": OpenAICodexProvider,
         "xai": OpenAIChatProvider,
         "qwencloud": OpenAIChatProvider,
+        "together": OpenAIChatProvider,
         "azure_openai": OpenAIChatProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -1,0 +1,277 @@
+"""Tests for the Together AI OpenAI-chat profile and model catalog."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import TOGETHER_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+@pytest.fixture
+def together_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "together",
+        ProviderConfig(
+            api_key="test-together-key",
+            base_url=TOGETHER_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="together"),
+    )
+
+
+def test_init_uses_openai_chat_provider(
+    together_provider: OpenAIChatProvider,
+) -> None:
+    assert together_provider._api_key == "test-together-key"
+    assert together_provider._base_url == TOGETHER_DEFAULT_BASE
+    assert together_provider._provider_name == "TOGETHER"
+
+
+def test_build_request_body_preserves_common_chat_tools_and_images(
+    together_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "zai-org/GLM-5.2",
+            "system": "Be concise.",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Inspect this image."},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "aW1hZ2U=",
+                            },
+                        },
+                    ],
+                }
+            ],
+            "tools": [
+                {
+                    "name": "inspect_image",
+                    "description": "Inspect an image",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                    },
+                }
+            ],
+        }
+    )
+
+    body = together_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["model"] == "zai-org/GLM-5.2"
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["messages"][0] == {"role": "system", "content": "Be concise."}
+    assert body["messages"][1]["content"] == [
+        {"type": "text", "text": "Inspect this image."},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aW1hZ2U="},
+        },
+    ]
+    assert body["tools"][0]["function"]["name"] == "inspect_image"
+
+
+@pytest.mark.parametrize("reasoning", [REASONING_OFF, REASONING_ON])
+def test_build_request_body_does_not_invent_catalog_wide_reasoning_control(
+    together_provider: OpenAIChatProvider,
+    reasoning,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "zai-org/GLM-5.2",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+    )
+
+    body = together_provider._build_request_body(request, reasoning=reasoning)
+    extra_body = body.get("extra_body", {})
+
+    for field in ("reasoning", "reasoning_effort", "chat_template_kwargs"):
+        assert field not in body
+        assert field not in extra_body
+
+
+def test_build_request_body_replays_documented_reasoning_field(
+    together_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "zai-org/GLM-5.2",
+            "messages": [
+                {"role": "user", "content": "Solve it."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Work through it."},
+                        {"type": "text", "text": "The answer is 42."},
+                    ],
+                },
+                {"role": "user", "content": "Continue."},
+            ],
+        }
+    )
+
+    body = together_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "The answer is 42.",
+        "reasoning": "Work through it.",
+    }
+    assert (
+        together_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning="next thought")
+        )
+        == "next thought"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lists_only_documented_chat_models(
+    together_provider: OpenAIChatProvider,
+) -> None:
+    together_provider._client.get = AsyncMock(
+        return_value=[
+            {"id": "zai-org/GLM-5.2", "type": "chat"},
+            {"id": "openai/gpt-oss-120b", "type": "chat"},
+            {"id": "codellama/CodeLlama-70b", "type": "code"},
+            {"id": "black-forest-labs/FLUX.2-dev", "type": "image"},
+            {"id": "intfloat/multilingual-e5-large", "type": "embedding"},
+            {"id": "meta-llama/Llama-Guard-4-12B", "type": "moderation"},
+            {"id": "mixedbread-ai/Mxbai-Rerank-Large-V2", "type": "rerank"},
+        ]
+    )
+    together_provider._client.models.list = AsyncMock()
+
+    model_infos = await together_provider.list_model_infos()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("zai-org/GLM-5.2"),
+            ProviderModelInfo("openai/gpt-oss-120b"),
+        }
+    )
+    together_provider._client.get.assert_awaited_once_with(
+        "/models",
+        cast_to=object,
+    )
+    together_provider._client.models.list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_configured_base_url_and_auth(
+    together_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": "zai-org/GLM-5.2",
+                    "object": "model",
+                    "created": 0,
+                    "type": "chat",
+                }
+            ],
+        )
+
+    await together_provider._client.close()
+    together_provider._client = AsyncOpenAI(
+        api_key="wire-together-key",
+        base_url=TOGETHER_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        model_infos = await together_provider.list_model_infos()
+    finally:
+        await together_provider.cleanup()
+
+    assert model_infos == frozenset({ProviderModelInfo("zai-org/GLM-5.2")})
+    assert len(requests) == 1
+    assert str(requests[0].url) == "https://api.together.ai/v1/models"
+    assert requests[0].headers["authorization"] == "Bearer wire-together-key"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"data": []}, "expected root array"),
+        ([{"type": "chat"}], "include id"),
+        ([{"id": "model"}], "include string type"),
+        ([{"id": "model", "type": 7}], "include string type"),
+        ([], "did not include any model ids"),
+        (
+            [{"id": "black-forest-labs/FLUX.2-dev", "type": "image"}],
+            "did not include any model ids",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rejects_malformed_or_unusable_catalog_atomically(
+    together_provider: OpenAIChatProvider,
+    payload: object,
+    message: str,
+) -> None:
+    together_provider._client.get = AsyncMock(return_value=payload)
+
+    with pytest.raises(ModelListResponseError, match=message):
+        await together_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_shared_retry_admission(
+    together_provider: OpenAIChatProvider,
+) -> None:
+    request = httpx.Request("GET", "https://api.together.ai/v1/models")
+    response = httpx.Response(429, request=request)
+    rate_limit_error = httpx.HTTPStatusError(
+        "rate limited",
+        request=request,
+        response=response,
+    )
+    together_provider._client.get = AsyncMock(
+        side_effect=[
+            rate_limit_error,
+            [{"id": "zai-org/GLM-5.2", "type": "chat"}],
+        ]
+    )
+
+    model_infos = await together_provider.list_model_infos()
+
+    assert model_infos == frozenset({ProviderModelInfo("zai-org/GLM-5.2")})
+    assert together_provider._client.get.await_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.22.0"
+version = "4.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC cannot discover or route Together AI models, so users cannot use Together's OpenAI-compatible inference catalog from supported coding agents.

## Changes

| Before | After |
| --- | --- |
| Together AI had no provider configuration or Admin surface. | `TOGETHER_API_KEY` and optional `TOGETHER_PROXY` configure a catalog-owned Together AI provider at `https://api.together.ai/v1`. |
| Together's documented root-array model response was incompatible with the pinned OpenAI SDK page parser and mixed chat with non-chat model types. | Discovery fetches the documented [`GET /models`](https://docs.together.ai/reference/models) shape directly, validates it atomically, and exposes only `type == "chat"` entries. |
| Together reasoning output and history had no explicit FCC contract. | The OpenAI-chat profile extracts and faithfully replays Together's documented [`reasoning`](https://docs.together.ai/docs/inference/chat/reasoning) field without adding model-specific reasoning controls. |
| Documentation and smoke configuration had no Together example. | README, environment examples, Admin metadata, and provider smoke defaults use `together/zai-org/GLM-5.2`, a documented [coding-agent and function-calling choice](https://docs.together.ai/docs/inference/recommended-models). |
| Together behavior was uncovered by deterministic tests. | Request conversion, discovery shape, authentication, filtering, retry admission, reasoning replay, catalog wiring, and smoke defaults are covered; authenticated live smoke remains pending because no local Together key is configured. |
| The package version was `4.22.0`. | The package version is `4.23.0` with a synchronized lockfile. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds Together AI as an OpenAI-compatible provider, including configuration, catalog metadata, chat-model discovery, reasoning replay, documentation, smoke defaults, and deterministic coverage.

The exercised provider paths behaved as intended: model discovery sent Bearer authentication to `https://api.together.ai/v1/models`, exposed only `type: "chat"` models, replayed prior assistant reasoning through Together's `reasoning` field, and converted streamed reasoning and text to the Anthropic-compatible response format. The focused provider, runtime, catalog-order, and smoke-config tests passed (103 tests).

## T-Rex validation blocked

A live Together-hosted smoke request could not run because the `TOGETHER_API_KEY` credential was not available. Credential-free local transport coverage exercised the same discovery and streaming integration paths without contacting the hosted service.
</details>

<h3>Confidence Score: 5/5</h3>

The implemented Together AI integration behaved correctly across the exercised model-discovery and streaming request paths.

No actionable defects remain in the final review. The focused test suite and a credential-free transport harness both exercised endpoint construction, authentication, chat-only filtering, assistant reasoning replay, and streamed response conversion.

**Files Needing Attention:** No files require changes from this review. Hosted Together service behavior remains dependent on a valid Together API credential.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Recreated the locked Python environment and ran the Together-focused provider, runtime, catalog-order, and smoke-config suite; all 103 tests passed.
- Executed a credential-free local mock transport through the provider's model-discovery and streaming paths, observed the models endpoint call with a Bearer token, filtered to chat-models, and verified the simulated assistant reasoning and streamed output.
- Validated the OpenAI chat profiles path by checking /models handling, root-array parsing, chat filtering, and reasoning; runtime validation confirmed each behavior.
- Noted a blocker: validating Together’s hosted API against a live account requires a TOGETHER\_API\_KEY, which was unavailable.

<a href="https://app.greptile.com/trex/runs/18569175/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Together AI provider"](https://github.com/alishahryar1/free-claude-code/commit/4019246f7de790c9f00ee4548603e0ceb71cd1e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52713602)</sub>

<!-- /greptile_comment -->