### PR TITLE
Add Chutes provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,10 @@ SILICONFLOW_API_KEY=""
 NEBIUS_API_KEY=""
 
 
+# Chutes (OpenAI-compatible Chat Completions at llm.chutes.ai/v1)
+CHUTES_API_KEY=""
+
+
 # Agnes AI (OpenAI-compatible Chat Completions at apihub.agnes-ai.com/v1)
 AGNES_API_KEY=""
 
@@ -166,7 +170,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "nebius" | "agnes" | "zenmux" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "agnes" | "zenmux" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 MODEL_FABLE=
 MODEL_OPUS=
 MODEL_SONNET=
@@ -213,6 +217,7 @@ FCC_SMOKE_MODEL_TOGETHER=
 FCC_SMOKE_MODEL_DEEPINFRA=
 FCC_SMOKE_MODEL_SILICONFLOW=
 FCC_SMOKE_MODEL_NEBIUS=
+FCC_SMOKE_MODEL_CHUTES=
 FCC_SMOKE_MODEL_AGNES=
 FCC_SMOKE_MODEL_ZENMUX=
 FCC_SMOKE_MODEL_SAMBANOVA=
@@ -244,6 +249,7 @@ TOGETHER_PROXY=""
 DEEPINFRA_PROXY=""
 SILICONFLOW_PROXY=""
 NEBIUS_PROXY=""
