### PR TITLE
Fix immediate Grok installer path discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.3"
+version = "5.13.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -282,6 +282,12 @@ function Add-KnownBinDirectories {
     if (-not [string]::IsNullOrWhiteSpace($env:APPDATA)) {
         Add-PathEntry (Join-Path $env:APPDATA "npm")
     }
+    if ($env:GROK_BIN_DIR) {
+        Add-PathEntry $env:GROK_BIN_DIR
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        Add-PathEntry (Join-Path $env:USERPROFILE ".grok\bin")
+    }
 }
 
 function Add-NpmBinDirectories {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -272,6 +272,12 @@ add_known_bin_directories() {
         add_path_entry "${XDG_DATA_HOME:-$HOME/.local/share}/pi-node/current/bin"
     fi
 
+    if [ -n "${GROK_BIN_DIR:-}" ]; then
+        add_path_entry "$GROK_BIN_DIR"
+    elif [ -n "${HOME:-}" ]; then
+        add_path_entry "$HOME/.grok/bin"
+    fi
+
     export PATH
     hash -r 2>/dev/null || true
 }

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -420,9 +420,10 @@ chmod +x "$HOME/.local/bin/hermes"
         """#!/bin/sh
 echo "grok-install" >> "$CALL_LOG"
 [ "$FAIL_STEP" = "grok-install" ] && exit 27
-mkdir -p "$HOME/.local/bin"
-cp "$FAKE_FIXTURES/grok-command.sh" "$HOME/.local/bin/grok"
-chmod +x "$HOME/.local/bin/grok"
+grok_bin="${GROK_BIN_DIR:-$HOME/.grok/bin}"
+mkdir -p "$grok_bin"
+cp "$FAKE_FIXTURES/grok-command.sh" "$grok_bin/grok"
+chmod +x "$grok_bin/grok"
 """,
     )
     _write_executable(
@@ -526,6 +527,7 @@ printf '%s  %s\n' "$checksum" "$1"
         }
     )
     env.pop("XDG_BIN_HOME", None)
+    env.pop("GROK_BIN_DIR", None)
     return PosixHarness(tmp_path, bin_dir, fixtures, tool_bin, log, env)
 
 
@@ -565,6 +567,24 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
         "fcc-server:--version",
     ]
     assert not any("hermes:setup" in call for call in calls)
