### PR TITLE
Repair stale Admin defaults without masking locked config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "4.30.1"
+version = "4.30.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/admin/persistence.py
+++ b/src/free_claude_code/config/admin/persistence.py
@@ -85,7 +85,7 @@ def target_values_with_updates(updates: Mapping[str, Any]) -> dict[str, str]:
 
     for field in FIELDS:
         values.setdefault(field.key, field.default)
-        if values[field.key] == "" and field.default:
+        if field.field_type == "select" and values[field.key] == "" and field.default:
             values[field.key] = field.default
     return values
 

--- a/src/free_claude_code/config/admin/persistence.py
+++ b/src/free_claude_code/config/admin/persistence.py
@@ -85,6 +85,8 @@ def target_values_with_updates(updates: Mapping[str, Any]) -> dict[str, str]:
 
     for field in FIELDS:
         values.setdefault(field.key, field.default)
+        if values[field.key] == "" and field.default:
+            values[field.key] = field.default
     return values
 
 

--- a/src/free_claude_code/config/admin/persistence.py
+++ b/src/free_claude_code/config/admin/persistence.py
@@ -56,7 +56,7 @@ class PreparedAdminUpdate:
 
 
 def target_values_with_updates(updates: Mapping[str, Any]) -> dict[str, str]:
-    """Return managed env values after applying admin updates."""
+    """Return a managed target after repairing stored state and applying updates."""
 
     state = load_value_state()
     values = template_values()
@@ -73,6 +73,13 @@ def target_values_with_updates(updates: Mapping[str, Any]) -> dict[str, str]:
             if entry["source"] in {"repo_env", "template", "default"}:
                 values[key] = str(entry["value"])
 
+    # Repair stale editable state before applying the explicit request. Empty
+    # select updates then remain intact for normal Settings validation to reject.
+    for field in FIELDS:
+        values.setdefault(field.key, field.default)
+        if field.field_type == "select" and values[field.key] == "" and field.default:
+            values[field.key] = field.default
+
     for key, value in updates.items():
         field = FIELD_BY_KEY.get(key)
         if field is None:
@@ -83,10 +90,6 @@ def target_values_with_updates(updates: Mapping[str, Any]) -> dict[str, str]:
             continue
         values[key] = normalize_for_env(value)
 
-    for field in FIELDS:
-        values.setdefault(field.key, field.default)
-        if field.field_type == "select" and values[field.key] == "" and field.default:
-            values[field.key] = field.default
     return values
 
 

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1195,6 +1195,58 @@ def test_admin_first_apply_migrates_repo_env(monkeypatch, tmp_path):
     assert "DEEPSEEK_API_KEY=deepseek-secret" in managed_text
 
 
