### PR TITLE
Cancel abandoned inference and make progress timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -314,6 +314,8 @@ REASONING_HAIKU=inherit
 PROVIDER_RATE_LIMIT=1
 PROVIDER_RATE_WINDOW=2
 PROVIDER_MAX_CONCURRENCY=2
+# Maximum seconds without a non-empty protocol event. Independent of HTTP reads.
+PROVIDER_PROGRESS_TIMEOUT=600
 
 
 # HTTP client timeouts (seconds) for provider API requests

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,10 +271,14 @@ configures logging, constructs the runtime owners and the configured voice
   their inbound-adapter port in [api/ports.py](src/free_claude_code/api/ports.py).
 
 [api/app.py](src/free_claude_code/api/app.py) registers routers and exception
-handlers around an explicit `ApiServices` value, then wraps the application in a
-pure ASGI correlation boundary. The boundary surrounds the complete wire send;
-it does not proxy streaming responses through `BaseHTTPMiddleware`. The API does
-not read global settings or construct runtime resources.
+handlers around an explicit `ApiServices` value, then composes pure ASGI
+correlation and inference-lifetime boundaries. Correlation surrounds the
+complete wire send. The inner lifetime boundary owns `http.disconnect` for
+Messages and Responses, cancelling the request application whether abandonment
+occurs during request processing, first-frame prefetch, non-streaming
+aggregation, or a silent committed stream. Neither boundary proxies streaming
+responses through `BaseHTTPMiddleware`. The API does not read global settings or
+construct runtime resources.
 `app.state.services` is the only runtime state published to FastAPI.
 
 [runtime/application.py](src/free_claude_code/runtime/application.py) owns process startup and shutdown, optional messaging,
@@ -433,6 +437,15 @@ response lifetime finalization under the concrete response owner. Starlette's
 outer server-error boundary bypasses user middleware for its catch-all 500, so
 that one handler explicitly attaches the same ingress-owned headers.
 
+Inference client lifetime is also owned at the HTTP boundary. One bounded
+receive pump is the sole reader of the server's ASGI `receive` channel while the
+application consumes the relayed request body. The complete application task is
+raced against `http.disconnect`; application completion wins a simultaneous
+race, while disconnect cancels and drains unfinished work. Existing route,
+response-body, provider-stream, and request-generation owners then perform their
+normal cancellation cleanup. FCC sends no synthetic timeout or terminal event
+to a client that has already left. Non-inference routes bypass this machinery.
+
 [api/handlers/](src/free_claude_code/api/handlers/) owns the public API product flows.
 `MessagesHandler` validates non-empty messages, resolves models, applies
 Claude-only safety-classifier and local optimization policy, handles local web
@@ -445,15 +458,19 @@ emits trace events, counts input tokens, and returns an Anthropic SSE iterator.
 It receives only a provider resolver and the few scalar collaborators it needs;
 it does not depend on FastAPI, provider implementations, or the full settings
 object. The executor also owns FCC's provider-progress deadline: every wait for
-the next non-empty provider chunk is limited to 240 seconds, leaving one minute
-below the five-minute idle watchdog shared by the first-party Claude, Codex, and
-Pi harnesses. Admission, retries, backoff, and recovery before a chunk all consume
-that same wait; a non-empty emitted chunk renews the next window. The timeout
-context ends before the executor yields, so downstream response backpressure is
-not mistaken for stalled provider work and cannot receive cancellation from the
-generator's timer. Expiry becomes a protocol-neutral, non-retryable 504
-`ExecutionFailure`; cancellation and provider-originated timeouts retain their
-existing meanings.
+the next non-empty provider chunk is limited by the Settings-owned
+`PROVIDER_PROGRESS_TIMEOUT`, which defaults to 600 seconds and is projected into
+the executor as a validated scalar. Admission, retries, backoff, and recovery
+before a chunk all consume that same wait; a non-empty emitted chunk renews the
+next window, while empty keepalives do not. The timeout context ends before the
+executor yields, so downstream response backpressure is not mistaken for
+stalled provider work and cannot receive cancellation from the generator's
+timer. Expiry becomes a protocol-neutral, non-retryable 504 `ExecutionFailure`;
+cancellation and provider-originated timeouts retain their existing meanings.
+This progress deadline is independent of provider `HTTP_READ_TIMEOUT` and of any
+client-owned deadline: provider HTTP adapters own read failures, the application
+owns visible-progress failure, and the API boundary owns actual client
+abandonment.
 
 [core/token_estimation.py](src/free_claude_code/core/token_estimation.py) owns
 process-wide best-effort plain-text token estimation. It acquires the shared

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.6.2"
+version = "5.7.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/app.py
+++ b/src/free_claude_code/api/app.py
@@ -28,6 +28,7 @@ from .request_ids import (
     attach_request_id_headers,
     get_request_id,
 )
+from .request_lifetime import InferenceRequestLifetimeMiddleware
 from .routes import router
 from .validation_log import summarize_request_validation_body
 
