### PR TITLE
Run CI for every pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ env:
 
 on:
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
 - All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- GitHub CI runs only for pull requests targeting `main`. Strict required checks keep each PR current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
+- GitHub CI runs for every pull request, including stacked PRs targeting non-`main` branches. Head updates trigger fresh checks; strict required checks keep PRs targeting `main` current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
 - Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests and strict required checks, keeps branches current, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
 - Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
 - All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
-- GitHub CI runs only for pull requests targeting `main`. Strict required checks keep each PR current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
+- GitHub CI runs for every pull request, including stacked PRs targeting non-`main` branches. Head updates trigger fresh checks; strict required checks keep PRs targeting `main` current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
 - Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests and strict required checks, keeps branches current, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
 - Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 


### PR DESCRIPTION
## Problem

CI only ran for pull requests targeting `main`, so pushes and force-pushes to stacked pull requests targeting another branch were not tested.

## Changes

| Before | After |
| --- | --- |
| The `pull_request` trigger filtered on the `main` base branch. | The `pull_request` trigger accepts every base branch while retaining its default opened, synchronized, and reopened events. |
| Repository guidance described main-only pull-request CI. | Repository guidance documents stacked pull-request coverage without restoring duplicate post-merge runs. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes CI run for pull requests targeting any branch, so stacked pull requests receive the same checks as pull requests targeting `main`. The workflow was exercised against `main`, a stacked-PR base branch, and a release branch: the prior configuration rejected the stacked branch, while the updated configuration accepted all tested targets and retained pull-request-only execution and the existing CI jobs. No defects were found; the change is safe to merge.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the workflow now covers stacked pull requests without enabling additional event types or removing CI jobs.

The workflow behavior was directly checked against both the previous and updated revisions, including main, stacked, and release pull-request targets. The updated revision met the intended behavior without introducing a defect.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the workflow trigger validation script against HEAD^ and HEAD to parse the workflow and exercise pull-request target matching for main, stacked-pr-base, and release/2026.08.
- The parent revision was rejected for stacked-pr-base because it used branches: \[main\], while the updated revision passed all target-branch checks, retained only the pull\_request trigger, and kept the CI jobs.
- The Python validator also confirms PR-only triggering, unrestricted base matching, and retained jobs as expected.
- Before-change output showed the exact command and parent-run details, including that branches: \[main\] excluded stacked-pr-base; After-change output showed all tested base branches match while only pull\_request is configured.

<a href="https://app.greptile.com/trex/runs/19013257/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Run CI for every pull request"](https://github.com/alishahryar1/free-claude-code/commit/40f96e147888ea16a1fffc4f796fe7fbae641db6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53579182)</sub>

<!-- /greptile_comment -->