### PR TITLE
Stabilize NVIDIA NIM smoke coverage and local CI isolation

### DIFF
--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -96,7 +96,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
 MISTRAL_REASONING_SMOKE_DEFAULT_MODEL = "mistral/mistral-medium-3-5"
 
 NVIDIA_NIM_CLI_DEFAULT_MODELS: tuple[str, ...] = (
-    "z-ai/glm-5.2",
+    "nvidia/nemotron-3.5-lightning-30b-a3b",
     "moonshotai/kimi-k2.6",
     "minimaxai/minimax-m2.7",
     "minimaxai/minimax-m3",

--- a/smoke/product/test_nvidia_nim_cli_product_live.py
+++ b/smoke/product/test_nvidia_nim_cli_product_live.py
@@ -36,6 +36,7 @@ def test_nvidia_nim_cli_matrix_e2e(smoke_config: SmokeConfig, tmp_path: Path) ->
                 "MODEL": provider_model.full_model,
                 "MESSAGING_PLATFORM": "none",
                 "REASONING_POLICY": "high",
+                "LOG_LEVEL": "DEBUG",
                 "LOG_RAW_API_PAYLOADS": "true",
                 "LOG_RAW_SSE_EVENTS": "true",
             },

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -978,7 +978,7 @@ def test_smoke_config_returns_nvidia_nim_cli_provider_models(monkeypatch) -> Non
     models = config.nvidia_nim_cli_models()
 
     assert models[0].provider == "nvidia_nim"
-    assert models[0].full_model == "nvidia_nim/z-ai/glm-5.2"
+    assert models[0].full_model == f"nvidia_nim/{NVIDIA_NIM_CLI_DEFAULT_MODELS[0]}"
     assert models[0].source == "nvidia_nim_cli_default"
 
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1994,21 +1994,7 @@ def test_install_ps1_stops_without_success_on_each_failure(
 def test_install_ps1_dry_run_never_executes_commands(
     powershell_harness: PowerShellHarness,
 ) -> None:
-    result = subprocess.run(
-        [
-            powershell_harness.powershell,
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            str(_repo_root() / "scripts" / "install.ps1"),
-            "-DryRun",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-        env=powershell_harness.env,
-    )
+    result = powershell_harness.run("-DryRun")
 
     assert result.returncode == 0, result.stderr
     assert powershell_harness.calls() == []

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -528,6 +528,19 @@ function Remove-Item {
     }
     Microsoft.PowerShell.Management\Remove-Item @PSBoundParameters
 }
+function Get-Process {
+    [CmdletBinding()]
+    param([string[]] $Name)
+
+    if ([string]::IsNullOrWhiteSpace($env:FCC_RUNNING_COMMAND)) {
+        return
+    }
+    foreach ($requestedName in $Name) {
+        if ($requestedName -eq $env:FCC_RUNNING_COMMAND) {
+            [pscustomobject] @{ Id = 4242; ProcessName = $requestedName }
+        }
+    }
+}
 $installer = [scriptblock]::Create([IO.File]::ReadAllText($env:FCC_UNINSTALLER))
 if ($env:UNINSTALL_DRY_RUN -eq "1") {
     & $installer -DryRun
@@ -569,6 +582,7 @@ else {
             "CALL_LOG": str(log),
             "FAKE_TOOL_BIN": str(tool_bin),
             "FCC_UNINSTALLER": str(_repo_root() / "scripts" / "uninstall.ps1"),
+            "FCC_RUNNING_COMMAND": "",
             "FAIL_STEP": "",
             "UNINSTALL_DRY_RUN": "0",
         }
@@ -694,6 +708,25 @@ def test_uninstall_ps1_dry_run_is_non_mutating(
     )
     assert powershell_uninstall_harness.calls() == []
     assert "Dry run complete. No changes were made." in result.stdout
+
+
+@pytest.mark.parametrize("command_name", FCC_COMMANDS)
+def test_uninstall_ps1_rejects_running_fcc_before_mutation(
+    powershell_uninstall_harness: PowerShellUninstallHarness,
+    command_name: str,
+) -> None:
+    powershell_uninstall_harness.env["FCC_RUNNING_COMMAND"] = command_name
+
+    result = powershell_uninstall_harness.run()
+
+    assert result.returncode != 0
+    assert command_name in result.stderr
+    assert powershell_uninstall_harness.fcc_home.exists()
+    assert all(
+        (powershell_uninstall_harness.tool_bin / f"{name}.cmd").exists()
+        for name in FCC_COMMANDS
+    )
+    assert powershell_uninstall_harness.calls() == []
 
 
 def test_uninstallers_guard_running_commands_and_preserve_shared_owners() -> None:


### PR DESCRIPTION
## Problem

The NVIDIA NIM CLI smoke started with an overloaded model, and INFO logging hid successful subagent evidence. Windows installer tests also inspected the developer process table, so local CI failed whenever FCC was running.

## Changes

| Before | After |
| --- | --- |
| The NIM CLI matrix started with `z-ai/glm-5.2`. | The matrix starts with the verified Nemotron 3.5 Lightning model. |
| INFO-level logs could hide Agent catalog evidence from live assertions. | The NIM CLI matrix captures DEBUG-level evidence. |
| The smoke contract duplicated a concrete default model slug. | The contract derives the expected slug from the canonical default. |
| PowerShell dry-run and uninstaller tests could detect real FCC processes. | PowerShell test harnesses own deterministic process state and retain explicit guard coverage. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change updates the default NVIDIA NIM smoke model, enables DEBUG-level logging for live NIM runs, and makes the PowerShell installer and uninstaller test harnesses independent of processes running on the developer machine. The NIM configuration contract passed before and after the change with 61 passing tests, and the portable installer/uninstaller script suite passed with 97 tests.

### T-Rex validation blocked
- **Missing credential:** `NVIDIA_NIM_API_KEY` is not configured, so the live NVIDIA NIM provider request could not be run.
- **Missing tool:** Windows PowerShell (`pwsh`/`powershell`) is unavailable on this Linux runner, so the native Windows installer and uninstaller paths could not be executed.
</details>

<h3>Confidence Score: 5/5</h3>

No actionable defect was found in the changed code, and the executable targeted coverage passed.

The NIM model configuration contract passed before and after the change, the portable installer and uninstaller suites passed, and inspection confirmed that the uninstaller process guard precedes destructive operations. Live provider execution and native PowerShell execution were unavailable due to missing environment prerequisites, but no failure was observed.

**Files Needing Attention:** No files require changes from this review. Live provider behavior in `smoke/product/test_nvidia_nim_cli_product_live.py` and native PowerShell behavior in `tests/scripts/test_installers.py` and `tests/scripts/test_uninstallers.py` can be exercised in environments with the required credential and Windows PowerShell.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The NIM configuration contract suite was run before and after the commit; both runs reported 61 passing tests, confirming the default-model configuration remained normalized.
- The live NIM smoke entry point was attempted but skipped due to missing NVIDIA\_NIM\_API\_KEY, blocking live smoke execution in this environment.
- The installer and uninstaller script suites were executed; 97 tests passed, while native PowerShell tests were skipped on this Linux runner due to the absence of Windows PowerShell.
- The targeted PowerShell guard selection was run; all 19 parameterized cases were skipped for the same Windows PowerShell prerequisite reason.

<a href="https://app.greptile.com/trex/runs/19350732/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Isolate PowerShell installer tests from ..."](https://github.com/alishahryar1/free-claude-code/commit/2789138ff6b5f572ce30bfe59b56682f76533d0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54261579)</sub>

<!-- /greptile_comment -->