### PR TITLE
Make README highlights communicate FCC scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
 - **Terminal, desktop, IDE, or phone.** Work through native launchers, VS Code, Codex App, JetBrains, Discord, or Telegram.
 - **Voice notes in. Code out.** Talk to your agent using local Whisper or NVIDIA NIM transcription.
-- **Agent capabilities stay intact.** Stream responses, use tools, reason, send images, and route Fable, Opus, Sonnet, and Haiku independently with compatible models.
+- **Agent capabilities stay intact.** Stream responses, use tools, preserve native interleaved thinking for maximum performance, send images, and route Fable, Opus, Sonnet, and Haiku independently with compatible models.
 
 <div align="center">
   <img src="assets/pic.png" alt="Claude Code running with Free Claude Code" width="700">

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@
 
 ## What You Get
 
-- **Use your preferred coding agent.** Run Claude Code, Codex, Pi, or OpenCode with FCC.
-- **Choose your own models.** Connect free, paid, or local providers and search their models from one Admin UI.
-- **Route work your way.** Set one default model or map Fable, Opus, Sonnet, and Haiku separately.
-- **Save time and tokens.** Five built-in optimizations handle quota probes, command-prefix detection, title generation, suggestion mode, and filepath extraction locally instead of calling your provider; optionally enable [RTK](https://github.com/rtk-ai/rtk) to filter noisy terminal output before it reaches the model.
-- **Keep coding-agent capabilities.** Use streaming, tools, reasoning, and image input with compatible models.
-- **Work where you want.** Launch from your desktop, connect supported IDEs, or use optional Discord and Telegram bots with voice notes.
+- **48 providers. One proxy.** Use free, paid, subscription, or local models from one searchable Admin UI.
+- **4 coding agents. One model catalog.** Run Claude Code, Codex, Pi, or OpenCode with your FCC models.
+- **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
+- **Terminal, desktop, IDE, or phone.** Work through native launchers, VS Code, Codex App, JetBrains, Discord, or Telegram.
+- **Voice notes in. Code out.** Talk to your agent using local Whisper or NVIDIA NIM transcription.
+- **Agent capabilities stay intact.** Stream responses, use tools, reason, send images, and route Fable, Opus, Sonnet, and Haiku independently with compatible models.
 
 <div align="center">
   <img src="assets/pic.png" alt="Claude Code running with Free Claude Code" width="700">


### PR DESCRIPTION
## Problem

The README opening lists capabilities but hides FCC scale and its strongest user-facing outcomes. New visitors must parse dense bullets before understanding the project value.

## Changes

| Before | After |
| --- | --- |
| Generic bullets described providers and clients without scale. | Named highlights lead with 48 providers and four coding agents. |
| Token savings were buried in one long optimization description. | The RTK up-to-90% terminal-output reduction and five local FCC optimizations are immediately visible. |
| Desktop, IDE, phone, and voice support shared a generic location bullet. | Work surfaces and voice-note support have distinct, scannable promises. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The README opening now emphasizes FCC’s provider and coding-agent coverage, RTK terminal-output filtering, supported work surfaces, voice transcription, and retained agent capabilities.

The concern about the “up to 90%” terminal-output reduction statement was dropped after an executed check followed the reader-visible RTK link in `README.md:26`. RTK’s documentation defines the measurement as bash output read by an agent, describes its `bytes / 4` estimation method, and lists applicable command workloads including `pytest`, `go test`, `cargo test`, `rake test`, `rspec`, and `vitest`. This disproves that the claim lacks verifiable scope or methodology.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the reviewed documentation-only change.

The only reported issue was contradicted by the linked RTK documentation, which provides the claimed reduction’s measurement scope, methodology, and representative workloads.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof and confirmed the exact text change in README.md:26 that states the claim about token reduction and its link to RTK.
- Validated that the RTK documentation cited in the proof describes cutting up to 90% of bash output and explains counting as bytes divided by four.
- Checked that the proof lists workload conditions and the scope of integrations to command interception for various test suites.

<a href="https://app.greptile.com/trex/runs/19065744/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Highlight native interleaved thinking"](https://github.com/alishahryar1/free-claude-code/commit/67996062586b037412d56eaaa2221c27923c4568) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53686910)</sub>

<!-- /greptile_comment -->