### PR TITLE
Add QwenCloud Coding Plan as a separate provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,10 @@ VERTEX_LOCATION="global"
 # QWENCLOUD_API_KEY=<your-token>
 
 
+# QwenCloud Coding Plan (separate sk-sp- key; personal interactive coding-agent use)
+# QWENCLOUD_CODING_API_KEY=<your-token>
+
+
 # Together AI (OpenAI-compatible Chat Completions at api.together.ai/v1)
 # TOGETHER_API_KEY=<your-token>
 
@@ -178,7 +182,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -221,6 +225,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # FCC_SMOKE_MODEL_VERTEX=<provider/model-id>
 # FCC_SMOKE_MODEL_GROQ=<provider/model-id>
 # FCC_SMOKE_MODEL_QWENCLOUD=<provider/model-id>
+# FCC_SMOKE_MODEL_QWENCLOUD_CODING=<provider/model-id>
 # FCC_SMOKE_MODEL_TOGETHER=<provider/model-id>
 # FCC_SMOKE_MODEL_DEEPINFRA=<provider/model-id>
 # FCC_SMOKE_MODEL_SILICONFLOW=<provider/model-id>
@@ -255,6 +260,7 @@ REASONING_HAIKU=inherit
 # OPENAI_PROXY=<http-or-socks-url>
 # XAI_PROXY=<http-or-socks-url>
 # QWENCLOUD_PROXY=<http-or-socks-url>
+# QWENCLOUD_CODING_PROXY=<http-or-socks-url>
 # TOGETHER_PROXY=<http-or-socks-url>
 # DEEPINFRA_PROXY=<http-or-socks-url>
 # SILICONFLOW_PROXY=<http-or-socks-url>

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -776,6 +776,11 @@ declarative profiles for their thinking, token, and `extra_body` policy. Kimi
 Code remains distinct from Kimi API because its subscription key and base URL
 are a separate customer contract; its profile maps provider-neutral reasoning
 to Kimi's named efforts and identifies FCC through the upstream user agent.
