### PR TITLE
Add W&B Inference provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,10 @@ VERTEX_LOCATION="global"
 # ZENMUX_API_KEY=<your-token>
 
 
+# W&B Inference (OpenAI-compatible Chat Completions at api.inference.wandb.ai/v1)
+# WANDB_API_KEY=<your-token>
+
+
 # SambaNova Cloud (OpenAI-compatible Chat Completions at api.sambanova.ai/v1)
 # SAMBANOVA_API_KEY=<your-token>
 
@@ -174,7 +178,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -225,6 +229,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # FCC_SMOKE_MODEL_FEATHERLESS=<provider/model-id>
 # FCC_SMOKE_MODEL_AGNES=<provider/model-id>
 # FCC_SMOKE_MODEL_ZENMUX=<provider/model-id>
+# FCC_SMOKE_MODEL_WANDB=<provider/model-id>
 # FCC_SMOKE_MODEL_SAMBANOVA=<provider/model-id>
 # FCC_SMOKE_MODEL_KILO=<provider/model-id>
 # FCC_SMOKE_MODEL_CEREBRAS=<provider/model-id>
@@ -258,6 +263,7 @@ REASONING_HAIKU=inherit
 # FEATHERLESS_PROXY=<http-or-socks-url>
 # AGNES_PROXY=<http-or-socks-url>
 # ZENMUX_PROXY=<http-or-socks-url>
+# WANDB_PROXY=<http-or-socks-url>
 # AZURE_OPENAI_PROXY=<http-or-socks-url>
 # NVIDIA_NIM_PROXY=<http-or-socks-url>
 # OPENROUTER_PROXY=<http-or-socks-url>

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ fcc-codex exec "hello"
 | [Featherless AI](https://featherless.ai/account/api-keys) | `FEATHERLESS_API_KEY` | `featherless/Qwen/Qwen3-32B` |
 | [Agnes AI](https://agnes-ai.com/) | `AGNES_API_KEY` | `agnes/agnes-2.0-flash` |
 | [ZenMux](https://zenmux.ai/platform/pay-as-you-go) | `ZENMUX_API_KEY` | `zenmux/deepseek/deepseek-v4-flash-free` |
+| [W&B Inference](https://wandb.ai/settings) | `WANDB_API_KEY` | `wandb/openai/gpt-oss-20b` |
 | [Azure OpenAI](https://learn.microsoft.com/azure/foundry/openai/how-to/chatgpt) | `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_BASE_URL` | `azure_openai/<deployment-name>` |
 | [Google AI Studio (Gemini)](https://aistudio.google.com/apikey) | `GEMINI_API_KEY` | `gemini/models/gemini-3.1-flash-lite` |
 | [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/start/openai) | `VERTEX_PROJECT_ID` + ADC | `vertex/google/gemini-3.5-flash` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.0.0"
+version = "5.1.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -88,6 +88,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "nararoute": "nararoute/kimi-k3-free",
     "agnes": "agnes/agnes-2.0-flash",
     "zenmux": "zenmux/deepseek/deepseek-v4-flash-free",
+    "wandb": "wandb/openai/gpt-oss-20b",
 }
 MISTRAL_REASONING_SMOKE_DEFAULT_MODEL = "mistral/mistral-medium-3-5"
 

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -251,6 +251,13 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "Create one at zenmux.ai/platform/pay-as-you-go."
         ),
     },
+    "WANDB_API_KEY": {
+        "label": "W&B Inference API Key",
+        "description": (
+            "W&B API key for Serverless Inference at api.inference.wandb.ai/v1. "
+            "Create one in [W&B User Settings](https://wandb.ai/settings)."
+        ),
+    },
 }
 
 

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -76,6 +76,8 @@ NARAROUTE_DEFAULT_BASE = "https://router.bynara.id/v1"
 AGNES_DEFAULT_BASE = "https://apihub.agnes-ai.com/v1"
 # ZenMux OpenAI-compatible Chat Completions gateway.
 ZENMUX_DEFAULT_BASE = "https://zenmux.ai/api/v1"
+# W&B Serverless Inference OpenAI-compatible API.
+WANDB_INFERENCE_DEFAULT_BASE = "https://api.inference.wandb.ai/v1"
 
 
 class ProviderAuthKind(StrEnum):
@@ -237,6 +239,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="zenmux_api_key",
         default_base_url=ZENMUX_DEFAULT_BASE,
         proxy_attr="zenmux_proxy",
+    ),
+    "wandb": ProviderDescriptor(
+        provider_id="wandb",
+        display_name="W&B Inference",
+        credential_env="WANDB_API_KEY",
+        credential_url="https://wandb.ai/settings",
+        credential_attr="wandb_api_key",
+        default_base_url=WANDB_INFERENCE_DEFAULT_BASE,
+        proxy_attr="wandb_proxy",
     ),
     "azure_openai": ProviderDescriptor(
         provider_id="azure_openai",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -250,6 +250,11 @@ class Settings(BaseModel):
         default=None, validation_alias="ZENMUX_API_KEY"
     )
 
+    # ==================== W&B Inference (OpenAI-compatible) ====================
+    wandb_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="WANDB_API_KEY"
+    )
+
     # ==================== Cerebras Inference (OpenAI-compatible) ====================
     cerebras_api_key: OptionalNonEmptyString = Field(
         default=None, validation_alias="CEREBRAS_API_KEY"
@@ -352,6 +357,9 @@ class Settings(BaseModel):
     )
     zenmux_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="ZENMUX_PROXY"
