### PR TITLE
Fix Hermes version parsing in the Windows installer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.11.0"
+version = "5.11.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -866,11 +866,11 @@ function Get-HermesVersion {
     param([string] $HermesPath)
 
     $output = Invoke-Utf8NativeCapture -FilePath $HermesPath -Arguments @("--version")
-    $version = Convert-SemanticVersionOutput $output
-    if ([string]::IsNullOrWhiteSpace($version)) {
-        throw "Hermes Agent is present, but 'hermes --version' did not return a valid semantic version."
+    if ($output -match '(?im)^\s*(?:Hermes Agent\s+)?v?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?=\s|$)') {
+        return $Matches["version"]
     }
-    return $version
+
+    throw "Hermes Agent is present, but 'hermes --version' did not return a valid semantic version."
 }
 
 function Confirm-HermesArchitecture {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -866,7 +866,7 @@ function Get-HermesVersion {
     param([string] $HermesPath)
 
     $output = Invoke-Utf8NativeCapture -FilePath $HermesPath -Arguments @("--version")
-    if ($output -match '(?im)^\s*(?:Hermes Agent\s+)?v?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?=\s|$)') {
+    if ($output -match '(?im)^\s*Hermes Agent\s+v?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?=\s|$)') {
         return $Matches["version"]
     }
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1950,12 +1950,21 @@ def test_install_ps1_preserves_compatible_existing_hermes(
     )
 
 
+@pytest.mark.parametrize("unrelated_version", ["3.12.11", "v3.12.11"])
 def test_install_ps1_rejects_unrelated_versions_in_hermes_output(
     powershell_harness: PowerShellHarness,
+    unrelated_version: str,
 ) -> None:
-    hermes_command = _batch_client("hermes").replace(
-        "echo Hermes Agent v0.20.4 (2026.8.18) · upstream deadbeef",
-        "echo Hermes Agent release unavailable",
+    hermes_command = (
+        _batch_client("hermes")
+        .replace(
+            "echo Hermes Agent v0.20.4 (2026.8.18) · upstream deadbeef",
+            "echo Hermes Agent release unavailable",
+        )
+        .replace(
+            "echo Python: 3.12.11",
+            f"echo {unrelated_version}",
+        )
     )
     _write_executable(powershell_harness.bin_dir / "hermes.cmd", hermes_command)
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1448,9 +1448,17 @@ def _batch_client(name: str) -> str:
         "node": "22.19.0",
     }.get(name, "1.0.0")
     version_output = (
-        f"Hermes Agent v{version} (test build)"
+        (
+            f'if "%1"=="--version" echo Hermes Agent v{version} '
+            "(2026.8.18) · upstream deadbeef\n"
+            'if "%1"=="--version" echo Install directory: C:\\fake-hermes\n'
+            'if "%1"=="--version" echo Install method: git\n'
+            'if "%1"=="--version" echo Python: 3.12.11\n'
+            'if "%1"=="--version" echo OpenAI SDK: 2.15.0\n'
+            'if "%1"=="--version" echo Up to date'
+        )
         if name == "hermes"
-        else f"{name} {version}"
+        else f'if "%1"=="--version" echo {name} {version}'
     )
     help_output = (
         "echo   --extension, -e ^<path^>  Load an extension\n"
@@ -1461,7 +1469,7 @@ def _batch_client(name: str) -> str:
     return f"""@echo off
 echo {name}:%*>>"%CALL_LOG%"
 if "%FAIL_STEP%"=="{name}-verify" exit /b 51
-if "%1"=="--version" echo {version_output}
+{version_output}
 if "%1"=="--help" (
 {help_output}
 )
@@ -1940,6 +1948,22 @@ def test_install_ps1_preserves_compatible_existing_hermes(
     assert not any(
         "hermes-agent.nousresearch.com" in call for call in powershell_harness.calls()
     )
+
+
+def test_install_ps1_rejects_unrelated_versions_in_hermes_output(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    hermes_command = _batch_client("hermes").replace(
+        "echo Hermes Agent v0.20.4 (2026.8.18) · upstream deadbeef",
+        "echo Hermes Agent release unavailable",
+    )
+    _write_executable(powershell_harness.bin_dir / "hermes.cmd", hermes_command)
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert "did not return a valid semantic version" in result.stderr
+    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
 
 
 def test_install_ps1_preserves_compatible_existing_grok(

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.11.0"
+version = "5.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Hermes now appends repository metadata and diagnostics to `hermes --version`. The Windows installer required the old full-line shape and aborted the default installation. Fixes #1490.

## Changes

| Before | After |
| --- | --- |
| Windows Hermes validation required the complete version line to match an older format. | Windows Hermes validation extracts the semantic version and permits trailing metadata. |
| Installer fixtures emitted an invented single-line Hermes response. | Installer fixtures exercise the current multiline response and reject unrelated Python or SDK versions. |
| The package remained at 5.11.0. | The patch release is 5.11.1. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Windows installer now accepts Hermes versions only when the output identifies Hermes Agent, preventing unrelated semantic-version lines from being treated as a compatible Hermes installation.
</details>

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The current parser requires the Hermes Agent identifier before extracting a version, addressing the previously reported acceptance path.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the Hermes parser contract in scripts/install.ps1.
- Checked for PowerShell executables before attempting runtime parser validation.
- Confirmed that neither pwsh nor powershell was available in the environment, so the Windows parser could not be executed.
- Reviewed the execution evidence log for the availability check, which records the command, the working directory, the exit code, and the blocker.

<a href="https://app.greptile.com/trex/runs/19872541/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Require Hermes identity in version outpu..."](https://github.com/alishahryar1/free-claude-code/commit/196760600192a701a45968178705984859496f0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55268159)</sub>

<!-- /greptile_comment -->