### PR TITLE
Preserve provider outcomes during transport cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -230,9 +230,10 @@ new places to add unrelated behavior:
   behavior. It separates immutable vendor profiles from per-request stream
   execution, recovery, request policy, and tool-call assembly. Within one
   request, the runner owns logical orchestration, a replaceable stream assembler
-  owns one replay epoch's ledger and parser state, the returned-attempt scope
-  owns physical stream cleanup, and `RecoveryController` alone owns downstream
-  commit policy. Shared protocol rules belong in [src/free_claude_code/core/](src/free_claude_code/core/).
+  owns one replay epoch's ledger and parser state, the shared
+  `ProviderAttemptScope` owns each returned physical stream and attempt, and
+  `RecoveryController` alone owns downstream commit policy. Shared protocol
+  rules belong in [src/free_claude_code/core/](src/free_claude_code/core/).
 - [messaging/workflow.py](src/free_claude_code/messaging/workflow.py) coordinates messaging runtime
   dependencies. Inbound turn intake, queued node execution, slash command
   dependencies, and tree queue internals live in separate modules so new
@@ -721,6 +722,14 @@ three scopes are explicit:
 - `ProviderAttempt` owns one physical provider HTTP/generation call, including
   its opaque execution claim, admission permit, concurrency lease, acceptance
   state, one idempotent outcome, and exact-once close.
+
+[providers/http.py](src/free_claude_code/providers/http.py) composes one
+`ProviderAttempt` with at most one retained transport resource through the
+idempotent `ProviderAttemptScope`. Resource cleanup is diagnostic-only: a close
+failure emits redacted type metadata but cannot replace established success,
+retry, terminal failure, or cancellation. Attempt cleanup remains authoritative
+and always runs in the scope's `finally`, releasing the execution claim and
+concurrency lease even when transport cleanup fails.
 
 Only `ProviderExecution.open_attempt()` can enter physical provider I/O. A
 strict sliding window admits the call before the concurrency bulkhead; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.4"
+version = "5.13.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/http.py
+++ b/src/free_claude_code/providers/http.py
@@ -1,11 +1,14 @@
 """Shared HTTP lifecycle helpers for upstream provider clients."""
 
 import inspect
-from typing import Any
+from typing import Any, TypeVar
 
 from loguru import logger
 
 from free_claude_code.core.trace import trace_event
+from free_claude_code.providers.admission import ProviderAttempt
+
+_ResourceT = TypeVar("_ResourceT")
 
 
 async def maybe_await_aclose(response: Any) -> None:
@@ -49,3 +52,45 @@ async def close_provider_stream(
             type(close_error).__name__,
             active_error_type,
         )
