### PR TITLE
Forward vision attachments for DeepSeek vision models

### DIFF
--- a/src/free_claude_code/providers/deepseek/compat.py
+++ b/src/free_claude_code/providers/deepseek/compat.py
@@ -39,6 +39,7 @@ _UNSUPPORTED_MESSAGE_BLOCK_TYPES = frozenset(
     }
 )
 _STRIPPABLE_MESSAGE_BLOCK_TYPES = frozenset({"image", "document"})
+_FORWARDABLE_ATTACHMENT_BLOCK_TYPES = frozenset({"image"})
 _OMITTED_ATTACHMENT_TEXT = (
     "[attachment omitted: DeepSeek does not support image or document inputs]"
 )
@@ -46,11 +47,11 @@ _OMITTED_ATTACHMENT_BLOCK = {"type": "text", "text": _OMITTED_ATTACHMENT_TEXT}
 
 
 def _is_vision_capable_model(model: str | None) -> bool:
-    """True when the DeepSeek model accepts image/document attachments.
+    """True when the DeepSeek model accepts OpenAI image parts.
 
     DeepSeek's vision models (e.g. ``deepseek-v4-flash-vision-exp``) support
-    OpenAI-format image parts natively; attachment blocks must be forwarded to
-    them instead of stripped.
+    image inputs natively. Document blocks are still stripped because the
+    shared OpenAI conversion path has no document parts.
     """
     if not model:
         return False
@@ -173,7 +174,7 @@ def sanitize_deepseek_messages_for_openai(messages: Any) -> Any:
 def _strip_unsupported_attachment_blocks(
     messages: Any, *, allow_attachments: bool = False
 ) -> Any:
-    if allow_attachments or not isinstance(messages, list):
+    if not isinstance(messages, list):
         return messages
 
     stripped: list[Any] = []
@@ -196,6 +197,12 @@ def _strip_unsupported_attachment_blocks(
             if isinstance(block, dict):
                 btype = block.get("type")
                 if btype in _STRIPPABLE_MESSAGE_BLOCK_TYPES:
+                    if (
+                        allow_attachments
+                        and btype in _FORWARDABLE_ATTACHMENT_BLOCK_TYPES
+                    ):
+                        new_content.append(block)
+                        continue
                     top_level_dropped[btype] = top_level_dropped.get(btype, 0) + 1
                     message_dropped_attachment = True
                     continue
@@ -209,6 +216,12 @@ def _strip_unsupported_attachment_blocks(
                                 and sub.get("type") in _STRIPPABLE_MESSAGE_BLOCK_TYPES
                             ):
                                 sub_type = sub["type"]
+                                if (
+                                    allow_attachments
+                                    and sub_type in _FORWARDABLE_ATTACHMENT_BLOCK_TYPES
+                                ):
+                                    filtered_inner.append(sub)
+                                    continue
                                 nested_dropped[sub_type] = (
                                     nested_dropped.get(sub_type, 0) + 1
                                 )
@@ -261,7 +274,7 @@ def _walk_block_list_for_unsupported(
             continue
         btype = block.get("type")
         if btype in _UNSUPPORTED_MESSAGE_BLOCK_TYPES:
-            if allow_attachments and btype in _STRIPPABLE_MESSAGE_BLOCK_TYPES:
+            if allow_attachments and btype in _FORWARDABLE_ATTACHMENT_BLOCK_TYPES:
                 continue
             raise InvalidRequestError(
                 f"DeepSeek native does not support {btype!r} blocks ({where})."

--- a/src/free_claude_code/providers/deepseek/compat.py
+++ b/src/free_claude_code/providers/deepseek/compat.py
@@ -45,6 +45,18 @@ _OMITTED_ATTACHMENT_TEXT = (
 _OMITTED_ATTACHMENT_BLOCK = {"type": "text", "text": _OMITTED_ATTACHMENT_TEXT}
 
 
+def _is_vision_capable_model(model: str | None) -> bool:
+    """True when the DeepSeek model accepts image/document attachments.
+
+    DeepSeek's vision models (e.g. ``deepseek-v4-flash-vision-exp``) support
+    OpenAI-format image parts natively; attachment blocks must be forwarded to
+    them instead of stripped.
+    """
+    if not model:
+        return False
+    return "vision" in str(model).rsplit("/", 1)[-1].lower()
+
+
 def build_deepseek_request_body(
     request_data: MessagesRequest, *, reasoning: ReasoningPolicy
 ) -> dict:
@@ -55,10 +67,13 @@ def build_deepseek_request_body(
         len(request_data.messages),
     )
 
+    vision_capable = _is_vision_capable_model(request_data.model)
     data = dump_messages_request(request_data)
     if "messages" in data:
-        data["messages"] = _strip_unsupported_attachment_blocks(data["messages"])
-    _validate_deepseek_request_dict(data)
+        data["messages"] = _strip_unsupported_attachment_blocks(
+            data["messages"], allow_attachments=vision_capable
+        )
+    _validate_deepseek_request_dict(data, allow_attachments=vision_capable)
     _downgrade_forced_tool_choice(data)
 
     has_tool_history = _has_tool_history(data)
@@ -155,8 +170,10 @@ def sanitize_deepseek_messages_for_openai(messages: Any) -> Any:
     return sanitized
 
 
-def _strip_unsupported_attachment_blocks(messages: Any) -> Any:
-    if not isinstance(messages, list):
+def _strip_unsupported_attachment_blocks(
+    messages: Any, *, allow_attachments: bool = False
+) -> Any:
+    if allow_attachments or not isinstance(messages, list):
         return messages
 
     stripped: list[Any] = []
@@ -234,7 +251,9 @@ def _is_server_listed_tool(tool: Mapping[str, Any]) -> bool:
     return False
 
 
-def _walk_block_list_for_unsupported(blocks: Any, *, where: str) -> None:
+def _walk_block_list_for_unsupported(
+    blocks: Any, *, where: str, allow_attachments: bool = False
+) -> None:
     if not isinstance(blocks, list):
         return
     for block in blocks:
@@ -242,16 +261,22 @@ def _walk_block_list_for_unsupported(blocks: Any, *, where: str) -> None:
             continue
         btype = block.get("type")
         if btype in _UNSUPPORTED_MESSAGE_BLOCK_TYPES:
+            if allow_attachments and btype in _STRIPPABLE_MESSAGE_BLOCK_TYPES:
+                continue
             raise InvalidRequestError(
                 f"DeepSeek native does not support {btype!r} blocks ({where})."
             )
         if btype == "tool_result" and "content" in block:
             _walk_block_list_for_unsupported(
-                block["content"], where=f"{where} (tool_result content)"
+                block["content"],
+                where=f"{where} (tool_result content)",
+                allow_attachments=allow_attachments,
             )
 
 
-def _validate_deepseek_request_dict(data: dict[str, Any]) -> None:
+def _validate_deepseek_request_dict(
+    data: dict[str, Any], *, allow_attachments: bool = False
+) -> None:
     mcp = data.get("mcp_servers")
     if mcp:
         raise InvalidRequestError("DeepSeek does not support mcp_servers on requests.")
@@ -270,11 +295,15 @@ def _validate_deepseek_request_dict(data: dict[str, Any]) -> None:
             continue
         content = message.get("content")
         if isinstance(content, list):
-            _walk_block_list_for_unsupported(content, where=f"messages[{i}].content")
+            _walk_block_list_for_unsupported(
+                content, where=f"messages[{i}].content", allow_attachments=allow_attachments
+            )
 
     system = data.get("system")
     if isinstance(system, list):
-        _walk_block_list_for_unsupported(system, where="system")
+        _walk_block_list_for_unsupported(
+            system, where="system", allow_attachments=allow_attachments
+        )
 
 
 def _has_tool_history_blocks(message: Mapping[str, Any]) -> bool:

--- a/src/free_claude_code/providers/deepseek/compat.py
+++ b/src/free_claude_code/providers/deepseek/compat.py
@@ -296,7 +296,9 @@ def _validate_deepseek_request_dict(
         content = message.get("content")
         if isinstance(content, list):
             _walk_block_list_for_unsupported(
-                content, where=f"messages[{i}].content", allow_attachments=allow_attachments
+                content,
+                where=f"messages[{i}].content",
+                allow_attachments=allow_attachments,
             )
 
     system = data.get("system")

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -10,6 +10,7 @@ from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 from free_claude_code.config.provider_catalog import DEEPSEEK_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import (
+    ContentBlockDocument,
     ContentBlockImage,
     Message,
     MessagesRequest,
@@ -764,6 +765,56 @@ def test_vision_model_forwards_user_image():
         if isinstance(part, dict) and part.get("type") == "text"
     ]
     assert text_parts[0]["text"] == "Describe this image"
+
+
+def test_vision_model_strips_user_document():
+    """Vision models still omit documents; conversion has no document parts."""
+    request = MessagesRequest(
+        model="deepseek-v4-flash-vision-exp",
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockDocument(
+                        type="document",
+                        source={
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": "YQ==",
+                        },
+                    )
+                ],
+            )
+        ],
+    )
+    provider = DeepSeekProvider(
+        make_provider_config(
+            api_key="k",
+            base_url=DEEPSEEK_DEFAULT_BASE,
+            rate_limit=1,
+            rate_window=1,
+        ),
+        admission=immediate_admission(),
+    )
+    provider.preflight_stream(request, reasoning=REASONING_ON)
+    body = provider._build_request_body(request, reasoning=reasoning_for(request))
+    content = body["messages"][0]["content"]
+    assert content
+    if isinstance(content, str):
+        lowered = content.lower()
+    else:
+        texts = [
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        lowered = "\n".join(texts).lower()
+        assert not any(
+            isinstance(part, dict) and part.get("type") == "image_url"
+            for part in content
+        )
+    assert "attachment omitted" in lowered
+    assert "image or document inputs" in lowered
 
 
 def test_preflight_rejects_mcp_servers():

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -752,12 +752,16 @@ def test_vision_model_forwards_user_image():
     content = body["messages"][0]["content"]
     assert isinstance(content, list)
     image_parts = [
-        part for part in content if isinstance(part, dict) and part.get("type") == "image_url"
+        part
+        for part in content
+        if isinstance(part, dict) and part.get("type") == "image_url"
     ]
     assert len(image_parts) == 1
     assert image_parts[0]["image_url"]["url"] == "data:image/png;base64,YQ=="
     text_parts = [
-        part for part in content if isinstance(part, dict) and part.get("type") == "text"
+        part
+        for part in content
+        if isinstance(part, dict) and part.get("type") == "text"
     ]
     assert text_parts[0]["text"] == "Describe this image"
 

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -716,6 +716,52 @@ def test_preflight_strips_user_image():
     assert "image or document inputs" in content.lower()
 
 
+def test_vision_model_forwards_user_image():
+    """Vision-capable DeepSeek models receive image blocks as OpenAI image_url parts."""
+    request = MessagesRequest(
+        model="deepseek-v4-flash-vision-exp",
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockImage(
+                        type="image",
+                        source={
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "YQ==",
+                        },
+                    ),
+                    {"type": "text", "text": "Describe this image"},
+                ],
+            )
+        ],
+    )
+    provider = DeepSeekProvider(
+        make_provider_config(
+            api_key="k",
+            base_url=DEEPSEEK_DEFAULT_BASE,
+            rate_limit=1,
+            rate_window=1,
+        ),
+        admission=immediate_admission(),
+    )
+    # Must not raise on preflight (no InvalidRequestError for image blocks).
+    provider.preflight_stream(request, reasoning=REASONING_ON)
+    body = provider._build_request_body(request, reasoning=reasoning_for(request))
+    content = body["messages"][0]["content"]
+    assert isinstance(content, list)
+    image_parts = [
+        part for part in content if isinstance(part, dict) and part.get("type") == "image_url"
+    ]
+    assert len(image_parts) == 1
+    assert image_parts[0]["image_url"]["url"] == "data:image/png;base64,YQ=="
+    text_parts = [
+        part for part in content if isinstance(part, dict) and part.get("type") == "text"
+    ]
+    assert text_parts[0]["text"] == "Describe this image"
+
+
 def test_preflight_rejects_mcp_servers():
     request = MessagesRequest(
         model="m",


### PR DESCRIPTION
## Summary
- DeepSeek now ships vision-capable models (e.g. `deepseek-v4-flash-vision-exp`). The DeepSeek compat layer previously stripped every `image`/`document` block unconditionally, so those models never received pictures even though the Anthropic-to-OpenAI conversion path already emits `image_url` parts.
- This change forwards attachments when the model name contains `vision` (provider prefix stripped), and keeps the existing strip-and-placeholder behavior for text-only DeepSeek models so non-vision sessions still cannot crash.
- Confirmed locally: a vision model request through FCC `/v1/messages` described a red rectangle with a blue circle; server logs no longer report `stripped unsupported attachment blocks`. Direct DeepSeek API calls with the same image already worked, which isolates the bug to the stripper.

## Related
- Closes the stale conclusion in #563 (`Deepseek v4 is text only` is outdated for official vision-exp models).
- Preserves the crash-prevention intent of #359 by making the strip conditional instead of removing it.
- Related to the broader vision-routing theme in #1167 (different provider; not addressed here).

## Out of scope
- `tool_result` nested images on vision models are no longer stripped, but `_normalize_tool_result_content` still JSON-serializes them as text. Full nested-image support would need a separate change.

## Test plan
- [x] `pytest tests/providers/test_deepseek.py` (includes new `test_vision_model_forwards_user_image` and existing `test_preflight_strips_user_image`)
- [x] End-to-end FCC `/v1/messages` request with `deepseek-v4-flash-vision-exp` and a real PNG





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

DeepSeek vision requests now preserve an explicit omission message when a document cannot be converted, while supported images are forwarded as OpenAI-compatible image parts. Focused attachment checks and the complete DeepSeek provider test suite pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised DeepSeek request-construction paths.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the baseline document-only vision request at baseline 0e8701e with the current HEAD at the DeepSeek provider boundary, and observed that HEAD retains a textual omission marker for document-only requests and provides an OpenAI-compatible image\_url data URL part for image requests.
- The before state silently converted the document-only vision request into an empty OpenAI messages list, while the current HEAD preserves a non-empty textual omission marker to indicate an unsupported attachment.
- The current HEAD produces the expected image\_url data URL part for image requests, confirming OpenAI compatibility.
- I ran the focused attachment contract tests and the full DeepSeek provider test suite; both completed successfully.

<a href="https://app.greptile.com/trex/runs/20084676/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep DeepSeek vision models stripping un..."](https://github.com/alishahryar1/free-claude-code/commit/b7984da0e3563b15390d83ed6f8f71acd8357e4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55686207)</sub>

<!-- /greptile_comment -->