### PR TITLE
Feat/atomic prime muse clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@
 
 </div>
 
+> This repository is built on top of
+> [Alishahryar1/free-claude-code](https://github.com/Alishahryar1/free-claude-code).
+> Extra clients here: Atomic Agents, Prime Agent, and Muse Code (optional MCP).
+> Do not commit `.env`, API keys, or passwords.
+
 ## What You Get
 
-- **Use your preferred coding agent.** Run Claude Code, Codex, or Pi with FCC.
+- **Use your preferred coding agent.** Run Claude Code, Codex, Pi, Atomic Agents, Prime Agent, or Muse Code with FCC.
 - **Choose your own models.** Connect free, paid, or local providers and search their models from one Admin UI.
 - **Route work your way.** Set one default model or map Fable, Opus, Sonnet, and Haiku separately.
 - **Save time and tokens.** Five built-in optimizations handle quota probes, command-prefix detection, title generation, suggestion mode, and filepath extraction locally instead of calling your provider; optionally enable [RTK](https://github.com/rtk-ai/rtk) to filter noisy terminal output before it reaches the model.
@@ -292,7 +297,33 @@ Providers that do not support a selected control retain their own behavior.
 
 ## Connect Your Client
 
-For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`, or `fcc-pi`. Use the guides below for editor integrations.
+For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`, `fcc-pi`, `fcc-atomic`, `fcc-prime`, or `fcc-muse`. Use the guides below for editor integrations.
+
+### Atomic Agents, Prime Agent, and Muse Code (simple)
+
+1. Put your provider key only in `~/.fcc/.env` (for example `OPENROUTER_API_KEY`). Never put keys in git.
+2. Start the proxy: `fcc-server`
+3. Pick a model in Admin, or set `MODEL=open_router/openai/gpt-4o-mini`
+4. Use one launcher:
+
+```bash
+# One Chat Completions turn (uses Atomic Agents if installed, otherwise the OpenAI wire format)
+fcc-atomic ping
+
+# Prime Agent through FCC (install Prime Agent first)
+fcc-prime
+
+# Muse Code through FCC (install Muse Code first)
+fcc-muse
+```
+
+Optional Muse MCP: set `FCC_MUSE_MCP_COMMAND` to a stdio MCP server command, or set `FCC_MUSE_MCP_SERVERS` to a JSON object. Those values stay in your environment; they are not written to the repo.
+
+```bash
+# Example: optional MCP server for Muse (replace with a server you trust)
+export FCC_MUSE_MCP_COMMAND="npx -y @modelcontextprotocol/server-filesystem"
+fcc-muse
+```
 
 <details>
 <summary><strong>Claude Code in VS Code</strong></summary>

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 </div>
 
-> This repository is built on top of
-> [Alishahryar1/free-claude-code](https://github.com/Alishahryar1/free-claude-code).
-> Extra clients here: Atomic Agents, Prime Agent, and Muse Code (optional MCP).
+> This repository is [vinothhacks/free-claude-code](https://github.com/vinothhacks/free-claude-code),
+> built on [Alishahryar1/free-claude-code](https://github.com/Alishahryar1/free-claude-code).
+> Extra clients here: `fcc-atomic`, `fcc-prime`, and `fcc-muse` (optional MCP).
 > Do not commit `.env`, API keys, or passwords.
 
 ## What You Get
@@ -42,18 +42,52 @@
 
 <a id="install"></a>
 
-### 1. Install Or Update
+### Install this fork (fcc-atomic, fcc-prime, fcc-muse)
+
+Share **this** repo with friends: [vinothhacks/free-claude-code](https://github.com/vinothhacks/free-claude-code). The upstream installer does not include these three commands.
+
+Need [uv](https://docs.astral.sh/uv/getting-started/installation/) and Python 3.14. Put provider keys only in `~/.fcc/.env` (for example `OPENROUTER_API_KEY`). Never put keys in git.
+
+```bash
+uv tool install --force --python 3.14 git+https://github.com/vinothhacks/free-claude-code.git
+```
+
+```powershell
+uv tool install --force --python 3.14 git+https://github.com/vinothhacks/free-claude-code.git
+```
+
+Then start the proxy and use the launchers:
+
+```bash
+fcc-server
+```
+
+```bash
+fcc-atomic ping
+fcc-prime
+fcc-muse
+```
+
+- **fcc-atomic** — one Chat Completions turn through FCC. Works without extra packages; install `atomic-agents` and `instructor` if you want the Atomic Agents library.
+- **fcc-prime** — needs Node.js 20.6+ and npm. Missing Prime Agent is installed automatically.
+- **fcc-muse** — macOS/Linux, or Windows with [WSL2](https://learn.microsoft.com/windows/wsl/install). Missing Muse Code is installed automatically.
+
+To update later, re-run the same `uv tool install --force ...` command.
+
+### 1. Full installer (optional)
+
+The full installer also offers Claude Code, Codex, Pi, Muse Code, and Prime Agent.
 
 macOS/Linux:
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.sh" | sh
+curl -fsSL "https://raw.githubusercontent.com/vinothhacks/free-claude-code/main/scripts/install.sh" | sh
 ```
 
 Windows PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1")))
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/vinothhacks/free-claude-code/main/scripts/install.ps1")))
 ```
 
 Re-run the same command whenever you want to update. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
@@ -132,7 +166,15 @@ Pi:
 fcc-pi
 ```
 
-All three launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
+Atomic Agents, Prime Agent, and Muse Code (this fork):
+
+```bash
+fcc-atomic ping
+fcc-prime
+fcc-muse
+```
+
+These launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
 
 ```bash
 fcc-codex exec "hello"
@@ -301,6 +343,8 @@ For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`, `fcc-p
 
 ### Atomic Agents, Prime Agent, and Muse Code (simple)
 
+Friends: install **this GitHub repo**, not upstream. See [Install this fork](#install-this-fork-fcc-atomic-fcc-prime-fcc-muse).
+
 1. Put your provider key only in `~/.fcc/.env` (for example `OPENROUTER_API_KEY`). Never put keys in git.
 2. Start the proxy: `fcc-server`
 3. Pick a model in Admin, or set `MODEL=open_router/openai/gpt-4o-mini`
@@ -310,12 +354,14 @@ For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`, `fcc-p
 # One Chat Completions turn (uses Atomic Agents if installed, otherwise the OpenAI wire format)
 fcc-atomic ping
 
-# Prime Agent through FCC (install Prime Agent first)
+# Prime Agent through FCC (installs Prime Agent with npm if missing)
 fcc-prime
 
-# Muse Code through FCC (install Muse Code first)
+# Muse Code through FCC (installs Muse Code if missing; uses WSL2 on Windows)
 fcc-muse
 ```
+
+`fcc-prime` and `fcc-muse` install the missing CLI the first time you run them. Prime uses npm and the GitHub release tarball. Muse uses Meta's official installer, and on Windows that runs inside WSL2. Set `FCC_NO_AUTO_INSTALL=1` to skip auto-install and only print the install URL.
 
 Optional Muse MCP: set `FCC_MUSE_MCP_COMMAND` to a stdio MCP server command, or set `FCC_MUSE_MCP_SERVERS` to a JSON object. Those values stay in your environment; they are not written to the repo.
 
@@ -527,13 +573,13 @@ replace the final option with the matching one from the table.
 macOS/Linux:
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.sh" | sh -s -- --voice-nim
+curl -fsSL "https://raw.githubusercontent.com/vinothhacks/free-claude-code/main/scripts/install.sh" | sh -s -- --voice-nim
 ```
 
 Windows PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1"))) -VoiceNim
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/vinothhacks/free-claude-code/main/scripts/install.ps1"))) -VoiceNim
 ```
 
 Restart `fcc-server`. In **Admin UI → Messaging → Voice**, enable voice notes, select `cpu`, `cuda`, or `nvidia_nim`, and choose the Whisper model. Local gated models need `HUGGINGFACE_API_KEY`; NVIDIA NIM transcription needs `NVIDIA_NIM_API_KEY`.
@@ -564,18 +610,20 @@ Stop every running FCC command before uninstalling.
 macOS/Linux:
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/uninstall.sh" | sh
+curl -fsSL "https://raw.githubusercontent.com/vinothhacks/free-claude-code/main/scripts/uninstall.sh" | sh
 ```
 
 Windows PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/uninstall.ps1")))
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/vinothhacks/free-claude-code/main/scripts/uninstall.ps1")))
 ```
 
 ## Project Links
 
-- [Report bugs or request features](https://github.com/Alishahryar1/free-claude-code/issues)
+- [This fork](https://github.com/vinothhacks/free-claude-code)
+- [Upstream Free Claude Code](https://github.com/Alishahryar1/free-claude-code)
+- [Report bugs or request features](https://github.com/vinothhacks/free-claude-code/issues)
 - [Architecture and extension guide](ARCHITECTURE.md)
 - [Contributing guide](CONTRIBUTING.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ fcc-server = "free_claude_code.cli.entrypoints:serve"
 fcc-claude = "free_claude_code.cli.launchers.claude:launch"
 fcc-codex = "free_claude_code.cli.launchers.codex:launch"
 fcc-pi = "free_claude_code.cli.launchers.pi:launch"
+fcc-atomic = "free_claude_code.cli.launchers.atomic:launch"
+fcc-prime = "free_claude_code.cli.launchers.prime:launch"
+fcc-muse = "free_claude_code.cli.launchers.muse:launch"
 
 [project.gui-scripts]
 fcc-desktop = "free_claude_code.cli.desktop_entrypoint:launch"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,13 +14,16 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-$RepoArchiveUrl = "https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
+$RepoArchiveUrl = "https://github.com/vinothhacks/free-claude-code/archive/refs/heads/main.zip"
 # Windows on ARM emulates x64, whose Python package ecosystem has broader wheel support.
 $PythonRequest = "cpython-3.14.0-windows-x86_64-none"
 $MinUvVersion = "0.11.16"
 $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"
+$MuseInstallUrl = "https://dev.meta.ai/install.sh"
+$PrimeStableUrl = "https://github.com/PrimeIntellect-ai/prime-agent/releases/latest/download/stable"
+$PrimeReleaseApiUrl = "https://api.github.com/repos/PrimeIntellect-ai/prime-agent/releases/latest"
 $RtkVersion = "0.44.2"
 $RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/download/v$RtkVersion"
 $RtkWindowsAssetName = "rtk-x86_64-pc-windows-msvc.zip"
@@ -29,7 +32,11 @@ $UvInstallUrl = "https://astral.sh/uv/install.ps1"
 $script:InstallClaudeCode = $true
 $script:InstallCodex = $true
 $script:InstallPi = $true
+$script:InstallMuse = $true
+$script:InstallPrime = $true
 $script:PiAvailable = $false
+$script:MuseAvailable = $false
+$script:PrimeAvailable = $false
 $script:EnableRtk = $Rtk.IsPresent
 $FccCommands = @(
     # Include retired entry points so updates reject older FCC processes before replacement.
@@ -38,6 +45,9 @@ $FccCommands = @(
     "fcc-claude",
     "fcc-codex",
     "fcc-pi",
+    "fcc-atomic",
+    "fcc-prime",
+    "fcc-muse",
     "fcc-init",
     "free-claude-code"
 )
@@ -97,8 +107,16 @@ function Select-CodingAgents {
         $script:InstallClaudeCode = Read-YesNo "Install or verify Claude Code for fcc-claude?"
         $script:InstallCodex = Read-YesNo "Install or verify Codex for fcc-codex?"
         $script:InstallPi = Read-YesNo "Install or verify Pi for fcc-pi?"
+        $script:InstallMuse = Read-YesNo "Install or verify Muse Code for fcc-muse?"
+        $script:InstallPrime = Read-YesNo "Install or verify Prime Agent for fcc-prime?"
 
-        if ($script:InstallClaudeCode -or $script:InstallCodex -or $script:InstallPi) {
+        if (
+            $script:InstallClaudeCode -or
+            $script:InstallCodex -or
+            $script:InstallPi -or
+            $script:InstallMuse -or
+            $script:InstallPrime
+        ) {
             break
         }
         Write-Host "Select at least one coding agent."
@@ -593,6 +611,137 @@ function Ensure-Pi {
     $script:PiAvailable = $true
 }
 
+function Test-WslUsable {
+    $wsl = Get-ApplicationCommand "wsl"
+    if (-not $wsl) {
+        return $false
+    }
+    & $wsl.Source -e true 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-PrimeAgentVersion {
+    try {
+        $version = (
+            Invoke-RestMethod -Uri $PrimeStableUrl -Headers @{ "User-Agent" = "free-claude-code" }
+        ).ToString().Trim().TrimStart("v")
+        if (-not [string]::IsNullOrWhiteSpace($version)) {
+            return $version
+        }
+    }
+    catch {
+        # Fall through to the GitHub releases API.
+    }
+
+    $release = Invoke-RestMethod `
+        -Uri $PrimeReleaseApiUrl `
+        -Headers @{
+            "User-Agent" = "free-claude-code"
+            "Accept" = "application/vnd.github+json"
+        }
+    $tag = [string] $release.tag_name
+    if ([string]::IsNullOrWhiteSpace($tag)) {
+        throw "Could not resolve the latest Prime Agent version."
+    }
+    return $tag.TrimStart("v")
+}
+
+function Ensure-Muse {
+    $script:MuseAvailable = $false
+    Add-KnownBinDirectories
+    if (Get-ApplicationCommand "muse") {
+        Write-Host "Muse Code already found on PATH; verifying it."
+        Confirm-Application -CommandName "muse" -DisplayName "Muse Code"
+        $script:MuseAvailable = $true
+        return
+    }
+
+    if (-not (Test-WslUsable)) {
+        Write-Host "Muse Code has no native Windows installer. Install WSL2, then rerun, or run fcc-muse later."
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "+ wsl bash -lc 'curl -fsSL $MuseInstallUrl | bash'"
+        $script:MuseAvailable = $true
+        return
+    }
+
+    $wsl = Get-ApplicationCommand "wsl"
+    Write-Host "Installing Muse Code inside WSL from $MuseInstallUrl"
+    Invoke-NativeCommand -FilePath $wsl.Source -Arguments @(
+        "bash",
+        "-lc",
+        "curl -fsSL --proto '=https' --tlsv1.2 $MuseInstallUrl | bash"
+    )
+    $script:MuseAvailable = $true
+}
+
+function Ensure-Prime {
+    $script:PrimeAvailable = $false
+    Add-PiBinDirectories
+    if (Get-ApplicationCommand "prime-agent") {
+        Write-Host "Prime Agent already found on PATH; verifying it."
+        Confirm-Application -CommandName "prime-agent" -DisplayName "Prime Agent"
+        $script:PrimeAvailable = $true
+        return
+    }
+
+    $npm = Get-ApplicationCommand "npm"
+    if (-not $npm) {
+        Write-Host "Node.js/npm not found; skipping Prime Agent. fcc-prime can install it later."
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "+ npm install -g <prime-agent-release-tarball>"
+        $script:PrimeAvailable = $true
+        return
+    }
+
+    $version = Get-PrimeAgentVersion
+    $tarballUrl = "https://github.com/PrimeIntellect-ai/prime-agent/releases/download/v$version/prime-agent-$version.tgz"
+    $tarball = Join-Path ([IO.Path]::GetTempPath()) ("prime-agent-" + $version + ".tgz")
+    Write-Host "+ downloading $tarballUrl"
+    Invoke-WebRequest -Uri $tarballUrl -OutFile $tarball -UseBasicParsing
+    $hadKernel = Test-Path Env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL
+    $previousKernel = $env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL
+    $hadTools = Test-Path Env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL
+    $previousTools = $env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL
+    try {
+        $env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL = "0"
+        $env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL = "1"
+        Invoke-NativeCommand -FilePath $npm.Source -Arguments @(
+            "install",
+            "-g",
+            "--no-fund",
+            "--no-audit",
+            $tarball
+        )
+    }
+    finally {
+        if ($hadKernel) {
+            $env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL = $previousKernel
+        }
+        else {
+            Remove-Item Env:PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL -ErrorAction SilentlyContinue
+        }
+        if ($hadTools) {
+            $env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL = $previousTools
+        }
+        else {
+            Remove-Item Env:PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL -ErrorAction SilentlyContinue
+        }
+        if (Test-Path -LiteralPath $tarball) {
+            Remove-Item -LiteralPath $tarball -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Add-PiBinDirectories
+    Confirm-Application -CommandName "prime-agent" -DisplayName "Prime Agent"
+    $script:PrimeAvailable = $true
+}
+
 function Ensure-SelectedCodingAgents {
     if ($script:InstallClaudeCode) {
         Write-Step "Ensuring Claude Code is installed"
@@ -609,7 +758,23 @@ function Ensure-SelectedCodingAgents {
         Ensure-Pi
     }
 
-    if ((-not $script:InstallClaudeCode) -and (-not $script:InstallCodex) -and (-not $script:PiAvailable)) {
+    if ($script:InstallMuse) {
+        Write-Step "Checking or installing Muse Code"
+        Ensure-Muse
+    }
+
+    if ($script:InstallPrime) {
+        Write-Step "Checking or installing Prime Agent"
+        Ensure-Prime
+    }
+
+    if (
+        (-not $script:InstallClaudeCode) -and
+        (-not $script:InstallCodex) -and
+        (-not $script:PiAvailable) -and
+        (-not $script:MuseAvailable) -and
+        (-not $script:PrimeAvailable)
+    ) {
         throw "No selected coding agent was installed. Re-run the installer and choose at least one."
     }
 }
@@ -965,5 +1130,11 @@ else {
     }
     if ($script:PiAvailable) {
         Write-Host "Run Pi with: fcc-pi"
+    }
+    if ($script:MuseAvailable) {
+        Write-Host "Run Muse Code with: fcc-muse"
+    }
+    if ($script:PrimeAvailable) {
+        Write-Host "Run Prime Agent with: fcc-prime"
     }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,19 +1,22 @@
 #!/bin/sh
 set -eu
 
-REPO_ARCHIVE_URL="https://github.com/Alishahryar1/free-claude-code/archive/refs/heads/main.zip"
+REPO_ARCHIVE_URL="https://github.com/vinothhacks/free-claude-code/archive/refs/heads/main.zip"
 PYTHON_VERSION="3.14.0"
 MIN_UV_VERSION="0.11.16"
 CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
 CODEX_INSTALL_URL="https://chatgpt.com/codex/install.sh"
 PI_INSTALL_URL="https://pi.dev/install.sh"
+MUSE_INSTALL_URL="https://dev.meta.ai/install.sh"
+PRIME_STABLE_URL="https://github.com/PrimeIntellect-ai/prime-agent/releases/latest/download/stable"
+PRIME_RELEASE_API_URL="https://api.github.com/repos/PrimeIntellect-ai/prime-agent/releases/latest"
 RTK_VERSION="0.44.2"
 RTK_RELEASE_BASE_URL="https://github.com/rtk-ai/rtk/releases/download/v$RTK_VERSION"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so updates reject older FCC processes before replacement.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-atomic fcc-prime fcc-muse fcc-init free-claude-code"
 
 dry_run=0
 voice_nim=0
@@ -22,12 +25,16 @@ voice_all=0
 install_claude=1
 install_codex=1
 install_pi=1
+install_muse=1
+install_prime=1
 enable_rtk=0
 torch_backend=""
 temporary_file=""
 temporary_binary=""
 tool_bin=""
 pi_available=0
+muse_available=0
+prime_available=0
 rtk_path=""
 
 show_usage() {
@@ -106,8 +113,20 @@ choose_coding_agents() {
         else
             install_pi=0
         fi
+        if prompt_yes_no "Install or verify Muse Code for fcc-muse?"; then
+            install_muse=1
+        else
+            install_muse=0
+        fi
+        if prompt_yes_no "Install or verify Prime Agent for fcc-prime?"; then
+            install_prime=1
+        else
+            install_prime=0
+        fi
 
-        if [ "$install_claude" -eq 1 ] || [ "$install_codex" -eq 1 ] || [ "$install_pi" -eq 1 ]; then
+        if [ "$install_claude" -eq 1 ] || [ "$install_codex" -eq 1 ] ||
+            [ "$install_pi" -eq 1 ] || [ "$install_muse" -eq 1 ] ||
+            [ "$install_prime" -eq 1 ]; then
             break
         fi
         printf 'Select at least one coding agent.\n\n' >&4
@@ -569,6 +588,84 @@ ensure_pi() {
     pi_available=1
 }
 
+resolve_prime_agent_version() {
+    version=$(curl -fsSL "$PRIME_STABLE_URL" 2>/dev/null | tr -d '[:space:]' | sed 's/^v//' || true)
+    case "$version" in
+        ''|*[!0-9A-Za-z.-]*) ;;
+        *)
+            printf '%s' "$version"
+            return 0
+            ;;
+    esac
+
+    version=$(
+        curl -fsSL "$PRIME_RELEASE_API_URL" \
+            -H 'User-Agent: free-claude-code' \
+            -H 'Accept: application/vnd.github+json' |
+            tr ',' '\n' |
+            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' |
+            head -n 1
+    ) || true
+    version=$(printf '%s' "$version" | tr -d '[:space:]' | sed 's/^v//')
+    [ -n "$version" ] || fail "Could not resolve the latest Prime Agent version."
+    printf '%s' "$version"
+}
+
+ensure_muse() {
+    muse_available=0
+    add_known_bin_directories
+    if command -v muse >/dev/null 2>&1; then
+        printf 'Muse Code already found on PATH; verifying it.\n'
+        verify_command muse "Muse Code"
+        muse_available=1
+        return 0
+    fi
+
+    download_and_run "$MUSE_INSTALL_URL" bash "Muse Code"
+    add_known_bin_directories
+    verify_command muse "Muse Code"
+    muse_available=1
+}
+
+ensure_prime() {
+    prime_available=0
+    add_pi_bin_directories
+    if command -v prime-agent >/dev/null 2>&1; then
+        printf 'Prime Agent already found on PATH; verifying it.\n'
+        verify_command prime-agent "Prime Agent"
+        prime_available=1
+        return 0
+    fi
+
+    if ! command -v npm >/dev/null 2>&1; then
+        printf 'npm not found; skipping Prime Agent. fcc-prime can install it later.\n'
+        return 0
+    fi
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command npm install -g "<prime-agent-release-tarball>"
+        prime_available=1
+        return 0
+    fi
+
+    version=$(resolve_prime_agent_version)
+    tarball_url="https://github.com/PrimeIntellect-ai/prime-agent/releases/download/v${version}/prime-agent-${version}.tgz"
+    temporary_file=$(mktemp "${TMPDIR:-/tmp}/fcc-prime-agent.XXXXXX.tgz") ||
+        fail "Unable to create a temporary file for Prime Agent."
+    print_command curl -fsSL "$tarball_url" -o "$temporary_file"
+    curl -fsSL "$tarball_url" -o "$temporary_file" ||
+        fail "Could not download Prime Agent v$version."
+    print_command npm install -g --no-fund --no-audit "$temporary_file"
+    PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0 \
+        PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 \
+        npm install -g --no-fund --no-audit "$temporary_file"
+    rm -f "$temporary_file"
+    temporary_file=""
+    add_pi_bin_directories
+    verify_command prime-agent "Prime Agent"
+    prime_available=1
+}
+
 ensure_selected_coding_agents() {
     if [ "$install_claude" -eq 1 ]; then
         step "Ensuring Claude Code is installed"
@@ -585,7 +682,19 @@ ensure_selected_coding_agents() {
         ensure_pi
     fi
 
-    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ] && [ "$pi_available" -eq 0 ]; then
+    if [ "$install_muse" -eq 1 ]; then
+        step "Checking or installing Muse Code"
+        ensure_muse
+    fi
+
+    if [ "$install_prime" -eq 1 ]; then
+        step "Checking or installing Prime Agent"
+        ensure_prime
+    fi
+
+    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ] &&
+        [ "$pi_available" -eq 0 ] && [ "$muse_available" -eq 0 ] &&
+        [ "$prime_available" -eq 0 ]; then
         fail "No selected coding agent was installed. Re-run the installer and choose at least one."
     fi
 }
@@ -900,7 +1009,7 @@ fi
 
 step "Checking installation prerequisites"
 require_command curl
-if [ "$install_claude" -eq 1 ]; then
+if [ "$install_claude" -eq 1 ] || [ "$install_muse" -eq 1 ]; then
     require_command bash
 fi
 require_command sh
@@ -948,5 +1057,11 @@ else
     fi
     if [ "$pi_available" -eq 1 ]; then
         printf 'Run Pi with: fcc-pi\n'
+    fi
+    if [ "$muse_available" -eq 1 ]; then
+        printf 'Run Muse Code with: fcc-muse\n'
+    fi
+    if [ "$prime_available" -eq 1 ]; then
+        printf 'Run Prime Agent with: fcc-prime\n'
     fi
 fi

--- a/src/free_claude_code/api/handlers/__init__.py
+++ b/src/free_claude_code/api/handlers/__init__.py
@@ -1,7 +1,13 @@
 """Product-flow handlers for public API routes."""
 
+from .chat_completions import ChatCompletionsHandler
 from .messages import MessagesHandler
 from .responses import ResponsesHandler
 from .token_count import TokenCountHandler
 
-__all__ = ["MessagesHandler", "ResponsesHandler", "TokenCountHandler"]
+__all__ = [
+    "ChatCompletionsHandler",
+    "MessagesHandler",
+    "ResponsesHandler",
+    "TokenCountHandler",
+]

--- a/src/free_claude_code/api/handlers/chat_completions.py
+++ b/src/free_claude_code/api/handlers/chat_completions.py
@@ -1,0 +1,240 @@
+"""OpenAI Chat Completions API product flow.
+
+This handler is a thin edge adapter over :class:`MessagesHandler`. It performs
+no routing, provider selection or streaming logic of its own -- it lowers the
+inbound request into Anthropic Messages, delegates, and lifts the result back
+into Chat Completions shape. Keeping it parasitic on the Messages flow means
+every provider, optimization and recovery path FCC already has applies here
+for free.
+"""
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi.responses import JSONResponse, StreamingResponse
+from loguru import logger
+
+from free_claude_code.api.request_ids import new_request_id
+from free_claude_code.api.response_streams import openai_responses_sse_streaming_response
+from free_claude_code.application.errors import ApplicationError
+from free_claude_code.application.execution import TokenCounter
+from free_claude_code.application.ports import ProviderResolver
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import get_token_count
+from free_claude_code.core.diagnostics import safe_exception_message
+from free_claude_code.core.openai_chat_api import (
+    ChatCompletionsRequest,
+    anthropic_message_to_chat_completion,
+    anthropic_sse_to_chat_sse,
+    chat_request_to_messages_request,
+    new_completion_id,
+)
+from free_claude_code.core.trace import trace_event
+
+from .messages import MessagesHandler
+
+_ANTHROPIC_ERROR_TO_OPENAI = {
+    "invalid_request_error": "invalid_request_error",
+    "authentication_error": "invalid_request_error",
+    "permission_error": "invalid_request_error",
+    "not_found_error": "invalid_request_error",
+    "rate_limit_error": "rate_limit_error",
+    "overloaded_error": "server_error",
+    "api_error": "server_error",
+}
+
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache, no-transform",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+
+def _openai_error_payload(anthropic_error: dict[str, Any]) -> dict[str, Any]:
+    error = anthropic_error.get("error")
+    if not isinstance(error, dict):
+        error = {}
+    anthropic_type = str(error.get("type") or "api_error")
+    return {
+        "error": {
+            "message": error.get("message") or "Request failed.",
+            "type": _ANTHROPIC_ERROR_TO_OPENAI.get(anthropic_type, "server_error"),
+            "code": anthropic_type,
+            "param": None,
+        }
+    }
+
+
+async def _decoded_chunks(source: AsyncIterator[Any]) -> AsyncIterator[str]:
+    """Normalise a body iterator that may yield ``bytes`` or ``str``."""
+    async for chunk in source:
+        if isinstance(chunk, bytes | bytearray):
+            yield bytes(chunk).decode("utf-8", errors="replace")
+        else:
+            yield str(chunk)
+
+
+class ChatCompletionsHandler:
+    """Handle inbound OpenAI-compatible Chat Completions requests."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        provider_resolver: ProviderResolver,
+        *,
+        token_counter: TokenCounter = get_token_count,
+        generation_id: int | None = None,
+    ) -> None:
+        self._settings = settings
+        self._messages = MessagesHandler(
+            settings,
+            provider_resolver=provider_resolver,
+            token_counter=token_counter,
+            generation_id=generation_id,
+        )
+
+    async def create(
+        self, request_data: ChatCompletionsRequest, *, request_id: str | None = None
+    ) -> object:
+        """Create a Chat Completions response (JSON, or SSE when stream=true)."""
+        request_id = request_id or new_request_id()
+        completion_id = new_completion_id()
+
+        messages_request = chat_request_to_messages_request(request_data)
+        trace_event(
+            stage="routing",
+            event="free_claude_code.api.chat_completions.translated",
+            source="api",
+            model=request_data.model,
+            stream=request_data.stream,
+            tools=len(messages_request.tools or []),
+        )
+        logger.debug(
+            "chat/completions -> messages: model={} stream={} tools={}",
+            request_data.model,
+            request_data.stream,
+            len(messages_request.tools or []),
+        )
+
+        try:
+            response = await self._messages.create(
+                messages_request, request_id=request_id
+            )
+        except ApplicationError:
+            raise
+
+        if request_data.stream:
+            return await self._stream_response(
+                response,
+                request_data=request_data,
+                completion_id=completion_id,
+            )
+        return self._json_response(
+            response,
+            request_data=request_data,
+            completion_id=completion_id,
+        )
+
+    async def _stream_response(
+        self,
+        response: object,
+        *,
+        request_data: ChatCompletionsRequest,
+        completion_id: str,
+    ) -> object:
+        if not isinstance(response, StreamingResponse):
+            # An error surfaced before the stream opened; report it in
+            # OpenAI's non-streaming error shape, which SDKs handle.
+            return self._error_passthrough(response)
+
+        return await openai_responses_sse_streaming_response(
+            self._lift_anthropic_sse(
+                response,
+                model=request_data.model,
+                completion_id=completion_id,
+                include_usage=request_data.wants_usage_in_stream(),
+            ),
+            headers=_SSE_HEADERS,
+            pre_start_error_response=self._pre_start_stream_error,
+        )
+
+    async def _lift_anthropic_sse(
+        self,
+        response: StreamingResponse,
+        *,
+        model: str,
+        completion_id: str,
+        include_usage: bool,
+    ) -> AsyncIterator[str]:
+        """Translate Anthropic SSE and close the inner Messages stream."""
+        try:
+            async for chunk in anthropic_sse_to_chat_sse(
+                _decoded_chunks(response.body_iterator),
+                model=model,
+                completion_id=completion_id,
+                include_usage=include_usage,
+            ):
+                yield chunk
+        finally:
+            aclose = getattr(response, "aclose", None)
+            if callable(aclose):
+                await aclose()
+
+    def _pre_start_stream_error(self, exc: BaseException) -> JSONResponse:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "message": safe_exception_message(exc) or "Request failed.",
+                    "type": "server_error",
+                    "code": "api_error",
+                    "param": None,
+                }
+            },
+        )
+
+    def _json_response(
+        self,
+        response: object,
+        *,
+        request_data: ChatCompletionsRequest,
+        completion_id: str,
+    ) -> object:
+        if not isinstance(response, JSONResponse):
+            return response
+
+        try:
+            payload = json.loads(bytes(response.body).decode("utf-8"))
+        except (TypeError, ValueError):
+            return response
+
+        if not isinstance(payload, dict) or payload.get("type") == "error":
+            return self._error_passthrough(response, payload=payload)
+        if "error" in payload:
+            return self._error_passthrough(response, payload=payload)
+
+        return JSONResponse(
+            content=anthropic_message_to_chat_completion(
+                payload,
+                model=request_data.model,
+                completion_id=completion_id,
+            )
+        )
+
+    def _error_passthrough(
+        self, response: object, *, payload: dict[str, Any] | None = None
+    ) -> object:
+        if not isinstance(response, JSONResponse):
+            return response
+        if payload is None:
+            try:
+                payload = json.loads(bytes(response.body).decode("utf-8"))
+            except (TypeError, ValueError):
+                return response
+        if not isinstance(payload, dict):
+            return response
+        return JSONResponse(
+            status_code=response.status_code,
+            content=_openai_error_payload(payload),
+        )

--- a/src/free_claude_code/api/request_errors.py
+++ b/src/free_claude_code/api/request_errors.py
@@ -22,7 +22,7 @@ from free_claude_code.core.openai_responses import (
     openai_error_type_for_failure,
 )
 
-WireApi = Literal["messages", "responses"]
+WireApi = Literal["messages", "responses", "chat_completions"]
 
 
 def require_non_empty_messages(messages: Sequence[object]) -> None:
@@ -37,7 +37,7 @@ def ordinary_application_error_response(
     request_id: str,
 ) -> JSONResponse:
     """Serialize a deterministic application error without terminal headers."""
-    if wire_api == "responses":
+    if wire_api in ("responses", "chat_completions"):
         return JSONResponse(
             status_code=error.status_code,
             content=openai_error_payload(

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -12,6 +12,7 @@ from free_claude_code.core.anthropic import (
     TokenCountRequest,
     get_token_count,
 )
+from free_claude_code.core.openai_chat_api import ChatCompletionsRequest
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.trace import trace_event
 
@@ -21,7 +22,12 @@ from .dependencies import (
     require_proxy_auth,
     resolve_provider,
 )
-from .handlers import MessagesHandler, ResponsesHandler, TokenCountHandler
+from .handlers import (
+    ChatCompletionsHandler,
+    MessagesHandler,
+    ResponsesHandler,
+    TokenCountHandler,
+)
 from .model_catalog import ModelsListResponse, build_models_list_response
 from .ports import ApiServices
 from .request_errors import ordinary_application_error_response
@@ -98,6 +104,38 @@ async def _create_responses_response(
     return await bind_response_lifetime(response, lease.release)
 
 
+async def _create_chat_completions_response(
+    services: ApiServices,
+    request_data: ChatCompletionsRequest,
+    *,
+    request_id: str,
+) -> object:
+    lease: RequestRuntimeLease | None = None
+    try:
+        lease = await services.requests.acquire()
+        handler = ChatCompletionsHandler(
+            lease.settings,
+            provider_resolver=_provider_resolver(lease),
+            token_counter=get_token_count,
+            generation_id=lease.generation_id,
+        )
+        response = await handler.create(request_data, request_id=request_id)
+    except ApplicationError as exc:
+        if lease is not None:
+            await lease.release()
+        return ordinary_application_error_response(
+            exc,
+            wire_api="chat_completions",
+            request_id=request_id,
+        )
+    except BaseException:
+        if lease is not None:
+            await lease.release()
+        raise
+    assert lease is not None
+    return await bind_response_lifetime(response, lease.release)
+
+
 def _probe_response(allow: str) -> Response:
     return Response(status_code=204, headers={"Allow": allow})
 
@@ -119,6 +157,31 @@ async def create_message(
 
 @router.api_route("/v1/messages", methods=["HEAD", "OPTIONS"])
 async def probe_messages(_auth=Depends(require_proxy_auth)):
+    return _probe_response("POST, HEAD, OPTIONS")
+
+
+@router.post("/v1/chat/completions")
+async def create_chat_completion(
+    request: Request,
+    request_data: ChatCompletionsRequest,
+    services: ApiServices = Depends(get_services),
+    _auth=Depends(require_proxy_auth),
+):
+    """Create a chat completion (JSON by default; stream=true returns OpenAI SSE).
+
+    Serves the OpenAI-compatible ecosystem -- Instructor, Atomic Agents,
+    Prime Agent, Muse Code, LangChain, and others -- against every provider
+    FCC has configured.
+    """
+    return await _create_chat_completions_response(
+        services,
+        request_data,
+        request_id=get_request_id(request),
+    )
+
+
+@router.api_route("/v1/chat/completions", methods=["HEAD", "OPTIONS"])
+async def probe_chat_completions(_auth=Depends(require_proxy_auth)):
     return _probe_response("POST, HEAD, OPTIONS")
 
 

--- a/src/free_claude_code/cli/launchers/atomic.py
+++ b/src/free_claude_code/cli/launchers/atomic.py
@@ -1,0 +1,169 @@
+"""Installed ``fcc-atomic`` launcher for Atomic Agents / Instructor clients."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+
+from free_claude_code.cli.local_http import open_local_request
+from free_claude_code.config.loader import get_settings
+from free_claude_code.config.server_urls import local_proxy_root_url
+
+from .common import preflight_proxy
+from .openai_compat import (
+    build_openai_compat_env,
+    openai_compat_base_url,
+    proxy_bearer_token,
+)
+
+_DISPLAY_NAME = "Atomic Agents"
+_PING_TIMEOUT_SECONDS = 90.0
+
+
+def launch(argv: Sequence[str] | None = None) -> None:
+    """Send one Atomic Agents / Chat Completions turn through the local FCC proxy."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    settings = get_settings()
+    proxy_root_url = local_proxy_root_url(settings)
+    if error := preflight_proxy(proxy_root_url):
+        print(
+            f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
+            file=sys.stderr,
+        )
+        print("Start it in another terminal with: fcc-server", file=sys.stderr)
+        raise SystemExit(1)
+
+    prompt = " ".join(args).strip() or "ping"
+    model = settings.model
+    auth_token = settings.proxy_auth_token
+    env = build_openai_compat_env(
+        proxy_root_url=proxy_root_url,
+        auth_token=auth_token,
+        base_env=os.environ,
+        model=model,
+    )
+    try:
+        text = run_atomic_turn(
+            proxy_root_url=proxy_root_url,
+            auth_token=auth_token,
+            model=model,
+            prompt=prompt,
+            env=env,
+        )
+    except (HTTPError, URLError, OSError, RuntimeError, ValueError) as exc:
+        print(f"{_DISPLAY_NAME} request failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(text)
+
+
+def run_atomic_turn(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    model: str,
+    prompt: str,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Run one turn with Atomic Agents when installed, else Chat Completions."""
+
+    try:
+        return run_atomic_agents_turn(
+            proxy_root_url=proxy_root_url,
+            auth_token=auth_token,
+            model=model,
+            prompt=prompt,
+            env=env,
+        )
+    except ImportError:
+        return run_chat_completions_ping(
+            proxy_root_url=proxy_root_url,
+            auth_token=auth_token,
+            model=model,
+            prompt=prompt,
+        )
+
+
+def run_atomic_agents_turn(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    model: str,
+    prompt: str,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Call Atomic Agents through Instructor against FCC ``/v1/chat/completions``."""
+
+    import instructor
+    from atomic_agents import AgentConfig, AtomicAgent, BasicChatInputSchema
+    from atomic_agents.context import ChatHistory
+    from openai import OpenAI
+
+    source = os.environ if env is None else env
+    client = instructor.from_openai(
+        OpenAI(
+            base_url=source.get("OPENAI_BASE_URL")
+            or openai_compat_base_url(proxy_root_url),
+            api_key=source.get("OPENAI_API_KEY") or proxy_bearer_token(auth_token),
+        )
+    )
+    agent = AtomicAgent[BasicChatInputSchema, object](
+        config=AgentConfig(
+            client=client,
+            model=model,
+            history=ChatHistory(),
+            model_api_parameters={"max_tokens": 64},
+        )
+    )
+    response = agent.run(BasicChatInputSchema(chat_message=prompt))
+    text = getattr(response, "chat_message", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    return str(response)
+
+
+def run_chat_completions_ping(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    model: str,
+    prompt: str,
+) -> str:
+    """POST one non-streaming Chat Completions request to the local proxy."""
+
+    url = f"{openai_compat_base_url(proxy_root_url)}/chat/completions"
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 64,
+        }
+    ).encode("utf-8")
+    request = Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {proxy_bearer_token(auth_token)}",
+        },
+        method="POST",
+    )
+    with open_local_request(request, timeout=_PING_TIMEOUT_SECONDS) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Chat Completions returned a non-object body.")
+    error = payload.get("error")
+    if isinstance(error, dict):
+        raise RuntimeError(str(error.get("message") or error))
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise RuntimeError("Chat Completions returned no choices.")
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("Chat Completions returned empty content.")
+    return content

--- a/src/free_claude_code/cli/launchers/ensure.py
+++ b/src/free_claude_code/cli/launchers/ensure.py
@@ -1,0 +1,419 @@
+"""Install missing Muse Code / Prime Agent CLIs the first time FCC launches them."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+NO_AUTO_INSTALL_ENV = "FCC_NO_AUTO_INSTALL"
+USER_AGENT = "free-claude-code"
+MUSE_INSTALL_URL = "https://dev.meta.ai/install.sh"
+MUSE_DOCS_URL = "https://dev.meta.ai/docs/muse-code/"
+PRIME_STABLE_URL = (
+    "https://github.com/PrimeIntellect-ai/prime-agent/releases/latest/download/stable"
+)
+PRIME_RELEASE_API_URL = (
+    "https://api.github.com/repos/PrimeIntellect-ai/prime-agent/releases/latest"
+)
+PRIME_TGZ_URL = (
+    "https://github.com/PrimeIntellect-ai/prime-agent/releases/download/"
+    "v{version}/prime-agent-{version}.tgz"
+)
+PRIME_SHA_URL = (
+    "https://github.com/PrimeIntellect-ai/prime-agent/releases/download/"
+    "v{version}/SHA256SUMS"
+)
+PRIME_DOCS_URL = "https://github.com/PrimeIntellect-ai/prime-agent"
+DOWNLOAD_TIMEOUT_SECONDS = 120
+
+
+@dataclass(frozen=True)
+class ClientSpec:
+    """How to invoke an installed client, including WSL-wrapped Muse on Windows."""
+
+    kind: str
+    binary: str
+
+    def map_path(self, path: Path) -> str:
+        if self.kind == "wsl":
+            return windows_path_to_wsl(path)
+        return str(path)
+
+    def build(self, args: Sequence[str]) -> list[str]:
+        if self.kind == "wsl":
+            return wsl_exec(self.binary, args)
+        return [self.binary, *args]
+
+
+def auto_install_enabled(env: dict[str, str] | None = None) -> bool:
+    source = os.environ if env is None else env
+    return source.get(NO_AUTO_INSTALL_ENV, "").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def extra_bin_directories() -> list[Path]:
+    """Return common install locations that may not yet be on PATH."""
+
+    directories: list[Path] = []
+    home = Path.home()
+    directories.append(home / ".local" / "bin")
+    appdata = os.environ.get("APPDATA", "").strip()
+    if appdata:
+        directories.append(Path(appdata) / "npm")
+    local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+    if local_appdata:
+        directories.append(Path(local_appdata) / "pi-node" / "current")
+    npm = shutil.which("npm")
+    if npm:
+        prefix = npm_global_prefix(npm)
+        if prefix:
+            prefix_path = Path(prefix)
+            directories.append(prefix_path)
+            directories.append(prefix_path / "bin")
+    return directories
+
+
+def which_command(name: str) -> str | None:
+    """Resolve a command on PATH or in FCC-known install directories."""
+
+    found = shutil.which(name)
+    if found:
+        return found
+    suffixes = ("", ".cmd", ".exe", ".bat") if os.name == "nt" else ("",)
+    for directory in extra_bin_directories():
+        for suffix in suffixes:
+            candidate = directory / f"{name}{suffix}"
+            if candidate.is_file():
+                prepend_path_directory(candidate.parent)
+                return str(candidate)
+    return None
+
+
+def muse_install_hint() -> str:
+    if sys.platform == "win32":
+        return (
+            "Muse Code has no native Windows installer. FCC can install it in WSL2 "
+            f"from {MUSE_INSTALL_URL} ({MUSE_DOCS_URL})."
+        )
+    return f"Install Muse Code from {MUSE_DOCS_URL}"
+
+
+def prime_install_hint() -> str:
+    return (
+        "Install Prime Agent with Node.js 20.6+ and npm from "
+        f"{PRIME_DOCS_URL}, or rerun fcc-prime and let FCC install it."
+    )
+
+
+def ensure_muse_client() -> ClientSpec:
+    """Return Muse Code, installing it when missing unless auto-install is disabled."""
+
+    existing = find_muse_client()
+    if existing is not None:
+        return existing
+    print("Could not find Muse Code command: muse", file=sys.stderr)
+    if not auto_install_enabled():
+        print(muse_install_hint(), file=sys.stderr)
+        raise SystemExit(127)
+    print("fcc-muse: installing Muse Code...", file=sys.stderr)
+    install_muse()
+    installed = find_muse_client()
+    if installed is None:
+        print(
+            "Muse Code install finished, but 'muse' is still not available.",
+            file=sys.stderr,
+        )
+        print(muse_install_hint(), file=sys.stderr)
+        raise SystemExit(127)
+    return installed
+
+
+def ensure_prime_binary() -> str:
+    """Return Prime Agent, installing it when missing unless auto-install is disabled."""
+
+    existing = find_prime_binary()
+    if existing is not None:
+        return existing
+    print("Could not find Prime Agent command: prime-agent", file=sys.stderr)
+    if not auto_install_enabled():
+        print(prime_install_hint(), file=sys.stderr)
+        raise SystemExit(127)
+    print("fcc-prime: installing Prime Agent...", file=sys.stderr)
+    install_prime()
+    installed = find_prime_binary()
+    if installed is None:
+        print(
+            "Prime Agent install finished, but 'prime-agent' is still not available.",
+            file=sys.stderr,
+        )
+        print(prime_install_hint(), file=sys.stderr)
+        raise SystemExit(127)
+    return installed
+
+
+def find_muse_client() -> ClientSpec | None:
+    native = which_command("muse")
+    if native:
+        return ClientSpec(kind="native", binary=native)
+    if sys.platform == "win32" and wsl_has_muse():
+        return ClientSpec(kind="wsl", binary="muse")
+    return None
+
+
+def find_prime_binary() -> str | None:
+    for name in ("prime-agent", "prime"):
+        found = which_command(name)
+        if found:
+            return found
+    return None
+
+
+def install_muse() -> None:
+    """Install Muse Code using Meta's official installer, via WSL on Windows."""
+
+    if sys.platform == "win32":
+        wsl = shutil.which("wsl")
+        if wsl is None or not wsl_is_usable(wsl):
+            print(
+                "Muse Code does not support native Windows. "
+                "Install WSL2, then rerun fcc-muse.",
+                file=sys.stderr,
+            )
+            print(f"Docs: {MUSE_DOCS_URL}", file=sys.stderr)
+            raise SystemExit(127)
+        print(
+            "fcc-muse: Meta's installer is Unix-only; running it inside WSL from "
+            f"{MUSE_INSTALL_URL}",
+            file=sys.stderr,
+        )
+        run_checked(
+            [
+                wsl,
+                "bash",
+                "-lc",
+                f'curl -fsSL --proto "=https" --tlsv1.2 {shlex.quote(MUSE_INSTALL_URL)} | bash',
+            ]
+        )
+        return
+
+    bash = shutil.which("bash")
+    if bash is None:
+        print("Installing Muse Code requires bash.", file=sys.stderr)
+        print(muse_install_hint(), file=sys.stderr)
+        raise SystemExit(127)
+    print(
+        f"fcc-muse: running official installer from {MUSE_INSTALL_URL}",
+        file=sys.stderr,
+    )
+    run_posix_installer(MUSE_INSTALL_URL, bash)
+    prepend_path_directory(Path.home() / ".local" / "bin")
+
+
+def install_prime() -> None:
+    """Install Prime Agent with npm from the latest GitHub release tarball."""
+
+    npm = shutil.which("npm")
+    if npm is None:
+        print(
+            "Prime Agent needs Node.js 20.6+ and npm. Install Node.js, then rerun fcc-prime.",
+            file=sys.stderr,
+        )
+        print(prime_install_hint(), file=sys.stderr)
+        raise SystemExit(127)
+
+    version = resolve_prime_version()
+    tarball_url = PRIME_TGZ_URL.format(version=version)
+    print(
+        f"fcc-prime: downloading Prime Agent v{version} and running npm install -g",
+        file=sys.stderr,
+    )
+    with tempfile.TemporaryDirectory(prefix="fcc-prime-install-") as raw:
+        directory = Path(raw)
+        tarball = directory / f"prime-agent-{version}.tgz"
+        download_file(tarball_url, tarball)
+        expected = download_prime_tarball_sha256(version)
+        if expected:
+            actual = sha256_file(tarball)
+            if actual != expected:
+                print(
+                    "Prime Agent download failed checksum verification. "
+                    f"Expected {expected}, got {actual}.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+        env = os.environ.copy()
+        env["PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL"] = "0"
+        env["PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL"] = "1"
+        run_checked(
+            [npm, "install", "-g", "--no-fund", "--no-audit", str(tarball)],
+            env=env,
+        )
+    prefix = npm_global_prefix(npm)
+    if prefix:
+        prepend_path_directory(Path(prefix))
+        prepend_path_directory(Path(prefix) / "bin")
+
+
+def resolve_prime_version() -> str:
+    try:
+        text = download_text(PRIME_STABLE_URL).strip().lstrip("v")
+        if text and all(ch.isalnum() or ch in ".-" for ch in text):
+            return text
+    except (HTTPError, URLError, OSError, TimeoutError):
+        pass
+    payload = json.loads(download_text(PRIME_RELEASE_API_URL))
+    tag = str(payload.get("tag_name") or "").strip().lstrip("v")
+    if not tag:
+        raise RuntimeError("Could not resolve the latest Prime Agent version.")
+    return tag
+
+
+def download_prime_tarball_sha256(version: str) -> str | None:
+    try:
+        body = download_text(PRIME_SHA_URL.format(version=version))
+    except (HTTPError, URLError, OSError, TimeoutError):
+        return None
+    wanted = f"prime-agent-{version}.tgz"
+    for line in body.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[-1].endswith(wanted):
+            digest = parts[0].strip().lower()
+            if len(digest) == 64 and all(ch in "0123456789abcdef" for ch in digest):
+                return digest
+    return None
+
+
+def windows_path_to_wsl(path: Path) -> str:
+    return windows_path_text_to_wsl(str(path.resolve()))
+
+
+def windows_path_text_to_wsl(resolved: str) -> str:
+    if len(resolved) >= 2 and resolved[1] == ":":
+        drive = resolved[0].lower()
+        rest = resolved[2:].replace("\\", "/")
+        if not rest.startswith("/"):
+            rest = "/" + rest
+        return f"/mnt/{drive}{rest}"
+    return resolved.replace("\\", "/")
+
+
+def wsl_exec(binary: str, args: Sequence[str]) -> list[str]:
+    inner = 'export PATH="$HOME/.local/bin:$PATH"; exec ' + " ".join(
+        shlex.quote(part) for part in [binary, *args]
+    )
+    return ["wsl", "bash", "-lc", inner]
+
+
+def wsl_is_usable(wsl: str | None = None) -> bool:
+    command = wsl or shutil.which("wsl")
+    if command is None:
+        return False
+    try:
+        completed = subprocess.run(
+            [command, "-e", "true"],
+            check=False,
+            capture_output=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def wsl_has_muse() -> bool:
+    wsl = shutil.which("wsl")
+    if wsl is None or not wsl_is_usable(wsl):
+        return False
+    try:
+        completed = subprocess.run(
+            [
+                wsl,
+                "bash",
+                "-lc",
+                'export PATH="$HOME/.local/bin:$PATH"; command -v muse',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0 and bool(completed.stdout.strip())
+
+
+def npm_global_prefix(npm: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            [npm, "prefix", "-g"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    prefix = completed.stdout.strip()
+    return prefix or None
+
+
+def prepend_path_directory(directory: Path) -> None:
+    resolved = str(directory)
+    current = os.environ.get("PATH", "")
+    parts = current.split(os.pathsep) if current else []
+    if resolved not in parts:
+        os.environ["PATH"] = os.pathsep.join([resolved, *parts]) if parts else resolved
+
+
+def run_posix_installer(url: str, bash: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="fcc-client-install-") as raw:
+        script = Path(raw) / "install.sh"
+        download_file(url, script)
+        run_checked([bash, str(script)])
+
+
+def run_checked(command: Sequence[str], *, env: dict[str, str] | None = None) -> None:
+    print("+ " + " ".join(command), file=sys.stderr)
+    completed = subprocess.run(list(command), check=False, env=env)
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+
+
+def download_file(url: str, dest: Path) -> None:
+    dest.write_bytes(download_bytes(url))
+
+
+def download_text(url: str) -> str:
+    return download_bytes(url).decode("utf-8")
+
+
+def download_bytes(url: str) -> bytes:
+    request = Request(url, headers={"User-Agent": USER_AGENT, "Accept": "*/*"})
+    with urlopen(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+        return response.read()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/src/free_claude_code/cli/launchers/muse.py
+++ b/src/free_claude_code/cli/launchers/muse.py
@@ -1,0 +1,167 @@
+"""Installed ``fcc-muse`` launcher for Meta Muse Code, including optional MCP."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from free_claude_code.config.loader import get_settings
+from free_claude_code.config.server_urls import local_proxy_root_url
+
+from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .openai_compat import build_openai_compat_env, proxy_bearer_token
+
+_DISPLAY_NAME = "Muse Code"
+_BINARY_NAME = "muse"
+_INSTALL_HINT = "Install Muse Code from https://dev.meta.ai/docs/muse-code/"
+_MCP_COMMAND_ENV = "FCC_MUSE_MCP_COMMAND"
+_MCP_SERVERS_ENV = "FCC_MUSE_MCP_SERVERS"
+
+
+def launch(argv: Sequence[str] | None = None) -> None:
+    """Launch Muse Code against the local FCC proxy, with optional MCP servers."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    settings = get_settings()
+    proxy_root_url = local_proxy_root_url(settings)
+    if error := preflight_proxy(proxy_root_url):
+        print(
+            f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
+            file=sys.stderr,
+        )
+        print("Start it in another terminal with: fcc-server", file=sys.stderr)
+        raise SystemExit(1)
+
+    binary_path = resolve_client_binary(
+        binary_name=_BINARY_NAME,
+        display_name=_DISPLAY_NAME,
+        install_hint=_INSTALL_HINT,
+    )
+    settings_path = write_muse_settings_file(
+        Path(tempfile.mkdtemp(prefix="fcc-muse-")),
+        mcp_servers=build_muse_mcp_servers(os.environ),
+    )
+    env = build_muse_launcher_env(
+        proxy_root_url=proxy_root_url,
+        auth_token=settings.proxy_auth_token,
+        model=settings.model,
+        base_env=os.environ,
+    )
+    print(
+        f"fcc-muse: routing Muse Code through {proxy_root_url} model {settings.model}",
+        file=sys.stderr,
+    )
+    run_client_process(
+        command=build_muse_launcher_command(
+            binary_path=binary_path,
+            argv=args,
+            proxy_root_url=proxy_root_url,
+            model=settings.model,
+            settings_path=settings_path,
+        ),
+        env=env,
+        binary_name=_BINARY_NAME,
+        display_name=_DISPLAY_NAME,
+        install_hint=_INSTALL_HINT,
+    )
+
+
+def build_muse_mcp_servers(env: Mapping[str, str]) -> dict[str, object]:
+    """Return Muse ``mcp_servers`` from env. Never reads passwords from disk."""
+
+    raw = env.get(_MCP_SERVERS_ENV, "").strip()
+    if raw:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise ValueError(f"{_MCP_SERVERS_ENV} must be a JSON object.")
+        return parsed
+
+    command = env.get(_MCP_COMMAND_ENV, "").strip()
+    if not command:
+        return {}
+    return {
+        "fcc-tools": {
+            "transport": "stdio",
+            "command": command,
+            "args": [],
+            "enabled": True,
+            "mode": "optional",
+        }
+    }
+
+
+def build_muse_settings_document(*, mcp_servers: Mapping[str, object]) -> dict[str, object]:
+    """Return a Muse settings object. Empty MCP map is omitted."""
+
+    document: dict[str, object] = {}
+    if mcp_servers:
+        document["mcp_servers"] = dict(mcp_servers)
+    return document
+
+
+def write_muse_settings_file(
+    directory: Path,
+    *,
+    mcp_servers: Mapping[str, object],
+) -> Path | None:
+    """Write a session settings file when MCP servers are configured."""
+
+    document = build_muse_settings_document(mcp_servers=mcp_servers)
+    if not document:
+        return None
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "settings.json"
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def build_muse_launcher_command(
+    *,
+    binary_path: str,
+    argv: Sequence[str],
+    proxy_root_url: str,
+    model: str,
+    settings_path: Path | None,
+) -> list[str]:
+    """Return the Muse CLI command pointed at FCC."""
+
+    args = list(argv)
+    extras: list[str] = []
+    if not _has_flag(args, "--provider"):
+        extras.extend(["--provider", "meta"])
+    if not _has_flag(args, "--base-url"):
+        extras.extend(["--base-url", proxy_root_url])
+    if not _has_flag(args, "--model"):
+        extras.extend(["--model", model])
+    if settings_path is not None and not _has_flag(args, "--settings"):
+        extras.extend(["--settings", str(settings_path)])
+    return [binary_path, *extras, *args]
+
+
+def build_muse_launcher_env(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    model: str,
+    base_env: Mapping[str, str],
+) -> dict[str, str]:
+    """Return Muse process env. The proxy token is not written to disk."""
+
+    env = build_openai_compat_env(
+        proxy_root_url=proxy_root_url,
+        auth_token=auth_token,
+        base_env=base_env,
+        model=model,
+    )
+    token = proxy_bearer_token(auth_token)
+    env["META_API_KEY"] = token
+    env["META_BASE_URL"] = proxy_root_url
+    return env
+
+
+def _has_flag(args: Sequence[str], flag: str) -> bool:
+    return any(item == flag or item.startswith(f"{flag}=") for item in args)

--- a/src/free_claude_code/cli/launchers/muse.py
+++ b/src/free_claude_code/cli/launchers/muse.py
@@ -12,12 +12,12 @@ from pathlib import Path
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import preflight_proxy, run_client_process
+from .ensure import ClientSpec, ensure_muse_client, muse_install_hint
 from .openai_compat import build_openai_compat_env, proxy_bearer_token
 
 _DISPLAY_NAME = "Muse Code"
 _BINARY_NAME = "muse"
-_INSTALL_HINT = "Install Muse Code from https://dev.meta.ai/docs/muse-code/"
 _MCP_COMMAND_ENV = "FCC_MUSE_MCP_COMMAND"
 _MCP_SERVERS_ENV = "FCC_MUSE_MCP_SERVERS"
 
@@ -36,11 +36,7 @@ def launch(argv: Sequence[str] | None = None) -> None:
         print("Start it in another terminal with: fcc-server", file=sys.stderr)
         raise SystemExit(1)
 
-    binary_path = resolve_client_binary(
-        binary_name=_BINARY_NAME,
-        display_name=_DISPLAY_NAME,
-        install_hint=_INSTALL_HINT,
-    )
+    client = ensure_muse_client()
     settings_path = write_muse_settings_file(
         Path(tempfile.mkdtemp(prefix="fcc-muse-")),
         mcp_servers=build_muse_mcp_servers(os.environ),
@@ -57,7 +53,7 @@ def launch(argv: Sequence[str] | None = None) -> None:
     )
     run_client_process(
         command=build_muse_launcher_command(
-            binary_path=binary_path,
+            client=client,
             argv=args,
             proxy_root_url=proxy_root_url,
             model=settings.model,
@@ -66,7 +62,7 @@ def launch(argv: Sequence[str] | None = None) -> None:
         env=env,
         binary_name=_BINARY_NAME,
         display_name=_DISPLAY_NAME,
-        install_hint=_INSTALL_HINT,
+        install_hint=muse_install_hint(),
     )
 
 
@@ -121,7 +117,8 @@ def write_muse_settings_file(
 
 def build_muse_launcher_command(
     *,
-    binary_path: str,
+    binary_path: str | None = None,
+    client: ClientSpec | None = None,
     argv: Sequence[str],
     proxy_root_url: str,
     model: str,
@@ -129,6 +126,7 @@ def build_muse_launcher_command(
 ) -> list[str]:
     """Return the Muse CLI command pointed at FCC."""
 
+    spec = client or ClientSpec(kind="native", binary=binary_path or "muse")
     args = list(argv)
     extras: list[str] = []
     if not _has_flag(args, "--provider"):
@@ -138,8 +136,8 @@ def build_muse_launcher_command(
     if not _has_flag(args, "--model"):
         extras.extend(["--model", model])
     if settings_path is not None and not _has_flag(args, "--settings"):
-        extras.extend(["--settings", str(settings_path)])
-    return [binary_path, *extras, *args]
+        extras.extend(["--settings", spec.map_path(settings_path)])
+    return spec.build([*extras, *args])
 
 
 def build_muse_launcher_env(

--- a/src/free_claude_code/cli/launchers/openai_compat.py
+++ b/src/free_claude_code/cli/launchers/openai_compat.py
@@ -1,0 +1,53 @@
+"""Shared OpenAI-compatible client env for Atomic Agents, Prime Agent, and Muse."""
+
+from collections.abc import Mapping
+
+from free_claude_code.cli.local_http import with_local_proxy_bypass
+
+_OPENAI_STRIP_KEYS = frozenset(
+    {
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+        "OPENAI_ORG_ID",
+        "OPENAI_ORGANIZATION",
+    }
+)
+
+_DEFAULT_AUTH = "fcc-no-auth"
+
+
+def openai_compat_base_url(proxy_root_url: str) -> str:
+    """Return the OpenAI-style ``/v1`` base URL for the local FCC proxy."""
+
+    return f"{proxy_root_url.rstrip('/')}/v1"
+
+
+def proxy_bearer_token(auth_token: str) -> str:
+    """Return a non-empty bearer token for OpenAI-compatible clients."""
+
+    stripped = auth_token.strip()
+    return stripped or _DEFAULT_AUTH
+
+
+def build_openai_compat_env(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    base_env: Mapping[str, str],
+    model: str | None = None,
+) -> dict[str, str]:
+    """Point OpenAI-compatible SDKs at FCC without leaking parent OpenAI keys."""
+
+    env = with_local_proxy_bypass(
+        {key: value for key, value in base_env.items() if key not in _OPENAI_STRIP_KEYS},
+        proxy_root_url=proxy_root_url,
+    )
+    base_url = openai_compat_base_url(proxy_root_url)
+    token = proxy_bearer_token(auth_token)
+    env["OPENAI_BASE_URL"] = base_url
+    env["OPENAI_API_BASE"] = base_url
+    env["OPENAI_API_KEY"] = token
+    if model:
+        env["FCC_MODEL"] = model
+    return env

--- a/src/free_claude_code/cli/launchers/prime.py
+++ b/src/free_claude_code/cli/launchers/prime.py
@@ -12,12 +12,15 @@ from pathlib import Path
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 
-from .common import preflight_proxy, resolve_client_binary, run_client_process
-from .openai_compat import build_openai_compat_env, openai_compat_base_url, proxy_bearer_token
+from .common import preflight_proxy, run_client_process
+from .ensure import ensure_prime_binary, prime_install_hint
+from .openai_compat import (
+    build_openai_compat_env,
+    openai_compat_base_url,
+    proxy_bearer_token,
+)
 
 _DISPLAY_NAME = "Prime Agent"
-_BINARY_CANDIDATES = ("prime-agent", "prime")
-_INSTALL_HINT = "Install Prime Agent from https://github.com/PrimeIntellect-ai/prime-agent"
 _API_KEY_ENV = "FCC_PRIME_API_KEY"
 
 
@@ -35,7 +38,7 @@ def launch(argv: Sequence[str] | None = None) -> None:
         print("Start it in another terminal with: fcc-server", file=sys.stderr)
         raise SystemExit(1)
 
-    binary_path = resolve_prime_binary()
+    binary_path = ensure_prime_binary()
     agent_dir = Path(tempfile.mkdtemp(prefix="fcc-prime-"))
     write_prime_agent_dir(
         agent_dir,
@@ -62,26 +65,8 @@ def launch(argv: Sequence[str] | None = None) -> None:
         env=env,
         binary_name=Path(binary_path).name,
         display_name=_DISPLAY_NAME,
-        install_hint=_INSTALL_HINT,
+        install_hint=prime_install_hint(),
     )
-
-
-def resolve_prime_binary() -> str:
-    """Return the first Prime Agent binary on PATH."""
-
-    last_error: SystemExit | None = None
-    for binary_name in _BINARY_CANDIDATES:
-        try:
-            return resolve_client_binary(
-                binary_name=binary_name,
-                display_name=_DISPLAY_NAME,
-                install_hint=_INSTALL_HINT,
-            )
-        except SystemExit as exc:
-            last_error = exc
-    if last_error is not None:
-        raise last_error
-    raise SystemExit(127)
 
 
 def build_prime_launcher_command(

--- a/src/free_claude_code/cli/launchers/prime.py
+++ b/src/free_claude_code/cli/launchers/prime.py
@@ -1,0 +1,185 @@
+"""Installed ``fcc-prime`` launcher for Prime Agent."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from free_claude_code.config.loader import get_settings
+from free_claude_code.config.server_urls import local_proxy_root_url
+
+from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .openai_compat import build_openai_compat_env, openai_compat_base_url, proxy_bearer_token
+
+_DISPLAY_NAME = "Prime Agent"
+_BINARY_CANDIDATES = ("prime-agent", "prime")
+_INSTALL_HINT = "Install Prime Agent from https://github.com/PrimeIntellect-ai/prime-agent"
+_API_KEY_ENV = "FCC_PRIME_API_KEY"
+
+
+def launch(argv: Sequence[str] | None = None) -> None:
+    """Launch Prime Agent with an ephemeral FCC OpenAI-compatible provider."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    settings = get_settings()
+    proxy_root_url = local_proxy_root_url(settings)
+    if error := preflight_proxy(proxy_root_url):
+        print(
+            f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
+            file=sys.stderr,
+        )
+        print("Start it in another terminal with: fcc-server", file=sys.stderr)
+        raise SystemExit(1)
+
+    binary_path = resolve_prime_binary()
+    agent_dir = Path(tempfile.mkdtemp(prefix="fcc-prime-"))
+    write_prime_agent_dir(
+        agent_dir,
+        proxy_root_url=proxy_root_url,
+        model=settings.model,
+    )
+    env = build_prime_launcher_env(
+        proxy_root_url=proxy_root_url,
+        auth_token=settings.proxy_auth_token,
+        model=settings.model,
+        agent_dir=agent_dir,
+        base_env=os.environ,
+    )
+    print(
+        f"fcc-prime: using FCC provider 'fcc' model {settings.model} via {proxy_root_url}",
+        file=sys.stderr,
+    )
+    run_client_process(
+        command=build_prime_launcher_command(
+            binary_path=binary_path,
+            argv=args,
+            model=settings.model,
+        ),
+        env=env,
+        binary_name=Path(binary_path).name,
+        display_name=_DISPLAY_NAME,
+        install_hint=_INSTALL_HINT,
+    )
+
+
+def resolve_prime_binary() -> str:
+    """Return the first Prime Agent binary on PATH."""
+
+    last_error: SystemExit | None = None
+    for binary_name in _BINARY_CANDIDATES:
+        try:
+            return resolve_client_binary(
+                binary_name=binary_name,
+                display_name=_DISPLAY_NAME,
+                install_hint=_INSTALL_HINT,
+            )
+        except SystemExit as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    raise SystemExit(127)
+
+
+def build_prime_launcher_command(
+    *,
+    binary_path: str,
+    argv: Sequence[str],
+    model: str,
+) -> list[str]:
+    """Return the Prime Agent command, defaulting to the FCC provider/model."""
+
+    args = list(argv)
+    extras: list[str] = []
+    if not _has_flag(args, "--provider"):
+        extras.extend(["--provider", "fcc"])
+    if not _has_flag(args, "--model"):
+        extras.extend(["--model", f"fcc/{model}"])
+    return [binary_path, *extras, *args]
+
+
+def build_prime_models_document(
+    *,
+    proxy_root_url: str,
+    model: str,
+    api_key_env: str = _API_KEY_ENV,
+) -> dict[str, object]:
+    """Return a Prime ``models.json`` that points at FCC Chat Completions.
+
+    ``apiKey`` is an environment variable *name*, never a secret value.
+    """
+
+    return {
+        "providers": {
+            "fcc": {
+                "baseUrl": openai_compat_base_url(proxy_root_url),
+                "api": "openai-completions",
+                "apiKey": api_key_env,
+                "compat": {
+                    "supportsDeveloperRole": False,
+                    "supportsReasoningEffort": False,
+                },
+                "models": [
+                    {
+                        "id": model,
+                        "name": f"FCC {model}",
+                        "reasoning": False,
+                        "input": ["text"],
+                        "contextWindow": 128000,
+                    }
+                ],
+            }
+        }
+    }
+
+
+def write_prime_agent_dir(
+    agent_dir: Path,
+    *,
+    proxy_root_url: str,
+    model: str,
+) -> Path:
+    """Write an ephemeral Prime config dir that contains no secrets."""
+
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    models_path = agent_dir / "models.json"
+    models_path.write_text(
+        json.dumps(
+            build_prime_models_document(
+                proxy_root_url=proxy_root_url,
+                model=model,
+            ),
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return models_path
+
+
+def build_prime_launcher_env(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    model: str,
+    agent_dir: Path,
+    base_env: Mapping[str, str],
+) -> dict[str, str]:
+    """Return process env for Prime Agent. Secrets stay in memory only."""
+
+    env = build_openai_compat_env(
+        proxy_root_url=proxy_root_url,
+        auth_token=auth_token,
+        base_env=base_env,
+        model=model,
+    )
+    env["PRIME_AGENT_CODING_AGENT_DIR"] = str(agent_dir)
+    env[_API_KEY_ENV] = proxy_bearer_token(auth_token)
+    return env
+
+
+def _has_flag(args: Sequence[str], flag: str) -> bool:
+    return any(item == flag or item.startswith(f"{flag}=") for item in args)

--- a/src/free_claude_code/core/openai_chat_api/__init__.py
+++ b/src/free_claude_code/core/openai_chat_api/__init__.py
@@ -1,0 +1,34 @@
+"""Inbound OpenAI Chat Completions protocol adapter.
+
+FCC speaks Anthropic Messages internally. This package translates the widely
+adopted Chat Completions wire format onto that pipeline so any OpenAI-compatible
+client can drive FCC's configured providers.
+"""
+
+from .models import (
+    ChatCompletionsRequest,
+    ChatFunctionDef,
+    ChatMessage,
+    ChatTool,
+    ChatToolCall,
+)
+from .translate import (
+    anthropic_message_to_chat_completion,
+    anthropic_sse_to_chat_sse,
+    chat_request_to_messages_request,
+    iter_sse_data,
+    new_completion_id,
+)
+
+__all__ = [
+    "ChatCompletionsRequest",
+    "ChatFunctionDef",
+    "ChatMessage",
+    "ChatTool",
+    "ChatToolCall",
+    "anthropic_message_to_chat_completion",
+    "anthropic_sse_to_chat_sse",
+    "chat_request_to_messages_request",
+    "iter_sse_data",
+    "new_completion_id",
+]

--- a/src/free_claude_code/core/openai_chat_api/models.py
+++ b/src/free_claude_code/core/openai_chat_api/models.py
@@ -1,0 +1,106 @@
+"""Pydantic models for the inbound OpenAI Chat Completions protocol.
+
+This is the *inbound* wire format FCC serves at ``POST /v1/chat/completions``.
+It is deliberately permissive (``extra="allow"``) because the ecosystem that
+speaks this protocol -- Instructor, Atomic Agents, LangChain, LlamaIndex,
+Aider, Cline, Continue, OpenWebUI -- each attach their own vendor fields.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _ChatBase(BaseModel):
+    """Pass through vendor extensions rather than rejecting them."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ChatFunctionCall(_ChatBase):
+    name: str | None = None
+    arguments: str | None = None
+
+
+class ChatToolCall(_ChatBase):
+    id: str | None = None
+    type: str | None = "function"
+    function: ChatFunctionCall
+
+
+class ChatMessage(_ChatBase):
+    role: Literal["system", "developer", "user", "assistant", "tool", "function"]
+    # ``content`` may be a plain string, a multimodal part array, or null when
+    # the assistant turn carries only tool calls.
+    content: str | list[dict[str, Any]] | None = None
+    name: str | None = None
+    tool_calls: list[ChatToolCall] | None = None
+    tool_call_id: str | None = None
+    # de-facto standard emitted by DeepSeek/vLLM/OpenRouter for thinking text
+    reasoning_content: str | None = None
+
+
+class ChatFunctionDef(_ChatBase):
+    name: str
+    description: str | None = None
+    parameters: dict[str, Any] | None = None
+
+
+class ChatTool(_ChatBase):
+    type: str | None = "function"
+    function: ChatFunctionDef
+
+
+class ChatCompletionsRequest(_ChatBase):
+    """An inbound OpenAI Chat Completions request."""
+
+    model: str
+    messages: list[ChatMessage]
+    stream: bool = False
+    stream_options: dict[str, Any] | None = None
+
+    max_tokens: int | None = None
+    # OpenAI's newer name for max_tokens; clients send one or the other.
+    max_completion_tokens: int | None = None
+
+    temperature: float | None = None
+    top_p: float | None = None
+    stop: str | list[str] | None = None
+
+    tools: list[ChatTool] | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    parallel_tool_calls: bool | None = None
+
+    # Instructor / Atomic Agents structured-output path.
+    response_format: dict[str, Any] | None = None
+
+    # Accepted and ignored -- FCC routes by model, not by these.
+    n: int | None = None
+    user: str | None = None
+    seed: int | None = None
+    logprobs: bool | None = None
+    presence_penalty: float | None = None
+    frequency_penalty: float | None = None
+
+    metadata: dict[str, Any] | None = Field(default=None)
+
+    def effective_max_tokens(self, default: int) -> int:
+        """Return a positive max_tokens; Anthropic requires one, OpenAI does not."""
+        for candidate in (self.max_tokens, self.max_completion_tokens):
+            if isinstance(candidate, int) and candidate > 0:
+                return candidate
+        return default
+
+    def stop_sequences(self) -> list[str] | None:
+        """Normalise ``stop`` into Anthropic's ``stop_sequences`` list form."""
+        if self.stop is None:
+            return None
+        if isinstance(self.stop, str):
+            return [self.stop] if self.stop else None
+        sequences = [item for item in self.stop if isinstance(item, str) and item]
+        return sequences or None
+
+    def wants_usage_in_stream(self) -> bool:
+        """Return whether the client asked for a final usage-bearing chunk."""
+        options = self.stream_options
+        return bool(isinstance(options, dict) and options.get("include_usage"))

--- a/src/free_claude_code/core/openai_chat_api/translate.py
+++ b/src/free_claude_code/core/openai_chat_api/translate.py
@@ -1,0 +1,520 @@
+"""Translation between OpenAI Chat Completions and Anthropic Messages.
+
+FCC's internal pipeline speaks Anthropic Messages end to end. Serving the
+Chat Completions protocol is therefore a pure edge translation: inbound
+requests are lowered into ``MessagesRequest`` and the resulting Anthropic
+response (JSON or SSE) is lifted back into Chat Completions shape. Nothing in
+routing, provider selection, reasoning policy or streaming recovery changes.
+"""
+
+import json
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterable
+from typing import Any
+
+from free_claude_code.core.anthropic import MessagesRequest
+
+from .models import ChatCompletionsRequest, ChatMessage
+
+_DEFAULT_MAX_TOKENS = 4096
+
+_STOP_REASON_TO_FINISH_REASON = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "tool_use": "tool_calls",
+    "pause_turn": "stop",
+    "refusal": "content_filter",
+}
+
+
+def new_completion_id() -> str:
+    """Return an OpenAI-shaped completion id."""
+    return f"chatcmpl-{uuid.uuid4().hex[:24]}"
+
+
+# --------------------------------------------------------------------------
+# Request: Chat Completions -> Anthropic Messages
+# --------------------------------------------------------------------------
+
+
+def _image_source_from_url(url: str) -> dict[str, Any]:
+    """Return an Anthropic image source for a data: or http(s): URL."""
+    if url.startswith("data:"):
+        header, _, payload = url.partition(",")
+        media_type = header[5:].split(";")[0] or "image/png"
+        return {"type": "base64", "media_type": media_type, "data": payload}
+    return {"type": "url", "url": url}
+
+
+def _content_parts_to_blocks(parts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Lower OpenAI multimodal content parts into Anthropic content blocks."""
+    blocks: list[dict[str, Any]] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type in ("text", "input_text"):
+            text = part.get("text") or ""
+            if text:
+                blocks.append({"type": "text", "text": text})
+        elif part_type in ("image_url", "input_image"):
+            raw = part.get("image_url") or part.get("image")
+            url = raw.get("url") if isinstance(raw, dict) else raw
+            if isinstance(url, str) and url:
+                blocks.append(
+                    {"type": "image", "source": _image_source_from_url(url)}
+                )
+    return blocks
+
+
+def _text_of(content: str | list[dict[str, Any]] | None) -> str:
+    """Flatten message content down to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") in ("text", "input_text")
+        )
+    return ""
+
+
+def _assistant_blocks(message: ChatMessage) -> list[dict[str, Any]]:
+    """Build Anthropic assistant content, including tool_use blocks."""
+    blocks: list[dict[str, Any]] = []
+    text = _text_of(message.content)
+    if text:
+        blocks.append({"type": "text", "text": text})
+    for call in message.tool_calls or []:
+        raw_args = call.function.arguments or "{}"
+        try:
+            parsed = json.loads(raw_args) if raw_args.strip() else {}
+        except (TypeError, ValueError):
+            # A malformed argument string must not abort the whole request;
+            # forward it verbatim so the model can still see what it emitted.
+            parsed = {"_raw_arguments": raw_args}
+        if not isinstance(parsed, dict):
+            parsed = {"value": parsed}
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": call.id or f"call_{uuid.uuid4().hex[:16]}",
+                "name": call.function.name or "unknown_tool",
+                "input": parsed,
+            }
+        )
+    return blocks
+
+
+def _tools_to_anthropic(request: ChatCompletionsRequest) -> list[dict[str, Any]] | None:
+    tools = [
+        {
+            "name": tool.function.name,
+            "description": tool.function.description or "",
+            "input_schema": tool.function.parameters
+            or {"type": "object", "properties": {}},
+        }
+        for tool in (request.tools or [])
+        if tool.function and tool.function.name
+    ]
+    return tools or None
+
+
+def _tool_choice_to_anthropic(choice: str | dict[str, Any] | None) -> dict[str, Any] | None:
+    if choice is None:
+        return None
+    if isinstance(choice, str):
+        return {
+            "auto": {"type": "auto"},
+            "required": {"type": "any"},
+            "any": {"type": "any"},
+            "none": {"type": "none"},
+        }.get(choice)
+    if isinstance(choice, dict):
+        if choice.get("type") == "function":
+            name = (choice.get("function") or {}).get("name")
+            if name:
+                return {"type": "tool", "name": name}
+        # already Anthropic-shaped
+        if choice.get("type") in ("auto", "any", "tool", "none"):
+            return choice
+    return None
+
+
+def _structured_output_tool(
+    response_format: dict[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Map ``response_format={"type":"json_schema"}`` onto a forced tool call.
+
+    Instructor -- and therefore Atomic Agents -- uses this to get structured
+    output. Anthropic has no ``response_format``, so the equivalent is a single
+    tool the model is forced to call.
+    """
+    if not isinstance(response_format, dict):
+        return None
+    if response_format.get("type") != "json_schema":
+        return None
+    schema_block = response_format.get("json_schema")
+    if not isinstance(schema_block, dict):
+        return None
+    schema = schema_block.get("schema")
+    if not isinstance(schema, dict):
+        return None
+    name = schema_block.get("name") or "structured_output"
+    tool = {
+        "name": name,
+        "description": schema_block.get("description")
+        or "Return the result using this schema.",
+        "input_schema": schema,
+    }
+    return tool, {"type": "tool", "name": name}
+
+
+def chat_request_to_messages_request(
+    request: ChatCompletionsRequest,
+) -> MessagesRequest:
+    """Lower an inbound Chat Completions request into a ``MessagesRequest``."""
+    system_chunks: list[str] = []
+    messages: list[dict[str, Any]] = []
+
+    def flush_tool_results(buffer: list[dict[str, Any]]) -> None:
+        if buffer:
+            messages.append({"role": "user", "content": list(buffer)})
+            buffer.clear()
+
+    pending_tool_results: list[dict[str, Any]] = []
+
+    for message in request.messages:
+        if message.role in ("system", "developer"):
+            flush_tool_results(pending_tool_results)
+            text = _text_of(message.content)
+            if text:
+                system_chunks.append(text)
+            continue
+
+        if message.role in ("tool", "function"):
+            # Parallel tool results must be batched into one user turn.
+            pending_tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": message.tool_call_id
+                    or f"call_{uuid.uuid4().hex[:16]}",
+                    "content": _text_of(message.content) or "",
+                }
+            )
+            continue
+
+        flush_tool_results(pending_tool_results)
+
+        if message.role == "assistant":
+            blocks = _assistant_blocks(message)
+            if blocks:
+                messages.append({"role": "assistant", "content": blocks})
+            continue
+
+        # user
+        if isinstance(message.content, list):
+            blocks = _content_parts_to_blocks(message.content)
+            messages.append(
+                {"role": "user", "content": blocks or [{"type": "text", "text": ""}]}
+            )
+        else:
+            messages.append({"role": "user", "content": message.content or ""})
+
+    flush_tool_results(pending_tool_results)
+
+    if not messages:
+        messages.append({"role": "user", "content": ""})
+
+    tools = _tools_to_anthropic(request)
+    tool_choice = _tool_choice_to_anthropic(request.tool_choice)
+
+    structured = _structured_output_tool(request.response_format)
+    if structured is not None:
+        forced_tool, forced_choice = structured
+        tools = [*(tools or []), forced_tool]
+        tool_choice = forced_choice
+
+    payload: dict[str, Any] = {
+        "model": request.model,
+        "messages": messages,
+        "max_tokens": request.effective_max_tokens(_DEFAULT_MAX_TOKENS),
+        "stream": request.stream,
+    }
+    if system_chunks:
+        payload["system"] = "\n\n".join(system_chunks)
+    if request.temperature is not None:
+        payload["temperature"] = request.temperature
+    if request.top_p is not None:
+        payload["top_p"] = request.top_p
+    if (stops := request.stop_sequences()) is not None:
+        payload["stop_sequences"] = stops
+    if tools:
+        payload["tools"] = tools
+    if tool_choice:
+        payload["tool_choice"] = tool_choice
+    if request.metadata:
+        payload["metadata"] = request.metadata
+
+    return MessagesRequest.model_validate(payload)
+
+
+# --------------------------------------------------------------------------
+# Response: Anthropic Messages -> Chat Completions
+# --------------------------------------------------------------------------
+
+
+def _usage_to_openai(usage: dict[str, Any] | None) -> dict[str, Any]:
+    usage = usage or {}
+    prompt = int(usage.get("input_tokens") or 0)
+    completion = int(usage.get("output_tokens") or 0)
+    cache_read = int(usage.get("cache_read_input_tokens") or 0)
+    payload: dict[str, Any] = {
+        "prompt_tokens": prompt + cache_read,
+        "completion_tokens": completion,
+        "total_tokens": prompt + cache_read + completion,
+    }
+    if cache_read:
+        payload["prompt_tokens_details"] = {"cached_tokens": cache_read}
+    return payload
+
+
+def anthropic_message_to_chat_completion(
+    message: dict[str, Any],
+    *,
+    model: str,
+    completion_id: str | None = None,
+) -> dict[str, Any]:
+    """Lift a complete Anthropic Message into a Chat Completions response."""
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    for block in message.get("content") or []:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text_parts.append(block.get("text") or "")
+        elif block_type == "thinking":
+            reasoning_parts.append(block.get("thinking") or "")
+        elif block_type == "tool_use":
+            tool_calls.append(
+                {
+                    "id": block.get("id") or f"call_{uuid.uuid4().hex[:16]}",
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name") or "unknown_tool",
+                        "arguments": json.dumps(block.get("input") or {}),
+                    },
+                }
+            )
+
+    chat_message: dict[str, Any] = {
+        "role": "assistant",
+        "content": "".join(text_parts) or None,
+    }
+    if reasoning_parts:
+        chat_message["reasoning_content"] = "".join(reasoning_parts)
+    if tool_calls:
+        chat_message["tool_calls"] = tool_calls
+
+    stop_reason = message.get("stop_reason")
+    finish_reason = _STOP_REASON_TO_FINISH_REASON.get(str(stop_reason), "stop")
+    if tool_calls and finish_reason == "stop":
+        finish_reason = "tool_calls"
+
+    return {
+        "id": completion_id or new_completion_id(),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": message.get("model") or model,
+        "choices": [
+            {"index": 0, "message": chat_message, "finish_reason": finish_reason}
+        ],
+        "usage": _usage_to_openai(message.get("usage")),
+    }
+
+
+# --------------------------------------------------------------------------
+# Streaming: Anthropic SSE -> Chat Completions SSE
+# --------------------------------------------------------------------------
+
+
+def iter_sse_data(raw: str, buffer: list[str]) -> Iterable[dict[str, Any]]:
+    """Yield decoded ``data:`` payloads from a raw SSE fragment.
+
+    ``buffer`` is a single-element carry list holding the incomplete tail
+    between fragments, since a provider chunk may split mid-line.
+    """
+    buffer[0] += raw
+    while "\n" in buffer[0]:
+        line, _, rest = buffer[0].partition("\n")
+        buffer[0] = rest
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            decoded = json.loads(payload)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(decoded, dict):
+            yield decoded
+
+
+def _chunk(
+    completion_id: str,
+    model: str,
+    delta: dict[str, Any],
+    *,
+    finish_reason: str | None = None,
+    usage: dict[str, Any] | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+
+
+async def anthropic_sse_to_chat_sse(
+    source: AsyncIterator[str],
+    *,
+    model: str,
+    completion_id: str,
+    include_usage: bool = False,
+) -> AsyncIterator[str]:
+    """Transform an Anthropic SSE stream into a Chat Completions SSE stream."""
+    buffer = [""]
+    # Anthropic indexes every content block; OpenAI indexes only tool calls.
+    tool_index_by_block: dict[int, int] = {}
+    next_tool_index = 0
+    finish_reason = "stop"
+    usage: dict[str, Any] = {}
+    role_sent = False
+    response_model = model
+    saw_tool_call = False
+
+    async for raw in source:
+        for event in iter_sse_data(raw, buffer):
+            event_type = event.get("type")
+
+            if event_type == "message_start":
+                message = event.get("message") or {}
+                response_model = message.get("model") or response_model
+                usage.update(message.get("usage") or {})
+                if not role_sent:
+                    role_sent = True
+                    yield _chunk(
+                        completion_id, response_model, {"role": "assistant", "content": ""}
+                    )
+
+            elif event_type == "content_block_start":
+                block = event.get("content_block") or {}
+                if block.get("type") == "tool_use":
+                    saw_tool_call = True
+                    block_index = int(event.get("index") or 0)
+                    tool_index_by_block[block_index] = next_tool_index
+                    yield _chunk(
+                        completion_id,
+                        response_model,
+                        {
+                            "tool_calls": [
+                                {
+                                    "index": next_tool_index,
+                                    "id": block.get("id")
+                                    or f"call_{uuid.uuid4().hex[:16]}",
+                                    "type": "function",
+                                    "function": {
+                                        "name": block.get("name") or "unknown_tool",
+                                        "arguments": "",
+                                    },
+                                }
+                            ]
+                        },
+                    )
+                    next_tool_index += 1
+
+            elif event_type == "content_block_delta":
+                delta = event.get("delta") or {}
+                delta_type = delta.get("type")
+                if delta_type == "text_delta":
+                    text = delta.get("text") or ""
+                    if text:
+                        yield _chunk(completion_id, response_model, {"content": text})
+                elif delta_type == "thinking_delta":
+                    thinking = delta.get("thinking") or ""
+                    if thinking:
+                        yield _chunk(
+                            completion_id,
+                            response_model,
+                            {"reasoning_content": thinking},
+                        )
+                elif delta_type == "input_json_delta":
+                    partial = delta.get("partial_json") or ""
+                    block_index = int(event.get("index") or 0)
+                    tool_index = tool_index_by_block.get(block_index, 0)
+                    if partial:
+                        yield _chunk(
+                            completion_id,
+                            response_model,
+                            {
+                                "tool_calls": [
+                                    {
+                                        "index": tool_index,
+                                        "function": {"arguments": partial},
+                                    }
+                                ]
+                            },
+                        )
+
+            elif event_type == "message_delta":
+                stop_reason = (event.get("delta") or {}).get("stop_reason")
+                if stop_reason:
+                    finish_reason = _STOP_REASON_TO_FINISH_REASON.get(
+                        str(stop_reason), "stop"
+                    )
+                usage.update(event.get("usage") or {})
+
+            elif event_type == "error":
+                # Surface a terminal frame the OpenAI SDK can classify.
+                error = event.get("error") or {}
+                yield (
+                    "data: "
+                    + json.dumps(
+                        {
+                            "error": {
+                                "message": error.get("message")
+                                or "Provider request failed.",
+                                "type": error.get("type") or "api_error",
+                            }
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n\n"
+                )
+                yield "data: [DONE]\n\n"
+                return
+
+    if saw_tool_call and finish_reason == "stop":
+        finish_reason = "tool_calls"
+
+    yield _chunk(
+        completion_id,
+        response_model,
+        {},
+        finish_reason=finish_reason,
+        usage=_usage_to_openai(usage) if include_usage else None,
+    )
+    yield "data: [DONE]\n\n"

--- a/tests/cli/test_agent_launchers.py
+++ b/tests/cli/test_agent_launchers.py
@@ -1,0 +1,117 @@
+import tempfile
+from pathlib import Path
+
+from free_claude_code.cli.launchers.muse import (
+    build_muse_launcher_command,
+    build_muse_launcher_env,
+    build_muse_mcp_servers,
+    build_muse_settings_document,
+)
+from free_claude_code.cli.launchers.openai_compat import (
+    build_openai_compat_env,
+    openai_compat_base_url,
+    proxy_bearer_token,
+)
+from free_claude_code.cli.launchers.prime import (
+    build_prime_launcher_command,
+    build_prime_launcher_env,
+    build_prime_models_document,
+    write_prime_agent_dir,
+)
+
+
+def test_openai_compat_env_points_at_local_proxy_without_parent_keys() -> None:
+    env = build_openai_compat_env(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        base_env={"OPENAI_API_KEY": "sk-parent", "PATH": "/bin"},
+        model="open_router/openai/gpt-4o-mini",
+    )
+    assert env["OPENAI_BASE_URL"] == "http://127.0.0.1:8082/v1"
+    assert env["OPENAI_API_KEY"] == "proxy-token"
+    assert env["FCC_MODEL"] == "open_router/openai/gpt-4o-mini"
+    assert "sk-parent" not in env.values()
+
+
+def test_proxy_bearer_token_uses_sentinel_when_empty() -> None:
+    assert proxy_bearer_token("  ") == "fcc-no-auth"
+    assert openai_compat_base_url("http://127.0.0.1:8082/") == "http://127.0.0.1:8082/v1"
+
+
+def test_prime_models_json_uses_env_name_not_secret() -> None:
+    document = build_prime_models_document(
+        proxy_root_url="http://127.0.0.1:8082",
+        model="open_router/openai/gpt-4o-mini",
+    )
+    provider = document["providers"]["fcc"]
+    assert provider["api"] == "openai-completions"
+    assert provider["baseUrl"] == "http://127.0.0.1:8082/v1"
+    assert provider["apiKey"] == "FCC_PRIME_API_KEY"
+    dumped = str(document)
+    assert "sk-" not in dumped
+    assert "password" not in dumped.lower()
+
+
+def test_prime_command_defaults_provider_and_preserves_user_args() -> None:
+    command = build_prime_launcher_command(
+        binary_path="prime-agent",
+        argv=["-p", "hello"],
+        model="open_router/openai/gpt-4o-mini",
+    )
+    assert command[:5] == [
+        "prime-agent",
+        "--provider",
+        "fcc",
+        "--model",
+        "fcc/open_router/openai/gpt-4o-mini",
+    ]
+    assert command[-2:] == ["-p", "hello"]
+
+
+def test_prime_temp_dir_has_no_secrets() -> None:
+    with tempfile.TemporaryDirectory(prefix="fcc-prime-test-") as raw:
+        tmp_path = Path(raw)
+        models_path = write_prime_agent_dir(
+            tmp_path,
+            proxy_root_url="http://127.0.0.1:8082",
+            model="open_router/openai/gpt-4o-mini",
+        )
+        text = models_path.read_text(encoding="utf-8")
+        assert "FCC_PRIME_API_KEY" in text
+        assert "sk-" not in text
+        env = build_prime_launcher_env(
+            proxy_root_url="http://127.0.0.1:8082",
+            auth_token="secret-token",
+            model="open_router/openai/gpt-4o-mini",
+            agent_dir=tmp_path,
+            base_env={},
+        )
+        assert env["FCC_PRIME_API_KEY"] == "secret-token"
+        assert env["PRIME_AGENT_CODING_AGENT_DIR"] == str(tmp_path)
+
+
+def test_muse_command_and_optional_mcp() -> None:
+    command = build_muse_launcher_command(
+        binary_path="muse",
+        argv=["exec", "ping"],
+        proxy_root_url="http://127.0.0.1:8082",
+        model="open_router/openai/gpt-4o-mini",
+        settings_path=Path("/tmp/fcc-muse/settings.json"),
+    )
+    assert "--provider" in command and "meta" in command
+    assert "--base-url" in command and "http://127.0.0.1:8082" in command
+    assert command[-2:] == ["exec", "ping"]
+    servers = build_muse_mcp_servers(
+        {"FCC_MUSE_MCP_COMMAND": "npx", "FCC_MUSE_MCP_SERVERS": ""}
+    )
+    assert servers["fcc-tools"]["mode"] == "optional"
+    document = build_muse_settings_document(mcp_servers=servers)
+    assert "mcp_servers" in document
+    env = build_muse_launcher_env(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="proxy-token",
+        model="open_router/openai/gpt-4o-mini",
+        base_env={},
+    )
+    assert env["META_API_KEY"] == "proxy-token"
+    assert env["META_BASE_URL"] == "http://127.0.0.1:8082"

--- a/tests/cli/test_agent_launchers.py
+++ b/tests/cli/test_agent_launchers.py
@@ -1,6 +1,13 @@
+import os
 import tempfile
 from pathlib import Path
 
+from free_claude_code.cli.launchers.ensure import (
+    ClientSpec,
+    auto_install_enabled,
+    windows_path_text_to_wsl,
+    wsl_exec,
+)
 from free_claude_code.cli.launchers.muse import (
     build_muse_launcher_command,
     build_muse_launcher_env,
@@ -115,3 +122,53 @@ def test_muse_command_and_optional_mcp() -> None:
     )
     assert env["META_API_KEY"] == "proxy-token"
     assert env["META_BASE_URL"] == "http://127.0.0.1:8082"
+
+
+def test_auto_install_env_defaults_on() -> None:
+    assert auto_install_enabled({}) is True
+    assert auto_install_enabled({"FCC_NO_AUTO_INSTALL": "1"}) is False
+    assert auto_install_enabled({"FCC_NO_AUTO_INSTALL": "true"}) is False
+
+
+def test_wsl_muse_command_quotes_settings_path() -> None:
+    client = ClientSpec(kind="wsl", binary="muse")
+    settings_path = Path("/tmp/fcc-muse/settings.json")
+    command = build_muse_launcher_command(
+        client=client,
+        argv=["exec", "ping"],
+        proxy_root_url="http://127.0.0.1:8082",
+        model="open_router/openai/gpt-4o-mini",
+        settings_path=settings_path,
+    )
+    assert command[:3] == ["wsl", "bash", "-lc"]
+    inner = command[3]
+    assert "exec muse" in inner
+    assert "--provider" in inner
+    assert "meta" in inner
+    assert "--settings" in inner
+    assert windows_path_text_to_wsl(r"C:\Users\me\settings.json") == (
+        "/mnt/c/Users/me/settings.json"
+    )
+
+
+def test_wsl_exec_quotes_spaces() -> None:
+    command = wsl_exec("muse", ["--settings", "/tmp/my settings.json"])
+    assert command[:3] == ["wsl", "bash", "-lc"]
+    assert "'/tmp/my settings.json'" in command[3]
+
+
+def test_prime_skips_install_when_disabled(monkeypatch, capsys) -> None:
+    from free_claude_code.cli.launchers import ensure as ensure_mod
+
+    monkeypatch.setattr(ensure_mod, "find_prime_binary", lambda: None)
+    monkeypatch.setenv("FCC_NO_AUTO_INSTALL", "1")
+    try:
+        ensure_mod.ensure_prime_binary()
+    except SystemExit as exc:
+        assert exc.code == 127
+    else:
+        raise AssertionError("expected SystemExit 127")
+    err = capsys.readouterr().err
+    assert "Could not find Prime Agent" in err
+    assert "fcc-prime can install it" in err or "github.com/PrimeIntellect-ai" in err
+    assert os.environ["FCC_NO_AUTO_INSTALL"] == "1"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds OpenAI-compatible chat support plus Atomic, Prime, and Muse launchers. Two user-facing regressions were reproduced: the CLI entrypoint test still rejects the three newly registered commands, and Muse and Prime leave per-run configuration directories on disk after their child process exits. The Prime installer temporary-file concern was disproved: executing the exact `mktemp` template successfully created the requested `.tgz` file without entering the failure path.

<h3>Confidence Score: 3/5</h3>

This change is not ready to merge until the stale command-registry assertion and temporary-directory cleanup are corrected.

Both reported runtime failures were reproduced with executable harnesses and captured output. The installer concern was exercised directly and contradicted by observed `mktemp` behavior.

**Files Needing Attention:** Update `tests/cli/test_entrypoints.py` for the new launcher commands, and add cleanup around the temporary directories created by `src/free_claude_code/cli/launchers/muse.py` and `src/free_claude_code/cli/launchers/prime.py`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for two posted P1 findings.
- T-Rex documented the Muse and Prime launcher cleanup harness and captured the baseline before launcher execution, plus directories remaining after launcher returns.
- T-Rex validated the general contract: the reproduction reported 7 actual scripts vs 4 expected, and the pytest import exited due to a ReasoningPolicy self-reference under Python 3.11.
- T-Rex inspected the source capture showing the claimed command at line 653, the mktemp path was accepted and returned a randomized .tgz path, and the failure path was not invoked.
- T-Rex verified the before/after capture state, including zero Muse and Prime temporary directories before capture, run\_client\_process\_returned flags after launch, remains\_after\_return, and that settings.json and models.json were kept, with harness outputs saved.

<a href="https://app.greptile.com/trex/runs/19032290/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (3)</h3>

1. `tests/cli/test_entrypoints.py`, line 62-67 ([link](https://github.com/alishahryar1/free-claude-code/blob/1b9b0e01362f88cdc84b63ddc5ff99bbaa342bc9/tests/cli/test_entrypoints.py#L62-L67)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Console registry test rejects new launchers**

   `pyproject.toml` now registers `fcc-atomic`, `fcc-prime`, and `fcc-muse`, but this exact-equality assertion still expects only the original four scripts. The reproduced assertion fails with those three extra entries, so the test suite will fail until its expected mapping is updated.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Entry-point equality reproduction source](https://app.greptile.com/trex/artifacts/e2c90175-6aff-4d85-9c04-8d63734d4e91)**

   - The exact generated Python source parses pyproject.toml and applies the same expected four-script equality assertion, providing a reproducible check.

   **[Entrypoint assertion failure with seven registered scripts](https://app.greptile.com/trex/artifacts/9980cf76-702e-48b6-9bdf-1ec52d9fa940)**

   - The equivalent assertion command exited 1 and shows seven actual scripts, four expected scripts, and the three unexpected registrations, confirming the stale expectation.

   **[Focused pytest command blocked during collection](https://app.greptile.com/trex/artifacts/81469798-6956-4a45-a167-2a2d37c53581)**

   - The exact focused pytest command exited 4 before executing the target due to a Python 3.11 NameError in ReasoningPolicy, so its direct result is blocked independently of the confirmed assertion mismatch.

   <a href="https://app.greptile.com/trex/runs/19032290/artifacts?artifact=e2c90175-6aff-4d85-9c04-8d63734d4e91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **CLI entrypoint registration test is stale after three launcher scripts were added**

   - **Bug**
     - `pyproject.toml` declares `fcc-atomic`, `fcc-prime`, and `fcc-muse`, but `test_cli_scripts_are_registered` compares the scripts mapping to a four-entry literal. The equivalent assertion fails deterministically.
   - **Cause**
     - The test expectation was not updated when the three console-script registrations were added.
   - **Fix**
     - Update the expected mapping in `tests/cli/test_entrypoints.py` to include the three registered launchers, or alter the test to intentionally validate the required script set if exact parity is not desired.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Muse and Prime launchers leak per-run temporary configuration directories**

   - **Bug**
     - `fcc-muse` creates an `fcc-muse-*` directory and, when MCP settings are configured, leaves `settings.json` in it after the child-process wrapper returns. `fcc-prime` creates an `fcc-prime-*` directory containing `models.json` and likewise leaves it behind. The controlled runtime harness confirmed both directories still exist after `run_client_process` returns.
   - **Cause**
     - `muse.launch()` calls `tempfile.mkdtemp()` at `src/free_claude_code/cli/launchers/muse.py:40-43` and invokes `run_client_process()` at lines 54-66 without a cleanup scope. `prime.launch()` does the same at `src/free_claude_code/cli/launchers/prime.py:42-47` and lines 59-69. Neither launcher removes the created directory in a `finally` block after the child returns or raises.
   - **Fix**
     - Wrap each launcher's temporary-directory lifetime in `try`/`finally` and remove it with `shutil.rmtree(directory, ignore_errors=True)` after `run_client_process()` exits, including its `SystemExit` and interrupt paths. Preserve the directory until the child has completed because its configuration is passed to the child.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Let friends install fcc-atomic, fcc-prim..."](https://github.com/alishahryar1/free-claude-code/commit/1b9b0e01362f88cdc84b63ddc5ff99bbaa342bc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53615469)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->