+
+
+class ProviderAttemptScope:
+    """Own one admitted provider attempt and its optional transport resource."""
+
+    def __init__(
+        self,
+        attempt: ProviderAttempt,
+        *,
+        provider_name: str,
+        request_id: str | None,
+    ) -> None:
+        self.attempt = attempt
+        self._resource: object | None = None
+        self._provider_name = provider_name
+        self._request_id = request_id
+        self._closed = False
+
+    def retain(self, resource: _ResourceT) -> _ResourceT:
+        """Retain and return the sole transport resource owned by this scope."""
+        if self._closed:
+            raise RuntimeError("provider attempt scope is already closed")
+        if self._resource is not None:
+            raise RuntimeError("provider attempt scope already owns a resource")
+        self._resource = resource
+        return resource
+
+    async def aclose(self, *, active_error: BaseException | None) -> None:
+        """Close transport state without masking the established operation outcome."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._resource is not None:
+                await close_provider_stream(
+                    self._resource,
+                    active_error=active_error,
+                    provider_name=self._provider_name,
+                    request_id=self._request_id,
+                )
+        finally:
+            await self.attempt.aclose()

--- a/src/free_claude_code/providers/http.py
+++ b/src/free_claude_code/providers/http.py
@@ -1,5 +1,6 @@
 """Shared HTTP lifecycle helpers for upstream provider clients."""
 
+import asyncio
 import inspect
 from typing import Any, TypeVar
 
@@ -31,7 +32,15 @@ async def close_provider_stream(
     """Close one stream without letting cleanup change its established outcome."""
     try:
         await maybe_await_aclose(stream)
-    except Exception as close_error:
+    except (Exception, asyncio.CancelledError) as close_error:
+        if isinstance(close_error, asyncio.CancelledError):
+            current_task = asyncio.current_task()
+            if (
+                isinstance(active_error, asyncio.CancelledError)
+                or current_task is None
+                or current_task.cancelling()
+            ):
+                raise
         active_error_type = (
             type(active_error).__name__ if active_error is not None else None
         )

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -50,6 +50,7 @@ from free_claude_code.providers.failure_policy import (
     underlying_provider_error,
 )
 from free_claude_code.providers.http import (
+    ProviderAttemptScope,
     close_provider_stream,
     maybe_await_aclose,
 )
@@ -155,38 +156,6 @@ class _OpenAIChatFailureResolution:
     outcome: _OpenAIChatFailureOutcome
     events: tuple[str, ...] = ()
     failure: ExecutionFailure | None = None
-
-
-class _OpenAIChatAttemptScope:
-    """Own one returned provider stream and its admitted attempt."""
-
-    def __init__(
-        self,
-        stream: Any,
-        attempt: ProviderAttempt,
-        *,
-        provider_name: str,
-        request_id: str | None,
-    ) -> None:
-        self.stream = stream
-        self.attempt = attempt
-        self._provider_name = provider_name
-        self._request_id = request_id
-        self._closed = False
-
-    async def aclose(self, *, active_error: BaseException | None) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        try:
-            await close_provider_stream(
-                self.stream,
-                active_error=active_error,
-                provider_name=self._provider_name,
-                request_id=self._request_id,
-            )
-        finally:
-            await self.attempt.aclose()
 
 
 class _OpenAIChatStreamAssembler:
@@ -891,23 +860,23 @@ class _OpenAIChatStreamRunner:
             for event in assembler.start_events():
                 for out_event in hold_event(event):
                     yield out_event
-            scope: _OpenAIChatAttemptScope | None = None
+            scope: ProviderAttemptScope | None = None
             try:
                 stream, body, attempt = await self._provider._create_stream(
                     body,
                     execution,
                     ProviderOperationKind.GENERATION,
                 )
-                scope = _OpenAIChatAttemptScope(
-                    stream,
+                scope = ProviderAttemptScope(
                     attempt,
                     provider_name=tag,
                     request_id=self._request_id,
                 )
+                stream = scope.retain(stream)
                 assembler.bind_tool_argument_aliases(
                     self._provider._tool_argument_aliases(body)
                 )
-                async for chunk in scope.stream:
+                async for chunk in stream:
                     if not scope.attempt.accepted:
                         await scope.attempt.accept()
                     for event in assembler.feed(chunk):
@@ -984,7 +953,7 @@ class _OpenAIChatStreamRunner:
         self,
         *,
         error: Exception,
-        scope: _OpenAIChatAttemptScope | None,
+        scope: ProviderAttemptScope | None,
         assembler: _OpenAIChatStreamAssembler,
         body: dict[str, Any],
         execution: ProviderExecution,
@@ -1118,21 +1087,26 @@ class _OpenAIChatStreamRunner:
         """Collect one complete buffered continuation response."""
         last_error: Exception | None = None
         while execution.can_attempt:
-            stream: Any | None = None
-            attempt: ProviderAttempt | None = None
+            scope: ProviderAttemptScope | None = None
             try:
                 stream, accepted_body, attempt = await self._provider._create_stream(
                     body,
                     execution,
                     operation_kind,
                 )
+                scope = ProviderAttemptScope(
+                    attempt,
+                    provider_name=self._provider._provider_name,
+                    request_id=self._request_id,
+                )
+                stream = scope.retain(stream)
                 text_parts: list[str] = []
                 thinking_parts: list[str] = []
                 tool_calls = OpenAIToolCallCollector()
                 terminal_seen = False
                 async for chunk in stream:
-                    if not attempt.accepted:
-                        await attempt.accept()
+                    if not scope.attempt.accepted:
+                        await scope.attempt.accept()
                     if not getattr(chunk, "choices", None):
                         continue
                     choice = chunk.choices[0]
@@ -1176,8 +1150,8 @@ class _OpenAIChatStreamRunner:
             except Exception as error:
                 last_error = error
                 retryable = is_retryable_stream_error(error)
-                if attempt is not None and not attempt.accepted:
-                    failure = await attempt.fail(
+                if scope is not None and not scope.attempt.accepted:
+                    failure = await scope.attempt.fail(
                         error,
                         provider_failure_override=(
                             self._provider._provider_failure_override
@@ -1197,10 +1171,8 @@ class _OpenAIChatStreamRunner:
                     exc_type=type(error).__name__,
                 )
             finally:
-                if stream is not None:
-                    await maybe_await_aclose(stream)
-                if attempt is not None:
-                    await attempt.aclose()
+                if scope is not None:
+                    await scope.aclose(active_error=sys.exception())
         if last_error is not None:
             raise last_error
         return _CollectedRecoveryOutput(text="", thinking="", tool_calls=())

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 import uuid
 from collections.abc import AsyncIterator
 from importlib.metadata import PackageNotFoundError, version
@@ -32,7 +33,6 @@ from free_claude_code.core.reasoning import (
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
-    ProviderAttempt,
     ProviderCorrectionAction,
     ProviderExecution,
     ProviderOperationKind,
@@ -43,7 +43,7 @@ from free_claude_code.providers.failure_policy import (
     classify_provider_failure,
     is_retryable_stream_error,
 )
-from free_claude_code.providers.http import maybe_await_aclose
+from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
 from free_claude_code.providers.stream_recovery import (
     RecoveryController,
     RecoveryFailureAction,
@@ -118,55 +118,54 @@ class OpenAICodexProvider(BaseProvider):
         execution = self._admission.start_execution()
         authentication_recovered = False
         while execution.can_attempt:
-            response: httpx.Response | None = None
-            attempt: ProviderAttempt | None = None
+            scope: ProviderAttemptScope | None = None
             try:
                 access = await self._auth.access()
                 attempt = await execution.open_attempt(
                     ProviderOperationKind.MODEL_DISCOVERY
                 )
-                response = await self._client.get(
-                    "models",
-                    params={"client_version": FCC_VERSION},
-                    headers={**self._client_headers, **_auth_headers(access)},
+                scope = ProviderAttemptScope(
+                    attempt,
+                    provider_name="OpenAI",
+                    request_id=execution.request_id,
+                )
+                response = scope.retain(
+                    await self._client.get(
+                        "models",
+                        params={"client_version": FCC_VERSION},
+                        headers={**self._client_headers, **_auth_headers(access)},
+                    )
                 )
                 if response.status_code == 401 and not authentication_recovered:
                     error = await _response_status_error(response)
-                    correction = await attempt.correct(error)
+                    correction = await scope.attempt.correct(error)
+                    closing_scope = scope
+                    scope = None
+                    await closing_scope.aclose(active_error=error)
                     if correction is ProviderCorrectionAction.FINAL:
-                        await response.aclose()
-                        response = None
-                        await attempt.aclose()
-                        attempt = None
                         raise error
-                    await response.aclose()
-                    response = None
-                    await attempt.aclose()
-                    attempt = None
                     await self._auth.recover_unauthorized(access.access_token)
                     authentication_recovered = True
                     continue
                 if not response.is_success:
                     raise await _response_status_error(response)
                 payload = response.json()
-                await attempt.accept()
+                await scope.attempt.accept()
                 execution.succeed()
                 return payload
             except asyncio.CancelledError:
                 execution.abandon()
                 raise
             except Exception as error:
-                if attempt is not None and not attempt.accepted:
-                    decision = await attempt.fail(error)
+                if scope is not None and not scope.attempt.accepted:
+                    decision = await scope.attempt.fail(error)
                     if decision.retry_allowed:
                         continue
                 execution.fail(error)
                 raise
             finally:
-                if response is not None:
-                    await response.aclose()
-                if attempt is not None:
-                    await attempt.aclose()
+                if scope is not None:
+                    await scope.aclose(active_error=sys.exception())
 
         if execution.last_failure is not None:
             raise execution.last_failure
@@ -282,33 +281,38 @@ class OpenAICodexProvider(BaseProvider):
                 for held in recovery.push(event):
                     yield held
 
-            response: httpx.Response | None = None
-            attempt: ProviderAttempt | None = None
+            scope: ProviderAttemptScope | None = None
             stream_opened = False
             try:
                 access = await self._auth.access()
                 attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
-                response = await self._client.send(
-                    self._client.build_request(
-                        "POST",
-                        "responses",
-                        json=body,
-                        headers={
-                            **self._client_headers,
-                            **_auth_headers(access),
-                            "Accept": "text/event-stream",
-                            "session_id": session_id,
-                        },
-                    ),
-                    stream=True,
+                scope = ProviderAttemptScope(
+                    attempt,
+                    provider_name="OpenAI",
+                    request_id=request_id,
+                )
+                response = scope.retain(
+                    await self._client.send(
+                        self._client.build_request(
+                            "POST",
+                            "responses",
+                            json=body,
+                            headers={
+                                **self._client_headers,
+                                **_auth_headers(access),
+                                "Accept": "text/event-stream",
+                                "session_id": session_id,
+                            },
+                        ),
+                        stream=True,
+                    )
                 )
                 if response.status_code == 401 and not authentication_recovered:
                     error = await _response_status_error(response)
-                    correction = await attempt.correct(error)
-                    await response.aclose()
-                    response = None
-                    await attempt.aclose()
-                    attempt = None
+                    correction = await scope.attempt.correct(error)
+                    closing_scope = scope
+                    scope = None
+                    await closing_scope.aclose(active_error=error)
                     if correction is ProviderCorrectionAction.FINAL:
                         raise error
                     recovery.discard()
@@ -332,8 +336,8 @@ class OpenAICodexProvider(BaseProvider):
                 stream_opened = True
 
                 async for event_type, payload in _iter_sse(response):
-                    if not attempt.accepted:
-                        await attempt.accept()
+                    if not scope.attempt.accepted:
+                        await scope.attempt.accept()
                     for event in stream.feed(event_type, payload):
                         for held in recovery.push(event):
                             yield held
@@ -356,8 +360,8 @@ class OpenAICodexProvider(BaseProvider):
             except Exception as raw_error:
                 error = _effective_error(raw_error)
                 attempt_failure = None
-                if attempt is not None and not attempt.accepted:
-                    attempt_failure = await attempt.fail(error)
+                if scope is not None and not scope.attempt.accepted:
+                    attempt_failure = await scope.attempt.fail(error)
                 if attempt_failure is not None and attempt_failure.retry_allowed:
                     recovery.discard()
                     trace_event(
@@ -414,10 +418,8 @@ class OpenAICodexProvider(BaseProvider):
                     yield event
                 raise failure from raw_error
             finally:
-                if response is not None:
-                    await response.aclose()
-                if attempt is not None:
-                    await attempt.aclose()
+                if scope is not None:
+                    await scope.aclose(active_error=sys.exception())
 
         if execution.last_failure is not None:
             raise execution.last_failure

--- a/tests/providers/test_execution_failure_boundary.py
+++ b/tests/providers/test_execution_failure_boundary.py
@@ -10,7 +10,11 @@ from free_claude_code.config.nim import NimSettings
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.core.async_iterators import AsyncCloseable
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
-from free_claude_code.providers.http import close_provider_stream
+from free_claude_code.providers.admission import ProviderOperationKind
+from free_claude_code.providers.http import (
+    ProviderAttemptScope,
+    close_provider_stream,
+)
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from tests.providers.request_factory import make_messages_request
 from tests.providers.support import (
@@ -186,6 +190,42 @@ async def test_stream_close_failure_without_active_error_is_observability_only()
         close_exc_type="RuntimeError",
         preserved_exc_type=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_attempt_scope_releases_attempt_when_resource_close_fails() -> None:
+    controller = immediate_admission()
+    execution = controller.start_execution(request_id="req_scope_close")
+    attempt = await execution.open_attempt(ProviderOperationKind.CONTINUATION)
+    stream = _FailingStream(
+        [],
+        None,
+        close_error=RuntimeError("cleanup api_key=SECRET"),
+    )
+    scope = ProviderAttemptScope(
+        attempt,
+        provider_name="TEST",
+        request_id="req_scope_close",
+    )
+    assert scope.retain(stream) is stream
+
+    with patch("free_claude_code.providers.http.trace_event") as trace_event:
+        await scope.aclose(active_error=ValueError("original"))
+        await scope.aclose(active_error=None)
+
+    replacement = await execution.open_attempt(ProviderOperationKind.CONTINUATION)
+    await replacement.aclose()
+    assert stream.close_calls == 1
+    trace_event.assert_called_once_with(
+        stage="provider",
+        event="provider.stream.close_failed",
+        source="provider",
+        provider="TEST",
+        request_id="req_scope_close",
+        close_exc_type="RuntimeError",
+        preserved_exc_type="ValueError",
+    )
+    assert "SECRET" not in repr(trace_event.call_args)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_execution_failure_boundary.py
+++ b/tests/providers/test_execution_failure_boundary.py
@@ -1,5 +1,6 @@
 """Provider streams raise canonical failures after closing committed blocks."""
 
+import asyncio
 from collections import deque
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -29,7 +30,7 @@ class _FailingStream:
         chunks: list[object],
         error: Exception | None,
         *,
-        close_error: Exception | None = None,
+        close_error: BaseException | None = None,
     ) -> None:
         self._chunks = chunks
         self._error = error
@@ -193,14 +194,26 @@ async def test_stream_close_failure_without_active_error_is_observability_only()
 
 
 @pytest.mark.asyncio
-async def test_attempt_scope_releases_attempt_when_resource_close_fails() -> None:
+@pytest.mark.parametrize(
+    "close_error",
+    [
+        pytest.param(RuntimeError("cleanup api_key=SECRET"), id="exception"),
+        pytest.param(
+            asyncio.CancelledError("cleanup api_key=SECRET"),
+            id="cleanup-cancellation",
+        ),
+    ],
+)
+async def test_attempt_scope_releases_attempt_when_resource_close_fails(
+    close_error: BaseException,
+) -> None:
     controller = immediate_admission()
     execution = controller.start_execution(request_id="req_scope_close")
     attempt = await execution.open_attempt(ProviderOperationKind.CONTINUATION)
     stream = _FailingStream(
         [],
         None,
-        close_error=RuntimeError("cleanup api_key=SECRET"),
+        close_error=close_error,
     )
     scope = ProviderAttemptScope(
         attempt,
@@ -222,14 +235,26 @@ async def test_attempt_scope_releases_attempt_when_resource_close_fails() -> Non
         source="provider",
         provider="TEST",
         request_id="req_scope_close",
-        close_exc_type="RuntimeError",
+        close_exc_type=type(close_error).__name__,
         preserved_exc_type="ValueError",
     )
     assert "SECRET" not in repr(trace_event.call_args)
 
 
 @pytest.mark.asyncio
-async def test_completed_stream_close_failure_preserves_success_lifecycle() -> None:
+@pytest.mark.parametrize(
+    "close_error",
+    [
+        pytest.param(RuntimeError("cleanup api_key=SECRET"), id="exception"),
+        pytest.param(
+            asyncio.CancelledError("cleanup api_key=SECRET"),
+            id="cleanup-cancellation",
+        ),
+    ],
+)
+async def test_completed_stream_close_failure_preserves_success_lifecycle(
+    close_error: BaseException,
+) -> None:
     provider = _provider()
     request = make_messages_request(
         "test-model",
@@ -239,7 +264,7 @@ async def test_completed_stream_close_failure_preserves_success_lifecycle() -> N
     stream = _FailingStream(
         [_chunk(content="complete", finish_reason="stop")],
         None,
-        close_error=RuntimeError("cleanup api_key=SECRET"),
+        close_error=close_error,
     )
 
     with (
@@ -270,10 +295,41 @@ async def test_completed_stream_close_failure_preserves_success_lifecycle() -> N
         source="provider",
         provider="NIM",
         request_id="req_successful_close_failure",
-        close_exc_type="RuntimeError",
+        close_exc_type=type(close_error).__name__,
         preserved_exc_type=None,
     )
     assert "SECRET" not in repr(trace_event.call_args)
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_during_stream_close_propagates() -> None:
+    class BlockingClose:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.close_calls = 0
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+            self.started.set()
+            await asyncio.Event().wait()
+
+    stream = BlockingClose()
+    with patch("free_claude_code.providers.http.trace_event") as trace_event:
+        close_task = asyncio.create_task(
+            close_provider_stream(
+                stream,
+                active_error=None,
+                provider_name="TEST",
+                request_id="req_cancelled_close",
+            )
+        )
+        await asyncio.wait_for(stream.started.wait(), timeout=1)
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+    assert stream.close_calls == 1
+    trace_event.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from typing import Any
@@ -43,6 +44,37 @@ class _FakeAuth(OpenAIAuthManager):
         return OpenAIAccess(self.current_token, "account_1", False)
 
 
+class _CloseTrackingResponse(httpx.Response):
+    """HTTPX response that records close order and can fail during cleanup."""
+
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        close_error: Exception | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(status_code, **kwargs)
+        self.close_calls = 0
+        self._close_error = close_error
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        await super().aclose()
+        if self._close_error is not None:
+            raise self._close_error
+
+
+class _CloseAwareAuth(_FakeAuth):
+    def __init__(self, responses: list[_CloseTrackingResponse]) -> None:
+        super().__init__()
+        self._responses = responses
+
+    async def recover_unauthorized(self, rejected_token: str) -> OpenAIAccess:
+        assert self._responses[-1].close_calls == 1
+        return await super().recover_unauthorized(rejected_token)
+
+
 def _config() -> ProviderConfig:
     return make_provider_config(
         api_key="",
@@ -53,12 +85,12 @@ def _config() -> ProviderConfig:
     )
 
 
-def _admission() -> ProviderAdmissionController:
+def _admission(*, max_concurrency: int = 2) -> ProviderAdmissionController:
     return ProviderAdmissionController(
         provider_name="openai",
         rate_limit=100,
         rate_window=1,
-        max_concurrency=2,
+        max_concurrency=max_concurrency,
         base_delay=0,
         max_delay=0,
         jitter=0,
@@ -194,6 +226,127 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
     events = parse_sse_text(body)
     assert_anthropic_stream_contract(events)
     assert text_content(events) == "hello"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_model_discovery_close_failure_preserves_success_and_permit() -> None:
+    responses: list[_CloseTrackingResponse] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = _CloseTrackingResponse(
+            200,
+            json={
+                "models": [
+                    {
+                        "slug": "gpt-visible",
+                        "visibility": "list",
+                        "supported_in_api": False,
+                    }
+                ]
+            },
+            request=request,
+            close_error=RuntimeError("cleanup failed"),
+        )
+        responses.append(response)
+        return response
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(),
+        auth=_FakeAuth(),
+        admission=_admission(max_concurrency=1),
+        client=client,
+    )
+
+    first = await asyncio.wait_for(provider.list_model_infos(), timeout=1)
+    second = await asyncio.wait_for(provider.list_model_infos(), timeout=1)
+
+    assert {info.model_id for info in first} == {"gpt-visible"}
+    assert {info.model_id for info in second} == {"gpt-visible"}
+    assert [response.close_calls for response in responses] == [1, 1]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_generation_close_failure_preserves_success_and_permit() -> None:
+    responses: list[_CloseTrackingResponse] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = _CloseTrackingResponse(
+            200,
+            text=_complete_stream("hello"),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+            close_error=RuntimeError("cleanup failed"),
+        )
+        responses.append(response)
+        return response
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(),
+        auth=_FakeAuth(),
+        admission=_admission(max_concurrency=1),
+        client=client,
+    )
+
+    first = await asyncio.wait_for(
+        _collect(provider.stream_response(_request(), response_model="claude-opus-4")),
+        timeout=1,
+    )
+    second = await asyncio.wait_for(
+        _collect(provider.stream_response(_request(), response_model="claude-opus-4")),
+        timeout=1,
+    )
+
+    assert text_content(parse_sse_text(first)) == "hello"
+    assert text_content(parse_sse_text(second)) == "hello"
+    assert [response.close_calls for response in responses] == [1, 1]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_generation_close_failure_preserves_provider_failure() -> None:
+    responses: list[_CloseTrackingResponse] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = _CloseTrackingResponse(
+            400,
+            json={"error": {"message": "original provider failure"}},
+            request=request,
+            close_error=RuntimeError("cleanup failed"),
+        )
+        responses.append(response)
+        return response
+
+    client = httpx.AsyncClient(
+        base_url="https://chatgpt.com/backend-api/codex/",
+        transport=httpx.MockTransport(handler),
+    )
+    provider = OpenAICodexProvider(
+        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await _collect(
+            provider.stream_response(
+                _request(),
+                request_id="req_close_failure",
+                response_model="claude-opus-4",
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "original provider failure" in exc_info.value.message
+    assert "cleanup failed" not in exc_info.value.message
+    assert [response.close_calls for response in responses] == [1]
     await client.aclose()
 
 
@@ -592,15 +745,18 @@ async def test_truncated_attempt_after_commit_is_not_retried_or_duplicated() -> 
 @pytest.mark.asyncio
 async def test_unauthorized_response_forces_one_auth_refresh() -> None:
     authorizations: list[str] = []
+    unauthorized_responses: list[_CloseTrackingResponse] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         authorizations.append(request.headers["authorization"])
         if len(authorizations) == 1:
-            return httpx.Response(
+            response = _CloseTrackingResponse(
                 401,
                 json={"error": {"message": "expired"}},
                 request=request,
             )
+            unauthorized_responses.append(response)
+            return response
         return httpx.Response(
             200,
             text=_complete_stream("recovered"),
@@ -612,7 +768,7 @@ async def test_unauthorized_response_forces_one_auth_refresh() -> None:
         base_url="https://chatgpt.com/backend-api/codex/",
         transport=httpx.MockTransport(handler),
     )
-    auth = _FakeAuth()
+    auth = _CloseAwareAuth(unauthorized_responses)
     provider = OpenAICodexProvider(
         _config(), auth=auth, admission=_admission(), client=client
     )
@@ -627,6 +783,7 @@ async def test_unauthorized_response_forces_one_auth_refresh() -> None:
 
     assert authorizations == ["Bearer access_1", "Bearer access_2"]
     assert auth.recovery_calls == 1
+    assert unauthorized_responses[0].close_calls == 1
     assert text_content(parse_sse_text(body)) == "recovered"
     await client.aclose()
 
@@ -634,11 +791,14 @@ async def test_unauthorized_response_forces_one_auth_refresh() -> None:
 @pytest.mark.asyncio
 async def test_model_discovery_re_request_is_a_second_admitted_attempt() -> None:
     authorizations: list[str] = []
+    unauthorized_responses: list[_CloseTrackingResponse] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         authorizations.append(request.headers["authorization"])
         if len(authorizations) == 1:
-            return httpx.Response(401, request=request)
+            response = _CloseTrackingResponse(401, request=request)
+            unauthorized_responses.append(response)
+            return response
         return httpx.Response(
             200,
             json={
@@ -658,7 +818,7 @@ async def test_model_discovery_re_request_is_a_second_admitted_attempt() -> None
         base_url="https://chatgpt.com/backend-api/codex/",
         transport=httpx.MockTransport(handler),
     )
-    auth = _FakeAuth()
+    auth = _CloseAwareAuth(unauthorized_responses)
     provider = OpenAICodexProvider(
         _config(), auth=auth, admission=_admission(), client=client
     )
@@ -669,6 +829,7 @@ async def test_model_discovery_re_request_is_a_second_admitted_attempt() -> None
     assert {info.model_id for info in infos} == {"gpt-visible"}
     assert authorizations == ["Bearer access_1", "Bearer access_2"]
     assert auth.recovery_calls == 1
+    assert unauthorized_responses[0].close_calls == 1
     attempt_rows = [
         call.kwargs
         for call in trace.call_args_list

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -1,5 +1,6 @@
 """Tests for streaming error handling in providers/nvidia_nim/client.py."""
 
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -72,12 +73,39 @@ def _recovery_output(
 class ClosableAsyncStreamMock(AsyncStreamMock):
     """Async stream mock that records cleanup."""
 
-    def __init__(self, chunks, error=None):
+    def __init__(self, chunks, error=None, *, close_error=None):
         super().__init__(chunks, error=error)
         self.closed = False
+        self.close_calls = 0
+        self._close_error = close_error
 
     async def aclose(self):
+        self.close_calls += 1
         self.closed = True
+        if self._close_error is not None:
+            raise self._close_error
+
+
+class BlockingClosableAsyncStreamMock:
+    """Async stream that blocks until its consumer is cancelled."""
+
+    def __init__(self, *, close_error=None):
+        self.entered = asyncio.Event()
+        self.close_calls = 0
+        self._close_error = close_error
+
+    def __aiter__(self):
+        return self._aiter()
+
+    async def _aiter(self):
+        self.entered.set()
+        await asyncio.Event().wait()
+        yield
+
+    async def aclose(self):
+        self.close_calls += 1
+        if self._close_error is not None:
+            raise self._close_error
 
 
 def _make_provider():
@@ -1403,6 +1431,139 @@ class TestStreamingExceptionHandling:
         assert result.thinking == ""
         assert result.tool_calls == ()
         assert stream.closed is True
+
+    @pytest.mark.asyncio
+    async def test_recovery_close_failure_preserves_completed_output(self):
+        """A failed stream close cannot replace completed recovery output."""
+        stream = ClosableAsyncStreamMock(
+            [
+                _make_chunk(content="world"),
+                _make_chunk(finish_reason="stop"),
+            ],
+            close_error=RuntimeError("cleanup failed"),
+        )
+        provider = _make_provider()
+        runner = _make_stream_runner(provider, request_id="req_recovery_success")
+        execution = provider._admission.start_execution(
+            request_id="req_recovery_success"
+        )
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            return_value=stream,
+        ):
+            result = await runner._collect_recovery_output(
+                {"messages": []},
+                include_reasoning=True,
+                execution=execution,
+                operation_kind=ProviderOperationKind.CONTINUATION,
+            )
+
+        replacement = await execution.open_attempt(ProviderOperationKind.CONTINUATION)
+        await replacement.aclose()
+        assert result.text == "world"
+        assert stream.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_recovery_close_failure_does_not_block_retry(self):
+        """Cleanup failure cannot replace a retryable recovery failure."""
+        failed = ClosableAsyncStreamMock(
+            [],
+            error=TimeoutError("original retryable failure"),
+            close_error=RuntimeError("cleanup failed"),
+        )
+        recovered = ClosableAsyncStreamMock(
+            [
+                _make_chunk(content="world"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
+        provider = _make_provider()
+        runner = _make_stream_runner(provider)
+        execution = provider._admission.start_execution()
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[failed, recovered],
+        ) as create:
+            result = await runner._collect_recovery_output(
+                {"messages": []},
+                include_reasoning=True,
+                execution=execution,
+                operation_kind=ProviderOperationKind.CONTINUATION,
+            )
+
+        assert result.text == "world"
+        assert create.await_count == 2
+        assert failed.close_calls == 1
+        assert recovered.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_recovery_close_failure_preserves_terminal_failure(self):
+        """Cleanup failure cannot mask a non-retryable recovery failure."""
+        stream = ClosableAsyncStreamMock(
+            [],
+            error=ValueError("original terminal failure"),
+            close_error=RuntimeError("cleanup failed"),
+        )
+        provider = _make_provider()
+        runner = _make_stream_runner(provider)
+        execution = provider._admission.start_execution()
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                return_value=stream,
+            ),
+            pytest.raises(ValueError, match="original terminal failure"),
+        ):
+            await runner._collect_recovery_output(
+                {"messages": []},
+                include_reasoning=True,
+                execution=execution,
+                operation_kind=ProviderOperationKind.CONTINUATION,
+            )
+
+        assert stream.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_recovery_close_failure_preserves_cancellation(self):
+        """Cleanup failure cannot turn caller cancellation into a provider error."""
+        stream = BlockingClosableAsyncStreamMock(
+            close_error=RuntimeError("cleanup failed")
+        )
+        provider = _make_provider()
+        runner = _make_stream_runner(provider)
+        execution = provider._admission.start_execution()
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            return_value=stream,
+        ):
+            task = asyncio.create_task(
+                runner._collect_recovery_output(
+                    {"messages": []},
+                    include_reasoning=True,
+                    execution=execution,
+                    operation_kind=ProviderOperationKind.CONTINUATION,
+                )
+            )
+            await asyncio.wait_for(stream.entered.wait(), timeout=1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        replacement = await execution.open_attempt(ProviderOperationKind.CONTINUATION)
+        await replacement.aclose()
+        assert stream.close_calls == 1
 
     @pytest.mark.asyncio
     async def test_recovery_collect_text_honors_provider_retry_classification(self):

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.4"
+version = "5.13.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

OpenAI-compatible recovery and Codex closed transport resources separately from their admitted attempts. A failing close could replace a successful result, retry, terminal failure, or cancellation and leave the provider lease active.

## Changes

| Before | After |
| --- | --- |
| Chat recovery and Codex paired resource and attempt cleanup manually. | A shared `ProviderAttemptScope` owns one transport resource and its admitted attempt. |
| Transport close errors could replace the established operation outcome and skip lease release. | Close errors emit redacted type-only diagnostics while attempt cleanup always runs. |
| Codex 401 handling closed responses and attempts through separate branches. | Codex closes the shared scope before authentication recovery and preserves the corrected-attempt lifecycle. |
| Cleanup edge cases had partial regression coverage. | Focused tests cover success, retry, terminal failure, cancellation, permit release, and 401 close ordering. |



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change centralizes provider-attempt and transport-resource cleanup for OpenAI Chat and OpenAI Codex. Established response outcomes and caller cancellation are preserved while completed attempts release their admission permits.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains in the changed provider cleanup paths.

The shared lifecycle, OpenAI Codex, and OpenAI Chat checks completed successfully, including cancellation propagation and one-permit admission reuse after cleanup.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked out the provider lifecycle refactor diff from the PR head to review cleanup-cancellation handling in advance of runtime validation.
- Executed the targeted ProviderAttemptScope and Codex cancellation runtime script to block cleanup, cancel the caller, and enforce a one-permit admission limit; the command exited successfully and demonstrated that direct scope cleanup and Codex streaming propagate caller cancellation while allowing a replacement attempt to acquire the released permit.
- Validated the focused regression suites for shared lifecycle, OpenAI Codex, and OpenAI Chat, observing 27 passing tests in the lifecycle/Codex subset and 54 passing tests in the Chat subset.

<a href="https://app.greptile.com/trex/runs/20148612/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Preserve outcomes from cleanup cancellat..."](https://github.com/alishahryar1/free-claude-code/commit/68a07bae6884f4b8c29c3b55885bd0fcaa920a4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55804821)</sub>

<!-- /greptile_comment -->