+CHUTES_PROXY=""
 AGNES_PROXY=""
 ZENMUX_PROXY=""
 AZURE_OPENAI_PROXY=""

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ fcc-codex exec "hello"
 | [DeepInfra](https://deepinfra.com/dash/api_keys) | `DEEPINFRA_API_KEY` | `deepinfra/deepseek-ai/DeepSeek-V4-Flash` |
 | [SiliconFlow](https://cloud.siliconflow.com/account/ak) | `SILICONFLOW_API_KEY` | `siliconflow/Qwen/Qwen3-32B` |
 | [Nebius Token Factory](https://tokenfactory.nebius.com/project/api-keys) | `NEBIUS_API_KEY` | `nebius/Qwen/Qwen3-30B-A3B` |
+| [Chutes](https://chutes.ai/docs/getting-started/authentication) | `CHUTES_API_KEY` | `chutes/Qwen/Qwen3-32B-TEE` |
 | [Agnes AI](https://agnes-ai.com/) | `AGNES_API_KEY` | `agnes/agnes-2.0-flash` |
 | [ZenMux](https://zenmux.ai/platform/pay-as-you-go) | `ZENMUX_API_KEY` | `zenmux/deepseek/deepseek-v4-flash-free` |
 | [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.28.0"
+version = "4.29.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -76,6 +76,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "deepinfra": "deepinfra/deepseek-ai/DeepSeek-V4-Flash",
     "siliconflow": "siliconflow/Qwen/Qwen3-32B",
     "nebius": "nebius/Qwen/Qwen3-30B-A3B",
+    "chutes": "chutes/Qwen/Qwen3-32B-TEE",
     "sambanova": "sambanova/Meta-Llama-3.3-70B-Instruct",
     "kilo": "kilo/kilo-auto/free",
     "cerebras": "cerebras/llama3.1-8b",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -179,6 +179,13 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "and tool-capable models."
         ),
     },
+    "CHUTES_API_KEY": {
+        "label": "Chutes API Key",
+        "description": (
+            "Chutes API key for OpenAI-compatible chat, reasoning, and "
+            "tool-capable models."
+        ),
+    },
     "SAMBANOVA_API_KEY": {
         "label": "SambaNova API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -64,6 +64,8 @@ DEEPINFRA_DEFAULT_BASE = "https://api.deepinfra.com/v1/openai"
 SILICONFLOW_DEFAULT_BASE = "https://api.siliconflow.com/v1"
 # Nebius Token Factory OpenAI-compatible Chat Completions API.
 NEBIUS_DEFAULT_BASE = "https://api.tokenfactory.nebius.com/v1"
+# Chutes OpenAI-compatible Chat Completions API.
+CHUTES_DEFAULT_BASE = "https://llm.chutes.ai/v1"
 # TokenRouter OpenAI-compatible Chat Completions gateway.
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 # NaraRoute OpenAI-compatible Chat Completions gateway.
@@ -197,6 +199,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="nebius_api_key",
         default_base_url=NEBIUS_DEFAULT_BASE,
         proxy_attr="nebius_proxy",
+    ),
+    "chutes": ProviderDescriptor(
+        provider_id="chutes",
+        display_name="Chutes",
+        credential_env="CHUTES_API_KEY",
+        credential_url="https://chutes.ai/docs/getting-started/authentication",
+        credential_attr="chutes_api_key",
+        default_base_url=CHUTES_DEFAULT_BASE,
+        proxy_attr="chutes_proxy",
     ),
     "agnes": ProviderDescriptor(
         provider_id="agnes",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -149,6 +149,9 @@ class Settings(BaseSettings):
     # ==================== Nebius Token Factory (OpenAI-compatible) ====================
     nebius_api_key: str = Field(default="", validation_alias="NEBIUS_API_KEY")
 
+    # ==================== Chutes (OpenAI-compatible) ====================
+    chutes_api_key: str = Field(default="", validation_alias="CHUTES_API_KEY")
+
     # ==================== Agnes AI (OpenAI-compatible) ====================
     agnes_api_key: str = Field(default="", validation_alias="AGNES_API_KEY")
 
@@ -214,6 +217,7 @@ class Settings(BaseSettings):
     deepinfra_proxy: str = Field(default="", validation_alias="DEEPINFRA_PROXY")
     siliconflow_proxy: str = Field(default="", validation_alias="SILICONFLOW_PROXY")
     nebius_proxy: str = Field(default="", validation_alias="NEBIUS_PROXY")
+    chutes_proxy: str = Field(default="", validation_alias="CHUTES_PROXY")
     agnes_proxy: str = Field(default="", validation_alias="AGNES_PROXY")
     zenmux_proxy: str = Field(default="", validation_alias="ZENMUX_PROXY")
     azure_openai_proxy: str = Field(default="", validation_alias="AZURE_OPENAI_PROXY")

--- a/src/free_claude_code/providers/model_listing.py
+++ b/src/free_claude_code/providers/model_listing.py
@@ -42,6 +42,7 @@ def extract_openai_model_infos(
     required_path_values: RequiredPathValues = (),
     required_null_field: str | None = None,
     required_sequence_items: tuple[tuple[str, str], ...] = (),
+    exclude_missing_sequence_fields: bool = False,
     tags_field: str | None = None,
     thinking_tag: str = "reasoning",
     non_thinking_tag: str | None = None,
@@ -91,8 +92,12 @@ def extract_openai_model_infos(
             if _field(item, required_null_field) is not None:
                 included = False
 
+        missing_sequence_field = False
         for field_name, required_item in required_sequence_items:
             values = _field(item, field_name)
+            if values is None and exclude_missing_sequence_fields:
+                missing_sequence_field = True
+                break
             if not _is_sequence(values) or any(
                 not isinstance(value, str) or not value.strip() for value in values
             ):
@@ -103,6 +108,9 @@ def extract_openai_model_infos(
                 )
             if required_item not in values:
                 included = False
+
+        if missing_sequence_field:
+            continue
 
         supports_thinking: bool | None = None
         if tags_field is not None:

--- a/src/free_claude_code/providers/model_listing.py
+++ b/src/free_claude_code/providers/model_listing.py
@@ -97,7 +97,7 @@ def extract_openai_model_infos(
             values = _field(item, field_name)
             if values is None and exclude_missing_sequence_fields:
                 missing_sequence_field = True
-                break
+                continue
             if not _is_sequence(values) or any(
                 not isinstance(value, str) or not value.strip() for value in values
             ):

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -77,6 +77,7 @@ class OpenAIModelListing:
     required_path_values: RequiredPathValues = ()
     required_null_field: str | None = None
     required_sequence_items: tuple[tuple[str, str], ...] = ()
+    exclude_missing_sequence_fields: bool = False
     tags_field: str | None = None
     thinking_tag: str = "reasoning"
     non_thinking_tag: str | None = None
@@ -268,6 +269,24 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             path="/models",
             query_params=(("verbose", "true"),),
             required_path_values=((("architecture", "modality"), ("text->text",)),),
+        ),
+    ),
+    "chutes": OpenAIChatProfile(
+        _policy(
+            "CHUTES",
+            ReasoningReplayMode.DISABLED,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NO_REASONING,
+        model_listing=OpenAIModelListing(
+            path="/models",
+            required_sequence_items=(
+                ("input_modalities", "text"),
+                ("output_modalities", "text"),
+                ("supported_features", "tools"),
+            ),
+            exclude_missing_sequence_fields=True,
+            tags_field="supported_features",
         ),
     ),
     "agnes": OpenAIChatProfile(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -153,6 +153,7 @@ class OpenAIChatProvider(BaseProvider):
             required_path_values=listing.required_path_values,
             required_null_field=listing.required_null_field,
             required_sequence_items=listing.required_sequence_items,
+            exclude_missing_sequence_fields=listing.exclude_missing_sequence_fields,
             tags_field=listing.tags_field,
             thinking_tag=listing.thinking_tag,
             non_thinking_tag=listing.non_thinking_tag,

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -16,6 +16,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "deepinfra",
     "siliconflow",
     "nebius",
+    "chutes",
     "agnes",
     "zenmux",
     "azure_openai",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -59,6 +59,7 @@ def _settings(**overrides):
         "deepinfra_api_key": "",
         "siliconflow_api_key": "",
         "nebius_api_key": "",
+        "chutes_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
         "ollama_api_key": "",
@@ -256,6 +257,23 @@ def test_nebius_provider_smoke_uses_documented_agent_model(monkeypatch) -> None:
 
     assert [model.provider for model in models] == ["nebius"]
     assert models[0].full_model == "nebius/Qwen/Qwen3-30B-A3B"
+    assert models[0].source == "provider_default"
+
+
+def test_chutes_provider_smoke_uses_documented_agent_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_CHUTES", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            chutes_api_key="chutes-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["chutes"]
+    assert models[0].full_model == "chutes/Qwen/Qwen3-32B-TEE"
     assert models[0].source == "provider_default"
 
 

--- a/tests/providers/test_chutes.py
+++ b/tests/providers/test_chutes.py
@@ -191,6 +191,35 @@ async def test_rejects_malformed_or_unusable_catalog_atomically(
         await chutes_provider.list_model_infos()
 
 
+@pytest.mark.parametrize(
+    "supported_features",
+    [("tools", 7), "tools"],
+)
+@pytest.mark.asyncio
+async def test_incomplete_record_cannot_bypass_later_metadata_validation(
+    chutes_provider: OpenAIChatProvider,
+    supported_features: object,
+) -> None:
+    chutes_provider._client.get = AsyncMock(
+        return_value={
+            "data": [
+                _catalog_model(),
+                {
+                    "id": "incomplete-malformed-model",
+                    "output_modalities": ["text"],
+                    "supported_features": supported_features,
+                },
+            ]
+        }
+    )
+
+    with pytest.raises(
+        ModelListResponseError,
+        match="supported_features string array",
+    ):
+        await chutes_provider.list_model_infos()
+
+
 @pytest.mark.asyncio
 async def test_model_catalog_uses_documented_url_and_bearer_auth(
     chutes_provider: OpenAIChatProvider,

--- a/tests/providers/test_chutes.py
+++ b/tests/providers/test_chutes.py
@@ -1,0 +1,219 @@
+"""Tests for the Chutes OpenAI-chat profile and semantic model catalog."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import CHUTES_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    profiled_provider,
+    reasoning_for,
+)
+
+_MODEL = "Qwen/Qwen3-32B-TEE"
+
+
+@pytest.fixture
+def chutes_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "chutes",
+        ProviderConfig(
+            api_key="test-chutes-key",
+            base_url=CHUTES_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="chutes"),
+    )
+
+
+def _catalog_model(
+    model_id: str = _MODEL,
+    *,
+    input_modalities: object = ("text",),
+    output_modalities: object = ("text",),
+    supported_features: object = ("tools", "reasoning"),
+) -> dict[str, object]:
+    return {
+        "id": model_id,
+        "input_modalities": input_modalities,
+        "output_modalities": output_modalities,
+        "supported_features": supported_features,
+    }
+
+
+@pytest.mark.parametrize("reasoning", [REASONING_OFF, REASONING_ON])
+def test_preserves_upstream_reasoning_default(
+    chutes_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": _MODEL,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+    )
+
+    body = chutes_provider._build_request_body(request, reasoning=reasoning)
+
+    assert "reasoning_effort" not in body
+    assert "reasoning" not in body
+    assert "extra_body" not in body
+
+
+def test_does_not_replay_reasoning_but_preserves_tool_history(
+    chutes_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": _MODEL,
+            "messages": [
+                {"role": "user", "content": "Inspect the file."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Read it first."},
+                        {"type": "text", "text": "I will inspect it."},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "read_file",
+                            "input": {"path": "example.py"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": "print('hello')",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    body = chutes_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assistant = body["messages"][1]
+    assert assistant["content"] == "I will inspect it."
+    assert assistant["tool_calls"][0]["id"] == "toolu_1"
+    assert "reasoning_content" not in assistant
+    assert "reasoning" not in assistant
+    assert body["messages"][2] == {
+        "role": "tool",
+        "tool_call_id": "toolu_1",
+        "content": "print('hello')",
+    }
+
+
+@pytest.mark.asyncio
+async def test_lists_only_semantically_agent_capable_models(
+    chutes_provider: OpenAIChatProvider,
+) -> None:
+    chutes_provider._client.get = AsyncMock(
+        return_value={
+            "data": [
+                _catalog_model(),
+                _catalog_model(
+                    "plain-agent",
+                    supported_features=("tools",),
+                ),
+                _catalog_model(
+                    "image-generator",
+                    output_modalities=("image",),
+                ),
+                _catalog_model(
+                    "chat-without-tools",
+                    supported_features=("reasoning",),
+                ),
+                {"id": "legacy-without-capability-metadata"},
+            ]
+        }
+    )
+
+    model_infos = await chutes_provider.list_model_infos()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo(_MODEL, supports_thinking=True),
+            ProviderModelInfo("plain-agent"),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("item", "message"),
+    [
+        (_catalog_model(input_modalities="text"), "input_modalities string array"),
+        (
+            _catalog_model(output_modalities=("text", 7)),
+            "output_modalities string array",
+        ),
+        (
+            _catalog_model(supported_features=("tools", "")),
+            "supported_features string array",
+        ),
+        (_catalog_model(""), "include id"),
+        ({"id": "legacy-without-capability-metadata"}, "did not include any model ids"),
+        (
+            _catalog_model("image-only", output_modalities=("image",)),
+            "did not include any model ids",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rejects_malformed_or_unusable_catalog_atomically(
+    chutes_provider: OpenAIChatProvider,
+    item: dict[str, object],
+    message: str,
+) -> None:
+    chutes_provider._client.get = AsyncMock(return_value={"data": [item]})
+
+    with pytest.raises(ModelListResponseError, match=message):
+        await chutes_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_documented_url_and_bearer_auth(
+    chutes_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"data": [_catalog_model()]})
+
+    await chutes_provider._client.close()
+    chutes_provider._client = AsyncOpenAI(
+        api_key="wire-chutes-key",
+        base_url=CHUTES_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        model_infos = await chutes_provider.list_model_infos()
+    finally:
+        await chutes_provider.cleanup()
+
+    assert model_infos == frozenset({ProviderModelInfo(_MODEL, supports_thinking=True)})
+    assert len(requests) == 1
+    assert str(requests[0].url) == "https://llm.chutes.ai/v1/models"
+    assert requests[0].headers["authorization"] == "Bearer wire-chutes-key"

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -13,6 +13,7 @@ from free_claude_code.config.nim import NimSettings
 from free_claude_code.config.provider_catalog import (
     AGNES_DEFAULT_BASE,
     BEDROCK_DEFAULT_BASE,
+    CHUTES_DEFAULT_BASE,
     COHERE_DEFAULT_BASE,
     DEEPINFRA_DEFAULT_BASE,
     GITHUB_MODELS_DEFAULT_BASE,
@@ -74,6 +75,7 @@ def _make_settings(**overrides):
     mock.deepinfra_api_key = "test_deepinfra_key"
     mock.siliconflow_api_key = "test_siliconflow_key"
     mock.nebius_api_key = "test_nebius_key"
+    mock.chutes_api_key = "test_chutes_key"
     mock.mistral_api_key = "test_mistral_key"
     mock.codestral_api_key = "test_codestral_key"
     mock.deepseek_api_key = "test_deepseek_key"
@@ -147,6 +149,7 @@ def _make_settings(**overrides):
     mock.deepinfra_proxy = ""
     mock.siliconflow_proxy = ""
     mock.nebius_proxy = ""
+    mock.chutes_proxy = ""
     mock.azure_openai_proxy = ""
     mock.provider_rate_limit = 40
     mock.provider_rate_window = 60
@@ -331,6 +334,29 @@ def test_nebius_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.base_url_attr is None
     assert config.api_key == "nebius-token"
     assert config.base_url == NEBIUS_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_chutes_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["chutes"]
+    settings = _make_settings(
+        chutes_api_key="chutes-token",
+        chutes_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("chutes", settings)
+
+    assert descriptor.display_name == "Chutes"
+    assert descriptor.credential_env == "CHUTES_API_KEY"
+    assert descriptor.credential_url == (
+        "https://chutes.ai/docs/getting-started/authentication"
+    )
+    assert descriptor.base_url_attr is None
+    assert config.api_key == "chutes-token"
+    assert config.base_url == CHUTES_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -672,6 +698,7 @@ def test_create_provider_instantiates_each_builtin():
         "deepinfra": OpenAIChatProvider,
         "siliconflow": OpenAIChatProvider,
         "nebius": OpenAIChatProvider,
+        "chutes": OpenAIChatProvider,
         "azure_openai": OpenAIChatProvider,
         "open_router": OpenRouterProvider,
         "mistral": MistralProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.28.0"
+version = "4.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Chutes is not available as an FCC provider even though it exposes an OpenAI-compatible chat API and a public capability-aware model catalog. Advertising every catalog ID would expose models that have not proven text output and tool support, while requiring capability arrays on every record would currently break discovery because two legacy catalog entries omit those arrays.

| Before | After |
| --- | --- |
| Chutes credentials and models cannot be used through FCC. | `chutes/<model-id>` uses the shared OpenAI Chat transport and advertises only catalog records that prove text input, text output, and tool support. |

## Changes

- Register `CHUTES_API_KEY`, `CHUTES_PROXY`, the documented `https://llm.chutes.ai/v1` endpoint, Admin UI metadata, README usage, and `Qwen/Qwen3-32B-TEE` as the live-smoke default.
- Add a declarative Chutes profile with provider-owned reasoning defaults: FCC sends no undocumented control, does not replay prior reasoning, and retains the shared current-output parser.
- Add an opt-in catalog rule that excludes records with missing capability arrays while preserving atomic failure for present malformed metadata; all existing providers retain their strict default.
- Cover capability filtering, reasoning/tool history conversion, bearer-auth model discovery, runtime construction, provider ordering, Admin metadata, and smoke selection. The live public catalog probe selected 11 agent-capable records and included the smoke model.
- Bump the release once from `4.28.0` to `4.29.0` and refresh `uv.lock`. Ruff, ty, 147 focused tests, smoke collection, and 3,062 full-suite tests pass locally; the two pre-existing Windows shortcut COM-isolation cases remain environment-dependent. An authenticated Chutes completion/tool smoke remains a pre-merge gate because this checkout has no Chutes credential.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Chutes as a configurable OpenAI-compatible provider with catalog discovery, capability filtering, tool-call support, documentation, and smoke configuration. The previously reported metadata-validation bypass was disproved: incomplete records still validate later present capability fields before exclusion. Focused checks also confirmed that configured Chutes requests use the expected endpoint and Bearer authentication while retaining compatible tool-capable text models.
</details>

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The Chutes provider configuration, catalog filtering, authentication contract, tool-request construction, and capability-metadata handling were exercised successfully.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran focused model-list validation against extract\_openai\_model\_infos with missing input modalities and malformed supported\_features; both cases raised a ModelListResponseError, and the focused regression test passed.
- Validated Chutes provider construction with and without CHUTES\_API\_KEY using a deterministic mock transport; without a key a configuration error occurred, and with a configured key the catalog request included Bearer authentication, retained Qwen/Qwen3-32B-TEE, excluded unsupported models, and produced a valid OpenAI tool request.
- Reviewed the sequence-validation path that detects a missing optional sequence field but then validates later fields before excluding the incomplete record; the deterministic validation source and test outputs showed the malformed later values were rejected and the regression test passed.
- Confirmed provider behavior with and without CHUTES\_API\_KEY; without a key, construction failed with a user-facing error, and with a key and mock transport the catalog fetch occurred with Authorization Bearer, Qwen remained listed, and tool conversion succeeded.

<a href="https://app.greptile.com/trex/runs/18649630/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fadd-chutes-provider%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fadd-chutes-provider%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231402%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=alishahryar1%2Ffree-claude-code&pr=1402&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["Validate incomplete model metadata atomi..."](https://github.com/alishahryar1/free-claude-code/commit/e1da08e37d8b2d08cac0331129fcf553fbf76989) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52859888)</sub>

<!-- /greptile_comment -->