+    home = Path(posix_harness.env["HOME"])
+    assert (home / ".grok" / "bin" / "grok").is_file()
+    assert not (home / ".local" / "bin" / "grok").exists()
+
+
+def test_install_sh_discovers_grok_in_custom_bin_directory(
+    posix_harness: PosixHarness,
+) -> None:
+    custom_grok_bin = posix_harness.root / "custom-grok-bin"
+    posix_harness.env["GROK_BIN_DIR"] = str(custom_grok_bin)
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert (custom_grok_bin / "grok").is_file()
+    assert not (Path(posix_harness.env["HOME"]) / ".grok" / "bin" / "grok").exists()
+    calls = posix_harness.calls()
+    assert calls.index("grok-install") < calls.index("grok:--version")
 
 
 def test_install_sh_installs_selected_hermes_without_setup(
@@ -1789,7 +1809,7 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "hermes-install:${NonInteractive}:
     )
     (fixtures / "grok-installer.ps1").write_text(
         r"""if ($env:FAIL_STEP -eq "grok-install") { exit 66 }
-$bin = Join-Path $env:USERPROFILE ".local\bin"
+$bin = if ($env:GROK_BIN_DIR) { $env:GROK_BIN_DIR } else { Join-Path $env:USERPROFILE ".grok\bin" }
 New-Item -ItemType Directory -Force -Path $bin | Out-Null
 Copy-Item (Join-Path $env:FAKE_FIXTURES "grok-command.cmd") (Join-Path $bin "grok.cmd") -Force
 Add-Content -LiteralPath $env:CALL_LOG -Value "grok-install"
@@ -1940,6 +1960,7 @@ $installer = [scriptblock]::Create($installerSource)
             "FAIL_STEP": "",
         }
     )
+    env.pop("GROK_BIN_DIR", None)
     return PowerShellHarness(
         tmp_path, bin_dir, fixtures, tool_bin, log, env, powershell, wrapper
     )
@@ -1986,6 +2007,8 @@ def test_install_ps1_fresh_install_is_verified(
     ]
     home = Path(powershell_harness.env["USERPROFILE"])
     app_data = Path(powershell_harness.env["APPDATA"])
+    assert (home / ".grok" / "bin" / "grok.cmd").is_file()
+    assert not (home / ".local" / "bin" / "grok.cmd").exists()
     icon = home / ".fcc" / "app-icon.ico"
     assert icon.read_text(encoding="utf-8").strip() == "fake icon"
     assert calls[-1] == f'fcc-desktop:--export-icon "{icon}"'
@@ -2007,6 +2030,23 @@ def test_install_ps1_fresh_install_is_verified(
         / "Programs"
         / "Free Claude Code.lnk"
     ).is_file()
+
+
+def test_install_ps1_discovers_grok_in_custom_bin_directory(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    custom_grok_bin = powershell_harness.root / "custom-grok-bin"
+    powershell_harness.env["GROK_BIN_DIR"] = str(custom_grok_bin)
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert (custom_grok_bin / "grok.cmd").is_file()
+    assert not (
+        Path(powershell_harness.env["USERPROFILE"]) / ".grok" / "bin" / "grok.cmd"
+    ).exists()
+    calls = powershell_harness.calls()
+    assert calls.index("grok-install") < calls.index("grok:--version")
 
 
 def test_install_ps1_preserves_compatible_existing_hermes(

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.3"
+version = "5.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The official Grok installer writes its command to `.grok/bin`, but its child-process PATH update cannot reach the running FCC installer. FCC therefore reported a successful Grok installation as unavailable, and the test fixtures hid the defect by installing Grok into `.local/bin`.

## Changes

| Before | After |
| --- | --- |
| FCC refreshed other known harness directories but omitted Grok's effective bin directory. | FCC refreshes Grok's default bin directory or the upstream `GROK_BIN_DIR` override on Windows and POSIX. |
| Fake Grok installers wrote commands into the already-known `.local/bin` directory. | Fake Grok installers mirror upstream default and override locations and verify same-process discovery. |
| The package version was 5.13.3. | The package version is 5.13.4 with one patch bump. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change refreshes the installer process PATH with Grok’s default and overridden binary directories so Grok can be verified immediately after installation. The focused POSIX installer flows were exercised for both `$HOME/.grok/bin` and `GROK_BIN_DIR`: the previous implementation failed to discover Grok in both cases, while the updated implementation passed both cases. The suspected POSIX same-process command-discovery failure is therefore disproved.

### T-Rex validation blocked
Windows PowerShell runtime coverage could not run because the required PowerShell tool (`pwsh` or `powershell`) is unavailable on the Linux host. The Windows-only default-directory and custom-directory tests were skipped and should be run on a Windows runner.
</details>


<h3>Confidence Score: 5/5</h3>

The validated POSIX installer behavior is safe to merge: Grok is discovered immediately after installation in both supported directory configurations.

The exact regression path was exercised against both the prior and updated POSIX installer, with the prior behavior failing and the updated behavior succeeding in the same deterministic tests. No defects remain in the final review.

**Files Needing Attention:** No files require changes. `scripts/install.ps1` should receive the existing Windows-only tests on a Windows runner when PowerShell is available.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the POSIX Grok installer discovery validation harness against HEAD^ and the current install script, exercising test\_install\_sh\_fresh\_install\_is\_verified and test\_install\_sh\_discovers\_grok\_in\_custom\_bin\_directory.
- Observed that the parent POSIX installer failed to discover Grok after installation, while the current POSIX installer passed, confirming that the in-process PATH refresh makes Grok discoverable from both the default directory and GROK\_BIN\_DIR.
- PowerShell scenarios were attempted but skipped because this Linux host does not provide PowerShell.
- Verified POSIX path refresh behavior by inspecting the install.sh changes at install.sh:275-282 and install.sh:1028-1031, and noted that the prior behavior fails at the same deterministic scope, demonstrating regression coverage.
- PowerShell has corresponding logic in install.ps1 at install.ps1:285-290 and 983-986, but Windows validation remains blocked by the Linux host gate rather than a test failure.

<a href="https://app.greptile.com/trex/runs/20148016/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Grok installer path discovery"](https://github.com/alishahryar1/free-claude-code/commit/614d04a9b01762bdb83b39bdda92f93d8bda3557) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55808780)</sub>

<!-- /greptile_comment -->