### PR TITLE
Simplify customer-facing README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,11 @@ Cline:
 fcc-cline
 ```
 
-All five launchers use the current Admin UI settings. Use the agent's model
-picker to choose from the models FCC exposes.
+All five launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
+
+```bash
+fcc-codex exec "hello"
+```
 
 FCC launchers leave your existing agent settings, sessions, credentials, and
 extensions unchanged.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ Windows PowerShell:
 & ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install.ps1")))
 ```
 
-Re-run the same command whenever you want to update. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
-
-The installer asks which coding agents to install or verify. Choose at least one; skipped agents are left unchanged. It can also install and configure RTK globally for the selected agents; RTK is off by default.
+Re-run the same command to update. When prompted, choose at least one coding agent and optionally RTK. You can review the installers before running them: [install.sh](scripts/install.sh) and [install.ps1](scripts/install.ps1).
 
 ### 2. Start FCC
 
@@ -75,21 +73,9 @@ Run:
 fcc-server
 ```
 
-On Windows and macOS, FCC runs in the system tray or menu bar without opening a
-terminal. Use its menu to open Admin, check server status, restart, or quit. On
-Windows, left-clicking the tray icon opens Admin directly.
-
-To print the installed Free Claude Code version without starting the server,
-run `fcc-server --version`.
-
-When using `fcc-server`, keep the terminal open. The Admin UI opens in your
-browser after startup by default. Its address is also shown in the log:
-
-```text
-INFO:     Admin UI: http://127.0.0.1:8082/admin (local-only)
-```
-
-Use the port shown in your terminal if it differs from `8082`.
+FCC opens the Admin UI after starting. On Windows and macOS, use the tray or
+menu-bar icon to open Admin, restart, or quit. When using `fcc-server`, keep its
+terminal open.
 
 <a id="nvidia-nim-provider"></a>
 
@@ -101,9 +87,8 @@ Use the port shown in your terminal if it differs from `8082`.
 4. Leave `MODEL` on the default `nvidia_nim/nvidia/nemotron-3-super-120b-a12b`, or search the model dropdown and select another model.
 5. Click **Validate**, then **Apply**.
 
-FCC stores Admin settings in `~/.fcc/.env`. To require a bearer token on the
-proxy API, enable **Proxy Authentication** in Admin; disabling enforcement keeps
-the same token available to FCC launchers.
+To protect the local proxy with a bearer token, enable **Proxy Authentication**
+in Admin.
 
 <div align="center">
   <img src="assets/admin-page.png" alt="Free Claude Code Admin UI" width="700">
@@ -141,16 +126,11 @@ Cline:
 fcc-cline
 ```
 
-All five launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
+All five launchers use the current Admin UI settings. Use the agent's model
+picker to choose from the models FCC exposes.
 
-```bash
-fcc-codex exec "hello"
-```
-
-`fcc-pi`, `fcc-opencode`, and `fcc-cline` configure FCC only for the launched
-process; your existing agent settings, sessions, credentials, and extensions
-remain unchanged. `fcc-cline` supports attached terminal sessions; run Cline's
-hub, schedule, connector, Zen, and sandbox-data workflows with ordinary `cline`.
+FCC launchers leave your existing agent settings, sessions, credentials, and
+extensions unchanged.
 
 <a id="model-picker"></a>
 
@@ -528,6 +508,8 @@ Restart `fcc-server`. In **Admin UI → Messaging → Voice**, enable voice note
 </details>
 
 ## Manage Your Installation
+
+Run `fcc-server --version` to check the installed version without starting FCC.
 
 ### Update
 


### PR DESCRIPTION
## Problem

Quick Start mixed required actions with implementation details, log examples, port troubleshooting, and launcher internals. The extra prose made installation and startup harder to scan.

## Changes

| Before | After |
| --- | --- |
| Installation behavior was explained across two detailed paragraphs. | Installation and update choices are summarized in one short paragraph. |
| Startup guidance included tray interactions, version lookup, exact logs, and port troubleshooting. | Startup guidance keeps one operational note and moves version lookup to Manage. |
| Configuration and launcher guidance exposed storage, token, process, and Cline workflow internals. | Configuration and launcher guidance states only the customer-facing security and state-preservation behavior. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This README update simplifies installation, startup, authentication, launcher, and version-management guidance. The revised startup and launcher guidance was exercised successfully: FCC served and opened Admin, and all five launchers completed without changing pre-existing native agent state.
</details>

<h3>Confidence Score: 5/5</h3>

The documentation changes are safe to merge based on successful runtime verification of the affected user flows.

An isolated live run confirmed that FCC serves and opens Admin after startup, and that the documented launcher behavior preserves existing native agent state. Focused CLI coverage also passed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- An isolated-HOME harness started fcc-server, requested /health and /admin, and captured the browser opening to the Admin URL.
- The server responded with HTTP 200 for health and Admin, served the Admin HTML, and opened the browser at the Admin URL.
- The live-server validation invoked fcc-claude, fcc-codex exec hello, fcc-pi, fcc-opencode, and fcc-cline against the live server with fake client binaries, and all launchers exited successfully with a native-state digest of NATIVE\_STATE\_UNCHANGED True.
- The focused CLI entrypoint test suite ran and reported 43 passing tests.
- The additional checks in the second proof corroborate the health and admin endpoint outcomes and launcher exit statuses described above, and note the README section examined as part of validation.

<a href="https://app.greptile.com/trex/runs/19152173/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Keep command examples in the README clea..."](https://github.com/alishahryar1/free-claude-code/commit/d5049cfc092597642c1b1debda281af38582d16a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53866868)</sub>

<!-- /greptile_comment -->