### PR TITLE
Add DeepSeek Harness as an FCC coding agent

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ and how contributors should extend it.
 
 Free Claude Code is a local proxy for agent clients. It accepts Anthropic
 Messages traffic from Claude Code and Pi clients and OpenAI Responses traffic
-from Codex, OpenCode, Cline, and Hermes clients, routes the request to a
+from Codex, OpenCode, Cline, Hermes, and DeepSeek Harness clients, routes the request to a
 configured upstream provider, and preserves the wire protocol expected by the
 caller.
 
@@ -21,7 +21,7 @@ There are three runtime surfaces:
 - HTTP proxy: FastAPI routes expose Anthropic-compatible, Responses-compatible,
   health, model-listing, stop, and admin endpoints.
 - CLI launchers: wrapper entrypoints prepare Claude Code, Codex, Pi, OpenCode,
-  Cline, and Hermes sessions so they target the local proxy.
+  Cline, Hermes, and DeepSeek Harness sessions so they target the local proxy.
 - Messaging bridge: optional Discord or Telegram adapters turn chat messages
   into managed client CLI sessions.
 
@@ -33,6 +33,7 @@ flowchart LR
     OpenCode[OpenCode CLI] --> ProxyAPI
     Cline[Cline CLI] --> ProxyAPI
     Hermes[Hermes Agent] --> ProxyAPI
+    DSH[DeepSeek Harness] --> ProxyAPI
     AdminUI[Local Admin UI] --> ProxyAPI
     Bots[Discord or Telegram Bots] --> Messaging[Messaging Bridge]
     Messaging --> ClientCLI[Managed Client CLI Sessions]
@@ -181,6 +182,9 @@ for real prompts against supported providers:
 - `fcc-hermes`, Hermes Agent 0.20.4 or newer, and the OpenAI Responses behavior
   it relies on for attached terminal sessions, including an FCC-scoped model
   catalog and process-local managed configuration.
+- `fcc-dsh`, DeepSeek Harness 0.1.0-rc.8, and the OpenAI Responses behavior it
+  relies on for attached Web and headless sessions, including an FCC-scoped
+  model catalog and process-local configuration.
 - Configured Discord and Telegram messaging bridges, including command handling,
   reply-based conversation branches, status updates, transcript rendering,
   managed Claude/Codex task execution where configured, task stop/clear flows,
@@ -238,6 +242,7 @@ Console scripts are registered in [pyproject.toml](pyproject.toml):
 - `fcc-opencode` calls `free_claude_code.cli.launchers.opencode:launch`.
 - `fcc-cline` calls `free_claude_code.cli.launchers.cline:launch`.
 - `fcc-hermes` calls `free_claude_code.cli.launchers.hermes:launch`.
+- `fcc-dsh` calls `free_claude_code.cli.launchers.dsh:launch`.
 
 [scripts/install.sh](scripts/install.sh) and [scripts/install.ps1](scripts/install.ps1)
 install or update the uv tool plus optional voice extras. On Windows the