+    )
+    wandb_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="WANDB_PROXY"
     )
     azure_openai_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="AZURE_OPENAI_PROXY"

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -33,6 +33,9 @@ _AUTHENTICATION_MESSAGE = "Provider authentication failed. Check API key."
 _PERMISSION_MESSAGE = (
     "Provider denied access. Check credential permissions and model access."
 )
+_BILLING_MESSAGE = (
+    "Provider requires payment or additional credits. Add credits or resolve billing."
+)
 _RATE_LIMIT_MESSAGE = "Provider rate limit reached. Please retry shortly."
 _INVALID_REQUEST_MESSAGE = "Invalid request sent to provider."
 _CONTEXT_WINDOW_EXCEEDED_MESSAGE = "Provider input exceeds the model context window."
@@ -276,7 +279,7 @@ def _classify_provider_failure(
                 FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
             )
         if effective_status == 402:
-            return _failure(FailureKind.PERMISSION, 402, _PERMISSION_MESSAGE, False)
+            return _failure(FailureKind.PERMISSION, 402, _BILLING_MESSAGE, False)
         if effective_status == 403:
             return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
         return _failure(
@@ -293,7 +296,7 @@ def _classify_provider_failure(
                 FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
             )
         if status == 402:
-            return _failure(FailureKind.PERMISSION, 402, _PERMISSION_MESSAGE, False)
+            return _failure(FailureKind.PERMISSION, 402, _BILLING_MESSAGE, False)
         if status == 403:
             return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
         if status == 429:

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -275,6 +275,8 @@ def _classify_provider_failure(
             return _failure(
                 FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
             )
+        if effective_status == 402:
+            return _failure(FailureKind.PERMISSION, 402, _PERMISSION_MESSAGE, False)
         if effective_status == 403:
             return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
         return _failure(
@@ -290,6 +292,8 @@ def _classify_provider_failure(
             return _failure(
                 FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
             )
+        if status == 402:
+            return _failure(FailureKind.PERMISSION, 402, _PERMISSION_MESSAGE, False)
         if status == 403:
             return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
         if status == 429:

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -358,6 +358,18 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         reasoning_delta_fallback_field="reasoning_content",
         structured_reasoning_details=True,
     ),
+    "wandb": OpenAIChatProfile(
+        _policy(
+            "WANDB",
+            ReasoningReplayMode.DISABLED,
+            include_extra_body=True,
+            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+            max_tokens_field="max_completion_tokens",
+        ),
+        ChatTemplateReasoning(field="enable_thinking"),
+        reasoning_delta_field="reasoning",
+    ),
     "azure_openai": OpenAIChatProfile(
         _policy(
             "AZURE_OPENAI",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -20,6 +20,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "featherless",
     "agnes",
     "zenmux",
+    "wandb",
     "azure_openai",
     "gemini",
     "vertex",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -61,6 +61,7 @@ def _settings(**overrides):
         "nebius_api_key": "",
         "chutes_api_key": "",
         "featherless_api_key": "",
+        "wandb_api_key": "",
         "sambanova_api_key": "",
         "cerebras_api_key": "",
         "ollama_api_key": "",
@@ -327,6 +328,40 @@ def test_zenmux_provider_smoke_uses_current_free_model(monkeypatch) -> None:
     assert [model.provider for model in models] == ["zenmux"]
     assert models[0].full_model == "zenmux/deepseek/deepseek-v4-flash-free"
     assert models[0].source == "provider_default"
+
+
+def test_wandb_provider_smoke_uses_documented_tool_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_WANDB", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            wandb_api_key="wandb-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["wandb"]
+    assert models[0].full_model == "wandb/openai/gpt-oss-20b"
+    assert models[0].source == "provider_default"
+
+
+def test_wandb_provider_smoke_honors_model_override(monkeypatch) -> None:
+    monkeypatch.setenv("FCC_SMOKE_MODEL_WANDB", "deepseek-ai/DeepSeek-V4-Flash")
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            wandb_api_key="wandb-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["wandb"]
+    assert models[0].full_model == "wandb/deepseek-ai/DeepSeek-V4-Flash"
+    assert models[0].source == "FCC_SMOKE_MODEL_WANDB"
 
 
 def test_connected_account_provider_smoke_requires_explicit_model(

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -98,6 +98,17 @@ _CASES = (
         False,
     ),
     _ClassificationCase(
+        "generic_openai_402",
+        lambda: _openai_status_error(
+            openai.APIStatusError,
+            status_code=402,
+            message="Inference credits exhausted",
+        ),
+        FailureKind.PERMISSION,
+        402,
+        False,
+    ),
+    _ClassificationCase(
         "generic_openai_403",
         lambda: _openai_status_error(
             openai.APIStatusError,
@@ -187,6 +198,13 @@ _CASES = (
         lambda: _http_status_error(401, "Unauthorized"),
         FailureKind.AUTHENTICATION,
         401,
+        False,
+    ),
+    _ClassificationCase(
+        "http_402_maps_billing_permission",
+        lambda: _http_status_error(402, "Inference credits exhausted"),
+        FailureKind.PERMISSION,
+        402,
         False,
     ),
     _ClassificationCase(

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -61,6 +61,7 @@ class _ClassificationCase:
     kind: FailureKind
     status_code: int
     retryable: bool
+    message: str | None = None
 
 
 _CASES = (
@@ -107,6 +108,7 @@ _CASES = (
         FailureKind.PERMISSION,
         402,
         False,
+        "Provider requires payment or additional credits. Add credits or resolve billing.",
     ),
     _ClassificationCase(
         "generic_openai_403",
@@ -206,6 +208,7 @@ _CASES = (
         FailureKind.PERMISSION,
         402,
         False,
+        "Provider requires payment or additional credits. Add credits or resolve billing.",
     ),
     _ClassificationCase(
         "http_403_maps_permission",
@@ -282,6 +285,8 @@ def test_raw_provider_failure_maps_to_canonical_failure(
     assert failure.message.strip()
     assert "Request ID: req_classification" in failure.message
     assert "SECRET" not in failure.message
+    if case.message is not None:
+        assert case.message in failure.message
 
 
 def test_classification_preserves_useful_body_while_redacting_credentials() -> None:

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -31,6 +31,7 @@ from free_claude_code.config.provider_catalog import (
     TOGETHER_DEFAULT_BASE,
     TOKENROUTER_DEFAULT_BASE,
     VERCEL_AI_GATEWAY_DEFAULT_BASE,
+    WANDB_INFERENCE_DEFAULT_BASE,
     XAI_DEFAULT_BASE,
     ZAI_DEFAULT_BASE,
     ZENMUX_DEFAULT_BASE,
@@ -97,6 +98,7 @@ def _make_settings(**overrides):
     mock.nararoute_base_url = NARAROUTE_DEFAULT_BASE
     mock.agnes_api_key = "test_agnes_key"
     mock.zenmux_api_key = "test_zenmux_key"
+    mock.wandb_api_key = "test_wandb_key"
     mock.lm_studio_base_url = "http://localhost:1234/v1"
     mock.llamacpp_base_url = "http://localhost:8080/v1"
     mock.ollama_base_url = "http://localhost:11434"
@@ -125,6 +127,7 @@ def _make_settings(**overrides):
     mock.nararoute_proxy = None
     mock.agnes_proxy = None
     mock.zenmux_proxy = None
+    mock.wandb_proxy = None
     mock.fireworks_proxy = None
     mock.fireworks_api_key = "test_fireworks_key"
     mock.novita_proxy = None
@@ -421,6 +424,27 @@ def test_zenmux_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.base_url_attr is None
     assert config.api_key == "zenmux-token"
     assert config.base_url == ZENMUX_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_wandb_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["wandb"]
+    settings = _make_settings(
+        wandb_api_key="wandb-token",
+        wandb_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("wandb", settings)
+
+    assert descriptor.display_name == "W&B Inference"
+    assert descriptor.credential_env == "WANDB_API_KEY"
+    assert descriptor.credential_url == "https://wandb.ai/settings"
+    assert descriptor.base_url_attr is None
+    assert config.api_key == "wandb-token"
+    assert config.base_url == WANDB_INFERENCE_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -752,6 +776,7 @@ def test_create_provider_instantiates_each_builtin():
         "nararoute": OpenAIChatProvider,
         "agnes": OpenAIChatProvider,
         "zenmux": OpenAIChatProvider,
+        "wandb": OpenAIChatProvider,
         "gemini": GeminiProvider,
         "vertex": VertexProvider,
         "groq": GroqProvider,

--- a/tests/providers/test_wandb.py
+++ b/tests/providers/test_wandb.py
@@ -1,0 +1,226 @@
+"""Tests for the W&B Inference OpenAI-chat provider profile."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import WANDB_INFERENCE_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    capture_openai_chat_wire_body,
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+@pytest.fixture
+def wandb_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "wandb",
+        make_provider_config(
+            api_key="test-wandb-key",
+            base_url=WANDB_INFERENCE_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="wandb"),
+    )
+
+
+def _request(**overrides: Any) -> MessagesRequest:
+    payload: dict[str, Any] = {
+        "model": "openai/gpt-oss-20b",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    payload.update(overrides)
+    return MessagesRequest.model_validate(payload)
+
+
+def test_init_uses_documented_endpoint(wandb_provider: OpenAIChatProvider) -> None:
+    assert wandb_provider._api_key == "test-wandb-key"
+    assert wandb_provider._base_url == WANDB_INFERENCE_DEFAULT_BASE
+    assert wandb_provider._provider_name == "WANDB"
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "enabled"),
+    [(REASONING_OFF, False), (REASONING_ON, True)],
+)
+def test_build_request_body_encodes_documented_thinking_control(
+    wandb_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+    enabled: bool,
+) -> None:
+    body = wandb_provider._build_request_body(_request(), reasoning=reasoning)
+
+    assert body["extra_body"] == {"chat_template_kwargs": {"enable_thinking": enabled}}
+
+
+def test_build_request_body_uses_provider_defaults_when_reasoning_is_inherited(
+    wandb_provider: OpenAIChatProvider,
+) -> None:
+    body = wandb_provider._build_request_body(
+        _request(),
+        reasoning=ReasoningPolicy.provider_default(),
+    )
+
+    assert "extra_body" not in body
+
+
+def test_build_request_body_drops_undocumented_reasoning_replay_but_keeps_tools(
+    wandb_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(
+        messages=[
+            {"role": "user", "content": "Inspect the file."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Read it first."},
+                    {"type": "text", "text": "I will inspect it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "read_file",
+                        "input": {"path": "example.py"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "print('hello')",
+                    }
+                ],
+            },
+        ]
+    )
+
+    body = wandb_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "I will inspect it.",
+        "tool_calls": [
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": '{"path": "example.py"}',
+                },
+            }
+        ],
+    }
+    assert body["messages"][2] == {
+        "role": "tool",
+        "tool_call_id": "toolu_1",
+        "content": "print('hello')",
+    }
+    assert (
+        wandb_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning="new thought")
+        )
+        == "new thought"
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["reasoning", "reasoning_effort", "thinking", "enable_thinking"],
+)
+def test_build_request_body_rejects_caller_reasoning_override(
+    wandb_provider: OpenAIChatProvider,
+    field: str,
+) -> None:
+    request = _request(extra_body={field: "caller-owned"})
+
+    with pytest.raises(InvalidRequestError, match="must not override reasoning"):
+        wandb_provider._build_request_body(request, reasoning=REASONING_ON)
+
+
+@pytest.mark.asyncio
+async def test_wire_body_uses_current_output_limit_and_thinking_fields(
+    wandb_provider: OpenAIChatProvider,
+) -> None:
+    body = wandb_provider._build_request_body(_request(), reasoning=REASONING_ON)
+
+    wire_body = await capture_openai_chat_wire_body(body)
+
+    assert wire_body["max_completion_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert "max_tokens" not in wire_body
+    assert wire_body["chat_template_kwargs"] == {"enable_thinking": True}
+    assert "extra_body" not in wire_body
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_documented_endpoint_and_bearer_auth() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": "openai/gpt-oss-20b",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "system",
+                        "root": "openai/gpt-oss-20b",
+                    }
+                ],
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    def build_client(*args: Any, **kwargs: Any) -> AsyncOpenAI:
+        kwargs["http_client"] = http_client
+        return AsyncOpenAI(*args, **kwargs)
+
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI",
+        side_effect=build_client,
+    ):
+        provider = profiled_provider(
+            "wandb",
+            make_provider_config(
+                api_key="wire-wandb-key",
+                base_url=WANDB_INFERENCE_DEFAULT_BASE,
+                rate_limit=10,
+                rate_window=60,
+            ),
+            admission=immediate_admission(provider_name="wandb"),
+        )
+    try:
+        model_infos = await provider.list_model_infos()
+    finally:
+        await provider.cleanup()
+
+    assert model_infos == frozenset({ProviderModelInfo("openai/gpt-oss-20b")})
+    assert len(requests) == 1
+    assert str(requests[0].url) == "https://api.inference.wandb.ai/v1/models"
+    assert requests[0].headers["authorization"] == "Bearer wire-wandb-key"
+    assert "openai-project" not in requests[0].headers

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.0.0"
+version = "5.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC cannot route coding agents through W&B Serverless Inference. Generic HTTP 402 quota failures are also classified as upstream errors instead of billing failures.

## Changes

| Before | After |
| --- | --- |
| W&B models are unavailable in FCC configuration and model discovery. | W&B Inference is catalog-driven with Admin settings, dynamic model discovery, proxy support, and `wandb/<model>` slugs. |
| W&B reasoning and output limits have no provider contract. | W&B uses documented boolean thinking control, `reasoning` output, no undocumented replay, and `max_completion_tokens`. |
| Generic provider HTTP 402 responses are upstream failures. | Generic provider HTTP 402 responses are non-retryable billing failures. |
| W&B compatibility has no deterministic or smoke coverage. | W&B request, discovery, tools, reasoning, authentication, smoke configuration, and failure contracts are covered. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds W&B Serverless Inference as an OpenAI-compatible provider with configuration, model discovery, request shaping, smoke defaults, and documentation. HTTP 402 responses now retain their status, avoid retries, and direct users to resolve billing or add credits.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised provider wire contract and failure-classification behavior.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Billing 402 deterministic validation script to exercise deterministic OpenAI/HTTPX exception branches and confirm the 402 behavior, resulting in two passing records and exit code 0.
- Validated the W&B wire validator against the parent and current revisions and ran the W&B provider test suite; the current revision discovered models and streamed a chat request via the OpenAI SDK using the W&B /v1 endpoint with Bearer authorization, enable\_thinking, and max\_completion\_tokens; the focused test suite reported 11 passing tests.
- Ran the wandb-provider wire deterministic validation, including the source, before/after state logs, and the focused test-suite, confirming the wire contract was exercised and that 11 tests passed.

<a href="https://app.greptile.com/trex/runs/18945443/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Use billing guidance for HTTP 402 failur..."](https://github.com/alishahryar1/free-claude-code/commit/3837e7ea2e273584251484b3aa3da4f03c3d4881) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53433790)</sub>

<!-- /greptile_comment -->