### PR TITLE
Restore full live smoke reliability across providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.5.0"
+version = "5.5.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -49,7 +49,7 @@ SECRET_KEY_PARTS = ("KEY", "TOKEN", "SECRET", "WEBHOOK", "AUTH")
 PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "nvidia_nim": "nvidia_nim/nvidia/nemotron-3-super-120b-a12b",
     "azure_openai": "azure_openai/gpt-5.1",
-    "open_router": "open_router/moonshotai/kimi-k2.6:free",
+    "open_router": "open_router/nvidia/nemotron-3-super-120b-a12b:free",
     "mistral": "mistral/devstral-small-latest",
     "mistral_codestral": "mistral_codestral/codestral-latest",
     "deepseek": "deepseek/deepseek-v4-pro",

--- a/smoke/product/test_client_product_live.py
+++ b/smoke/product/test_client_product_live.py
@@ -70,7 +70,7 @@ def test_pi_cli_prompt_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> None:
     if not uv_bin:
         pytest.skip("missing_env: uv not found")
     provider_model = ProviderMatrixDriver(smoke_config).first_model()
-    auth_token = "fcc-pi-smoke-token"
+    auth_token = smoke_config.settings.proxy_auth_token
 
     with SmokeServerDriver(
         smoke_config,
@@ -126,7 +126,7 @@ def test_opencode_cli_prompt_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> N
     if not uv_bin:
         pytest.skip("missing_env: uv not found")
     provider_model = ProviderMatrixDriver(smoke_config).first_model()
-    auth_token = "fcc-opencode-smoke-token"
+    auth_token = smoke_config.settings.proxy_auth_token
     isolated_home = tmp_path / "opencode-home"
     isolated_config = tmp_path / "opencode-config"
     for path in (isolated_home, isolated_config):

--- a/smoke/product/test_provider_product_live.py
+++ b/smoke/product/test_provider_product_live.py
@@ -125,7 +125,7 @@ def test_mistral_native_reasoning_model_e2e(smoke_config: SmokeConfig) -> None:
 
     payload = {
         "model": "claude-opus-4-7",
-        "max_tokens": 256,
+        "max_tokens": 1024,
         "messages": [{"role": "user", "content": "Reply with one short sentence."}],
         "thinking": {"type": "adaptive"},
     }
@@ -302,7 +302,7 @@ def _scenario_adaptive_thinking_history(
 ) -> None:
     payload = {
         "model": "claude-opus-4-7",
-        "max_tokens": 256,
+        "max_tokens": 2048,
         "messages": [
             {"role": "user", "content": "hello"},
             {
@@ -327,7 +327,7 @@ def _scenario_interleaved_history(
 ) -> None:
     payload = {
         "model": "claude-sonnet-4-5-20250929",
-        "max_tokens": 256,
+        "max_tokens": 1024,
         "messages": [
             {"role": "user", "content": "Use the tool."},
             {
@@ -458,7 +458,7 @@ def _scenario_interrupted_tool_turn_resume(
     tool_id = "toolu_interrupted123456789"
     payload = {
         "model": "claude-sonnet-4-5-20250929",
-        "max_tokens": 32,
+        "max_tokens": 256,
         "stream": True,
         "messages": [
             {"role": "user", "content": "Use echo_smoke with value FCC_INTERRUPTED."},

--- a/src/free_claude_code/providers/lmstudio/client.py
+++ b/src/free_claude_code/providers/lmstudio/client.py
@@ -52,6 +52,7 @@ _PROFILE = OpenAIChatProfile(
         disabled_value="none",
         enabled_value="high",
         budget_field="reasoning_tokens",
+        use_extra_body=True,
     ),
 )
 

--- a/src/free_claude_code/providers/mistral/reasoning.py
+++ b/src/free_claude_code/providers/mistral/reasoning.py
@@ -244,7 +244,7 @@ def _split_mistral_content(content: Any) -> tuple[str | None, str | None, bool]:
     return (
         "".join(text_parts) or None,
         "".join(reasoning_parts) or None,
-        bool(text_parts or reasoning_parts),
+        True,
     )
 
 

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -522,7 +522,7 @@ def test_openrouter_provider_smoke_uses_concrete_free_model(monkeypatch) -> None
     models = config.provider_smoke_models()
 
     assert [model.provider for model in models] == ["open_router"]
-    assert models[0].full_model == "open_router/moonshotai/kimi-k2.6:free"
+    assert models[0].full_model == "open_router/nvidia/nemotron-3-super-120b-a12b:free"
     assert models[0].source == "provider_default"
 
 

--- a/tests/providers/test_lmstudio.py
+++ b/tests/providers/test_lmstudio.py
@@ -67,7 +67,8 @@ def test_adaptive_client_reasoning_uses_documented_named_effort(lmstudio_provide
 
     body = lmstudio_provider._build_request_body(req, reasoning=REASONING_ON)
 
-    assert body["reasoning_effort"] == "high"
+    assert body["extra_body"]["reasoning_effort"] == "high"
+    assert "reasoning_effort" not in body
 
 
 def test_exact_client_budget_is_not_derived_from_output_tokens(lmstudio_provider):
@@ -81,7 +82,8 @@ def test_exact_client_budget_is_not_derived_from_output_tokens(lmstudio_provider
         ),
     )
 
-    assert body["reasoning_tokens"] == 1024
+    assert body["extra_body"]["reasoning_tokens"] == 1024
+    assert "reasoning_tokens" not in body
     assert body["max_tokens"] == 8192
 
 
@@ -185,6 +187,49 @@ async def test_stream_response_text(lmstudio_provider):
         assert any(
             '"text_delta"' in event and "Hello back!" in event for event in events
         )
+
+
+@pytest.mark.asyncio
+async def test_stream_response_passes_exact_reasoning_budget_via_extra_body(
+    lmstudio_provider,
+):
+    req = make_request()
+    policy = ReasoningPolicy.on(
+        effort=ReasoningEffort.HIGH,
+        budget_tokens=1024,
+    )
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content="Done", reasoning_content=None, tool_calls=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=1, prompt_tokens=1)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        lmstudio_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [
+            event
+            async for event in lmstudio_provider.stream_response(
+                req,
+                reasoning=policy,
+            )
+        ]
+
+    await_args = mock_create.await_args
+    assert await_args is not None
+    create_kwargs = await_args.kwargs
+    assert create_kwargs["extra_body"] == {"reasoning_tokens": 1024}
+    assert "reasoning_tokens" not in create_kwargs
+    assert any("message_stop" in event for event in events)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_mistral.py
+++ b/tests/providers/test_mistral.py
@@ -436,6 +436,45 @@ async def test_stream_response_preserves_mixed_native_content_array(
 
 
 @pytest.mark.asyncio
+async def test_stream_response_ignores_unknown_native_content_chunks(
+    mistral_provider,
+):
+    req = make_request()
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(
+                content=[
+                    {
+                        "type": "reference",
+                        "reference_ids": ["ref_1"],
+                    }
+                ],
+                reasoning_content=None,
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=1, prompt_tokens=1)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        mistral_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [event async for event in mistral_provider.stream_response(req)]
+
+    event_text = "\n".join(events)
+    assert "reference_ids" not in event_text
+    assert "message_stop" in event_text
+
+
+@pytest.mark.asyncio
 async def test_stream_response_suppresses_native_mistral_thinking_when_disabled(
     mistral_provider,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.5.0"
+version = "5.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The complete live smoke suite exposed provider-wire and smoke-contract regressions. LM Studio reasoning failed before reaching upstream, Mistral native content arrays could crash streaming, and stale smoke inputs obscured current compatibility.

## Changes

| Before | After |
| --- | --- |
| LM Studio sent custom reasoning fields as unsupported SDK keyword arguments. | LM Studio sends custom reasoning fields through the SDK's `extra_body` wire escape hatch. |
| Mistral native content arrays could reach the generic string parser. | Mistral normalizes every native content array and safely ignores unsupported metadata chunks. |
| OpenRouter smoke used a removed free model, launcher smokes could disagree with managed auth, and reasoning scenarios could exhaust their output budget before answering. | Smoke uses a current free model, FCC's effective auth token, and output budgets that leave room for visible answers. |
| The complete default live suite had 15 failures. | The complete default live suite passes 134 scenarios with 25 intentional skips. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change updates LM Studio reasoning request serialization, Mistral native-content normalization, live-smoke defaults, and client smoke authentication.

LM Studio serialization was exercised through a mocked OpenAI SDK request and correctly emitted `reasoning_tokens` at the outbound request top level. Mistral unknown-only content arrays completed without emitting malformed text or reasoning. The OpenRouter smoke configuration contract passed, and both Pi and OpenCode smoke flows propagated the configured proxy token instead of the previous hard-coded values.

The LM Studio, Mistral, OpenRouter configuration, and client-token failure hypotheses were disproved by those executions. One unrelated compatibility issue remains: on the project’s declared Python 3.14 runtime, importing the reasoning-policy module fails before the application or tests can start.
</details>


<h3>Confidence Score: 4/5</h3>

Do not merge until the Python 3.14 import-time failure in the reasoning-policy module is corrected.

The failure was directly reproduced on CPython 3.14.0 with an uploaded test-collection log. The changed provider serialization, Mistral normalization, smoke configuration, and configured-token paths were exercised successfully.

**Files Needing Attention:** src/free_claude_code/core/reasoning.py needs postponed or quoted self-referential annotations; the changed provider and smoke files were validated successfully.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- The token-validation harness was run and exited successfully, with artifacts showing that Pi and OpenCode token propagation did not use the hard-coded token.
- The client-token-validation script run further confirmed the above by showing redacted tokens for both Pi and OpenCode and contradicting the remaining defect hypothesis that a hard-coded token is used.

<a href="https://app.greptile.com/trex/runs/19071197/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `src/free_claude_code/core/reasoning.py`, line 66 ([link](https://github.com/alishahryar1/free-claude-code/blob/66332263709128f9de7746565be1103c3ba4966c/src/free_claude_code/core/reasoning.py#L66)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Self-referential annotations break module import**

   On Python 3.14, evaluating the `-> ReasoningPolicy` return annotation while `ReasoningPolicy` is still being defined raises `NameError`. Because this module is imported during application initialization, the proxy and test suite cannot start on the project’s declared supported runtime. Postpone annotation evaluation or quote the self-referential return annotations.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Provider-suite startup failure on Python 3.14](https://app.greptile.com/trex/artifacts/1c36678a-8269-48ee-9bc5-5617d93d807d)**

   - Ran the focused LM Studio and Mistral provider tests before correcting the unrelated Python 3.14 import blocker; the log shows the exact NameError that prevented test collection.

   <a href="https://app.greptile.com/trex/runs/19071197/artifacts?artifact=1c36678a-8269-48ee-9bc5-5617d93d807d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-live-smoke-regressions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-live-smoke-regressions%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffree_claude_code%2Fcore%2Freasoning.py%0ALine%3A%2066%0A%0AComment%3A%0A**Self-referential%20annotations%20break%20module%20import**%0A%0AOn%20Python%203.14%2C%20evaluating%20the%20%60-%3E%20ReasoningPolicy%60%20return%20annotation%20while%20%60ReasoningPolicy%60%20is%20still%20being%20defined%20raises%20%60NameError%60.%20Because%20this%20module%20is%20imported%20during%20application%20initialization%2C%20the%20proxy%20and%20test%20suite%20cannot%20start%20on%20the%20project%E2%80%99s%20declared%20supported%20runtime.%20Postpone%20annotation%20evaluation%20or%20quote%20the%20self-referential%20return%20annotations.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1442&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-live-smoke-regressions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-live-smoke-regressions%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231442%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=alishahryar1%2Ffree-claude-code&pr=1442&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-live-smoke-regressions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-live-smoke-regressions%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fcore%2Freasoning.py%3A66%0A**Self-referential%20annotations%20break%20module%20import**%0A%0AOn%20Python%203.14%2C%20evaluating%20the%20%60-%3E%20ReasoningPolicy%60%20return%20annotation%20while%20%60ReasoningPolicy%60%20is%20still%20being%20defined%20raises%20%60NameError%60.%20Because%20this%20module%20is%20imported%20during%20application%20initialization%2C%20the%20proxy%20and%20test%20suite%20cannot%20start%20on%20the%20project%E2%80%99s%20declared%20supported%20runtime.%20Postpone%20annotation%20evaluation%20or%20quote%20the%20self-referential%20return%20annotations.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1442&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix provider live smoke regressions"](https://github.com/alishahryar1/free-claude-code/commit/66332263709128f9de7746565be1103c3ba4966c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53698433)</sub>

<!-- /greptile_comment -->