@@ -246,7 +251,7 @@ per-user application bundle and desktop link. [scripts/uninstall.sh](scripts/uni
 and [scripts/uninstall.ps1](scripts/uninstall.ps1) remove those exact desktop
 artifacts, the FCC uv tool, and the managed `~/.fcc/` tree from
 [config/paths.py](src/free_claude_code/config/paths.py); they do not remove
-uv, Claude Code, Codex, Pi, OpenCode, Cline, Hermes, or uv-managed Python runtimes. [scripts/ci.sh](scripts/ci.sh) and
+uv, Claude Code, Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, or uv-managed Python runtimes. [scripts/ci.sh](scripts/ci.sh) and
 [scripts/ci.ps1](scripts/ci.ps1) mirror [.github/workflows/tests.yml](.github/workflows/tests.yml)
 for local pre-push verification.
 
@@ -1284,8 +1289,9 @@ client environment.
 owns the client-neutral projection from FCC's `/v1/models` response to direct,
 nested `provider/model` routes. It removes Claude-only compatibility aliases,
 deduplicates normal and no-thinking forms deterministically, and is shared by
-Codex, OpenCode, Cline, and Hermes. Each launcher remains responsible for translating those
-neutral entries into its client's configuration format.
+Codex, OpenCode, Cline, Hermes, and DeepSeek Harness. Each launcher remains
+responsible for translating those neutral entries into its client's
+configuration format.
 
 [cli/launchers/pi.py](src/free_claude_code/cli/launchers/pi.py) owns the installed
 `fcc-pi` launcher and [cli/launchers/pi_extension.ts](src/free_claude_code/cli/launchers/pi_extension.ts)
@@ -1378,6 +1384,31 @@ own the installed `fcc-hermes` launcher for Hermes Agent 0.20.4 or newer:
   A deliberate in-session `/model` switch is an explicit opt-out; Hermes has no
   process-wide provider lock for every plugin or future subsystem.
 
+[cli/launchers/dsh.py](src/free_claude_code/cli/launchers/dsh.py) and
+[cli/launchers/dsh_config.py](src/free_claude_code/cli/launchers/dsh_config.py)
+own the installed `fcc-dsh` launcher for DeepSeek Harness 0.1.0-rc.8:
+
+- Only the shipped attached Web and headless profiles route through FCC. Bare
+  `fcc-dsh` selects Web; native help, version, profile dumps, and plugin
+  management pass through without requiring FCC.
+- Routed sessions require an exact audited DSH version, a reachable FCC server,
+  a canonical proxy token, and a non-empty routable `/v1/models` snapshot.
+  Preparation is fail-closed.
+- Each invocation writes private temporary settings, credentials, and patch
+  files. The patch configures DSH's existing `openai-responses` transport for
+  FCC's `/v1` endpoint and explicit model snapshot; the bearer token remains in
+  a child-only environment variable. `DSH_HOME`, sessions, presets, attachments,
+  and plugins remain DSH-owned.
+- The native DeepSeek model adapter, native model-backed Web search, and bundled
+  Web tool are disabled for the FCC session. DSH provider retries are set to
+  zero so `ProviderExecutor` alone owns retries and ordered model fallback. The
+  DSH stream-idle timeout is derived from FCC's provider progress timeout with
+  a shutdown margin.
+- The exact pre-release gate is intentional because DSH declares breaking
+  preview changes. Third-party DSH plugins remain capable of their own network
+  activity; `fcc-dsh` owns the configured model route, not a general plugin
+  sandbox.
+
 [cli/managed/](src/free_claude_code/cli/managed/) owns managed Claude Code subprocesses used by
 Discord and Telegram messaging. Managed task invocations extend the same proxy
 environment only with non-interactive terminal settings, optional `--resume`,
@@ -1401,9 +1432,10 @@ reports a count-only failure, and leaves failures available for the next cleanup
 attempt. Real-session registration is collision-safe and becomes durable tree
 state only after the manager accepts it.
 
-Codex, Pi, OpenCode, Cline, and Hermes are supported through their installed launchers. FCC
-does not keep internal managed session runners for them because no user-facing
-messaging setting selects those clients for Discord or Telegram.
+Codex, Pi, OpenCode, Cline, Hermes, and DeepSeek Harness are supported through
+their installed launchers. FCC does not keep internal managed session runners
+for them because no user-facing messaging setting selects those clients for
+Discord or Telegram.
 
 ## Messaging Architecture
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## What You Get
 
 - **48 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
-- **6 coding agents. One model catalog.** Run [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://github.com/openai/codex), [Pi](https://github.com/earendil-works/pi), [OpenCode](https://github.com/anomalyco/opencode), [Cline](https://github.com/cline/cline), or [Hermes](https://github.com/NousResearch/hermes-agent) with your FCC models.
+- **7 coding agents. One model catalog.** Run [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://github.com/openai/codex), [Pi](https://github.com/earendil-works/pi), [OpenCode](https://github.com/anomalyco/opencode), [Cline](https://github.com/cline/cline), [Hermes](https://github.com/NousResearch/hermes-agent), or [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) with your FCC models.
 - **Keep coding through provider outages.** After retries are exhausted, FCC automatically tries your next configured model without making you restart the turn—across every client.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
 - **Terminal, desktop, IDE, or phone.** Work through native launchers, [VS Code](https://code.visualstudio.com/), [Codex App](https://learn.chatgpt.com/docs/app), [JetBrains](https://www.jetbrains.com/), [Discord](https://discord.com/), or [Telegram](https://telegram.org/).
@@ -137,7 +137,19 @@ Hermes:
 fcc-hermes
 ```
 
-All six launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
+DeepSeek Harness Web:
+
+```bash
+fcc-dsh
+```
+
+DeepSeek Harness headless:
+
+```bash
+fcc-dsh --profile headless "your task"
+```
+
+All seven launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
 
 ```bash
 fcc-codex exec "hello"
@@ -146,6 +158,9 @@ fcc-codex exec "hello"
 FCC launchers leave your existing agent settings, sessions, credentials, and
 extensions unchanged. `fcc-hermes` starts attached sessions through FCC; choosing
 another provider with Hermes `/model` intentionally leaves the FCC route.
+`fcc-dsh` keeps DeepSeek Harness sessions and plugins while applying temporary
+FCC provider settings. It currently supports the preview release `0.1.0-rc.8`
+on Node.js `^22.19` or `>=24`.
 
 <a id="model-picker"></a>
 
@@ -295,7 +310,7 @@ Open **Admin UI → Model Config → Reasoning** and select the behavior you wan
 
 | Selection | Behavior |
 | --- | --- |
-| **From client** (default) | Use the effort sent by Claude Code, Codex, Pi, OpenCode, Cline, or Hermes. If none is sent, keep the provider default. |
+| **From client** (default) | Use the effort sent by Claude Code, Codex, Pi, OpenCode, Cline, Hermes, or DeepSeek Harness. If none is sent, keep the provider default. |
 | **Off** | Request reasoning to be disabled. |
 | **Low**, **Medium**, **High**, **X-High**, or **Max** | Override the client with the selected reasoning level. |
 | **Inherit** (Fable, Opus, Sonnet, and Haiku only) | Use the root Reasoning selection. |
@@ -309,7 +324,7 @@ Providers that do not support a selected control retain their own behavior.
 ## Connect Your Client
 
 For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`,
-`fcc-pi`, `fcc-opencode`, `fcc-cline`, or `fcc-hermes`. Use the guides below for editor integrations.
+`fcc-pi`, `fcc-opencode`, `fcc-cline`, `fcc-hermes`, or `fcc-dsh`. Use the guides below for editor integrations.
 
 <details>
 <summary><strong>Claude Code in VS Code</strong></summary>
@@ -546,7 +561,7 @@ Stop every running FCC command before uninstalling.
 **Keeps**
 
 - uv and Python
-- Claude Code, Codex, Pi, OpenCode, Cline, Hermes, and RTK
+- Claude Code, Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, and RTK
 - Shared PATH entries
 
 macOS/Linux:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.9.0"
+version = "5.10.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -36,6 +36,7 @@ fcc-pi = "free_claude_code.cli.launchers.pi:launch"
 fcc-opencode = "free_claude_code.cli.launchers.opencode:launch"
 fcc-cline = "free_claude_code.cli.launchers.cline:launch"
 fcc-hermes = "free_claude_code.cli.launchers.hermes:launch"
+fcc-dsh = "free_claude_code.cli.launchers.dsh:launch"
 
 [project.gui-scripts]
 fcc-desktop = "free_claude_code.cli.desktop_entrypoint:launch"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -26,6 +26,8 @@ $MinOpenCodeVersion = "1.18.18"
 $MinClineVersion = "3.0.55"
 $HermesInstallUrl = "https://hermes-agent.nousresearch.com/install.ps1"
 $MinHermesVersion = "0.20.4"
+$DshVersion = "0.1.0-rc.8"
+$DshPackage = "@deepseek-ai/dsh@$DshVersion"
 $RtkVersion = "0.44.2"
 $RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/download/v$RtkVersion"
 $RtkWindowsAssetName = "rtk-x86_64-pc-windows-msvc.zip"
@@ -37,6 +39,7 @@ $script:InstallPi = $true
 $script:InstallOpenCode = $true
 $script:InstallCline = $false
 $script:InstallHermes = $true
+$script:InstallDsh = $true
 $script:PiAvailable = $false
 $script:EnableRtk = $Rtk.IsPresent
 $FccCommands = @(
@@ -49,6 +52,7 @@ $FccCommands = @(
     "fcc-opencode",
     "fcc-cline",
     "fcc-hermes",
+    "fcc-dsh",
     "fcc-init",
     "free-claude-code"
 )
@@ -115,8 +119,11 @@ function Select-CodingAgents {
         $script:InstallHermes = Read-YesNo `
             -Prompt "Install or verify Hermes Agent for fcc-hermes?" `
             -DefaultYes $script:InstallHermes
+        $script:InstallDsh = Read-YesNo `
+            -Prompt "Install or verify DeepSeek Harness for fcc-dsh?" `
+            -DefaultYes $script:InstallDsh
 
-        if ($script:InstallClaudeCode -or $script:InstallCodex -or $script:InstallPi -or $script:InstallOpenCode -or $script:InstallCline -or $script:InstallHermes) {
+        if ($script:InstallClaudeCode -or $script:InstallCodex -or $script:InstallPi -or $script:InstallOpenCode -or $script:InstallCline -or $script:InstallHermes -or $script:InstallDsh) {
             break
         }
         Write-Host "Select at least one coding agent."
@@ -635,7 +642,7 @@ function Convert-SemanticVersionOutput {
     if ([string]::IsNullOrWhiteSpace($Output)) {
         return ""
     }
-    if ($Output -match '(?m)^\s*(?:(?:uv|opencode|cline)(?:\s+version)?\s+|Hermes Agent\s+v?|v)?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?:\s+\([^\r\n]*\))?\s*$') {
+    if ($Output -match '(?m)^\s*(?:(?:uv|opencode|cline|dsh|node)(?:\s+version)?\s+|Hermes Agent\s+v?|v)?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?:\s+\([^\r\n]*\))?\s*$') {
         return $Matches["version"]
     }
     return ""
@@ -925,6 +932,132 @@ function Ensure-Hermes {
     Confirm-HermesApplication
 }
 
+function Get-DshVersion {
+    param([string] $DshPath)
+
+    $output = Invoke-Utf8NativeCapture -FilePath $DshPath -Arguments @("--version")
+    $version = Convert-SemanticVersionOutput $output
+    if ([string]::IsNullOrWhiteSpace($version) -or (-not $version.Contains("-"))) {
+        throw "DeepSeek Harness is present, but 'dsh --version' did not return its preview semantic version."
+    }
+    return $version
+}
+
+function Get-DshNodeVersion {
+    param([string] $NodePath)
+
+    $output = Invoke-Utf8NativeCapture -FilePath $NodePath -Arguments @("--version")
+    $version = Convert-SemanticVersionOutput $output
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        throw "DeepSeek Harness requires a readable Node.js version."
+    }
+    return $version
+}
+
+function Test-DshNodeVersion {
+    param([string] $Version)
+
+    try {
+        $parsed = [version] (($Version -replace '^v', '') -replace '[-+].*$', '')
+    }
+    catch {
+        return $false
+    }
+    return (
+        (($parsed.Major -eq 22) -and ($parsed.Minor -ge 19)) -or
+        ($parsed.Major -ge 24)
+    )
+}
+
+function Test-DshToolchain {
+    $node = Get-ApplicationCommand "node"
+    $npm = Get-ApplicationCommand "npm"
+    if ((-not $node) -or (-not $npm)) {
+        return $false
+    }
+    try {
+        return (Test-DshNodeVersion -Version (Get-DshNodeVersion $node.Source))
+    }
+    catch {
+        return $false
+    }
+}
+
+function Confirm-DshToolchain {
+    $node = Get-ApplicationCommand "node"
+    if (-not $node) {
+        throw "DeepSeek Harness requires Node.js ^22.19.0 or >=24.0.0 and npm. Install Node.js, then rerun the installer."
+    }
+    $npm = Get-ApplicationCommand "npm"
+    if (-not $npm) {
+        throw "DeepSeek Harness requires npm. Install npm, then rerun the installer."
+    }
+    $version = Get-DshNodeVersion $node.Source
+    if (-not (Test-DshNodeVersion $version)) {
+        throw "DeepSeek Harness requires Node.js ^22.19.0 or >=24.0.0; found Node.js $version."
+    }
+    return $npm.Source
+}
+
+function Confirm-DshApplication {
+    if ($DryRun) {
+        Write-Host "+ dsh --version"
+        return
+    }
+
+    $command = Get-ApplicationCommand "dsh"
+    if (-not $command) {
+        throw "DeepSeek Harness was installed, but 'dsh' is not available on PATH."
+    }
+    $version = Get-DshVersion $command.Source
+    if ($version -ne $DshVersion) {
+        throw "DeepSeek Harness $DshVersion is required; found $version after installation."
+    }
+    Write-Host "Verified DeepSeek Harness $version."
+}
+
+function Install-Dsh {
+    $npmPath = Confirm-DshToolchain
+    Invoke-NativeCommand -FilePath $npmPath -Arguments @("install", "-g", $DshPackage)
+    Add-NpmBinDirectories
+}
+
+function Ensure-Dsh {
+    Add-NpmBinDirectories
+
+    if ($DryRun) {
+        if (Get-ApplicationCommand "dsh") {
+            Write-Host "+ dsh --version"
+            Write-Host "The exact supported DeepSeek Harness preview will be preserved; another version will be replaced."
+        }
+        else {
+            $node = Get-ApplicationCommand "node"
+            $npm = Get-ApplicationCommand "npm"
+            if ((-not $node) -or (-not $npm)) {
+                throw "DeepSeek Harness requires Node.js ^22.19.0 or >=24.0.0 and npm. Install Node.js, then rerun the installer."
+            }
+            $npmPath = $npm.Source
+            Write-Host "+ $(Format-Command -FilePath $npmPath -Arguments @('install', '-g', $DshPackage))"
+        }
+        Confirm-DshApplication
+        return
+    }
+
+    [void] (Confirm-DshToolchain)
+    $command = Get-ApplicationCommand "dsh"
+    if ($command) {
+        $version = Get-DshVersion $command.Source
+        if ($version -eq $DshVersion) {
+            Write-Host "DeepSeek Harness $version already matches the supported preview; leaving it unchanged."
+            return
+        }
+        Write-Host "DeepSeek Harness $version does not match $DshVersion; replacing it with the supported preview."
+    }
+
+    Install-Dsh
+    Confirm-DshApplication
+}
+
 function Ensure-SelectedCodingAgents {
     if ($script:InstallClaudeCode) {
         Write-Step "Ensuring Claude Code is installed"
@@ -956,7 +1089,12 @@ function Ensure-SelectedCodingAgents {
         Ensure-Hermes
     }
 
-    if ((-not $script:InstallClaudeCode) -and (-not $script:InstallCodex) -and (-not $script:PiAvailable) -and (-not $script:InstallOpenCode) -and (-not $script:InstallCline) -and (-not $script:InstallHermes)) {
+    if ($script:InstallDsh) {
+        Write-Step "Ensuring DeepSeek Harness is installed"
+        Ensure-Dsh
+    }
+
+    if ((-not $script:InstallClaudeCode) -and (-not $script:InstallCodex) -and (-not $script:PiAvailable) -and (-not $script:InstallOpenCode) -and (-not $script:InstallCline) -and (-not $script:InstallHermes) -and (-not $script:InstallDsh)) {
         throw "No selected coding agent was installed. Re-run the installer and choose at least one."
     }
 }
@@ -1111,7 +1249,7 @@ function Configure-AndConfirmFreeClaudeCode {
     if ($DryRun) {
         Write-Host "+ uv tool update-shell"
         Write-Host "+ uv tool dir --bin"
-        Write-Host "+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, and fcc-hermes in the uv tool bin directory"
+        Write-Host "+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, and fcc-dsh in the uv tool bin directory"
         Write-Host "+ fcc-server --version"
         Export-FccDesktopIcon `
             -DesktopCommand "<uv-tool-bin>\fcc-desktop.exe" `
@@ -1138,7 +1276,7 @@ function Configure-AndConfirmFreeClaudeCode {
         [IO.Path]::AltDirectorySeparatorChar
     )
     $installedCommands = @{}
-    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-codex", "fcc-pi", "fcc-opencode", "fcc-cline", "fcc-hermes")) {
+    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-codex", "fcc-pi", "fcc-opencode", "fcc-cline", "fcc-hermes", "fcc-dsh")) {
         $command = Get-ApplicationCommand $commandName
         if (-not $command) {
             throw "Free Claude Code installation did not create '$commandName'."
@@ -1242,9 +1380,18 @@ if ((-not [string]::IsNullOrWhiteSpace($TorchBackend)) -and (-not ($VoiceLocal -
 
 Add-KnownBinDirectories
 $script:InstallCline = [bool] ((Get-ApplicationCommand "cline") -or (Get-ApplicationCommand "npm"))
-
 Write-Step "Checking for running Free Claude Code processes"
 Assert-NoFccProcessesRunning
+
+if (-not (Test-InteractiveInstaller)) {
+    $hasDsh = [bool] (Get-ApplicationCommand "dsh")
+    $hasDryRunToolchain = [bool] (
+        $DryRun -and
+        (Get-ApplicationCommand "node") -and
+        (Get-ApplicationCommand "npm")
+    )
+    $script:InstallDsh = $hasDsh -or $hasDryRunToolchain -or (Test-DshToolchain)
+}
 
 if (Test-InteractiveInstaller) {
     Write-Step "Choosing coding agents"
@@ -1293,5 +1440,11 @@ else {
     }
     else {
         Write-Host "The fcc-hermes wrapper is ready after you install Hermes Agent."
+    }
+    if ($script:InstallDsh) {
+        Write-Host "Run DeepSeek Harness with: fcc-dsh"
+    }
+    else {
+        Write-Host "The fcc-dsh wrapper is ready after you install DeepSeek Harness $DshVersion."
     }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,13 +12,15 @@ MIN_OPENCODE_VERSION="1.18.18"
 MIN_CLINE_VERSION="3.0.55"
 HERMES_INSTALL_URL="https://hermes-agent.nousresearch.com/install.sh"
 MIN_HERMES_VERSION="0.20.4"
+DSH_VERSION="0.1.0-rc.8"
+DSH_PACKAGE="@deepseek-ai/dsh@$DSH_VERSION"
 RTK_VERSION="0.44.2"
 RTK_RELEASE_BASE_URL="https://github.com/rtk-ai/rtk/releases/download/v$RTK_VERSION"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so updates reject older FCC processes before replacement.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-init free-claude-code"
 
 dry_run=0
 voice_nim=0
@@ -30,6 +32,7 @@ install_pi=1
 install_opencode=1
 install_cline=0
 install_hermes=1
+install_dsh=1
 enable_rtk=0
 torch_backend=""
 temporary_file=""
@@ -142,7 +145,18 @@ choose_coding_agents() {
             install_hermes=0
         fi
 
-        if [ "$install_claude" -eq 1 ] || [ "$install_codex" -eq 1 ] || [ "$install_pi" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_cline" -eq 1 ] || [ "$install_hermes" -eq 1 ]; then
+        if [ "$install_dsh" -eq 1 ]; then
+            dsh_default=yes
+        else
+            dsh_default=no
+        fi
+        if prompt_yes_no "Install or verify DeepSeek Harness for fcc-dsh?" "$dsh_default"; then
+            install_dsh=1
+        else
+            install_dsh=0
+        fi
+
+        if [ "$install_claude" -eq 1 ] || [ "$install_codex" -eq 1 ] || [ "$install_pi" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_cline" -eq 1 ] || [ "$install_hermes" -eq 1 ] || [ "$install_dsh" -eq 1 ]; then
             break
         fi
         printf 'Select at least one coding agent.\n\n' >&4
@@ -833,6 +847,118 @@ ensure_hermes() {
     verify_hermes_command
 }
 
+current_dsh_version() {
+    if output=$(dsh --version 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
+
+    version=$(printf '%s\n' "$output" | awk '
+        match($0, /[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z][0-9A-Za-z.-]*/) {
+            print substr($0, RSTART, RLENGTH)
+            exit
+        }
+    ')
+    [ -n "$version" ] || return 1
+    printf '%s\n' "$version"
+}
+
+current_node_version() {
+    if output=$(node --version 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
+
+    version=$(printf '%s\n' "$output" | awk '
+        match($0, /[0-9]+\.[0-9]+\.[0-9]+/) {
+            print substr($0, RSTART, RLENGTH)
+            exit
+        }
+    ')
+    [ -n "$version" ] || return 1
+    printf '%s\n' "$version"
+}
+
+dsh_node_version_is_supported() {
+    version=$1
+    major=${version%%.*}
+    rest=${version#*.}
+    [ "$rest" != "$version" ] || return 1
+    minor=${rest%%.*}
+    case "$major:$minor" in
+        *[!0-9:]*|:*) return 1 ;;
+    esac
+    if [ "$major" -eq 22 ]; then
+        [ "$minor" -ge 19 ]
+        return
+    fi
+    [ "$major" -ge 24 ]
+}
+
+dsh_toolchain_is_supported() {
+    command -v node >/dev/null 2>&1 || return 1
+    command -v npm >/dev/null 2>&1 || return 1
+    version=$(current_node_version) || return 1
+    dsh_node_version_is_supported "$version"
+}
+
+require_dsh_toolchain() {
+    command -v node >/dev/null 2>&1 || fail "DeepSeek Harness requires Node.js ^22.19.0 or >=24.0.0 and npm. Install Node.js, then rerun the installer."
+    command -v npm >/dev/null 2>&1 || fail "DeepSeek Harness requires npm. Install npm, then rerun the installer."
+    version=$(current_node_version) || fail "DeepSeek Harness requires a readable Node.js version."
+    dsh_node_version_is_supported "$version" || fail "DeepSeek Harness requires Node.js ^22.19.0 or >=24.0.0; found Node.js $version."
+}
+
+verify_dsh_command() {
+    if [ "$dry_run" -eq 1 ]; then
+        print_command dsh --version
+        return 0
+    fi
+
+    command -v dsh >/dev/null 2>&1 || fail "DeepSeek Harness was installed, but 'dsh' is not available on PATH."
+    version=$(current_dsh_version) || fail "DeepSeek Harness is present, but 'dsh --version' did not return its preview semantic version."
+    [ "$version" = "$DSH_VERSION" ] || fail "DeepSeek Harness $DSH_VERSION is required; found $version after installation."
+    printf 'Verified DeepSeek Harness %s.\n' "$version"
+}
+
+install_dsh_package() {
+    require_dsh_toolchain
+    run npm install -g "$DSH_PACKAGE"
+    add_npm_bin_directories
+}
+
+ensure_dsh() {
+    add_npm_bin_directories
+
+    if [ "$dry_run" -eq 1 ]; then
+        if command -v dsh >/dev/null 2>&1; then
+            print_command dsh --version
+            printf 'The exact supported DeepSeek Harness preview will be preserved; another version will be replaced.\n'
+        else
+            command -v node >/dev/null 2>&1 || fail "DeepSeek Harness requires Node.js ^22.19.0 or >=24.0.0 and npm. Install Node.js, then rerun the installer."
+            command -v npm >/dev/null 2>&1 || fail "DeepSeek Harness requires npm. Install npm, then rerun the installer."
+            print_command npm install -g "$DSH_PACKAGE"
+        fi
+        verify_dsh_command
+        return 0
+    fi
+
+    require_dsh_toolchain
+    if command -v dsh >/dev/null 2>&1; then
+        version=$(current_dsh_version) || fail "DeepSeek Harness is present, but 'dsh --version' did not return its preview semantic version."
+        if [ "$version" = "$DSH_VERSION" ]; then
+            printf 'DeepSeek Harness %s already matches the supported preview; leaving it unchanged.\n' "$version"
+            return 0
+        fi
+        printf 'DeepSeek Harness %s does not match %s; replacing it with the supported preview.\n' "$version" "$DSH_VERSION"
+    fi
+
+    install_dsh_package
+    verify_dsh_command
+}
+
 ensure_selected_coding_agents() {
     if [ "$install_claude" -eq 1 ]; then
         step "Ensuring Claude Code is installed"
@@ -864,7 +990,12 @@ ensure_selected_coding_agents() {
         ensure_hermes
     fi
 
-    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ] && [ "$pi_available" -eq 0 ] && [ "$install_opencode" -eq 0 ] && [ "$install_cline" -eq 0 ] && [ "$install_hermes" -eq 0 ]; then
+    if [ "$install_dsh" -eq 1 ]; then
+        step "Ensuring DeepSeek Harness is installed"
+        ensure_dsh
+    fi
+
+    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ] && [ "$pi_available" -eq 0 ] && [ "$install_opencode" -eq 0 ] && [ "$install_cline" -eq 0 ] && [ "$install_hermes" -eq 0 ] && [ "$install_dsh" -eq 0 ]; then
         fail "No selected coding agent was installed. Re-run the installer and choose at least one."
     fi
 }
@@ -1051,7 +1182,7 @@ configure_and_verify_free_claude_code() {
 
     if [ "$dry_run" -eq 1 ]; then
         print_command uv tool dir --bin
-        printf '+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, and fcc-hermes in the uv tool bin directory\n'
+        printf '+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, and fcc-dsh in the uv tool bin directory\n'
         print_command fcc-server --version
         return 0
     fi
@@ -1069,7 +1200,7 @@ configure_and_verify_free_claude_code() {
     export PATH
     hash -r 2>/dev/null || true
 
-    for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes; do
+    for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh; do
         [ -x "$tool_bin/$command_name" ] || fail "Free Claude Code installation did not create $tool_bin/$command_name."
     done
 
@@ -1174,9 +1305,16 @@ fi
 if ! command -v hermes >/dev/null 2>&1 && ! hermes_platform_is_supported; then
     install_hermes=0
 fi
-
 step "Checking for running Free Claude Code processes"
 assert_no_fcc_processes_running
+
+if ! installer_is_interactive && ! command -v dsh >/dev/null 2>&1; then
+    if [ "$dry_run" -eq 1 ] && command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+        install_dsh=1
+    elif ! dsh_toolchain_is_supported; then
+        install_dsh=0
+    fi
+fi
 
 if installer_is_interactive; then
     step "Choosing coding agents"
@@ -1246,5 +1384,10 @@ else
         printf 'Run Hermes Agent with: fcc-hermes\n'
     else
         printf 'The fcc-hermes wrapper is ready after you install Hermes Agent.\n'
+    fi
+    if [ "$install_dsh" -eq 1 ]; then
+        printf 'Run DeepSeek Harness with: fcc-dsh\n'
+    else
+        printf 'The fcc-dsh wrapper is ready after you install DeepSeek Harness %s.\n' "$DSH_VERSION"
     fi
 fi

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -20,6 +20,7 @@ $FccCommands = @(
     "fcc-opencode",
     "fcc-cline",
     "fcc-hermes",
+    "fcc-dsh",
     "fcc-init",
     "free-claude-code"
 )
@@ -336,5 +337,5 @@ if ($DryRun) {
 }
 else {
     Write-Host "Free Claude Code has been removed and verified."
-    Write-Host "uv, Claude Code, Codex, Pi, OpenCode, Cline, Hermes Agent, the uv-managed Python runtime, and shared PATH entries were left installed."
+    Write-Host "uv, Claude Code, Codex, Pi, OpenCode, Cline, Hermes Agent, DeepSeek Harness, the uv-managed Python runtime, and shared PATH entries were left installed."
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,7 +6,7 @@ FCC_HOME_DIRNAME=".fcc"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so older installations are fully stopped and removed.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-init free-claude-code"
 
 dry_run=0
 uv_tool_bin=""
@@ -298,5 +298,5 @@ if [ "$dry_run" -eq 1 ]; then
     printf '\nDry run complete. No changes were made.\n'
 else
     printf '\nFree Claude Code has been removed and verified.\n'
-    printf 'uv, Claude Code, Codex, Pi, OpenCode, Cline, Hermes Agent, the uv-managed Python runtime, and shared PATH entries were left installed.\n'
+    printf 'uv, Claude Code, Codex, Pi, OpenCode, Cline, Hermes Agent, DeepSeek Harness, the uv-managed Python runtime, and shared PATH entries were left installed.\n'
 fi

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -56,7 +56,7 @@ Default targets do not send real bot messages or load voice backends:
 | `api` | messages, count_tokens full payload, errors, `/stop`, optimizations | configured provider only for streaming messages |
 | `auth` | canonical bearer auth, conflicting legacy headers, invalid/missing auth | none; test sets an isolated token |
 | `cli` | server entrypoint, Claude CLI adaptive thinking, automatic WebSearch, Auto-mode classifier, session cleanup | Claude CLI binary and provider only for real CLI; connected OpenAI account for Auto mode; `FCC_SMOKE_RUN_WEB_TOOLS=1` for WebSearch |
-| `clients` | VS Code and JetBrains protocol payloads; Pi, OpenCode, Cline, and Hermes CLI prompts | configured provider; installed Pi/OpenCode/Cline binaries; Hermes uses a local fake upstream |
+| `clients` | VS Code and JetBrains protocol payloads; Pi, OpenCode, Cline, Hermes, and DeepSeek Harness CLI prompts | configured provider; installed Pi/OpenCode/Cline binaries; Hermes and DSH use a local fake upstream |
 | `config` | env precedence, removed-env migration, proxy/timeouts | none |
 | `extensibility` | provider runtime and platform factory construction | none |
 | `messaging` | fake Discord/Telegram full flow, literal clear scopes, trees, persistence, voice cancel | none |

--- a/smoke/capabilities.py
+++ b/smoke/capabilities.py
@@ -582,6 +582,24 @@ CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
         ("test_hermes_cli_prompt_e2e",),
     ),
     CapabilityContract(
+        "cli",
+        "dsh_cli_integration",
+        "dsh_cli_integration",
+        "free_claude_code.cli.launchers.dsh",
+        "DeepSeek Harness 0.1.0-rc.8, live FCC catalog, and process-only patch",
+        "Responses provider scoped to FCC for attached Web and headless sessions",
+        "version, proxy, catalog, or private-config failure exits before inference",
+        (
+            "tests/cli/test_dsh_config.py",
+            "tests/cli/test_dsh_launcher.py",
+        ),
+        (
+            "test_dsh_cli_headless_e2e",
+            "test_dsh_cli_terminal_failure_e2e",
+            "test_dsh_cli_web_startup_e2e",
+        ),
+    ),
+    CapabilityContract(
         "extensibility",
         "provider_platform_abcs",
         "extensible_provider_platform_abcs",

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -151,6 +151,23 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
         "skip only when Hermes is absent; the local fake upstream must pass",
     ),
     FeatureCoverage(
+        "dsh_cli_integration",
+        "DeepSeek Harness discovers FCC models and sends Responses through the proxy",
+        (
+            "tests/cli/test_dsh_config.py",
+            "tests/cli/test_dsh_launcher.py",
+        ),
+        ("test_probe_and_models_routes",),
+        (
+            "test_dsh_cli_headless_e2e",
+            "test_dsh_cli_terminal_failure_e2e",
+            "test_dsh_cli_web_startup_e2e",
+        ),
+        ("clients",),
+        ("DeepSeek Harness 0.1.0-rc.8",),
+        "skip only when DSH is absent; the local fake upstream must pass",
+    ),
+    FeatureCoverage(
         "provider_matrix",
         "Every configured provider prefix can satisfy conversation scenarios",
         ("tests/api/test_dependencies.py", "tests/providers/"),

--- a/smoke/product/test_client_product_live.py
+++ b/smoke/product/test_client_product_live.py
@@ -1,8 +1,10 @@
 import json
 import os
 import shutil
+import signal
 import subprocess
 import threading
+import time
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -10,6 +12,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+import httpx
 import pytest
 
 from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
@@ -23,6 +26,7 @@ from smoke.lib.e2e import (
     SmokeServerDriver,
     assert_product_stream,
 )
+from smoke.lib.server import find_free_port
 
 pytestmark = [pytest.mark.live]
 
@@ -385,6 +389,195 @@ def test_hermes_cli_prompt_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> Non
     assert native_env.read_bytes() == env_before
 
 
+@pytest.mark.smoke_target("clients")
+def test_dsh_cli_headless_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> None:
+    dsh_bin = shutil.which("dsh")
+    if not dsh_bin:
+        pytest.skip("missing_env: DeepSeek Harness not found")
+    uv_bin = shutil.which("uv")
+    if not uv_bin:
+        pytest.skip("missing_env: uv not found")
+
+    model_id = "fcc-smoke-dsh"
+    full_model = f"lmstudio/{model_id}"
+    marker = "FCC_SMOKE_DSH"
+    auth_token = smoke_config.settings.proxy_auth_token
+    credential_env_keys = _provider_credential_env_keys()
+
+    with (
+        _successful_openai_provider(model_id=model_id, marker=marker) as (
+            provider_base_url,
+            provider_requests,
+        ),
+        SmokeServerDriver(
+            smoke_config,
+            name="product-dsh-cli-headless",
+            env_overrides=_local_provider_overrides(full_model, provider_base_url),
+            env_unset=credential_env_keys,
+        ).run() as server,
+    ):
+        env = _isolated_dsh_env(
+            tmp_path=tmp_path,
+            server_port=server.port,
+            auth_token=auth_token,
+            credential_env_keys=credential_env_keys,
+        )
+        result = subprocess.run(
+            [
+                uv_bin,
+                "run",
+                "--project",
+                str(smoke_config.root),
+                "--no-sync",
+                "fcc-dsh",
+                "--profile",
+                "headless",
+                f"Reply with exactly {marker}",
+            ],
+            cwd=tmp_path,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=smoke_config.timeout_s + 30,
+        )
+        server_log = server.log_path.read_text(encoding="utf-8", errors="replace")
+
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip() == marker
+    assert auth_token not in combined
+    assert "GET /v1/models" in server_log
+    assert server_log.count("POST /v1/responses") == 1
+    assert "POST /v1/chat/completions" not in server_log
+    assert [request["path"] for request in provider_requests] == [
+        "/v1/chat/completions"
+    ]
+    provider_body = provider_requests[0]["body"]
+    assert isinstance(provider_body, dict)
+    assert provider_body["model"] == model_id
+
+
+@pytest.mark.smoke_target("clients")
+def test_dsh_cli_terminal_failure_e2e(
+    smoke_config: SmokeConfig, tmp_path: Path
+) -> None:
+    if not shutil.which("dsh"):
+        pytest.skip("missing_env: DeepSeek Harness not found")
+    uv_bin = shutil.which("uv")
+    if not uv_bin:
+        pytest.skip("missing_env: uv not found")
+
+    full_model = "lmstudio/fcc-smoke-failing-model"
+    auth_token = smoke_config.settings.proxy_auth_token
+    credential_env_keys = _provider_credential_env_keys()
+    with (
+        _deliberately_failing_openai_provider() as (
+            provider_base_url,
+            provider_requests,
+        ),
+        SmokeServerDriver(
+            smoke_config,
+            name="product-dsh-cli-provider-error",
+            env_overrides=_local_provider_overrides(full_model, provider_base_url),
+            env_unset=credential_env_keys,
+        ).run() as server,
+    ):
+        env = _isolated_dsh_env(
+            tmp_path=tmp_path,
+            server_port=server.port,
+            auth_token=auth_token,
+            credential_env_keys=credential_env_keys,
+        )
+        result = subprocess.run(
+            [
+                uv_bin,
+                "run",
+                "--project",
+                str(smoke_config.root),
+                "--no-sync",
+                "fcc-dsh",
+                "--profile",
+                "headless",
+                "Reply with exactly FCC_SMOKE_UNREACHABLE",
+            ],
+            cwd=tmp_path,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=smoke_config.timeout_s + 30,
+        )
+        server_log = server.log_path.read_text(encoding="utf-8", errors="replace")
+
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert auth_token not in combined
+    assert server_log.count("POST /v1/responses") == 1
+    assert provider_requests == ["/v1/chat/completions"]
+
+
+@pytest.mark.smoke_target("clients")
+def test_dsh_cli_web_startup_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> None:
+    if not shutil.which("dsh"):
+        pytest.skip("missing_env: DeepSeek Harness not found")
+    uv_bin = shutil.which("uv")
+    if not uv_bin:
+        pytest.skip("missing_env: uv not found")
+
+    model_id = "fcc-smoke-dsh-web"
+    full_model = f"lmstudio/{model_id}"
+    auth_token = smoke_config.settings.proxy_auth_token
+    credential_env_keys = _provider_credential_env_keys()
+    web_port = find_free_port()
+    with (
+        _successful_openai_provider(model_id=model_id, marker="unused") as (
+            provider_base_url,
+            provider_requests,
+        ),
+        SmokeServerDriver(
+            smoke_config,
+            name="product-dsh-cli-web",
+            env_overrides=_local_provider_overrides(full_model, provider_base_url),
+            env_unset=credential_env_keys,
+        ).run() as server,
+    ):
+        env = _isolated_dsh_env(
+            tmp_path=tmp_path,
+            server_port=server.port,
+            auth_token=auth_token,
+            credential_env_keys=credential_env_keys,
+        )
+        command = [
+            uv_bin,
+            "run",
+            "--project",
+            str(smoke_config.root),
+            "--no-sync",
+            "fcc-dsh",
+            "web",
+            "--no-open",
+            "--port",
+            str(web_port),
+        ]
+        process = _start_attached_process(command, cwd=tmp_path, env=env)
+        try:
+            _wait_for_web_root(
+                process,
+                url=f"http://127.0.0.1:{web_port}/",
+                timeout_s=smoke_config.timeout_s + 30,
+            )
+            assert process.poll() is None
+        finally:
+            stdout, stderr = _stop_attached_process(process)
+        server_log = server.log_path.read_text(encoding="utf-8", errors="replace")
+
+    assert process.poll() is not None
+    assert auth_token not in f"{stdout}\n{stderr}"
+    assert "GET /v1/models" in server_log
+    assert provider_requests == []
+
+
 @pytest.mark.smoke_target("cli")
 def test_claude_cli_adaptive_thinking_e2e(
     smoke_config: SmokeConfig, tmp_path: Path
@@ -658,6 +851,129 @@ def test_claude_cli_provider_error_e2e(
     assert provider_requests == ["/v1/chat/completions"]
 
 
+def _provider_credential_env_keys() -> set[str]:
+    return {
+        descriptor.credential_env
+        for descriptor in PROVIDER_CATALOG.values()
+        if descriptor.credential_env is not None
+    }
+
+
+def _local_provider_overrides(
+    full_model: str, provider_base_url: str
+) -> dict[str, str]:
+    return {
+        "MODEL": full_model,
+        "MODEL_FABLE": full_model,
+        "MODEL_OPUS": full_model,
+        "MODEL_SONNET": full_model,
+        "MODEL_HAIKU": full_model,
+        "LM_STUDIO_BASE_URL": provider_base_url,
+        "MESSAGING_PLATFORM": "none",
+    }
+
+
+def _isolated_dsh_env(
+    *,
+    tmp_path: Path,
+    server_port: int,
+    auth_token: str,
+    credential_env_keys: set[str],
+) -> dict[str, str]:
+    isolated_home = tmp_path / "home"
+    dsh_home = tmp_path / "dsh-home"
+    isolated_home.mkdir(exist_ok=True)
+    dsh_home.mkdir(exist_ok=True)
+
+    env = os.environ.copy()
+    for key in credential_env_keys:
+        env.pop(key, None)
+    for key in tuple(env):
+        if key.startswith("FCC_DSH_"):
+            env.pop(key)
+    env.update(
+        {
+            "HOST": "127.0.0.1",
+            "PORT": str(server_port),
+            "FCC_OPEN_BROWSER": "0",
+            "ANTHROPIC_AUTH_TOKEN": auth_token,
+            "HOME": str(isolated_home),
+            "USERPROFILE": str(isolated_home),
+            "DSH_HOME": str(dsh_home),
+        }
+    )
+    return env
+
+
+def _start_attached_process(
+    command: list[str], *, cwd: Path, env: dict[str, str]
+) -> subprocess.Popen[str]:
+    if os.name == "nt":
+        return subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
+    return subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def _wait_for_web_root(
+    process: subprocess.Popen[str], *, url: str, timeout_s: float
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_error = ""
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            break
+        try:
+            response = httpx.get(url, timeout=2.0, follow_redirects=True)
+            if response.status_code == HTTPStatus.OK:
+                return
+            last_error = f"HTTP {response.status_code}: {response.text[:200]}"
+        except httpx.HTTPError as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(0.25)
+    raise AssertionError(
+        "DeepSeek Harness Web did not become ready. "
+        f"exit={process.poll()!r} last_error={last_error!r}"
+    )
+
+
+def _stop_attached_process(process: subprocess.Popen[str]) -> tuple[str, str]:
+    if process.poll() is None:
+        try:
+            if os.name == "nt":
+                process.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                os.killpg(process.pid, signal.SIGINT)
+        except ProcessLookupError:
+            pass
+    try:
+        return process.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                check=False,
+                capture_output=True,
+            )
+        else:
+            os.killpg(process.pid, signal.SIGKILL)
+        return process.communicate(timeout=5)
+
+
 @contextmanager
 def _deliberately_failing_openai_provider() -> Iterator[tuple[str, list[str]]]:
     provider_requests: list[str] = []
@@ -775,8 +1091,10 @@ def _successful_openai_provider(
             self.send_response(status)
             self.send_header("content-type", "application/json")
             self.send_header("content-length", str(len(body)))
+            self.send_header("connection", "close")
             self.end_headers()
             self.wfile.write(body)
+            self.close_connection = True
 
         def _write_chunk(
             self, *, content: str | None, finish_reason: str | None

--- a/src/free_claude_code/cli/launchers/dsh.py
+++ b/src/free_claude_code/cli/launchers/dsh.py
@@ -1,0 +1,358 @@
+"""Installed `fcc-dsh` launcher for attached DeepSeek Harness sessions."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Never
+
+from free_claude_code.cli.local_http import with_local_proxy_bypass
+from free_claude_code.config.loader import get_settings
+from free_claude_code.config.server_urls import local_proxy_root_url
+from free_claude_code.core.json_types import JsonValue
+
+from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .dsh_config import (
+    DSH_API_KEY_ENV,
+    DSH_ENV_PREFIX,
+    build_dsh_launch_config,
+)
+from .model_catalog import (
+    ClientModel,
+    client_models_from_response,
+    fetch_proxy_models_response,
+)
+
+_BINARY_NAME = "dsh"
+_DISPLAY_NAME = "DeepSeek Harness"
+_SUPPORTED_VERSION = "0.1.0-rc.8"
+_INSTALL_COMMAND = f"npm install -g @deepseek-ai/dsh@{_SUPPORTED_VERSION}"
+_INSTALL_HINT = (
+    f"Install the supported DeepSeek Harness release with: {_INSTALL_COMMAND}"
+)
+_VERSION_TIMEOUT_SECONDS = 5.0
+_VERSION_PATTERN = re.compile(
+    r"(?im)^\s*(?:dsh\s+)?v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)\s*$"
+)
+_SUPPORTED_PROFILES = frozenset({"web", "headless"})
+_ROOT_HELP_FLAGS = frozenset({"-h", "--help"})
+_ROOT_VERSION_FLAGS = frozenset({"-V", "--version"})
+
+
+@dataclass(frozen=True, slots=True)
+class DshInvocation:
+    """One minimally classified DSH command line."""
+
+    args: tuple[str, ...]
+    patch_index: int | None
+
+    @property
+    def is_routed(self) -> bool:
+        return self.patch_index is not None
+
+
+def launch(argv: Sequence[str] | None = None) -> None:
+    """Launch one attached DSH Web or headless process through FCC."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    binary_path = resolve_client_binary(
+        binary_name=_BINARY_NAME,
+        display_name=_DISPLAY_NAME,
+        install_hint=_INSTALL_HINT,
+    )
+    invocation = classify_dsh_invocation(args)
+    if not invocation.is_routed:
+        _run(binary_path, invocation.args, os.environ)
+        return
+
+    require_compatible_dsh(binary_path)
+    settings = get_settings()
+    auth_token = settings.proxy_auth_token.strip()
+    if not auth_token:
+        print("Free Claude Code proxy authentication token is empty.", file=sys.stderr)
+        raise SystemExit(1)
+
+    proxy_root_url = local_proxy_root_url(settings)
+    if error := preflight_proxy(proxy_root_url):
+        print(
+            f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
+            file=sys.stderr,
+        )
+        print("Start it in another terminal with: fcc-server", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        models = client_models_from_response(
+            fetch_proxy_models_response(proxy_root_url, auth_token)
+        )
+    except Exception as exc:
+        print(
+            f"Could not prepare the DeepSeek Harness FCC model catalog: {exc}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from None
+
+    _run_with_dsh_config(
+        binary_path=binary_path,
+        invocation=invocation,
+        models=models,
+        proxy_root_url=proxy_root_url,
+        auth_token=auth_token,
+        provider_progress_timeout=settings.provider_progress_timeout,
+    )
+
+
+def classify_dsh_invocation(argv: Sequence[str]) -> DshInvocation:
+    """Classify only DSH's documented launcher prefix and supported profiles."""
+
+    args = list(argv)
+    if not args:
+        return DshInvocation(args=("web",), patch_index=1)
+    if args[0] == "plugin":
+        return DshInvocation(args=tuple(args), patch_index=None)
+    if args[0] == "web":
+        return _classify_web(args)
+    return _classify_profile(args)
+
+
+def require_compatible_dsh(binary_path: str) -> None:
+    """Exit unless DSH exactly matches FCC's audited preview contract."""
+
+    version = dsh_binary_version(binary_path)
+    if version == _SUPPORTED_VERSION:
+        return
+
+    found = version or "an unrecognized version"
+    print(
+        f"fcc-dsh requires DeepSeek Harness {_SUPPORTED_VERSION}; found {found}.",
+        file=sys.stderr,
+    )
+    print(f"Install it with: {_INSTALL_COMMAND}", file=sys.stderr)
+    raise SystemExit(126)
+
+
+def dsh_binary_version(binary_path: str) -> str | None:
+    """Read DSH's semantic preview version without invoking a shell."""
+
+    try:
+        result = subprocess.run(
+            [binary_path, "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=_VERSION_TIMEOUT_SECONDS,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0:
+        return None
+
+    match = _VERSION_PATTERN.search(result.stdout)
+    return match.group(1) if match is not None else None
+
+
+def build_dsh_launcher_env(
+    *,
+    auth_token: str,
+    proxy_root_url: str,
+    base_env: Mapping[str, str],
+) -> dict[str, str]:
+    """Build a child-only DSH environment while preserving native state."""
+
+    filtered = {
+        key: value
+        for key, value in base_env.items()
+        if not key.startswith(DSH_ENV_PREFIX)
+    }
+    env = with_local_proxy_bypass(filtered, proxy_root_url=proxy_root_url)
+    env[DSH_API_KEY_ENV] = auth_token
+    env["DSH_TELEMETRY_DISABLED"] = "1"
+    return env
+
+
+def _classify_web(args: list[str]) -> DshInvocation:
+    patch_index = len(args)
+    default_dump = False
+    index = 1
+    while index < len(args):
+        argument = args[index]
+        if argument == "--patch" or argument.startswith("--patch="):
+            _patch_override_error()
+        if argument == "--dump-default-config":
+            default_dump = True
+            index += 1
+            continue
+        if argument == "--dump-config":
+            index += 1
+            continue
+        patch_index = index
+        break
+
+    if default_dump or (
+        patch_index < len(args) and args[patch_index] in _ROOT_HELP_FLAGS
+    ):
+        return DshInvocation(args=tuple(args), patch_index=None)
+    return DshInvocation(args=tuple(args), patch_index=patch_index)
+
+
+def _classify_profile(args: list[str]) -> DshInvocation:
+    profile: str | None = None
+    patch_index = len(args)
+    default_dump = False
+    index = 0
+    while index < len(args):
+        argument = args[index]
+        if argument in _ROOT_VERSION_FLAGS:
+            return DshInvocation(args=tuple(args), patch_index=None)
+        if argument in _ROOT_HELP_FLAGS and profile is None:
+            return DshInvocation(args=tuple(args), patch_index=None)
+        if argument == "--profile":
+            if index + 1 >= len(args) or not args[index + 1]:
+                _profile_value_error()
+            profile = args[index + 1]
+            index += 2
+            continue
+        if argument.startswith("--profile="):
+            profile = argument.partition("=")[2]
+            if not profile:
+                _profile_value_error()
+            index += 1
+            continue
+        if argument == "--patch" or argument.startswith("--patch="):
+            _patch_override_error()
+        if argument == "--dump-default-config":
+            default_dump = True
+            index += 1
+            continue
+        if argument == "--dump-config":
+            index += 1
+            continue
+        patch_index = index
+        break
+
+    if profile is not None and profile not in _SUPPORTED_PROFILES:
+        _unsupported_profile_error(profile)
+    if default_dump:
+        return DshInvocation(args=tuple(args), patch_index=None)
+    if profile is not None:
+        if patch_index < len(args) and args[patch_index] in _ROOT_HELP_FLAGS:
+            return DshInvocation(args=tuple(args), patch_index=None)
+        return DshInvocation(args=tuple(args), patch_index=patch_index)
+
+    normalized = ["web", *args]
+    return DshInvocation(args=tuple(normalized), patch_index=1)
+
+
+def _run_with_dsh_config(
+    *,
+    binary_path: str,
+    invocation: DshInvocation,
+    models: tuple[ClientModel, ...],
+    proxy_root_url: str,
+    auth_token: str,
+    provider_progress_timeout: float,
+) -> None:
+    try:
+        temp_config = tempfile.TemporaryDirectory(prefix="fcc-dsh-")
+    except OSError as exc:
+        _temporary_config_error(exc)
+
+    with temp_config as temp_directory:
+        directory = Path(temp_directory)
+        patch_path = directory / "fcc.patch.yml"
+        settings_path = directory / "settings.yaml"
+        credentials_path = directory / ".credentials.yaml"
+        try:
+            if os.name != "nt":
+                directory.chmod(0o700)
+            config = build_dsh_launch_config(
+                models,
+                proxy_root_url=proxy_root_url,
+                settings_path=settings_path,
+                credentials_path=credentials_path,
+                provider_progress_timeout=provider_progress_timeout,
+            )
+            _write_private_json(patch_path, config.patch)
+            _write_private_json(settings_path, {})
+            _write_private_json(credentials_path, {})
+        except ValueError as exc:
+            print(
+                f"Could not prepare DeepSeek Harness configuration: {exc}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from None
+        except OSError as exc:
+            _temporary_config_error(exc)
+
+        child_env = build_dsh_launcher_env(
+            auth_token=auth_token,
+            proxy_root_url=proxy_root_url,
+            base_env=os.environ,
+        )
+        _run(
+            binary_path,
+            _args_with_patch(invocation, patch_path),
+            child_env,
+        )
+
+
+def _args_with_patch(invocation: DshInvocation, patch_path: Path) -> list[str]:
+    if invocation.patch_index is None:
+        raise ValueError("native DSH passthrough cannot receive an FCC patch")
+    args = list(invocation.args)
+    args[invocation.patch_index : invocation.patch_index] = ["--patch", str(patch_path)]
+    return args
+
+
+def _write_private_json(path: Path, payload: JsonValue) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+        json.dump(payload, output, ensure_ascii=True, indent=2)
+        output.write("\n")
+
+
+def _run(binary_path: str, args: Sequence[str], env: Mapping[str, str]) -> None:
+    run_client_process(
+        command=[binary_path, *args],
+        env=env,
+        binary_name=_BINARY_NAME,
+        display_name=_DISPLAY_NAME,
+        install_hint=_INSTALL_HINT,
+    )
+
+
+def _profile_value_error() -> Never:
+    print("fcc-dsh requires a value after --profile.", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _patch_override_error() -> Never:
+    print(
+        "fcc-dsh owns the final DeepSeek Harness patch. "
+        "Use ordinary dsh for custom profile patches.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _unsupported_profile_error(profile: str) -> Never:
+    print(
+        f"fcc-dsh supports only the web and headless profiles, not {profile!r}. "
+        "Use ordinary dsh for custom profiles.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _temporary_config_error(exc: OSError) -> Never:
+    print(
+        f"Could not create temporary DeepSeek Harness configuration: {exc}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from None

--- a/src/free_claude_code/cli/launchers/dsh_config.py
+++ b/src/free_claude_code/cli/launchers/dsh_config.py
@@ -1,0 +1,125 @@
+"""Process-local DeepSeek Harness configuration for FCC model routing."""
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from free_claude_code.core.json_types import JsonObject
+
+from .common import proxy_v1_url
+from .model_catalog import ClientModel
+
+DSH_API_KEY_ENV = "FCC_DSH_API_KEY"
+DSH_ENV_PREFIX = "FCC_DSH_"
+DSH_PROVIDER_ID = "free-claude-code"
+
+_MAX_TIMER_DELAY_MS = 2_147_483_647
+_STREAM_TIMEOUT_MARGIN_SECONDS = 60
+_REASONING_EFFORTS: JsonObject = {
+    "off": "none",
+    "minimal": "minimal",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "xhigh",
+    "max": "max",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DshLaunchConfig:
+    """Secret-free DSH patch for one attached FCC launch."""
+
+    patch: tuple[JsonObject, ...] = field(repr=False)
+    selected_model: str
+    api_key_env: str = DSH_API_KEY_ENV
+
+
+def build_dsh_launch_config(
+    models: tuple[ClientModel, ...],
+    *,
+    proxy_root_url: str,
+    settings_path: Path,
+    credentials_path: Path,
+    provider_progress_timeout: float,
+) -> DshLaunchConfig:
+    """Translate FCC's catalog and timeout into an isolated DSH overlay."""
+
+    if not models:
+        raise ValueError("DeepSeek Harness requires at least one routable FCC model")
+
+    stream_idle_timeout_ms = _stream_idle_timeout_ms(provider_progress_timeout)
+    selected_model = models[0].wire_slug
+    provider: JsonObject = {
+        "displayName": "Free Claude Code",
+        "apiKeyEnv": DSH_API_KEY_ENV,
+        "api": "openai-responses",
+        "baseURL": proxy_v1_url(proxy_root_url),
+        "models": [_model_profile(model) for model in models],
+        "defaultInput": ["text"],
+        "retryPolicy": {"mode": "normal", "maxRetries": 0},
+        "streamIdleTimeoutMs": stream_idle_timeout_ms,
+    }
+    patch = (
+        _configured_row(
+            "settings",
+            "@deepseek-ai/dsh-settings-file",
+            {"path": str(settings_path), "watch": False},
+        ),
+        _configured_row(
+            "credentials",
+            "@deepseek-ai/dsh-credentials-local",
+            {"path": str(credentials_path), "watch": False},
+        ),
+        _configured_row(
+            "llm-pi-ai",
+            "@deepseek-ai/dsh-llm-pi-ai",
+            {"providers": {DSH_PROVIDER_ID: provider}},
+        ),
+        _configured_row(
+            "agent-default-model",
+            "@deepseek-ai/dsh-agent-default-model",
+            {"provider": DSH_PROVIDER_ID, "model": selected_model},
+        ),
+        _disabled_row("llm-deepseek", "@deepseek-ai/dsh-llm-deepseek"),
+        _disabled_row(
+            "web-search-deepseek",
+            "@deepseek-ai/dsh-web-search-deepseek",
+        ),
+        _disabled_row("tool-web", "@deepseek-ai/dsh-tool-web"),
+    )
+    return DshLaunchConfig(patch=patch, selected_model=selected_model)
+
+
+def _stream_idle_timeout_ms(provider_progress_timeout: float) -> int:
+    if not math.isfinite(provider_progress_timeout) or provider_progress_timeout <= 0:
+        raise ValueError("PROVIDER_PROGRESS_TIMEOUT must be a positive finite value")
+
+    timeout_ms = math.ceil(
+        (provider_progress_timeout + _STREAM_TIMEOUT_MARGIN_SECONDS) * 1000
+    )
+    if timeout_ms > _MAX_TIMER_DELAY_MS:
+        raise ValueError(
+            "PROVIDER_PROGRESS_TIMEOUT is too large for DeepSeek Harness; "
+            "lower it so the DSH stream timeout stays within Node's timer limit"
+        )
+    return timeout_ms
+
+
+def _model_profile(model: ClientModel) -> JsonObject:
+    profile: JsonObject = {
+        "id": model.wire_slug,
+        "name": model.display_name,
+    }
+    profile["reasoningEfforts"] = (
+        dict(_REASONING_EFFORTS) if model.allows_reasoning else False
+    )
+    return profile
+
+
+def _configured_row(row_id: str, name: str, config: JsonObject) -> JsonObject:
+    return {"id": row_id, "name": name, "config": config}
+
+
+def _disabled_row(row_id: str, name: str) -> JsonObject:
+    return {"id": row_id, "name": name, "disabled": True}

--- a/tests/cli/test_dsh_config.py
+++ b/tests/cli/test_dsh_config.py
@@ -1,0 +1,173 @@
+"""Contracts for the process-local DeepSeek Harness configuration."""
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from free_claude_code.cli.launchers.dsh_config import build_dsh_launch_config
+from free_claude_code.cli.launchers.model_catalog import ClientModel
+
+
+def _models() -> tuple[ClientModel, ...]:
+    return (
+        ClientModel(
+            wire_slug="nvidia_nim/vendor/model",
+            provider_model_ref="nvidia_nim/vendor/model",
+            display_name="Nested model",
+            allows_reasoning=True,
+        ),
+        ClientModel(
+            wire_slug="claude-3-freecc-no-thinking/open_router/plain-model",
+            provider_model_ref="open_router/plain-model",
+            display_name="No-thinking model",
+            allows_reasoning=False,
+        ),
+    )
+
+
+def _row_by_id(patch: tuple[dict, ...], row_id: str) -> dict:
+    return next(row for row in patch if row["id"] == row_id)
+
+
+def test_dsh_config_pins_responses_models_retries_and_private_state(
+    tmp_path: Path,
+) -> None:
+    settings_path = tmp_path / "settings.yaml"
+    credentials_path = tmp_path / ".credentials.yaml"
+    launch = build_dsh_launch_config(
+        _models(),
+        proxy_root_url="http://127.0.0.1:9191/",
+        settings_path=settings_path,
+        credentials_path=credentials_path,
+        provider_progress_timeout=600.0,
+    )
+
+    assert launch.selected_model == "nvidia_nim/vendor/model"
+    assert launch.api_key_env == "FCC_DSH_API_KEY"
+
+    settings = _row_by_id(launch.patch, "settings")
+    assert settings == {
+        "id": "settings",
+        "name": "@deepseek-ai/dsh-settings-file",
+        "config": {"path": str(settings_path), "watch": False},
+    }
+    credentials = _row_by_id(launch.patch, "credentials")
+    assert credentials == {
+        "id": "credentials",
+        "name": "@deepseek-ai/dsh-credentials-local",
+        "config": {"path": str(credentials_path), "watch": False},
+    }
+
+    llm = _row_by_id(launch.patch, "llm-pi-ai")
+    provider = llm["config"]["providers"]["free-claude-code"]
+    assert provider == {
+        "displayName": "Free Claude Code",
+        "apiKeyEnv": "FCC_DSH_API_KEY",
+        "api": "openai-responses",
+        "baseURL": "http://127.0.0.1:9191/v1",
+        "models": [
+            {
+                "id": "nvidia_nim/vendor/model",
+                "name": "Nested model",
+                "reasoningEfforts": {
+                    "off": "none",
+                    "minimal": "minimal",
+                    "low": "low",
+                    "medium": "medium",
+                    "high": "high",
+                    "xhigh": "xhigh",
+                    "max": "max",
+                },
+            },
+            {
+                "id": "claude-3-freecc-no-thinking/open_router/plain-model",
+                "name": "No-thinking model",
+                "reasoningEfforts": False,
+            },
+        ],
+        "defaultInput": ["text"],
+        "retryPolicy": {"mode": "normal", "maxRetries": 0},
+        "streamIdleTimeoutMs": 660_000,
+    }
+    assert _row_by_id(launch.patch, "agent-default-model") == {
+        "id": "agent-default-model",
+        "name": "@deepseek-ai/dsh-agent-default-model",
+        "config": {
+            "provider": "free-claude-code",
+            "model": "nvidia_nim/vendor/model",
+        },
+    }
+
+    for row_id, package in (
+        ("llm-deepseek", "@deepseek-ai/dsh-llm-deepseek"),
+        ("web-search-deepseek", "@deepseek-ai/dsh-web-search-deepseek"),
+        ("tool-web", "@deepseek-ai/dsh-tool-web"),
+    ):
+        assert _row_by_id(launch.patch, row_id) == {
+            "id": row_id,
+            "name": package,
+            "disabled": True,
+        }
+
+    serialized = json.dumps(launch.patch)
+    assert "proxy-token" not in serialized
+    for unsupported in (
+        "contextWindow",
+        "maxTokens",
+        "input",
+        "compat",
+        "headers",
+        "telemetry",
+    ):
+        assert unsupported not in serialized
+
+
+def test_dsh_config_rounds_fractional_progress_timeout_up() -> None:
+    launch = build_dsh_launch_config(
+        _models(),
+        proxy_root_url="http://127.0.0.1:9191",
+        settings_path=Path("settings.yaml"),
+        credentials_path=Path("credentials.yaml"),
+        provider_progress_timeout=0.0001,
+    )
+
+    provider = _row_by_id(launch.patch, "llm-pi-ai")["config"]["providers"][
+        "free-claude-code"
+    ]
+    assert provider["streamIdleTimeoutMs"] == 60_001
+
+
+def test_dsh_config_rejects_empty_catalog() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        build_dsh_launch_config(
+            (),
+            proxy_root_url="http://127.0.0.1:9191",
+            settings_path=Path("settings.yaml"),
+            credentials_path=Path("credentials.yaml"),
+            provider_progress_timeout=600,
+        )
+
+
+@pytest.mark.parametrize("timeout", [0.0, -1.0, math.inf, math.nan])
+def test_dsh_config_rejects_invalid_progress_timeout(timeout: float) -> None:
+    with pytest.raises(ValueError, match="positive finite"):
+        build_dsh_launch_config(
+            _models(),
+            proxy_root_url="http://127.0.0.1:9191",
+            settings_path=Path("settings.yaml"),
+            credentials_path=Path("credentials.yaml"),
+            provider_progress_timeout=timeout,
+        )
+
+
+def test_dsh_config_rejects_timeout_beyond_node_timer_limit() -> None:
+    with pytest.raises(ValueError, match="too large"):
+        build_dsh_launch_config(
+            _models(),
+            proxy_root_url="http://127.0.0.1:9191",
+            settings_path=Path("settings.yaml"),
+            credentials_path=Path("credentials.yaml"),
+            provider_progress_timeout=2_147_424,
+        )

--- a/tests/cli/test_dsh_launcher.py
+++ b/tests/cli/test_dsh_launcher.py
@@ -1,0 +1,436 @@
+"""Contract tests for the installed `fcc-dsh` launcher."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from free_claude_code.cli.launchers.dsh import DshInvocation
+from free_claude_code.cli.launchers.model_catalog import ClientModel
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.json_types import JsonObject
+
+
+def _settings(*, token: str = "proxy-token") -> Settings:
+    return Settings(
+        host="0.0.0.0",
+        port=9191,
+        proxy_auth_enabled=False,
+        proxy_auth_token=token,
+        model="nvidia_nim/test-model",
+        provider_progress_timeout=600,
+    )
+
+
+def _models_payload() -> JsonObject:
+    return {
+        "data": [
+            {
+                "id": "anthropic/nvidia_nim/vendor/model",
+                "display_name": "Nested model",
+            },
+            {
+                "id": "claude-3-freecc-no-thinking/open_router/plain-model",
+                "display_name": "No-thinking model",
+            },
+        ]
+    }
+
+
+def _models() -> tuple[ClientModel, ...]:
+    return (
+        ClientModel(
+            wire_slug="nvidia_nim/vendor/model",
+            provider_model_ref="nvidia_nim/vendor/model",
+            display_name="Nested model",
+            allows_reasoning=True,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_args", "patch_index"),
+    [
+        ([], ("web",), 1),
+        (["--no-open"], ("web", "--no-open"), 1),
+        (["web"], ("web",), 1),
+        (["web", "--port", "3199"], ("web", "--port", "3199"), 1),
+        (
+            ["--profile", "web", "--no-open"],
+            ("--profile", "web", "--no-open"),
+            2,
+        ),
+        (
+            ["--profile=headless", "write", "--patch", "as prompt"],
+            ("--profile=headless", "write", "--patch", "as prompt"),
+            1,
+        ),
+        (
+            ["--profile", "headless", "hello"],
+            ("--profile", "headless", "hello"),
+            2,
+        ),
+        (["--dump-config"], ("web", "--dump-config"), 1),
+        (
+            ["--profile", "web", "--dump-config"],
+            ("--profile", "web", "--dump-config"),
+            3,
+        ),
+    ],
+)
+def test_dsh_routed_surface_classification(
+    argv: list[str], expected_args: tuple[str, ...], patch_index: int
+) -> None:
+    from free_claude_code.cli.launchers.dsh import classify_dsh_invocation
+
+    invocation = classify_dsh_invocation(argv)
+
+    assert invocation.is_routed
+    assert invocation.args == expected_args
+    assert invocation.patch_index == patch_index
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["-h"],
+        ["--version"],
+        ["-V"],
+        ["plugin", "--profile", "web", "list"],
+        ["web", "--help"],
+        ["--profile", "headless", "--help"],
+        ["--dump-default-config"],
+        ["web", "--dump-default-config"],
+        ["--profile", "web", "--dump-default-config"],
+    ],
+)
+def test_dsh_management_surfaces_are_native_passthrough(argv: list[str]) -> None:
+    from free_claude_code.cli.launchers.dsh import classify_dsh_invocation
+
+    invocation = classify_dsh_invocation(argv)
+
+    assert not invocation.is_routed
+    assert invocation.args == tuple(argv)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--patch", "custom.yml"],
+        ["--patch=custom.yml"],
+        ["web", "--patch", "custom.yml"],
+        ["--profile", "headless", "--patch=custom.yml", "task"],
+    ],
+)
+def test_dsh_caller_patch_is_rejected_before_launch(argv: list[str]) -> None:
+    from free_claude_code.cli.launchers.dsh import classify_dsh_invocation
+
+    with pytest.raises(SystemExit) as exc_info:
+        classify_dsh_invocation(argv)
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--profile", "tui"],
+        ["--profile=custom", "task"],
+        ["--profile", ""],
+        ["--profile"],
+    ],
+)
+def test_dsh_unsupported_or_missing_profile_is_rejected(argv: list[str]) -> None:
+    from free_claude_code.cli.launchers.dsh import classify_dsh_invocation
+
+    with pytest.raises(SystemExit) as exc_info:
+        classify_dsh_invocation(argv)
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    ("output", "return_code", "expected"),
+    [
+        ("0.1.0-rc.8\n", 0, "0.1.0-rc.8"),
+        ("dsh v0.1.0-rc.8\n", 0, "0.1.0-rc.8"),
+        ("0.1.0-rc.7\n", 0, "0.1.0-rc.7"),
+        ("0.1.0\n", 0, "0.1.0"),
+        ("not a version\n", 0, None),
+        ("0.1.0-rc.8\n", 1, None),
+    ],
+)
+def test_dsh_version_parsing(
+    output: str, return_code: int, expected: str | None
+) -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with patch.object(
+        dsh.subprocess,
+        "run",
+        return_value=SimpleNamespace(returncode=return_code, stdout=output),
+    ):
+        assert dsh.dsh_binary_version("resolved-dsh") == expected
+
+
+def test_dsh_version_timeout_is_incompatible() -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with patch.object(
+        dsh.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired("dsh", 5),
+    ):
+        assert dsh.dsh_binary_version("resolved-dsh") is None
+
+
+@pytest.mark.parametrize("version", ["0.1.0-rc.7", "0.1.0", "0.1.0-rc.9", None])
+def test_dsh_requires_exact_audited_version_before_proxy(
+    version: str | None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with (
+        patch.object(dsh, "resolve_client_binary", return_value="resolved-dsh"),
+        patch.object(dsh, "dsh_binary_version", return_value=version),
+        patch.object(dsh, "get_settings") as get_settings,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dsh.launch([])
+
+    assert exc_info.value.code == 126
+    assert "0.1.0-rc.8" in capsys.readouterr().err
+    get_settings.assert_not_called()
+
+
+def test_dsh_native_passthrough_needs_no_proxy() -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with (
+        patch.object(dsh, "resolve_client_binary", return_value="resolved-dsh"),
+        patch.object(dsh, "get_settings") as get_settings,
+        patch.object(dsh, "require_compatible_dsh") as require_version,
+        patch.object(dsh, "run_client_process") as run_client_process,
+    ):
+        dsh.launch(["plugin", "--profile", "web", "list"])
+
+    run_client_process.assert_called_once_with(
+        command=["resolved-dsh", "plugin", "--profile", "web", "list"],
+        env=os.environ,
+        binary_name="dsh",
+        display_name="DeepSeek Harness",
+        install_hint="Install the supported DeepSeek Harness release with: "
+        "npm install -g @deepseek-ai/dsh@0.1.0-rc.8",
+    )
+    get_settings.assert_not_called()
+    require_version.assert_not_called()
+
+
+def test_dsh_launch_prepares_authenticated_catalog_and_timeout() -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with (
+        patch.object(dsh, "resolve_client_binary", return_value="resolved-dsh"),
+        patch.object(dsh, "require_compatible_dsh"),
+        patch.object(dsh, "get_settings", return_value=_settings()),
+        patch.object(dsh, "preflight_proxy", return_value=None),
+        patch.object(
+            dsh, "fetch_proxy_models_response", return_value=_models_payload()
+        ) as fetch_models,
+        patch.object(dsh, "_run_with_dsh_config") as run_configured,
+    ):
+        dsh.launch(["--profile", "headless", "hello", "world"])
+
+    fetch_models.assert_called_once_with("http://127.0.0.1:9191", "proxy-token")
+    call = run_configured.call_args.kwargs
+    assert call["binary_path"] == "resolved-dsh"
+    assert call["invocation"] == DshInvocation(
+        args=("--profile", "headless", "hello", "world"), patch_index=2
+    )
+    assert [model.wire_slug for model in call["models"]] == [
+        "nvidia_nim/vendor/model",
+        "claude-3-freecc-no-thinking/open_router/plain-model",
+    ]
+    assert call["auth_token"] == "proxy-token"
+    assert call["provider_progress_timeout"] == 600
+
+
+def test_dsh_proxy_failure_does_not_fetch_catalog(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with (
+        patch.object(dsh, "resolve_client_binary", return_value="resolved-dsh"),
+        patch.object(dsh, "require_compatible_dsh"),
+        patch.object(dsh, "get_settings", return_value=_settings()),
+        patch.object(dsh, "preflight_proxy", return_value="connection refused"),
+        patch.object(dsh, "fetch_proxy_models_response") as fetch_models,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dsh.launch([])
+
+    assert exc_info.value.code == 1
+    fetch_models.assert_not_called()
+    assert "fcc-server" in capsys.readouterr().err
+
+
+def test_dsh_empty_proxy_token_fails_before_health_check() -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with (
+        patch.object(dsh, "resolve_client_binary", return_value="resolved-dsh"),
+        patch.object(dsh, "require_compatible_dsh"),
+        patch.object(
+            dsh,
+            "get_settings",
+            return_value=SimpleNamespace(proxy_auth_token="   "),
+        ),
+        patch.object(dsh, "preflight_proxy") as preflight,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dsh.launch([])
+
+    assert exc_info.value.code == 1
+    preflight.assert_not_called()
+
+
+def test_dsh_catalog_failure_never_starts_child(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with (
+        patch.object(dsh, "resolve_client_binary", return_value="resolved-dsh"),
+        patch.object(dsh, "require_compatible_dsh"),
+        patch.object(dsh, "get_settings", return_value=_settings()),
+        patch.object(dsh, "preflight_proxy", return_value=None),
+        patch.object(
+            dsh,
+            "fetch_proxy_models_response",
+            side_effect=RuntimeError("catalog unavailable"),
+        ),
+        patch.object(dsh, "_run_with_dsh_config") as run_configured,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dsh.launch([])
+
+    assert exc_info.value.code == 1
+    run_configured.assert_not_called()
+    assert "catalog unavailable" in capsys.readouterr().err
+
+
+def test_dsh_child_environment_preserves_native_state_and_replaces_owned_keys() -> None:
+    from free_claude_code.cli.launchers.dsh import build_dsh_launcher_env
+
+    env = build_dsh_launcher_env(
+        auth_token="proxy-token",
+        proxy_root_url="http://127.0.0.1:9191",
+        base_env={
+            "PATH": "keep",
+            "DSH_HOME": "native-home",
+            "DEEPSEEK_API_KEY": "native-key",
+            "FCC_DSH_API_KEY": "stale",
+            "FCC_DSH_OTHER": "stale",
+            "DSH_TELEMETRY_DISABLED": "0",
+            "NO_PROXY": "example.com",
+        },
+    )
+
+    assert env["PATH"] == "keep"
+    assert env["DSH_HOME"] == "native-home"
+    assert env["DEEPSEEK_API_KEY"] == "native-key"
+    assert env["FCC_DSH_API_KEY"] == "proxy-token"
+    assert "FCC_DSH_OTHER" not in env
+    assert env["DSH_TELEMETRY_DISABLED"] == "1"
+    for key in ("NO_PROXY", "no_proxy"):
+        assert "example.com" in env[key]
+        assert "127.0.0.1" in env[key]
+
+
+def test_dsh_private_config_lives_for_child_and_is_removed_after_exit(
+    tmp_path: Path,
+) -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    observed_directory: Path | None = None
+
+    def inspect_child(**kwargs: object) -> None:
+        nonlocal observed_directory
+        command = kwargs["command"]
+        env = kwargs["env"]
+        assert isinstance(command, list)
+        assert isinstance(env, dict)
+        patch_index = command.index("--patch") + 1
+        patch_path = Path(command[patch_index])
+        observed_directory = patch_path.parent
+        assert patch_path.is_file()
+        assert command[:4] == [
+            "resolved-dsh",
+            "--profile",
+            "headless",
+            "--patch",
+        ]
+        assert command[-1] == "hello"
+        patch_payload = json.loads(patch_path.read_text(encoding="utf-8"))
+        settings_path = patch_path.parent / "settings.yaml"
+        credentials_path = patch_path.parent / ".credentials.yaml"
+        assert json.loads(settings_path.read_text(encoding="utf-8")) == {}
+        assert json.loads(credentials_path.read_text(encoding="utf-8")) == {}
+        settings_row = next(row for row in patch_payload if row["id"] == "settings")
+        credentials_row = next(
+            row for row in patch_payload if row["id"] == "credentials"
+        )
+        assert settings_row["config"]["path"] == str(settings_path)
+        assert credentials_row["config"]["path"] == str(credentials_path)
+        assert "proxy-token" not in json.dumps(patch_payload)
+        assert env["FCC_DSH_API_KEY"] == "proxy-token"
+        raise SystemExit(23)
+
+    invocation = DshInvocation(
+        args=("--profile", "headless", "hello"),
+        patch_index=2,
+    )
+    with (
+        patch.object(dsh.tempfile, "tempdir", str(tmp_path), create=True),
+        patch.object(dsh, "run_client_process", side_effect=inspect_child),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dsh._run_with_dsh_config(
+            binary_path="resolved-dsh",
+            invocation=invocation,
+            models=_models(),
+            proxy_root_url="http://127.0.0.1:9191",
+            auth_token="proxy-token",
+            provider_progress_timeout=600,
+        )
+
+    assert exc_info.value.code == 23
+    assert observed_directory is not None
+    assert not observed_directory.exists()
+
+
+def test_dsh_empty_catalog_fails_before_child() -> None:
+    from free_claude_code.cli.launchers import dsh
+
+    with (
+        patch.object(dsh, "run_client_process") as run_client_process,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        dsh._run_with_dsh_config(
+            binary_path="resolved-dsh",
+            invocation=DshInvocation(args=("web",), patch_index=1),
+            models=(),
+            proxy_root_url="http://127.0.0.1:9191",
+            auth_token="proxy-token",
+            provider_progress_timeout=600,
+        )
+
+    assert exc_info.value.code == 1
+    run_client_process.assert_not_called()

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -67,6 +67,7 @@ def test_cli_scripts_are_registered() -> None:
         "fcc-opencode": "free_claude_code.cli.launchers.opencode:launch",
         "fcc-cline": "free_claude_code.cli.launchers.cline:launch",
         "fcc-hermes": "free_claude_code.cli.launchers.hermes:launch",
+        "fcc-dsh": "free_claude_code.cli.launchers.dsh:launch",
     }
     assert pyproject["project"]["gui-scripts"] == {
         "fcc-desktop": "free_claude_code.cli.desktop_entrypoint:launch",

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -20,6 +20,7 @@ FCC_COMMANDS = (
     "fcc-opencode",
     "fcc-cline",
     "fcc-hermes",
+    "fcc-dsh",
     "fcc-init",
     "free-claude-code",
 )
@@ -54,6 +55,8 @@ def _posix_command(name: str) -> str:
         "opencode": "1.18.18",
         "cline": "3.0.55",
         "hermes": "0.20.4",
+        "dsh": "0.1.0-rc.8",
+        "node": "22.19.0",
     }.get(name, "1.0.0")
     version_output = (
         f"Hermes Agent v{version} (test build)"
@@ -88,6 +91,13 @@ if [ "${1:-}" = "install" ] && [ "${2:-}" = "-g" ] && [ "${3:-}" = "cline" ]; th
     mkdir -p "$FAKE_NPM_PREFIX/bin"
     cp "$FAKE_FIXTURES/cline-command.sh" "$FAKE_NPM_PREFIX/bin/cline"
     chmod +x "$FAKE_NPM_PREFIX/bin/cline"
+    exit 0
+fi
+if [ "${1:-}" = "install" ] && [ "${2:-}" = "-g" ] && [ "${3:-}" = "@deepseek-ai/dsh@0.1.0-rc.8" ]; then
+    [ "$FAIL_STEP" = "dsh-install" ] && exit 73
+    mkdir -p "$FAKE_NPM_PREFIX/bin"
+    cp "$FAKE_FIXTURES/dsh-command.sh" "$FAKE_NPM_PREFIX/bin/dsh"
+    chmod +x "$FAKE_NPM_PREFIX/bin/dsh"
     exit 0
 fi
 if [ "${1:-}" = "prefix" ] && [ "${2:-}" = "-g" ]; then
@@ -127,6 +137,7 @@ if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "install" ]; then
     cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-opencode"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-cline"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-hermes"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-dsh"
     if [ "$FAIL_STEP" != "fcc-missing" ]; then
         cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-codex"
     fi
@@ -411,6 +422,7 @@ chmod +x "$HOME/.local/bin/uv"
     _write_executable(fixtures / "opencode-command.sh", _posix_command("opencode"))
     _write_executable(fixtures / "cline-command.sh", _posix_command("cline"))
     _write_executable(fixtures / "hermes-command.sh", _posix_command("hermes"))
+    _write_executable(fixtures / "dsh-command.sh", _posix_command("dsh"))
     rtk_command = _posix_rtk_command().encode()
     with tarfile.open(
         fixtures / "rtk-x86_64-unknown-linux-musl.tar.gz", "w:gz"
@@ -448,6 +460,7 @@ esac
 """,
     )
     _write_executable(bin_dir / "opencode", _posix_command("opencode"))
+    _write_executable(bin_dir / "node", _posix_command("node"))
     npm_prefix = tmp_path / "npm-prefix"
     npm_prefix.mkdir()
     _write_executable(bin_dir / "npm", _posix_npm_command())
@@ -500,6 +513,9 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
     assert calls.index("hermes-install:--non-interactive --skip-setup") < calls.index(
         "hermes:--version"
     )
+    assert calls.index("npm:install -g @deepseek-ai/dsh@0.1.0-rc.8") < calls.index(
+        "dsh:--version"
+    )
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
         call.startswith(
@@ -521,7 +537,7 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
 def test_install_sh_installs_selected_hermes_without_setup(
     posix_harness: PosixHarness,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\n")
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\nn\n")
 
     assert result.returncode == 0, result.stdout
     calls = posix_harness.calls()
@@ -540,7 +556,9 @@ def test_install_sh_stops_when_selected_hermes_install_fails(
     posix_harness: PosixHarness,
     failure: str,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\n", fail_step=failure)
+    result = posix_harness.run_interactive(
+        "n\nn\nn\nn\nn\ny\nn\nn\n", fail_step=failure
+    )
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
@@ -553,7 +571,7 @@ def test_install_sh_rejects_unsupported_hermes_platform_before_download(
     posix_harness.env["FAKE_UNAME"] = "Darwin"
     posix_harness.env["FAKE_UNAME_MACHINE"] = "x86_64"
 
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\n")
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\nn\n")
 
     assert result.returncode != 0
     assert "does not provide a supported release for Darwin x86_64" in result.stdout
@@ -574,6 +592,96 @@ def test_install_sh_preserves_compatible_existing_hermes(
     assert not any(
         "hermes-agent.nousresearch.com" in call for call in posix_harness.calls()
     )
+
+
+def test_install_sh_installs_selected_dsh_at_exact_preview(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\ny\nn\n")
+
+    assert result.returncode == 0, result.stdout
+    calls = posix_harness.calls()
+    assert "npm:install -g @deepseek-ai/dsh@0.1.0-rc.8" in calls
+    assert calls.index("npm:install -g @deepseek-ai/dsh@0.1.0-rc.8") < calls.index(
+        "dsh:--version"
+    )
+    assert "Run DeepSeek Harness with: fcc-dsh" in result.stdout
+    assert not any(call.startswith("rtk:init") for call in calls)
+
+
+def test_install_sh_replaces_mismatched_dsh_preview(
+    posix_harness: PosixHarness,
+) -> None:
+    _write_executable(
+        posix_harness.bin_dir / "dsh",
+        _posix_command("dsh").replace("0.1.0-rc.8", "0.1.0-rc.7"),
+    )
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "does not match 0.1.0-rc.8" in result.stdout
+    assert "npm:install -g @deepseek-ai/dsh@0.1.0-rc.8" in posix_harness.calls()
+
+
+def test_install_sh_rejects_exact_dsh_on_unsupported_node(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_client("dsh")
+    _write_executable(
+        posix_harness.bin_dir / "node",
+        _posix_command("node").replace("node 22.19.0", "node 23.9.0"),
+    )
+
+    result = posix_harness.run()
+
+    assert result.returncode != 0
+    assert "requires Node.js ^22.19.0 or >=24.0.0" in result.stdout
+    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+
+
+@pytest.mark.parametrize("node_version", ["22.18.0", "23.9.0", "not-a-version"])
+def test_install_sh_rejects_incompatible_node_for_selected_dsh(
+    posix_harness: PosixHarness,
+    node_version: str,
+) -> None:
+    _write_executable(
+        posix_harness.bin_dir / "node",
+        _posix_command("node").replace("node 22.19.0", f"node {node_version}"),
+    )
+
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\ny\nn\n")
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+
+
+def test_install_sh_noninteractive_skips_dsh_without_node(
+    posix_harness: PosixHarness,
+) -> None:
+    (posix_harness.bin_dir / "node").unlink()
+    (posix_harness.bin_dir / "npm").unlink()
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "fcc-dsh wrapper is ready after you install DeepSeek Harness" in result.stdout
+    )
+    assert not any("@deepseek-ai/dsh" in call for call in posix_harness.calls())
+
+
+def test_install_sh_stops_when_selected_dsh_install_fails(
+    posix_harness: PosixHarness,
+) -> None:
+    result = posix_harness.run_interactive(
+        "n\nn\nn\nn\nn\nn\ny\nn\n", fail_step="dsh-install"
+    )
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    assert not any(call.startswith("uv:") for call in posix_harness.calls())
 
 
 def test_install_sh_installs_and_configures_rtk_for_selected_agents(
@@ -662,7 +770,7 @@ def test_install_sh_preserves_existing_rtk_and_configures_only_selected_agent(
 ) -> None:
     posix_harness.add_rtk()
 
-    result = posix_harness.run_interactive("n\ny\nn\nn\nn\nn\ny\n")
+    result = posix_harness.run_interactive("n\ny\nn\nn\nn\nn\nn\ny\n")
 
     assert result.returncode == 0, result.stdout
     assert "verifying it without updating it" in result.stdout
@@ -709,7 +817,9 @@ def test_install_sh_stops_when_rtk_setup_fails(
 def test_install_sh_reprompts_then_installs_only_selected_agent(
     posix_harness: PosixHarness,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\nn\ny\nn\nn\nn\nn\nn\n")
+    result = posix_harness.run_interactive(
+        "n\nn\nn\nn\nn\nn\nn\nn\ny\nn\nn\nn\nn\nn\nn\n"
+    )
 
     assert result.returncode == 0, result.stdout
     assert "Select at least one coding agent." in result.stdout
@@ -728,7 +838,9 @@ def test_install_sh_reprompts_then_installs_only_selected_agent(
 def test_install_sh_rejects_uninstalled_only_selection(
     posix_harness: PosixHarness,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\ny\nn\nn\nn\nn\n", fail_step="pi-skip")
+    result = posix_harness.run_interactive(
+        "n\nn\ny\nn\nn\nn\nn\nn\n", fail_step="pi-skip"
+    )
 
     assert result.returncode != 0
     assert "No selected coding agent was installed." in result.stdout
@@ -1272,6 +1384,8 @@ def _batch_client(name: str) -> str:
         "opencode": "1.18.18",
         "cline": "3.0.55",
         "hermes": "0.20.4",
+        "dsh": "0.1.0-rc.8",
+        "node": "22.19.0",
     }.get(name, "1.0.0")
     version_output = (
         f"Hermes Agent v{version} (test build)"
@@ -1299,6 +1413,7 @@ def _batch_npm() -> str:
     return r"""@echo off
 echo npm:%*>>"%CALL_LOG%"
 if "%1"=="install" if "%2"=="-g" if "%3"=="cline" goto install_cline
+if "%1"=="install" if "%2"=="-g" if "%3"=="@deepseek-ai/dsh@0.1.0-rc.8" goto install_dsh
 if "%1"=="prefix" if "%2"=="-g" echo %FAKE_NPM_PREFIX%& exit /b 0
 if "%1"=="config" if "%2"=="get" if "%3"=="prefix" echo %FAKE_NPM_PREFIX%& exit /b 0
 exit /b 71
@@ -1306,6 +1421,11 @@ exit /b 71
 if "%FAIL_STEP%"=="cline-install" exit /b 72
 if not exist "%FAKE_NPM_PREFIX%" mkdir "%FAKE_NPM_PREFIX%"
 copy /y "%FAKE_FIXTURES%\cline-command.cmd" "%FAKE_NPM_PREFIX%\cline.cmd" >nul
+exit /b 0
+:install_dsh
+if "%FAIL_STEP%"=="dsh-install" exit /b 73
+if not exist "%FAKE_NPM_PREFIX%" mkdir "%FAKE_NPM_PREFIX%"
+copy /y "%FAKE_FIXTURES%\dsh-command.cmd" "%FAKE_NPM_PREFIX%\dsh.cmd" >nul
 exit /b 0
 """
 
@@ -1333,6 +1453,7 @@ copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-pi.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-opencode.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-cline.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-hermes.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-dsh.cmd" >nul
 if not "%FAIL_STEP%"=="fcc-missing" copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-codex.cmd" >nul
 exit /b 0
 :update_shell
@@ -1463,6 +1584,7 @@ def powershell_harness(
     (fixtures / "hermes-command.cmd").write_text(
         _batch_client("hermes"), encoding="utf-8"
     )
+    (fixtures / "dsh-command.cmd").write_text(_batch_client("dsh"), encoding="utf-8")
     (fixtures / "rtk-command.cmd").write_text(_batch_rtk(), encoding="utf-8")
     (fixtures / "uv-command.cmd").write_text(_batch_uv("0.11.28"), encoding="utf-8")
     (fixtures / "fcc-command.cmd").write_text(
@@ -1548,6 +1670,7 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "uv-install"
                 arcname="opencode.exe",
             )
     (bin_dir / "opencode.cmd").write_text(_batch_client("opencode"), encoding="utf-8")
+    (bin_dir / "node.cmd").write_text(_batch_client("node"), encoding="utf-8")
     npm_prefix = tmp_path / "npm-prefix"
     npm_prefix.mkdir()
     (bin_dir / "npm.cmd").write_text(_batch_npm(), encoding="utf-8")
@@ -1684,6 +1807,9 @@ def test_install_ps1_fresh_install_is_verified(
     assert calls.index("npm:install -g cline") < calls.index("cline:--version")
     assert any("hermes-agent.nousresearch.com/install.ps1" in call for call in calls)
     assert "hermes-install:True:True" in calls
+    assert calls.index("npm:install -g @deepseek-ai/dsh@0.1.0-rc.8") < calls.index(
+        "dsh:--version"
+    )
     assert not any("hermes:setup" in call for call in calls)
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
@@ -1738,6 +1864,99 @@ def test_install_ps1_preserves_compatible_existing_hermes(
     assert not any(
         "hermes-agent.nousresearch.com" in call for call in powershell_harness.calls()
     )
+
+
+def test_install_ps1_preserves_exact_dsh_preview(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("dsh")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "already matches the supported preview" in result.stdout
+    assert "npm:install -g @deepseek-ai/dsh@0.1.0-rc.8" not in (
+        powershell_harness.calls()
+    )
+
+
+def test_install_ps1_replaces_mismatched_dsh_preview(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    (powershell_harness.bin_dir / "dsh.cmd").write_text(
+        _batch_client("dsh").replace("0.1.0-rc.8", "0.1.0-rc.7"),
+        encoding="utf-8",
+    )
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "does not match 0.1.0-rc.8" in result.stdout
+    assert "npm:install -g @deepseek-ai/dsh@0.1.0-rc.8" in (powershell_harness.calls())
+
+
+def test_install_ps1_rejects_exact_dsh_on_unsupported_node(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("dsh")
+    (powershell_harness.bin_dir / "node.cmd").write_text(
+        _batch_client("node").replace("node 22.19.0", "node 23.9.0"),
+        encoding="utf-8",
+    )
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert "requires Node.js ^22.19.0 or >=24.0.0" in (
+        f"{result.stdout}\n{result.stderr}"
+    )
+    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+
+
+@pytest.mark.parametrize("node_version", ["22.18.0", "23.9.0", "not-a-version"])
+def test_install_ps1_rejects_incompatible_node_for_selected_dsh(
+    powershell_harness: PowerShellHarness,
+    node_version: str,
+) -> None:
+    (powershell_harness.bin_dir / "dsh.cmd").write_text(
+        _batch_client("dsh").replace("0.1.0-rc.8", "0.1.0-rc.7"),
+        encoding="utf-8",
+    )
+    (powershell_harness.bin_dir / "node.cmd").write_text(
+        _batch_client("node").replace("node 22.19.0", f"node {node_version}"),
+        encoding="utf-8",
+    )
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+
+
+def test_install_ps1_noninteractive_skips_dsh_without_node(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    (powershell_harness.bin_dir / "node.cmd").unlink()
+    (powershell_harness.bin_dir / "npm.cmd").unlink()
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "fcc-dsh wrapper is ready after you install DeepSeek Harness" in result.stdout
+    )
+    assert not any("@deepseek-ai/dsh" in call for call in powershell_harness.calls())
+
+
+def test_install_ps1_stops_when_selected_dsh_install_fails(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    result = powershell_harness.run(fail_step="dsh-install")
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
 
 
 def test_install_ps1_upgrades_old_hermes_with_noninteractive_setup_skipped(
@@ -2356,8 +2575,8 @@ Invoke-DownloadedPowerShellInstaller `
     ("answers", "expected", "expected_messages"),
     [
         (
-            ("", "", "", "", "", "", ""),
-            "True,True,True,True,False,True,False",
+            ("", "", "", "", "", "", "", ""),
+            "True,True,True,True,False,True,True,False",
             (),
         ),
         (
@@ -2370,14 +2589,16 @@ Invoke-DownloadedPowerShellInstaller `
                 "n",
                 "n",
                 "n",
+                "n",
                 "y",
+                "n",
                 "n",
                 "n",
                 "n",
                 "n",
                 "y",
             ),
-            "False,True,False,False,False,False,True",
+            "False,True,False,False,False,False,False,True",
             ("Please answer Y or N.", "Select at least one coding agent."),
         ),
     ],
@@ -2402,6 +2623,7 @@ $script:InstallPi = $true
 $script:InstallOpenCode = $true
 $script:InstallCline = $false
 $script:InstallHermes = $true
+$script:InstallDsh = $true
 $script:EnableRtk = $false
 function Read-Host {{
     param([string] $Prompt)
@@ -2412,7 +2634,7 @@ function Read-Host {{
 function Read-YesNo {{{read_yes_no}}}
 function Select-CodingAgents {{{select_agents}}}
 Select-CodingAgents
-Write-Output "selection:$($script:InstallClaudeCode),$($script:InstallCodex),$($script:InstallPi),$($script:InstallOpenCode),$($script:InstallCline),$($script:InstallHermes),$($script:EnableRtk)"
+Write-Output "selection:$($script:InstallClaudeCode),$($script:InstallCodex),$($script:InstallPi),$($script:InstallOpenCode),$($script:InstallCline),$($script:InstallHermes),$($script:InstallDsh),$($script:EnableRtk)"
 """
 
     result = subprocess.run(
@@ -2440,6 +2662,7 @@ $script:InstallPi = $false
 $script:InstallOpenCode = $false
 $script:InstallCline = $false
 $script:InstallHermes = $false
+$script:InstallDsh = $false
 $script:PiAvailable = $false
 $script:Calls = @()
 function Write-Step {{ param([string] $Message) }}
@@ -2449,6 +2672,7 @@ function Ensure-Pi {{ $script:Calls += "pi"; $script:PiAvailable = $true }}
 function Ensure-OpenCode {{ $script:Calls += "opencode" }}
 function Ensure-Cline {{ $script:Calls += "cline" }}
 function Ensure-Hermes {{ $script:Calls += "hermes" }}
+function Ensure-Dsh {{ $script:Calls += "dsh" }}
 function Ensure-SelectedCodingAgents {{{body}}}
 Ensure-SelectedCodingAgents
 Write-Output "calls:$($script:Calls -join ',')"
@@ -2480,6 +2704,7 @@ $script:InstallPi = $true
 $script:InstallOpenCode = $false
 $script:InstallCline = $false
 $script:InstallHermes = $false
+$script:InstallDsh = $false
 $script:PiAvailable = $false
 $script:Calls = @()
 function Write-Step {{ param([string] $Message) }}
@@ -2516,6 +2741,7 @@ $script:InstallPi = $true
 $script:InstallOpenCode = $false
 $script:InstallCline = $false
 $script:InstallHermes = $false
+$script:InstallDsh = $false
 $script:PiAvailable = $false
 function Write-Step {{ param([string] $Message) }}
 function Ensure-ClaudeCode {{ }}
@@ -2524,6 +2750,7 @@ function Ensure-Pi {{ }}
 function Ensure-OpenCode {{ }}
 function Ensure-Cline {{ }}
 function Ensure-Hermes {{ }}
+function Ensure-Dsh {{ }}
 function Ensure-SelectedCodingAgents {{{body}}}
 Ensure-SelectedCodingAgents
 """

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -636,7 +636,7 @@ def test_install_sh_rejects_exact_dsh_on_unsupported_node(
     result = posix_harness.run()
 
     assert result.returncode != 0
-    assert "requires Node.js ^22.19.0 or >=24.0.0" in result.stdout
+    assert "requires Node.js ^22.19.0 or >=24.0.0" in result.stderr
     assert not any(call.startswith("uv:") for call in posix_harness.calls())
 
 

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -15,6 +15,7 @@ FCC_COMMANDS = (
     "fcc-opencode",
     "fcc-cline",
     "fcc-hermes",
+    "fcc-dsh",
     "fcc-init",
     "free-claude-code",
 )
@@ -138,9 +139,13 @@ def posix_uninstall_harness(tmp_path: Path) -> PosixUninstallHarness:
     _write_executable(bin_dir / "opencode", "#!/bin/sh\nexit 0\n")
     _write_executable(bin_dir / "cline", "#!/bin/sh\nexit 0\n")
     _write_executable(bin_dir / "hermes", "#!/bin/sh\nexit 0\n")
+    _write_executable(bin_dir / "dsh", "#!/bin/sh\nexit 0\n")
     hermes_state = home / ".hermes" / "sessions" / "state.json"
     hermes_state.parent.mkdir(parents=True)
     hermes_state.write_text('{"native": true}\n', encoding="utf-8")
+    dsh_state = home / ".dsh" / "sessions" / "state.json"
+    dsh_state.parent.mkdir(parents=True)
+    dsh_state.write_text('{"native": true}\n', encoding="utf-8")
     _write_executable(
         bin_dir / "pgrep",
         """#!/bin/sh
@@ -172,7 +177,7 @@ if [ "${1:-}" = "tool" ] && [ "${2:-}" = "uninstall" ]; then
         echo 'Tool `free-claude-code` is not installed' >&2
         exit 2
     fi
-    for name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-init free-claude-code; do
+    for name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-init free-claude-code; do
         /bin/rm -f "$FAKE_TOOL_BIN/$name"
     done
     echo "Uninstalled free-claude-code"
@@ -244,8 +249,12 @@ def test_uninstall_sh_removes_and_verifies_only_fcc(
     assert (posix_uninstall_harness.bin_dir / "opencode").exists()
     assert (posix_uninstall_harness.bin_dir / "cline").exists()
     assert (posix_uninstall_harness.bin_dir / "hermes").exists()
+    assert (posix_uninstall_harness.bin_dir / "dsh").exists()
     assert (
         posix_uninstall_harness.home / ".hermes" / "sessions" / "state.json"
+    ).read_text(encoding="utf-8") == '{"native": true}\n'
+    assert (
+        posix_uninstall_harness.home / ".dsh" / "sessions" / "state.json"
     ).read_text(encoding="utf-8") == '{"native": true}\n'
     assert posix_uninstall_harness.calls() == [
         "uv:tool dir --bin",
@@ -493,11 +502,14 @@ def powershell_uninstall_harness(
         (tool_bin / f"{name}.cmd").write_text(
             "@echo off\nexit /b 0\n", encoding="utf-8"
         )
-    for name in ("claude", "codex", "pi", "opencode", "cline", "hermes"):
+    for name in ("claude", "codex", "pi", "opencode", "cline", "hermes", "dsh"):
         (bin_dir / f"{name}.cmd").write_text("@echo off\nexit /b 0\n", encoding="utf-8")
     hermes_state = local_app_data / "hermes" / "state.json"
     hermes_state.parent.mkdir(parents=True)
     hermes_state.write_text('{"native": true}\n', encoding="utf-8")
+    dsh_state = home / ".dsh" / "sessions" / "state.json"
+    dsh_state.parent.mkdir(parents=True)
+    dsh_state.write_text('{"native": true}\n', encoding="utf-8")
 
     uv_commands = " ".join(FCC_COMMANDS)
     (bin_dir / "uv.cmd").write_text(
@@ -625,8 +637,12 @@ def test_uninstall_ps1_removes_and_verifies_only_fcc(
     assert (powershell_uninstall_harness.bin_dir / "opencode.cmd").exists()
     assert (powershell_uninstall_harness.bin_dir / "cline.cmd").exists()
     assert (powershell_uninstall_harness.bin_dir / "hermes.cmd").exists()
+    assert (powershell_uninstall_harness.bin_dir / "dsh.cmd").exists()
     assert (
         Path(powershell_uninstall_harness.env["LOCALAPPDATA"]) / "hermes" / "state.json"
+    ).read_text(encoding="utf-8") == '{"native": true}\n'
+    assert (
+        powershell_uninstall_harness.home / ".dsh" / "sessions" / "state.json"
     ).read_text(encoding="utf-8") == '{"native": true}\n'
     assert powershell_uninstall_harness.calls() == [
         "uv:tool dir --bin",

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.9.0"
+version = "5.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

DeepSeek Harness users cannot use FCC's live model catalog in its Web and headless interfaces without reconfiguring native DSH state, while DSH-owned retries can duplicate FCC's retry and model-fallback lifecycle.

## Changes

| Before | After |
| --- | --- |
| DeepSeek Harness had no FCC launcher. | `fcc-dsh` opens the attached Web UI or runs the shipped headless profile through FCC's Responses endpoint. |
| Routing required native DSH settings and credentials. | Each launch uses private temporary settings, credentials, and a fail-closed FCC model snapshot while preserving native sessions and plugins. |
| DSH and FCC could both retry the same model request. | DSH provider retries are disabled so FCC alone owns retries, ordered fallback, and progress timing. |
| Installation did not recognize the DSH preview contract. | Both installers offer and verify exact DSH 0.1.0-rc.8 on a supported Node runtime; FCC uninstall preserves DSH and its state. |
| Compatibility depended on assumptions about the preview client. | Deterministic contracts plus real zero-cost headless, failure, and Web-startup smokes verify the current integration. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds DeepSeek Harness as a Free Claude Code coding-agent integration, including an `fcc-dsh` launcher, isolated process-local configuration, installer support, and product smoke coverage. The exact supported DSH preview accepted the generated configuration, and both routed headless use and Web startup completed successfully against local upstream services.
</details>

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The generated DeepSeek Harness configuration was accepted by the supported runtime, and the routed headless, Web startup, and terminal provider-failure flows completed with their expected behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The environment originally lacked dsh, so we installed @deepseek-ai/dsh@0.1.0-rc.8 into an isolated user-writable npm prefix.
- We ran a patch-contract harness test where a malformed non-list overlay was rejected by DSH, while the FCC-generated overlay composed and exited successfully.
- We executed the local Free Claude Code proxy integration smoke tests with the exact DSH preview; headless use and Web startup passed.
- We tested the failing-provider route through Free Claude Code and DSH; the terminal-failure flow behaved as expected.
- We conducted final routing validation showing two passes for headless and web, and one pass for the terminal-provider-failure path.

<a href="https://app.greptile.com/trex/runs/19764049/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix POSIX DSH installer assertion"](https://github.com/alishahryar1/free-claude-code/commit/197d14d8210dd785c10e539719e9203be9f4344d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55058114)</sub>

<!-- /greptile_comment -->