### PR TITLE
Add Anthropic trademark disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 
 </div>
 
+<p align="center">
+  <em>Independent open-source project. Not affiliated with or endorsed by Anthropic. Claude and Claude Code are trademarks of Anthropic.</em>
+</p>
+
 ## What You Get
 
 - **48 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.


### PR DESCRIPTION
## Problem

The project uses Claude and Claude Code branding without explicitly distinguishing itself from Anthropic.

## Changes

| Before | After |
| --- | --- |
| The README did not state the project's relationship to Anthropic. | The README identifies FCC as independent and attributes the Claude trademarks to Anthropic. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a centered statement clarifying that Free Claude Code is an independent open-source project, is not affiliated with or endorsed by Anthropic, and that Claude and Claude Code are Anthropic trademarks.

The README opening was checked before and after the change. The potential rendering issue was disproved: the disclaimer is a balanced centered HTML block, appears after the closed hero and navigation section, and precedes the first content heading. The exact README diff also passed whitespace validation.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the documentation addition preserves the README’s opening structure and rendering boundaries.

A focused before-and-after structural check confirmed the disclaimer is balanced, centered, and placed outside the closed hero block; the exact diff has no whitespace errors.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the README hero validation script for the base and HEAD revisions to compare the opening structure.
- Observed that the base version had no disclaimer and the hero div was balanced, while HEAD adds a centered disclaimer after the hero and before the first content heading.
- Executed git diff --check across 5610907...HEAD and confirmed there were no whitespace errors.
- In the second validation pass, the base run shows no disclaimer and the HEAD run confirms the disclaimer on line 23 with balanced HTML events and placement after the closing hero div.
- The second diff check reports no whitespace errors, aligning the two revisions structurally.

<a href="https://app.greptile.com/trex/runs/19508836/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Anthropic trademark disclaimer"](https://github.com/alishahryar1/free-claude-code/commit/8c74d1e8947066e3386faba810be26b5c40442d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54567604)</sub>

<!-- /greptile_comment -->