### PR TITLE
Use one writer for shared CI caches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
           version: "0.11.16"
           enable-cache: true
           cache-python: true
+          save-cache: ${{ matrix.id == 'ruff-format' }}
 
       - name: Run
         run: ${{ matrix.run }}


### PR DESCRIPTION
## Problem

All four parallel quality jobs restore and then try to save the same uv and managed-Python cache keys. On cold caches, losing uploads produce cache-reservation warning annotations even though CI succeeds.

## Changes

| Before | After |
| --- | --- |
| Every quality job restored and saved the shared uv caches. | Every quality job restores the shared caches, while ruff-format is the sole writer. |
| Cold-cache runs allowed competing uploads for the same keys. | Cold-cache runs produce one upload per shared key without serializing the matrix. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change keeps uv and managed-Python cache restoration enabled for every quality job while making `ruff-format` the only job that saves the shared cache. An executable workflow check evaluated all four matrix jobs and confirmed that `ruff-format`, `ruff-check`, `ty`, and `pytest` restore caches, while only `ruff-format` writes them. No defects were found.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the cache configuration preserves restoration for every quality job and eliminates concurrent writers for the shared cache.

The workflow behavior was checked across every declared quality-matrix entry, with the pre-change configuration showing four writers and the updated configuration showing exactly one writer without removing restoration.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran trex-artifacts/pr1431-cache-condition-check.py against the parent and updated workflow configurations to verify cache restoration and the save-cache condition across every matrix entry.
- Validated the before-change and after-change outputs to confirm that the PR creates a single-writer cache while keeping restoration enabled for all jobs.

<a href="https://app.greptile.com/trex/runs/19014704/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Use one writer for shared CI caches"](https://github.com/alishahryar1/free-claude-code/commit/aa2ab494a06fa33b7a69f148a58710af3ec58621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53581448)</sub>

<!-- /greptile_comment -->