### PR TITLE
Add ClinePass subscription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,10 @@ VERTEX_LOCATION="global"
 # GROQ_API_KEY=<your-token>
 
 
+# ClinePass subscription (create a programmatic key under Settings > API Keys at app.cline.bot)
+# CLINE_API_KEY=<your-token>
+
+
 # xAI / Grok (OpenAI-compatible Chat Completions at api.x.ai/v1)
 # XAI_API_KEY=<your-token>
 
@@ -183,7 +187,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -226,6 +230,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # FCC_SMOKE_MODEL_GEMINI=<provider/model-id>
 # FCC_SMOKE_MODEL_VERTEX=<provider/model-id>
 # FCC_SMOKE_MODEL_GROQ=<provider/model-id>
+# FCC_SMOKE_MODEL_CLINE_PASS=<provider/model-id>
 # FCC_SMOKE_MODEL_QWENCLOUD=<provider/model-id>
 # FCC_SMOKE_MODEL_QWENCLOUD_CODING=<provider/model-id>
 # FCC_SMOKE_MODEL_TOGETHER=<provider/model-id>
@@ -300,6 +305,7 @@ REASONING_HAIKU=inherit
 # GEMINI_PROXY=<http-or-socks-url>
 # VERTEX_PROXY=<http-or-socks-url>
 # GROQ_PROXY=<http-or-socks-url>
+# CLINE_PASS_PROXY=<http-or-socks-url>
 # SAMBANOVA_PROXY=<http-or-socks-url>
 # KILO_PROXY=<http-or-socks-url>
 # CEREBRAS_PROXY=<http-or-socks-url>

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -796,6 +796,13 @@ because its subscription key, quota, endpoint, and personal interactive-use
 contract are separate. It uses the ordinary OpenAI Chat transport, preserves
 reasoning history through `reasoning_content`, and does not impose one reasoning
 control or output-token default across its heterogeneous model catalog.