@@ -36,8 +37,9 @@ def create_app(services: ApiServices) -> FastAPI:
     """Create the HTTP adapter around explicitly supplied runtime services."""
     app = FastAPI(title="Claude Code Proxy", version=package_version())
     app.state.services = services
-    app.add_middleware(RequestCorrelationMiddleware)
     app.add_middleware(AdminNoStoreMiddleware)
+    app.add_middleware(InferenceRequestLifetimeMiddleware)
+    app.add_middleware(RequestCorrelationMiddleware)
 
     app.include_router(admin_router)
     app.include_router(router)

--- a/src/free_claude_code/api/handlers/messages.py
+++ b/src/free_claude_code/api/handlers/messages.py
@@ -83,6 +83,7 @@ class MessagesHandler:
         self._token_counter = token_counter
         self._provider_executor = provider_executor or ProviderExecutor(
             provider_resolver,
+            progress_timeout_seconds=settings.provider_progress_timeout,
             token_counter=token_counter,
             generation_id=generation_id,
             log_raw_payloads=settings.log_raw_api_payloads,

--- a/src/free_claude_code/api/handlers/responses.py
+++ b/src/free_claude_code/api/handlers/responses.py
@@ -47,6 +47,7 @@ class ResponsesHandler:
         self._responses_adapter = responses_adapter or OpenAIResponsesAdapter()
         self._provider_executor = provider_executor or ProviderExecutor(
             provider_resolver,
+            progress_timeout_seconds=settings.provider_progress_timeout,
             generation_id=generation_id,
             log_raw_payloads=settings.log_raw_api_payloads,
         )

--- a/src/free_claude_code/api/request_lifetime.py
+++ b/src/free_claude_code/api/request_lifetime.py
@@ -1,0 +1,121 @@
+"""Client-owned lifetime boundary for long-running inference requests."""
+
+import asyncio
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_INFERENCE_PATHS = frozenset({"/v1/messages", "/v1/responses"})
+
+
+class InferenceRequestLifetimeMiddleware:
+    """Cancel inference when its HTTP client disconnects."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        if not _owns_inference_lifetime(scope):
+            await self._app(scope, receive, send)
+            return
+
+        messages: asyncio.Queue[Message] = asyncio.Queue(maxsize=1)
+
+        async def receive_until_disconnect() -> None:
+            while True:
+                message = await receive()
+                if message["type"] == "http.disconnect":
+                    return
+                await messages.put(message)
+
+        async def receive_for_application() -> Message:
+            return await messages.get()
+
+        async def run_application() -> None:
+            await self._app(scope, receive_for_application, send)
+
+        application_task = asyncio.create_task(
+            run_application(),
+            name="fcc-inference-application",
+        )
+        receive_task = asyncio.create_task(
+            receive_until_disconnect(),
+            name="fcc-inference-disconnect-receiver",
+        )
+        try:
+            done, _pending = await asyncio.wait(
+                (application_task, receive_task),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if application_task in done:
+                try:
+                    application_task.result()
+                finally:
+                    await _cancel_and_wait(receive_task)
+                return
+
+            receive_outcome = _task_outcome(receive_task)
+            (application_outcome,) = await _cancel_and_wait(application_task)
+            if receive_outcome is not None:
+                raise receive_outcome
+            if application_outcome is not None and not isinstance(
+                application_outcome,
+                asyncio.CancelledError,
+            ):
+                raise application_outcome
+        except asyncio.CancelledError:
+            cleanup_task = asyncio.create_task(
+                _cancel_and_wait(application_task, receive_task),
+                name="fcc-inference-lifetime-cleanup",
+            )
+            await _wait_for_cleanup(cleanup_task)
+            raise
+
+
+def _owns_inference_lifetime(scope: Scope) -> bool:
+    return (
+        scope["type"] == "http"
+        and scope.get("method") == "POST"
+        and scope.get("path") in _INFERENCE_PATHS
+    )
+
+
+def _task_outcome(task: asyncio.Task[None]) -> BaseException | None:
+    try:
+        task.result()
+    except BaseException as exc:
+        return exc
+    return None
+
+
+async def _cancel_and_wait(
+    *tasks: asyncio.Task[None],
+) -> tuple[BaseException | None, ...]:
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+
+    outcomes: list[BaseException | None] = []
+    for task in tasks:
+        try:
+            await task
+        except BaseException as exc:
+            outcomes.append(exc)
+        else:
+            outcomes.append(None)
+    return tuple(outcomes)
+
+
+async def _wait_for_cleanup(
+    task: asyncio.Task[tuple[BaseException | None, ...]],
+) -> None:
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+    task.result()

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -30,7 +30,6 @@ TokenCounter = Callable[
     int,
 ]
 WireApi = Literal["messages", "responses"]
-PROVIDER_PROGRESS_TIMEOUT_SECONDS = 240.0
 
 
 class ProviderExecutor:
@@ -40,10 +39,10 @@ class ProviderExecutor:
         self,
         provider_resolver: ProviderResolver,
         *,
+        progress_timeout_seconds: float,
         token_counter: TokenCounter = get_token_count,
         generation_id: int | None = None,
         log_raw_payloads: bool = False,
-        progress_timeout_seconds: float = PROVIDER_PROGRESS_TIMEOUT_SECONDS,
     ) -> None:
         if not math.isfinite(progress_timeout_seconds) or progress_timeout_seconds <= 0:
             raise ValueError("progress_timeout_seconds must be finite and positive")

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -213,6 +213,19 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         settings_attr="provider_max_concurrency",
     ),
     ConfigFieldSpec(
+        "PROVIDER_PROGRESS_TIMEOUT",
+        "Provider Progress Timeout",
+        "runtime",
+        "number",
+        settings_attr="provider_progress_timeout",
+        description=(
+            "Maximum seconds without a non-empty protocol event, including "
+            "provider admission, retries, and backoff. Independent of HTTP Read "
+            "Timeout."
+        ),
+        advanced=True,
+    ),
+    ConfigFieldSpec(
         "HTTP_READ_TIMEOUT",
         "HTTP Read Timeout",
         "runtime",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -482,6 +482,12 @@ class Settings(BaseModel):
     provider_max_concurrency: int = Field(
         default=2, validation_alias="PROVIDER_MAX_CONCURRENCY"
     )
+    provider_progress_timeout: float = Field(
+        default=600.0,
+        gt=0,
+        allow_inf_nan=False,
+        validation_alias="PROVIDER_PROGRESS_TIMEOUT",
+    )
     reasoning_policy: ReasoningPreference = Field(
         default=ReasoningPreference.CLIENT,
         validation_alias="REASONING_POLICY",

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -427,6 +427,17 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
     assert open_browser_field["type"] == "boolean"
     assert open_browser_field["value"] == "true"
     assert open_browser_field["restart_required"] is False
+    progress_timeout_field = next(
+        field for field in body["fields"] if field["key"] == "PROVIDER_PROGRESS_TIMEOUT"
+    )
+    assert progress_timeout_field["label"] == "Provider Progress Timeout"
+    assert progress_timeout_field["section"] == "runtime"
+    assert progress_timeout_field["type"] == "number"
+    assert progress_timeout_field["value"] == "600.0"
+    assert progress_timeout_field["advanced"] is True
+    assert progress_timeout_field["restart_required"] is False
+    assert "non-empty protocol event" in progress_timeout_field["description"]
+    assert "Independent of HTTP Read Timeout" in progress_timeout_field["description"]
     model_field_types = {
         field["key"]: field["type"]
         for field in body["fields"]
@@ -590,6 +601,51 @@ def test_admin_apply_persists_open_browser_for_next_launch(monkeypatch, tmp_path
     }
     managed_env = tmp_path / ".fcc" / ".env"
     assert "FCC_OPEN_BROWSER=false" in managed_env.read_text(encoding="utf-8")
+
+
+def test_admin_apply_hot_publishes_provider_progress_timeout(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"PROVIDER_PROGRESS_TIMEOUT": 900}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied"] is True
+    assert body["pending_fields"] == []
+    assert body["restart"]["required"] is False
+    assert (
+        provider_manager_for_app(app).current_settings().provider_progress_timeout
+        == 900.0
+    )
+    managed_env = tmp_path / ".fcc" / ".env"
+    assert "PROVIDER_PROGRESS_TIMEOUT=900" in managed_env.read_text(encoding="utf-8")
+
+
+def test_admin_rejects_invalid_provider_progress_timeout_without_writing(
+    monkeypatch,
+    tmp_path,
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    response = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"PROVIDER_PROGRESS_TIMEOUT": 0}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["applied"] is False
+    assert body["valid"] is False
+    assert any("PROVIDER_PROGRESS_TIMEOUT" in error for error in body["errors"])
+    managed_env = tmp_path / ".fcc" / ".env"
+    assert "PROVIDER_PROGRESS_TIMEOUT=" not in managed_env.read_text(encoding="utf-8")
 
 
 def test_admin_apply_masks_telegram_proxy_credentials(monkeypatch, tmp_path):

--- a/tests/api/test_execution_failure_contract.py
+++ b/tests/api/test_execution_failure_contract.py
@@ -1,5 +1,6 @@
 """Public commit-boundary behavior for canonical execution failures."""
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -7,9 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import MessagesRequest
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.core.anthropic.streaming import format_sse_event
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.core.reasoning import ReasoningPolicy
 from tests.api.support import create_test_app
 
 _PARTIAL_CONTENT = "PARTIAL_ASSISTANT_CONTENT"
@@ -63,6 +67,37 @@ class CanonicalFailureProvider:
         raise failure
 
 
+class StalledProvider:
+    """Provider double that makes no protocol-visible progress."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def preflight_stream(
+        self,
+        _request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
+    ) -> None:
+        del reasoning
+
+    async def stream_response(
+        self,
+        _request: MessagesRequest,
+        *,
+        input_tokens: int,
+        request_id: str,
+        response_model: str,
+        reasoning: ReasoningPolicy,
+    ) -> AsyncIterator[str]:
+        del input_tokens, request_id, response_model, reasoning
+        try:
+            await asyncio.Event().wait()
+            yield ""
+        finally:
+            self.close_calls += 1
+
+
 def _messages_payload(*, stream: bool) -> dict[str, object]:
     return {
         "model": "nvidia_nim/test-model",
@@ -110,8 +145,12 @@ def _partial_anthropic_stream(*, close_block: bool) -> list[str]:
     return chunks
 
 
-def _client_for(provider: CanonicalFailureProvider):
-    app = create_test_app()
+def _client_for(
+    provider: CanonicalFailureProvider | StalledProvider,
+    *,
+    settings: Settings | None = None,
+):
+    app = create_test_app(settings)
     return (
         patch("free_claude_code.api.routes.resolve_provider", return_value=provider),
         TestClient(app),
@@ -145,9 +184,35 @@ def _timeout_provider(chunks: list[str]) -> CanonicalFailureProvider:
         chunks,
         kind=FailureKind.TIMEOUT,
         status_code=504,
-        message="Provider execution made no progress for 240 seconds.",
+        message="Provider execution made no progress for 600 seconds.",
         retryable=False,
     )
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/v1/messages", _messages_payload(stream=True)),
+        ("/v1/responses", _responses_payload()),
+    ],
+)
+def test_configured_progress_timeout_reaches_default_handler_executor(
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    provider = StalledProvider()
+    resolver_patch, client = _client_for(
+        provider,
+        settings=Settings(provider_progress_timeout=0.02),
+    )
+
+    with resolver_patch, client:
+        response = client.post(path, json=payload)
+
+    assert response.status_code == 504
+    assert response.headers["x-should-retry"] == "false"
+    assert "made no progress for 0.02 seconds" in response.json()["error"]["message"]
+    assert provider.close_calls == 1
 
 
 @pytest.mark.parametrize(
@@ -543,7 +608,7 @@ def test_pre_start_progress_timeout_is_terminal_504(
     assert response.json()["error"] == {
         "type": "timeout_error",
         "message": (
-            "Provider execution made no progress for 240 seconds.\n\n"
+            "Provider execution made no progress for 600 seconds.\n\n"
             f"Request ID: {request_id}"
         ),
         **({} if path == "/v1/messages" else {"param": None, "code": None}),
@@ -593,7 +658,7 @@ def test_post_start_progress_timeout_is_terminal_protocol_event(path: str) -> No
         error = events[-1].data["response"]["error"]
     assert error["type"] == "timeout_error"
     assert error["message"] == (
-        "Provider execution made no progress for 240 seconds.\n\n"
+        "Provider execution made no progress for 600 seconds.\n\n"
         f"Request ID: {request_id}"
     )
     trace = _terminal_trace(trace_mock)
@@ -615,7 +680,7 @@ def test_stream_false_progress_timeout_discards_partial_content() -> None:
     assert response.json()["error"] == {
         "type": "timeout_error",
         "message": (
-            "Provider execution made no progress for 240 seconds.\n\n"
+            "Provider execution made no progress for 600 seconds.\n\n"
             f"Request ID: {request_id}"
         ),
     }

--- a/tests/api/test_request_ids.py
+++ b/tests/api/test_request_ids.py
@@ -16,6 +16,7 @@ from free_claude_code.api.request_ids import (
     RequestCorrelationMiddleware,
     get_request_id,
 )
+from free_claude_code.api.request_lifetime import InferenceRequestLifetimeMiddleware
 from tests.api.support import create_test_app
 
 
@@ -40,9 +41,14 @@ def _http_scope(path: str) -> Scope:
 
 def test_application_uses_the_pure_asgi_correlation_owner() -> None:
     app = create_test_app()
-    middleware_classes = [middleware.cls for middleware in app.user_middleware]
+    middleware_classes = [
+        cast(type[object], middleware.cls) for middleware in app.user_middleware
+    ]
 
     assert sum(cls is RequestCorrelationMiddleware for cls in middleware_classes) == 1
+    assert middleware_classes.index(
+        RequestCorrelationMiddleware
+    ) < middleware_classes.index(InferenceRequestLifetimeMiddleware)
     assert all(cls is not BaseHTTPMiddleware for cls in middleware_classes)
 
 

--- a/tests/api/test_request_lifetime.py
+++ b/tests/api/test_request_lifetime.py
@@ -1,0 +1,636 @@
+"""Inference request lifetime contracts at the pure-ASGI boundary."""
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import cast
+
+import pytest
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from free_claude_code.api.app import create_app
+from free_claude_code.api.ports import AdminRuntimePort, ApiServices
+from free_claude_code.api.request_lifetime import (
+    InferenceRequestLifetimeMiddleware,
+)
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.application.ports import (
+    ProviderPort,
+    RequestRuntimeLease,
+    RequestRuntimePort,
+    TaskController,
+)
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import MessagesRequest
+from free_claude_code.core.anthropic.streaming import format_sse_event
+from free_claude_code.core.reasoning import ReasoningPolicy
+
+
+def _http_scope(
+    path: str = "/v1/messages",
+    *,
+    method: str = "POST",
+) -> Scope:
+    return cast(
+        Scope,
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "client": None,
+            "server": None,
+        },
+    )
+
+
+async def _unused_send(_message: Message) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope",
+    [
+        _http_scope("/health"),
+        _http_scope("/v1/messages", method="OPTIONS"),
+        cast(Scope, {"type": "lifespan", "asgi": {"version": "3.0"}}),
+    ],
+)
+async def test_non_inference_scopes_delegate_with_original_callables(
+    scope: Scope,
+) -> None:
+    observed: tuple[Scope, Receive, Send] | None = None
+
+    async def receive() -> Message:
+        return {"type": "http.disconnect"}
+
+    async def send(_message: Message) -> None:
+        return None
+
+    async def app(
+        received_scope: Scope,
+        received_receive: Receive,
+        received_send: Send,
+    ) -> None:
+        nonlocal observed
+        observed = (received_scope, received_receive, received_send)
+
+    await InferenceRequestLifetimeMiddleware(cast(ASGIApp, app))(
+        scope,
+        receive,
+        send,
+    )
+
+    assert observed == (scope, receive, send)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/v1/messages", "/v1/responses"])
+async def test_request_body_frames_are_relayed_once_in_order(path: str) -> None:
+    frames: asyncio.Queue[Message] = asyncio.Queue()
+    receiver_closed = asyncio.Event()
+    first = {
+        "type": "http.request",
+        "body": b"first",
+        "more_body": True,
+    }
+    second = {
+        "type": "http.request",
+        "body": b"second",
+        "more_body": False,
+    }
+    await frames.put(first)
+    await frames.put(second)
+
+    async def receive() -> Message:
+        if not frames.empty():
+            return frames.get_nowait()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            receiver_closed.set()
+        raise AssertionError("unreachable")
+
+    received: list[Message] = []
+
+    async def app(_scope: Scope, app_receive: Receive, _send: Send) -> None:
+        received.append(await app_receive())
+        received.append(await app_receive())
+
+    await InferenceRequestLifetimeMiddleware(cast(ASGIApp, app))(
+        _http_scope(path),
+        receive,
+        _unused_send,
+    )
+
+    assert received == [first, second]
+    assert receiver_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_receive_pump_buffers_only_a_bounded_number_of_frames() -> None:
+    receive_calls = 0
+    app_started = asyncio.Event()
+    stop_app = asyncio.Event()
+
+    async def receive() -> Message:
+        nonlocal receive_calls
+        receive_calls += 1
+        return {
+            "type": "http.request",
+            "body": str(receive_calls).encode(),
+            "more_body": True,
+        }
+
+    async def app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        app_started.set()
+        await stop_app.wait()
+
+    request = asyncio.create_task(
+        InferenceRequestLifetimeMiddleware(cast(ASGIApp, app))(
+            _http_scope(),
+            receive,
+            _unused_send,
+        )
+    )
+    await app_started.wait()
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert receive_calls == 2
+
+    stop_app.set()
+    await request
+
+
+type DisconnectScenario = Callable[
+    [Scope, Receive, Send],
+    Awaitable[None],
+]
+
+
+async def _run_disconnect_scenario(
+    app: DisconnectScenario,
+    ready: asyncio.Event,
+) -> list[Message]:
+    allow_disconnect = asyncio.Event()
+    body_consumed = asyncio.Event()
+    sent: list[Message] = []
+    first_receive = True
+
+    async def receive() -> Message:
+        nonlocal first_receive
+        if first_receive:
+            first_receive = False
+            body_consumed.set()
+            return {
+                "type": "http.request",
+                "body": b"{}",
+                "more_body": False,
+            }
+        await allow_disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    request = asyncio.create_task(
+        InferenceRequestLifetimeMiddleware(app)(
+            _http_scope(),
+            receive,
+            send,
+        )
+    )
+    await body_consumed.wait()
+    await ready.wait()
+    allow_disconnect.set()
+    await request
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_disconnect_before_response_start_cancels_application() -> None:
+    app_started = asyncio.Event()
+    app_closed = asyncio.Event()
+
+    async def app(_scope: Scope, app_receive: Receive, _send: Send) -> None:
+        await app_receive()
+        app_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            app_closed.set()
+
+    sent = await _run_disconnect_scenario(app, app_started)
+
+    assert sent == []
+    assert app_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_after_response_start_cancels_silent_body() -> None:
+    body_started = asyncio.Event()
+    app_closed = asyncio.Event()
+
+    async def app(_scope: Scope, app_receive: Receive, send: Send) -> None:
+        await app_receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"first",
+                "more_body": True,
+            }
+        )
+        body_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            app_closed.set()
+
+    sent = await _run_disconnect_scenario(app, body_started)
+
+    assert [message["type"] for message in sent] == [
+        "http.response.start",
+        "http.response.body",
+    ]
+    assert app_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_preserves_application_cleanup_failure() -> None:
+    app_started = asyncio.Event()
+
+    async def app(_scope: Scope, app_receive: Receive, _send: Send) -> None:
+        await app_receive()
+        app_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            raise RuntimeError("cleanup failed")
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await _run_disconnect_scenario(app, app_started)
+
+
+@pytest.mark.asyncio
+async def test_application_error_wins_and_receive_pump_is_closed() -> None:
+    receive_closed = asyncio.Event()
+
+    async def receive() -> Message:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            receive_closed.set()
+        raise AssertionError("unreachable")
+
+    async def app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        raise RuntimeError("application failed")
+
+    with pytest.raises(RuntimeError, match="application failed"):
+        await InferenceRequestLifetimeMiddleware(cast(ASGIApp, app))(
+            _http_scope(),
+            receive,
+            _unused_send,
+        )
+
+    assert receive_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_receive_error_cancels_application_and_is_preserved() -> None:
+    app_closed = asyncio.Event()
+
+    async def receive() -> Message:
+        raise RuntimeError("receive failed")
+
+    async def app(_scope: Scope, app_receive: Receive, _send: Send) -> None:
+        try:
+            await app_receive()
+        finally:
+            app_closed.set()
+
+    with pytest.raises(RuntimeError, match="receive failed"):
+        await InferenceRequestLifetimeMiddleware(cast(ASGIApp, app))(
+            _http_scope(),
+            receive,
+            _unused_send,
+        )
+
+    assert app_closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_outer_cancellation_drains_both_owned_tasks() -> None:
+    app_started = asyncio.Event()
+    app_cleanup_started = asyncio.Event()
+    app_closed = asyncio.Event()
+    receive_started = asyncio.Event()
+    receive_cleanup_started = asyncio.Event()
+    receive_closed = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+
+    async def receive() -> Message:
+        receive_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            receive_cleanup_started.set()
+            await allow_cleanup.wait()
+            receive_closed.set()
+        raise AssertionError("unreachable")
+
+    async def app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        app_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            app_cleanup_started.set()
+            await allow_cleanup.wait()
+            app_closed.set()
+
+    request = asyncio.create_task(
+        InferenceRequestLifetimeMiddleware(cast(ASGIApp, app))(
+            _http_scope(),
+            receive,
+            _unused_send,
+        )
+    )
+    await app_started.wait()
+    await receive_started.wait()
+
+    request.cancel()
+    await app_cleanup_started.wait()
+    await receive_cleanup_started.wait()
+    request.cancel()
+    allow_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await request
+
+    assert app_closed.is_set()
+    assert receive_closed.is_set()
+
+
+class _ControlledProvider:
+    def __init__(self, chunks: tuple[str, ...]) -> None:
+        self._chunks = chunks
+        self.blocked = asyncio.Event()
+        self.closed = asyncio.Event()
+        self.request_ids: list[str] = []
+
+    def preflight_stream(
+        self,
+        _request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
+    ) -> None:
+        del reasoning
+
+    async def stream_response(
+        self,
+        _request: MessagesRequest,
+        *,
+        input_tokens: int,
+        request_id: str,
+        response_model: str,
+        reasoning: ReasoningPolicy,
+    ) -> AsyncIterator[str]:
+        del input_tokens, response_model, reasoning
+        self.request_ids.append(request_id)
+        try:
+            for chunk in self._chunks:
+                yield chunk
+            self.blocked.set()
+            await asyncio.Event().wait()
+        finally:
+            self.closed.set()
+
+
+class _Lease:
+    generation_id = 1
+
+    def __init__(self, settings: Settings, provider: ProviderPort) -> None:
+        self.settings = settings
+        self._provider = provider
+        self.release_calls = 0
+
+    def is_provider_cached(self, provider_id: str) -> bool:
+        del provider_id
+        return True
+
+    def resolve_provider(self, provider_id: str) -> ProviderPort:
+        assert provider_id == "nvidia_nim"
+        return self._provider
+
+    async def release(self) -> None:
+        self.release_calls += 1
+
+
+class _Requests:
+    def __init__(self, lease: _Lease) -> None:
+        self._lease = lease
+
+    async def acquire(self) -> RequestRuntimeLease:
+        return self._lease
+
+    def current_settings(self) -> Settings:
+        return self._lease.settings
+
+    def cached_model_supports_thinking(
+        self,
+        provider_id: str,
+        model_id: str,
+    ) -> bool | None:
+        del provider_id, model_id
+        return None
+
+    def cached_prefixed_model_infos(self) -> tuple[ProviderModelInfo, ...]:
+        return ()
+
+
+def _message_start() -> str:
+    return format_sse_event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_lifetime",
+                "type": "message",
+                "role": "assistant",
+                "model": "test-model",
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        },
+    )
+
+
+def _partial_message_stream() -> tuple[str, ...]:
+    return (
+        _message_start(),
+        format_sse_event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "partial"},
+            },
+        ),
+    )
+
+
+async def _disconnect_real_app(
+    *,
+    path: str,
+    payload: dict[str, object],
+    provider: _ControlledProvider,
+) -> tuple[list[Message], _Lease]:
+    settings = Settings(provider_progress_timeout=60.0)
+    lease = _Lease(settings, cast(ProviderPort, provider))
+    requests = _Requests(lease)
+    app = create_app(
+        ApiServices(
+            requests=cast(RequestRuntimePort, requests),
+            admin=cast(AdminRuntimePort, object()),
+            tasks=cast(TaskController, object()),
+        )
+    )
+    body = json.dumps(payload).encode()
+    scope = _http_scope(path)
+    scope["headers"] = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode()),
+    ]
+    allow_disconnect = asyncio.Event()
+    sent: list[Message] = []
+    request_pending = True
+
+    async def receive() -> Message:
+        nonlocal request_pending
+        if request_pending:
+            request_pending = False
+            return {
+                "type": "http.request",
+                "body": body,
+                "more_body": False,
+            }
+        await allow_disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    async def run_app() -> None:
+        await app(scope, receive, send)
+
+    request = asyncio.create_task(run_app())
+    await asyncio.wait_for(provider.blocked.wait(), timeout=1)
+    allow_disconnect.set()
+    await asyncio.wait_for(request, timeout=1)
+    await asyncio.wait_for(provider.closed.wait(), timeout=1)
+    return sent, lease
+
+
+def _messages_payload(*, stream: bool) -> dict[str, object]:
+    return {
+        "model": "nvidia_nim/test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 32,
+        "stream": stream,
+    }
+
+
+def _responses_payload() -> dict[str, object]:
+    return {
+        "model": "nvidia_nim/test-model",
+        "input": "Hello",
+        "max_output_tokens": 32,
+        "stream": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_real_messages_disconnect_before_first_event_releases_lease() -> None:
+    provider = _ControlledProvider(())
+
+    sent, lease = await _disconnect_real_app(
+        path="/v1/messages",
+        payload=_messages_payload(stream=True),
+        provider=provider,
+    )
+
+    assert sent == []
+    assert provider.request_ids[0].startswith("req_")
+    assert lease.release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_real_messages_stream_false_disconnect_discards_partial_body() -> None:
+    provider = _ControlledProvider(_partial_message_stream())
+
+    sent, lease = await _disconnect_real_app(
+        path="/v1/messages",
+        payload=_messages_payload(stream=False),
+        provider=provider,
+    )
+
+    assert sent == []
+    assert lease.release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_real_messages_post_start_disconnect_has_no_terminal_error() -> None:
+    provider = _ControlledProvider(_partial_message_stream())
+
+    sent, lease = await _disconnect_real_app(
+        path="/v1/messages",
+        payload=_messages_payload(stream=True),
+        provider=provider,
+    )
+
+    wire = b"".join(
+        message.get("body", b"")
+        for message in sent
+        if message["type"] == "http.response.body"
+    ).decode()
+    assert any(message["type"] == "http.response.start" for message in sent)
+    assert "event: error" not in wire
+    assert "message_stop" not in wire
+    assert lease.release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_real_responses_post_start_disconnect_has_no_failed_event() -> None:
+    provider = _ControlledProvider((_message_start(),))
+
+    sent, lease = await _disconnect_real_app(
+        path="/v1/responses",
+        payload=_responses_payload(),
+        provider=provider,
+    )
+
+    wire = b"".join(
+        message.get("body", b"")
+        for message in sent
+        if message["type"] == "http.response.body"
+    ).decode()
+    assert any(message["type"] == "http.response.start" for message in sent)
+    assert "event: response.created" in wire
+    assert "response.failed" not in wire
+    assert lease.release_calls == 1

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -189,6 +189,7 @@ async def test_executor_uses_structural_provider_port_and_preflights_eagerly() -
     request = routed.request
     executor = ProviderExecutor(
         lambda _provider_id: provider,
+        progress_timeout_seconds=60.0,
         token_counter=lambda _messages, _system, _tools: 17,
     )
 
@@ -220,6 +221,7 @@ async def test_closing_executor_stream_closes_provider_stream_once() -> None:
     routed = _routed_request()
     executor = ProviderExecutor(
         lambda _provider_id: provider,
+        progress_timeout_seconds=60.0,
         token_counter=lambda _messages, _system, _tools: 17,
     )
     stream = executor.stream(
@@ -242,6 +244,7 @@ async def test_stream_construction_failure_remains_deferred_to_iteration() -> No
     provider = FailingStreamConstructionProvider()
     executor = ProviderExecutor(
         lambda _provider_id: provider,
+        progress_timeout_seconds=60.0,
         token_counter=lambda _messages, _system, _tools: 17,
     )
 
@@ -262,6 +265,7 @@ def test_executor_preflight_failure_stays_before_token_count_and_stream() -> Non
     token_counter = MagicMock(return_value=17)
     executor = ProviderExecutor(
         lambda _provider_id: provider,
+        progress_timeout_seconds=60.0,
         token_counter=token_counter,
     )
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -33,6 +33,7 @@ def test_settings_defaults_are_valid_and_nonempty() -> None:
     assert settings.provider_rate_limit == 1
     assert settings.provider_rate_window == 2
     assert settings.provider_max_concurrency == 2
+    assert settings.provider_progress_timeout == 600.0
     assert settings.http_read_timeout == 120.0
     assert settings.http_write_timeout == 10.0
     assert settings.http_connect_timeout == HTTP_CONNECT_TIMEOUT_DEFAULT
@@ -80,6 +81,12 @@ def test_direct_settings_construction_performs_no_environment_io(
     [
         ("MODEL", "model", "deepseek/deepseek-chat", "deepseek/deepseek-chat"),
         ("PROVIDER_RATE_LIMIT", "provider_rate_limit", "20", 20),
+        (
+            "PROVIDER_PROGRESS_TIMEOUT",
+            "provider_progress_timeout",
+            "900",
+            900.0,
+        ),
         ("HTTP_READ_TIMEOUT", "http_read_timeout", "600", 600.0),
         ("FCC_OPEN_BROWSER", "open_admin_browser", "false", False),
         ("REASONING_POLICY", "reasoning_policy", "off", ReasoningPreference.OFF),
@@ -97,6 +104,21 @@ def test_process_values_are_parsed_at_the_loader_boundary(
 
     assert getattr(snapshot.settings, attribute) == expected
     assert snapshot.sources[attribute] is ConfigSource.PROCESS
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0.0, -1.0, float("inf"), float("-inf"), float("nan")],
+)
+def test_provider_progress_timeout_must_be_finite_and_positive(value: float) -> None:
+    with pytest.raises(ValidationError):
+        Settings(provider_progress_timeout=value)
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "inf", "-inf", "nan"])
+def test_loader_rejects_invalid_provider_progress_timeout(value: str) -> None:
+    with pytest.raises(ValidationError):
+        compose_settings_snapshot({}, {"PROVIDER_PROGRESS_TIMEOUT": value})
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.6.2"
+version = "5.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC used a hardcoded four-minute provider-progress deadline based on assumed client timeouts. Slow models could be terminated while disconnected clients left provider work running until that deadline. Fixes #1447. Fixes #1457.

## Changes

| Before | After |
| --- | --- |
| Provider progress was fixed at 240 seconds. | `PROVIDER_PROGRESS_TIMEOUT` defaults to 600 seconds and can be hot-applied from Admin or environment configuration. |
| Silent client disconnects were not observed across every inference phase. | A pure-ASGI boundary cancels Messages and Responses work before streaming, during non-streaming aggregation, and after stream commitment. |
| Progress, HTTP read, and client timeout ownership were coupled in architecture guidance. | Each timeout has one explicit owner while existing retries, wire errors, and cleanup remain unchanged. |
| Disconnect lifecycle coverage stopped at isolated response behavior. | Deterministic ASGI, full-app, and live provider tests prove cancellation, provider closure, request correlation, one-time lease release, and healthy follow-up requests. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes Messages and Responses inference work stop when its client disconnects, avoiding continued provider work after an abandoned request. It also adds a validated provider-progress timeout with a 600-second default and makes it configurable through environment values and Admin settings.

Verified request-body relaying, disconnect handling before and after response output begins, cancellation cleanup, request-lease release, and timeout propagation to both API handlers. The exercised paths completed successfully and no defects were found.
</details>

<h3>Confidence Score: 5/5</h3>

The reviewed inference lifetime and timeout configuration changes are safe to merge based on the exercised behavior.

Focused execution covered the new ASGI cancellation boundary, body-frame relay, cleanup under repeated cancellation, real Messages and Responses disconnect behavior, configuration validation, and runtime timeout injection into both handlers; no actionable failure was observed.

**Files Needing Attention:** No files need follow-up based on the verified paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused pytest suite covering ASGI body-frame relaying, disconnect cancellation before and after response output, repeated cancellation cleanup, real Messages and Responses provider-stream cancellation, timeout validation, and handler behavior, with 96 tests passing.
- Performed a before-and-after runtime probe showing the new configured timeout is absent from the baseline and reaches both default API executors within 0.02 seconds.
- Documented exact execution commands, working directories, and exit codes at the top of each log artifact, and summarized that request-body frames are preserved, disconnect cancels streams, repeated outer cancellations drain owned tasks, and the timeout is included in both default API handlers.

<a href="https://app.greptile.com/trex/runs/19340093/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Own inference request lifetimes"](https://github.com/alishahryar1/free-claude-code/commit/2aec4168172804b602eacf2e33325767f8b32d95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54237553)</sub>

<!-- /greptile_comment -->