### PR TITLE
Highlight 1.2B+ monthly free tokens in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@
 
 ## What You Get
 
-- **48 providers. One proxy.** Use free, paid, subscription, or local models from one searchable Admin UI.
+- **48 providers. 1.2B+ free tokens a month. One proxy.** Use free, paid, subscription, or local models from one searchable Admin UI.
 - **4 coding agents. One model catalog.** Run Claude Code, Codex, Pi, or OpenCode with your FCC models.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
 - **Terminal, desktop, IDE, or phone.** Work through native launchers, VS Code, Codex App, JetBrains, Discord, or Telegram.
 - **Voice notes in. Code out.** Talk to your agent using local Whisper or NVIDIA NIM transcription.
 - **Agent capabilities stay intact.** Stream responses, use tools, preserve native interleaved thinking for maximum performance, send images, and route Fable, Opus, Sonnet, and Haiku independently with compatible models.
+
+Free-tier availability and limits are controlled by each provider and may change.
 
 <div align="center">
   <img src="assets/pic.png" alt="Claude Code running with Free Claude Code" width="700">


### PR DESCRIPTION
## Problem

The README highlights FCC's provider breadth but hides the recurring free inference capacity available across those integrations.

## Changes

| Before | After |
| --- | --- |
| The opening said FCC supports 48 providers. | The opening highlights 1.2B+ free tokens a month across 48 providers. |
| Free-tier ownership was implicit. | A concise note clarifies that providers control availability and limits. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This README-only change adds a headline claim that users can access 1.2B+ free tokens per month across 48 providers and notes that provider limits may change. The claim cannot be independently checked from the repository because it has no source, provider list, eligibility assumptions, calculation, or retrieval date. Remove the aggregate or support it with a maintained, dated methodology before merging.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge until the prominent capacity claim is made verifiable or removed.

The documented aggregate was directly checked against the repository before and after the change, confirming that no tracked inputs or sources support the new statement.

**Files Needing Attention:** README.md needs an attributable source or calculation for the monthly free-token aggregate.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and shared a focused README capacity validation script.
- T-Rex captured a README capacity check before the PR change.
- T-Rex captured a README capacity check after the PR change.
- T-Rex generated a second finding-comment-proof for another P1 finding.
- T-Rex executed the general contract validation against HEAD^ and HEAD with the capacity-check script; both runs exited 0, and the after-run results reported claim\_line=24 and the status claim-has-no-repository-calculation-or-provider-limit-source.

<a href="https://app.greptile.com/trex/runs/19074967/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **README monthly free-token capacity claim has no verifiable basis**

   - **Bug**
     - README.md:24 states “48 providers. 1.2B+ free tokens a month.” The repository contains no source attribution, calculation, contributing-provider set, or provider monthly-limit data from which a reader can reproduce that number. Because availability and limits explicitly may change, the bare disclaimer at line 31 does not make the headline capacity claim verifiable or stable.
   - **Cause**
     - The README-only PR introduced a calculated aggregate capacity figure without adding its inputs, methodology, date, or upstream sources.
   - **Fix**
     - Remove the numeric capacity assertion, or link it to a maintained calculation that lists each included provider/model, free-tier monthly limit, eligibility assumptions, retrieval date, and upstream limit sources; qualify the claim as an estimate rather than guaranteed user capacity.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Freadme-free-token-headline%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Freadme-free-token-headline%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231443%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=alishahryar1%2Ffree-claude-code&pr=1443&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Freadme-free-token-headline%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Freadme-free-token-headline%22.%0A%0A%23%23%23%20Issue%201%0AREADME.md%3A24%0A**Unverifiable%20monthly%20token%20capacity%20claim**%0A%0AThe%20new%20%601.2B%2B%20free%20tokens%20a%20month%60%20headline%20has%20no%20linked%20source%2C%20provider%20list%2C%20eligibility%20assumptions%2C%20calculation%2C%20or%20retrieval%20date.%20Since%20the%20adjacent%20disclaimer%20says%20provider%20limits%20can%20change%2C%20readers%20cannot%20determine%20what%20the%20aggregate%20represents%20or%20verify%20that%20it%20remains%20accurate.%20Remove%20the%20precise%20aggregate%20or%20link%20it%20to%20a%20maintained%2C%20dated%20calculation%20with%20included%20providers%20and%20their%20upstream%20limits.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1443&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Highlight monthly free token capacity"](https://github.com/alishahryar1/free-claude-code/commit/e38ff3b11425da9283c1e0048857edaa09ed682b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53705222)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->