### PR TITLE
Suppress OpenAI SDK debug payload logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.5"
+version = "5.13.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/logging_config.py
+++ b/src/free_claude_code/config/logging_config.py
@@ -152,8 +152,8 @@ def configure_logging(
     On verbosity change alone, updates only the third-party logger levels.
     Use force=True to reconfigure from scratch.
 
-    When ``verbose_third_party`` is false, noisy HTTP and Telegram loggers are
-    capped at WARNING unless explicitly configured otherwise.
+    When ``verbose_third_party`` is false, managed noisy third-party loggers
+    are capped at WARNING unless explicitly configured otherwise.
     """
     global _configured, _current_path, _current_level, _current_verbose, _sink_id
 

--- a/src/free_claude_code/config/logging_config.py
+++ b/src/free_claude_code/config/logging_config.py
@@ -21,6 +21,7 @@ _current_verbose: bool | None = None
 _sink_id: int | None = None
 
 _THIRD_PARTY_LOGGERS = (
+    "openai",
     "httpx",
     "httpcore",
     "httpcore.http11",

--- a/tests/config/test_logging_config.py
+++ b/tests/config/test_logging_config.py
@@ -95,17 +95,48 @@ def test_bearer_substring_redacted_in_log_file(tmp_path) -> None:
     assert "Bearer" in text
 
 
-def test_httpx_logger_quieted_when_not_verbose_third_party(tmp_path) -> None:
+def test_noisy_third_party_loggers_quieted_when_not_verbose(tmp_path) -> None:
     log_file = str(tmp_path / "quiet.log")
     configure_logging(log_file, force=True, verbose_third_party=False)
+    assert logging.getLogger("openai").level >= logging.WARNING
+    assert (
+        logging.getLogger("openai._base_client").getEffectiveLevel() >= logging.WARNING
+    )
     assert logging.getLogger("httpx").level >= logging.WARNING
     assert logging.getLogger("httpcore").level >= logging.WARNING
 
 
-def test_httpx_resets_to_notset_when_verbose_third_party(tmp_path) -> None:
+def test_noisy_third_party_loggers_reset_when_verbose(tmp_path) -> None:
     log_file = str(tmp_path / "verbose.log")
     configure_logging(log_file, force=True, verbose_third_party=True)
+    assert logging.getLogger("openai").level == logging.NOTSET
     assert logging.getLogger("httpx").level == logging.NOTSET
+
+
+def test_openai_request_payload_debug_requires_verbose_third_party(tmp_path) -> None:
+    log_file = tmp_path / "openai.log"
+    marker = "Request options: sensitive-prompt"
+    openai_logger = logging.getLogger("openai._base_client")
+
+    configure_logging(
+        log_file,
+        force=True,
+        level="DEBUG",
+        verbose_third_party=False,
+    )
+    openai_logger.debug(marker)
+    logger.complete()
+    assert marker not in log_file.read_text(encoding="utf-8")
+
+    configure_logging(
+        log_file,
+        force=True,
+        level="DEBUG",
+        verbose_third_party=True,
+    )
+    openai_logger.debug(marker)
+    logger.complete()
+    assert marker in log_file.read_text(encoding="utf-8")
 
 
 def test_configure_logging_respects_level(tmp_path) -> None:
@@ -195,12 +226,14 @@ def test_configure_logging_updates_verbosity_on_same_level(tmp_path) -> None:
 
     # Start with verbosity off (third-party loggers at WARNING)
     configure_logging(log_file, force=True, level="DEBUG", verbose_third_party=False)
+    assert logging.getLogger("openai").level >= logging.WARNING
     assert logging.getLogger("httpx").level >= logging.WARNING
     assert logging.getLogger("httpcore").level >= logging.WARNING
     assert logging.getLogger("telegram").level >= logging.WARNING
 
     # Restart with same level but verbosity on
     configure_logging(log_file, level="DEBUG", verbose_third_party=True)
+    assert logging.getLogger("openai").level == logging.NOTSET
     assert logging.getLogger("httpx").level == logging.NOTSET
     assert logging.getLogger("httpcore").level == logging.NOTSET
     assert logging.getLogger("telegram").level == logging.NOTSET

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.5"
+version = "5.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

At DEBUG level, OpenAI SDK request payloads could reach the log even when `LOG_RAW_API_PAYLOADS=false` because the SDK logger inherited the root DEBUG level.

## Changes

| Before | After |
| --- | --- |
| The OpenAI SDK logger inherited root DEBUG logging by default. | The `openai` logger hierarchy is capped at WARNING unless raw payload logging is enabled. |
| Enabling raw payload logging controlled HTTP client noise but not OpenAI SDK noise. | Enabling raw payload logging explicitly restores OpenAI SDK DEBUG output. |
| Logging tests covered HTTP client verbosity only. | Logging tests verify OpenAI request payload records are suppressed by default and restored explicitly. |



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The logging configuration now suppresses OpenAI SDK debug payload records in normal operation while allowing them when third-party verbosity is explicitly enabled. Runtime checks confirmed that changing verbosity in place correctly enables and disables the OpenAI child logger output.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge: the intended default suppression and explicit diagnostic opt-in both behaved correctly in runtime checks.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an authored runtime probe against the parent revision and the current logging implementation, emitting unique DEBUG payload markers through openai.\_base\_client, and confirmed that the marker is absent with verbose\_third\_party=False on the parent, appears with verbose\_third\_party=True on the current implementation, and is absent again after disabling verbosity without force, with the probe exiting successfully and validating the OpenAI logger gating and runtime verbosity transitions.
- Captured the current runtime results showing payload absence with verbose\_third\_party=False, presence with verbose\_third\_party=True, and correct reversal without force, and observed that the predecessor leaked the payload under all three states due to lack of level-capping; an attempt to run the existing pytest module was blocked by an environment mismatch, but the direct library runtime probe executed along the changed path.

<a href="https://app.greptile.com/trex/runs/20153821/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Document managed third-party logging"](https://github.com/alishahryar1/free-claude-code/commit/e4798d2abd2e2d850629e536971f3c19df5cd792) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55820164)</sub>

<!-- /greptile_comment -->