### PR TITLE
Add Muse Code as a first-class FCC client

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,17 +12,17 @@ and how contributors should extend it.
 
 Free Claude Code is a local proxy for agent clients. It accepts Anthropic
 Messages traffic from Claude Code and Pi clients and OpenAI Responses traffic
-from Codex, OpenCode, Cline, Hermes, DeepSeek Harness, and Grok Build clients,
-routes the request to a configured upstream provider, and preserves the wire
-protocol expected by the caller.
+from Codex, OpenCode, Cline, Hermes, DeepSeek Harness, Grok Build, and Muse Code
+clients, routes the request to a configured upstream provider, and preserves
+the wire protocol expected by the caller.
 
 There are three runtime surfaces:
 
 - HTTP proxy: FastAPI routes expose Anthropic-compatible, Responses-compatible,
   health, model-listing, stop, and admin endpoints.
 - CLI launchers: wrapper entrypoints prepare Claude Code, Codex, Pi, OpenCode,
-  Cline, Hermes, DeepSeek Harness, and Grok Build sessions so they target the
-  local proxy.
+  Cline, Hermes, DeepSeek Harness, Grok Build, and Muse Code sessions so they
+  target the local proxy.
 - Messaging bridge: optional Discord or Telegram adapters turn chat messages
   into managed client CLI sessions.
 
@@ -36,6 +36,7 @@ flowchart LR
     Hermes[Hermes Agent] --> ProxyAPI
     DSH[DeepSeek Harness] --> ProxyAPI
     Grok[Grok Build] --> ProxyAPI
+    Muse[Muse Code] --> ProxyAPI
     AdminUI[Local Admin UI] --> ProxyAPI
     Bots[Discord or Telegram Bots] --> Messaging[Messaging Bridge]
     Messaging --> ClientCLI[Managed Client CLI Sessions]
@@ -190,6 +191,9 @@ for real prompts against supported providers:
 - `fcc-grok`, Grok Build 1.0.5 or newer, and the OpenAI Responses behavior it
   relies on for attached terminal, headless, and ACP sessions, including an
   FCC-scoped model catalog and process-local configuration.
+- `fcc-muse`, Muse Code 0.2.1 or newer, and the OpenAI Responses behavior it
+  relies on for attached TUI, exec, and resume sessions, including an
+  FCC-scoped model catalog and process-local routing.
 - Configured Discord and Telegram messaging bridges, including command handling,
   reply-based conversation branches, status updates, transcript rendering,
   managed Claude/Codex task execution where configured, task stop/clear flows,
@@ -249,6 +253,7 @@ Console scripts are registered in [pyproject.toml](pyproject.toml):
 - `fcc-hermes` calls `free_claude_code.cli.launchers.hermes:launch`.
 - `fcc-dsh` calls `free_claude_code.cli.launchers.dsh:launch`.
 - `fcc-grok` calls `free_claude_code.cli.launchers.grok:launch`.
+- `fcc-muse` calls `free_claude_code.cli.launchers.muse:launch`.
 
 [scripts/install.sh](scripts/install.sh) and [scripts/install.ps1](scripts/install.ps1)
 install or update the uv tool plus optional voice extras. On Windows the
@@ -258,7 +263,7 @@ and [scripts/uninstall.ps1](scripts/uninstall.ps1) remove those exact desktop
 artifacts, the FCC uv tool, and the managed `~/.fcc/` tree from
 [config/paths.py](src/free_claude_code/config/paths.py); they do not remove
 uv, Claude Code, Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, Grok
-Build, or uv-managed Python runtimes. [scripts/ci.sh](scripts/ci.sh) and
+Build, Muse Code, or uv-managed Python runtimes. [scripts/ci.sh](scripts/ci.sh) and
 [scripts/ci.ps1](scripts/ci.ps1) mirror [.github/workflows/tests.yml](.github/workflows/tests.yml)
 for local pre-push verification.
 
@@ -432,6 +437,8 @@ non-loopback clients and non-local origins.
 - `POST /v1/responses`: OpenAI Responses-compatible requests.
 - `POST /v1/messages/count_tokens`: Anthropic token counting.
 - `GET /v1/models`: gateway and Claude-compatible model listing.
+- `GET /muse-code/models`: authenticated Muse compatibility alias for the
+  direct Responses model view.
 - `GET /health`: health check.
 - `POST /stop`: stop CLI sessions and pending tasks.
 - `HEAD` and `OPTIONS` probes for compatibility on supported endpoints.
@@ -1297,8 +1304,9 @@ client environment.
 [cli/launchers/model_catalog.py](src/free_claude_code/cli/launchers/model_catalog.py)
 consumes the direct Responses view, validates its nested `provider/model`
 references, and is shared by Codex, OpenCode, Cline, Hermes, DeepSeek Harness,
-and Grok Build. The API owns compatibility filtering and direct wire identity;
-each launcher owns only translation into its client's configuration format.
+Grok Build, and Muse Code. The API owns compatibility filtering and direct wire
+identity; each launcher owns only translation into its client's configuration
+format.
 
 [cli/launchers/pi.py](src/free_claude_code/cli/launchers/pi.py) owns the installed
 `fcc-pi` launcher and [cli/launchers/pi_extension.ts](src/free_claude_code/cli/launchers/pi_extension.ts)
@@ -1434,6 +1442,30 @@ installed `fcc-grok` launcher for stable Grok Build 1.0.5 or newer:
   Responses-side service contract FCC does not implement. Ordinary `grok`
   remains unchanged.
 
+[cli/launchers/muse.py](src/free_claude_code/cli/launchers/muse.py) owns the
+installed `fcc-muse` launcher for Muse Code 0.2.1 or newer:
+
+- Attached TUI, `exec`, and `resume` sessions require a reachable FCC server,
+  a canonical proxy token, and a non-empty direct Responses catalog. Caller
+  provider and base-URL overrides are rejected, and explicit model choices are
+  validated before Muse starts.
+- A child-only environment replaces Muse's Meta bearer token and removes
+  inherited model, custom-header, and routing controls. Grammar-correct
+  `--provider meta`, FCC `/v1`, and model flags route the native Muse Responses
+  transport through FCC without writing Muse configuration or account state.
+- Muse fetches `/muse-code/models`; that authenticated route is a fixed alias
+  over FCC's existing Responses catalog builder rather than another inventory.
+  Native help, authentication, configuration, export, trace, skills, sandbox,
+  and initialization commands pass through without requiring FCC.
+- Muse retains its native whole-request retry loop because release 0.2.1 has no
+  complete process-scoped retry-off control and does not honor
+  `x-should-retry: false`. FCC still owns provider retries and ordered model
+  fallback inside each repeated request; the launcher does not mutate Muse's
+  persistent retry settings.
+- Meta's official installer currently supports macOS, Linux, and WSL. The
+  PowerShell installer verifies an existing compatible Muse binary but does not
+  invent a Windows installation or update path.
+
 [cli/managed/](src/free_claude_code/cli/managed/) owns managed Claude Code subprocesses used by
 Discord and Telegram messaging. Managed task invocations extend the same proxy
 environment only with non-interactive terminal settings, optional `--resume`,
@@ -1457,10 +1489,10 @@ reports a count-only failure, and leaves failures available for the next cleanup
 attempt. Real-session registration is collision-safe and becomes durable tree
 state only after the manager accepts it.
 
-Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, and Grok Build are
-supported through their installed launchers. FCC does not keep internal managed
-session runners for them because no user-facing messaging setting selects those
-clients for Discord or Telegram.
+Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, Grok Build, and Muse Code
+are supported through their installed launchers. FCC does not keep internal
+managed session runners for them because no user-facing messaging setting
+selects those clients for Discord or Telegram.
 
 ## Messaging Architecture
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## What You Get
 
 - **48 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
