### PR TITLE
Isolate launcher and uninstaller tests from host state

### DIFF
--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -46,6 +46,12 @@ class _JsonResponse:
         return json.dumps(self._payload).encode("utf-8")
 
 
+@pytest.fixture
+def empty_proxy_bypass_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+
+
 def test_cli_scripts_are_registered() -> None:
     pyproject = tomllib.loads(
         (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(
@@ -318,6 +324,7 @@ def test_claude_child_env_targets_current_proxy_config() -> None:
 
 def test_launch_claude_passes_args_and_child_env(
     monkeypatch: pytest.MonkeyPatch,
+    empty_proxy_bypass_env: None,
 ) -> None:
     from free_claude_code.cli.launchers.claude import launch
 
@@ -371,6 +378,7 @@ def test_launch_claude_passes_args_and_child_env(
 def test_launch_codex_passes_responses_config_and_child_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    empty_proxy_bypass_env: None,
 ) -> None:
     from free_claude_code.cli.launchers.codex import launch
 
@@ -586,6 +594,7 @@ def test_pi_launcher_builds_scoped_session_command_and_proxy_env(
 def test_launch_pi_registers_bundled_extension_for_sessions(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    empty_proxy_bypass_env: None,
 ) -> None:
     from free_claude_code.cli.launchers.pi import launch
 

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -133,6 +133,16 @@ def posix_uninstall_harness(tmp_path: Path) -> PosixUninstallHarness:
     _write_executable(bin_dir / "codex", "#!/bin/sh\nexit 0\n")
     _write_executable(bin_dir / "pi", "#!/bin/sh\nexit 0\n")
     _write_executable(
+        bin_dir / "pgrep",
+        """#!/bin/sh
+[ -n "${FCC_RUNNING_COMMAND:-}" ] || exit 1
+case "$*" in
+    *"$FCC_RUNNING_COMMAND"*) printf '4242\n'; exit 0 ;;
+    *) exit 1 ;;
+esac
+""",
+    )
+    _write_executable(
         bin_dir / "uv",
         """#!/bin/sh
 echo "uv:$*" >> "$CALL_LOG"
@@ -199,6 +209,7 @@ printf '%s\n' "$FAKE_UNAME"
             "CALL_LOG": str(log),
             "FAKE_TOOL_BIN": str(tool_bin),
             "FAKE_UNAME": "Darwin",
+            "FCC_RUNNING_COMMAND": "",
             "FAIL_STEP": "",
         }
     )
@@ -348,6 +359,24 @@ def test_uninstall_sh_rejects_invalid_options_before_mutation(
 
     assert result.returncode != 0
     assert posix_uninstall_harness.fcc_home.exists()
+    assert posix_uninstall_harness.calls() == []
+
+
+@pytest.mark.parametrize("command_name", FCC_COMMANDS)
+def test_uninstall_sh_rejects_running_fcc_before_mutation(
+    posix_uninstall_harness: PosixUninstallHarness,
+    command_name: str,
+) -> None:
+    posix_uninstall_harness.env["FCC_RUNNING_COMMAND"] = command_name
+
+    result = posix_uninstall_harness.run()
+
+    assert result.returncode != 0
+    assert command_name in result.stderr
+    assert posix_uninstall_harness.fcc_home.exists()
+    assert all(
+        (posix_uninstall_harness.tool_bin / name).exists() for name in FCC_COMMANDS
+    )
     assert posix_uninstall_harness.calls() == []
 
 


### PR DESCRIPTION
## Problem

Launcher tests inherited developer and runner proxy-bypass settings despite asserting clean defaults. The POSIX uninstaller fixture could also inspect the host process table instead of deterministic test state. Fixes #1386 after stacked parent #1427 resolves the token-estimation findings.

## Changes

| Before | After |
| --- | --- |
| Three launcher tests inherited host `NO_PROXY` and `no_proxy` values. | Those tests explicitly declare an empty proxy-bypass precondition. |
| The POSIX uninstaller fixture could call the host `pgrep`. | The fixture owns a fake `pgrep` that reports no process by default. |
| Running-process coverage depended on ambient machine state. | Every FCC command receives deterministic positive guard coverage with no mutation. |
| Windows could cover only its native uninstaller paths locally. | The stacked CI run covers the real POSIX shell paths on Ubuntu. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes launcher and POSIX uninstaller tests independent of inherited machine state. The exercised launcher environments consistently use loopback proxy bypasses, running FCC commands stop uninstallation before any mutation, and the no-process path continues through normal removal.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: no blocking failure remains.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reviewed the changed launcher fixture and the POSIX uninstaller harness to understand the PR impact.
- I executed the review-authored launcher environment script and observed that inherited NO\_PROXY values were retained by child builders, and that the PR removes those inherited entries before tests run.
- I ran the isolated uninstaller harness and verified seven FCC running-command cases aborted before invoking uv or rm, while the no-process path reached uv tool dir --bin, uv tool uninstall free-claude-code, and configuration removal.
- I attempted focused pytest collection but it could not collect under Python 3.11, which is unrelated to this PR because Python 3.14 or newer is required.
- I reviewed the PR commit diff and fixture changes to confirm the inherited host entries were removed before launcher tests.

<a href="https://app.greptile.com/trex/runs/19012626/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: isolate launcher and uninstaller h..."](https://github.com/alishahryar1/free-claude-code/commit/94e84d37e2840467021a5f9c9074048a1376f9b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53577372)</sub>

<!-- /greptile_comment -->