### PR TITLE
Restore the 5.8.2 release bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.8.1"
+version = "5.8.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.8.1"
+version = "5.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

PR #1471 changed production provider behavior without advancing the package version, leaving the new behavior published under `5.8.1`.

## Changes

| Before | After |
| --- | --- |
| The OpenCode user-agent change remained under `5.8.1`. | The package and lockfile advance to `5.8.2`. |
| Release metadata did not identify the provider behavior change. | The corrected patch release has distinct version metadata. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change advances the package release metadata from 5.8.1 to 5.8.2 in both the project manifest and editable lockfile. Version consistency and lock acceptance were exercised: both metadata sources report 5.8.2, `uv lock --check` accepted the lockfile, and the focused version and uv-policy tests passed (8 tests). No issues were found.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release metadata is consistent and the locked installation validation succeeded.

The change only updates package release metadata. Direct comparison confirmed matching versions, and the lockfile and focused metadata-policy checks completed successfully.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the project manifest and editable lock metadata both report free-claude-code version 5.8.2, then ran uv lock --check and uv run --locked pytest for the specified tests, and observed the lock check exit cleanly with all eight tests passing.
- Confirmed there were no changes to tracked files and that only untracked evidence files were created, with the run in /home/user/repo completing and reporting lock=0 and tests=0.

<a href="https://app.greptile.com/trex/runs/19556232/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump version to 5.8.2"](https://github.com/alishahryar1/free-claude-code/commit/588142187f06aa167ce5147b52e73a40938a309b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54664098)</sub>

<!-- /greptile_comment -->