### PR TITLE
Add SiliconFlow provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,10 @@ TOGETHER_API_KEY=""
 DEEPINFRA_API_KEY=""
 
 
+# SiliconFlow (OpenAI-compatible Chat Completions at api.siliconflow.com/v1)
+SILICONFLOW_API_KEY=""
+
+
 # Agnes AI (OpenAI-compatible Chat Completions at apihub.agnes-ai.com/v1)
 AGNES_API_KEY=""
 
@@ -158,7 +162,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "agnes" | "zenmux" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "agnes" | "zenmux" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -203,6 +207,7 @@ FCC_SMOKE_MODEL_GROQ=
 FCC_SMOKE_MODEL_QWENCLOUD=
 FCC_SMOKE_MODEL_TOGETHER=
 FCC_SMOKE_MODEL_DEEPINFRA=
+FCC_SMOKE_MODEL_SILICONFLOW=
 FCC_SMOKE_MODEL_AGNES=
 FCC_SMOKE_MODEL_ZENMUX=
 FCC_SMOKE_MODEL_SAMBANOVA=
@@ -232,6 +237,7 @@ XAI_PROXY=""
 QWENCLOUD_PROXY=""
 TOGETHER_PROXY=""
 DEEPINFRA_PROXY=""
+SILICONFLOW_PROXY=""
 AGNES_PROXY=""
 ZENMUX_PROXY=""
 AZURE_OPENAI_PROXY=""

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ fcc-codex exec "hello"
 | [QwenCloud Token Plan](https://home.qwencloud.com/api-keys) | `QWENCLOUD_API_KEY` | `qwencloud/qwen3.7-plus` |
 | [Together AI](https://api.together.ai/settings/api-keys) | `TOGETHER_API_KEY` | `together/zai-org/GLM-5.2` |
 | [DeepInfra](https://deepinfra.com/dash/api_keys) | `DEEPINFRA_API_KEY` | `deepinfra/deepseek-ai/DeepSeek-V4-Flash` |
+| [SiliconFlow](https://cloud.siliconflow.com/account/ak) | `SILICONFLOW_API_KEY` | `siliconflow/Qwen/Qwen3-32B` |
 | [Agnes AI](https://agnes-ai.com/) | `AGNES_API_KEY` | `agnes/agnes-2.0-flash` |
 | [ZenMux](https://zenmux.ai/platform/pay-as-you-go) | `ZENMUX_API_KEY` | `zenmux/deepseek/deepseek-v4-flash-free` |
 | [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.26.0"
+version = "4.27.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -74,6 +74,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "qwencloud": "qwencloud/qwen3.7-plus",
     "together": "together/zai-org/GLM-5.2",
     "deepinfra": "deepinfra/deepseek-ai/DeepSeek-V4-Flash",
+    "siliconflow": "siliconflow/Qwen/Qwen3-32B",
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -165,6 +165,13 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "DeepInfra API key for OpenAI-compatible chat and reasoning models."
         ),
     },
+    "SILICONFLOW_API_KEY": {
+        "label": "SiliconFlow API Key",
+        "description": (
+            "SiliconFlow API key for OpenAI-compatible chat, reasoning, and "
+            "vision models."
+        ),
+    },
     "SAMBANOVA_API_KEY": {
         "label": "SambaNova API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -60,6 +60,8 @@ QWENCLOUD_DEFAULT_BASE = (
 TOGETHER_DEFAULT_BASE = "https://api.together.ai/v1"
 # DeepInfra OpenAI-compatible Chat Completions API.
 DEEPINFRA_DEFAULT_BASE = "https://api.deepinfra.com/v1/openai"
+# SiliconFlow OpenAI-compatible Chat Completions API.
+SILICONFLOW_DEFAULT_BASE = "https://api.siliconflow.com/v1"
 # TokenRouter OpenAI-compatible Chat Completions gateway.
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 # NaraRoute OpenAI-compatible Chat Completions gateway.
@@ -175,6 +177,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="deepinfra_api_key",
         default_base_url=DEEPINFRA_DEFAULT_BASE,
         proxy_attr="deepinfra_proxy",
+    ),
+    "siliconflow": ProviderDescriptor(
+        provider_id="siliconflow",
+        display_name="SiliconFlow",
+        credential_env="SILICONFLOW_API_KEY",
+        credential_url="https://cloud.siliconflow.com/account/ak",
+        credential_attr="siliconflow_api_key",
+        default_base_url=SILICONFLOW_DEFAULT_BASE,
+        proxy_attr="siliconflow_proxy",
     ),
     "agnes": ProviderDescriptor(
         provider_id="agnes",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -143,6 +143,9 @@ class Settings(BaseSettings):
     # ==================== DeepInfra (OpenAI-compatible) ====================
     deepinfra_api_key: str = Field(default="", validation_alias="DEEPINFRA_API_KEY")
 
+    # ==================== SiliconFlow (OpenAI-compatible) ====================
+    siliconflow_api_key: str = Field(default="", validation_alias="SILICONFLOW_API_KEY")
+
     # ==================== Agnes AI (OpenAI-compatible) ====================
     agnes_api_key: str = Field(default="", validation_alias="AGNES_API_KEY")
 
@@ -206,6 +209,7 @@ class Settings(BaseSettings):
     qwencloud_proxy: str = Field(default="", validation_alias="QWENCLOUD_PROXY")
     together_proxy: str = Field(default="", validation_alias="TOGETHER_PROXY")
     deepinfra_proxy: str = Field(default="", validation_alias="DEEPINFRA_PROXY")
+    siliconflow_proxy: str = Field(default="", validation_alias="SILICONFLOW_PROXY")
     agnes_proxy: str = Field(default="", validation_alias="AGNES_PROXY")
     zenmux_proxy: str = Field(default="", validation_alias="ZENMUX_PROXY")
     azure_openai_proxy: str = Field(default="", validation_alias="AZURE_OPENAI_PROXY")

--- a/src/free_claude_code/providers/openai_chat/extra_body.py
+++ b/src/free_claude_code/providers/openai_chat/extra_body.py
@@ -22,6 +22,8 @@ CANONICAL_OPENAI_CHAT_BODY_KEYS = frozenset(
         "reasoning_tokens",
         "thinking",
         "thinking_budget_tokens",
+        "enable_thinking",
+        "thinking_budget",
     }
 )
 
@@ -32,6 +34,8 @@ REASONING_OPENAI_CHAT_BODY_KEYS = frozenset(
         "reasoning_tokens",
         "thinking",
         "thinking_budget_tokens",
+        "enable_thinking",
+        "thinking_budget",
     }
 )
 

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -69,6 +69,7 @@ class OpenAIModelListing:
     """Declarative model-list endpoint and response shape."""
 
     path: str | None = None
+    query_params: tuple[tuple[str, str], ...] = ()
     collection_field: str | None = "data"
     id_field: str = "id"
     aliases_field: str | None = None
@@ -235,6 +236,20 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             required_null_field="deprecated",
             tags_field="tags",
             non_thinking_tag="non-reasoning",
+        ),
+    ),
+    "siliconflow": OpenAIChatProfile(
+        _policy(
+            "SILICONFLOW",
+            ReasoningReplayMode.REASONING_CONTENT,
+            include_extra_body=True,
+            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NO_REASONING,
+        model_listing=OpenAIModelListing(
+            path="/models",
+            query_params=(("sub_type", "chat"),),
         ),
     ),
     "agnes": OpenAIChatProfile(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -169,9 +169,16 @@ class OpenAIChatProvider(BaseProvider):
 
     async def _fetch_models_payload(self) -> Any:
         """Fetch the profile-selected model-list endpoint once."""
-        path = self._profile.model_listing.path
+        listing = self._profile.model_listing
+        path = listing.path
         if path is None:
             return await self._client.models.list()
+        if listing.query_params:
+            return await self._client.get(
+                path,
+                cast_to=object,
+                options={"params": dict(listing.query_params)},
+            )
         return await self._client.get(path, cast_to=object)
 
     def _build_request_body(

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -14,6 +14,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "qwencloud",
     "together",
     "deepinfra",
+    "siliconflow",
     "agnes",
     "zenmux",
     "azure_openai",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -57,6 +57,7 @@ def _settings(**overrides):
         "qwencloud_api_key": "",
         "together_api_key": "",
         "deepinfra_api_key": "",
+        "siliconflow_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
         "ollama_api_key": "",
@@ -220,6 +221,23 @@ def test_deepinfra_provider_smoke_uses_current_coding_model(monkeypatch) -> None
 
     assert [model.provider for model in models] == ["deepinfra"]
     assert models[0].full_model == "deepinfra/deepseek-ai/DeepSeek-V4-Flash"
+    assert models[0].source == "provider_default"
+
+
+def test_siliconflow_provider_smoke_uses_documented_chat_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_SILICONFLOW", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            siliconflow_api_key="siliconflow-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["siliconflow"]
+    assert models[0].full_model == "siliconflow/Qwen/Qwen3-32B"
     assert models[0].source == "provider_default"
 
 

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -23,6 +23,7 @@ from free_claude_code.config.provider_catalog import (
     OLLAMA_CLOUD_DEFAULT_BASE,
     PROVIDER_CATALOG,
     QWENCLOUD_DEFAULT_BASE,
+    SILICONFLOW_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
     TOGETHER_DEFAULT_BASE,
     TOKENROUTER_DEFAULT_BASE,
@@ -70,6 +71,7 @@ def _make_settings(**overrides):
     mock.qwencloud_api_key = "test_qwencloud_key"
     mock.together_api_key = "test_together_key"
     mock.deepinfra_api_key = "test_deepinfra_key"
+    mock.siliconflow_api_key = "test_siliconflow_key"
     mock.mistral_api_key = "test_mistral_key"
     mock.codestral_api_key = "test_codestral_key"
     mock.deepseek_api_key = "test_deepseek_key"
@@ -141,6 +143,7 @@ def _make_settings(**overrides):
     mock.qwencloud_proxy = ""
     mock.together_proxy = ""
     mock.deepinfra_proxy = ""
+    mock.siliconflow_proxy = ""
     mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
@@ -282,6 +285,26 @@ def test_deepinfra_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.credential_env == "DEEPINFRA_API_KEY"
     assert config.api_key == "deepinfra-token"
     assert config.base_url == DEEPINFRA_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_siliconflow_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["siliconflow"]
+    settings = _make_settings(
+        siliconflow_api_key="siliconflow-token",
+        siliconflow_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("siliconflow", settings)
+
+    assert descriptor.display_name == "SiliconFlow"
+    assert descriptor.credential_env == "SILICONFLOW_API_KEY"
+    assert descriptor.base_url_attr is None
+    assert config.api_key == "siliconflow-token"
+    assert config.base_url == SILICONFLOW_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -621,6 +644,7 @@ def test_create_provider_instantiates_each_builtin():
         "qwencloud": OpenAIChatProvider,
         "together": OpenAIChatProvider,
         "deepinfra": OpenAIChatProvider,
+        "siliconflow": OpenAIChatProvider,
         "azure_openai": OpenAIChatProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,

--- a/tests/providers/test_siliconflow.py
+++ b/tests/providers/test_siliconflow.py
@@ -1,0 +1,290 @@
+"""Tests for the SiliconFlow OpenAI-chat profile and model catalog."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import SILICONFLOW_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+_MODEL = "Qwen/Qwen3-32B"
+_CATALOG_URL = "https://api.siliconflow.com/v1/models?sub_type=chat"
+
+
+def _request(**overrides: Any) -> MessagesRequest:
+    payload: dict[str, Any] = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    payload.update(overrides)
+    return MessagesRequest.model_validate(payload)
+
+
+@pytest.fixture
+def siliconflow_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "siliconflow",
+        ProviderConfig(
+            api_key="test-siliconflow-key",
+            base_url=SILICONFLOW_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="siliconflow"),
+    )
+
+
+def test_init_uses_documented_endpoint(
+    siliconflow_provider: OpenAIChatProvider,
+) -> None:
+    assert siliconflow_provider._api_key == "test-siliconflow-key"
+    assert siliconflow_provider._base_url == SILICONFLOW_DEFAULT_BASE
+    assert siliconflow_provider._provider_name == "SILICONFLOW"
+
+
+def test_build_request_body_preserves_common_chat_tools_and_images(
+    siliconflow_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(
+        system="Be concise.",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Inspect this image."},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "aW1hZ2U=",
+                        },
+                    },
+                ],
+            }
+        ],
+        tools=[
+            {
+                "name": "inspect_image",
+                "description": "Inspect an image",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"detail": {"type": "string"}},
+                },
+            }
+        ],
+    )
+
+    body = siliconflow_provider._build_request_body(
+        request,
+        reasoning=ReasoningPolicy.provider_default(),
+    )
+
+    assert body["model"] == _MODEL
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["messages"][0] == {"role": "system", "content": "Be concise."}
+    assert body["messages"][1]["content"] == [
+        {"type": "text", "text": "Inspect this image."},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aW1hZ2U="},
+        },
+    ]
+    assert body["tools"][0]["function"]["name"] == "inspect_image"
+    assert "extra_body" not in body
+
+
+@pytest.mark.parametrize(
+    "reasoning",
+    [
+        ReasoningPolicy.provider_default(),
+        REASONING_OFF,
+        REASONING_ON,
+        ReasoningPolicy.on(budget_tokens=777),
+        *[ReasoningPolicy.on(effort=effort) for effort in ReasoningEffort],
+    ],
+)
+def test_build_request_body_omits_model_specific_thinking_controls(
+    siliconflow_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+) -> None:
+    body = siliconflow_provider._build_request_body(_request(), reasoning=reasoning)
+
+    assert "extra_body" not in body
+
+
+def test_build_request_body_preserves_unrelated_extra_body(
+    siliconflow_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(extra_body={"min_p": 0.05})
+
+    body = siliconflow_provider._build_request_body(
+        request,
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+
+    assert body["extra_body"] == {
+        "min_p": 0.05,
+    }
+
+
+@pytest.mark.parametrize("field", ["enable_thinking", "thinking_budget"])
+def test_build_request_body_rejects_caller_thinking_override(
+    siliconflow_provider: OpenAIChatProvider,
+    field: str,
+) -> None:
+    request = _request(extra_body={field: "caller-owned"})
+
+    with pytest.raises(InvalidRequestError, match="must not override reasoning"):
+        siliconflow_provider._build_request_body(request, reasoning=REASONING_ON)
+
+
+def test_build_request_body_replays_reasoning_content_verbatim(
+    siliconflow_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(
+        messages=[
+            {"role": "user", "content": "Use a tool."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Need the tool."},
+                    {"type": "text", "text": "Calling it."},
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+    )
+
+    body = siliconflow_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "Calling it.",
+        "reasoning_content": "Need the tool.",
+    }
+    assert (
+        siliconflow_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning_content="next thought")
+        )
+        == "next thought"
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_chat_query(
+    siliconflow_provider: OpenAIChatProvider,
+) -> None:
+    siliconflow_provider._client.get = AsyncMock(
+        return_value={"data": [{"id": _MODEL}]}
+    )
+
+    model_infos = await siliconflow_provider.list_model_infos()
+
+    assert model_infos == frozenset({ProviderModelInfo(_MODEL)})
+    siliconflow_provider._client.get.assert_awaited_once_with(
+        "/models",
+        cast_to=object,
+        options={"params": {"sub_type": "chat"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_documented_endpoint_query_and_auth() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"data": [{"id": _MODEL}]})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    def build_client(*args: Any, **kwargs: Any) -> AsyncOpenAI:
+        kwargs["http_client"] = http_client
+        return AsyncOpenAI(*args, **kwargs)
+
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI",
+        side_effect=build_client,
+    ):
+        provider = profiled_provider(
+            "siliconflow",
+            ProviderConfig(
+                api_key="wire-siliconflow-key",
+                base_url=SILICONFLOW_DEFAULT_BASE,
+                rate_limit=10,
+                rate_window=60,
+            ),
+            admission=immediate_admission(provider_name="siliconflow"),
+        )
+    try:
+        model_infos = await provider.list_model_infos()
+    finally:
+        await provider.cleanup()
+
+    assert model_infos == frozenset({ProviderModelInfo(_MODEL)})
+    assert len(requests) == 1
+    assert str(requests[0].url) == _CATALOG_URL
+    assert requests[0].headers["authorization"] == "Bearer wire-siliconflow-key"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"models": []}, "expected top-level data array"),
+        ({"data": [{}]}, "include id"),
+        ({"data": []}, "did not include any model ids"),
+    ],
+)
+async def test_rejects_malformed_or_empty_catalog_atomically(
+    siliconflow_provider: OpenAIChatProvider,
+    payload: object,
+    message: str,
+) -> None:
+    siliconflow_provider._client.get = AsyncMock(return_value=payload)
+
+    with pytest.raises(ModelListResponseError, match=message):
+        await siliconflow_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_shared_retry_admission(
+    siliconflow_provider: OpenAIChatProvider,
+) -> None:
+    request = httpx.Request("GET", _CATALOG_URL)
+    response = httpx.Response(429, request=request)
+    rate_limit_error = httpx.HTTPStatusError(
+        "rate limited",
+        request=request,
+        response=response,
+    )
+    siliconflow_provider._client.get = AsyncMock(
+        side_effect=[rate_limit_error, {"data": [{"id": _MODEL}]}]
+    )
+
+    model_infos = await siliconflow_provider.list_model_infos()
+
+    assert model_infos == frozenset({ProviderModelInfo(_MODEL)})
+    assert siliconflow_provider._client.get.await_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.26.0"
+version = "4.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC does not expose SiliconFlow as a configurable provider, so users cannot route its current chat catalog through FCC.

## Changes

| Before | After |
| --- | --- |
| SiliconFlow credentials and models were absent from FCC. | SiliconFlow is available through SILICONFLOW_API_KEY with chat-only model discovery. |
| Model discovery could not attach semantic query parameters to raw OpenAI-compatible catalog requests. | Model discovery sends the documented sub_type=chat query through the shared authenticated retry path. |
| SiliconFlow reasoning history had no provider contract. | SiliconFlow replays reasoning_content verbatim without unsafe model-specific thinking controls. |
| No SiliconFlow provider smoke target existed. | The provider matrix uses Qwen/Qwen3-32B by default and supports FCC_SMOKE_MODEL_SILICONFLOW overrides. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds SiliconFlow as a configurable OpenAI-compatible provider, including credentials, proxy configuration, model discovery, smoke defaults, and provider documentation.

The configured SiliconFlow model-catalog flow was exercised with a hermetic HTTP transport. It sent authenticated requests to `/v1/models?sub_type=chat`, recovered from a synthetic rate-limit response through the shared retry path, and parsed `Qwen/Qwen3-32B`. The focused SiliconFlow provider contract suite also passed. The potential failure where catalog discovery would omit the `sub_type=chat` filter, authentication, retry behavior, or model parsing was disproved by this executed flow.

## T-Rex validation blocked
Live upstream SiliconFlow validation could not run because the `SILICONFLOW_API_KEY` credential is not configured in this environment. No credential values were exposed.
</details>

<h3>Confidence Score: 5/5</h3>

The verified SiliconFlow configuration and catalog-discovery behavior is safe to merge.

Production settings and provider construction were exercised with an HTTP transport that verified the catalog URL, query parameter, bearer authentication, retry recovery, and parsed model result. Focused provider contracts also passed. No defects remain in the final findings.

**Files Needing Attention:** No files require follow-up based on the verified behavior. Live behavior in `src/free_claude_code/providers/openai_chat/provider.py` can be additionally exercised when a SiliconFlow credential is available.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the SiliconFlow catalog harness in before and after phases and executed the provider test suite; the retry path recovered from HTTP 429 and the tests completed with 22 passing, confirming catalog-discovery behavior and model detection of Qwen/Qwen3-32B.
- Executed the exact harness commands and performed post-run validation, noting two authenticated requests to /v1/models?sub\_type=chat, retry traces, Bearer \[REDACTED\], and the absence of synthetic credential markers in the captured logs.

<a href="https://app.greptile.com/trex/runs/18618933/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add SiliconFlow provider"](https://github.com/alishahryar1/free-claude-code/commit/8a68576f4e333aa2843a38e8b3124e786394ab3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52806146)</sub>

<!-- /greptile_comment -->