### PR TITLE
Feature/poolside support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,10 @@ VERTEX_LOCATION="global"
 # OLLAMA_API_KEY=<your-token>
 
 
+# Poolside AI (OpenAI-compatible Chat Completions at inference.poolside.ai/v1)
+# POOLSIDE_API_KEY=<your-token>
+
+
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
@@ -187,7 +191,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # Default model and optional Claude tier overrides
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "poolside"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -313,6 +317,7 @@ REASONING_HAIKU=inherit
 # KILO_PROXY=<http-or-socks-url>
 # CEREBRAS_PROXY=<http-or-socks-url>
 # OLLAMA_CLOUD_PROXY=<http-or-socks-url>
+# POOLSIDE_PROXY=<http-or-socks-url>
 
 PROVIDER_RATE_LIMIT=1
 PROVIDER_RATE_WINDOW=2

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ from more than one provider before succeeding.
 | [LM Studio](https://lmstudio.ai/) | `LM_STUDIO_BASE_URL` | `lmstudio/<model-id>` |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | `LLAMACPP_BASE_URL` | `llamacpp/<model-id>` |
 | [Ollama](https://ollama.com/) | `OLLAMA_BASE_URL` | `ollama/<model-tag>` |
+| [Poolside AI](https://inference.poolside.ai/) | `POOLSIDE_API_KEY` | `poolside/<model-name>` |
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.9.0"
+version = "5.8.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.8.2"
+version = "5.9.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -83,6 +83,8 @@ AGNES_DEFAULT_BASE = "https://apihub.agnes-ai.com/v1"
 ZENMUX_DEFAULT_BASE = "https://zenmux.ai/api/v1"
 # W&B Serverless Inference OpenAI-compatible API.
 WANDB_INFERENCE_DEFAULT_BASE = "https://api.inference.wandb.ai/v1"
+# Poolside AI OpenAI-compatible Chat Completions API.
+POOLSIDE_DEFAULT_BASE = "https://inference.poolside.ai/v1"
 
 
 class ProviderAuthKind(StrEnum):
@@ -561,6 +563,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=OLLAMA_DEFAULT_BASE,
         base_url_attr="ollama_base_url",
         local=True,
+    ),
+    "poolside": ProviderDescriptor(
+        provider_id="poolside",
+        display_name="Poolside AI",
+        credential_env="POOLSIDE_API_KEY",
+        credential_url="https://inference.poolside.ai/",
+        credential_attr="poolside_api_key",
+        default_base_url=POOLSIDE_DEFAULT_BASE,
+        proxy_attr="poolside_proxy",
     ),
 }
 

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -307,6 +307,11 @@ class Settings(BaseModel):
         default=None, validation_alias="OLLAMA_API_KEY"
     )
 
+    # ==================== Poolside AI (OpenAI-compatible) ====================
+    poolside_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="POOLSIDE_API_KEY"
+    )
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord" | "none"
     messaging_platform: NonEmptyString = Field(
@@ -508,6 +513,9 @@ class Settings(BaseModel):
     )
     ollama_cloud_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="OLLAMA_CLOUD_PROXY"
+    )
+    poolside_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="POOLSIDE_PROXY"
     )
 
     # ==================== Provider Rate Limiting ====================

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -656,4 +656,11 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         normalize_base_url=True,
         reasoning_delta_field="reasoning",
     ),
+    "poolside": OpenAIChatProfile(
+        _policy(
+            "POOLSIDE",
+            ReasoningReplayMode.REASONING_CONTENT,
+        ),
+        NO_REASONING,
+    ),
 }

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -54,6 +54,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "lmstudio",
     "llamacpp",
     "ollama",
+    "poolside",
 )
 
 

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -25,6 +25,7 @@ from free_claude_code.config.provider_catalog import (
     NARAROUTE_DEFAULT_BASE,
     NEBIUS_DEFAULT_BASE,
     OLLAMA_CLOUD_DEFAULT_BASE,
+    POOLSIDE_DEFAULT_BASE,
     PROVIDER_CATALOG,
     QWENCLOUD_CODING_DEFAULT_BASE,
     QWENCLOUD_DEFAULT_BASE,
@@ -107,6 +108,7 @@ def _make_settings(**overrides):
     mock.llamacpp_base_url = "http://localhost:8080/v1"
     mock.ollama_base_url = "http://localhost:11434"
     mock.ollama_api_key = "test_ollama_cloud_key"
+    mock.poolside_api_key = "test_poolside_key"
     mock.nvidia_nim_proxy = None
     mock.open_router_proxy = None
     mock.lmstudio_proxy = None
@@ -152,6 +154,7 @@ def _make_settings(**overrides):
     mock.cerebras_api_key = ""
     mock.cerebras_proxy = None
     mock.ollama_cloud_proxy = None
+    mock.poolside_proxy = None
     mock.kilo_api_key = "test_kilo_key"
     mock.kilo_proxy = None
     mock.openai_proxy = None
@@ -231,6 +234,30 @@ def test_ollama_cloud_provider_config_uses_key_and_proxy():
     assert config.api_key == "ollama-cloud-token"
     assert config.base_url == OLLAMA_CLOUD_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
+
+
+def test_poolside_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["poolside"]
+    settings = _make_settings(
+        poolside_api_key="poolside-token",
+        poolside_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("poolside", settings)
+
+    assert descriptor.display_name == "Poolside AI"
+    assert descriptor.credential_env == "POOLSIDE_API_KEY"
+    assert descriptor.credential_attr == "poolside_api_key"
+    assert descriptor.credential_url == "https://inference.poolside.ai/"
+    assert descriptor.default_base_url == POOLSIDE_DEFAULT_BASE
+    assert descriptor.base_url_attr is None
+    assert descriptor.proxy_attr == "poolside_proxy"
+    assert config.api_key == "poolside-token"
+    assert config.base_url == POOLSIDE_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
 
 
 def test_xai_provider_config_uses_key_base_and_proxy() -> None:
@@ -843,6 +870,7 @@ def test_create_provider_instantiates_each_builtin():
         "ollama_cloud": OpenAIChatProvider,
         "wafer": OpenAIChatProvider,
         "opencode_zen": OpenAIChatProvider,
+        "poolside": OpenAIChatProvider,
         "opencode_go": OpenAIChatProvider,
         "vercel": OpenAIChatProvider,
         "bedrock": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.8.2"
+version = "5.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.9.0"
+version = "5.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
I just added Poolside AI API support for [Poolside Console](https://platform.poolside.ai/) users.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Poolside as an OpenAI-compatible provider, including endpoint registration, credential and proxy configuration, runtime profile support, documentation, and contract coverage. Project metadata and the editable lockfile are synchronized.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the lock validation script to compare project metadata and the editable lockfile against the UV lock check, and confirmed 5.8.3 in both records with one editable root-package and UV\_LOCK\_CHECK\_EXIT\_CODE 0 after resolving 154 packages.
- Documented the exact current values used by the validation: pyproject.toml project.version is 5.8.3; uv.lock contains one free-claude-code record with version 5.8.3 and source set to {'editable': '.'}, and the run reported Resolved 154 packages with UV\_LOCK\_CHECK\_EXIT\_CODE 0.

<a href="https://app.greptile.com/trex/runs/19647181/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fixed version bump to minor (5.8.3) with..."](https://github.com/alishahryar1/free-claude-code/commit/f7f54735e60733d54de298669cc6cb3eed07e50c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54846722)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->