-- **8 coding agents. One model catalog.** Run [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://github.com/openai/codex), [Pi](https://github.com/earendil-works/pi), [OpenCode](https://github.com/anomalyco/opencode), [Cline](https://github.com/cline/cline), [Hermes](https://github.com/NousResearch/hermes-agent), [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), or [Grok Build](https://github.com/xai-org/grok-build) with your FCC models.
+- **9 coding agents. One model catalog.** Run [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://github.com/openai/codex), [Pi](https://github.com/earendil-works/pi), [OpenCode](https://github.com/anomalyco/opencode), [Cline](https://github.com/cline/cline), [Hermes](https://github.com/NousResearch/hermes-agent), [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), [Grok Build](https://github.com/xai-org/grok-build), or [Muse Code](https://research.meta.ai/blog/introducing-muse-code-and-muse-spark-1-2/) with your FCC models.
 - **Keep coding through provider outages.** After retries are exhausted, FCC automatically tries your next configured model without making you restart the turn—across every client.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
 - **Terminal, desktop, IDE, or phone.** Work through native launchers, [VS Code](https://code.visualstudio.com/), [Codex App](https://learn.chatgpt.com/docs/app), [JetBrains](https://www.jetbrains.com/), [Discord](https://discord.com/), or [Telegram](https://telegram.org/).
@@ -155,7 +155,13 @@ Grok Build:
 fcc-grok
 ```
 
-All eight launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
+Muse Code:
+
+```bash
+fcc-muse
+```
+
+All nine launchers use the current Admin UI settings. Use the agent's model picker to choose from the models FCC exposes. Normal CLI arguments still work, for example:
 
 ```bash
 fcc-codex exec "hello"
@@ -170,6 +176,9 @@ on Node.js `^22.19` or `>=24`.
 `fcc-grok` keeps Grok Build's sessions and plugins, while routing attached
 sessions through FCC. Web search and fetch stay disabled until FCC supports
 Grok Build's Responses-side web-tool contract.
+`fcc-muse` keeps Muse Code's native sessions and settings while routing attached
+sessions through FCC. Muse is beta; Meta's official installer currently supports
+macOS, Linux, and WSL, while Windows requires a compatible preinstalled binary.
 
 <a id="model-picker"></a>
 
@@ -319,7 +328,7 @@ Open **Admin UI → Model Config → Reasoning** and select the behavior you wan
 
 | Selection | Behavior |
 | --- | --- |
-| **From client** (default) | Use the effort sent by Claude Code, Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, or Grok Build. If none is sent, keep the provider default. |
+| **From client** (default) | Use the effort sent by Claude Code, Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, Grok Build, or Muse Code. If none is sent, keep the provider default. |
 | **Off** | Request reasoning to be disabled. |
 | **Low**, **Medium**, **High**, **X-High**, or **Max** | Override the client with the selected reasoning level. |
 | **Inherit** (Fable, Opus, Sonnet, and Haiku only) | Use the root Reasoning selection. |
@@ -333,7 +342,8 @@ Providers that do not support a selected control retain their own behavior.
 ## Connect Your Client
 
 For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`,
-`fcc-pi`, `fcc-opencode`, `fcc-cline`, `fcc-hermes`, `fcc-dsh`, or `fcc-grok`.
+`fcc-pi`, `fcc-opencode`, `fcc-cline`, `fcc-hermes`, `fcc-dsh`, `fcc-grok`, or
+`fcc-muse`.
 Use the guides below for editor integrations.
 
 <details>
@@ -571,7 +581,7 @@ Stop every running FCC command before uninstalling.
 **Keeps**
 
 - uv and Python
-- Claude Code, Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, Grok Build, and RTK
+- Claude Code, Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, Grok Build, Muse Code, and RTK
 - Shared PATH entries
 
 macOS/Linux:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.11.1"
+version = "5.12.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -38,6 +38,7 @@ fcc-cline = "free_claude_code.cli.launchers.cline:launch"
 fcc-hermes = "free_claude_code.cli.launchers.hermes:launch"
 fcc-dsh = "free_claude_code.cli.launchers.dsh:launch"
 fcc-grok = "free_claude_code.cli.launchers.grok:launch"
+fcc-muse = "free_claude_code.cli.launchers.muse:launch"
 
 [project.gui-scripts]
 fcc-desktop = "free_claude_code.cli.desktop_entrypoint:launch"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -30,6 +30,7 @@ $DshVersion = "0.1.0-rc.8"
 $DshPackage = "@deepseek-ai/dsh@$DshVersion"
 $GrokInstallUrl = "https://x.ai/cli/install.ps1"
 $MinGrokVersion = "1.0.5"
+$MinMuseVersion = "0.2.1"
 $RtkVersion = "0.44.2"
 $RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/download/v$RtkVersion"
 $RtkWindowsAssetName = "rtk-x86_64-pc-windows-msvc.zip"
@@ -43,7 +44,9 @@ $script:InstallCline = $false
 $script:InstallHermes = $true
 $script:InstallDsh = $true
 $script:InstallGrok = $true
+$script:InstallMuse = $true
 $script:PiAvailable = $false
+$script:MuseAvailable = $false
 $script:EnableRtk = $Rtk.IsPresent
 $FccCommands = @(
     # Include retired entry points so updates reject older FCC processes before replacement.
@@ -57,6 +60,7 @@ $FccCommands = @(
     "fcc-hermes",
     "fcc-dsh",
     "fcc-grok",
+    "fcc-muse",
     "fcc-init",
     "free-claude-code"
 )
@@ -129,8 +133,11 @@ function Select-CodingAgents {
         $script:InstallGrok = Read-YesNo `
             -Prompt "Install or verify Grok Build for fcc-grok?" `
             -DefaultYes $script:InstallGrok
+        $script:InstallMuse = Read-YesNo `
+            -Prompt "Install or verify Muse Code for fcc-muse?" `
+            -DefaultYes $script:InstallMuse
 
-        if ($script:InstallClaudeCode -or $script:InstallCodex -or $script:InstallPi -or $script:InstallOpenCode -or $script:InstallCline -or $script:InstallHermes -or $script:InstallDsh -or $script:InstallGrok) {
+        if ($script:InstallClaudeCode -or $script:InstallCodex -or $script:InstallPi -or $script:InstallOpenCode -or $script:InstallCline -or $script:InstallHermes -or $script:InstallDsh -or $script:InstallGrok -or $script:InstallMuse) {
             break
         }
         Write-Host "Select at least one coding agent."
@@ -999,6 +1006,40 @@ function Ensure-Grok {
     Confirm-GrokApplication
 }
 
+function Get-MuseVersion {
+    param([string] $MusePath)
+
+    $output = Invoke-Utf8NativeCapture -FilePath $MusePath -Arguments @("--version")
+    if ($output -match '(?m)^\s*Muse Code\s+(?<version>\d+\.\d+\.\d+)(?:\s+\([^\r\n]+\))?\s*$') {
+        return $Matches["version"]
+    }
+
+    throw "Muse Code is present, but 'muse --version' did not return the expected 'Muse Code x.y.z' version."
+}
+
+function Ensure-Muse {
+    $script:MuseAvailable = $false
+    $command = Get-ApplicationCommand "muse"
+    if (-not $command) {
+        Write-Host "Muse Code is not installed. Meta does not currently publish an official Windows installer; fcc-muse will be ready when a compatible Muse binary is on PATH."
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "+ muse --version"
+        Write-Host "A compatible preinstalled Muse Code will be preserved; FCC does not update Muse on Windows."
+        $script:MuseAvailable = $true
+        return
+    }
+
+    $version = Get-MuseVersion $command.Source
+    if (-not (Test-SupportedStableVersion -Version $version -Minimum $MinMuseVersion)) {
+        throw "Muse Code $MinMuseVersion or newer is required; found Muse Code $version. Meta does not currently publish an official Windows updater."
+    }
+    Write-Host "Verified Muse Code $version."
+    $script:MuseAvailable = $true
+}
+
 function Get-DshVersion {
     param([string] $DshPath)
 
@@ -1166,7 +1207,12 @@ function Ensure-SelectedCodingAgents {
         Ensure-Grok
     }
 
-    if ((-not $script:InstallClaudeCode) -and (-not $script:InstallCodex) -and (-not $script:PiAvailable) -and (-not $script:InstallOpenCode) -and (-not $script:InstallCline) -and (-not $script:InstallHermes) -and (-not $script:InstallDsh) -and (-not $script:InstallGrok)) {
+    if ($script:InstallMuse) {
+        Write-Step "Checking for Muse Code"
+        Ensure-Muse
+    }
+
+    if ((-not $script:InstallClaudeCode) -and (-not $script:InstallCodex) -and (-not $script:PiAvailable) -and (-not $script:InstallOpenCode) -and (-not $script:InstallCline) -and (-not $script:InstallHermes) -and (-not $script:InstallDsh) -and (-not $script:InstallGrok) -and (-not $script:MuseAvailable)) {
         throw "No selected coding agent was installed. Re-run the installer and choose at least one."
     }
 }
@@ -1321,7 +1367,7 @@ function Configure-AndConfirmFreeClaudeCode {
     if ($DryRun) {
         Write-Host "+ uv tool update-shell"
         Write-Host "+ uv tool dir --bin"
-        Write-Host "+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, and fcc-grok in the uv tool bin directory"
+        Write-Host "+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, fcc-grok, and fcc-muse in the uv tool bin directory"
         Write-Host "+ fcc-server --version"
         Export-FccDesktopIcon `
             -DesktopCommand "<uv-tool-bin>\fcc-desktop.exe" `
@@ -1348,7 +1394,7 @@ function Configure-AndConfirmFreeClaudeCode {
         [IO.Path]::AltDirectorySeparatorChar
     )
     $installedCommands = @{}
-    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-codex", "fcc-pi", "fcc-opencode", "fcc-cline", "fcc-hermes", "fcc-dsh", "fcc-grok")) {
+    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-codex", "fcc-pi", "fcc-opencode", "fcc-cline", "fcc-hermes", "fcc-dsh", "fcc-grok", "fcc-muse")) {
         $command = Get-ApplicationCommand $commandName
         if (-not $command) {
             throw "Free Claude Code installation did not create '$commandName'."
@@ -1524,5 +1570,11 @@ else {
     }
     else {
         Write-Host "The fcc-grok wrapper is ready after you install Grok Build $MinGrokVersion or newer."
+    }
+    if ($script:MuseAvailable) {
+        Write-Host "Run Muse Code with: fcc-muse"
+    }
+    else {
+        Write-Host "The fcc-muse wrapper is ready after you install Muse Code $MinMuseVersion or newer."
     }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,13 +16,15 @@ DSH_VERSION="0.1.0-rc.8"
 DSH_PACKAGE="@deepseek-ai/dsh@$DSH_VERSION"
 GROK_INSTALL_URL="https://x.ai/cli/install.sh"
 MIN_GROK_VERSION="1.0.5"
+MUSE_INSTALL_URL="https://dev.meta.ai/install.sh"
+MIN_MUSE_VERSION="0.2.1"
 RTK_VERSION="0.44.2"
 RTK_RELEASE_BASE_URL="https://github.com/rtk-ai/rtk/releases/download/v$RTK_VERSION"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so updates reject older FCC processes before replacement.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-init free-claude-code"
 
 dry_run=0
 voice_nim=0
@@ -36,6 +38,7 @@ install_cline=0
 install_hermes=1
 install_dsh=1
 install_grok=1
+install_muse=1
 enable_rtk=0
 torch_backend=""
 temporary_file=""
@@ -170,7 +173,18 @@ choose_coding_agents() {
             install_grok=0
         fi
 
-        if [ "$install_claude" -eq 1 ] || [ "$install_codex" -eq 1 ] || [ "$install_pi" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_cline" -eq 1 ] || [ "$install_hermes" -eq 1 ] || [ "$install_dsh" -eq 1 ] || [ "$install_grok" -eq 1 ]; then
+        if [ "$install_muse" -eq 1 ]; then
+            muse_default=yes
+        else
+            muse_default=no
+        fi
+        if prompt_yes_no "Install or verify Muse Code for fcc-muse?" "$muse_default"; then
+            install_muse=1
+        else
+            install_muse=0
+        fi
+
+        if [ "$install_claude" -eq 1 ] || [ "$install_codex" -eq 1 ] || [ "$install_pi" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_cline" -eq 1 ] || [ "$install_hermes" -eq 1 ] || [ "$install_dsh" -eq 1 ] || [ "$install_grok" -eq 1 ] || [ "$install_muse" -eq 1 ]; then
             break
         fi
         printf 'Select at least one coding agent.\n\n' >&4
@@ -1035,6 +1049,72 @@ ensure_grok() {
     verify_grok_command
 }
 
+current_muse_version() {
+    if output=$(muse --version 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
+
+    version=$(printf '%s\n' "$output" | awk '
+        /^[[:space:]]*Muse Code[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+([[:space:]]+\([^\r\n]+\))?[[:space:]]*$/ &&
+        match($0, /[0-9]+\.[0-9]+\.[0-9]+/) {
+            print substr($0, RSTART, RLENGTH)
+            exit
+        }
+    ')
+    [ -n "$version" ] || return 1
+    printf '%s\n' "$version"
+}
+
+verify_muse_command() {
+    if [ "$dry_run" -eq 1 ]; then
+        print_command muse --version
+        return 0
+    fi
+
+    command -v muse >/dev/null 2>&1 || fail "Muse Code was installed, but 'muse' is not available on PATH."
+    version=$(current_muse_version) || fail "Muse Code is present, but 'muse --version' did not return the expected 'Muse Code x.y.z' version."
+    if ! stable_version_is_supported "$version" "$MIN_MUSE_VERSION"; then
+        fail "Muse Code $MIN_MUSE_VERSION or newer is required; found Muse Code $version after installation."
+    fi
+    printf 'Verified Muse Code %s.\n' "$version"
+}
+
+install_muse_code() {
+    case "$(uname -s)" in
+        Darwin|Linux) ;;
+        *) fail "Meta's official Muse Code installer supports macOS, Linux, and WSL only." ;;
+    esac
+    download_and_run "$MUSE_INSTALL_URL" bash "Muse Code"
+    add_known_bin_directories
+}
+
+ensure_muse() {
+    if [ "$dry_run" -eq 1 ]; then
+        if command -v muse >/dev/null 2>&1; then
+            print_command muse --version
+            printf 'A compatible Muse Code will be preserved; an older version will be upgraded with the official installer.\n'
+        else
+            install_muse_code
+        fi
+        verify_muse_command
+        return 0
+    fi
+
+    if command -v muse >/dev/null 2>&1; then
+        version=$(current_muse_version) || fail "Muse Code is present, but 'muse --version' did not return the expected 'Muse Code x.y.z' version."
+        if stable_version_is_supported "$version" "$MIN_MUSE_VERSION"; then
+            printf 'Muse Code %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_MUSE_VERSION"
+            return 0
+        fi
+        printf 'Muse Code %s does not satisfy >=%s; upgrading it with the official installer.\n' "$version" "$MIN_MUSE_VERSION"
+    fi
+
+    install_muse_code
+    verify_muse_command
+}
+
 ensure_selected_coding_agents() {
     if [ "$install_claude" -eq 1 ]; then
         step "Ensuring Claude Code is installed"
@@ -1076,7 +1156,12 @@ ensure_selected_coding_agents() {
         ensure_grok
     fi
 
-    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ] && [ "$pi_available" -eq 0 ] && [ "$install_opencode" -eq 0 ] && [ "$install_cline" -eq 0 ] && [ "$install_hermes" -eq 0 ] && [ "$install_dsh" -eq 0 ] && [ "$install_grok" -eq 0 ]; then
+    if [ "$install_muse" -eq 1 ]; then
+        step "Ensuring Muse Code is installed"
+        ensure_muse
+    fi
+
+    if [ "$install_claude" -eq 0 ] && [ "$install_codex" -eq 0 ] && [ "$pi_available" -eq 0 ] && [ "$install_opencode" -eq 0 ] && [ "$install_cline" -eq 0 ] && [ "$install_hermes" -eq 0 ] && [ "$install_dsh" -eq 0 ] && [ "$install_grok" -eq 0 ] && [ "$install_muse" -eq 0 ]; then
         fail "No selected coding agent was installed. Re-run the installer and choose at least one."
     fi
 }
@@ -1263,7 +1348,7 @@ configure_and_verify_free_claude_code() {
 
     if [ "$dry_run" -eq 1 ]; then
         print_command uv tool dir --bin
-        printf '+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, and fcc-grok in the uv tool bin directory\n'
+        printf '+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, fcc-grok, and fcc-muse in the uv tool bin directory\n'
         print_command fcc-server --version
         return 0
     fi
@@ -1281,7 +1366,7 @@ configure_and_verify_free_claude_code() {
     export PATH
     hash -r 2>/dev/null || true
 
-    for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok; do
+    for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse; do
         [ -x "$tool_bin/$command_name" ] || fail "Free Claude Code installation did not create $tool_bin/$command_name."
     done
 
@@ -1404,7 +1489,7 @@ fi
 
 step "Checking installation prerequisites"
 require_command curl
-if [ "$install_claude" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_hermes" -eq 1 ] || [ "$install_grok" -eq 1 ]; then
+if [ "$install_claude" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_hermes" -eq 1 ] || [ "$install_grok" -eq 1 ] || [ "$install_muse" -eq 1 ]; then
     require_command bash
 fi
 require_command sh
@@ -1475,5 +1560,10 @@ else
         printf 'Run Grok Build with: fcc-grok\n'
     else
         printf 'The fcc-grok wrapper is ready after you install Grok Build %s or newer.\n' "$MIN_GROK_VERSION"
+    fi
+    if [ "$install_muse" -eq 1 ]; then
+        printf 'Run Muse Code with: fcc-muse\n'
+    else
+        printf 'The fcc-muse wrapper is ready after you install Muse Code %s or newer.\n' "$MIN_MUSE_VERSION"
     fi
 fi

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -22,6 +22,7 @@ $FccCommands = @(
     "fcc-hermes",
     "fcc-dsh",
     "fcc-grok",
+    "fcc-muse",
     "fcc-init",
     "free-claude-code"
 )

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,7 +6,7 @@ FCC_HOME_DIRNAME=".fcc"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so older installations are fully stopped and removed.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-init free-claude-code"
 
 dry_run=0
 uv_tool_bin=""

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -56,7 +56,7 @@ Default targets do not send real bot messages or load voice backends:
 | `api` | messages, count_tokens full payload, errors, `/stop`, optimizations | configured provider only for streaming messages |
 | `auth` | canonical bearer auth, conflicting legacy headers, invalid/missing auth | none; test sets an isolated token |
 | `cli` | server entrypoint, Claude CLI adaptive thinking, automatic WebSearch, Auto-mode classifier, session cleanup | Claude CLI binary and provider only for real CLI; connected OpenAI account for Auto mode; `FCC_SMOKE_RUN_WEB_TOOLS=1` for WebSearch |
-| `clients` | VS Code and JetBrains protocol payloads; Pi, OpenCode, Cline, Hermes, DeepSeek Harness, and Grok Build CLI prompts | configured provider; installed Pi/OpenCode/Cline binaries; Hermes, DSH, and Grok use a local fake upstream |
+| `clients` | VS Code and JetBrains protocol payloads; Pi, OpenCode, Cline, Hermes, DeepSeek Harness, Grok Build, and Muse Code CLI prompts | configured provider; installed Pi/OpenCode/Cline binaries; Hermes, DSH, Grok, and Muse use a local fake upstream |
 | `config` | env precedence, removed-env migration, proxy/timeouts | none |
 | `extensibility` | provider runtime and platform factory construction | none |
 | `messaging` | fake Discord/Telegram full flow, literal clear scopes, trees, persistence, voice cancel | none |

--- a/smoke/capabilities.py
+++ b/smoke/capabilities.py
@@ -614,6 +614,20 @@ CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
         ("test_grok_cli_headless_e2e",),
     ),
     CapabilityContract(
+        "cli",
+        "muse_cli_integration",
+        "muse_cli_integration",
+        "free_claude_code.cli.launchers.muse",
+        "Muse Code 0.2.1+, live FCC Responses catalog, and child-only route",
+        "Responses route scoped to FCC for attached TUI, exec, and resume sessions",
+        "version, route conflict, proxy, or catalog failure exits before inference",
+        (
+            "tests/cli/test_muse_launcher.py",
+            "tests/api/test_model_listing.py",
+        ),
+        ("test_muse_cli_headless_e2e",),
+    ),
+    CapabilityContract(
         "extensibility",
         "provider_platform_abcs",
         "extensible_provider_platform_abcs",

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -181,6 +181,19 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
         "skip only when Grok Build is absent; the local fake upstream must pass",
     ),
     FeatureCoverage(
+        "muse_cli_integration",
+        "Muse Code discovers FCC models and sends Responses through the proxy",
+        (
+            "tests/cli/test_muse_launcher.py",
+            "tests/api/test_model_listing.py",
+        ),
+        ("test_muse_model_catalog_is_the_fixed_responses_projection",),
+        ("test_muse_cli_headless_e2e",),
+        ("clients",),
+        ("Muse Code 0.2.1+",),
+        "skip only when Muse is absent; the local fake upstream must pass",
+    ),
+    FeatureCoverage(
         "provider_matrix",
         "Every configured provider prefix can satisfy conversation scenarios",
         ("tests/api/test_dependencies.py", "tests/providers/"),

--- a/smoke/product/test_client_product_live.py
+++ b/smoke/product/test_client_product_live.py
@@ -663,6 +663,110 @@ def test_grok_cli_headless_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> Non
         assert provider_body["model"] == model_id
 
 
+@pytest.mark.smoke_target("clients")
+def test_muse_cli_headless_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> None:
+    if not shutil.which("muse"):
+        pytest.skip("missing_env: Muse Code not found")
+    uv_bin = shutil.which("uv")
+    if not uv_bin:
+        pytest.skip("missing_env: uv not found")
+
+    model_id = "fcc-smoke-muse"
+    full_model = f"lmstudio/{model_id}"
+    marker = "FCC_SMOKE_MUSE"
+    auth_token = smoke_config.settings.proxy_auth_token
+    credential_env_keys = _provider_credential_env_keys()
+
+    with (
+        _successful_openai_provider(model_id=model_id, marker=marker) as (
+            provider_base_url,
+            provider_requests,
+        ),
+        SmokeServerDriver(
+            smoke_config,
+            name="product-muse-cli-headless",
+            env_overrides=_local_provider_overrides(full_model, provider_base_url),
+            env_unset=credential_env_keys,
+        ).run() as server,
+    ):
+        isolated_home = tmp_path / "muse-home"
+        isolated_home.mkdir()
+        env = os.environ.copy()
+        for key in credential_env_keys:
+            env.pop(key, None)
+        for key in tuple(env):
+            if key.startswith("FCC_MUSE_"):
+                env.pop(key)
+        for key in (
+            "META_API_KEY",
+            "MUSE_MODEL",
+            "MUSE_CUSTOM_HEADERS",
+            "MUSE_WWW_ROUTING",
+        ):
+            env.pop(key, None)
+        env.update(
+            {
+                "HOST": "127.0.0.1",
+                "PORT": str(server.port),
+                "FCC_OPEN_BROWSER": "0",
+                "ANTHROPIC_AUTH_TOKEN": auth_token,
+                "HOME": str(isolated_home),
+                "USERPROFILE": str(isolated_home),
+                "XDG_CONFIG_HOME": str(isolated_home / "config"),
+                "XDG_DATA_HOME": str(isolated_home / "data"),
+                "XDG_CACHE_HOME": str(isolated_home / "cache"),
+                "XDG_STATE_HOME": str(isolated_home / "state"),
+                "MUSE_NO_AUTO_UPDATE": "1",
+            }
+        )
+        result = subprocess.run(
+            [
+                uv_bin,
+                "run",
+                "--project",
+                str(smoke_config.root),
+                "--no-sync",
+                "fcc-muse",
+                "exec",
+                "--json",
+                "--no-session-log",
+                "--disable-web-tools",
+                "--disable-write",
+                "--disable-shell",
+                "--max-model-steps",
+                "1",
+                "--model",
+                full_model,
+                f"Reply with exactly {marker}",
+            ],
+            cwd=tmp_path,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=smoke_config.timeout_s + 30,
+        )
+        server_log = server.log_path.read_text(encoding="utf-8", errors="replace")
+
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert marker in result.stdout
+    assert auth_token not in combined
+    assert "GET /v1/models?view=responses" in server_log
+    assert "GET /muse-code/models" in server_log
+    responses_count = server_log.count("POST /v1/responses")
+    assert responses_count >= 1
+    assert responses_count == len(provider_requests)
+    assert "POST /v1/chat/completions" not in server_log
+    assert all(
+        request["path"] == "/v1/chat/completions" for request in provider_requests
+    )
+    for request in provider_requests:
+        provider_body = request["body"]
+        assert isinstance(provider_body, dict)
+        assert provider_body["model"] == model_id
+
+
 @pytest.mark.smoke_target("cli")
 def test_claude_cli_adaptive_thinking_e2e(
     smoke_config: SmokeConfig, tmp_path: Path

--- a/src/free_claude_code/api/request_ids.py
+++ b/src/free_claude_code/api/request_ids.py
@@ -12,7 +12,9 @@ from free_claude_code.core.trace import extract_claude_session_id_from_headers
 REQUEST_ID_HEADER = "request-id"
 OPENAI_REQUEST_ID_HEADER = "x-request-id"
 _REQUEST_ID_STATE_ATTRIBUTE = "fcc_request_id"
-_OPENAI_REQUEST_ID_PATHS = frozenset({"/v1/responses", "/v1/models"})
+_OPENAI_REQUEST_ID_PATHS = frozenset(
+    {"/v1/responses", "/v1/models", "/muse-code/models"}
+)
 
 
 class RequestCorrelationMiddleware:

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -206,6 +206,25 @@ async def list_models(
     return build_models_list_response(settings, services.requests, view=view)
 
 
+@router.get(
+    "/muse-code/models",
+    response_model=ModelsListResponse,
+    response_model_exclude_none=True,
+)
+async def list_muse_models(
+    services: ApiServices = Depends(get_services),
+    settings: Settings = Depends(get_settings),
+    _auth=Depends(require_proxy_auth),
+):
+    """List the direct Responses models expected by Muse Code."""
+    trace_event(stage="ingress", event="free_claude_code.api.models.list", source="api")
+    return build_models_list_response(
+        settings,
+        services.requests,
+        view=ModelCatalogView.RESPONSES,
+    )
+
+
 @router.post("/stop")
 async def stop_cli(
     services: ApiServices = Depends(get_services),

--- a/src/free_claude_code/cli/launchers/muse.py
+++ b/src/free_claude_code/cli/launchers/muse.py
@@ -1,0 +1,384 @@
+"""Installed `fcc-muse` launcher for attached Muse Code sessions."""
+
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+
+from free_claude_code.cli.local_http import with_local_proxy_bypass
+from free_claude_code.config.loader import get_settings
+from free_claude_code.config.server_urls import local_proxy_root_url
+
+from .common import (
+    preflight_proxy,
+    proxy_v1_url,
+    resolve_client_binary,
+    run_client_process,
+)
+from .model_catalog import (
+    ClientModel,
+    client_models_from_response,
+    fetch_proxy_models_response,
+)
+
+_BINARY_NAME = "muse"
+_DISPLAY_NAME = "Muse Code"
+_INSTALL_HINT = (
+    "Install Muse Code on macOS/Linux/WSL with "
+    "`curl -fsSL https://dev.meta.ai/install.sh | bash`. "
+    "Meta does not currently publish an official Windows installer."
+)
+_MINIMUM_VERSION = (0, 2, 1)
+_VERSION_TIMEOUT_SECONDS = 5.0
+_VERSION_PATTERN = re.compile(
+    r"(?m)^\s*Muse Code\s+(\d+)\.(\d+)\.(\d+)"
+    r"(?:\s+\([^\r\n]+\))?\s*$"
+)
+_PASSTHROUGH_COMMANDS = frozenset(
+    {
+        "auth",
+        "config",
+        "export",
+        "init",
+        "login",
+        "logout",
+        "sandbox",
+        "session-message",
+        "skills",
+        "trace",
+    }
+)
+_PASSTHROUGH_FLAGS = frozenset({"-h", "--help", "-V", "--version"})
+_ROOT_VALUE_OPTIONS = frozenset(
+    {
+        "--agents",
+        "--provider",
+        "--preset",
+        "--model",
+        "--reasoning-effort",
+        "--base-url",
+        "--image",
+        "--workspace",
+        "--worktree-base",
+        "--worktree-existing",
+        "--approval-mode",
+        "--approval-judge",
+        "--echo-delay-ms",
+        "--sandbox-network",
+    }
+)
+_ROOT_OPTIONAL_VALUE_OPTIONS = frozenset({"-w", "--worktree"})
+_WORKTREE_VALUES = frozenset({"off", "create", "existing"})
+_ROOT_BOOLEAN_OPTIONS = frozenset(
+    {
+        "--parallel-tool-calls",
+        "--no-parallel-tool-calls",
+        "--subagent-worktree-isolation",
+        "--no-session-log",
+        "--yolo",
+        "--trust-workspace",
+        "--disable-approval",
+        "--disable-sandbox",
+        "--disable-write",
+        "--disable-shell",
+        "--enable-shell-tool",
+    }
+)
+_ROUTE_OVERRIDE_OPTIONS = frozenset({"--provider", "--base-url"})
+_ROUTING_ENV_KEYS = frozenset(
+    {"META_API_KEY", "MUSE_MODEL", "MUSE_CUSTOM_HEADERS", "MUSE_WWW_ROUTING"}
+)
+
+
+class MuseInvocationMode(StrEnum):
+    """How `fcc-muse` treats one Muse invocation."""
+
+    PASSTHROUGH = "passthrough"
+    TUI = "tui"
+    EXEC = "exec"
+    RESUME = "resume"
+
+
+@dataclass(frozen=True, slots=True)
+class MuseInvocation:
+    """The minimal Muse command classification FCC needs for flag placement."""
+
+    mode: MuseInvocationMode
+    command_index: int | None = None
+
+
+def launch(argv: Sequence[str] | None = None) -> None:
+    """Launch one attached Muse Code process through FCC."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    binary_path = resolve_client_binary(
+        binary_name=_BINARY_NAME,
+        display_name=_DISPLAY_NAME,
+        install_hint=_INSTALL_HINT,
+    )
+    invocation = classify_muse_invocation(args)
+    if invocation.mode is MuseInvocationMode.PASSTHROUGH:
+        _run(binary_path, args, os.environ)
+        return
+
+    _reject_routing_overrides(args, invocation)
+    require_compatible_muse(binary_path)
+
+    settings = get_settings()
+    auth_token = settings.proxy_auth_token.strip()
+    if not auth_token:
+        print("Free Claude Code proxy authentication token is empty.", file=sys.stderr)
+        raise SystemExit(1)
+
+    proxy_root_url = local_proxy_root_url(settings)
+    if error := preflight_proxy(proxy_root_url):
+        print(
+            f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
+            file=sys.stderr,
+        )
+        print("Start it in another terminal with: fcc-server", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        models = client_models_from_response(
+            fetch_proxy_models_response(proxy_root_url, auth_token)
+        )
+        if not models:
+            raise ValueError("model catalog contains no routable models")
+    except Exception as exc:
+        print(f"Could not prepare the Muse FCC model catalog: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+    try:
+        selected_model, cleaned_args = _select_and_remove_model(args, models)
+    except ValueError as exc:
+        print(f"Invalid Muse Code model selection: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None
+
+    child_env = build_muse_launcher_env(
+        proxy_root_url=proxy_root_url,
+        auth_token=auth_token,
+        base_env=os.environ,
+    )
+    command_args = _routed_args(
+        cleaned_args,
+        invocation.mode,
+        proxy_root_url=proxy_root_url,
+        selected_model=selected_model,
+    )
+    _run(binary_path, command_args, child_env)
+
+
+def classify_muse_invocation(argv: Sequence[str]) -> MuseInvocation:
+    """Classify only Muse surfaces whose attached lifecycle FCC can own."""
+
+    before_separator = _before_separator(argv)
+    if any(argument in _PASSTHROUGH_FLAGS for argument in before_separator):
+        return MuseInvocation(MuseInvocationMode.PASSTHROUGH)
+    if before_separator and before_separator[0] in _PASSTHROUGH_COMMANDS:
+        return MuseInvocation(MuseInvocationMode.PASSTHROUGH)
+    if before_separator and before_separator[0] == "exec":
+        return MuseInvocation(MuseInvocationMode.EXEC, command_index=0)
+
+    positional_index = _first_root_positional_index(before_separator)
+    if positional_index is not None and before_separator[positional_index] == "resume":
+        return MuseInvocation(MuseInvocationMode.RESUME, command_index=positional_index)
+    return MuseInvocation(MuseInvocationMode.TUI)
+
+
+def muse_binary_version(binary_path: str) -> tuple[int, int, int] | None:
+    """Read the released Muse semantic version without invoking a shell."""
+
+    try:
+        result = subprocess.run(
+            [binary_path, "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=_VERSION_TIMEOUT_SECONDS,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0:
+        return None
+
+    match = _VERSION_PATTERN.search(result.stdout)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def require_compatible_muse(binary_path: str) -> None:
+    """Exit unless Muse satisfies FCC's released base-URL contract."""
+
+    version = muse_binary_version(binary_path)
+    if version is not None and version >= _MINIMUM_VERSION:
+        return
+
+    minimum = ".".join(str(part) for part in _MINIMUM_VERSION)
+    print(
+        f"The Muse Code CLI at {binary_path} must be at least version {minimum}.",
+        file=sys.stderr,
+    )
+    print(_INSTALL_HINT, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def build_muse_launcher_env(
+    *,
+    proxy_root_url: str,
+    auth_token: str,
+    base_env: Mapping[str, str],
+) -> dict[str, str]:
+    """Build the child-only Muse route while preserving native Muse state."""
+
+    filtered = {
+        key: value
+        for key, value in base_env.items()
+        if not key.startswith("FCC_MUSE_") and key not in _ROUTING_ENV_KEYS
+    }
+    env = with_local_proxy_bypass(filtered, proxy_root_url=proxy_root_url)
+    env["META_API_KEY"] = auth_token
+    return env
+
+
+def _reject_routing_overrides(argv: Sequence[str], invocation: MuseInvocation) -> None:
+    for argument in _before_separator(argv):
+        if argument in _ROUTE_OVERRIDE_OPTIONS or any(
+            argument.startswith(f"{option}=") for option in _ROUTE_OVERRIDE_OPTIONS
+        ):
+            print(
+                "fcc-muse owns the attached Muse provider and base URL. "
+                "Use ordinary muse for a native Meta route.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        if invocation.mode is MuseInvocationMode.EXEC and argument == "--api-key-stdin":
+            print(
+                "fcc-muse supplies the attached Muse credential. "
+                "Use ordinary muse exec with --api-key-stdin for a native route.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+
+
+def _select_and_remove_model(
+    argv: Sequence[str], models: Sequence[ClientModel]
+) -> tuple[str, list[str]]:
+    selected: str | None = None
+    cleaned: list[str] = []
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument == "--":
+            cleaned.extend(argv[index:])
+            break
+        if argument == "--model":
+            if index + 1 >= len(argv) or not argv[index + 1]:
+                raise ValueError("--model requires a model value")
+            if selected is not None:
+                raise ValueError("multiple --model values are not supported")
+            selected = argv[index + 1]
+            index += 2
+            continue
+        if argument.startswith("--model="):
+            value = argument.partition("=")[2]
+            if not value:
+                raise ValueError("--model requires a model value")
+            if selected is not None:
+                raise ValueError("multiple --model values are not supported")
+            selected = value
+            index += 1
+            continue
+        cleaned.append(argument)
+        index += 1
+
+    chosen = selected or models[0].wire_slug
+    available = {model.wire_slug for model in models}
+    if chosen not in available:
+        raise ValueError(f"model {chosen!r} is not in the current FCC catalog")
+    return chosen, cleaned
+
+
+def _routed_args(
+    argv: Sequence[str],
+    mode: MuseInvocationMode,
+    *,
+    proxy_root_url: str,
+    selected_model: str,
+) -> list[str]:
+    route = [
+        "--provider",
+        "meta",
+        "--base-url",
+        proxy_v1_url(proxy_root_url),
+        "--model",
+        selected_model,
+    ]
+    args = list(argv)
+    if mode is MuseInvocationMode.EXEC:
+        return ["exec", *route, *args[1:]]
+    if mode is MuseInvocationMode.RESUME:
+        command_index = _first_root_positional_index(_before_separator(args))
+        if command_index is None or args[command_index] != "resume":
+            raise ValueError("Muse resume command could not be located")
+        return [*args[: command_index + 1], *route, *args[command_index + 1 :]]
+    return [*route, *args]
+
+
+def _first_root_positional_index(argv: Sequence[str]) -> int | None:
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument == "--":
+            return index + 1 if index + 1 < len(argv) else None
+        if argument in _ROOT_VALUE_OPTIONS:
+            index += 2
+            continue
+        if _is_joined_root_value_option(argument):
+            index += 1
+            continue
+        if argument in _ROOT_OPTIONAL_VALUE_OPTIONS:
+            if index + 1 < len(argv) and argv[index + 1] in _WORKTREE_VALUES:
+                index += 2
+            else:
+                index += 1
+            continue
+        if argument in _ROOT_BOOLEAN_OPTIONS or argument in _PASSTHROUGH_FLAGS:
+            index += 1
+            continue
+        if argument.startswith("-"):
+            return None
+        return index
+    return None
+
+
+def _is_joined_root_value_option(argument: str) -> bool:
+    if any(
+        argument.startswith(f"{option}=")
+        for option in _ROOT_VALUE_OPTIONS | _ROOT_OPTIONAL_VALUE_OPTIONS
+        if option.startswith("--")
+    ):
+        return True
+    return argument.startswith("-w") and len(argument) > 2
+
+
+def _before_separator(argv: Sequence[str]) -> Sequence[str]:
+    try:
+        return argv[: argv.index("--")]
+    except ValueError:
+        return argv
+
+
+def _run(binary_path: str, args: Sequence[str], env: Mapping[str, str]) -> None:
+    run_client_process(
+        command=[binary_path, *args],
+        env=env,
+        binary_name=_BINARY_NAME,
+        display_name=_DISPLAY_NAME,
+        install_hint=_INSTALL_HINT,
+    )

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -111,19 +111,20 @@ def test_proxy_auth_token_normalizes_configured_whitespace():
     app.dependency_overrides.clear()
 
 
-def test_proxy_auth_token_applies_to_models_endpoint():
+def test_proxy_auth_token_applies_to_model_catalog_endpoints():
     client = TestClient(app)
     settings = Settings(proxy_auth_enabled=True, proxy_auth_token="models-token")
     app.dependency_overrides[get_settings] = lambda: settings
 
-    r = client.get("/v1/models")
-    assert r.status_code == 401
-    assert r.headers["x-request-id"] == r.headers["request-id"]
-    assert "x-should-retry" not in r.headers
+    for path in ("/v1/models", "/muse-code/models"):
+        r = client.get(path)
+        assert r.status_code == 401
+        assert r.headers["x-request-id"] == r.headers["request-id"]
+        assert "x-should-retry" not in r.headers
 
-    r = client.get("/v1/models", headers={"Authorization": "Bearer models-token"})
-    assert r.status_code == 200
-    assert "data" in r.json()
+        r = client.get(path, headers={"Authorization": "Bearer models-token"})
+        assert r.status_code == 200
+        assert "data" in r.json()
 
     app.dependency_overrides.clear()
 

--- a/tests/api/test_model_listing.py
+++ b/tests/api/test_model_listing.py
@@ -225,6 +225,31 @@ def test_direct_model_views_exclude_claude_aliases_and_duplicate_variants():
     assert "reasoningEfforts" not in plain
 
 
+def test_muse_model_catalog_is_the_fixed_responses_projection():
+    app = create_test_app(_settings(model_opus=None, model_haiku=None))
+    manager = provider_manager_for_app(app)
+    manager.cache_model_infos(
+        "open_router",
+        {
+            ProviderModelInfo("reasoning-model", supports_thinking=True),
+            ProviderModelInfo("plain-model", supports_thinking=False),
+        },
+    )
+    client = TestClient(app)
+
+    responses = client.get("/v1/models?view=responses")
+    muse = client.get("/muse-code/models?view=claude")
+
+    assert responses.status_code == 200
+    assert muse.status_code == 200
+    assert muse.json() == responses.json()
+    assert [row["id"] for row in muse.json()["data"]] == [
+        "deepseek/deepseek-chat",
+        "claude-3-freecc-no-thinking/open_router/plain-model",
+        "open_router/reasoning-model",
+    ]
+
+
 def test_responses_model_view_rounds_timeout_up_before_margin():
     app = create_test_app(
         _settings().model_copy(update={"provider_progress_timeout": 1.1})

--- a/tests/api/test_openai_responses.py
+++ b/tests/api/test_openai_responses.py
@@ -439,6 +439,63 @@ def test_create_response_accepts_codex_namespace_tool_request() -> None:
     assert call["name"] == "js"
 
 
+def test_create_response_accepts_muse_code_request_shape() -> None:
+    provider = FakeProvider(_anthropic_tool_stream(tool_name="muse__read_file"))
+    app = create_test_app()
+    with (
+        patch("free_claude_code.api.routes.resolve_provider", return_value=provider),
+        TestClient(app) as client,
+    ):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "nvidia_nim/test-model",
+                "input": "Read the file",
+                "instructions": "Be concise.",
+                "max_output_tokens": 64,
+                "store": False,
+                "stream": True,
+                "reasoning": {"effort": "high", "summary": "auto"},
+                "include": ["reasoning.encrypted_content"],
+                "prompt_cache_key": "muse-session-1",
+                "tools": [
+                    {
+                        "type": "namespace",
+                        "name": "muse",
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "read_file",
+                                "description": "Read one file.",
+                                "strict": True,
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {"path": {"type": "string"}},
+                                    "required": ["path"],
+                                    "additionalProperties": False,
+                                },
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    routed = provider.requests[0]
+    assert routed.max_tokens == 64
+    assert routed.output_config == {"effort": "high"}
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy(
+        control=ReasoningControl.DEFAULT,
+        effort=ReasoningEffort.HIGH,
+    )
+    assert [tool.name for tool in routed.tools] == ["muse__read_file"]
+    completed = parse_sse_text(response.text)[-1].data["response"]
+    call = completed["output"][0]
+    assert call["namespace"] == "muse"
+    assert call["name"] == "read_file"
+
+
 def test_create_response_accepts_codex_custom_tool_request() -> None:
     provider = FakeProvider(
         _anthropic_tool_stream(

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -69,6 +69,7 @@ def test_cli_scripts_are_registered() -> None:
         "fcc-hermes": "free_claude_code.cli.launchers.hermes:launch",
         "fcc-dsh": "free_claude_code.cli.launchers.dsh:launch",
         "fcc-grok": "free_claude_code.cli.launchers.grok:launch",
+        "fcc-muse": "free_claude_code.cli.launchers.muse:launch",
     }
     assert pyproject["project"]["gui-scripts"] == {
         "fcc-desktop": "free_claude_code.cli.desktop_entrypoint:launch",

--- a/tests/cli/test_muse_launcher.py
+++ b/tests/cli/test_muse_launcher.py
@@ -1,0 +1,451 @@
+"""Contract tests for the installed `fcc-muse` launcher."""
+
+import os
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.json_types import JsonObject
+
+
+def _settings(*, token: str = "proxy-token") -> Settings:
+    settings = Settings(
+        host="0.0.0.0",
+        port=9191,
+        proxy_auth_enabled=False,
+        proxy_auth_token=token or "placeholder-token",
+        model="nvidia_nim/test-model",
+    )
+    return settings.model_copy(update={"proxy_auth_token": token})
+
+
+def _models_payload() -> JsonObject:
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "nvidia_nim/vendor/model",
+                "provider_model_ref": "nvidia_nim/vendor/model",
+                "display_name": "Nested model",
+            },
+            {
+                "id": "claude-3-freecc-no-thinking/open_router/plain-model",
+                "provider_model_ref": "open_router/plain-model",
+                "display_name": "No-thinking model",
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("argv", "str_mode", "command_index"),
+    [
+        ([], "tui", None),
+        (["fix the bug"], "tui", None),
+        (["--workspace", "repo", "fix the bug"], "tui", None),
+        (["exec", "--json", "fix the bug"], "exec", 0),
+        (["resume"], "resume", 0),
+        (["resume", "--last"], "resume", 0),
+        (["--workspace", "repo", "resume", "session-id"], "resume", 2),
+        (["-w", "resume", "--last"], "resume", 1),
+        (["--worktree", "existing", "resume"], "resume", 2),
+        (["--worktree=create", "resume"], "resume", 1),
+        (["--", "resume"], "tui", None),
+    ],
+)
+def test_muse_invocation_classification(
+    argv: list[str], str_mode: str, command_index: int | None
+) -> None:
+    from free_claude_code.cli.launchers.muse import (
+        MuseInvocationMode,
+        classify_muse_invocation,
+    )
+
+    invocation = classify_muse_invocation(argv)
+
+    assert invocation.mode is MuseInvocationMode(str_mode)
+    assert invocation.command_index == command_index
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["exec", "--help"],
+        ["resume", "--help"],
+        ["--version"],
+        ["auth", "status"],
+        ["login"],
+        ["logout"],
+        ["config", "validate"],
+        ["export", "session-id"],
+        ["trace", "session-id"],
+        ["skills", "list"],
+        ["sandbox", "status"],
+        ["session-message", "send"],
+        ["init"],
+    ],
+)
+def test_management_surfaces_are_native_passthrough(argv: list[str]) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "require_compatible_muse") as require_version,
+        patch.object(muse, "get_settings") as get_settings,
+        patch.object(muse, "run_client_process") as run_client_process,
+    ):
+        muse.launch(argv)
+
+    assert run_client_process.call_args.kwargs["command"] == [
+        "resolved-muse",
+        *argv,
+    ]
+    assert run_client_process.call_args.kwargs["env"] is os.environ
+    require_version.assert_not_called()
+    get_settings.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--provider", "meta", "prompt"],
+        ["--provider=meta", "prompt"],
+        ["--base-url", "https://example.test/v1", "prompt"],
+        ["--base-url=https://example.test/v1", "prompt"],
+        ["resume", "--provider", "meta"],
+        ["exec", "--api-key-stdin", "prompt"],
+    ],
+)
+def test_routed_invocations_reject_caller_owned_route(
+    argv: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "require_compatible_muse") as require_version,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        muse.launch(argv)
+
+    assert exc_info.value.code == 2
+    assert "ordinary muse" in capsys.readouterr().err
+    require_version.assert_not_called()
+
+
+def test_route_like_prompt_content_after_separator_is_not_rejected() -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "require_compatible_muse"),
+        patch.object(muse, "get_settings", return_value=_settings()),
+        patch.object(muse, "preflight_proxy", return_value=None),
+        patch.object(
+            muse, "fetch_proxy_models_response", return_value=_models_payload()
+        ),
+        patch.object(muse, "run_client_process") as run_client_process,
+    ):
+        muse.launch(["exec", "--", "--provider", "native", "--model", "words"])
+
+    assert run_client_process.call_args.kwargs["command"] == [
+        "resolved-muse",
+        "exec",
+        "--provider",
+        "meta",
+        "--base-url",
+        "http://127.0.0.1:9191/v1",
+        "--model",
+        "nvidia_nim/vendor/model",
+        "--",
+        "--provider",
+        "native",
+        "--model",
+        "words",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (
+            ["fix the bug"],
+            [
+                "--provider",
+                "meta",
+                "--base-url",
+                "http://127.0.0.1:9191/v1",
+                "--model",
+                "nvidia_nim/vendor/model",
+                "fix the bug",
+            ],
+        ),
+        (
+            ["exec", "--json", "fix the bug"],
+            [
+                "exec",
+                "--provider",
+                "meta",
+                "--base-url",
+                "http://127.0.0.1:9191/v1",
+                "--model",
+                "nvidia_nim/vendor/model",
+                "--json",
+                "fix the bug",
+            ],
+        ),
+        (
+            ["resume", "--last"],
+            [
+                "resume",
+                "--provider",
+                "meta",
+                "--base-url",
+                "http://127.0.0.1:9191/v1",
+                "--model",
+                "nvidia_nim/vendor/model",
+                "--last",
+            ],
+        ),
+        (
+            ["--workspace", "repo", "resume", "session-id"],
+            [
+                "--workspace",
+                "repo",
+                "resume",
+                "--provider",
+                "meta",
+                "--base-url",
+                "http://127.0.0.1:9191/v1",
+                "--model",
+                "nvidia_nim/vendor/model",
+                "session-id",
+            ],
+        ),
+    ],
+)
+def test_routed_launch_places_flags_in_muse_grammar(
+    argv: list[str], expected: list[str]
+) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "require_compatible_muse"),
+        patch.object(muse, "get_settings", return_value=_settings()),
+        patch.object(muse, "preflight_proxy", return_value=None),
+        patch.object(
+            muse, "fetch_proxy_models_response", return_value=_models_payload()
+        ) as fetch_models,
+        patch.object(muse, "run_client_process") as run_client_process,
+    ):
+        muse.launch(argv)
+
+    assert run_client_process.call_args.kwargs["command"] == [
+        "resolved-muse",
+        *expected,
+    ]
+    fetch_models.assert_called_once_with("http://127.0.0.1:9191", "proxy-token")
+
+
+@pytest.mark.parametrize(
+    "model_args",
+    [
+        ["--model", "claude-3-freecc-no-thinking/open_router/plain-model"],
+        ["--model=claude-3-freecc-no-thinking/open_router/plain-model"],
+    ],
+)
+def test_explicit_model_is_validated_and_reinserted_once(
+    model_args: list[str],
+) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "require_compatible_muse"),
+        patch.object(muse, "get_settings", return_value=_settings()),
+        patch.object(muse, "preflight_proxy", return_value=None),
+        patch.object(
+            muse, "fetch_proxy_models_response", return_value=_models_payload()
+        ),
+        patch.object(muse, "run_client_process") as run_client_process,
+    ):
+        muse.launch(["exec", *model_args, "prompt"])
+
+    command = run_client_process.call_args.kwargs["command"]
+    assert command == [
+        "resolved-muse",
+        "exec",
+        "--provider",
+        "meta",
+        "--base-url",
+        "http://127.0.0.1:9191/v1",
+        "--model",
+        "claude-3-freecc-no-thinking/open_router/plain-model",
+        "prompt",
+    ]
+    assert command.count("--model") == 1
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (["exec", "--model"], "requires a model value"),
+        (["exec", "--model="], "requires a model value"),
+        (["exec", "--model", "missing/model", "prompt"], "not in the current"),
+        (
+            [
+                "exec",
+                "--model",
+                "nvidia_nim/vendor/model",
+                "--model=nvidia_nim/vendor/model",
+            ],
+            "multiple --model",
+        ),
+    ],
+)
+def test_invalid_model_selection_fails_closed(
+    argv: list[str], message: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "require_compatible_muse"),
+        patch.object(muse, "get_settings", return_value=_settings()),
+        patch.object(muse, "preflight_proxy", return_value=None),
+        patch.object(
+            muse, "fetch_proxy_models_response", return_value=_models_payload()
+        ),
+        patch.object(muse, "run_client_process") as run_client_process,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        muse.launch(argv)
+
+    assert exc_info.value.code == 2
+    assert message in capsys.readouterr().err
+    run_client_process.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("output", "return_code", "expected"),
+    [
+        ("Muse Code 0.2.1 (0.2.1-R1215.1)\n", 0, (0, 2, 1)),
+        ("Muse Code 1.4.2 (1.4.2-R99.3)\n", 0, (1, 4, 2)),
+        ("Muse Code 0.2.1\n", 0, (0, 2, 1)),
+        ("unexpected Muse Code 0.2.1\n", 0, None),
+        ("Muse Code 0.2.1 (0.2.1-R1215.1)\n", 1, None),
+    ],
+)
+def test_muse_version_probe(
+    output: str,
+    return_code: int,
+    expected: tuple[int, int, int] | None,
+) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with patch.object(
+        muse.subprocess,
+        "run",
+        return_value=SimpleNamespace(stdout=output, returncode=return_code),
+    ):
+        assert muse.muse_binary_version("resolved-muse") == expected
+
+
+def test_muse_version_probe_handles_timeout() -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with patch.object(
+        muse.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired("muse", 5),
+    ):
+        assert muse.muse_binary_version("resolved-muse") is None
+
+
+@pytest.mark.parametrize("version", [(0, 2, 0), None])
+def test_incompatible_muse_fails_before_settings(
+    version: tuple[int, int, int] | None,
+) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "muse_binary_version", return_value=version),
+        patch.object(muse, "get_settings") as get_settings,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        muse.launch([])
+
+    assert exc_info.value.code == 1
+    get_settings.assert_not_called()
+
+
+def test_muse_child_environment_replaces_only_route_controls() -> None:
+    from free_claude_code.cli.launchers.muse import build_muse_launcher_env
+
+    env = build_muse_launcher_env(
+        proxy_root_url="http://127.0.0.1:9191",
+        auth_token="proxy-token",
+        base_env={
+            "META_API_KEY": "native-token",
+            "MUSE_MODEL": "native-model",
+            "MUSE_CUSTOM_HEADERS": "Authorization: native",
+            "MUSE_WWW_ROUTING": "native",
+            "FCC_MUSE_OLD": "stale",
+            "MUSE_NO_AUTO_UPDATE": "1",
+            "HOME": "native-home",
+            "HTTPS_PROXY": "http://proxy.test:8080",
+            "NO_PROXY": "existing.test",
+            "no_proxy": "lower.test",
+        },
+    )
+
+    assert env["META_API_KEY"] == "proxy-token"
+    assert "MUSE_MODEL" not in env
+    assert "MUSE_CUSTOM_HEADERS" not in env
+    assert "MUSE_WWW_ROUTING" not in env
+    assert "FCC_MUSE_OLD" not in env
+    assert env["MUSE_NO_AUTO_UPDATE"] == "1"
+    assert env["HOME"] == "native-home"
+    assert env["HTTPS_PROXY"] == "http://proxy.test:8080"
+    assert "127.0.0.1" in env["NO_PROXY"]
+    assert "127.0.0.1" in env["no_proxy"]
+
+
+@pytest.mark.parametrize(
+    ("token", "preflight_error", "catalog", "expected"),
+    [
+        ("", None, _models_payload(), "authentication token is empty"),
+        ("proxy-token", "connection refused", _models_payload(), "not reachable"),
+        ("proxy-token", None, {"object": "list", "data": []}, "no routable"),
+        ("proxy-token", None, {"unexpected": True}, "no routable"),
+    ],
+)
+def test_preflight_failures_never_start_muse(
+    token: str,
+    preflight_error: str | None,
+    catalog: JsonObject,
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from free_claude_code.cli.launchers import muse
+
+    with (
+        patch.object(muse, "resolve_client_binary", return_value="resolved-muse"),
+        patch.object(muse, "require_compatible_muse"),
+        patch.object(muse, "get_settings", return_value=_settings(token=token)),
+        patch.object(muse, "preflight_proxy", return_value=preflight_error),
+        patch.object(muse, "fetch_proxy_models_response", return_value=catalog),
+        patch.object(muse, "run_client_process") as run_client_process,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        muse.launch(["prompt"])
+
+    assert exc_info.value.code == 1
+    assert expected in capsys.readouterr().err
+    run_client_process.assert_not_called()

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -876,6 +876,7 @@ def test_install_sh_selects_pinned_rtk_release_for_platform(
 def test_install_sh_rejects_unsupported_rtk_platform(
     posix_harness: PosixHarness,
 ) -> None:
+    posix_harness.add_client("muse")
     posix_harness.env["FAKE_UNAME"] = "FreeBSD"
     posix_harness.env["FAKE_UNAME_MACHINE"] = "riscv64"
 
@@ -1063,6 +1064,7 @@ def test_install_sh_preserves_valid_existing_tools(
     posix_harness.add_client("cline")
     posix_harness.add_client("hermes")
     posix_harness.add_client("grok")
+    posix_harness.add_client("muse")
     posix_harness.add_uv(uv_version)
 
     result = posix_harness.run()

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -22,6 +22,7 @@ FCC_COMMANDS = (
     "fcc-hermes",
     "fcc-dsh",
     "fcc-grok",
+    "fcc-muse",
     "fcc-init",
     "free-claude-code",
 )
@@ -58,13 +59,15 @@ def _posix_command(name: str) -> str:
         "hermes": "0.20.4",
         "dsh": "0.1.0-rc.8",
         "grok": "1.0.5",
+        "muse": "0.2.1",
         "node": "22.19.0",
     }.get(name, "1.0.0")
-    version_output = (
-        f"Hermes Agent v{version} (test build)"
-        if name == "hermes"
-        else f"{name} {version}"
-    )
+    if name == "hermes":
+        version_output = f"Hermes Agent v{version} (test build)"
+    elif name == "muse":
+        version_output = f"Muse Code {version} ({version}-R1215.1)"
+    else:
+        version_output = f"{name} {version}"
     help_output = (
         '    echo "  --extension, -e <path>  Load an extension"\n'
         '    echo "  --models <patterns>     Scope models"'
@@ -141,6 +144,7 @@ if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "install" ]; then
     cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-hermes"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-dsh"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-grok"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-muse"
     if [ "$FAIL_STEP" != "fcc-missing" ]; then
         cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-codex"
     fi
@@ -330,7 +334,7 @@ while [ "$#" -gt 0 ]; do
 done
 echo "download:$url" >> "$CALL_LOG"
 case "$url:$FAIL_STEP" in
-    *claude.ai*:claude-download|*chatgpt.com*:codex-download|*pi.dev*:pi-download|*opencode.ai*:opencode-download|*hermes-agent.nousresearch.com*:hermes-download|*x.ai*:grok-download|*rtk-ai*:rtk-download|*astral.sh*:uv-download)
+    *claude.ai*:claude-download|*chatgpt.com*:codex-download|*pi.dev*:pi-download|*opencode.ai*:opencode-download|*hermes-agent.nousresearch.com*:hermes-download|*x.ai*:grok-download|*dev.meta.ai*:muse-download|*rtk-ai*:rtk-download|*astral.sh*:uv-download)
         exit 41
         ;;
 esac
@@ -341,6 +345,7 @@ case "$url" in
     *opencode.ai*) source="$FAKE_FIXTURES/opencode-installer.sh" ;;
     *hermes-agent.nousresearch.com*) source="$FAKE_FIXTURES/hermes-installer.sh" ;;
     *x.ai*) source="$FAKE_FIXTURES/grok-installer.sh" ;;
