### PR TITLE
Add Nebius Token Factory provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,10 @@ DEEPINFRA_API_KEY=""
 SILICONFLOW_API_KEY=""
 
 
+# Nebius Token Factory (OpenAI-compatible Chat Completions at api.tokenfactory.nebius.com/v1)
+NEBIUS_API_KEY=""
+
+
 # Agnes AI (OpenAI-compatible Chat Completions at apihub.agnes-ai.com/v1)
 AGNES_API_KEY=""
 
@@ -162,7 +166,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "agnes" | "zenmux" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "nebius" | "agnes" | "zenmux" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -208,6 +212,7 @@ FCC_SMOKE_MODEL_QWENCLOUD=
 FCC_SMOKE_MODEL_TOGETHER=
 FCC_SMOKE_MODEL_DEEPINFRA=
 FCC_SMOKE_MODEL_SILICONFLOW=
+FCC_SMOKE_MODEL_NEBIUS=
 FCC_SMOKE_MODEL_AGNES=
 FCC_SMOKE_MODEL_ZENMUX=
 FCC_SMOKE_MODEL_SAMBANOVA=
@@ -238,6 +243,7 @@ QWENCLOUD_PROXY=""
 TOGETHER_PROXY=""
 DEEPINFRA_PROXY=""
 SILICONFLOW_PROXY=""
