### PR TITLE
Add DeepInfra provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,10 @@ QWENCLOUD_API_KEY=""
 TOGETHER_API_KEY=""
 
 
+# DeepInfra (OpenAI-compatible Chat Completions at api.deepinfra.com/v1/openai)
+DEEPINFRA_API_KEY=""
+
+
 # SambaNova Cloud (OpenAI-compatible Chat Completions at api.sambanova.ai/v1)
 SAMBANOVA_API_KEY=""
 
@@ -147,7 +151,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -191,6 +195,7 @@ FCC_SMOKE_MODEL_VERTEX=
 FCC_SMOKE_MODEL_GROQ=
 FCC_SMOKE_MODEL_QWENCLOUD=
 FCC_SMOKE_MODEL_TOGETHER=
+FCC_SMOKE_MODEL_DEEPINFRA=
 FCC_SMOKE_MODEL_SAMBANOVA=
 FCC_SMOKE_MODEL_KILO=
 FCC_SMOKE_MODEL_CEREBRAS=
@@ -217,6 +222,7 @@ OPENAI_PROXY=""
 XAI_PROXY=""
 QWENCLOUD_PROXY=""
 TOGETHER_PROXY=""
+DEEPINFRA_PROXY=""
 AZURE_OPENAI_PROXY=""
 NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ fcc-codex exec "hello"
 | [xAI (Grok)](https://console.x.ai/team/default/api-keys) | `XAI_API_KEY` | `xai/grok-4.5` |
 | [QwenCloud Token Plan](https://home.qwencloud.com/api-keys) | `QWENCLOUD_API_KEY` | `qwencloud/qwen3.7-plus` |
 | [Together AI](https://api.together.ai/settings/api-keys) | `TOGETHER_API_KEY` | `together/zai-org/GLM-5.2` |
+| [DeepInfra](https://deepinfra.com/dash/api_keys) | `DEEPINFRA_API_KEY` | `deepinfra/deepseek-ai/DeepSeek-V4-Flash` |
 | [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |
 | [Google AI Studio (Gemini)](https://aistudio.google.com/apikey) | `GEMINI_API_KEY` | `gemini/models/gemini-3.1-flash-lite` |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/start/openai) | `VERTEX_PROJECT_ID` + ADC | `vertex/google/gemini-3.5-flash` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.23.0"
+version = "4.24.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -73,6 +73,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "xai": "xai/grok-4.5",
     "qwencloud": "qwencloud/qwen3.7-plus",
     "together": "together/zai-org/GLM-5.2",
+    "deepinfra": "deepinfra/deepseek-ai/DeepSeek-V4-Flash",
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -159,6 +159,12 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "chat models."
         ),
     },
+    "DEEPINFRA_API_KEY": {
+        "label": "DeepInfra API Key",
+        "description": (
+            "DeepInfra API key for OpenAI-compatible chat and reasoning models."
+        ),
+    },
     "SAMBANOVA_API_KEY": {
         "label": "SambaNova API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -58,6 +58,8 @@ QWENCLOUD_DEFAULT_BASE = (
 )
 # Together AI OpenAI-compatible Chat Completions API.
 TOGETHER_DEFAULT_BASE = "https://api.together.ai/v1"
+# DeepInfra OpenAI-compatible Chat Completions API.
+DEEPINFRA_DEFAULT_BASE = "https://api.deepinfra.com/v1/openai"
 # TokenRouter OpenAI-compatible Chat Completions gateway.
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 # NaraRoute OpenAI-compatible Chat Completions gateway.
@@ -160,6 +162,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="together_api_key",
         default_base_url=TOGETHER_DEFAULT_BASE,
         proxy_attr="together_proxy",
+    ),
+    "deepinfra": ProviderDescriptor(
+        provider_id="deepinfra",
+        display_name="DeepInfra",
+        credential_env="DEEPINFRA_API_KEY",
+        credential_url="https://deepinfra.com/dash/api_keys",
+        credential_attr="deepinfra_api_key",
+        default_base_url=DEEPINFRA_DEFAULT_BASE,
+        proxy_attr="deepinfra_proxy",
     ),
     "azure_openai": ProviderDescriptor(
         provider_id="azure_openai",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -140,6 +140,9 @@ class Settings(BaseSettings):
     # ==================== Together AI (OpenAI-compatible) ====================
     together_api_key: str = Field(default="", validation_alias="TOGETHER_API_KEY")
 
+    # ==================== DeepInfra (OpenAI-compatible) ====================
+    deepinfra_api_key: str = Field(default="", validation_alias="DEEPINFRA_API_KEY")
+
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: str = Field(default="", validation_alias="CEREBRAS_API_KEY")
 
@@ -196,6 +199,7 @@ class Settings(BaseSettings):
     xai_proxy: str = Field(default="", validation_alias="XAI_PROXY")
     qwencloud_proxy: str = Field(default="", validation_alias="QWENCLOUD_PROXY")
     together_proxy: str = Field(default="", validation_alias="TOGETHER_PROXY")
+    deepinfra_proxy: str = Field(default="", validation_alias="DEEPINFRA_PROXY")
     azure_openai_proxy: str = Field(default="", validation_alias="AZURE_OPENAI_PROXY")
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")

--- a/src/free_claude_code/providers/model_listing.py
+++ b/src/free_claude_code/providers/model_listing.py
@@ -32,23 +32,29 @@ def extract_openai_model_infos(
     *,
     provider_name: str,
     collection_field: str | None = "data",
+    id_field: str = "id",
     aliases_field: str | None = None,
     field_equals: tuple[str, str] | None = None,
+    required_null_field: str | None = None,
+    tags_field: str | None = None,
+    thinking_tag: str = "reasoning",
+    non_thinking_tag: str | None = None,
 ) -> frozenset[_ProviderModelInfo]:
     """Extract routable IDs from an OpenAI-compatible model-list response."""
-    model_ids: set[str] = set()
+    model_infos: set[_ProviderModelInfo] = set()
     item_location = collection_field or "root-array"
     for item in model_list_items(
         payload,
         provider_name=provider_name,
         collection_field=collection_field,
     ):
-        model_id = _field(item, "id")
+        model_id = _field(item, id_field)
         if not isinstance(model_id, str) or not model_id.strip():
             raise _malformed(
                 provider_name,
-                f"expected every {item_location} item to include id",
+                f"expected every {item_location} item to include {id_field}",
             )
+        included = True
         if field_equals is not None:
             field_name, expected_value = field_equals
             field_value = _field(item, field_name)
@@ -59,8 +65,44 @@ def extract_openai_model_infos(
                     f"string {field_name}",
                 )
             if field_value != expected_value:
-                continue
-        model_ids.add(model_id)
+                included = False
+
+        if required_null_field is not None:
+            if not _has_field(item, required_null_field):
+                raise _malformed(
+                    provider_name,
+                    f"expected every {item_location} item to include "
+                    f"{required_null_field}",
+                )
+            if _field(item, required_null_field) is not None:
+                included = False
+
+        supports_thinking: bool | None = None
+        if tags_field is not None:
+            tags_value = _field(item, tags_field)
+            if not _is_sequence(tags_value) or any(
+                not isinstance(tag, str) or not tag.strip() for tag in tags_value
+            ):
+                raise _malformed(
+                    provider_name,
+                    f"expected every {item_location} item to include "
+                    f"{tags_field} string array",
+                )
+            tags = frozenset(tags_value)
+            if thinking_tag in tags:
+                supports_thinking = True
+            elif non_thinking_tag is not None and non_thinking_tag in tags:
+                supports_thinking = False
+
+        if not included:
+            continue
+
+        model_infos.add(
+            _ProviderModelInfo(
+                model_id=model_id,
+                supports_thinking=supports_thinking,
+            )
+        )
         if aliases_field is not None:
             aliases = _field(item, aliases_field)
             if not _is_sequence(aliases):
@@ -75,11 +117,16 @@ def extract_openai_model_infos(
                         provider_name,
                         f"expected every {aliases_field} item to be a model id",
                     )
-                model_ids.add(alias)
+                model_infos.add(
+                    _ProviderModelInfo(
+                        model_id=alias,
+                        supports_thinking=supports_thinking,
+                    )
+                )
 
-    if not model_ids:
+    if not model_infos:
         raise _malformed(provider_name, "response did not include any model ids")
-    return model_infos_from_ids(model_ids)
+    return frozenset(model_infos)
 
 
 def extract_tool_capable_model_infos(
@@ -137,6 +184,12 @@ def _field(item: Any, name: str) -> Any:
     if isinstance(item, Mapping):
         return item.get(name)
     return getattr(item, name, None)
+
+
+def _has_field(item: Any, name: str) -> bool:
+    if isinstance(item, Mapping):
+        return name in item
+    return hasattr(item, name)
 
 
 def _is_sequence(value: Any) -> bool:

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -60,8 +60,13 @@ class OpenAIModelListing:
 
     path: str | None = None
     collection_field: str | None = "data"
+    id_field: str = "id"
     aliases_field: str | None = None
     field_equals: tuple[str, str] | None = None
+    required_null_field: str | None = None
+    tags_field: str | None = None
+    thinking_tag: str = "reasoning"
+    non_thinking_tag: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,6 +189,30 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             field_equals=("type", "chat"),
         ),
         reasoning_delta_field="reasoning",
+    ),
+    "deepinfra": OpenAIChatProfile(
+        _policy(
+            "DEEPINFRA",
+            ReasoningReplayMode.REASONING_CONTENT,
+            include_extra_body=True,
+            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NamedEffortReasoning(
+            _ALL_EFFORTS,
+            disabled_value="none",
+            enabled_value="high",
+            use_extra_body=True,
+        ),
+        model_listing=OpenAIModelListing(
+            path="https://api.deepinfra.com/models/list",
+            collection_field=None,
+            id_field="model_name",
+            field_equals=("reported_type", "text-generation"),
+            required_null_field="deprecated",
+            tags_field="tags",
+            non_thinking_tag="non-reasoning",
+        ),
     ),
     "azure_openai": OpenAIChatProfile(
         _policy(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -148,8 +148,13 @@ class OpenAIChatProvider(BaseProvider):
             payload,
             provider_name=self._provider_name,
             collection_field=listing.collection_field,
+            id_field=listing.id_field,
             aliases_field=listing.aliases_field,
             field_equals=listing.field_equals,
+            required_null_field=listing.required_null_field,
+            tags_field=listing.tags_field,
+            thinking_tag=listing.thinking_tag,
+            non_thinking_tag=listing.non_thinking_tag,
         )
 
     async def _list_models_payload(self) -> Any:

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -13,6 +13,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "xai",
     "qwencloud",
     "together",
+    "deepinfra",
     "azure_openai",
     "gemini",
     "vertex",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -56,6 +56,7 @@ def _settings(**overrides):
         "xai_api_key": "",
         "qwencloud_api_key": "",
         "together_api_key": "",
+        "deepinfra_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
         "ollama_api_key": "",
@@ -202,6 +203,23 @@ def test_together_provider_smoke_uses_current_coding_model(monkeypatch) -> None:
 
     assert [model.provider for model in models] == ["together"]
     assert models[0].full_model == "together/zai-org/GLM-5.2"
+    assert models[0].source == "provider_default"
+
+
+def test_deepinfra_provider_smoke_uses_current_coding_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_DEEPINFRA", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            deepinfra_api_key="deepinfra-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["deepinfra"]
+    assert models[0].full_model == "deepinfra/deepseek-ai/DeepSeek-V4-Flash"
     assert models[0].source == "provider_default"
 
 

--- a/tests/providers/test_deepinfra.py
+++ b/tests/providers/test_deepinfra.py
@@ -1,0 +1,434 @@
+"""Tests for the DeepInfra OpenAI-chat profile and model catalog."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import DEEPINFRA_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+_CATALOG_URL = "https://api.deepinfra.com/models/list"
+
+
+@pytest.fixture
+def deepinfra_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "deepinfra",
+        ProviderConfig(
+            api_key="test-deepinfra-key",
+            base_url=DEEPINFRA_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="deepinfra"),
+    )
+
+
+def test_init_uses_openai_chat_provider(
+    deepinfra_provider: OpenAIChatProvider,
+) -> None:
+    assert deepinfra_provider._api_key == "test-deepinfra-key"
+    assert deepinfra_provider._base_url == DEEPINFRA_DEFAULT_BASE
+    assert deepinfra_provider._provider_name == "DEEPINFRA"
+
+
+def test_build_request_body_preserves_common_chat_tools_and_images(
+    deepinfra_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "deepseek-ai/DeepSeek-V4-Flash",
+            "system": "Be concise.",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Inspect this image."},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "aW1hZ2U=",
+                            },
+                        },
+                    ],
+                }
+            ],
+            "tools": [
+                {
+                    "name": "inspect_image",
+                    "description": "Inspect an image",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                    },
+                }
+            ],
+        }
+    )
+
+    body = deepinfra_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["model"] == "deepseek-ai/DeepSeek-V4-Flash"
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["messages"][0] == {"role": "system", "content": "Be concise."}
+    assert body["messages"][1]["content"] == [
+        {"type": "text", "text": "Inspect this image."},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aW1hZ2U="},
+        },
+    ]
+    assert body["tools"][0]["function"]["name"] == "inspect_image"
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "expected"),
+    [
+        (REASONING_OFF, "none"),
+        (REASONING_ON, "high"),
+        *[
+            (ReasoningPolicy.on(effort=effort), effort.value)
+            for effort in ReasoningEffort
+        ],
+    ],
+)
+def test_build_request_body_encodes_documented_reasoning_effort(
+    deepinfra_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+    expected: str,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "deepseek-ai/DeepSeek-V4-Flash",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+    )
+
+    body = deepinfra_provider._build_request_body(request, reasoning=reasoning)
+
+    assert body["extra_body"] == {"reasoning_effort": expected}
+
+
+def test_build_request_body_preserves_extra_body_without_reasoning_override(
+    deepinfra_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "deepseek-ai/DeepSeek-V4-Flash",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "extra_body": {"service_tier": "priority"},
+        }
+    )
+
+    body = deepinfra_provider._build_request_body(request, reasoning=REASONING_ON)
+
+    assert body["extra_body"] == {
+        "service_tier": "priority",
+        "reasoning_effort": "high",
+    }
+
+
+@pytest.mark.parametrize("field", ["reasoning", "reasoning_effort"])
+def test_build_request_body_rejects_caller_reasoning_override(
+    deepinfra_provider: OpenAIChatProvider,
+    field: str,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "deepseek-ai/DeepSeek-V4-Flash",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "extra_body": {field: "caller-owned"},
+        }
+    )
+
+    with pytest.raises(InvalidRequestError, match="must not override reasoning"):
+        deepinfra_provider._build_request_body(request, reasoning=REASONING_ON)
+
+
+def test_build_request_body_replays_documented_reasoning_content(
+    deepinfra_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "deepseek-ai/DeepSeek-V4-Flash",
+            "messages": [
+                {"role": "user", "content": "Solve it."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Work through it."},
+                        {"type": "text", "text": "The answer is 42."},
+                    ],
+                },
+                {"role": "user", "content": "Continue."},
+            ],
+        }
+    )
+
+    body = deepinfra_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "The answer is 42.",
+        "reasoning_content": "Work through it.",
+    }
+    assert (
+        deepinfra_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning_content="next thought")
+        )
+        == "next thought"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lists_only_active_text_models_with_thinking_metadata(
+    deepinfra_provider: OpenAIChatProvider,
+) -> None:
+    deepinfra_provider._client.get = AsyncMock(
+        return_value=[
+            {
+                "model_name": "reasoning-model",
+                "reported_type": "text-generation",
+                "deprecated": None,
+                "tags": ["openai", "reasoning", "tools"],
+            },
+            {
+                "model_name": "plain-model",
+                "reported_type": "text-generation",
+                "deprecated": None,
+                "tags": ["openai", "non-reasoning", "tools"],
+            },
+            {
+                "model_name": "hybrid-model",
+                "reported_type": "text-generation",
+                "deprecated": None,
+                "tags": ["reasoning", "non-reasoning"],
+            },
+            {
+                "model_name": "unknown-model",
+                "reported_type": "text-generation",
+                "deprecated": None,
+                "tags": ["openai"],
+            },
+            {
+                "model_name": "deprecated-model",
+                "reported_type": "text-generation",
+                "deprecated": 1_700_000_000,
+                "tags": ["reasoning"],
+            },
+            {
+                "model_name": "image-model",
+                "reported_type": "text-to-image",
+                "deprecated": None,
+                "tags": [],
+            },
+        ]
+    )
+
+    model_infos = await deepinfra_provider.list_model_infos()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("reasoning-model", supports_thinking=True),
+            ProviderModelInfo("plain-model", supports_thinking=False),
+            ProviderModelInfo("hybrid-model", supports_thinking=True),
+            ProviderModelInfo("unknown-model"),
+        }
+    )
+    deepinfra_provider._client.get.assert_awaited_once_with(
+        _CATALOG_URL,
+        cast_to=object,
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_absolute_public_url(
+    deepinfra_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "model_name": "deepseek-ai/DeepSeek-V4-Flash",
+                    "reported_type": "text-generation",
+                    "deprecated": None,
+                    "tags": ["reasoning", "tools"],
+                }
+            ],
+        )
+
+    await deepinfra_provider._client.close()
+    deepinfra_provider._client = AsyncOpenAI(
+        api_key="wire-deepinfra-key",
+        base_url=DEEPINFRA_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        model_infos = await deepinfra_provider.list_model_infos()
+    finally:
+        await deepinfra_provider.cleanup()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo(
+                "deepseek-ai/DeepSeek-V4-Flash",
+                supports_thinking=True,
+            )
+        }
+    )
+    assert len(requests) == 1
+    assert str(requests[0].url) == _CATALOG_URL
+    assert requests[0].headers["authorization"] == "Bearer wire-deepinfra-key"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"data": []}, "expected root array"),
+        (
+            [{"reported_type": "text-generation", "deprecated": None, "tags": []}],
+            "include model_name",
+        ),
+        (
+            [{"model_name": "model", "deprecated": None, "tags": []}],
+            "include string reported_type",
+        ),
+        (
+            [
+                {
+                    "model_name": "model",
+                    "reported_type": 7,
+                    "deprecated": None,
+                    "tags": [],
+                }
+            ],
+            "include string reported_type",
+        ),
+        (
+            [{"model_name": "model", "reported_type": "text-generation", "tags": []}],
+            "include deprecated",
+        ),
+        (
+            [
+                {
+                    "model_name": "model",
+                    "reported_type": "text-generation",
+                    "deprecated": None,
+                }
+            ],
+            "include tags string array",
+        ),
+        (
+            [
+                {
+                    "model_name": "model",
+                    "reported_type": "text-generation",
+                    "deprecated": None,
+                    "tags": [7],
+                }
+            ],
+            "include tags string array",
+        ),
+        ([], "did not include any model ids"),
+        (
+            [
+                {
+                    "model_name": "image",
+                    "reported_type": "text-to-image",
+                    "deprecated": None,
+                    "tags": [],
+                }
+            ],
+            "did not include any model ids",
+        ),
+        (
+            [
+                {
+                    "model_name": "old",
+                    "reported_type": "text-generation",
+                    "deprecated": 1,
+                    "tags": [],
+                }
+            ],
+            "did not include any model ids",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rejects_malformed_or_unusable_catalog_atomically(
+    deepinfra_provider: OpenAIChatProvider,
+    payload: object,
+    message: str,
+) -> None:
+    deepinfra_provider._client.get = AsyncMock(return_value=payload)
+
+    with pytest.raises(ModelListResponseError, match=message):
+        await deepinfra_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_shared_retry_admission(
+    deepinfra_provider: OpenAIChatProvider,
+) -> None:
+    request = httpx.Request("GET", _CATALOG_URL)
+    response = httpx.Response(429, request=request)
+    rate_limit_error = httpx.HTTPStatusError(
+        "rate limited",
+        request=request,
+        response=response,
+    )
+    deepinfra_provider._client.get = AsyncMock(
+        side_effect=[
+            rate_limit_error,
+            [
+                {
+                    "model_name": "deepseek-ai/DeepSeek-V4-Flash",
+                    "reported_type": "text-generation",
+                    "deprecated": None,
+                    "tags": ["reasoning", "tools"],
+                }
+            ],
+        ]
+    )
+
+    model_infos = await deepinfra_provider.list_model_infos()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo(
+                "deepseek-ai/DeepSeek-V4-Flash",
+                supports_thinking=True,
+            )
+        }
+    )
+    assert deepinfra_provider._client.get.await_count == 2

--- a/tests/providers/test_deepinfra.py
+++ b/tests/providers/test_deepinfra.py
@@ -1,7 +1,8 @@
 """Tests for the DeepInfra OpenAI-chat profile and model catalog."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -25,6 +26,38 @@ from tests.providers.support import (
 )
 
 _CATALOG_URL = "https://api.deepinfra.com/models/list"
+_MODEL = "deepseek-ai/DeepSeek-V4-Flash"
+_MISSING = object()
+
+
+def _request(**overrides: Any) -> MessagesRequest:
+    payload: dict[str, Any] = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    payload.update(overrides)
+    return MessagesRequest.model_validate(payload)
+
+
+def _catalog_model(
+    model_name: object = "model",
+    *,
+    reported_type: object = "text-generation",
+    deprecated: object = None,
+    tags: object = (),
+) -> dict[str, object]:
+    item: dict[str, object] = {}
+    for field, value in (
+        ("model_name", model_name),
+        ("reported_type", reported_type),
+        ("deprecated", deprecated),
+        ("tags", tags),
+    ):
+        if value is not _MISSING:
+            item[field] = (
+                list(value) if field == "tags" and isinstance(value, tuple) else value
+            )
+    return item
 
 
 @pytest.fixture
@@ -119,12 +152,7 @@ def test_build_request_body_encodes_documented_reasoning_effort(
     reasoning: ReasoningPolicy,
     expected: str,
 ) -> None:
-    request = MessagesRequest.model_validate(
-        {
-            "model": "deepseek-ai/DeepSeek-V4-Flash",
-            "messages": [{"role": "user", "content": "Hello"}],
-        }
-    )
+    request = _request()
 
     body = deepinfra_provider._build_request_body(request, reasoning=reasoning)
 
@@ -134,13 +162,7 @@ def test_build_request_body_encodes_documented_reasoning_effort(
 def test_build_request_body_preserves_extra_body_without_reasoning_override(
     deepinfra_provider: OpenAIChatProvider,
 ) -> None:
-    request = MessagesRequest.model_validate(
-        {
-            "model": "deepseek-ai/DeepSeek-V4-Flash",
-            "messages": [{"role": "user", "content": "Hello"}],
-            "extra_body": {"service_tier": "priority"},
-        }
-    )
+    request = _request(extra_body={"service_tier": "priority"})
 
     body = deepinfra_provider._build_request_body(request, reasoning=REASONING_ON)
 
@@ -155,13 +177,7 @@ def test_build_request_body_rejects_caller_reasoning_override(
     deepinfra_provider: OpenAIChatProvider,
     field: str,
 ) -> None:
-    request = MessagesRequest.model_validate(
-        {
-            "model": "deepseek-ai/DeepSeek-V4-Flash",
-            "messages": [{"role": "user", "content": "Hello"}],
-            "extra_body": {field: "caller-owned"},
-        }
-    )
+    request = _request(extra_body={field: "caller-owned"})
 
     with pytest.raises(InvalidRequestError, match="must not override reasoning"):
         deepinfra_provider._build_request_body(request, reasoning=REASONING_ON)
@@ -211,42 +227,16 @@ async def test_lists_only_active_text_models_with_thinking_metadata(
 ) -> None:
     deepinfra_provider._client.get = AsyncMock(
         return_value=[
-            {
-                "model_name": "reasoning-model",
-                "reported_type": "text-generation",
-                "deprecated": None,
-                "tags": ["openai", "reasoning", "tools"],
-            },
-            {
-                "model_name": "plain-model",
-                "reported_type": "text-generation",
-                "deprecated": None,
-                "tags": ["openai", "non-reasoning", "tools"],
-            },
-            {
-                "model_name": "hybrid-model",
-                "reported_type": "text-generation",
-                "deprecated": None,
-                "tags": ["reasoning", "non-reasoning"],
-            },
-            {
-                "model_name": "unknown-model",
-                "reported_type": "text-generation",
-                "deprecated": None,
-                "tags": ["openai"],
-            },
-            {
-                "model_name": "deprecated-model",
-                "reported_type": "text-generation",
-                "deprecated": 1_700_000_000,
-                "tags": ["reasoning"],
-            },
-            {
-                "model_name": "image-model",
-                "reported_type": "text-to-image",
-                "deprecated": None,
-                "tags": [],
-            },
+            _catalog_model("reasoning-model", tags=("openai", "reasoning", "tools")),
+            _catalog_model("plain-model", tags=("openai", "non-reasoning", "tools")),
+            _catalog_model("hybrid-model", tags=("reasoning", "non-reasoning")),
+            _catalog_model("unknown-model", tags=("openai",)),
+            _catalog_model(
+                "deprecated-model",
+                deprecated=1_700_000_000,
+                tags=("reasoning",),
+            ),
+            _catalog_model("image-model", reported_type="text-to-image"),
         ]
     )
 
@@ -267,36 +257,40 @@ async def test_lists_only_active_text_models_with_thinking_metadata(
 
 
 @pytest.mark.asyncio
-async def test_model_catalog_uses_absolute_public_url(
-    deepinfra_provider: OpenAIChatProvider,
-) -> None:
+async def test_model_catalog_uses_absolute_public_url() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         return httpx.Response(
             200,
-            json=[
-                {
-                    "model_name": "deepseek-ai/DeepSeek-V4-Flash",
-                    "reported_type": "text-generation",
-                    "deprecated": None,
-                    "tags": ["reasoning", "tools"],
-                }
-            ],
+            json=[_catalog_model(_MODEL, tags=("reasoning", "tools"))],
         )
 
-    await deepinfra_provider._client.close()
-    deepinfra_provider._client = AsyncOpenAI(
-        api_key="wire-deepinfra-key",
-        base_url=DEEPINFRA_DEFAULT_BASE,
-        max_retries=0,
-        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
-    )
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    def build_client(*args: Any, **kwargs: Any) -> AsyncOpenAI:
+        kwargs["http_client"] = http_client
+        return AsyncOpenAI(*args, **kwargs)
+
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI",
+        side_effect=build_client,
+    ):
+        provider = profiled_provider(
+            "deepinfra",
+            ProviderConfig(
+                api_key="wire-deepinfra-key",
+                base_url=DEEPINFRA_DEFAULT_BASE,
+                rate_limit=10,
+                rate_window=60,
+            ),
+            admission=immediate_admission(provider_name="deepinfra"),
+        )
     try:
-        model_infos = await deepinfra_provider.list_model_infos()
+        model_infos = await provider.list_model_infos()
     finally:
-        await deepinfra_provider.cleanup()
+        await provider.cleanup()
 
     assert model_infos == frozenset(
         {
@@ -315,71 +309,19 @@ async def test_model_catalog_uses_absolute_public_url(
     ("payload", "message"),
     [
         ({"data": []}, "expected root array"),
-        (
-            [{"reported_type": "text-generation", "deprecated": None, "tags": []}],
-            "include model_name",
-        ),
-        (
-            [{"model_name": "model", "deprecated": None, "tags": []}],
-            "include string reported_type",
-        ),
-        (
-            [
-                {
-                    "model_name": "model",
-                    "reported_type": 7,
-                    "deprecated": None,
-                    "tags": [],
-                }
-            ],
-            "include string reported_type",
-        ),
-        (
-            [{"model_name": "model", "reported_type": "text-generation", "tags": []}],
-            "include deprecated",
-        ),
-        (
-            [
-                {
-                    "model_name": "model",
-                    "reported_type": "text-generation",
-                    "deprecated": None,
-                }
-            ],
-            "include tags string array",
-        ),
-        (
-            [
-                {
-                    "model_name": "model",
-                    "reported_type": "text-generation",
-                    "deprecated": None,
-                    "tags": [7],
-                }
-            ],
-            "include tags string array",
-        ),
+        ([_catalog_model(model_name=_MISSING)], "include model_name"),
+        ([_catalog_model(reported_type=_MISSING)], "include string reported_type"),
+        ([_catalog_model(reported_type=7)], "include string reported_type"),
+        ([_catalog_model(deprecated=_MISSING)], "include deprecated"),
+        ([_catalog_model(tags=_MISSING)], "include tags string array"),
+        ([_catalog_model(tags=[7])], "include tags string array"),
         ([], "did not include any model ids"),
         (
-            [
-                {
-                    "model_name": "image",
-                    "reported_type": "text-to-image",
-                    "deprecated": None,
-                    "tags": [],
-                }
-            ],
+            [_catalog_model("image", reported_type="text-to-image")],
             "did not include any model ids",
         ),
         (
-            [
-                {
-                    "model_name": "old",
-                    "reported_type": "text-generation",
-                    "deprecated": 1,
-                    "tags": [],
-                }
-            ],
+            [_catalog_model("old", deprecated=1)],
             "did not include any model ids",
         ),
     ],
@@ -410,14 +352,7 @@ async def test_model_catalog_uses_shared_retry_admission(
     deepinfra_provider._client.get = AsyncMock(
         side_effect=[
             rate_limit_error,
-            [
-                {
-                    "model_name": "deepseek-ai/DeepSeek-V4-Flash",
-                    "reported_type": "text-generation",
-                    "deprecated": None,
-                    "tags": ["reasoning", "tools"],
-                }
-            ],
+            [_catalog_model(_MODEL, tags=("reasoning", "tools"))],
         ]
     )
 

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -13,6 +13,7 @@ from free_claude_code.config.nim import NimSettings
 from free_claude_code.config.provider_catalog import (
     BEDROCK_DEFAULT_BASE,
     COHERE_DEFAULT_BASE,
+    DEEPINFRA_DEFAULT_BASE,
     GITHUB_MODELS_DEFAULT_BASE,
     HUGGINGFACE_DEFAULT_BASE,
     KIMI_CODE_DEFAULT_BASE,
@@ -66,6 +67,7 @@ def _make_settings(**overrides):
     mock.xai_api_key = "test_xai_key"
     mock.qwencloud_api_key = "test_qwencloud_key"
     mock.together_api_key = "test_together_key"
+    mock.deepinfra_api_key = "test_deepinfra_key"
     mock.mistral_api_key = "test_mistral_key"
     mock.codestral_api_key = "test_codestral_key"
     mock.deepseek_api_key = "test_deepseek_key"
@@ -132,6 +134,7 @@ def _make_settings(**overrides):
     mock.xai_proxy = ""
     mock.qwencloud_proxy = ""
     mock.together_proxy = ""
+    mock.deepinfra_proxy = ""
     mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
@@ -254,6 +257,25 @@ def test_together_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.credential_env == "TOGETHER_API_KEY"
     assert config.api_key == "together-token"
     assert config.base_url == TOGETHER_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_deepinfra_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["deepinfra"]
+    settings = _make_settings(
+        deepinfra_api_key="deepinfra-token",
+        deepinfra_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("deepinfra", settings)
+
+    assert descriptor.display_name == "DeepInfra"
+    assert descriptor.credential_env == "DEEPINFRA_API_KEY"
+    assert config.api_key == "deepinfra-token"
+    assert config.base_url == DEEPINFRA_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -552,6 +574,7 @@ def test_create_provider_instantiates_each_builtin():
         "xai": OpenAIChatProvider,
         "qwencloud": OpenAIChatProvider,
         "together": OpenAIChatProvider,
+        "deepinfra": OpenAIChatProvider,
         "azure_openai": OpenAIChatProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.23.0"
+version = "4.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Free Claude Code cannot route requests to DeepInfra or discover its models. Treating DeepInfra's mixed public catalog as a standard OpenAI model list would expose deprecated and non-chat models while losing reasoning capability metadata.

## Changes

| Before | After |
| --- | --- |
| DeepInfra had no provider identity, credential, proxy, or API base configuration. | `deepinfra/` routes through the shared OpenAI Chat transport using `DEEPINFRA_API_KEY`, `DEEPINFRA_PROXY`, and DeepInfra's [OpenAI-compatible API](https://docs.deepinfra.com/chat/overview). |
| Model discovery could not interpret DeepInfra's root-array catalog. | Discovery consumes DeepInfra's [public model catalog](https://docs.deepinfra.com/api-reference/models/models-list), validates it atomically, and exposes only active text-generation models. |
| Model metadata could not represent DeepInfra's reasoning and non-reasoning tags. | Catalog tags produce explicit thinking support when known and preserve unknown capability when the catalog is silent. |
| DeepInfra reasoning behavior was undefined. | Requests replay `reasoning_content` and translate FCC reasoning intent to DeepInfra's documented [reasoning controls](https://docs.deepinfra.com/chat/reasoning). |
| Admin setup, README usage, and provider smoke defaults omitted DeepInfra. | All customer-facing configuration and smoke surfaces include DeepInfra with `deepseek-ai/DeepSeek-V4-Flash` as the initial smoke model. |
| No DeepInfra contract coverage existed. | 131 focused tests cover conversion, reasoning, discovery, malformed catalogs, retries, configuration, Admin, and smoke behavior; a live public-catalog probe discovered 99 active text models, while authenticated inference remains pending because no local key is configured. |
| The package version was `4.23.0`. | The package version is `4.24.0`, with `uv.lock` synchronized. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds DeepInfra as an OpenAI-compatible provider with API-key and proxy configuration, model discovery, reasoning-effort support, documentation, smoke defaults, and provider coverage. The exercised provider flow sends the authenticated catalog request to the public DeepInfra endpoint, filters active text-generation models, and serializes reasoning effort correctly for OpenAI-compatible requests.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised DeepInfra provider construction, catalog discovery, model parsing, and request serialization paths.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a deterministic uv run validation against the production provider with a real constructed AsyncOpenAI client over httpx.MockTransport, observed the request to the models/list endpoint, parsed the active text-generation models, and verified the reasoning-effort serialization on the OpenAI payload.
- Executed the focused DeepInfra provider test module and confirmed all 27 tests passed, validating provider construction, catalog, parser, and request-encoding paths end-to-end.
- Captured the temporary validation script exactly as executed and recorded the command, working directory, exit code, and PASS results, and collected runtime and test-run logs showing the command invocation and PASS outcomes.

<a href="https://app.greptile.com/trex/runs/18600015/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Refine DeepInfra provider tests"](https://github.com/alishahryar1/free-claude-code/commit/417249b43016ff77106301cc5828eac87438b47a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52750145)</sub>

<!-- /greptile_comment -->