+    *dev.meta.ai*) source="$FAKE_FIXTURES/muse-installer.sh" ;;
     *rtk-ai*)
         if [ "$FAIL_STEP" = "rtk-install" ]; then
             printf 'invalid archive\n' > "$output"
@@ -421,6 +426,16 @@ chmod +x "$HOME/.local/bin/grok"
 """,
     )
     _write_executable(
+        fixtures / "muse-installer.sh",
+        """#!/bin/sh
+echo "muse-install" >> "$CALL_LOG"
+[ "$FAIL_STEP" = "muse-install" ] && exit 28
+mkdir -p "$HOME/.local/bin"
+cp "$FAKE_FIXTURES/muse-command.sh" "$HOME/.local/bin/muse"
+chmod +x "$HOME/.local/bin/muse"
+""",
+    )
+    _write_executable(
         fixtures / "uv-installer.sh",
         """#!/bin/sh
 echo "uv-install" >> "$CALL_LOG"
@@ -438,6 +453,7 @@ chmod +x "$HOME/.local/bin/uv"
     _write_executable(fixtures / "hermes-command.sh", _posix_command("hermes"))
     _write_executable(fixtures / "dsh-command.sh", _posix_command("dsh"))
     _write_executable(fixtures / "grok-command.sh", _posix_command("grok"))
