### PR TITLE
Restore FastAPI application delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - **Dead code**: Remove unused code, legacy systems, and hardcoded values. Use settings/config instead of literals (e.g. `settings.provider_type` not `"nvidia_nim"`).
 - **Performance**: Use list accumulation for strings (not `+=` in loops), cache env vars at init, prefer iterative over recursive when stack depth matters.
 - **Platform-agnostic naming**: Use generic names (e.g. `PLATFORM_EDIT`) not platform-specific ones (e.g. `TELEGRAM_EDIT`) in shared code.
+- **Precise types**: Avoid `typing.Any`. Use owner-defined domain types for known values, `JsonValue`/`JsonObject` for JSON, and `object` only at genuinely opaque boundaries where the value is narrowed before use. Enforce this through design review and type checking, not a mechanical text ban in CI.
 - **No type ignores**: Do not add `# type: ignore` or `# ty: ignore`. Fix the underlying type issue.
 - **Python 3.14 annotations**: Do not use `from __future__ import annotations`; rely on native lazy annotations and fix circular import boundaries instead of hiding them with annotation stringization.
 - **Imports**: Prefer top-level imports. Avoid `TYPE_CHECKING` and local imports for first-party or required dependencies; if a top-level import creates a cycle, move shared types/protocols to a neutral owner.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,6 +141,13 @@ facade-only. Package initialization and those leaves must remain import-order sa
 The model-list schema stays beside its API-owned construction policy in
 `api/model_catalog.py`; there is no generic API model package.
 
+Type annotations follow the same ownership boundaries. Known values use the
+domain types owned by their package, and JSON wire values use `JsonValue` or
+`JsonObject` from `core.json_types`. `object` is reserved for genuinely opaque
+integration boundaries and is narrowed before use. Explicit `typing.Any` is
+avoided because it disables checking, but this remains a semantic design-review
+rule rather than a mechanical text ban in CI.
+
 ## Customer-Facing Contract
 
 FCC optimizes for installed user workflows, not internal compatibility. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@
 - **Dead code**: Remove unused code, legacy systems, and hardcoded values. Use settings/config instead of literals (e.g. `settings.provider_type` not `"nvidia_nim"`).
 - **Performance**: Use list accumulation for strings (not `+=` in loops), cache env vars at init, prefer iterative over recursive when stack depth matters.
 - **Platform-agnostic naming**: Use generic names (e.g. `PLATFORM_EDIT`) not platform-specific ones (e.g. `TELEGRAM_EDIT`) in shared code.
+- **Precise types**: Avoid `typing.Any`. Use owner-defined domain types for known values, `JsonValue`/`JsonObject` for JSON, and `object` only at genuinely opaque boundaries where the value is narrowed before use. Enforce this through design review and type checking, not a mechanical text ban in CI.
 - **No type ignores**: Do not add `# type: ignore` or `# ty: ignore`. Fix the underlying type issue.
 - **Python 3.14 annotations**: Do not use `from __future__ import annotations`; rely on native lazy annotations and fix circular import boundaries instead of hiding them with annotation stringization.
 - **Imports**: Prefer top-level imports. Avoid `TYPE_CHECKING` and local imports for first-party or required dependencies; if a top-level import creates a cycle, move shared types/protocols to a neutral owner.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.3.3"
+version = "5.3.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/runtime/asgi.py
+++ b/src/free_claude_code/runtime/asgi.py
@@ -13,6 +13,10 @@ class RuntimeASGIApp:
         self.app = app
         self.runtime = runtime
 
+    def __getattr__(self, name: str) -> object:
+        """Expose the wrapped application's public interface transparently."""
+        return getattr(self.app, name)
+
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "lifespan":
             await self.app(scope, receive, send)

--- a/tests/api/test_app_lifespan_and_errors.py
+++ b/tests/api/test_app_lifespan_and_errors.py
@@ -312,6 +312,17 @@ def test_bootstrap_configures_default_log_and_publishes_only_services(tmp_path):
     assert set(api_app.state._state) == {"services"}
 
 
+def test_bootstrap_app_transparently_exposes_fastapi_interface() -> None:
+    with patch("free_claude_code.runtime.bootstrap.configure_logging"):
+        asgi_app = build_asgi_app(_settings())
+
+    api_app = cast(FastAPI, asgi_app.app)
+    assert asgi_app.router is api_app.router
+    assert asgi_app.routes is api_app.routes
+    assert asgi_app.state is api_app.state
+    assert asgi_app.openapi == api_app.openapi
+
+
 def test_bootstrap_wires_the_codex_catalog_publisher() -> None:
     publisher = MagicMock()
 

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.3.3"
+version = "5.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

PR #1432 removed `RuntimeASGIApp` attribute delegation while eliminating `Any`. The public application returned by `build_asgi_app()` no longer exposed standard FastAPI attributes.

## Changes

| Before | After |
| --- | --- |
| The runtime wrapper exposed only its own attributes and ASGI call path. | The runtime wrapper transparently delegates unknown attributes to the wrapped FastAPI app. |
| Dynamic delegation used `Any`. | The genuinely opaque delegation boundary returns `object` without disabling type checking. |
| Public FastAPI attribute compatibility had no regression coverage. | Bootstrap coverage verifies `router`, `routes`, `state`, and `openapi` delegation. |
| Precise typing had no explicit architectural rule. | Architecture and agent guidance prefer domain and JSON types, reserve `object` for opaque boundaries, and reject a mechanical CI text ban. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change restores transparent FastAPI interface access through `RuntimeASGIApp`, adds regression coverage, updates the patch version, and documents typing guidance. Executed checks confirmed that the wrapper exposes the wrapped application's router, routes, state, and OpenAPI interface; routes registered through the wrapper serve HTTP 200 responses; and runtime startup and shutdown ownership remains unchanged. The checked interface-regression hypothesis was disproved by the exercised HTTP and lifespan paths. The change is ready to merge.
</details>

<h3>Confidence Score: 5/5</h3>

The wrapper retains its runtime lifecycle behavior while restoring the expected FastAPI-facing interface.

Executable checks covered attribute delegation, delegated route registration, an HTTP request, and lifespan startup and shutdown behavior, with all expected outcomes observed and no final defects found.

**Files Needing Attention:** No files need further attention for this change.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored RuntimeASGIApp validation script with --before from the repository root.
- Ran the authored RuntimeASGIApp validation script without --before from the repository root.
- The after-run exited with code 0 and reported preserved interface access, delegated route registration, HTTP 200 response, and one startup/one shutdown runtime await.
- It was confirmed that no product code was modified and only review artifacts were created.

<a href="https://app.greptile.com/trex/runs/19017363/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Document precise typing guidance"](https://github.com/alishahryar1/free-claude-code/commit/eca0baf974b0fd4205dc08e5f17625e8c42f82cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53586768)</sub>

<!-- /greptile_comment -->