### PR TITLE
Link README products to official resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
 ## What You Get
 
 - **48 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
-- **5 coding agents. One model catalog.** Run Claude Code, Codex, Pi, OpenCode, or Cline with your FCC models.
+- **5 coding agents. One model catalog.** Run [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://github.com/openai/codex), [Pi](https://github.com/earendil-works/pi), [OpenCode](https://github.com/anomalyco/opencode), or [Cline](https://github.com/cline/cline) with your FCC models.
 - **Keep coding through provider outages.** After retries are exhausted, FCC automatically tries your next configured model without making you restart the turn—across every client.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
-- **Terminal, desktop, IDE, or phone.** Work through native launchers, VS Code, Codex App, JetBrains, Discord, or Telegram.
-- **Voice notes in. Code out.** Talk to your agent using local Whisper or NVIDIA NIM transcription.
-- **Agent capabilities stay intact.** Stream responses, use tools, preserve native interleaved thinking for maximum performance, send images, and route Fable, Opus, Sonnet, and Haiku independently with compatible models.
+- **Terminal, desktop, IDE, or phone.** Work through native launchers, [VS Code](https://code.visualstudio.com/), [Codex App](https://learn.chatgpt.com/docs/app), [JetBrains](https://www.jetbrains.com/), [Discord](https://discord.com/), or [Telegram](https://telegram.org/).
+- **Voice notes in. Code out.** Talk to your agent using local [Whisper](https://github.com/openai/whisper) or [NVIDIA NIM](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/whisper.html) transcription.
+- **Agent capabilities stay intact.** Stream responses, use tools, preserve native interleaved thinking for maximum performance, send images, and route [Fable](https://www.anthropic.com/claude/fable), [Opus](https://www.anthropic.com/claude/opus), [Sonnet](https://www.anthropic.com/claude/sonnet), and [Haiku](https://www.anthropic.com/claude/haiku) independently with compatible models.
 
 Free-tier availability and limits are controlled by each provider and may change.
 


### PR DESCRIPTION
## Problem

The README names supported coding agents and integrations without linking readers to their official resources.

## Changes

| Before | After |
| --- | --- |
| Supported coding agents appeared as plain text. | Each supported coding agent links to its official documentation or repository. |
| Client surfaces, messaging platforms, transcription backends, and Claude tiers appeared as plain text. | Each named product links to its official resource. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This README-only update links supported coding agents, client surfaces, transcription backends, and Claude model tiers to their official resources. Link validation checked all 16 newly added destinations: each resolved successfully after redirects with an HTTP 200 response, and the updated Markdown rendered all 16 link labels without formatting or whitespace errors. No broken-link issue was found.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the README links are reachable and the Markdown is correctly formed.

The changed README lines were checked against the prior revision, including redirect-aware HTTP requests for every new URL and Markdown-format validation; no defects remain.

**Files Needing Attention:** None. README.md was the only changed file and its added links were verified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the readme links validator against revision f0430594542a016e429493e0b80fa75a0344abcc and observed zero added lines and exit code 0.
- Reran the validator against HEAD and observed four added lines, 16 links, 16 renderable hrefs, HTTP 200 for every checked resource, markdown\_format=OK, and exit code 0.
- The before-state and after-state outputs, along with the validator source, are captured as artifacts for audit.
- Artifacts were prepared and uploaded to accompany the proof for review.

<a href="https://app.greptile.com/trex/runs/19374382/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Link README product names"](https://github.com/alishahryar1/free-claude-code/commit/5efe11ecdf25bcf98581535c92338fe53232ce8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54310412)</sub>

<!-- /greptile_comment -->