+    _write_executable(fixtures / "muse-command.sh", _posix_command("muse"))
     rtk_command = _posix_rtk_command().encode()
     with tarfile.open(
         fixtures / "rtk-x86_64-unknown-linux-musl.tar.gz", "w:gz"
@@ -532,6 +548,7 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
         "dsh:--version"
     )
     assert calls.index("grok-install") < calls.index("grok:--version")
+    assert calls.index("muse-install") < calls.index("muse:--version")
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
         call.startswith(
@@ -553,7 +570,7 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
 def test_install_sh_installs_selected_hermes_without_setup(
     posix_harness: PosixHarness,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\nn\nn\n")
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\nn\nn\nn\n")
 
     assert result.returncode == 0, result.stdout
     calls = posix_harness.calls()
@@ -573,7 +590,7 @@ def test_install_sh_stops_when_selected_hermes_install_fails(
     failure: str,
 ) -> None:
     result = posix_harness.run_interactive(
-        "n\nn\nn\nn\nn\ny\nn\nn\nn\n", fail_step=failure
+        "n\nn\nn\nn\nn\ny\nn\nn\nn\nn\n", fail_step=failure
     )
 
     assert result.returncode != 0
@@ -587,7 +604,7 @@ def test_install_sh_rejects_unsupported_hermes_platform_before_download(
     posix_harness.env["FAKE_UNAME"] = "Darwin"
     posix_harness.env["FAKE_UNAME_MACHINE"] = "x86_64"
 
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\nn\nn\n")
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\ny\nn\nn\nn\nn\n")
 
     assert result.returncode != 0
     assert "does not provide a supported release for Darwin x86_64" in result.stdout
@@ -644,7 +661,52 @@ def test_install_sh_stops_when_grok_install_fails(
     failure: str,
 ) -> None:
     result = posix_harness.run_interactive(
-        "n\nn\nn\nn\nn\nn\nn\ny\nn\n", fail_step=failure
+        "n\nn\nn\nn\nn\nn\nn\ny\nn\nn\n", fail_step=failure
+    )
+
+    assert result.returncode != 0
+    assert "Free Claude Code is installed and verified." not in result.stdout
+    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+
+
+def test_install_sh_preserves_compatible_existing_muse(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.add_client("muse")
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Muse Code 0.2.1 already satisfies >=0.2.1" in result.stdout
+    assert not any("dev.meta.ai" in call for call in posix_harness.calls())
+
+
+def test_install_sh_upgrades_old_muse_with_official_installer(
+    posix_harness: PosixHarness,
+) -> None:
+    _write_executable(
+        posix_harness.bin_dir / "muse",
+        _posix_command("muse").replace(
+            "Muse Code 0.2.1 (0.2.1-R1215.1)",
+            "Muse Code 0.2.0 (0.2.0-R1200.1)",
+        ),
+    )
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Muse Code 0.2.0 does not satisfy >=0.2.1" in result.stdout
+    assert "download:https://dev.meta.ai/install.sh" in posix_harness.calls()
+    assert "muse-install" in posix_harness.calls()
+
+
+@pytest.mark.parametrize("failure", ["muse-download", "muse-install"])
+def test_install_sh_stops_when_muse_install_fails(
+    posix_harness: PosixHarness,
+    failure: str,
+) -> None:
+    result = posix_harness.run_interactive(
+        "n\nn\nn\nn\nn\nn\nn\nn\ny\nn\n", fail_step=failure
     )
 
     assert result.returncode != 0
@@ -655,7 +717,7 @@ def test_install_sh_stops_when_grok_install_fails(
 def test_install_sh_installs_selected_dsh_at_exact_preview(
     posix_harness: PosixHarness,
 ) -> None:
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\ny\nn\nn\n")
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\ny\nn\nn\nn\n")
 
     assert result.returncode == 0, result.stdout
     calls = posix_harness.calls()
@@ -708,7 +770,7 @@ def test_install_sh_rejects_incompatible_node_for_selected_dsh(
         _posix_command("node").replace("node 22.19.0", f"node {node_version}"),
     )
 
-    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\ny\nn\nn\n")
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\ny\nn\nn\nn\n")
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
@@ -734,7 +796,7 @@ def test_install_sh_stops_when_selected_dsh_install_fails(
     posix_harness: PosixHarness,
 ) -> None:
     result = posix_harness.run_interactive(
-        "n\nn\nn\nn\nn\nn\ny\nn\nn\n", fail_step="dsh-install"
+        "n\nn\nn\nn\nn\nn\ny\nn\nn\nn\n", fail_step="dsh-install"
     )
 
     assert result.returncode != 0
@@ -828,7 +890,7 @@ def test_install_sh_preserves_existing_rtk_and_configures_only_selected_agent(
 ) -> None:
     posix_harness.add_rtk()
 
-    result = posix_harness.run_interactive("n\ny\nn\nn\nn\nn\nn\nn\ny\n")
+    result = posix_harness.run_interactive("n\ny\nn\nn\nn\nn\nn\nn\nn\ny\n")
 
     assert result.returncode == 0, result.stdout
     assert "verifying it without updating it" in result.stdout
@@ -876,7 +938,7 @@ def test_install_sh_reprompts_then_installs_only_selected_agent(
     posix_harness: PosixHarness,
 ) -> None:
     result = posix_harness.run_interactive(
-        "n\nn\nn\nn\nn\nn\nn\nn\nn\ny\nn\nn\nn\nn\nn\nn\nn\n"
+        "n\nn\nn\nn\nn\nn\nn\nn\nn\nn\ny\nn\nn\nn\nn\nn\nn\nn\nn\n"
     )
 
     assert result.returncode == 0, result.stdout
@@ -897,7 +959,7 @@ def test_install_sh_rejects_uninstalled_only_selection(
     posix_harness: PosixHarness,
 ) -> None:
     result = posix_harness.run_interactive(
-        "n\nn\ny\nn\nn\nn\nn\nn\nn\n", fail_step="pi-skip"
+        "n\nn\ny\nn\nn\nn\nn\nn\nn\nn\n", fail_step="pi-skip"
     )
 
     assert result.returncode != 0
@@ -1445,6 +1507,7 @@ def _batch_client(name: str) -> str:
         "hermes": "0.20.4",
         "dsh": "0.1.0-rc.8",
         "grok": "1.0.5",
+        "muse": "0.2.1",
         "node": "22.19.0",
     }.get(name, "1.0.0")
     version_output = (
@@ -1458,7 +1521,11 @@ def _batch_client(name: str) -> str:
             'if "%1"=="--version" echo Up to date'
         )
         if name == "hermes"
-        else f'if "%1"=="--version" echo {name} {version}'
+        else (
+            f'if "%1"=="--version" echo Muse Code {version} ({version}-R1215.1)'
+            if name == "muse"
+            else f'if "%1"=="--version" echo {name} {version}'
+        )
     )
     help_output = (
         "echo   --extension, -e ^<path^>  Load an extension\n"
@@ -1523,6 +1590,7 @@ copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-cline.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-hermes.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-dsh.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-grok.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-muse.cmd" >nul
 if not "%FAIL_STEP%"=="fcc-missing" copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-codex.cmd" >nul
 exit /b 0
 :update_shell
@@ -1655,6 +1723,7 @@ def powershell_harness(
     )
     (fixtures / "dsh-command.cmd").write_text(_batch_client("dsh"), encoding="utf-8")
     (fixtures / "grok-command.cmd").write_text(_batch_client("grok"), encoding="utf-8")
+    (fixtures / "muse-command.cmd").write_text(_batch_client("muse"), encoding="utf-8")
     (fixtures / "rtk-command.cmd").write_text(_batch_rtk(), encoding="utf-8")
     (fixtures / "uv-command.cmd").write_text(_batch_uv("0.11.28"), encoding="utf-8")
     (fixtures / "fcc-command.cmd").write_text(
@@ -1894,6 +1963,8 @@ def test_install_ps1_fresh_install_is_verified(
         "dsh:--version"
     )
     assert calls.index("grok-install") < calls.index("grok:--version")
+    assert "Muse Code is not installed" in result.stdout
+    assert not any(call.startswith("muse:") for call in calls)
     assert not any("hermes:setup" in call for call in calls)
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
@@ -1985,6 +2056,45 @@ def test_install_ps1_preserves_compatible_existing_grok(
     assert result.returncode == 0, result.stderr
     assert "Grok Build 1.0.5 already satisfies >=1.0.5" in result.stdout
     assert not any("x.ai/cli" in call for call in powershell_harness.calls())
+
+
+def test_install_ps1_preserves_compatible_existing_muse(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    powershell_harness.add_client("muse")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Verified Muse Code 0.2.1" in result.stdout
+    assert "Run Muse Code with: fcc-muse" in result.stdout
+    assert not any("meta.ai" in call for call in powershell_harness.calls())
+
+
+@pytest.mark.parametrize(
+    "version_output",
+    [
+        "Muse Code 0.2.0 (0.2.0-R1200.1)",
+        "Meta launcher build 0.2.1",
+    ],
+)
+def test_install_ps1_rejects_incompatible_muse_without_inventing_an_updater(
+    powershell_harness: PowerShellHarness,
+    version_output: str,
+) -> None:
+    _write_executable(
+        powershell_harness.bin_dir / "muse.cmd",
+        _batch_client("muse").replace(
+            "Muse Code 0.2.1 (0.2.1-R1215.1)", version_output
+        ),
+    )
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert "Muse Code" in result.stderr
+    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+    assert not any("meta.ai" in call for call in powershell_harness.calls())
 
 
 def test_install_ps1_upgrades_old_grok_with_official_installer(
@@ -2676,6 +2786,9 @@ def test_installers_use_native_clients_and_single_python_selection() -> None:
     assert "https://pi.dev/install.ps1" in powershell
     assert "https://x.ai/cli/install.sh" in shell
     assert "https://x.ai/cli/install.ps1" in powershell
+    assert "https://dev.meta.ai/install.sh" in shell
+    assert "dev.meta.ai" not in powershell
+    assert "muse-code/channels" not in powershell
 
 
 def test_install_ps1_uses_x64_python_for_windows_arm_compatibility() -> None:
@@ -2727,8 +2840,8 @@ Invoke-DownloadedPowerShellInstaller `
     ("answers", "expected", "expected_messages"),
     [
         (
-            ("", "", "", "", "", "", "", "", ""),
-            "True,True,True,True,False,True,True,True,False",
+            ("", "", "", "", "", "", "", "", "", ""),
+            "True,True,True,True,False,True,True,True,True,False",
             (),
         ),
         (
@@ -2743,7 +2856,9 @@ Invoke-DownloadedPowerShellInstaller `
                 "n",
                 "n",
                 "n",
+                "n",
                 "y",
+                "n",
                 "n",
                 "n",
                 "n",
@@ -2752,7 +2867,7 @@ Invoke-DownloadedPowerShellInstaller `
                 "n",
                 "y",
             ),
-            "False,True,False,False,False,False,False,False,True",
+            "False,True,False,False,False,False,False,False,False,True",
             ("Please answer Y or N.", "Select at least one coding agent."),
         ),
     ],
@@ -2779,6 +2894,7 @@ $script:InstallCline = $false
 $script:InstallHermes = $true
 $script:InstallDsh = $true
 $script:InstallGrok = $true
+$script:InstallMuse = $true
 $script:EnableRtk = $false
 function Read-Host {{
     param([string] $Prompt)
@@ -2789,7 +2905,7 @@ function Read-Host {{
 function Read-YesNo {{{read_yes_no}}}
 function Select-CodingAgents {{{select_agents}}}
 Select-CodingAgents
-Write-Output "selection:$($script:InstallClaudeCode),$($script:InstallCodex),$($script:InstallPi),$($script:InstallOpenCode),$($script:InstallCline),$($script:InstallHermes),$($script:InstallDsh),$($script:InstallGrok),$($script:EnableRtk)"
+Write-Output "selection:$($script:InstallClaudeCode),$($script:InstallCodex),$($script:InstallPi),$($script:InstallOpenCode),$($script:InstallCline),$($script:InstallHermes),$($script:InstallDsh),$($script:InstallGrok),$($script:InstallMuse),$($script:EnableRtk)"
 """
 
     result = subprocess.run(
@@ -2819,7 +2935,9 @@ $script:InstallCline = $false
 $script:InstallHermes = $false
 $script:InstallDsh = $false
 $script:InstallGrok = $false
+$script:InstallMuse = $false
 $script:PiAvailable = $false
+$script:MuseAvailable = $false
 $script:Calls = @()
 function Write-Step {{ param([string] $Message) }}
 function Ensure-ClaudeCode {{ $script:Calls += "claude" }}
@@ -2830,6 +2948,7 @@ function Ensure-Cline {{ $script:Calls += "cline" }}
 function Ensure-Hermes {{ $script:Calls += "hermes" }}
 function Ensure-Dsh {{ $script:Calls += "dsh" }}
 function Ensure-Grok {{ $script:Calls += "grok" }}
+function Ensure-Muse {{ $script:Calls += "muse"; $script:MuseAvailable = $true }}
 function Ensure-SelectedCodingAgents {{{body}}}
 Ensure-SelectedCodingAgents
 Write-Output "calls:$($script:Calls -join ',')"
@@ -2863,7 +2982,9 @@ $script:InstallCline = $false
 $script:InstallHermes = $false
 $script:InstallDsh = $false
 $script:InstallGrok = $false
+$script:InstallMuse = $false
 $script:PiAvailable = $false
+$script:MuseAvailable = $false
 $script:Calls = @()
 function Write-Step {{ param([string] $Message) }}
 function Ensure-Rtk {{ $script:Calls += "ensure" }}
@@ -2901,7 +3022,9 @@ $script:InstallCline = $false
 $script:InstallHermes = $false
 $script:InstallDsh = $false
 $script:InstallGrok = $false
+$script:InstallMuse = $false
 $script:PiAvailable = $false
+$script:MuseAvailable = $false
 function Write-Step {{ param([string] $Message) }}
 function Ensure-ClaudeCode {{ }}
 function Ensure-Codex {{ }}
@@ -2911,6 +3034,7 @@ function Ensure-Cline {{ }}
 function Ensure-Hermes {{ }}
 function Ensure-Dsh {{ }}
 function Ensure-Grok {{ }}
+function Ensure-Muse {{ }}
 function Ensure-SelectedCodingAgents {{{body}}}
 Ensure-SelectedCodingAgents
 """

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -17,6 +17,7 @@ FCC_COMMANDS = (
     "fcc-hermes",
     "fcc-dsh",
     "fcc-grok",
+    "fcc-muse",
     "fcc-init",
     "free-claude-code",
 )
@@ -142,6 +143,7 @@ def posix_uninstall_harness(tmp_path: Path) -> PosixUninstallHarness:
     _write_executable(bin_dir / "hermes", "#!/bin/sh\nexit 0\n")
     _write_executable(bin_dir / "dsh", "#!/bin/sh\nexit 0\n")
     _write_executable(bin_dir / "grok", "#!/bin/sh\nexit 0\n")
+    _write_executable(bin_dir / "muse", "#!/bin/sh\nexit 0\n")
     hermes_state = home / ".hermes" / "sessions" / "state.json"
     hermes_state.parent.mkdir(parents=True)
     hermes_state.write_text('{"native": true}\n', encoding="utf-8")
@@ -151,6 +153,9 @@ def posix_uninstall_harness(tmp_path: Path) -> PosixUninstallHarness:
     grok_state = home / ".grok" / "sessions" / "state.json"
     grok_state.parent.mkdir(parents=True)
     grok_state.write_text('{"native": true}\n', encoding="utf-8")
+    muse_state = home / ".local" / "share" / "muse" / "sessions" / "state.json"
+    muse_state.parent.mkdir(parents=True)
+    muse_state.write_text('{"native": true}\n', encoding="utf-8")
     _write_executable(
         bin_dir / "pgrep",
         """#!/bin/sh
@@ -182,7 +187,7 @@ if [ "${1:-}" = "tool" ] && [ "${2:-}" = "uninstall" ]; then
         echo 'Tool `free-claude-code` is not installed' >&2
         exit 2
     fi
-    for name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-init free-claude-code; do
+    for name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-init free-claude-code; do
         /bin/rm -f "$FAKE_TOOL_BIN/$name"
     done
     echo "Uninstalled free-claude-code"
@@ -256,6 +261,7 @@ def test_uninstall_sh_removes_and_verifies_only_fcc(
     assert (posix_uninstall_harness.bin_dir / "hermes").exists()
     assert (posix_uninstall_harness.bin_dir / "dsh").exists()
     assert (posix_uninstall_harness.bin_dir / "grok").exists()
+    assert (posix_uninstall_harness.bin_dir / "muse").exists()
     assert (
         posix_uninstall_harness.home / ".hermes" / "sessions" / "state.json"
     ).read_text(encoding="utf-8") == '{"native": true}\n'
@@ -264,6 +270,14 @@ def test_uninstall_sh_removes_and_verifies_only_fcc(
     ).read_text(encoding="utf-8") == '{"native": true}\n'
     assert (
         posix_uninstall_harness.home / ".grok" / "sessions" / "state.json"
+    ).read_text(encoding="utf-8") == '{"native": true}\n'
+    assert (
+        posix_uninstall_harness.home
+        / ".local"
+        / "share"
+        / "muse"
+        / "sessions"
+        / "state.json"
     ).read_text(encoding="utf-8") == '{"native": true}\n'
     assert posix_uninstall_harness.calls() == [
         "uv:tool dir --bin",
@@ -520,6 +534,7 @@ def powershell_uninstall_harness(
         "hermes",
         "dsh",
         "grok",
+        "muse",
     ):
         (bin_dir / f"{name}.cmd").write_text("@echo off\nexit /b 0\n", encoding="utf-8")
     hermes_state = local_app_data / "hermes" / "state.json"
@@ -531,6 +546,9 @@ def powershell_uninstall_harness(
     grok_state = home / ".grok" / "sessions" / "state.json"
     grok_state.parent.mkdir(parents=True)
     grok_state.write_text('{"native": true}\n', encoding="utf-8")
+    muse_state = local_app_data / "Muse Code" / "sessions" / "state.json"
+    muse_state.parent.mkdir(parents=True)
+    muse_state.write_text('{"native": true}\n', encoding="utf-8")
 
     uv_commands = " ".join(FCC_COMMANDS)
     (bin_dir / "uv.cmd").write_text(
@@ -660,6 +678,7 @@ def test_uninstall_ps1_removes_and_verifies_only_fcc(
     assert (powershell_uninstall_harness.bin_dir / "hermes.cmd").exists()
     assert (powershell_uninstall_harness.bin_dir / "dsh.cmd").exists()
     assert (powershell_uninstall_harness.bin_dir / "grok.cmd").exists()
+    assert (powershell_uninstall_harness.bin_dir / "muse.cmd").exists()
     assert (
         Path(powershell_uninstall_harness.env["LOCALAPPDATA"]) / "hermes" / "state.json"
     ).read_text(encoding="utf-8") == '{"native": true}\n'
@@ -668,6 +687,12 @@ def test_uninstall_ps1_removes_and_verifies_only_fcc(
     ).read_text(encoding="utf-8") == '{"native": true}\n'
     assert (
         powershell_uninstall_harness.home / ".grok" / "sessions" / "state.json"
+    ).read_text(encoding="utf-8") == '{"native": true}\n'
+    assert (
+        Path(powershell_uninstall_harness.env["LOCALAPPDATA"])
+        / "Muse Code"
+        / "sessions"
+        / "state.json"
     ).read_text(encoding="utf-8") == '{"native": true}\n'
     assert powershell_uninstall_harness.calls() == [
         "uv:tool dir --bin",

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.11.1"
+version = "5.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Muse Code could not discover FCC models or route attached sessions through the proxy without manual configuration. Its native catalog path and platform-specific installation contract were not represented by FCC.

## Changes

| Before | After |
| --- | --- |
| Muse Code had no FCC launcher or compatible model-catalog path. | `fcc-muse` routes TUI, `exec`, and `resume` sessions through FCC and serves the existing Responses catalog at Muse's authenticated path. |
| Inherited Meta credentials, model defaults, or routing headers could select a native route. | Child-only routing replaces those values, validates the FCC model, and fails closed before inference. |
| Installers and uninstallers did not recognize Muse Code. | The POSIX installer uses Meta's official installer, Windows verifies a compatible existing binary, and uninstall preserves native Muse state. |
| Muse request compatibility was unverified. | Deterministic contracts and a signed-client smoke cover catalog auth, namespaced tools, reasoning, routing, and upstream model selection. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Muse Code support as an FCC client, including authenticated model discovery, local proxy routing, and Responses API compatibility. The exercised local flow completed model discovery and a streaming response successfully.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised Muse launcher, catalog, authentication, and streaming response paths.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a hostile fcc-muse exec invocation with a caller-controlled base URL, and the launcher exited with code 2 before starting the client, confirming that attached routing is fail-closed.
- Ran an executable local integration flow using a Uvicorn FCC API and Muse-compatible child process; authenticated catalog discovery, environment cleanup, selected-model routing, and a terminal response.completed event all succeeded.
- Ran the focused Muse launcher, model catalog, Responses API, and authentication regression suite; all 93 tests passed.
- Uploaded the executable validation source used for the local launcher-to-API contract flow.

<a href="https://app.greptile.com/trex/runs/19921109/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Muse installer test fixtures"](https://github.com/alishahryar1/free-claude-code/commit/325596329807f467b9c4cfb72d4872f41ed9afaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55353952)</sub>

<!-- /greptile_comment -->