+def test_admin_first_apply_repairs_empty_defaulted_repo_values(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+    (tmp_path / ".env").write_text(
+        "MESSAGING_PLATFORM=\nWHISPER_DEVICE=\n",
+        encoding="utf-8",
+    )
+
+    response = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"NVIDIA_NIM_API_KEY": "nim-secret"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["applied"] is True
+    managed_text = (tmp_path / ".fcc" / ".env").read_text("utf-8")
+    assert "NVIDIA_NIM_API_KEY=nim-secret" in managed_text
+    assert "MESSAGING_PLATFORM=discord" in managed_text
+    assert "WHISPER_DEVICE=nvidia_nim" in managed_text
+
+
+@pytest.mark.parametrize("source", ("process", "explicit_env_file"))
+def test_admin_apply_rejects_empty_locked_defaulted_value(
+    monkeypatch,
+    tmp_path,
+    source,
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+    if source == "process":
+        monkeypatch.setenv("MESSAGING_PLATFORM", "")
+    else:
+        env_file = tmp_path / "locked.env"
+        env_file.write_text("MESSAGING_PLATFORM=\n", encoding="utf-8")
+        monkeypatch.setenv("FCC_ENV_FILE", str(env_file))
+
+    response = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"NVIDIA_NIM_API_KEY": "nim-secret"}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied"] is False
+    assert any(
+        "messaging_platform" in error and "got ''" in error for error in body["errors"]
+    )
+    assert not (tmp_path / ".fcc" / ".env").exists()
+
+
 def test_admin_local_provider_status_reports_reachable(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1195,7 +1195,7 @@ def test_admin_first_apply_migrates_repo_env(monkeypatch, tmp_path):
     assert "DEEPSEEK_API_KEY=deepseek-secret" in managed_text
 
 
-def test_admin_first_apply_repairs_empty_defaulted_repo_values(monkeypatch, tmp_path):
+def test_admin_first_apply_repairs_empty_select_repo_values(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)
     app = create_test_app()
@@ -1217,8 +1217,31 @@ def test_admin_first_apply_repairs_empty_defaulted_repo_values(monkeypatch, tmp_
     assert "WHISPER_DEVICE=nvidia_nim" in managed_text
 
 
+def test_admin_apply_preserves_empty_managed_auth_token(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    env_file = tmp_path / ".fcc" / ".env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text(
+        "ANTHROPIC_AUTH_TOKEN=\nPROVIDER_RATE_LIMIT=1\n",
+        encoding="utf-8",
+    )
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"PROVIDER_RATE_LIMIT": "2"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["applied"] is True
+    managed_lines = env_file.read_text("utf-8").splitlines()
+    assert "ANTHROPIC_AUTH_TOKEN=" in managed_lines
+    assert "PROVIDER_RATE_LIMIT=2" in managed_lines
+
+
 @pytest.mark.parametrize("source", ("process", "explicit_env_file"))
-def test_admin_apply_rejects_empty_locked_defaulted_value(
+def test_admin_apply_rejects_empty_locked_select_value(
     monkeypatch,
     tmp_path,
     source,

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1240,6 +1240,30 @@ def test_admin_apply_preserves_empty_managed_auth_token(monkeypatch, tmp_path):
     assert "PROVIDER_RATE_LIMIT=2" in managed_lines
 
 
+def test_admin_apply_rejects_explicit_empty_select_update(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    env_file = tmp_path / ".fcc" / ".env"
+    env_file.parent.mkdir(parents=True)
+    original = "ANTHROPIC_AUTH_TOKEN=\nMESSAGING_PLATFORM=none\n"
+    env_file.write_text(original, encoding="utf-8")
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"MESSAGING_PLATFORM": ""}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied"] is False
+    assert body["valid"] is False
+    assert any(
+        "messaging_platform" in error and "got ''" in error for error in body["errors"]
+    )
+    assert env_file.read_text("utf-8") == original
+
+
 @pytest.mark.parametrize("source", ("process", "explicit_env_file"))
 def test_admin_apply_rejects_empty_locked_select_value(
     monkeypatch,

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1144,8 +1144,12 @@ def _create_windows_shortcut(
     )
 
 
-def _windows_shortcut_icon(powershell: str, shortcut_path: Path) -> str:
-    env = os.environ | {"FCC_TEST_SHORTCUT": str(shortcut_path)}
+def _windows_shortcut_icon(
+    powershell: str,
+    shortcut_path: Path,
+    env: dict[str, str],
+) -> str:
+    process_env = env | {"FCC_TEST_SHORTCUT": str(shortcut_path)}
     completed = subprocess.run(
         [
             powershell,
@@ -1160,7 +1164,7 @@ def _windows_shortcut_icon(powershell: str, shortcut_path: Path) -> str:
         check=True,
         capture_output=True,
         text=True,
-        env=env,
+        env=process_env,
     )
     return completed.stdout
 
@@ -1521,6 +1525,7 @@ def test_install_ps1_fresh_install_is_verified(
         _windows_shortcut_icon(
             powershell_harness.powershell,
             desktop_shortcut,
+            powershell_harness.env,
         )
         == f"{icon},0"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "4.30.1"
+version = "4.30.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Stale empty select values in editable dotenv files can block unrelated Admin changes. Explicit empty selections must still fail instead of silently changing to a default. Windows shortcut verification also expands `%USERPROFILE%` through the developer environment instead of the isolated test harness.

## Changes

| Before | After |
| --- | --- |
| Loaded empty editable select values reached managed-target validation unchanged. | Loaded empty editable select values use their declared defaults before request updates are applied. |
| Explicit empty select updates were repaired alongside stored state. | Explicit empty select updates remain intact and fail normal settings validation. |
| Broad empty-value normalization could replace an intentional empty secret. | Empty secrets and other non-select values remain explicit, including no-auth configuration. |
| Shortcut verification launched its COM reader with the host environment. | Shortcut verification carries the harness environment into the COM reader. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Admin configuration update flow now preserves an explicitly empty proxy-auth token, repairs legacy empty select values during unrelated saves, and rejects explicitly empty select submissions. The two previously reported Admin configuration regressions were disproved by exercising the real apply route: an empty `ANTHROPIC_AUTH_TOKEN` remains empty after an unrelated save, and an empty `MESSAGING_PLATFORM` request is rejected rather than defaulted.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the affected Admin configuration flows preserve intentional authentication settings and reject invalid explicit selections.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated harness to exercise the real local FastAPI Admin apply route with temporary managed dotenv files.
- Observed that saving an unrelated PROVIDER\_RATE\_LIMIT value preserved ANTHROPIC\_AUTH\_TOKEN and submitting MESSAGING\_PLATFORM="" produced an unapplied invalid response; an unrelated update repaired legacy empty MESSAGING\_PLATFORM and WHISPER\_DEVICE values.
- Applied an unrelated update that repaired legacy empty MESSAGING\_PLATFORM and WHISPER\_DEVICE values, aligning the route for subsequent updates.
- Executed focused Admin config pytest checks, including locked-source handling, and confirmed the tests pass, validating the route behavior against configuration rules.
- Reviewed persistence and validation code paths that implement the observed behavior (prepare\_admin\_update, settings\_from\_values, and the admin route), tying the tests to the code locations.

<a href="https://app.greptile.com/trex/runs/18827242/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Separate stored repair from admin update..."](https://github.com/alishahryar1/free-claude-code/commit/ce68aeb47f5cb97c22823a9e443fdd02f5721e92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53202613)</sub>

<!-- /greptile_comment -->