+ClinePass is a distinct subscription provider using Cline's programmatic
+`CLINE_API_KEY` and fixed OpenAI Chat Completions endpoint. Its declarative
+profile discovers only the dynamic `clinePass` catalog collection, consumes
+plaintext `reasoning`, preserves documented opaque `reasoning_details`, and
+sends no invented catalog-wide reasoning control. General Cline usage billing,
+CLI account authentication, and Cline-native tools remain separate product
+decisions.
 Z.ai Coding Plan (`zai`) and Z.ai API (`zai_api`) are distinct provider
 identities because their fixed endpoints select Coding Plan quota versus
 pay-as-you-go balance. They share the upstream `ZAI_API_KEY` and one declarative

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ fcc-codex exec "hello"
 | [NVIDIA NIM](https://build.nvidia.com/settings/api-keys) | `NVIDIA_NIM_API_KEY` | `nvidia_nim/nvidia/nemotron-3-super-120b-a12b` |
 | [OpenRouter](https://openrouter.ai/keys) | `OPENROUTER_API_KEY` | `open_router/openrouter/free` |
 | [Groq](https://console.groq.com/keys) | `GROQ_API_KEY` | `groq/llama-3.3-70b-versatile` |
+| [ClinePass](https://docs.cline.bot/getting-started/clinepass) | `CLINE_API_KEY` | `cline_pass/cline-pass/kimi-k3` |
 | [OpenAI / ChatGPT](https://learn.chatgpt.com/docs/auth) | Connect ChatGPT in the Admin UI | `openai/<model-id>` |
 | [xAI (Grok)](https://console.x.ai/team/default/api-keys) | `XAI_API_KEY` | `xai/grok-4.5` |
 | [QwenCloud Token Plan](https://home.qwencloud.com/api-keys) | `QWENCLOUD_API_KEY` | `qwencloud/qwen3.7-plus` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.3.4"
+version = "5.4.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -72,6 +72,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini/models/gemini-3.1-flash-lite",
     "vertex": "vertex/google/gemini-3.5-flash",
     "groq": "groq/llama-3.3-70b-versatile",
+    "cline_pass": "cline_pass/cline-pass/deepseek-v4-flash",
     "xai": "xai/grok-4.5",
     "qwencloud": "qwencloud/qwen3.7-plus",
     "qwencloud_coding": "qwencloud_coding/qwen3.7-plus",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -153,6 +153,14 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, ProviderFieldOverride] = {
             "[OpenAI compatibility docs](https://console.groq.com/docs/openai)."
         ),
     },
+    "CLINE_API_KEY": {
+        "label": "Cline API Key",
+        "description": (
+            "Subscribe to ClinePass, then create a programmatic API key under "
+            "Settings > API Keys at app.cline.bot. This is not the Cline CLI's "
+            "managed account token."
+        ),
+    },
     "XAI_API_KEY": {
         "label": "xAI API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -46,6 +46,8 @@ GEMINI_DEFAULT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai/"
 # Vertex AI API root. The provider owns project/location endpoint composition.
 VERTEX_AI_API_ROOT = "https://aiplatform.googleapis.com"
 GROQ_DEFAULT_BASE = "https://api.groq.com/openai/v1"
+# ClinePass subscription models through Cline's OpenAI-compatible API.
+CLINE_DEFAULT_BASE = "https://api.cline.bot/api/v1"
 CEREBRAS_DEFAULT_BASE = "https://api.cerebras.ai/v1"
 SAMBANOVA_DEFAULT_BASE = "https://api.sambanova.ai/v1"
 # Kilo.ai gateway OpenAI-compatible Chat Completions API.
@@ -145,6 +147,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="groq_api_key",
         default_base_url=GROQ_DEFAULT_BASE,
         proxy_attr="groq_proxy",
+    ),
+    "cline_pass": ProviderDescriptor(
+        provider_id="cline_pass",
+        display_name="ClinePass",
+        credential_env="CLINE_API_KEY",
+        credential_url="https://app.cline.bot",
+        credential_attr="cline_api_key",
+        default_base_url=CLINE_DEFAULT_BASE,
+        proxy_attr="cline_pass_proxy",
     ),
     "openai": ProviderDescriptor(
         provider_id="openai",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -200,6 +200,11 @@ class Settings(BaseModel):
         default=None, validation_alias="GROQ_API_KEY"
     )
 
+    # ==================== ClinePass (OpenAI-compatible) ====================
+    cline_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="CLINE_API_KEY"
+    )
+
     # ==================== xAI / Grok (OpenAI-compatible) ====================
     xai_api_key: OptionalNonEmptyString = Field(
         default=None, validation_alias="XAI_API_KEY"
@@ -458,6 +463,9 @@ class Settings(BaseModel):
     )
     groq_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="GROQ_PROXY"
+    )
+    cline_pass_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="CLINE_PASS_PROXY"
     )
     cerebras_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="CEREBRAS_PROXY"

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -211,6 +211,17 @@ def _zai_profile(provider_name: str) -> OpenAIChatProfile:
 
 
 OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
+    "cline_pass": OpenAIChatProfile(
+        _policy("CLINE_PASS", ReasoningReplayMode.DISABLED),
+        NO_REASONING,
+        postprocessors=(apply_reasoning_details_replay,),
+        model_listing=OpenAIModelListing(
+            path="/ai/cline/recommended-models",
+            collection_field="clinePass",
+        ),
+        reasoning_delta_field="reasoning",
+        structured_reasoning_details=True,
+    ),
     "xai": OpenAIChatProfile(
         _policy(
             "XAI",

--- a/tests/contracts/test_admin_provider_manifest.py
+++ b/tests/contracts/test_admin_provider_manifest.py
@@ -163,6 +163,33 @@ def test_qwencloud_coding_key_is_a_distinct_admin_provider_field() -> None:
     assert "separate endpoints" in entry.description
 
 
+def test_cline_pass_admin_fields_use_programmatic_key_and_fixed_endpoint() -> None:
+    from free_claude_code.config.admin.status import provider_config_status
+
+    key = FIELD_BY_KEY["CLINE_API_KEY"]
+    proxy = FIELD_BY_KEY["CLINE_PASS_PROXY"]
+    status = next(
+        item
+        for item in provider_config_status(
+            {"CLINE_API_KEY": _test_value("cline-programmatic-key")}
+        )
+        if item["provider_id"] == "cline_pass"
+    )
+
+    assert key.label == "Cline API Key"
+    assert key.settings_attr == "cline_api_key"
+    assert key.section_id == "providers"
+    assert key.secret is True
+    assert "Subscribe to ClinePass" in key.description
+    assert "Settings > API Keys" in key.description
+    assert "not the Cline CLI's managed account token" in key.description
+    assert proxy.settings_attr == "cline_pass_proxy"
+    assert proxy.secret is True
+    assert "CLINE_BASE_URL" not in FIELD_BY_KEY
+    assert status["display_name"] == "ClinePass"
+    assert status["status"] == "configured"
+
+
 def test_zai_shared_key_configures_both_distinct_provider_surfaces() -> None:
     from free_claude_code.config.admin.status import provider_config_status
 

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -9,6 +9,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "nvidia_nim",
     "open_router",
     "groq",
+    "cline_pass",
     "openai",
     "xai",
     "qwencloud",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -53,6 +53,7 @@ def _settings(**overrides):
         "vertex_project_id": "",
         "vertex_location": "global",
         "groq_api_key": "",
+        "cline_api_key": "",
         "xai_api_key": "",
         "qwencloud_api_key": "",
         "qwencloud_coding_api_key": "",
@@ -176,6 +177,45 @@ def test_xai_provider_smoke_uses_current_grok_model(monkeypatch) -> None:
     assert [model.provider for model in models] == ["xai"]
     assert models[0].full_model == "xai/grok-4.5"
     assert models[0].source == "provider_default"
+
+
+def test_cline_pass_provider_smoke_uses_low_cost_subscription_model(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_CLINE_PASS", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            cline_api_key="cline-key",
+        )
+    )
+
+    models = config.provider_smoke_models()
+
+    assert [model.provider for model in models] == ["cline_pass"]
+    assert models[0].full_model == "cline_pass/cline-pass/deepseek-v4-flash"
+    assert models[0].source == "provider_default"
+
+
+def test_cline_pass_smoke_override_accepts_full_or_upstream_model_ref(
+    monkeypatch,
+) -> None:
+    settings = _settings(
+        model="ollama/llama3.1",
+        ollama_base_url="",
+        cline_api_key="cline-key",
+    )
+    for override in (
+        "cline_pass/cline-pass/kimi-k3",
+        "cline-pass/kimi-k3",
+    ):
+        monkeypatch.setenv("FCC_SMOKE_MODEL_CLINE_PASS", override)
+        models = _smoke_config(settings=settings).provider_smoke_models()
+
+        assert [model.provider for model in models] == ["cline_pass"]
+        assert models[0].full_model == "cline_pass/cline-pass/kimi-k3"
+        assert models[0].source == "FCC_SMOKE_MODEL_CLINE_PASS"
 
 
 def test_zai_shared_key_enables_both_provider_smoke_surfaces(monkeypatch) -> None:

--- a/tests/providers/test_cline_pass.py
+++ b/tests/providers/test_cline_pass.py
@@ -45,6 +45,33 @@ def cline_pass_provider() -> OpenAIChatProvider:
     )
 
 
+def _provider_with_transport(
+    transport: httpx.AsyncBaseTransport,
+    *,
+    api_key: str = "wire-cline-key",
+) -> OpenAIChatProvider:
+    client = AsyncOpenAI(
+        api_key=api_key,
+        base_url=CLINE_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=transport),
+    )
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI",
+        return_value=client,
+    ):
+        return profiled_provider(
+            "cline_pass",
+            make_provider_config(
+                api_key=api_key,
+                base_url=CLINE_DEFAULT_BASE,
+                rate_limit=10,
+                rate_window=60,
+            ),
+            admission=immediate_admission(provider_name="cline_pass"),
+        )
+
+
 def _request(**overrides: JsonValue) -> MessagesRequest:
     payload: JsonObject = {
         "model": "cline-pass/kimi-k3",
@@ -315,9 +342,7 @@ async def test_stream_uses_upstream_sse_and_preserves_reasoning_details(
 
 
 @pytest.mark.asyncio
-async def test_model_catalog_uses_cline_pass_collection_endpoint_and_auth(
-    cline_pass_provider: OpenAIChatProvider,
-) -> None:
+async def test_model_catalog_uses_cline_pass_collection_endpoint_and_auth() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -335,17 +360,13 @@ async def test_model_catalog_uses_cline_pass_collection_endpoint_and_auth(
             },
         )
 
-    await cline_pass_provider._client.close()
-    cline_pass_provider._client = AsyncOpenAI(
-        api_key="wire-cline-key",
-        base_url=CLINE_DEFAULT_BASE,
-        max_retries=0,
-        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    provider = _provider_with_transport(
+        httpx.MockTransport(handler),
     )
     try:
-        model_infos = await cline_pass_provider.list_model_infos()
+        model_infos = await provider.list_model_infos()
     finally:
-        await cline_pass_provider.cleanup()
+        await provider.cleanup()
 
     assert model_infos == frozenset(
         {
@@ -370,18 +391,24 @@ async def test_model_catalog_uses_cline_pass_collection_endpoint_and_auth(
 )
 @pytest.mark.asyncio
 async def test_model_catalog_rejects_malformed_or_empty_cline_pass_collection(
-    cline_pass_provider: OpenAIChatProvider,
     payload: JsonObject,
     message: str,
 ) -> None:
-    cline_pass_provider._client.get = AsyncMock(return_value=payload)
-    cline_pass_provider._client.models.list = AsyncMock()
+    requests: list[httpx.Request] = []
 
-    with pytest.raises(ModelListResponseError, match=message):
-        await cline_pass_provider.list_model_infos()
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=payload)
 
-    cline_pass_provider._client.get.assert_awaited_once_with(
-        "/ai/cline/recommended-models",
-        cast_to=object,
-    )
-    cline_pass_provider._client.models.list.assert_not_awaited()
+    provider = _provider_with_transport(httpx.MockTransport(handler))
+
+    try:
+        with pytest.raises(ModelListResponseError, match=message):
+            await provider.list_model_infos()
+    finally:
+        await provider.cleanup()
+
+    assert [str(request.url) for request in requests] == [
+        "https://api.cline.bot/api/v1/ai/cline/recommended-models"
+    ]
+    assert requests[0].headers["authorization"] == ("Bearer wire-cline-key")

--- a/tests/providers/test_cline_pass.py
+++ b/tests/providers/test_cline_pass.py
@@ -1,0 +1,387 @@
+"""Tests for the ClinePass OpenAI-chat profile and dynamic model catalog."""
+
+import json
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import CLINE_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.stream_contracts import (
+    parse_sse_text,
+    text_content,
+    thinking_content,
+)
+from free_claude_code.core.json_types import JsonObject, JsonValue
+from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_DEFAULT,
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+)
+
+
+@pytest.fixture
+def cline_pass_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "cline_pass",
+        make_provider_config(
+            api_key="test-cline-key",
+            base_url=CLINE_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="cline_pass"),
+    )
+
+
+def _request(**overrides: JsonValue) -> MessagesRequest:
+    payload: JsonObject = {
+        "model": "cline-pass/kimi-k3",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    payload.update(overrides)
+    return MessagesRequest.model_validate(payload)
+
+
+class AsyncStream:
+    def __init__(self, chunks: list[SimpleNamespace]) -> None:
+        self._chunks = chunks
+        self.closed = False
+
+    def __aiter__(self) -> AsyncIterator[SimpleNamespace]:
+        return self._iter()
+
+    async def _iter(self) -> AsyncIterator[SimpleNamespace]:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _chunk(
+    *,
+    content: str | None = None,
+    reasoning: str | None = None,
+    reasoning_details: list[JsonObject] | None = None,
+    finish_reason: str | None = None,
+) -> SimpleNamespace:
+    delta = SimpleNamespace(
+        content=content,
+        reasoning=reasoning,
+        reasoning_details=reasoning_details,
+        tool_calls=None,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+def test_init_uses_documented_cline_api(
+    cline_pass_provider: OpenAIChatProvider,
+) -> None:
+    assert cline_pass_provider._api_key == "test-cline-key"
+    assert cline_pass_provider._base_url == CLINE_DEFAULT_BASE
+    assert cline_pass_provider._provider_name == "CLINE_PASS"
+    assert cline_pass_provider._profile.user_agent is None
+
+
+def test_build_request_body_preserves_nested_model_images_tools_and_results(
+    cline_pass_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(
+        max_tokens=321,
+        system="Be concise.",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Inspect this image."},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "aW1hZ2U=",
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_inspect",
+                        "name": "inspect_image",
+                        "input": {"detail": "high"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_inspect",
+                        "content": "image contents",
+                    }
+                ],
+            },
+        ],
+        tools=[
+            {
+                "name": "inspect_image",
+                "description": "Inspect an image",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"detail": {"type": "string"}},
+                },
+            }
+        ],
+        tool_choice={"type": "tool", "name": "inspect_image"},
+        extra_body={"provider_option": "must-not-pass-through"},
+    )
+
+    body = cline_pass_provider._build_request_body(
+        request,
+        reasoning=ReasoningPolicy.on(),
+    )
+
+    assert body["model"] == "cline-pass/kimi-k3"
+    assert body["max_tokens"] == 321
+    assert "max_completion_tokens" not in body
+    assert body["messages"][0] == {"role": "system", "content": "Be concise."}
+    assert body["messages"][1]["content"] == [
+        {"type": "text", "text": "Inspect this image."},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aW1hZ2U="},
+        },
+    ]
+    assert body["messages"][2]["tool_calls"] == [
+        {
+            "id": "call_inspect",
+            "type": "function",
+            "function": {
+                "name": "inspect_image",
+                "arguments": '{"detail": "high"}',
+            },
+        }
+    ]
+    assert body["messages"][3] == {
+        "role": "tool",
+        "tool_call_id": "call_inspect",
+        "content": "image contents",
+    }
+    assert body["tools"][0]["function"]["name"] == "inspect_image"
+    assert body["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "inspect_image"},
+    }
+    assert "extra_body" not in body
+
+
+@pytest.mark.parametrize(
+    "reasoning",
+    [REASONING_DEFAULT, REASONING_OFF, REASONING_ON],
+)
+def test_build_request_body_adds_no_undocumented_reasoning_control_or_default_cap(
+    cline_pass_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+) -> None:
+    body = cline_pass_provider._build_request_body(
+        _request(),
+        reasoning=reasoning,
+    )
+
+    assert "max_tokens" not in body
+    assert "max_completion_tokens" not in body
+    assert "extra_body" not in body
+    for field in (
+        "reasoning",
+        "reasoning_effort",
+        "thinking",
+        "enable_thinking",
+        "chat_template_kwargs",
+    ):
+        assert field not in body
+
+
+def test_build_request_body_replays_only_opaque_reasoning_details(
+    cline_pass_provider: OpenAIChatProvider,
+) -> None:
+    detail: JsonObject = {
+        "type": "reasoning.text",
+        "text": "Need a tool.",
+        "signature": "signed-opaque-value",
+        "format": "anthropic-claude-v1",
+        "index": 0,
+    }
+    request = _request(
+        messages=[
+            {"role": "user", "content": "Inspect the repository."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Need a tool."},
+                    {"type": "redacted_thinking", "data": json.dumps(detail)},
+                    {"type": "text", "text": "I will inspect it."},
+                ],
+            },
+            {"role": "user", "content": "Continue."},
+        ]
+    )
+
+    body = cline_pass_provider._build_request_body(
+        request,
+        reasoning=ReasoningPolicy.on(),
+    )
+    assistant = next(
+        message for message in body["messages"] if message["role"] == "assistant"
+    )
+
+    assert assistant["content"] == "I will inspect it."
+    assert assistant["reasoning_details"] == [detail]
+    assert "reasoning" not in assistant
+    assert "reasoning_content" not in assistant
+    assert (
+        cline_pass_provider._profile.reasoning_delta(
+            SimpleNamespace(reasoning="next thought", reasoning_content="ignored")
+        )
+        == "next thought"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_uses_upstream_sse_and_preserves_reasoning_details(
+    cline_pass_provider: OpenAIChatProvider,
+) -> None:
+    detail: JsonObject = {
+        "type": "reasoning.text",
+        "text": "plan ",
+        "signature": "signed-opaque-value",
+        "format": "anthropic-claude-v1",
+        "index": 0,
+    }
+    stream = AsyncStream(
+        [
+            _chunk(reasoning="plan ", reasoning_details=[detail]),
+            _chunk(content="done", finish_reason="stop"),
+        ]
+    )
+    create = AsyncMock(return_value=stream)
+    with patch.object(
+        cline_pass_provider._client.chat.completions,
+        "create",
+        create,
+    ):
+        event_text = "".join(
+            [
+                event
+                async for event in cline_pass_provider.stream_response(
+                    _request(),
+                    reasoning=ReasoningPolicy.on(),
+                )
+            ]
+        )
+
+    events = parse_sse_text(event_text)
+    await_args = create.await_args
+    assert await_args is not None
+    assert await_args.kwargs["stream"] is True
+    assert await_args.kwargs["model"] == "cline-pass/kimi-k3"
+    assert thinking_content(events) == "plan "
+    assert text_content(events) == "done"
+    redacted_blocks = [
+        event.data["content_block"]
+        for event in events
+        if event.event == "content_block_start"
+        and event.data.get("content_block", {}).get("type") == "redacted_thinking"
+    ]
+    assert len(redacted_blocks) == 1
+    assert json.loads(redacted_blocks[0]["data"]) == detail
+    assert stream.closed
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_cline_pass_collection_endpoint_and_auth(
+    cline_pass_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "recommended": [{"id": "anthropic/claude-sonnet-4-6"}],
+                "free": [{"id": "cline/free-model"}],
+                "clinePass": [
+                    {"id": "cline-pass/kimi-k3"},
+                    {"id": "cline-pass/deepseek-v4-flash"},
+                ],
+                "clineCloud": [{"id": "anthropic/claude-opus-4-6"}],
+            },
+        )
+
+    await cline_pass_provider._client.close()
+    cline_pass_provider._client = AsyncOpenAI(
+        api_key="wire-cline-key",
+        base_url=CLINE_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        model_infos = await cline_pass_provider.list_model_infos()
+    finally:
+        await cline_pass_provider.cleanup()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("cline-pass/kimi-k3"),
+            ProviderModelInfo("cline-pass/deepseek-v4-flash"),
+        }
+    )
+    assert len(requests) == 1
+    assert str(requests[0].url) == (
+        "https://api.cline.bot/api/v1/ai/cline/recommended-models"
+    )
+    assert requests[0].headers["authorization"] == "Bearer wire-cline-key"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"recommended": []}, "top-level clinePass array"),
+        ({"clinePass": []}, "did not include any model ids"),
+        ({"clinePass": [{}]}, "clinePass item to include id"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_model_catalog_rejects_malformed_or_empty_cline_pass_collection(
+    cline_pass_provider: OpenAIChatProvider,
+    payload: JsonObject,
+    message: str,
+) -> None:
+    cline_pass_provider._client.get = AsyncMock(return_value=payload)
+    cline_pass_provider._client.models.list = AsyncMock()
+
+    with pytest.raises(ModelListResponseError, match=message):
+        await cline_pass_provider.list_model_infos()
+
+    cline_pass_provider._client.get.assert_awaited_once_with(
+        "/ai/cline/recommended-models",
+        cast_to=object,
+    )
+    cline_pass_provider._client.models.list.assert_not_awaited()

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -14,6 +14,7 @@ from free_claude_code.config.provider_catalog import (
     AGNES_DEFAULT_BASE,
     BEDROCK_DEFAULT_BASE,
     CHUTES_DEFAULT_BASE,
+    CLINE_DEFAULT_BASE,
     COHERE_DEFAULT_BASE,
     DEEPINFRA_DEFAULT_BASE,
     FEATHERLESS_DEFAULT_BASE,
@@ -146,6 +147,8 @@ def _make_settings(**overrides):
     mock.vertex_proxy = None
     mock.groq_api_key = ""
     mock.groq_proxy = None
+    mock.cline_api_key = ""
+    mock.cline_pass_proxy = None
     mock.cerebras_api_key = ""
     mock.cerebras_proxy = None
     mock.ollama_cloud_proxy = None
@@ -266,6 +269,29 @@ def test_qwencloud_provider_config_uses_key_base_and_proxy() -> None:
     assert config.base_url == QWENCLOUD_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_cline_pass_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["cline_pass"]
+    settings = _make_settings(
+        cline_api_key="cline-programmatic-token",
+        cline_pass_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("cline_pass", settings)
+
+    assert descriptor.display_name == "ClinePass"
+    assert descriptor.credential_env == "CLINE_API_KEY"
+    assert descriptor.credential_attr == "cline_api_key"
+    assert descriptor.credential_url == "https://app.cline.bot"
+    assert descriptor.base_url_attr is None
+    assert config.api_key == "cline-programmatic-token"
+    assert config.base_url == CLINE_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+    assert provider._provider_name == "CLINE_PASS"
 
 
 def test_qwencloud_coding_provider_config_uses_key_base_and_proxy() -> None:
@@ -769,6 +795,7 @@ def test_create_provider_instantiates_each_builtin():
         gemini_api_key="test_gemini_key",
         vertex_project_id="test-vertex-project",
         groq_api_key="test_groq_key",
+        cline_api_key="test_cline_key",
         cerebras_api_key="test_cerebras_key",
         fireworks_api_key="test_fireworks_key",
         novita_api_key="test_novita_key",
@@ -789,6 +816,7 @@ def test_create_provider_instantiates_each_builtin():
     cases = {
         "nvidia_nim": NvidiaNimProvider,
         "openai": OpenAICodexProvider,
+        "cline_pass": OpenAIChatProvider,
         "xai": OpenAIChatProvider,
         "qwencloud": OpenAIChatProvider,
         "qwencloud_coding": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.3.4"
+version = "5.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC cannot route requests through a user's ClinePass subscription, even though Cline documents programmatic access through its OpenAI-compatible API.

## Changes

| Before | After |
| --- | --- |
| ClinePass had no FCC provider identity or configuration path. | Added `cline_pass` with `CLINE_API_KEY`, a fixed Cline API endpoint, per-provider proxy support, and Admin UI guidance that distinguishes API keys from CLI login tokens. |
| ClinePass models had to be entered without provider-owned discovery. | Added dynamic discovery from Cline's `clinePass` catalog collection while preserving exact nested model IDs such as `cline_pass/cline-pass/kimi-k3`. |
| Cline reasoning behavior had no explicit FCC contract. | Added documented `delta.reasoning` output and opaque `reasoning_details` replay without inventing a catalog-wide reasoning control. |
| ClinePass had no release, smoke, or deterministic contract coverage. | Bumped FCC to 5.4.0, added opt-in provider smoke configuration, passed all five local CI checks and 3,114 tests, and verified the public catalog live. Credentialed inference was not run because no paid ClinePass entitlement was available. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the ClinePass provider test suite so catalog requests are exercised through a constructed HTTP client and mock transport.
</details>

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Catalog tests now build an AsyncOpenAI instance with httpx.MockTransport before provider construction and verify the actual request URL and authentication.
- The streaming test continues to access the private \_client and patches the private OpenAI SDK resource method, so it does not exercise the constructed transport, the SDK streaming parser, or the client lifecycle.
- The proof notes that no security impact was verified and identifies a test-isolation/regression-detection gap.

<a href="https://app.greptile.com/trex/runs/19022035/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: inject ClinePass catalog client at..."](https://github.com/alishahryar1/free-claude-code/commit/400c9b2f30c5422a6c70f1292c1dae4580d3c9fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53595033)</sub>

<!-- /greptile_comment -->