### PR TITLE
Open Admin when FCC Desktop starts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.12.0"
+version = "5.12.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/desktop.py
+++ b/src/free_claude_code/cli/desktop.py
@@ -112,7 +112,7 @@ class DesktopController:
             self._server_thread.start()
 
     def _run_server(self) -> None:
-        self._supervisor.run(open_admin_browser=False)
+        self._supervisor.run()
 
 
 def launch_desktop(tray_factory: DesktopTrayFactory) -> None:

--- a/tests/cli/test_desktop.py
+++ b/tests/cli/test_desktop.py
@@ -117,7 +117,7 @@ def test_desktop_controller_owns_server_thread_and_graceful_quit() -> None:
 
     assert tray is not None
     assert tray.run_thread_id == main_thread_id
-    assert supervisor.run_arguments == [False]
+    assert supervisor.run_arguments == [None]
     assert supervisor.schedule_count == 1
     assert supervisor.restart_count == 1
     assert supervisor.stop_count >= 1
@@ -142,7 +142,7 @@ def test_restart_during_server_startup_is_accepted_without_waiting() -> None:
             return True
 
         def run(self, *, open_admin_browser: bool | None = None) -> None:
-            assert open_admin_browser is False
+            assert open_admin_browser is None
             self.run_called.set()
             assert self.allow_run.wait(2)
             self.run_scheduled = False
@@ -247,7 +247,7 @@ def test_desktop_attaches_to_terminal_server_instead_of_binding_twice() -> None:
     instance_lock.release.assert_called_once_with()
 
 
-def test_fresh_desktop_launch_disables_console_and_automatic_browser() -> None:
+def test_fresh_desktop_launch_uses_console_free_supervisor() -> None:
     from free_claude_code.cli import desktop
 
     settings = _settings()

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -158,10 +158,11 @@ def test_schedule_open_admin_browser_opens_when_health_ready() -> None:
     assert opened_urls == [local_admin_url(settings)]
 
 
-def test_serve_skips_admin_browser_when_setting_is_disabled() -> None:
+@pytest.mark.parametrize("open_admin_browser", (False, True))
+def test_serve_respects_admin_browser_setting(open_admin_browser: bool) -> None:
     from free_claude_code.cli import commands
 
-    settings = _launcher_settings(open_admin_browser=False)
+    settings = _launcher_settings(open_admin_browser=open_admin_browser)
     get_settings = MagicMock(return_value=settings)
 
     with (
@@ -175,7 +176,7 @@ def test_serve_skips_admin_browser_when_setting_is_disabled() -> None:
 
     run_server.assert_called_once_with(
         settings,
-        open_admin_browser=False,
+        open_admin_browser=open_admin_browser,
         restart_generation=0,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.12.0"
+version = "5.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC Desktop forced automatic Admin browser startup off even when **Open Admin on Startup** was enabled. A first desktop launch could therefore appear to do nothing, as reported in #1494.

## Changes

| Before | After |
| --- | --- |
| Desktop startup always passed `open_admin_browser=False`. | Desktop startup delegates browser policy to the shared server supervisor. |
| The desktop path ignored the enabled and disabled setting states. | Windows and macOS desktop launches respect **Open Admin on Startup**, including its enabled default. |
| Lifecycle tests encoded the desktop-only override. | Lifecycle tests require neutral delegation and verify both setting states. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

FCC Desktop now lets the shared server supervisor apply the saved Admin-browser preference rather than forcing the browser closed. The concern that desktop startup could still ignore an enabled preference was disproved by exercising the full desktop lifecycle: disabled settings remained disabled and enabled settings reached server startup as enabled. Focused desktop and CLI lifecycle tests passed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on exercised desktop startup behavior for both Admin-browser preference states and passing focused regression coverage.

The real desktop launch path, controller worker thread, and server supervisor were exercised with enabled and disabled persisted settings. The enabled state now reaches server startup correctly, while the disabled state remains unchanged.

**Files Needing Attention:** No files need additional attention. The behavioral change in src/free_claude_code/cli/desktop.py is covered by the updated desktop and entrypoint tests.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the PR, with HEAD^, disabled settings produced \_run\_once(...=False) and enabled settings still produced False, causing the script to fail as expected.
- After the PR, with HEAD, disabled settings produced False and enabled settings produced True, and the script passed (exit 0), while console logging stayed off.
- Ran the review-authored desktop lifecycle validation through the DesktopController and ServerSupervisor to confirm that the current revision preserves the saved Admin-browser setting.
- Ran the desktop CLI tests with pytest; 44 tests passed, confirming the desktop lifecycle preservation.

<a href="https://app.greptile.com/trex/runs/19948897/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix desktop Admin startup behavior"](https://github.com/alishahryar1/free-claude-code/commit/9e8324223821d0c58f00ae04252fba5f2a1faa8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55427833)</sub>

<!-- /greptile_comment -->