+NEBIUS_PROXY=""
 AGNES_PROXY=""
 ZENMUX_PROXY=""
 AZURE_OPENAI_PROXY=""

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ fcc-codex exec "hello"
 | [Together AI](https://api.together.ai/settings/api-keys) | `TOGETHER_API_KEY` | `together/zai-org/GLM-5.2` |
 | [DeepInfra](https://deepinfra.com/dash/api_keys) | `DEEPINFRA_API_KEY` | `deepinfra/deepseek-ai/DeepSeek-V4-Flash` |
 | [SiliconFlow](https://cloud.siliconflow.com/account/ak) | `SILICONFLOW_API_KEY` | `siliconflow/Qwen/Qwen3-32B` |
+| [Nebius Token Factory](https://tokenfactory.nebius.com/project/api-keys) | `NEBIUS_API_KEY` | `nebius/Qwen/Qwen3-30B-A3B` |
 | [Agnes AI](https://agnes-ai.com/) | `AGNES_API_KEY` | `agnes/agnes-2.0-flash` |
 | [ZenMux](https://zenmux.ai/platform/pay-as-you-go) | `ZENMUX_API_KEY` | `zenmux/deepseek/deepseek-v4-flash-free` |
 | [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.27.0"
+version = "4.28.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -75,6 +75,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "together": "together/zai-org/GLM-5.2",
     "deepinfra": "deepinfra/deepseek-ai/DeepSeek-V4-Flash",
     "siliconflow": "siliconflow/Qwen/Qwen3-32B",
+    "nebius": "nebius/Qwen/Qwen3-30B-A3B",
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -172,6 +172,13 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "vision models."
         ),
     },
+    "NEBIUS_API_KEY": {
+        "label": "Nebius Token Factory API Key",
+        "description": (
+            "Nebius Token Factory API key for OpenAI-compatible chat, reasoning, "
+            "and tool-capable models."
+        ),
+    },
     "SAMBANOVA_API_KEY": {
         "label": "SambaNova API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -62,6 +62,8 @@ TOGETHER_DEFAULT_BASE = "https://api.together.ai/v1"
 DEEPINFRA_DEFAULT_BASE = "https://api.deepinfra.com/v1/openai"
 # SiliconFlow OpenAI-compatible Chat Completions API.
 SILICONFLOW_DEFAULT_BASE = "https://api.siliconflow.com/v1"
+# Nebius Token Factory OpenAI-compatible Chat Completions API.
+NEBIUS_DEFAULT_BASE = "https://api.tokenfactory.nebius.com/v1"
 # TokenRouter OpenAI-compatible Chat Completions gateway.
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 # NaraRoute OpenAI-compatible Chat Completions gateway.
@@ -186,6 +188,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="siliconflow_api_key",
         default_base_url=SILICONFLOW_DEFAULT_BASE,
         proxy_attr="siliconflow_proxy",
+    ),
+    "nebius": ProviderDescriptor(
+        provider_id="nebius",
+        display_name="Nebius Token Factory",
+        credential_env="NEBIUS_API_KEY",
+        credential_url="https://tokenfactory.nebius.com/project/api-keys",
+        credential_attr="nebius_api_key",
+        default_base_url=NEBIUS_DEFAULT_BASE,
+        proxy_attr="nebius_proxy",
     ),
     "agnes": ProviderDescriptor(
         provider_id="agnes",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -146,6 +146,9 @@ class Settings(BaseSettings):
     # ==================== SiliconFlow (OpenAI-compatible) ====================
     siliconflow_api_key: str = Field(default="", validation_alias="SILICONFLOW_API_KEY")
 
+    # ==================== Nebius Token Factory (OpenAI-compatible) ====================
+    nebius_api_key: str = Field(default="", validation_alias="NEBIUS_API_KEY")
+
     # ==================== Agnes AI (OpenAI-compatible) ====================
     agnes_api_key: str = Field(default="", validation_alias="AGNES_API_KEY")
 
@@ -210,6 +213,7 @@ class Settings(BaseSettings):
     together_proxy: str = Field(default="", validation_alias="TOGETHER_PROXY")
     deepinfra_proxy: str = Field(default="", validation_alias="DEEPINFRA_PROXY")
     siliconflow_proxy: str = Field(default="", validation_alias="SILICONFLOW_PROXY")
+    nebius_proxy: str = Field(default="", validation_alias="NEBIUS_PROXY")
     agnes_proxy: str = Field(default="", validation_alias="AGNES_PROXY")
     zenmux_proxy: str = Field(default="", validation_alias="ZENMUX_PROXY")
     azure_openai_proxy: str = Field(default="", validation_alias="AZURE_OPENAI_PROXY")

--- a/src/free_claude_code/providers/model_listing.py
+++ b/src/free_claude_code/providers/model_listing.py
@@ -7,6 +7,11 @@ from free_claude_code.application.model_metadata import (
     ProviderModelInfo as _ProviderModelInfo,
 )
 
+type ModelListScalar = str | bool
+type RequiredPathValues = tuple[
+    tuple[tuple[str, ...], tuple[ModelListScalar, ...]], ...
+]
+
 
 class ModelListResponseError(ValueError):
     """A provider model-list response cannot be parsed safely."""
@@ -34,7 +39,7 @@ def extract_openai_model_infos(
     collection_field: str | None = "data",
     id_field: str = "id",
     aliases_field: str | None = None,
-    field_equals: tuple[str, str] | None = None,
+    required_path_values: RequiredPathValues = (),
     required_null_field: str | None = None,
     required_sequence_items: tuple[tuple[str, str], ...] = (),
     tags_field: str | None = None,
@@ -57,16 +62,23 @@ def extract_openai_model_infos(
                 f"expected every {item_location} item to include {id_field}",
             )
         included = True
-        if field_equals is not None:
-            field_name, expected_value = field_equals
-            field_value = _field(item, field_name)
-            if not isinstance(field_value, str):
+        for path, allowed_values in required_path_values:
+            path_value = _path(item, path)
+            matching_types = tuple(
+                allowed
+                for allowed in allowed_values
+                if type(path_value) is type(allowed)
+            )
+            if path_value is _MISSING or not matching_types:
+                expected_types = "/".join(
+                    dict.fromkeys(_scalar_type_name(value) for value in allowed_values)
+                )
                 raise _malformed(
                     provider_name,
                     f"expected every {item_location} item to include "
-                    f"string {field_name}",
+                    f"{'.'.join(path)} as {expected_types}",
                 )
-            if field_value != expected_value:
+            if path_value not in matching_types:
                 included = False
 
         if required_null_field is not None:
@@ -233,6 +245,10 @@ def _is_sequence(value: Any) -> bool:
     return isinstance(value, Sequence) and not isinstance(
         value, str | bytes | bytearray
     )
+
+
+def _scalar_type_name(value: ModelListScalar) -> str:
+    return type(value).__name__
 
 
 def _malformed(provider_name: str, reason: str) -> ModelListResponseError:

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -10,6 +10,7 @@ from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKEN
 from free_claude_code.core.anthropic import ReasoningReplayMode
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.model_listing import RequiredPathValues
 
 from .base_url import openai_v1_base_url
 from .extra_body import (
@@ -73,7 +74,7 @@ class OpenAIModelListing:
     collection_field: str | None = "data"
     id_field: str = "id"
     aliases_field: str | None = None
-    field_equals: tuple[str, str] | None = None
+    required_path_values: RequiredPathValues = ()
     required_null_field: str | None = None
     required_sequence_items: tuple[tuple[str, str], ...] = ()
     tags_field: str | None = None
@@ -210,7 +211,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         model_listing=OpenAIModelListing(
             path="/models",
             collection_field=None,
-            field_equals=("type", "chat"),
+            required_path_values=((("type",), ("chat",)),),
         ),
         reasoning_delta_field="reasoning",
     ),
@@ -232,7 +233,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             path="https://api.deepinfra.com/models/list",
             collection_field=None,
             id_field="model_name",
-            field_equals=("reported_type", "text-generation"),
+            required_path_values=((("reported_type",), ("text-generation",)),),
             required_null_field="deprecated",
             tags_field="tags",
             non_thinking_tag="non-reasoning",
@@ -250,6 +251,23 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         model_listing=OpenAIModelListing(
             path="/models",
             query_params=(("sub_type", "chat"),),
+        ),
+    ),
+    "nebius": OpenAIChatProfile(
+        _policy(
+            "NEBIUS",
+            ReasoningReplayMode.REASONING_CONTENT,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NamedEffortReasoning(
+            _MINIMAL_TO_XHIGH,
+            disabled_value="none",
+            enabled_value="xhigh",
+        ),
+        model_listing=OpenAIModelListing(
+            path="/models",
+            query_params=(("verbose", "true"),),
+            required_path_values=((("architecture", "modality"), ("text->text",)),),
         ),
     ),
     "agnes": OpenAIChatProfile(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -150,7 +150,7 @@ class OpenAIChatProvider(BaseProvider):
             collection_field=listing.collection_field,
             id_field=listing.id_field,
             aliases_field=listing.aliases_field,
-            field_equals=listing.field_equals,
+            required_path_values=listing.required_path_values,
             required_null_field=listing.required_null_field,
             required_sequence_items=listing.required_sequence_items,
             tags_field=listing.tags_field,

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -15,6 +15,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "together",
     "deepinfra",
     "siliconflow",
+    "nebius",
     "agnes",
     "zenmux",
     "azure_openai",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -58,6 +58,7 @@ def _settings(**overrides):
         "together_api_key": "",
         "deepinfra_api_key": "",
         "siliconflow_api_key": "",
+        "nebius_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
         "ollama_api_key": "",
@@ -238,6 +239,23 @@ def test_siliconflow_provider_smoke_uses_documented_chat_model(monkeypatch) -> N
 
     assert [model.provider for model in models] == ["siliconflow"]
     assert models[0].full_model == "siliconflow/Qwen/Qwen3-32B"
+    assert models[0].source == "provider_default"
+
+
+def test_nebius_provider_smoke_uses_documented_agent_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_NEBIUS", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            nebius_api_key="nebius-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["nebius"]
+    assert models[0].full_model == "nebius/Qwen/Qwen3-30B-A3B"
     assert models[0].source == "provider_default"
 
 

--- a/tests/providers/test_deepinfra.py
+++ b/tests/providers/test_deepinfra.py
@@ -310,8 +310,8 @@ async def test_model_catalog_uses_absolute_public_url() -> None:
     [
         ({"data": []}, "expected root array"),
         ([_catalog_model(model_name=_MISSING)], "include model_name"),
-        ([_catalog_model(reported_type=_MISSING)], "include string reported_type"),
-        ([_catalog_model(reported_type=7)], "include string reported_type"),
+        ([_catalog_model(reported_type=_MISSING)], "include reported_type as str"),
+        ([_catalog_model(reported_type=7)], "include reported_type as str"),
         ([_catalog_model(deprecated=_MISSING)], "include deprecated"),
         ([_catalog_model(tags=_MISSING)], "include tags string array"),
         ([_catalog_model(tags=[7])], "include tags string array"),

--- a/tests/providers/test_nebius.py
+++ b/tests/providers/test_nebius.py
@@ -1,0 +1,224 @@
+"""Tests for the Nebius Token Factory OpenAI-chat profile and catalog."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import NEBIUS_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+_MODEL = "Qwen/Qwen3-30B-A3B"
+
+
+@pytest.fixture
+def nebius_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "nebius",
+        ProviderConfig(
+            api_key="test-nebius-key",
+            base_url=NEBIUS_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="nebius"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "expected"),
+    [
+        (REASONING_OFF, "none"),
+        (REASONING_ON, "xhigh"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.MINIMAL), "minimal"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.LOW), "low"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.MEDIUM), "medium"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.HIGH), "high"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.XHIGH), "xhigh"),
+        (ReasoningPolicy.on(effort=ReasoningEffort.MAX), "xhigh"),
+    ],
+)
+def test_encodes_documented_reasoning_effort(
+    nebius_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+    expected: str,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": _MODEL,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+    )
+
+    body = nebius_provider._build_request_body(request, reasoning=reasoning)
+
+    assert body["reasoning_effort"] == expected
+    assert "extra_body" not in body
+
+
+def test_replays_reasoning_content(nebius_provider: OpenAIChatProvider) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": _MODEL,
+            "messages": [
+                {"role": "user", "content": "Solve it."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Work through it."},
+                        {"type": "text", "text": "The answer is 42."},
+                    ],
+                },
+                {"role": "user", "content": "Continue."},
+            ],
+        }
+    )
+
+    body = nebius_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "The answer is 42.",
+        "reasoning_content": "Work through it.",
+    }
+    assert (
+        nebius_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning_content="next thought")
+        )
+        == "next thought"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lists_only_text_output_models(
+    nebius_provider: OpenAIChatProvider,
+) -> None:
+    nebius_provider._client.get = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": _MODEL,
+                    "architecture": {"modality": "text->text"},
+                },
+                {
+                    "id": "black-forest-labs/flux",
+                    "architecture": {"modality": "text->image"},
+                },
+            ]
+        }
+    )
+
+    model_infos = await nebius_provider.list_model_infos()
+
+    assert model_infos == frozenset({ProviderModelInfo(_MODEL)})
+    nebius_provider._client.get.assert_awaited_once_with(
+        "/models",
+        cast_to=object,
+        options={"params": {"verbose": "true"}},
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"data": [{"id": _MODEL}]}, "architecture.modality"),
+        (
+            {"data": [{"id": _MODEL, "architecture": {}}]},
+            "architecture.modality",
+        ),
+        (
+            {
+                "data": [
+                    {"id": _MODEL, "architecture": {"modality": True}},
+                ]
+            },
+            "architecture.modality",
+        ),
+        (
+            {
+                "data": [
+                    {"id": "", "architecture": {"modality": "text->text"}},
+                ]
+            },
+            "include id",
+        ),
+        (
+            {
+                "data": [
+                    {
+                        "id": "image-model",
+                        "architecture": {"modality": "text->image"},
+                    },
+                ]
+            },
+            "did not include any model ids",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rejects_malformed_or_unusable_catalog_atomically(
+    nebius_provider: OpenAIChatProvider,
+    payload: object,
+    message: str,
+) -> None:
+    nebius_provider._client.get = AsyncMock(return_value=payload)
+
+    with pytest.raises(ModelListResponseError, match=message):
+        await nebius_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_documented_url_auth_and_verbose_query(
+    nebius_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": _MODEL,
+                        "architecture": {"modality": "text->text"},
+                    }
+                ]
+            },
+        )
+
+    await nebius_provider._client.close()
+    nebius_provider._client = AsyncOpenAI(
+        api_key="wire-nebius-key",
+        base_url=NEBIUS_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        model_infos = await nebius_provider.list_model_infos()
+    finally:
+        await nebius_provider.cleanup()
+
+    assert model_infos == frozenset({ProviderModelInfo(_MODEL)})
+    assert len(requests) == 1
+    assert str(requests[0].url) == (
+        "https://api.tokenfactory.nebius.com/v1/models?verbose=true"
+    )
+    assert requests[0].headers["authorization"] == "Bearer wire-nebius-key"

--- a/tests/providers/test_openai_model_listing_filters.py
+++ b/tests/providers/test_openai_model_listing_filters.py
@@ -1,0 +1,70 @@
+"""Tests for neutral OpenAI-compatible model-list filtering."""
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.providers.model_listing import (
+    ModelListResponseError,
+    RequiredPathValues,
+    extract_openai_model_infos,
+)
+
+
+def test_required_path_values_match_nested_json_scalars() -> None:
+    model_infos = extract_openai_model_infos(
+        {
+            "data": [
+                {
+                    "id": "included",
+                    "metadata": {
+                        "kind": "chat",
+                        "enabled": True,
+                    },
+                },
+                {
+                    "id": "excluded",
+                    "metadata": {
+                        "kind": "image",
+                        "enabled": True,
+                    },
+                },
+            ]
+        },
+        provider_name="TEST",
+        required_path_values=(
+            (("metadata", "kind"), ("chat", "code")),
+            (("metadata", "enabled"), (True,)),
+        ),
+    )
+
+    assert model_infos == frozenset({ProviderModelInfo("included")})
+
+
+@pytest.mark.parametrize(
+    ("metadata", "required_path_values", "path"),
+    [
+        ({}, ((("kind",), ("chat",)),), "kind"),
+        ({"kind": True}, ((("kind",), ("chat",)),), "kind"),
+        ({"enabled": 1}, ((("enabled",), (True,)),), "enabled"),
+    ],
+)
+def test_required_path_values_reject_missing_or_wrong_scalar_types(
+    metadata: dict[str, object],
+    required_path_values: RequiredPathValues,
+    path: str,
+) -> None:
+    with pytest.raises(ModelListResponseError, match=path):
+        extract_openai_model_infos(
+            {"data": [{"id": "model", **metadata}]},
+            provider_name="TEST",
+            required_path_values=required_path_values,
+        )
+
+
+def test_required_path_values_reject_an_empty_included_set() -> None:
+    with pytest.raises(ModelListResponseError, match="did not include any model ids"):
+        extract_openai_model_infos(
+            {"data": [{"id": "image", "type": "image"}]},
+            provider_name="TEST",
+            required_path_values=((("type",), ("chat",)),),
+        )

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -20,6 +20,7 @@ from free_claude_code.config.provider_catalog import (
     KIMI_CODE_DEFAULT_BASE,
     MINIMAX_DEFAULT_BASE,
     NARAROUTE_DEFAULT_BASE,
+    NEBIUS_DEFAULT_BASE,
     OLLAMA_CLOUD_DEFAULT_BASE,
     PROVIDER_CATALOG,
     QWENCLOUD_DEFAULT_BASE,
@@ -72,6 +73,7 @@ def _make_settings(**overrides):
     mock.together_api_key = "test_together_key"
     mock.deepinfra_api_key = "test_deepinfra_key"
     mock.siliconflow_api_key = "test_siliconflow_key"
+    mock.nebius_api_key = "test_nebius_key"
     mock.mistral_api_key = "test_mistral_key"
     mock.codestral_api_key = "test_codestral_key"
     mock.deepseek_api_key = "test_deepseek_key"
@@ -144,6 +146,7 @@ def _make_settings(**overrides):
     mock.together_proxy = ""
     mock.deepinfra_proxy = ""
     mock.siliconflow_proxy = ""
+    mock.nebius_proxy = ""
     mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
@@ -305,6 +308,29 @@ def test_siliconflow_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.base_url_attr is None
     assert config.api_key == "siliconflow-token"
     assert config.base_url == SILICONFLOW_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_nebius_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["nebius"]
+    settings = _make_settings(
+        nebius_api_key="nebius-token",
+        nebius_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("nebius", settings)
+
+    assert descriptor.display_name == "Nebius Token Factory"
+    assert descriptor.credential_env == "NEBIUS_API_KEY"
+    assert descriptor.credential_url == (
+        "https://tokenfactory.nebius.com/project/api-keys"
+    )
+    assert descriptor.base_url_attr is None
+    assert config.api_key == "nebius-token"
+    assert config.base_url == NEBIUS_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -645,6 +671,7 @@ def test_create_provider_instantiates_each_builtin():
         "together": OpenAIChatProvider,
         "deepinfra": OpenAIChatProvider,
         "siliconflow": OpenAIChatProvider,
+        "nebius": OpenAIChatProvider,
         "azure_openai": OpenAIChatProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -232,8 +232,8 @@ async def test_model_catalog_uses_configured_base_url_and_auth(
     [
         ({"data": []}, "expected root array"),
         ([{"type": "chat"}], "include id"),
-        ([{"id": "model"}], "include string type"),
-        ([{"id": "model", "type": 7}], "include string type"),
+        ([{"id": "model"}], "include type as str"),
+        ([{"id": "model", "type": 7}], "include type as str"),
         ([], "did not include any model ids"),
         (
             [{"id": "black-forest-labs/FLUX.2-dev", "type": "image"}],

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.27.0"
+version = "4.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC cannot configure or discover Nebius Token Factory models. Existing flat catalog equality filtering cannot express Nebius's nested modality metadata.

## Changes

| Before | After |
| --- | --- |
| Nebius credentials, proxy settings, Admin fields, and model discovery were unavailable. | Nebius Token Factory is configurable through `NEBIUS_API_KEY` and `NEBIUS_PROXY`, with dynamic rich-catalog discovery. |
| Catalog equality filtering handled only one flat string field. | One strict nested string/boolean predicate serves Nebius, Together, and DeepInfra while preserving DeepInfra's distinct nullness contract. |
| Nebius reasoning and history behavior had no provider contract. | FCC maps the documented `none` through `xhigh` effort vocabulary and replays assistant reasoning as `reasoning_content`. |
| No Nebius provider smoke target existed. | The provider matrix defaults to `Qwen/Qwen3-30B-A3B` and supports `FCC_SMOKE_MODEL_NEBIUS`. |
| Nebius behavior had no deterministic coverage. | Focused catalog, reasoning, runtime, smoke, and migration tests pass; 3,047 repository tests pass outside two pre-existing Windows installer shortcut isolation assertions. |
| No Nebius credential is available in the development environment. | Authenticated upstream smoke remains an explicit pre-merge gate and is not represented as completed. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds Nebius Token Factory as an OpenAI-compatible provider, including credential and proxy configuration, model catalog discovery, reasoning controls, Admin metadata, documentation, and smoke defaults. It also extends shared model-list filtering to support nested string and boolean predicates.

Nebius request construction, reasoning replay, catalog URL construction, authentication headers, and text-model filtering were exercised with a focused runtime harness. The shared filtering behavior was also exercised for Together, DeepInfra, and Nebius; the focused regression suite passed 62 tests. No defects were found.

## T-Rex validation blocked

A successful live Nebius catalog request and chat completion could not be exercised because `NEBIUS_API_KEY` was not available. Credential-free requests reached the configured Nebius endpoints and received authentication-required responses, while deterministic mock-transport checks covered the implemented request and response contract.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge based on the exercised provider contracts and focused regression coverage.

No final findings remain. Validation covered Nebius reasoning request encoding and replay, exact catalog routing and authorization headers, text-only model filtering, malformed model metadata handling, and shared filtering behavior for Together and DeepInfra.

**Files Needing Attention:** No files require corrective changes. A future authenticated smoke run against Nebius would provide additional upstream integration assurance once a Nebius API key is available.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Nebius runtime harness to build chat requests, verify reasoning\_effort encoding and assistant reasoning\_content replay, exercise catalog filtering via an OpenAI mock transport, and assert the exact catalog URL and bearer authorization header; executed 16 tests with pytest and all tests passed; attempted credential-free live calls to Nebius endpoints, which returned authentication-required responses rather than route failures.
- Performed an exact-path pytest validation against the parent revision and HEAD to exercise Together, DeepInfra, Nebius catalog inclusion, and malformed-scalar rejection paths; observed four expected failures in the parent revision before the new predicates existed, while HEAD passed all six checks; then ran the focused project regression suite for Together, DeepInfra, Nebius, and neutral filtering, and all 62 tests passed.
- Tried a live Nebius catalog parse and chat completion, but the NEBIUS\_API\_KEY was unavailable; credential-free requests did reach the configured endpoints and returned authentication-required responses.
- Reviewed outcomes and concluded there were no API-contract violations based on the exercised checks; however, authenticated upstream semantics remain unverified due to the missing API key.
- Documented test-run artifacts for nested catalog predicates, including the HEAD^ before-change run, the HEAD after-change run, and the focused project-suite run.

<a href="https://app.greptile.com/trex/runs/18636857/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fadd-nebius-token-factory%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fadd-nebius-token-factory%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231399%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=alishahryar1%2Ffree-claude-code&pr=1399&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["Add Nebius Token Factory provider"](https://github.com/alishahryar1/free-claude-code/commit/c2345833566898d28fde02303d09e90a762be755) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52840406)</sub>

<!-- /greptile_comment -->