### PR TITLE
Make provider setup discoverable in the Admin UI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # Branch protection: require every status check this workflow reports, for example:
 #   Ban suppressions and legacy annotations
-#   ruff-format, ruff-check, ty, pytest
+#   ruff-format, ruff-check, ty, pytest, playwright
 # GitHub may prefix with the workflow name (e.g. "CI / ruff-format"); use the names the branch protection UI offers after a run.
 
 name: CI
@@ -56,6 +56,11 @@ jobs:
             run: uv run ty check
           - id: pytest
             run: uv run pytest -v --tb=short
+          - id: playwright
+            run: >-
+              uv run pytest e2e -n 0 -v --tb=short
+              --tracing=retain-on-failure --screenshot=only-on-failure
+              --full-page-screenshot --output=test-results
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -71,5 +76,18 @@ jobs:
           cache-python: true
           save-cache: ${{ matrix.id == 'ruff-format' }}
 
+      - name: Install Chromium
+        if: matrix.id == 'playwright'
+        run: uv run playwright install --with-deps chromium
+
       - name: Run
         run: ${{ matrix.run }}
+
+      - name: Upload Playwright failure artifacts
+        if: failure() && matrix.id == 'playwright'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: playwright-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ debug-*.log
 .coverage
 llama_cache
 .smoke-results
+/test-results/
 .vscode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,11 @@
 - Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
-- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
+- All 6 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest, playwright).
+- Deterministic rendered Admin UI interactions live under `e2e/` and run separately from ordinary pytest. Install Chromium once with `uv run playwright install chromium`; API and unit contracts remain under `tests/`.
 - GitHub CI runs for every pull request, including stacked PRs targeting non-`main` branches. Head updates trigger fresh checks; strict required checks keep PRs targeting `main` current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
 - Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests and strict required checks, keeps branches current, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
-- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
+- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**, **playwright**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 
 ## IDENTITY & CONTEXT
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -381,6 +381,16 @@ secrets. Preview and Apply validate the same prospective Settings snapshot, and
 Apply atomically writes only configured values plus preserved unknown managed
 assignments. Process-owned fields are visible but locked.
 
+[config/admin/status.py](src/free_claude_code/config/admin/status.py) owns
+provider configuration readiness and exposes ordered Admin field keys for each
+catalog descriptor. The browser uses those keys to navigate directly from a
+provider card to its first missing field; it never parses presentation text.
+Explicit remote model-list checks and local reachability probes are separate,
+ephemeral results. They render in their own live region and never overwrite the
+stable `Configured`/`Missing` badge or configuration description. Runtime and
+API owners return bounded credential-redacted messages for failed checks rather
+than Python exception class names.
+
 The provider composition root narrows optional Settings into provider-ready
 state. Static-key providers receive a non-empty key, Vertex receives renewable
 ADC with `api_key=None`, and optional proxies remain `None` until configured.
@@ -1637,6 +1647,15 @@ provider access from helper modules. These tests protect current architectural
 properties rather than preserving deleted modules or an exact internal file
 layout.
 
+Rendered Admin workflows live separately under [e2e/](e2e/). They use the
+official Python Playwright pytest plugin with headless Chromium, a temporary FCC
+home, fake providers, deterministic local probes, and a real loopback FastAPI
+server on an OS-assigned port. The suite proves scrolling, focus, responsive
+layout, configuration-versus-check state separation, model-option updates, and
+credential redaction without reading developer configuration or contacting an
+upstream service. Browser traces and full-page screenshots are retained only on
+failure.
+
 Live and local product tests live under [smoke/](smoke/). See
 [smoke/README.md](smoke/README.md) for target taxonomy, environment variables,
 failure classes, and examples. Smoke tests can launch subprocesses, call real
@@ -1645,11 +1664,12 @@ providers, touch local model servers, and optionally send bot messages.
 CI is defined in [.github/workflows/tests.yml](.github/workflows/tests.yml). It
 enforces:
 
-- `Ban type ignore suppressions`;
+- `Ban suppressions and legacy annotations`;
 - `ruff-format`;
 - `ruff-check`;
 - `ty`;
-- `pytest`.
+- `pytest`;
+- `playwright`.
 
 Contributor verification commands:
 
@@ -1658,6 +1678,8 @@ uv run ruff format
 uv run ruff check
 uv run ty check
 uv run pytest
+uv run playwright install chromium
+uv run pytest e2e -n 0
 ```
 
 For docs-only architecture changes, a source-link and accuracy review is usually

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -388,8 +388,8 @@ provider card to its first missing field; it never parses presentation text.
 Explicit remote model-list checks and local reachability probes are separate,
 ephemeral results. They render in their own live region and never overwrite the
 stable `Configured`/`Missing` badge or configuration description. Runtime and
-API owners return bounded credential-redacted messages for failed checks rather
-than Python exception class names.
+API owners return stable guidance for failed checks and keep all exception text
+out of the browser response; server logs record only safe failure metadata.
 
 The provider composition root narrows optional Settings into provider-ready
 state. Static-key providers receive a non-empty key, Vertex receives renewable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@
 - Fall back to individual repair commands when debugging local failures: `uv run ruff format`, `uv run ruff check --fix`, `uv run ty check`, `uv run pytest -v --tb=short`. Use GitHub-style checks only when verifying enforcement locally: `uv run ruff format --check`, `uv run ruff check`.
 - Do not add `# type: ignore` or `# ty: ignore`; fix the underlying type issue.
 - Do not add `from __future__ import annotations`; Python 3.14 native lazy annotations are the project standard.
-- All 5 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest).
+- All 6 check IDs are represented in `scripts/ci.sh` / `scripts/ci.ps1` and enforced by `tests.yml` before each merge (parallel jobs: suppression grep, ruff-format, ruff-check, ty, pytest, playwright).
+- Deterministic rendered Admin UI interactions live under `e2e/` and run separately from ordinary pytest. Install Chromium once with `uv run playwright install chromium`; API and unit contracts remain under `tests/`.
 - GitHub CI runs for every pull request, including stacked PRs targeting non-`main` branches. Head updates trigger fresh checks; strict required checks keep PRs targeting `main` current with `main`, so the tested PR tree is the tree squash-merged without a duplicate post-merge run.
 - Repository protection should use rulesets: a non-bypassable main integrity ruleset requires pull requests and strict required checks, keeps branches current, and blocks direct/force pushes to `main`; a separate review ruleset may allow `Alishahryar1`/admins to bypass review only.
-- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
+- Required status checks: set **required status checks** to **all** of those statuses (e.g. **Ban suppressions and legacy annotations**, **ruff-format**, **ruff-check**, **ty**, **pytest**, **playwright**—use the exact labels GitHub shows, which may be prefixed with **CI /**). Remove **ci** from required checks if it was previously added for the old gate job.
 
 ## IDENTITY & CONTEXT
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -129,7 +129,7 @@ def admin_base_url(
     monkeypatch.setattr(env_migrations, "verified_checkout_env_path", lambda: None)
     clear_settings_cache()
 
-    provider_secret = "sk-browser-provider-secret"
+    provider_secret = "CREDENTIAL[unrecognized-format-987654321]"
     providers: dict[str, BaseProvider] = {
         "open_router": _ModelListingProvider(
             frozenset(
@@ -140,9 +140,7 @@ def admin_base_url(
             )
         ),
         "groq": _ModelListingProvider(
-            error=RuntimeError(
-                f"Authorization: Bearer {provider_secret} could not connect"
-            )
+            error=RuntimeError(f"Provider rejected credential {provider_secret}")
         ),
     }
     manager = ProviderRuntimeManager(

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,215 @@
+"""Isolated browser-test composition for the local Admin UI."""
+
+import asyncio
+import socket
+import threading
+import time
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+
+import pytest
+import uvicorn
+
+from free_claude_code.api.app import create_app
+from free_claude_code.api.ports import ApiServices
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config import env_migrations, paths
+from free_claude_code.config.env_migrations import recognized_env_keys
+from free_claude_code.config.loader import clear_settings_cache, get_settings
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
+from free_claude_code.providers.base import BaseProvider, ProviderConfig
+from free_claude_code.providers.runtime import ProviderRuntime
+from free_claude_code.runtime.application import ApplicationRuntime
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+class _ModelListingProvider(BaseProvider):
+    def __init__(
+        self,
+        model_infos: frozenset[ProviderModelInfo] = frozenset(),
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__(
+            ProviderConfig(
+                api_key="browser-test",
+                base_url="https://provider.invalid/v1",
+                rate_limit=1_000,
+                rate_window=1,
+                max_concurrency=100,
+                http_read_timeout=1.0,
+                http_write_timeout=1.0,
+                http_connect_timeout=1.0,
+                proxy=None,
+                log_raw_sse_events=False,
+                log_api_error_tracebacks=False,
+            )
+        )
+        self._model_infos = model_infos
+        self._error = error
+
+    def preflight_stream(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> None:
+        return None
+
+    async def cleanup(self) -> None:
+        return None
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        if self._error is not None:
+            raise self._error
+        return self._model_infos
+
+    async def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> AsyncIterator[str]:
+        if False:
+            yield ""
+
+
+def _close_manager(manager: ProviderRuntimeManager) -> None:
+    """Close async runtime ownership outside Playwright's active sync loop."""
+
+    errors: list[BaseException] = []
+
+    def close() -> None:
+        try:
+            asyncio.run(manager.close())
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(
+        target=close,
+        name="fcc-admin-playwright-cleanup",
+        daemon=True,
+    )
+    thread.start()
+    thread.join(timeout=5.0)
+    if thread.is_alive():
+        pytest.fail("Admin browser-test runtime did not close")
+    if errors:
+        raise errors[0]
+
+
+@pytest.fixture
+def admin_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[str]:
+    """Serve one fully isolated Admin application on an OS-assigned port."""
+
+    config_dir = tmp_path / ".fcc"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    for key in recognized_env_keys():
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("FCC_ENV_FILE", raising=False)
+    monkeypatch.setenv("MODEL", "open_router/e2e-default")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "e2e-openrouter-key")
+    monkeypatch.setenv("GROQ_API_KEY", "e2e-groq-key")
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "e2e-cloudflare-token")
+    monkeypatch.setenv("MESSAGING_PLATFORM", "none")
+    monkeypatch.setenv("VOICE_NOTE_ENABLED", "false")
+    monkeypatch.setenv("FCC_OPEN_BROWSER", "false")
+    monkeypatch.setenv("PROXY_AUTH_ENABLED", "false")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "e2e-proxy-token")
+    monkeypatch.setattr(paths, "config_dir_path", lambda: config_dir)
+    monkeypatch.setattr(env_migrations, "legacy_env_paths", lambda: ())
+    monkeypatch.setattr(env_migrations, "verified_checkout_env_path", lambda: None)
+    clear_settings_cache()
+
+    provider_secret = "sk-browser-provider-secret"
+    providers: dict[str, BaseProvider] = {
+        "open_router": _ModelListingProvider(
+            frozenset(
+                {
+                    ProviderModelInfo("vendor/model-a"),
+                    ProviderModelInfo("vendor/model-b"),
+                }
+            )
+        ),
+        "groq": _ModelListingProvider(
+            error=RuntimeError(
+                f"Authorization: Bearer {provider_secret} could not connect"
+            )
+        ),
+    }
+    manager = ProviderRuntimeManager(
+        get_settings(),
+        runtime_factory=lambda snapshot: ProviderRuntime(snapshot, dict(providers)),
+    )
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    app = create_app(
+        ApiServices(
+            requests=manager,
+            admin=runtime,
+            tasks=runtime,
+        )
+    )
+
+    async def local_provider_result(
+        provider_id: str,
+        base_url: str,
+        path: str,
+    ) -> dict[str, object]:
+        return {
+            "provider_id": provider_id,
+            "status": "reachable",
+            "label": "Reachable",
+            "base_url": base_url,
+        }
+
+    monkeypatch.setattr(
+        "free_claude_code.api.admin_routes._check_local_provider",
+        local_provider_result,
+    )
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(128)
+    port = listener.getsockname()[1]
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            log_level="error",
+            access_log=False,
+            lifespan="off",
+        )
+    )
+    thread = threading.Thread(
+        target=server.run,
+        kwargs={"sockets": [listener]},
+        name="fcc-admin-playwright",
+        daemon=True,
+    )
+    thread.start()
+
+    deadline = time.monotonic() + 5.0
+    try:
+        while not server.started:
+            if not thread.is_alive():
+                raise RuntimeError("Admin browser-test server exited during startup")
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Admin browser-test server did not start")
+            time.sleep(0.01)
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+        listener.close()
+        _close_manager(manager)
+        clear_settings_cache()
+        if thread.is_alive():
+            pytest.fail("Admin browser-test server did not stop")

--- a/e2e/test_admin_providers.py
+++ b/e2e/test_admin_providers.py
@@ -1,0 +1,127 @@
+"""Rendered provider-setup regressions for the local Admin UI."""
+
+import pytest
+from playwright.sync_api import ConsoleMessage, Page, ViewportSize, expect
+
+
+def _open_admin(
+    page: Page,
+    admin_base_url: str,
+    viewport: ViewportSize,
+) -> None:
+    page.set_viewport_size(viewport)
+    page.emulate_media(reduced_motion="reduce")
+    page.goto(f"{admin_base_url}/admin")
+    expect(page.locator("#messageArea")).to_have_text("")
+
+
+@pytest.mark.parametrize(
+    ("viewport", "desktop"),
+    (
+        ({"width": 1280, "height": 720}, True),
+        ({"width": 390, "height": 844}, False),
+    ),
+)
+def test_missing_provider_configuration_scrolls_to_exact_field(
+    page: Page,
+    admin_base_url: str,
+    viewport: ViewportSize,
+    desktop: bool,
+) -> None:
+    _open_admin(page, admin_base_url, viewport)
+    card = page.locator('[data-provider="nvidia_nim"]')
+    key_input = page.locator("#field-NVIDIA_NIM_API_KEY")
+
+    expect(card.locator(".status-pill")).to_have_text("Missing key")
+    expect(card.locator(".provider-meta")).to_have_text("NVIDIA_NIM_API_KEY")
+    expect(card.get_by_role("button", name="Configure", exact=True)).to_be_visible()
+    expect(card.get_by_role("button", name="Refresh models", exact=True)).to_have_count(
+        0
+    )
+    expect(key_input).not_to_be_in_viewport()
+
+    card.get_by_role("button", name="Configure", exact=True).click()
+
+    expect(key_input).to_be_in_viewport()
+    expect(key_input).to_be_focused()
+    if desktop:
+        sidebar = page.locator(".sidebar")
+        expect(sidebar).to_have_css("position", "sticky")
+        assert (
+            round(
+                float(
+                    sidebar.evaluate("element => element.getBoundingClientRect().top")
+                )
+            )
+            == 0
+        )
+
+
+def test_configured_provider_check_keeps_readiness_and_adds_models(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _open_admin(page, admin_base_url, {"width": 1280, "height": 720})
+    card = page.locator('[data-provider="open_router"]')
+    badge = card.locator(".status-pill")
+    meta = card.locator(".provider-meta")
+
+    expect(badge).to_have_text("Configured")
+    expect(meta).to_have_text("OPENROUTER_API_KEY")
+    expect(card.get_by_role("button", name="Edit", exact=True)).to_be_visible()
+    card.get_by_role("button", name="Refresh models", exact=True).click()
+
+    expect(card.locator(".provider-check-result")).to_have_text("2 models available")
+    expect(badge).to_have_text("Configured")
+    expect(meta).to_have_text("OPENROUTER_API_KEY")
+
+    page.get_by_role("button", name="Model Config", exact=True).click()
+    page.get_by_role("button", name="Show Fable Override options", exact=True).click()
+    expect(
+        page.get_by_role("option", name="open_router/vendor/model-a", exact=True)
+    ).to_be_visible()
+
+
+def test_provider_check_failure_is_separate_detailed_and_redacted(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    console_messages: list[str] = []
+
+    def record_console(message: ConsoleMessage) -> None:
+        console_messages.append(message.text)
+
+    page.on("console", record_console)
+    _open_admin(page, admin_base_url, {"width": 1280, "height": 720})
+    card = page.locator('[data-provider="groq"]')
+    card.get_by_role("button", name="Refresh models", exact=True).click()
+
+    result = card.locator(".provider-check-result")
+    expect(result).to_contain_text("Unavailable:")
+    expect(result).to_contain_text("<redacted>")
+    expect(card.locator(".status-pill")).to_have_text("Configured")
+    expect(card.locator(".provider-meta")).to_have_text("GROQ_API_KEY")
+    page_text = page.locator("body").inner_text()
+    assert "sk-browser-provider-secret" not in page_text
+    assert "RuntimeError" not in page_text
+    assert "sk-browser-provider-secret" not in "\n".join(console_messages)
+
+
+def test_multi_field_provider_targets_first_missing_configuration(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _open_admin(page, admin_base_url, {"width": 1280, "height": 720})
+    card = page.locator('[data-provider="cloudflare"]')
+    account_input = page.locator("#field-CLOUDFLARE_ACCOUNT_ID")
+
+    expect(card.locator(".status-pill")).to_have_text("Missing configuration")
+    expect(card.locator(".provider-meta")).to_have_text(
+        "CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID"
+    )
+    expect(account_input).not_to_be_in_viewport()
+
+    card.get_by_role("button", name="Configure", exact=True).click()
+
+    expect(account_input).to_be_in_viewport()
+    expect(account_input).to_be_focused()

--- a/e2e/test_admin_providers.py
+++ b/e2e/test_admin_providers.py
@@ -82,7 +82,7 @@ def test_configured_provider_check_keeps_readiness_and_adds_models(
     ).to_be_visible()
 
 
-def test_provider_check_failure_is_separate_detailed_and_redacted(
+def test_provider_check_failure_is_separate_and_never_exposes_exception_text(
     page: Page,
     admin_base_url: str,
 ) -> None:
@@ -97,14 +97,17 @@ def test_provider_check_failure_is_separate_detailed_and_redacted(
     card.get_by_role("button", name="Refresh models", exact=True).click()
 
     result = card.locator(".provider-check-result")
-    expect(result).to_contain_text("Unavailable:")
-    expect(result).to_contain_text("<redacted>")
+    expect(result).to_have_text(
+        "Unavailable: Could not refresh this provider's models. "
+        "Verify its configuration and access."
+    )
     expect(card.locator(".status-pill")).to_have_text("Configured")
     expect(card.locator(".provider-meta")).to_have_text("GROQ_API_KEY")
     page_text = page.locator("body").inner_text()
-    assert "sk-browser-provider-secret" not in page_text
+    secret = "CREDENTIAL[unrecognized-format-987654321]"
+    assert secret not in page_text
     assert "RuntimeError" not in page_text
-    assert "sk-browser-provider-secret" not in "\n".join(console_messages)
+    assert secret not in "\n".join(console_messages)
 
 
 def test_multi_field_provider_targets_first_missing_configuration(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.6.0"
+version = "5.6.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -74,6 +74,7 @@ dev = [
     "ty>=0.0.70",
     "ruff>=0.16.2",
     "pytest-xdist>=3.8.0",
+    "pytest-playwright>=0.9.0",
 ]
 
 [tool.ruff]

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -15,7 +15,8 @@ $CheckOrder = @(
     "ruff-format",
     "ruff-check",
     "ty",
-    "pytest"
+    "pytest",
+    "playwright"
 )
 
 function Show-Usage {
@@ -23,7 +24,7 @@ function Show-Usage {
 Usage: ci.ps1 [options]
 
 Runs the local sequence for the same check IDs enforced by GitHub CI.
-Requires uv on PATH when running ruff, ty, or pytest checks.
+Requires uv on PATH when running ruff, ty, pytest, or Playwright checks.
 Local ruff checks repair formatting and autofixable lint before later checks.
 
 Checks (in order):
@@ -32,6 +33,7 @@ Checks (in order):
   ruff-check     uv run ruff check --fix
   ty             uv run ty check
   pytest         uv run pytest -v --tb=short
+  playwright     Install Chromium and run deterministic Admin browser tests
 
 Options:
   -Only ID              Run only the given check (repeatable)
@@ -165,6 +167,16 @@ function Invoke-PytestCheck {
     Invoke-CiCommand -FilePath "uv" -Arguments @("run", "pytest", "-v", "--tb=short")
 }
 
+function Invoke-PlaywrightCheck {
+    Write-Step "playwright"
+    Invoke-CiCommand -FilePath "uv" -Arguments @("run", "playwright", "install", "chromium")
+    Invoke-CiCommand -FilePath "uv" -Arguments @(
+        "run", "pytest", "e2e", "-n", "0", "-v", "--tb=short",
+        "--tracing=retain-on-failure", "--screenshot=only-on-failure",
+        "--full-page-screenshot", "--output=test-results"
+    )
+}
+
 function Invoke-Check {
     param([string] $CheckId)
 
@@ -174,6 +186,7 @@ function Invoke-Check {
         "ruff-check" { Invoke-RuffLintCheck }
         "ty" { Invoke-TyCheck }
         "pytest" { Invoke-PytestCheck }
+        "playwright" { Invoke-PlaywrightCheck }
         default { throw "unknown check id: $CheckId" }
     }
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-CHECK_ORDER="suppressions ruff-format ruff-check ty pytest"
+CHECK_ORDER="suppressions ruff-format ruff-check ty pytest playwright"
 
 dry_run=0
 only_checks=""
@@ -12,7 +12,7 @@ show_usage() {
 Usage: ci.sh [options]
 
 Runs the local sequence for the same check IDs enforced by GitHub CI.
-Requires uv on PATH when running ruff, ty, or pytest checks.
+Requires uv on PATH when running ruff, ty, pytest, or Playwright checks.
 Local ruff checks repair formatting and autofixable lint before later checks.
 
 Checks (in order):
@@ -21,6 +21,7 @@ Checks (in order):
   ruff-check     uv run ruff check --fix
   ty             uv run ty check
   pytest         uv run pytest -v --tb=short
+  playwright     Install Chromium and run deterministic Admin browser tests
 
 Options:
   --only ID                Run only the given check (repeatable)
@@ -69,7 +70,7 @@ run() {
 
 valid_check_id() {
     case "$1" in
-        suppressions | ruff-format | ruff-check | ty | pytest) return 0 ;;
+        suppressions | ruff-format | ruff-check | ty | pytest | playwright) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -156,6 +157,14 @@ run_pytest() {
     run uv run pytest -v --tb=short
 }
 
+run_playwright() {
+    step "playwright"
+    run uv run playwright install chromium
+    run uv run pytest e2e -n 0 -v --tb=short \
+        --tracing=retain-on-failure --screenshot=only-on-failure \
+        --full-page-screenshot --output=test-results
+}
+
 run_check() {
     case "$1" in
         suppressions) run_suppressions ;;
@@ -163,6 +172,7 @@ run_check() {
         ruff-check) run_ruff_check ;;
         ty) run_ty ;;
         pytest) run_pytest ;;
+        playwright) run_playwright ;;
         *) fail "unknown check id: $1" ;;
     esac
 }

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -22,6 +22,7 @@ from free_claude_code.config.provider_catalog import (
     PROVIDER_CATALOG,
     ProviderAuthKind,
 )
+from free_claude_code.core.diagnostics import format_user_error_preview
 from free_claude_code.core.json_types import JsonObject, JsonValue
 
 from .dependencies import get_services
@@ -299,7 +300,7 @@ async def _check_local_provider(
             "status": "offline",
             "label": "Offline",
             "base_url": base_url,
-            "error_type": type(exc).__name__,
+            "message": format_user_error_preview(exc),
         }
 
 

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -8,6 +8,7 @@ from urllib.parse import urlsplit
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
+from loguru import logger
 from pydantic import BaseModel, Field
 
 from free_claude_code.application.connected_accounts import (
@@ -22,7 +23,6 @@ from free_claude_code.config.provider_catalog import (
     PROVIDER_CATALOG,
     ProviderAuthKind,
 )
-from free_claude_code.core.diagnostics import format_user_error_preview
 from free_claude_code.core.json_types import JsonObject, JsonValue
 
 from .dependencies import get_services
@@ -36,6 +36,9 @@ LOCAL_PROVIDER_PATHS = {
     "llamacpp": "/models",
     "ollama": "/api/tags",
 }
+_LOCAL_PROVIDER_CHECK_FAILURE_MESSAGE = (
+    "Could not connect. Verify the URL and that the local provider is running."
+)
 
 
 class AdminConfigPayload(BaseModel):
@@ -295,12 +298,17 @@ async def _check_local_provider(
             "status_code": response.status_code,
         }
     except Exception as exc:
+        logger.debug(
+            "Admin local provider check failed: provider={} exc_type={}",
+            provider_id,
+            type(exc).__name__,
+        )
         return {
             "provider_id": provider_id,
             "status": "offline",
             "label": "Offline",
             "base_url": base_url,
-            "message": format_user_error_preview(exc),
+            "message": _LOCAL_PROVIDER_CHECK_FAILURE_MESSAGE,
         }
 
 

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -337,6 +337,25 @@ textarea:focus-visible,
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
+.provider-check-result {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.provider-check-result.ok {
+  color: var(--ok);
+}
+
+.provider-check-result.error {
+  color: var(--error);
+}
+
+.provider-check-result.checking {
+  color: var(--info);
+}
+
 .provider-actions {
   display: flex;
   flex-wrap: wrap;

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1,7 +1,6 @@
 const state = {
   config: null,
   fields: new Map(),
-  localStatus: new Map(),
   modelOptions: [],
   modelComboboxes: new Set(),
   authPollers: new Map(),
@@ -167,29 +166,84 @@ function renderProviders(providerStatus) {
 
     const title = document.createElement("div");
     title.className = "provider-title";
-    title.innerHTML = `<strong>${provider.display_name || provider.provider_id}</strong>`;
+    const name = document.createElement("strong");
+    name.textContent = provider.display_name || provider.provider_id;
 
     const pill = document.createElement("span");
     pill.className = `status-pill ${statusClass(provider.status)}`;
     pill.textContent = provider.label;
-    title.appendChild(pill);
+    title.append(name, pill);
 
     const meta = document.createElement("div");
     meta.className = "provider-meta";
-    meta.textContent =
-      provider.kind === "local"
-        ? provider.base_url || "No local URL configured"
-        : provider.configuration;
+    const configurationKeys = Array.isArray(provider.configuration_keys)
+      ? provider.configuration_keys
+      : [];
+    const missingConfigurationKeys = Array.isArray(
+      provider.missing_configuration_keys,
+    )
+      ? provider.missing_configuration_keys
+      : [];
+    meta.textContent = configurationKeys.join(" + ");
 
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "test-button";
-    button.textContent = provider.kind === "local" ? "Test" : "Refresh models";
-    button.addEventListener("click", () => testProvider(provider.provider_id, button));
+    const result = document.createElement("div");
+    result.className = "provider-check-result";
+    result.dataset.providerCheckResult = provider.provider_id;
+    result.setAttribute("aria-live", "polite");
+    result.hidden = true;
 
-    card.append(title, meta, button);
+    const actions = document.createElement("div");
+    actions.className = "provider-actions";
+    if (configurationKeys.length) {
+      const configuring = missingConfigurationKeys.length > 0;
+      actions.appendChild(
+        providerActionButton(configuring ? "Configure" : "Edit", () =>
+          navigateToProviderConfiguration(provider, configuring),
+        ),
+      );
+    }
+
+    if (missingConfigurationKeys.length === 0) {
+      const button = providerActionButton(
+        provider.kind === "local" ? "Test" : "Refresh models",
+        () => testProvider(provider.provider_id, button),
+        "secondary-button",
+      );
+      actions.appendChild(button);
+    }
+
+    card.append(title, meta, result, actions);
     grid.appendChild(card);
   });
+}
+
+function providerActionButton(label, action, className = "test-button") {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = className;
+  button.textContent = label;
+  button.addEventListener("click", action);
+  return button;
+}
+
+function navigateToProviderConfiguration(provider, configuring) {
+  const keys = configuring
+    ? provider.missing_configuration_keys
+    : provider.configuration_keys;
+  const fieldKey = Array.isArray(keys) ? keys[0] : null;
+  const input = fieldKey ? byId(`field-${fieldKey}`) : null;
+  if (!input) {
+    showMessage("Provider configuration field is unavailable.", "error");
+    return;
+  }
+  const reducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)",
+  ).matches;
+  input.scrollIntoView({
+    behavior: reducedMotion ? "instant" : "smooth",
+    block: "center",
+  });
+  input.focus({ preventScroll: true });
 }
 
 function renderConnectedAccountCard(provider, status = provider) {
@@ -416,15 +470,13 @@ async function copyDeviceCode(code) {
   }
 }
 
-function updateProviderCard(providerId, status, label, metaText) {
+function updateProviderCheckResult(providerId, status, message) {
   const card = document.querySelector(`[data-provider="${providerId}"]`);
   if (!card) return;
-  const pill = card.querySelector(".status-pill");
-  pill.className = `status-pill ${statusClass(status)}`;
-  pill.textContent = label;
-  if (metaText) {
-    card.querySelector(".provider-meta").textContent = metaText;
-  }
+  const result = card.querySelector(".provider-check-result");
+  result.className = `provider-check-result ${status}`;
+  result.textContent = message;
+  result.hidden = !message;
 }
 
 function renderSections(sections, fields) {
@@ -883,37 +935,61 @@ async function apply() {
 async function refreshLocalStatus() {
   const result = await api("/admin/api/providers/local-status");
   result.providers.forEach((provider) => {
-    state.localStatus.set(provider.provider_id, provider);
-    const meta = provider.status_code
-      ? `${provider.base_url} returned HTTP ${provider.status_code}`
-      : provider.base_url;
-    updateProviderCard(provider.provider_id, provider.status, provider.label, meta);
+    if (provider.status === "missing_url") return;
+    if (provider.status === "reachable") {
+      updateProviderCheckResult(
+        provider.provider_id,
+        "ok",
+        `Reachable: ${provider.base_url}`,
+      );
+      return;
+    }
+    const detail = provider.message
+      ? provider.message
+      : provider.status_code
+        ? `${provider.base_url} returned HTTP ${provider.status_code}`
+        : "The local provider did not respond.";
+    updateProviderCheckResult(
+      provider.provider_id,
+      "error",
+      `Unavailable: ${detail}`,
+    );
   });
 }
 
 async function testProvider(providerId, button) {
   const original = button.textContent;
   button.disabled = true;
-  button.textContent = "Testing";
+  button.textContent = "Checking...";
+  updateProviderCheckResult(providerId, "checking", "Checking...");
   try {
     const result = await api(`/admin/api/providers/${providerId}/test`, {
       method: "POST",
       body: "{}",
     });
     if (result.ok) {
-      updateProviderCard(
+      updateProviderCheckResult(
         providerId,
-        "reachable",
-        `${result.models.length} models`,
-        result.models.slice(0, 3).join(", ") || "No models returned",
+        "ok",
+        `${result.models.length} models available`,
       );
       setModelOptions([
         ...state.modelOptions,
         ...result.models.map((model) => `${providerId}/${model}`),
       ]);
     } else {
-      updateProviderCard(providerId, "offline", result.error_type, result.error_type);
+      updateProviderCheckResult(
+        providerId,
+        "error",
+        `Unavailable: ${result.message || "Provider check failed."}`,
+      );
     }
+  } catch {
+    updateProviderCheckResult(
+      providerId,
+      "error",
+      "Provider check could not be completed.",
+    );
   } finally {
     button.disabled = false;
     button.textContent = original;

--- a/src/free_claude_code/config/admin/status.py
+++ b/src/free_claude_code/config/admin/status.py
@@ -29,6 +29,20 @@ def provider_config_status(
                 }
             )
             continue
+
+        configuration_attrs = descriptor.configuration_attrs()
+        configuration_keys = [
+            _field_key_for_settings_attr(attr) for attr in configuration_attrs
+        ]
+        missing_attrs = tuple(
+            attr
+            for attr in configuration_attrs
+            if not _value_for_settings_attr(state, attr)
+        )
+        missing_configuration_keys = [
+            _field_key_for_settings_attr(attr) for attr in missing_attrs
+        ]
+
         if descriptor.local:
             base_url: str | None = None
             if descriptor.base_url_attr is not None:
@@ -38,23 +52,16 @@ def provider_config_status(
                     "provider_id": provider_id,
                     "display_name": descriptor.display_name,
                     "kind": "local",
-                    "status": "missing_url" if not base_url else "unknown",
-                    "label": "Missing URL" if not base_url else "Not checked",
+                    "status": "missing_url" if missing_attrs else "configured",
+                    "label": "Missing URL" if missing_attrs else "Configured",
                     "base_url": base_url or descriptor.default_base_url or "",
+                    "configuration_keys": configuration_keys,
+                    "missing_configuration_keys": missing_configuration_keys,
                 }
             )
             continue
 
-        configuration_attrs = descriptor.configuration_attrs()
-        missing_attrs = tuple(
-            attr
-            for attr in configuration_attrs
-            if not _value_for_settings_attr(state, attr)
-        )
         configured = not missing_attrs
-        configuration = " + ".join(
-            _field_key_for_settings_attr(attr) for attr in configuration_attrs
-        )
         missing_key = descriptor.credential_attr in missing_attrs
         statuses.append(
             {
@@ -75,7 +82,8 @@ def provider_config_status(
                     if missing_key
                     else "Missing configuration"
                 ),
-                "configuration": configuration,
+                "configuration_keys": configuration_keys,
+                "missing_configuration_keys": missing_configuration_keys,
             }
         )
     return statuses

--- a/src/free_claude_code/core/diagnostics.py
+++ b/src/free_claude_code/core/diagnostics.py
@@ -76,7 +76,7 @@ def safe_exception_message(
 
 
 def format_user_error_preview(exc: BaseException, *, max_len: int = 200) -> str:
-    """Return a short redacted exception preview for chat surfaces."""
+    """Return a short redacted exception preview for user-facing surfaces."""
     return safe_exception_message(exc)[:max_len]
 
 

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -34,7 +34,6 @@ from free_claude_code.config.model_refs import parse_provider_type
 from free_claude_code.config.paths import messaging_state_dir_path
 from free_claude_code.config.server_urls import local_admin_url, local_proxy_root_url
 from free_claude_code.config.settings import Settings
-from free_claude_code.core.diagnostics import format_user_error_preview
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.messaging.platforms import factory as messaging_platform_factory
 from free_claude_code.messaging.platforms.factory import MessagingPlatformOptions
@@ -47,6 +46,10 @@ from free_claude_code.messaging.voice import Transcriber
 from .provider_manager import ProviderRuntimeManager
 
 RestartCallback = Callable[[], Awaitable[None] | None]
+
+_PROVIDER_CHECK_FAILURE_MESSAGE = (
+    "Could not refresh this provider's models. Verify its configuration and access."
+)
 
 
 async def best_effort(
@@ -230,10 +233,15 @@ class ApplicationRuntime:
             provider = lease.resolve_provider(provider_id)
             infos = await provider.list_model_infos()
         except Exception as exc:
+            logger.warning(
+                "Admin provider check failed: provider={} exc_type={}",
+                provider_id,
+                type(exc).__name__,
+            )
             return {
                 "provider_id": provider_id,
                 "ok": False,
-                "message": format_user_error_preview(exc),
+                "message": _PROVIDER_CHECK_FAILURE_MESSAGE,
             }
         finally:
             await lease.release()

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -34,6 +34,7 @@ from free_claude_code.config.model_refs import parse_provider_type
 from free_claude_code.config.paths import messaging_state_dir_path
 from free_claude_code.config.server_urls import local_admin_url, local_proxy_root_url
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.diagnostics import format_user_error_preview
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.messaging.platforms import factory as messaging_platform_factory
 from free_claude_code.messaging.platforms.factory import MessagingPlatformOptions
@@ -232,7 +233,7 @@ class ApplicationRuntime:
             return {
                 "provider_id": provider_id,
                 "ok": False,
-                "error_type": type(exc).__name__,
+                "message": format_user_error_preview(exc),
             }
         finally:
             await lease.release()

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -18,7 +18,7 @@ from free_claude_code.config.admin.values import MASKED_SECRET
 from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
 from free_claude_code.config.server_urls import local_admin_url
 from free_claude_code.config.settings import Settings
-from tests.api.support import create_test_app, provider_manager_for_app
+from tests.api.support import create_test_app, provider_manager_for_app, runtime_for_app
 
 
 def _local_client(app):
@@ -264,15 +264,6 @@ def test_admin_rejects_auth_routes_for_non_connected_provider(monkeypatch, tmp_p
     )
 
     assert response.status_code == 404
-
-
-def test_admin_provider_cards_support_non_key_configuration():
-    script = Path("src/free_claude_code/api/admin_static/admin.js").read_text(
-        encoding="utf-8"
-    )
-
-    assert '"missing_config"' in script
-    assert ": provider.configuration;" in script
 
 
 def test_admin_page_no_longer_renders_generated_env_panel(monkeypatch, tmp_path):
@@ -1398,6 +1389,88 @@ def test_admin_local_provider_status_reports_reachable(monkeypatch, tmp_path):
     assert response.status_code == 200
     providers = response.json()["providers"]
     assert {provider["status"] for provider in providers} == {"reachable"}
+
+
+def test_admin_config_exposes_structured_provider_configuration_targets(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+
+    response = _local_client(create_test_app()).get("/admin/api/config")
+
+    assert response.status_code == 200
+    providers = {
+        provider["provider_id"]: provider
+        for provider in response.json()["provider_status"]
+    }
+    assert providers["nvidia_nim"]["configuration_keys"] == ["NVIDIA_NIM_API_KEY"]
+    assert providers["nvidia_nim"]["missing_configuration_keys"] == [
+        "NVIDIA_NIM_API_KEY"
+    ]
+    assert "configuration" not in providers["nvidia_nim"]
+    assert providers["lmstudio"]["status"] == "configured"
+    assert providers["lmstudio"]["configuration_keys"] == ["LM_STUDIO_BASE_URL"]
+
+
+def test_admin_local_provider_failure_is_detailed_and_redacted(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    class FailingAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url: str):
+            raise RuntimeError(
+                "Authorization: Bearer sk-local-provider-secret could not connect"
+            )
+
+    with patch(
+        "free_claude_code.api.admin_routes.httpx.AsyncClient",
+        return_value=FailingAsyncClient(),
+    ):
+        response = _local_client(app).get("/admin/api/providers/local-status")
+
+    assert response.status_code == 200
+    providers = response.json()["providers"]
+    assert {provider["status"] for provider in providers} == {"offline"}
+    for provider in providers:
+        assert "<redacted>" in provider["message"]
+        assert "sk-local-provider-secret" not in provider["message"]
+        assert "error_type" not in provider
+
+
+@pytest.mark.parametrize(
+    "result",
+    (
+        {"provider_id": "nvidia_nim", "ok": True, "models": ["model-a"]},
+        {
+            "provider_id": "nvidia_nim",
+            "ok": False,
+            "message": "NVIDIA_NIM_API_KEY is not set.",
+        },
+    ),
+)
+def test_admin_provider_test_route_preserves_runtime_result(
+    monkeypatch, tmp_path, result
+):
+    _set_home(monkeypatch, tmp_path)
+    app = create_test_app()
+    runtime = runtime_for_app(app)
+
+    with patch.object(runtime, "test_provider", new=AsyncMock(return_value=result)):
+        response = _local_client(app).post(
+            "/admin/api/providers/nvidia_nim/test",
+            json={},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == result
 
 
 def test_admin_launch_url_uses_loopback_for_wildcard_host():

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1413,7 +1413,9 @@ def test_admin_config_exposes_structured_provider_configuration_targets(
     assert providers["lmstudio"]["configuration_keys"] == ["LM_STUDIO_BASE_URL"]
 
 
-def test_admin_local_provider_failure_is_detailed_and_redacted(monkeypatch, tmp_path):
+def test_admin_local_provider_failure_does_not_return_exception_text(
+    monkeypatch, tmp_path
+):
     _set_home(monkeypatch, tmp_path)
     _clear_process_config(monkeypatch)
     app = create_test_app()
@@ -1427,7 +1429,7 @@ def test_admin_local_provider_failure_is_detailed_and_redacted(monkeypatch, tmp_
 
         async def get(self, url: str):
             raise RuntimeError(
-                "Authorization: Bearer sk-local-provider-secret could not connect"
+                "Provider rejected credential CREDENTIAL[unrecognized-format-987654321]"
             )
 
     with patch(
@@ -1440,8 +1442,11 @@ def test_admin_local_provider_failure_is_detailed_and_redacted(monkeypatch, tmp_
     providers = response.json()["providers"]
     assert {provider["status"] for provider in providers} == {"offline"}
     for provider in providers:
-        assert "<redacted>" in provider["message"]
-        assert "sk-local-provider-secret" not in provider["message"]
+        assert provider["message"] == (
+            "Could not connect. Verify the URL and that the local provider is running."
+        )
+        assert "CREDENTIAL[unrecognized-format-987654321]" not in provider["message"]
+        assert "RuntimeError" not in provider["message"]
         assert "error_type" not in provider
 
 

--- a/tests/config/test_admin_status.py
+++ b/tests/config/test_admin_status.py
@@ -1,0 +1,98 @@
+from free_claude_code.config.admin.manifest import FIELD_BY_KEY
+from free_claude_code.config.admin.state import ConfigValueState
+from free_claude_code.config.admin.status import provider_config_status
+from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
+from free_claude_code.core.json_types import JsonObject
+
+
+def _value(value: str | None) -> ConfigValueState:
+    return ConfigValueState(value=value, source="test")
+
+
+def _provider_status(
+    provider_id: str,
+    state: dict[str, ConfigValueState],
+) -> JsonObject:
+    return next(
+        status
+        for status in provider_config_status(state)
+        if status["provider_id"] == provider_id
+    )
+
+
+def test_remote_status_exposes_ordered_configuration_targets() -> None:
+    missing = _provider_status(
+        "nvidia_nim",
+        {"NVIDIA_NIM_API_KEY": _value(None)},
+    )
+    configured = _provider_status(
+        "nvidia_nim",
+        {"NVIDIA_NIM_API_KEY": _value("configured")},
+    )
+
+    assert missing == {
+        "provider_id": "nvidia_nim",
+        "display_name": "NVIDIA NIM",
+        "kind": "remote",
+        "status": "missing_key",
+        "label": "Missing key",
+        "configuration_keys": ["NVIDIA_NIM_API_KEY"],
+        "missing_configuration_keys": ["NVIDIA_NIM_API_KEY"],
+    }
+    assert configured["status"] == "configured"
+    assert configured["label"] == "Configured"
+    assert configured["configuration_keys"] == ["NVIDIA_NIM_API_KEY"]
+    assert configured["missing_configuration_keys"] == []
+    assert "configuration" not in configured
+
+
+def test_multi_field_status_preserves_catalog_order_and_first_missing_target() -> None:
+    status = _provider_status(
+        "cloudflare",
+        {
+            "CLOUDFLARE_API_TOKEN": _value("configured"),
+            "CLOUDFLARE_ACCOUNT_ID": _value(None),
+        },
+    )
+
+    assert status["status"] == "missing_config"
+    assert status["configuration_keys"] == [
+        "CLOUDFLARE_API_TOKEN",
+        "CLOUDFLARE_ACCOUNT_ID",
+    ]
+    assert status["missing_configuration_keys"] == ["CLOUDFLARE_ACCOUNT_ID"]
+
+
+def test_local_status_keeps_configuration_separate_from_reachability() -> None:
+    missing = _provider_status(
+        "lmstudio",
+        {"LM_STUDIO_BASE_URL": _value(None)},
+    )
+    configured = _provider_status(
+        "lmstudio",
+        {"LM_STUDIO_BASE_URL": _value("http://127.0.0.1:1234/v1")},
+    )
+
+    assert missing["status"] == "missing_url"
+    assert missing["label"] == "Missing URL"
+    assert missing["missing_configuration_keys"] == ["LM_STUDIO_BASE_URL"]
+    assert configured["status"] == "configured"
+    assert configured["label"] == "Configured"
+    assert configured["configuration_keys"] == ["LM_STUDIO_BASE_URL"]
+    assert configured["missing_configuration_keys"] == []
+
+
+def test_connected_accounts_have_no_configuration_navigation_contract() -> None:
+    status = _provider_status("openai", {})
+
+    assert status["kind"] == "connected_account"
+    assert "configuration_keys" not in status
+    assert "missing_configuration_keys" not in status
+
+
+def test_every_catalog_configuration_attribute_has_an_admin_field() -> None:
+    for descriptor in PROVIDER_CATALOG.values():
+        for settings_attr in descriptor.configuration_attrs():
+            assert any(
+                field.settings_attr == settings_attr for field in FIELD_BY_KEY.values()
+            ), settings_attr

--- a/tests/contracts/test_admin_provider_manifest.py
+++ b/tests/contracts/test_admin_provider_manifest.py
@@ -226,7 +226,8 @@ def test_vertex_admin_status_uses_project_configuration_not_an_api_key() -> None
 
     assert vertex_status("")["status"] == "missing_config"
     assert vertex_status("")["label"] == "Missing configuration"
-    assert vertex_status("")["configuration"] == "VERTEX_PROJECT_ID"
+    assert vertex_status("")["configuration_keys"] == ["VERTEX_PROJECT_ID"]
+    assert vertex_status("")["missing_configuration_keys"] == ["VERTEX_PROJECT_ID"]
     assert vertex_status("vertex-project")["status"] == "configured"
 
 
@@ -254,9 +255,11 @@ def test_azure_openai_admin_status_distinguishes_key_and_url() -> None:
     missing_url = azure_status("azure-key", "")
     assert missing_url["status"] == "missing_config"
     assert missing_url["label"] == "Missing configuration"
-    assert missing_url["configuration"] == (
-        "AZURE_OPENAI_API_KEY + AZURE_OPENAI_BASE_URL"
-    )
+    assert missing_url["configuration_keys"] == [
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_BASE_URL",
+    ]
+    assert missing_url["missing_configuration_keys"] == ["AZURE_OPENAI_BASE_URL"]
 
     assert (
         azure_status(

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import AsyncIterator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,9 +10,12 @@ from free_claude_code.application.connected_accounts import (
     ConnectedAccountState,
     ConnectedAccountStatus,
 )
+from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.admin.persistence import PreparedAdminUpdate
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
 from free_claude_code.messaging.command_context import StopOutcome
 from free_claude_code.messaging.platforms.ports import (
     InboundMessageHandler,
@@ -20,9 +24,11 @@ from free_claude_code.messaging.platforms.ports import (
 )
 from free_claude_code.messaging.session import SessionStore
 from free_claude_code.messaging.workflow import MessagingWorkflow
+from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+from tests.providers.support import make_provider_config
 
 
 class TrackingRuntime(ProviderRuntime):
@@ -33,6 +39,51 @@ class TrackingRuntime(ProviderRuntime):
     async def cleanup(self) -> None:
         self.cleanup_calls += 1
         await super().cleanup()
+
+
+class AdminModelProvider(BaseProvider):
+    def __init__(
+        self,
+        model_infos: frozenset[ProviderModelInfo] = frozenset(),
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__(
+            make_provider_config(
+                api_key="test",
+                base_url="https://provider.invalid/v1",
+            )
+        )
+        self._model_infos = model_infos
+        self._error = error
+
+    def preflight_stream(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> None:
+        return None
+
+    async def cleanup(self) -> None:
+        return None
+
+    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
+        if self._error is not None:
+            raise self._error
+        return self._model_infos
+
+    async def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+    ) -> AsyncIterator[str]:
+        if False:
+            yield ""
 
 
 class TrackingFactory:
@@ -159,6 +210,88 @@ def _applied_response(pending_fields: tuple[str, ...] = ()) -> dict[str, object]
         "path": ".env",
         "pending_fields": list(pending_fields),
     }
+
+
+def _runtime_with_admin_provider(
+    provider: BaseProvider,
+) -> tuple[ApplicationRuntime, ProviderRuntimeManager]:
+    settings = _settings("nvidia_nim/fallback").model_copy(
+        update={"nvidia_nim_api_key": "test-key"}
+    )
+    manager = ProviderRuntimeManager(
+        settings,
+        runtime_factory=lambda snapshot: ProviderRuntime(
+            snapshot,
+            {"nvidia_nim": provider},
+        ),
+    )
+    return ApplicationRuntime(manager, transcriber=None), manager
+
+
+@pytest.mark.asyncio
+async def test_provider_check_caches_and_returns_sorted_models() -> None:
+    provider = AdminModelProvider(
+        frozenset(
+            {
+                ProviderModelInfo("vendor/model-b"),
+                ProviderModelInfo("vendor/model-a"),
+            }
+        )
+    )
+    runtime, manager = _runtime_with_admin_provider(provider)
+
+    result = await runtime.test_provider("nvidia_nim")
+
+    assert result == {
+        "provider_id": "nvidia_nim",
+        "ok": True,
+        "models": ["vendor/model-a", "vendor/model-b"],
+    }
+    assert manager.cached_model_ids()["nvidia_nim"] == frozenset(
+        {"vendor/model-a", "vendor/model-b"}
+    )
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_check_preserves_actionable_application_error() -> None:
+    provider = AdminModelProvider(
+        error=ApplicationUnavailableError(
+            "NVIDIA_NIM_API_KEY is not set. Add it in the Admin UI."
+        )
+    )
+    runtime, manager = _runtime_with_admin_provider(provider)
+
+    result = await runtime.test_provider("nvidia_nim")
+
+    assert result == {
+        "provider_id": "nvidia_nim",
+        "ok": False,
+        "message": "NVIDIA_NIM_API_KEY is not set. Add it in the Admin UI.",
+    }
+    assert "error_type" not in result
+    await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_check_redacts_and_caps_unexpected_error() -> None:
+    secret = "sk-admin-provider-secret"
+    provider = AdminModelProvider(
+        error=RuntimeError(
+            f"Authorization: Bearer {secret} could not connect " + "x" * 500
+        )
+    )
+    runtime, manager = _runtime_with_admin_provider(provider)
+
+    result = await runtime.test_provider("nvidia_nim")
+
+    message = result["message"]
+    assert isinstance(message, str)
+    assert "<redacted>" in message
+    assert secret not in message
+    assert len(message) == 200
+    assert "error_type" not in result
+    await manager.close()
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -254,7 +255,7 @@ async def test_provider_check_caches_and_returns_sorted_models() -> None:
 
 
 @pytest.mark.asyncio
-async def test_provider_check_preserves_actionable_application_error() -> None:
+async def test_provider_check_returns_stable_failure_for_application_error() -> None:
     provider = AdminModelProvider(
         error=ApplicationUnavailableError(
             "NVIDIA_NIM_API_KEY is not set. Add it in the Admin UI."
@@ -267,29 +268,40 @@ async def test_provider_check_preserves_actionable_application_error() -> None:
     assert result == {
         "provider_id": "nvidia_nim",
         "ok": False,
-        "message": "NVIDIA_NIM_API_KEY is not set. Add it in the Admin UI.",
+        "message": (
+            "Could not refresh this provider's models. "
+            "Verify its configuration and access."
+        ),
     }
     assert "error_type" not in result
     await manager.close()
 
 
 @pytest.mark.asyncio
-async def test_provider_check_redacts_and_caps_unexpected_error() -> None:
-    secret = "sk-admin-provider-secret"
+async def test_provider_check_never_returns_unrecognized_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret = "CREDENTIAL[unrecognized-format-987654321]"
     provider = AdminModelProvider(
-        error=RuntimeError(
-            f"Authorization: Bearer {secret} could not connect " + "x" * 500
-        )
+        error=RuntimeError(f"Provider rejected credential {secret}")
     )
     runtime, manager = _runtime_with_admin_provider(provider)
 
-    result = await runtime.test_provider("nvidia_nim")
+    with caplog.at_level(logging.WARNING):
+        result = await runtime.test_provider("nvidia_nim")
 
-    message = result["message"]
-    assert isinstance(message, str)
-    assert "<redacted>" in message
-    assert secret not in message
-    assert len(message) == 200
+    assert result == {
+        "provider_id": "nvidia_nim",
+        "ok": False,
+        "message": (
+            "Could not refresh this provider's models. "
+            "Verify its configuration and access."
+        ),
+    }
+    log_text = " | ".join(record.getMessage() for record in caplog.records)
+    assert "provider=nvidia_nim" in log_text
+    assert "exc_type=RuntimeError" in log_text
+    assert secret not in log_text
     assert "error_type" not in result
     await manager.close()
 

--- a/tests/scripts/test_ci_scripts.py
+++ b/tests/scripts/test_ci_scripts.py
@@ -61,7 +61,9 @@ def test_ci_sh_runs_ci_checks_in_order() -> None:
     text = _script_text("ci.sh")
     legacy_future_import = "from __future__ import " + "annotations"
 
-    assert 'CHECK_ORDER="suppressions ruff-format ruff-check ty pytest"' in text
+    assert (
+        'CHECK_ORDER="suppressions ruff-format ruff-check ty pytest playwright"' in text
+    )
     assert "grep -rE" in text
     assert "Fix the underlying type/import issue instead" in text
     assert legacy_future_import in text
@@ -73,6 +75,8 @@ def test_ci_sh_runs_ci_checks_in_order() -> None:
     assert "uv run ruff check --fix" in text
     assert "uv run ty check" in text
     assert "uv run pytest -v --tb=short" in text
+    assert "uv run playwright install chromium" in text
+    assert "uv run pytest e2e -n 0" in text
     assert "--only" in text
     assert "--skip" in text
     assert "--dry-run" in text
@@ -100,6 +104,28 @@ def test_ci_sh_dry_run_does_not_require_uv() -> None:
 
     assert result.returncode == 0
     assert "+ uv run pytest -v --tb=short" in result.stdout
+    assert "uv is required" not in result.stderr
+
+
+def test_ci_sh_playwright_dry_run_prints_browser_and_test_commands() -> None:
+    result = subprocess.run(
+        [
+            _shell_interpreter(),
+            str(_repo_root() / "scripts" / "ci.sh"),
+            "--only",
+            "playwright",
+            "--dry-run",
+        ],
+        cwd=_repo_root(),
+        env={**os.environ, "PATH": _path_without_uv()},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "+ uv run playwright install chromium" in result.stdout
+    assert "+ uv run pytest e2e -n 0" in result.stdout
     assert "uv is required" not in result.stderr
 
 
@@ -174,9 +200,15 @@ def test_ci_sh_fail_fast_runs_checks_sequentially() -> None:
     ruff_check_index = text.index("run_ruff_check()")
     ty_index = text.index("run_ty()")
     pytest_index = text.index("run_pytest()")
+    playwright_index = text.index("run_playwright()")
 
     assert (
-        suppress_index < ruff_format_index < ruff_check_index < ty_index < pytest_index
+        suppress_index
+        < ruff_format_index
+        < ruff_check_index
+        < ty_index
+        < pytest_index
+        < playwright_index
     )
     assert "for check_id in $CHECK_ORDER" in main
 
@@ -190,6 +222,7 @@ def test_ci_ps1_runs_ci_checks_in_order() -> None:
     assert '"ruff-check"' in text
     assert '"ty"' in text
     assert '"pytest"' in text
+    assert '"playwright"' in text
     assert "Select-String -Pattern" in text
     assert "Fix the underlying type/import issue instead" in text
     assert legacy_future_import in text
@@ -200,6 +233,8 @@ def test_ci_ps1_runs_ci_checks_in_order() -> None:
     assert '"format", "--check"' not in text
     assert '"run", "ruff", "check", "--fix"' in text
     assert '"-v", "--tb=short"' in text
+    assert '"run", "playwright", "install", "chromium"' in text
+    assert '"run", "pytest", "e2e", "-n", "0"' in text
     assert "-Only" in text
     assert "-Skip" in text
     assert "-DryRun" in text
@@ -229,6 +264,30 @@ def test_ci_ps1_dry_run_does_not_require_uv() -> None:
 
     assert result.returncode == 0
     assert "+ uv run pytest -v --tb=short" in result.stdout
+    assert "uv is required" not in result.stderr
+
+
+def test_ci_ps1_playwright_dry_run_prints_browser_and_test_commands() -> None:
+    result = subprocess.run(
+        [
+            _powershell_interpreter(),
+            "-NoProfile",
+            "-File",
+            str(_repo_root() / "scripts" / "ci.ps1"),
+            "-Only",
+            "playwright",
+            "-DryRun",
+        ],
+        cwd=_repo_root(),
+        env={**os.environ, "PATH": _path_without_uv()},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "+ uv run playwright install chromium" in result.stdout
+    assert "+ uv run pytest e2e -n 0" in result.stdout
     assert "uv is required" not in result.stderr
 
 
@@ -295,13 +354,20 @@ def test_ci_ps1_fail_fast_runs_checks_sequentially() -> None:
     assert "Invoke-RuffLintCheck" in text
     assert "Invoke-TyCheck" in text
     assert "Invoke-PytestCheck" in text
+    assert "Invoke-PlaywrightCheck" in text
 
     suppress_index = text.index("function Invoke-SuppressionsCheck")
     ruff_format_index = text.index("function Invoke-RuffFormatCheck")
     ruff_check_index = text.index("function Invoke-RuffLintCheck")
     ty_index = text.index("function Invoke-TyCheck")
     pytest_index = text.index("function Invoke-PytestCheck")
+    playwright_index = text.index("function Invoke-PlaywrightCheck")
 
     assert (
-        suppress_index < ruff_format_index < ruff_check_index < ty_index < pytest_index
+        suppress_index
+        < ruff_format_index
+        < ruff_check_index
+        < ty_index
+        < pytest_index
+        < playwright_index
     )

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.6.0"
+version = "5.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -647,6 +647,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-playwright" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
@@ -686,6 +687,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-playwright", specifier = ">=0.9.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.16.2" },
     { name = "ty", specifier = ">=0.0.70" },
@@ -757,6 +759,53 @@ wheels = [
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
 ]
 
 [[package]]
@@ -1493,6 +1542,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1710,6 +1778,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1812,6 +1892,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1823,6 +1916,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/c4/31cab1a9edfa35546950bb30c033dbfe4d4f3a216f4bafb0537a1469a70c/pytest_playwright-0.9.0.tar.gz", hash = "sha256:bd44daa852b0fb8b0e55a2f88b727507dedda0e350bea5d09420647252f2454b", size = 17899, upload-time = "2026-08-10T10:20:16.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/70/72ff5c3833f0faa9b5fb23f24c0a606f070ad33bb61b802ba38dfe125e7d/pytest_playwright-0.9.0-py3-none-any.whl", hash = "sha256:9d9dc74e335c647944cecfffa706cc9e6e4bf4c25e84592c128b584d494d4471", size = 17915, upload-time = "2026-08-10T10:20:18.253Z" },
 ]
 
 [[package]]
@@ -1854,6 +1962,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -2325,6 +2445,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Provider cards offered checks before required setup was complete, while failures replaced useful configuration state with exception class names. Required fields could sit several screens below the card with no path to reach them. Fixes #1452.

## Changes

| Before | After |
| --- | --- |
| Missing providers offered checks that could only fail. | Missing providers offer Configure and focus their first missing field. |
| Check results overwrote configuration readiness. | Readiness and redacted check results render independently. |
| Rendered Admin workflows had no deterministic browser coverage. | A uv-managed Playwright Chromium check covers desktop, mobile, success, failure, and multi-field navigation. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Admin provider experience now identifies incomplete configuration and directs administrators to the required settings. Provider-check failures return stable guidance without exposing backend exception text. A live Admin API check with a unique credential sentinel confirmed that the response omits the sentinel and preserves the generic failure message.
</details>

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain after exercising the provider-check failure path through the Admin API.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the Admin provider-check credential guard to exercise the credential protection path.
- Observed that the pre-change response included the unique credential sentinel, while the current route returns HTTP 200 with a stable credential-free message.
- Ran focused runtime and Admin-route regression tests; the guard completed successfully and all three tests passed.
- Validated the Admin route's delegation to test\_provider(provider\_id) and the minified exception handling that returns a stable failure message.
- Executed the provider-check script in the project workspace and confirmed exit code 0 with a stable credential-free JSON response.

<a href="https://app.greptile.com/trex/runs/19197531/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep provider exception text out of Admi..."](https://github.com/alishahryar1/free-claude-code/commit/7429b1722229e2f821d8ca36d5a6e52005fa589a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53954310)</sub>

<!-- /greptile_comment -->