+QwenCloud Coding Plan likewise remains distinct from QwenCloud Token Plan
+because its subscription key, quota, endpoint, and personal interactive-use
+contract are separate. It uses the ordinary OpenAI Chat transport, preserves
+reasoning history through `reasoning_content`, and does not impose one reasoning
+control or output-token default across its heterogeneous model catalog.
 Z.ai is treated as the GLM Coding Plan provider and uses Z.ai's Coding Plan
 OpenAI base.
 Mistral La Plateforme keeps its native `reasoning_effort` and thinking-chunk

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ fcc-codex exec "hello"
 | [OpenAI / ChatGPT](https://learn.chatgpt.com/docs/auth) | Connect ChatGPT in the Admin UI | `openai/<model-id>` |
 | [xAI (Grok)](https://console.x.ai/team/default/api-keys) | `XAI_API_KEY` | `xai/grok-4.5` |
 | [QwenCloud Token Plan](https://home.qwencloud.com/api-keys) | `QWENCLOUD_API_KEY` | `qwencloud/qwen3.7-plus` |
+| [QwenCloud Coding Plan](https://home.qwencloud.com/api-keys) | `QWENCLOUD_CODING_API_KEY` | `qwencloud_coding/qwen3.7-plus` |
 | [Together AI](https://api.together.ai/settings/api-keys) | `TOGETHER_API_KEY` | `together/zai-org/GLM-5.2` |
 | [DeepInfra](https://deepinfra.com/dash/api_keys) | `DEEPINFRA_API_KEY` | `deepinfra/deepseek-ai/DeepSeek-V4-Flash` |
 | [SiliconFlow](https://cloud.siliconflow.com/account/ak) | `SILICONFLOW_API_KEY` | `siliconflow/Qwen/Qwen3-32B` |
@@ -219,6 +220,10 @@ fcc-codex exec "hello"
 - Kimi Code subscription keys use `kimi_code/`; Kimi API credit keys use
   `kimi/`. Kimi Code plans are for personal interactive coding-agent use under
   [Kimi's community guidelines](https://www.kimi.com/code/docs/en/kimi-code/community-guidelines.html).
+- QwenCloud Coding Plan keys use `qwencloud_coding/`; QwenCloud Token Plan keys
+  use `qwencloud/`. The keys and endpoints are not interchangeable. Coding Plan
+  is for local, personal, interactive coding-agent use under the
+  [Coding Plan terms](https://www.alibabacloud.com/help/en/model-studio/coding-plan).
 - OpenCode Zen and OpenCode Go share `OPENCODE_API_KEY` but use the explicit
   `opencode_zen/` and `opencode_go/` model prefixes.
 - For Amazon Bedrock, set `BEDROCK_BASE_URL` to the URL for the same region as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.1.2"
+version = "5.2.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -73,6 +73,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "groq": "groq/llama-3.3-70b-versatile",
     "xai": "xai/grok-4.5",
     "qwencloud": "qwencloud/qwen3.7-plus",
+    "qwencloud_coding": "qwencloud_coding/qwen3.7-plus",
     "together": "together/zai-org/GLM-5.2",
     "deepinfra": "deepinfra/deepseek-ai/DeepSeek-V4-Flash",
     "siliconflow": "siliconflow/Qwen/Qwen3-32B",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -152,6 +152,14 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, dict[str, Any]] = {
             "mixed."
         ),
     },
+    "QWENCLOUD_CODING_API_KEY": {
+        "label": "QwenCloud Coding Plan API Key",
+        "description": (
+            "Dedicated QwenCloud Coding Plan key (sk-sp-...) for personal, "
+            "interactive coding-agent use. Token Plan, Coding Plan, and "
+            "pay-as-you-go keys use separate endpoints and cannot be mixed."
+        ),
+    },
     "TOGETHER_API_KEY": {
         "label": "Together AI API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -56,6 +56,8 @@ XAI_DEFAULT_BASE = "https://api.x.ai/v1"
 QWENCLOUD_DEFAULT_BASE = (
     "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
 )
+# QwenCloud Coding Plan OpenAI-compatible Chat Completions API.
+QWENCLOUD_CODING_DEFAULT_BASE = "https://coding-intl.dashscope.aliyuncs.com/v1"
 # Together AI OpenAI-compatible Chat Completions API.
 TOGETHER_DEFAULT_BASE = "https://api.together.ai/v1"
 # DeepInfra OpenAI-compatible Chat Completions API.
@@ -167,6 +169,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="qwencloud_api_key",
         default_base_url=QWENCLOUD_DEFAULT_BASE,
         proxy_attr="qwencloud_proxy",
+    ),
+    "qwencloud_coding": ProviderDescriptor(
+        provider_id="qwencloud_coding",
+        display_name="QwenCloud Coding Plan",
+        credential_env="QWENCLOUD_CODING_API_KEY",
+        credential_url="https://home.qwencloud.com/api-keys",
+        credential_attr="qwencloud_coding_api_key",
+        default_base_url=QWENCLOUD_CODING_DEFAULT_BASE,
+        proxy_attr="qwencloud_coding_proxy",
     ),
     "together": ProviderDescriptor(
         provider_id="together",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -210,6 +210,11 @@ class Settings(BaseModel):
         default=None, validation_alias="QWENCLOUD_API_KEY"
     )
 
+    # ==================== QwenCloud Coding Plan (OpenAI-compatible) ====================
+    qwencloud_coding_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="QWENCLOUD_CODING_API_KEY"
+    )
+
     # ==================== Together AI (OpenAI-compatible) ====================
     together_api_key: OptionalNonEmptyString = Field(
         default=None, validation_alias="TOGETHER_API_KEY"
@@ -333,6 +338,9 @@ class Settings(BaseModel):
     )
     qwencloud_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="QWENCLOUD_PROXY"
+    )
+    qwencloud_coding_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="QWENCLOUD_CODING_PROXY"
     )
     together_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="TOGETHER_PROXY"

--- a/src/free_claude_code/providers/openai_chat/output_cap.py
+++ b/src/free_claude_code/providers/openai_chat/output_cap.py
@@ -26,6 +26,10 @@ _OUTPUT_TOKEN_KEYWORDS = ("max_completion_tokens", "max_tokens")
 # Comparator phrases that precede the allowed maximum in provider error text.
 _CAP_VALUE_PATTERN = r"[`'\"]?(\d+)[`'\"]?"
 _CAP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        rf"range\s+of\s+(?:max_completion_tokens|max_tokens)\s+should\s+be\s+"
+        rf"\[\s*1\s*,\s*{_CAP_VALUE_PATTERN}\s*\]"
+    ),
     re.compile(rf"less than or equal to\s+{_CAP_VALUE_PATTERN}"),
     re.compile(rf"smaller than or equal to\s+{_CAP_VALUE_PATTERN}"),
     re.compile(rf"<=\s*{_CAP_VALUE_PATTERN}"),

--- a/src/free_claude_code/providers/openai_chat/output_cap.py
+++ b/src/free_claude_code/providers/openai_chat/output_cap.py
@@ -20,23 +20,36 @@ import openai
 # Body keys that carry the output-token budget across OpenAI-compatible policies.
 _OUTPUT_TOKEN_FIELDS = ("max_completion_tokens", "max_tokens")
 
-# Only treat a 400 as an output-cap rejection when it names one of these fields.
-_OUTPUT_TOKEN_KEYWORDS = ("max_completion_tokens", "max_tokens")
-
-# Comparator phrases that precede the allowed maximum in provider error text.
 _CAP_VALUE_PATTERN = r"[`'\"]?(\d+)[`'\"]?"
-_CAP_PATTERNS: tuple[re.Pattern[str], ...] = (
+_OUTPUT_TOKEN_FIELD_PATTERN = r"[`'\"]?(?:max_completion_tokens|max_tokens)[`'\"]?"
+
+# An accepted grammar must bind the output-token field and its numeric limit.
+# A field mentioned elsewhere in the response must never authorize an unrelated
+# comparator.
+_FIELD_BOUND_CAP_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
-        rf"range\s+of\s+(?:max_completion_tokens|max_tokens)\s+should\s+be\s+"
+        rf"range\s+of\s+{_OUTPUT_TOKEN_FIELD_PATTERN}\s+should\s+be\s+"
         rf"\[\s*1\s*,\s*{_CAP_VALUE_PATTERN}\s*\]"
     ),
-    re.compile(rf"less than or equal to\s+{_CAP_VALUE_PATTERN}"),
-    re.compile(rf"smaller than or equal to\s+{_CAP_VALUE_PATTERN}"),
-    re.compile(rf"<=\s*{_CAP_VALUE_PATTERN}"),
-    re.compile(rf"at most\s+{_CAP_VALUE_PATTERN}"),
-    re.compile(rf"must not exceed\s+{_CAP_VALUE_PATTERN}"),
-    re.compile(rf"maximum(?:\s+value)?(?:\s+for\s+\S+)?\s+is\s+{_CAP_VALUE_PATTERN}"),
-    re.compile(rf"maximum(?:\s+allowed)?(?:\s+value)?\s+of\s+{_CAP_VALUE_PATTERN}"),
+    re.compile(
+        rf"{_OUTPUT_TOKEN_FIELD_PATTERN}\s*(?::\s*)?"
+        rf"(?:"
+        rf"(?:(?:must|should)\s+be\s+)?"
+        rf"(?:less|smaller)\s+than\s+or\s+equal\s+to"
+        rf"|(?:(?:must|should)\s+be\s*)?<="
+        rf"|(?:(?:must|should)\s+be\s+)?at\s+most"
+        rf"|(?:must|should)\s+not\s+exceed"
+        rf"|maximum(?:\s+allowed)?(?:\s+value)?\s+(?:is|of)"
+        rf")\s*{_CAP_VALUE_PATTERN}"
+    ),
+    re.compile(
+        rf"maximum(?:\s+allowed)?(?:\s+value)?\s+for\s+"
+        rf"{_OUTPUT_TOKEN_FIELD_PATTERN}\s+is\s+{_CAP_VALUE_PATTERN}"
+    ),
+    re.compile(
+        rf"maximum(?:\s+allowed)?(?:\s+value)?\s+of\s+"
+        rf"{_CAP_VALUE_PATTERN}\s+for\s+{_OUTPUT_TOKEN_FIELD_PATTERN}"
+    ),
 )
 
 
@@ -46,12 +59,41 @@ def _is_bad_request(error: Exception) -> bool:
     )
 
 
-def _error_text(error: Exception) -> str:
-    text = str(error)
+def _error_texts(error: Exception) -> tuple[str, ...]:
+    """Normalize free-form and structured errors into field-bound text."""
+    texts = [str(error)]
     body = getattr(error, "body", None)
     if body is not None:
-        text = f"{text} {json.dumps(body, default=str)}"
-    return text.lower()
+        texts.append(json.dumps(body, default=str))
+
+    pending: list[Any] = [body]
+    while pending:
+        value = pending.pop()
+        if isinstance(value, dict):
+            param = value.get("param")
+            message = value.get("message")
+            if (
+                isinstance(param, str)
+                and param.strip("`'\" ").lower() in _OUTPUT_TOKEN_FIELDS
+                and isinstance(message, str)
+            ):
+                # Prefixing an explicitly named structured parameter lets the
+                # same field-bound grammar handle comparator-only messages.
+                texts.append(f"{param} {message}")
+            pending.extend(value.values())
+        elif isinstance(value, list):
+            pending.extend(value)
+    return tuple(text.lower() for text in texts)
+
+
+def _parse_cap(text: str) -> int | None:
+    for pattern in _FIELD_BOUND_CAP_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            cap = int(match.group(1))
+            if cap > 0:
+                return cap
+    return None
 
 
 def parse_output_token_cap(error: Exception) -> int | None:
@@ -59,16 +101,10 @@ def parse_output_token_cap(error: Exception) -> int | None:
     if not _is_bad_request(error):
         return None
 
-    text = _error_text(error)
-    if not any(keyword in text for keyword in _OUTPUT_TOKEN_KEYWORDS):
-        return None
-
-    for pattern in _CAP_PATTERNS:
-        match = pattern.search(text)
-        if match:
-            cap = int(match.group(1))
-            if cap > 0:
-                return cap
+    for text in _error_texts(error):
+        cap = _parse_cap(text)
+        if cap is not None:
+            return cap
     return None
 
 

--- a/src/free_claude_code/providers/openai_chat/output_cap.py
+++ b/src/free_claude_code/providers/openai_chat/output_cap.py
@@ -11,7 +11,6 @@ retry once and succeed. The provider also remembers the learned cap per model
 so later requests clamp proactively instead of paying the 400 every time.
 """
 
-import json
 import re
 from typing import Any
 
@@ -19,9 +18,13 @@ import openai
 
 # Body keys that carry the output-token budget across OpenAI-compatible policies.
 _OUTPUT_TOKEN_FIELDS = ("max_completion_tokens", "max_tokens")
+_STRUCTURED_TEXT_FIELDS = ("message", "detail", "error")
+_STRUCTURED_CONTAINER_FIELDS = ("error", "errors", "detail", "details")
 
 _CAP_VALUE_PATTERN = r"[`'\"]?(\d+)[`'\"]?"
-_OUTPUT_TOKEN_FIELD_PATTERN = r"[`'\"]?(?:max_completion_tokens|max_tokens)[`'\"]?"
+_OUTPUT_TOKEN_FIELD_PATTERN = (
+    r"(?<!\w)[`'\"]?(?:max_completion_tokens|max_tokens)[`'\"]?(?!\w)"
+)
 
 # An accepted grammar must bind the output-token field and its numeric limit.
 # A field mentioned elsewhere in the response must never authorize an unrelated
@@ -59,30 +62,64 @@ def _is_bad_request(error: Exception) -> bool:
     )
 
 
-def _error_texts(error: Exception) -> tuple[str, ...]:
-    """Normalize free-form and structured errors into field-bound text."""
-    texts = [str(error)]
-    body = getattr(error, "body", None)
-    if body is not None:
-        texts.append(json.dumps(body, default=str))
+def _normalized_output_field(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    field = value.strip("`'\" ").lower()
+    return field if field in _OUTPUT_TOKEN_FIELDS else None
 
-    pending: list[Any] = [body]
+
+def _structured_error_texts(body: dict[str, Any] | list[Any]) -> tuple[str, ...]:
+    """Extract messages without discarding their structured parameter scope."""
+    texts: list[str] = []
+    pending: list[dict[str, Any] | list[Any]] = [body]
     while pending:
         value = pending.pop()
-        if isinstance(value, dict):
-            param = value.get("param")
-            message = value.get("message")
-            if (
-                isinstance(param, str)
-                and param.strip("`'\" ").lower() in _OUTPUT_TOKEN_FIELDS
-                and isinstance(message, str)
-            ):
-                # Prefixing an explicitly named structured parameter lets the
-                # same field-bound grammar handle comparator-only messages.
-                texts.append(f"{param} {message}")
-            pending.extend(value.values())
-        elif isinstance(value, list):
-            pending.extend(value)
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    texts.append(item)
+                elif isinstance(item, (dict, list)):
+                    pending.append(item)
+            continue
+
+        param = value.get("param")
+        output_field = _normalized_output_field(param)
+        messages = tuple(
+            message
+            for field in _STRUCTURED_TEXT_FIELDS
+            if isinstance(message := value.get(field), str)
+        )
+        if output_field is not None:
+            # Structured parameter metadata is authoritative. Prefixing the
+            # paired field supports comparator-only messages such as "<= 8192".
+            texts.extend(f"{output_field} {message}" for message in messages)
+        if param is not None:
+            # Do not let text nested below an explicitly scoped validation error
+            # escape that scope and become a new unscoped candidate.
+            continue
+
+        texts.extend(messages)
+        for field in _STRUCTURED_CONTAINER_FIELDS:
+            nested = value.get(field)
+            if isinstance(nested, (dict, list)):
+                pending.append(nested)
+    return tuple(texts)
+
+
+def _error_texts(error: Exception) -> tuple[str, ...]:
+    """Keep unstructured text separate from structured validation messages."""
+    body = getattr(error, "body", None)
+    if body is None:
+        texts = (str(error),)
+    elif isinstance(body, str):
+        texts = (body,)
+    elif isinstance(body, (dict, list)):
+        # The OpenAI SDK embeds a representation of this body in ``str(error)``.
+        # Parsing both would flatten the parameter scopes restored above.
+        texts = _structured_error_texts(body)
+    else:
+        texts = ()
     return tuple(text.lower() for text in texts)
 
 

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -214,6 +214,13 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         ),
         NO_REASONING,
     ),
+    "qwencloud_coding": OpenAIChatProfile(
+        _policy(
+            "QWENCLOUD_CODING",
+            ReasoningReplayMode.REASONING_CONTENT,
+        ),
+        NO_REASONING,
+    ),
     "together": OpenAIChatProfile(
         _policy(
             "TOGETHER",

--- a/tests/contracts/test_admin_provider_manifest.py
+++ b/tests/contracts/test_admin_provider_manifest.py
@@ -139,6 +139,16 @@ def test_vertex_project_and_location_are_admin_provider_fields() -> None:
     assert location.resolved_default() == "global"
 
 
+def test_qwencloud_coding_key_is_a_distinct_admin_provider_field() -> None:
+    entry = FIELD_BY_KEY["QWENCLOUD_CODING_API_KEY"]
+
+    assert entry.label == "QwenCloud Coding Plan API Key"
+    assert entry.settings_attr == "qwencloud_coding_api_key"
+    assert entry.section_id == "providers"
+    assert entry.secret is True
+    assert "separate endpoints" in entry.description
+
+
 def test_vertex_admin_status_uses_project_configuration_not_an_api_key() -> None:
     from free_claude_code.config.admin.status import provider_config_status
 

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -12,6 +12,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "openai",
     "xai",
     "qwencloud",
+    "qwencloud_coding",
     "together",
     "deepinfra",
     "siliconflow",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -55,6 +55,7 @@ def _settings(**overrides):
         "groq_api_key": "",
         "xai_api_key": "",
         "qwencloud_api_key": "",
+        "qwencloud_coding_api_key": "",
         "together_api_key": "",
         "deepinfra_api_key": "",
         "siliconflow_api_key": "",
@@ -192,6 +193,52 @@ def test_qwencloud_provider_smoke_uses_current_coding_model(monkeypatch) -> None
     assert [model.provider for model in models] == ["qwencloud"]
     assert models[0].full_model == "qwencloud/qwen3.7-plus"
     assert models[0].source == "provider_default"
+
+
+def test_qwencloud_coding_provider_smoke_uses_recommended_model(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_QWENCLOUD_CODING", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            qwencloud_coding_api_key="qwencloud-coding-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["qwencloud_coding"]
+    assert models[0].full_model == "qwencloud_coding/qwen3.7-plus"
+    assert models[0].source == "provider_default"
+
+
+def test_qwencloud_coding_smoke_override_is_independent_from_token_plan(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_QWENCLOUD", raising=False)
+    monkeypatch.setenv(
+        "FCC_SMOKE_MODEL_QWENCLOUD_CODING",
+        "qwencloud_coding/kimi-k2.5",
+    )
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            qwencloud_api_key="qwencloud-key",
+            qwencloud_coding_api_key="qwencloud-coding-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [(model.provider, model.full_model, model.source) for model in models] == [
+        ("qwencloud", "qwencloud/qwen3.7-plus", "provider_default"),
+        (
+            "qwencloud_coding",
+            "qwencloud_coding/kimi-k2.5",
+            "FCC_SMOKE_MODEL_QWENCLOUD_CODING",
+        ),
+    ]
 
 
 def test_together_provider_smoke_uses_current_coding_model(monkeypatch) -> None:

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -127,6 +127,66 @@ def test_parse_cap_uses_only_the_structured_output_parameter_message():
     assert parse_output_token_cap(error) is None
 
 
+def test_parse_cap_respects_structured_non_output_parameter():
+    body = {
+        "param": "temperature",
+        "message": "max_tokens must not exceed 2",
+    }
+    error = _BadRequest(
+        f"Error code: 400 - {body}",
+        body=body,
+    )
+
+    assert parse_output_token_cap(error) is None
+
+
+def test_parse_cap_does_not_escape_structured_parameter_scope():
+    error = _BadRequest(
+        "invalid request",
+        body={
+            "param": "temperature",
+            "details": {"message": "max_tokens must not exceed 2"},
+        },
+    )
+
+    assert parse_output_token_cap(error) is None
+
+
+def test_parse_cap_ignores_text_outside_structured_error_schema():
+    error = _BadRequest(
+        "invalid request",
+        body={"request": {"message": "max_tokens must not exceed 2"}},
+    )
+
+    assert parse_output_token_cap(error) is None
+
+
+def test_parse_cap_reads_unscoped_structured_message():
+    error = _BadRequest(
+        "invalid request",
+        body={"message": "max_tokens must not exceed 8192"},
+    )
+
+    assert parse_output_token_cap(error) == 8192
+
+
+def test_parse_cap_selects_matching_parameter_from_structured_error_list():
+    error = _BadRequest(
+        "invalid request",
+        body={
+            "errors": [
+                {
+                    "param": "temperature",
+                    "message": "max_tokens must not exceed 2",
+                },
+                {"param": "max_tokens", "message": "<= 8192"},
+            ]
+        },
+    )
+
+    assert parse_output_token_cap(error) == 8192
+
+
 def test_parse_cap_returns_none_without_number():
     assert (
         parse_output_token_cap(_BadRequest("max_tokens is larger than allowed")) is None
@@ -274,9 +334,14 @@ async def test_mixed_field_400_does_not_retry_or_poison_learned_cap(groq_provide
             thinking={"enabled": False},
         )
     )
+    error_body = {
+        "param": "temperature",
+        "message": "max_completion_tokens must not exceed 2",
+    }
     create = AsyncMock(
         side_effect=_BadRequest(
-            "temperature must be <= 2; max_completion_tokens is invalid"
+            f"Error code: 400 - {error_body}",
+            body=error_body,
         )
     )
 

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -67,6 +67,30 @@ def test_parse_cap_reads_json_body():
     assert parse_output_token_cap(error) == 12000
 
 
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("Range of max_tokens should be [1, 32768]", 32768),
+        ("range of max_completion_tokens should be [ 1 , `8192` ]", 8192),
+    ],
+)
+def test_parse_cap_from_inclusive_range(message, expected):
+    assert parse_output_token_cap(_BadRequest(message)) == expected
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Range of temperature should be [0, 2] for max_tokens requests",
+        "Range of max_tokens should be [0, 4096]",
+        "Range of max_tokens should be [1, unlimited]",
+        "Range of max_tokens is [1, 4096]",
+    ],
+)
+def test_parse_cap_ignores_unrecognized_ranges(message):
+    assert parse_output_token_cap(_BadRequest(message)) is None
+
+
 def test_parse_cap_ignores_non_400():
     error = _BadRequest("max_tokens must be less than or equal to 40960")
     error.status_code = 500

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -101,6 +101,32 @@ def test_parse_cap_ignores_unrelated_400():
     assert parse_output_token_cap(_BadRequest("temperature must be <= 2")) is None
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        "temperature must be <= 2; max_tokens is invalid",
+        "max_completion_tokens is invalid; temperature at most 2",
+        "maximum allowed value of 2 for temperature; max_tokens is invalid",
+    ],
+)
+def test_parse_cap_does_not_bind_unrelated_comparator_to_output_field(message):
+    assert parse_output_token_cap(_BadRequest(message)) is None
+
+
+def test_parse_cap_uses_only_the_structured_output_parameter_message():
+    error = _BadRequest(
+        "max_tokens is invalid",
+        body={
+            "errors": [
+                {"param": "temperature", "message": "must not exceed 2"},
+                {"param": "top_p", "message": "<= 1"},
+            ]
+        },
+    )
+
+    assert parse_output_token_cap(error) is None
+
+
 def test_parse_cap_returns_none_without_number():
     assert (
         parse_output_token_cap(_BadRequest("max_tokens is larger than allowed")) is None
@@ -229,6 +255,34 @@ async def test_unrelated_400_is_not_clamped_and_propagates(groq_provider):
     with (
         patch.object(groq_provider._client.chat.completions, "create", create),
         pytest.raises(Exception, match="wizard"),
+    ):
+        await groq_provider._create_stream(
+            body,
+            groq_provider._admission.new_retry_session(),
+        )
+
+    assert create.call_count == 1
+    assert groq_provider._model_output_caps == {}
+
+
+@pytest.mark.asyncio
+async def test_mixed_field_400_does_not_retry_or_poison_learned_cap(groq_provider):
+    body = groq_provider._build_request_body(
+        make_messages_request(
+            "llama-3.3-70b-versatile",
+            max_tokens=64000,
+            thinking={"enabled": False},
+        )
+    )
+    create = AsyncMock(
+        side_effect=_BadRequest(
+            "temperature must be <= 2; max_completion_tokens is invalid"
+        )
+    )
+
+    with (
+        patch.object(groq_provider._client.chat.completions, "create", create),
+        pytest.raises(Exception, match="temperature"),
     ):
         await groq_provider._create_stream(
             body,

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -25,6 +25,7 @@ from free_claude_code.config.provider_catalog import (
     NEBIUS_DEFAULT_BASE,
     OLLAMA_CLOUD_DEFAULT_BASE,
     PROVIDER_CATALOG,
+    QWENCLOUD_CODING_DEFAULT_BASE,
     QWENCLOUD_DEFAULT_BASE,
     SILICONFLOW_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
@@ -73,6 +74,7 @@ def _make_settings(**overrides):
     mock.open_router_api_key = "test_openrouter_key"
     mock.xai_api_key = "test_xai_key"
     mock.qwencloud_api_key = "test_qwencloud_key"
+    mock.qwencloud_coding_api_key = "test_qwencloud_coding_key"
     mock.together_api_key = "test_together_key"
     mock.deepinfra_api_key = "test_deepinfra_key"
     mock.siliconflow_api_key = "test_siliconflow_key"
@@ -150,6 +152,7 @@ def _make_settings(**overrides):
     mock.openai_proxy = None
     mock.xai_proxy = None
     mock.qwencloud_proxy = None
+    mock.qwencloud_coding_proxy = None
     mock.together_proxy = None
     mock.deepinfra_proxy = None
     mock.siliconflow_proxy = None
@@ -259,6 +262,25 @@ def test_qwencloud_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.credential_env == "QWENCLOUD_API_KEY"
     assert config.api_key == "qwencloud-token"
     assert config.base_url == QWENCLOUD_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_qwencloud_coding_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["qwencloud_coding"]
+    settings = _make_settings(
+        qwencloud_coding_api_key="qwencloud-coding-token",
+        qwencloud_coding_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("qwencloud_coding", settings)
+
+    assert descriptor.display_name == "QwenCloud Coding Plan"
+    assert descriptor.credential_env == "QWENCLOUD_CODING_API_KEY"
+    assert config.api_key == "qwencloud-coding-token"
+    assert config.base_url == QWENCLOUD_CODING_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -742,6 +764,7 @@ def test_create_provider_instantiates_each_builtin():
         "openai": OpenAICodexProvider,
         "xai": OpenAIChatProvider,
         "qwencloud": OpenAIChatProvider,
+        "qwencloud_coding": OpenAIChatProvider,
         "together": OpenAIChatProvider,
         "deepinfra": OpenAIChatProvider,
         "siliconflow": OpenAIChatProvider,

--- a/tests/providers/test_qwencloud_coding.py
+++ b/tests/providers/test_qwencloud_coding.py
@@ -1,0 +1,244 @@
+"""Tests for the QwenCloud Coding Plan OpenAI-chat provider profile."""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import QWENCLOUD_CODING_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+    reasoning_for,
+)
+
+
+@pytest.fixture
+def qwencloud_coding_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "qwencloud_coding",
+        make_provider_config(
+            api_key="test-qwencloud-coding-key",
+            base_url=QWENCLOUD_CODING_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="qwencloud_coding"),
+    )
+
+
+def test_init_uses_openai_chat_provider(
+    qwencloud_coding_provider: OpenAIChatProvider,
+) -> None:
+    assert qwencloud_coding_provider._api_key == "test-qwencloud-coding-key"
+    assert qwencloud_coding_provider._base_url == QWENCLOUD_CODING_DEFAULT_BASE
+    assert qwencloud_coding_provider._provider_name == "QWENCLOUD_CODING"
+
+
+def test_build_request_body_preserves_tools_and_images_without_inventing_a_cap(
+    qwencloud_coding_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "qwen3.7-plus",
+            "system": "Be concise.",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Inspect this image."},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "aW1hZ2U=",
+                            },
+                        },
+                    ],
+                }
+            ],
+            "tools": [
+                {
+                    "name": "inspect_image",
+                    "description": "Inspect an image",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                    },
+                }
+            ],
+        }
+    )
+
+    body = qwencloud_coding_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["model"] == "qwen3.7-plus"
+    assert "max_tokens" not in body
+    assert body["messages"][0] == {"role": "system", "content": "Be concise."}
+    assert body["messages"][1]["content"] == [
+        {"type": "text", "text": "Inspect this image."},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aW1hZ2U="},
+        },
+    ]
+    assert body["tools"][0]["function"]["name"] == "inspect_image"
+    assert "tool_stream" not in body
+
+
+def test_build_request_body_preserves_explicit_client_cap(
+    qwencloud_coding_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "qwen3.7-plus",
+            "max_tokens": 321,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+    )
+
+    body = qwencloud_coding_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["max_tokens"] == 321
+
+
+@pytest.mark.parametrize(
+    "reasoning",
+    [
+        REASONING_OFF,
+        REASONING_ON,
+        ReasoningPolicy.on(effort=ReasoningEffort.MAX),
+    ],
+)
+def test_build_request_body_does_not_invent_catalog_wide_reasoning_control(
+    qwencloud_coding_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "qwen3.7-plus",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+    )
+
+    body = qwencloud_coding_provider._build_request_body(request, reasoning=reasoning)
+    extra_body = body.get("extra_body", {})
+
+    for field in (
+        "enable_thinking",
+        "preserve_thinking",
+        "reasoning",
+        "reasoning_effort",
+        "thinking",
+        "thinking_budget",
+        "tool_stream",
+    ):
+        assert field not in body
+        assert field not in extra_body
+
+
+def test_build_request_body_replays_prior_reasoning_content(
+    qwencloud_coding_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": "qwen3.7-plus",
+            "messages": [
+                {"role": "user", "content": "Solve it."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Work through it."},
+                        {"type": "text", "text": "The answer is 42."},
+                    ],
+                },
+                {"role": "user", "content": "Continue."},
+            ],
+        }
+    )
+
+    body = qwencloud_coding_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "The answer is 42.",
+        "reasoning_content": "Work through it.",
+    }
+    assert (
+        qwencloud_coding_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning_content="next thought")
+        )
+        == "next thought"
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_standard_endpoint_base_url_and_auth(
+    qwencloud_coding_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "id": "qwen3.7-plus",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "qwencloud",
+                    },
+                    {
+                        "id": "kimi-k2.5",
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "qwencloud",
+                    },
+                ],
+            },
+        )
+
+    await qwencloud_coding_provider._client.close()
+    qwencloud_coding_provider._client = AsyncOpenAI(
+        api_key="wire-qwencloud-coding-key",
+        base_url=QWENCLOUD_CODING_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        model_infos = await qwencloud_coding_provider.list_model_infos()
+    finally:
+        await qwencloud_coding_provider.cleanup()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("qwen3.7-plus"),
+            ProviderModelInfo("kimi-k2.5"),
+        }
+    )
+    assert len(requests) == 1
+    assert str(requests[0].url) == (
+        "https://coding-intl.dashscope.aliyuncs.com/v1/models"
+    )
+    assert requests[0].headers["authorization"] == ("Bearer wire-qwencloud-coding-key")

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.1.2"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

QwenCloud Token Plan and Coding Plan use separate keys and endpoints, but FCC exposed only Token Plan. Coding Plan users could not route their subscription through its supported OpenAI-compatible surface.

## Changes

| Before | After |
| --- | --- |
| QwenCloud had one Token Plan identity and endpoint. | QwenCloud Coding Plan has its own provider ID, credential, proxy, endpoint, and Admin controls. |
| Coding Plan models had no FCC discovery or smoke contract. | FCC discovers the live model catalog and defaults smoke coverage to qwen3.7-plus. |
| A shared profile could invent one output cap or reasoning control for heterogeneous models. | Coding Plan preserves client caps, replays reasoning content, and leaves unsupported reasoning controls to each model. |
| Range-form max-token errors could not teach the shared cap recovery. | The generic parser learns the upper bound from the documented [1, N] rejection shape. |
| The package version was 5.1.2. | The package version is 5.2.0. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds QwenCloud Coding Plan as an independently configured provider, including catalog registration, credentials, administration controls, documentation, and smoke configuration. It also improves output-token-cap recovery so structured validation messages remain bound to their declared parameter, and adds a no-progress timeout for provider streams.

The reviewed recovery and timeout behaviors completed successfully under focused executable checks. The change is safe to merge.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: focused executable checks confirmed the output-cap recovery and provider-stream timeout behaviors.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the temperature-scoped regression script against a structured 400 error and ran the focused OpenAI chat output-cap tests; the results show that a non-output structured parameter cannot trigger an output-cap retry or cache update.
- Executed the provider-progress-timeout regression repro and ran the application tests; progress renews the deadline on normal progress while a stalled source yields a 504 timeout and clean closure.
- Validated scope-protection and parse/recovery behavior showing that non-output params stop escaping scope and that parse\_output\_token\_cap and related code paths do not generate a cap or retry behavior; observed redacted values while max\_tokens remained unchanged.
- Captured progress-pipeline behavior and confirmed the focused test suite passes, with progress chunks reported and stalled-timeout paths validated.

<a href="https://app.greptile.com/trex/runs/19003706/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: preserve structured validation scop..."](https://github.com/alishahryar1/free-claude-code/commit/92f9ca3ecf270f2bca0901371efb6f360bce69b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53548160)</sub>

<!-- /greptile_comment -->