### PR TITLE
Lead with ToS-friendly provider access

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## What You Get
 
-- **48 ToS-friendly providers. 1.3B+ free tokens every month. Zero ban-risk shortcuts.** Use free, paid, subscription, and local models from one searchable UI—without shared accounts, scraped sessions, client impersonation, quota evasion, or access-control bypasses.
+- **48 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
 - **5 coding agents. One model catalog.** Run Claude Code, Codex, Pi, OpenCode, or Cline with your FCC models.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
 - **Terminal, desktop, IDE, or phone.** Work through native launchers, VS Code, Codex App, JetBrains, Discord, or Telegram.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## What You Get
 
-- **48 providers. 1.3B+ free tokens a month. One proxy.** Use free, paid, subscription, or local models from one searchable Admin UI.
+- **48 ToS-friendly providers. 1.3B+ free tokens every month. Zero ban-risk shortcuts.** Use free, paid, subscription, and local models from one searchable UI—without shared accounts, scraped sessions, client impersonation, quota evasion, or access-control bypasses.
 - **5 coding agents. One model catalog.** Run Claude Code, Codex, Pi, OpenCode, or Cline with your FCC models.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
 - **Terminal, desktop, IDE, or phone.** Work through native launchers, VS Code, Codex App, JetBrains, Discord, or Telegram.


### PR DESCRIPTION
## Problem

The README led with a proxy implementation detail, then described account safety with technical jargon. Users need the direct benefit: FCC follows provider terms so its integrations do not put their accounts at risk.

## Changes

| Before | After |
| --- | --- |
| The opening pitch ended with “One proxy.” | The opening pitch leads with 48 ToS-friendly providers. |
| Account safety was explained through technical mechanisms. | Account safety is explained plainly: FCC follows provider terms and removes integrations if they stop being allowed. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The README now presents provider access as account-safe and states that integrations will be removed when provider terms no longer allow them. The documented and implemented behavior does not support that promise: provider removal only follows an explicit configuration disconnect and prunes cached metadata. The wording should be qualified or backed by a documented provider-terms review and removal process.
</details>


<h3>Confidence Score: 4/5</h3>

Do not merge the current README claim until it accurately describes the safeguards and provider-term handling the project actually provides.

The changed wording was compared with the prior README, the relevant source and documentation were examined, and the provider-removal test confirmed the implemented behavior is limited to configuration-driven cache pruning.

**Files Needing Attention:** README.md line 24 needs revised, supportable wording.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-proof for a posted P1 finding and attached five artifacts illustrating the pre-PR README line, the README line claiming the PR, the policy-check source, its output, and the provider cache removal runtime test.
- T-Rex produced a second finding-proof for another posted P1 finding.
- T-Rex produced a general-contract-validation-proof that validates the provider-terms policy check and the removal-runtime behavior, with artifacts showing the before/after README lines, the policy-check script, its output, and the runtime test.

<a href="https://app.greptile.com/trex/runs/19145600/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **README promises provider-terms enforcement and account safety without a documented or implemented policy**

   - **Bug**
     - `README.md:24` says users can use providers "without putting your account at risk" and that FCC "follows provider terms and removes integrations if they stop being allowed." The focused executed scan found no ToS/compliance policy documentation or implementation beyond this new README line. The only removal path found is `ProviderRuntimeManager.connected_provider_changed(..., connected=False)` at `src/free_claude_code/runtime/provider_manager.py:197-208`, which calls `ProviderModelCache.remove_provider(provider_id)` only when a connected account is explicitly disconnected. `src/free_claude_code/providers/runtime/model_cache.py:44-48` merely evicts cached metadata for its supplied provider ID; it has no terms-status input, policy source, monitor, or automatic trigger. The focused runtime test validates config-driven cache pruning, not ToS enforcement.
   - **Cause**
     - The documentation converts a provider-selection/configuration behavior into an unqualified ongoing compliance, integration-removal, and account-risk guarantee, but the repository contains neither a policy/process documenting that promise nor code capable of detecting a provider-term change and triggering removal.
   - **Fix**
     - Replace the categorical statements with verifiable, scoped wording (for example, users must comply with each provider's terms and availability can change), or add and document an actual provider-terms review/removal policy and an implementation/process that can enact it before retaining the claim.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22agent%2Fadvertise-tos-friendly-access%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fadvertise-tos-friendly-access%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231450%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=alishahryar1%2Ffree-claude-code&pr=1450&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22agent%2Fadvertise-tos-friendly-access%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fadvertise-tos-friendly-access%22.%0A%0A%23%23%23%20Issue%201%0AREADME.md%3A24%0A**Provider-terms%20enforcement%20is%20not%20implemented**%0A%0AThis%20sentence%20promises%20that%20FCC%20will%20keep%20account%20use%20risk-free%2C%20follow%20provider%20terms%2C%20and%20remove%20integrations%20when%20those%20terms%20change.%20The%20implemented%20removal%20path%20only%20prunes%20a%20provider's%20cached%20metadata%20after%20a%20user%20explicitly%20disconnects%20that%20provider%3B%20it%20has%20no%20terms-status%20input%20or%20automatic%20trigger.%20There%20is%20also%20no%20documented%20compliance%2Fremoval%20policy.%20Replace%20these%20categorical%20guarantees%20with%20scoped%2C%20verifiable%20wording%20%28for%20example%2C%20that%20users%20must%20comply%20with%20provider%20terms%20and%20availability%20may%20change%29%2C%20or%20implement%20and%20document%20the%20promised%20review%2Fremoval%20process.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1450&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Explain the ToS-friendly benefit plainly"](https://github.com/alishahryar1/free-claude-code/commit/359365a0371c92e1422fe1b45d58a154e43dd40f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53854476)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->