### PR TITLE
Fail pytest on warnings without unsafe PTY forks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.3.1"
+version = "5.3.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -109,6 +109,7 @@ skip-magic-trailing-comma = false
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 addopts = "-n auto"
+filterwarnings = ["error"]
 testpaths = ["tests"]
 markers = [
     "live: opt-in local smoke tests that can touch real services",

--- a/tests/scripts/_pty_runner.py
+++ b/tests/scripts/_pty_runner.py
@@ -1,0 +1,15 @@
+"""Run a command behind a PTY from a fresh single-threaded process."""
+
+import os
+import pty
+import sys
+
+
+def main() -> int:
+    spawn = vars(pty)["spawn"]
+    status = spawn(sys.argv[1:])
+    return os.waitstatus_to_exitcode(status)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -214,11 +214,6 @@ printf '%s\n' "$FCC_PS_OUTPUT"
         *args: str,
         fail_step: str = "",
     ) -> subprocess.CompletedProcess[str]:
-        import errno
-        import pty
-        import select
-        import time
-
         env = self.env | {
             "FAIL_STEP": fail_step,
             "FCC_INSTALLER": str(_repo_root() / "scripts" / "install.sh"),
@@ -230,53 +225,20 @@ printf '%s\n' "$FCC_PS_OUTPUT"
             "fcc-installer",
             *args,
         ]
-        fork = vars(pty)["fork"]
-        wait_without_blocking = vars(os)["WNOHANG"]
-        child_pid, master_fd = fork()
-        if child_pid == 0:
-            os.execve(command[0], command, env)
-
-        output = bytearray()
-        status: int | None = None
-        deadline = time.monotonic() + 30
-        try:
-            os.write(master_fd, answers.encode())
-            while status is None:
-                readable, _, _ = select.select([master_fd], [], [], 0.1)
-                if readable:
-                    try:
-                        output.extend(os.read(master_fd, 65536))
-                    except OSError as error:
-                        if error.errno != errno.EIO:
-                            raise
-
-                waited_pid, wait_status = os.waitpid(child_pid, wait_without_blocking)
-                if waited_pid == child_pid:
-                    status = wait_status
-                elif time.monotonic() >= deadline:
-                    os.kill(child_pid, 9)
-                    os.waitpid(child_pid, 0)
-                    raise AssertionError("Interactive installer did not finish")
-
-            while True:
-                readable, _, _ = select.select([master_fd], [], [], 0)
-                if not readable:
-                    break
-                try:
-                    output.extend(os.read(master_fd, 65536))
-                except OSError as error:
-                    if error.errno == errno.EIO:
-                        break
-                    raise
-        finally:
-            os.close(master_fd)
-
-        assert status is not None
-        return subprocess.CompletedProcess(
-            command,
-            os.waitstatus_to_exitcode(status),
-            output.decode(errors="replace"),
-            "",
+        return subprocess.run(
+            [
+                sys.executable,
+                "-W",
+                "error",
+                str(Path(__file__).with_name("_pty_runner.py")),
+                *command,
+            ],
+            input=answers,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
         )
 
     def calls(self) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.3.1"
+version = "5.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Python 3.14 reported unsafe `forkpty()` calls from multi-threaded pytest workers, but the suite remained green and allowed warning regressions to accumulate.

## Changes

| Before | After |
| --- | --- |
| Interactive installer tests created and managed a PTY directly inside the pytest worker. | A fresh single-threaded helper owns the PTY while the pytest worker uses a normal subprocess boundary. |
| The PTY harness manually implemented fork, select, wait, timeout, and output collection. | The helper uses the standard PTY copy loop and removes the manual process machinery. |
| Pytest displayed warning summaries without failing. | Pytest treats every unhandled warning as an error through repository-wide configuration. |
| The package version was `5.3.1`. | The patch version is `5.3.2` with a synchronized lockfile. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes pytest warnings fatal, updates the package and lockfile version to 5.3.2, and runs interactive installer scenarios through a dedicated PTY helper process. The potential PTY input, output, exit-status, and hang regression was disproved: focused successful, reprompt, and invalid-selection installer flows passed under parallel pytest, and the full installer test module completed with 66 passing tests and 56 expected PowerShell-dependent skips.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised interactive installer flows and complete installer test coverage.

No actionable defects remain. The changed PTY path was exercised with scripted input across success, reprompt, and failure-selection behavior, then covered by the complete installer test module using the normal parallel pytest configuration.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused interactive installer tests ran with a PTY flow and passed, showing 3 passed and 1 skipped for the focused run and 66 passed and 56 skipped in the full module run.
- Focused PTY-based tests exercised scripted input for successful installation, a reprompt, and an invalid selection.
- No review script was authored; the artifacts are verbatim captured command outputs, including command, working directory, and exit code.

<a href="https://app.greptile.com/trex/runs/19014011/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fail pytest on warnings"](https://github.com/alishahryar1/free-claude-code/commit/43b2104dac11ba01f109ed449fa0c3dedc67a37a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53580510)</sub>

<!-- /greptile_comment -->