### PR TITLE
Add /v1/chat/completions endpoint for OpenAI Chat Completions compatibility

### DIFF
--- a/src/free_claude_code/api/handlers/chat_completions.py
+++ b/src/free_claude_code/api/handlers/chat_completions.py
@@ -1,0 +1,160 @@
+"""OpenAI Chat Completions API product flow."""
+
+import json
+
+from fastapi.responses import JSONResponse, StreamingResponse
+from loguru import logger
+
+from free_claude_code.application.errors import ApplicationError
+from free_claude_code.application.execution import ProviderExecutor
+from free_claude_code.application.routing import ModelRouter
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic import MessagesRequest
+from free_claude_code.core.chat_completions.converter import (
+    ChatCompletionsToAnthropicConverter,
+)
+from free_claude_code.core.chat_completions.models import ChatCompletionsRequest
+from free_claude_code.core.chat_completions.stream import (
+    chat_completions_sse_from_anthropic,
+)
+from free_claude_code.core.diagnostics import safe_exception_message
+
+
+class ChatCompletionsHandler:
+    """Handle OpenAI Chat Completions requests by converting to Anthropic format.
+
+    The route acquires a RequestRuntimeLease and passes the already-resolved
+    provider_executor here. This handler only owns conversion logic.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        model_router: ModelRouter | None = None,
+        provider_executor: ProviderExecutor,
+    ) -> None:
+        self._model_router = model_router or ModelRouter(settings)
+        self._provider_executor = provider_executor
+
+    async def create(self, request_data: ChatCompletionsRequest) -> object:
+        """Create a Chat Completions response."""
+        try:
+            anthropic_payload = (
+                ChatCompletionsToAnthropicConverter.to_anthropic_payload(request_data)
+            )
+            response_request = MessagesRequest(**anthropic_payload)
+            routed = self._model_router.resolve_messages_request(response_request)
+
+            streamed = self._provider_executor.stream(
+                routed,
+                wire_api="messages",
+                raw_log_label="CHAT_COMPLETIONS_PAYLOAD",
+                raw_log_payload=request_data.model_dump(mode="json", exclude_none=True),
+                request_id="",
+            )
+
+            if request_data.stream is False:
+                from free_claude_code.core.anthropic import (
+                    aggregate_anthropic_sse_to_message,
+                )
+
+                message = await aggregate_anthropic_sse_to_message(streamed)
+                return self._to_non_streaming_response(message, request_data.model)
+
+            async def event_stream():
+                async for chunk in chat_completions_sse_from_anthropic(
+                    streamed, request_data.model
+                ):
+                    yield chunk
+
+            return StreamingResponse(
+                event_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        except ApplicationError:
+            raise
+        except Exception as exc:
+            logger.error("Chat Completions error: {}", safe_exception_message(exc))
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": {
+                        "message": safe_exception_message(exc),
+                        "type": "server_error",
+                    }
+                },
+            )
+
+    def _to_non_streaming_response(self, message: object, model: str) -> dict:
+        """Convert an aggregated Anthropic message to Chat Completions format."""
+        content = ""
+        tool_calls: list[dict] = []
+        finish_reason = "stop"
+
+        if hasattr(message, "content"):
+            blocks = (
+                message.content
+                if isinstance(message.content, list)
+                else [message.content]
+            )
+            for block in blocks:
+                if not hasattr(block, "type"):
+                    continue
+                if block.type == "text":
+                    content += block.text
+                elif block.type == "tool_use":
+                    tool_calls.append(
+                        {
+                            "id": block.id,
+                            "type": "function",
+                            "function": {
+                                "name": block.name,
+                                "arguments": json.dumps(block.input)
+                                if isinstance(block.input, dict)
+                                else str(block.input),
+                            },
+                        }
+                    )
+
+        if hasattr(message, "stop_reason"):
+            stop_map = {
+                "end_turn": "stop",
+                "stop_sequence": "stop",
+                "max_tokens": "length",
+                "tool_use": "tool_calls",
+            }
+            finish_reason = stop_map.get(message.stop_reason, "stop")
+
+        choice: dict = {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": content or None,
+            },
+            "finish_reason": finish_reason,
+        }
+        if tool_calls:
+            choice["message"]["tool_calls"] = tool_calls
+
+        import time
+        import uuid
+
+        return {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [choice],
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+            },
+        }

--- a/src/free_claude_code/api/handlers/chat_completions.py
+++ b/src/free_claude_code/api/handlers/chat_completions.py
@@ -1,10 +1,13 @@
 """OpenAI Chat Completions API product flow."""
 
 import json
+import time
+import uuid
 
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse
 from loguru import logger
 
+from free_claude_code.api.response_streams import ManagedStreamingResponse
 from free_claude_code.application.errors import ApplicationError
 from free_claude_code.application.execution import ProviderExecutor
 from free_claude_code.application.routing import ModelRouter
@@ -68,7 +71,7 @@ class ChatCompletionsHandler:
                 ):
                     yield chunk
 
-            return StreamingResponse(
+            return ManagedStreamingResponse(
                 event_stream(),
                 media_type="text/event-stream",
                 headers={
@@ -142,9 +145,6 @@ class ChatCompletionsHandler:
         }
         if tool_calls:
             choice["message"]["tool_calls"] = tool_calls
-
-        import time
-        import uuid
 
         return {
             "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -12,6 +12,7 @@ from free_claude_code.core.anthropic import (
     TokenCountRequest,
     get_token_count,
 )
+from free_claude_code.core.chat_completions.models import ChatCompletionsRequest
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.trace import trace_event
 
@@ -247,3 +248,54 @@ async def stop_cli(
     )
     logger.info("STOP_CLI: source=messaging_workflow cancelled_count={}", count)
     return {"status": "stopped", "cancelled_count": count}
+
+
+async def _create_chat_completions_response(
+    services: ApiServices,
+    request_data: ChatCompletionsRequest,
+) -> object:
+    lease: RequestRuntimeLease | None = None
+    try:
+        lease = await services.requests.acquire()
+        from free_claude_code.application.execution import ProviderExecutor
+
+        from .handlers.chat_completions import ChatCompletionsHandler
+
+        handler = ChatCompletionsHandler(
+            lease.settings,
+            provider_executor=ProviderExecutor(
+                _provider_resolver(lease),
+                progress_timeout_seconds=lease.settings.provider_progress_timeout,
+            ),
+        )
+        response = await handler.create(request_data)
+    except ApplicationError as exc:
+        if lease is not None:
+            await lease.release()
+        return ordinary_application_error_response(
+            exc,
+            wire_api="messages",
+            request_id="",
+        )
+    except BaseException:
+        if lease is not None:
+            await lease.release()
+        raise
+    assert lease is not None
+    return await bind_response_lifetime(response, lease.release)
+
+
+@router.post("/v1/chat/completions")
+async def create_chat_completion(
+    request: Request,
+    request_data: ChatCompletionsRequest,
+    services: ApiServices = Depends(get_services),
+    _auth=Depends(require_proxy_auth),
+):
+    """OpenAI Chat Completions endpoint. Converts to Anthropic Messages format."""
+    return await _create_chat_completions_response(services, request_data)
+
+
+@router.api_route("/v1/chat/completions", methods=["HEAD", "OPTIONS"])
+async def probe_chat_completions(_auth=Depends(require_proxy_auth)):
+    return _probe_response("POST, HEAD, OPTIONS")

--- a/src/free_claude_code/core/chat_completions/__init__.py
+++ b/src/free_claude_code/core/chat_completions/__init__.py
@@ -1,0 +1,11 @@
+"""OpenAI Chat Completions protocol adapter."""
+
+from .converter import ChatCompletionsToAnthropicConverter
+from .models import ChatCompletionsRequest
+from .stream import chat_completions_sse_from_anthropic
+
+__all__ = [
+    "ChatCompletionsRequest",
+    "ChatCompletionsToAnthropicConverter",
+    "chat_completions_sse_from_anthropic",
+]

--- a/src/free_claude_code/core/chat_completions/converter.py
+++ b/src/free_claude_code/core/chat_completions/converter.py
@@ -1,0 +1,185 @@
+"""Convert OpenAI Chat Completions requests to Anthropic Messages format."""
+
+import json
+import uuid
+from typing import Any
+
+
+class ChatCompletionsToAnthropicConverter:
+    """Convert OpenAI Chat Completions format to Anthropic Messages format."""
+
+    @staticmethod
+    def to_anthropic_payload(request: Any) -> dict[str, Any]:
+        """Convert a ChatCompletionsRequest to an Anthropic Messages payload."""
+        messages: list[dict[str, Any]] = []
+        system_parts: list[str] = []
+
+        for msg in request.messages:
+            role = msg.role
+            content = msg.content
+
+            if role == "system":
+                # Anthropic uses a top-level `system` field
+                if isinstance(content, str):
+                    system_parts.append(content)
+                elif isinstance(content, list):
+                    system_parts.extend(
+                        part.get("text", "")
+                        for part in content
+                        if isinstance(part, dict) and part.get("type") == "text"
+                    )
+                continue
+
+            if role == "user":
+                if isinstance(content, str):
+                    messages.append({"role": "user", "content": content})
+                elif isinstance(content, list):
+                    # Convert multipart content
+                    anthropic_content = []
+                    for part in content:
+                        if isinstance(part, dict):
+                            if part.get("type") == "text":
+                                anthropic_content.append(
+                                    {
+                                        "type": "text",
+                                        "text": part.get("text", ""),
+                                    }
+                                )
+                            elif part.get("type") == "image_url":
+                                image_url = part.get("image_url", {})
+                                url = image_url.get("url", "")
+                                if url.startswith("data:"):
+                                    # base64 image
+                                    media_type = url.split(";")[0].split(":")[1]
+                                    data = url.split(",", 1)[1]
+                                    anthropic_content.append(
+                                        {
+                                            "type": "image",
+                                            "source": {
+                                                "type": "base64",
+                                                "media_type": media_type,
+                                                "data": data,
+                                            },
+                                        }
+                                    )
+                                else:
+                                    anthropic_content.append(
+                                        {
+                                            "type": "image",
+                                            "source": {"type": "url", "url": url},
+                                        }
+                                    )
+                    if anthropic_content:
+                        messages.append({"role": "user", "content": anthropic_content})
+                    else:
+                        messages.append({"role": "user", "content": str(content)})
+                else:
+                    messages.append({"role": "user", "content": str(content)})
+
+            elif role == "assistant":
+                if isinstance(content, str):
+                    messages.append({"role": "assistant", "content": content})
+                elif isinstance(content, list):
+                    # Already Anthropic-style content blocks
+                    messages.append({"role": "assistant", "content": content})
+                elif msg.tool_calls:
+                    # Assistant with tool calls
+                    content_blocks: list[dict[str, Any]] = []
+                    if content:
+                        content_blocks.append({"type": "text", "text": content})
+                    for tc in msg.tool_calls:
+                        func = tc.get("function", {})
+                        args = func.get("arguments", "{}")
+                        if isinstance(args, str):
+                            try:
+                                args = json.loads(args)
+                            except json.JSONDecodeError, TypeError:
+                                args = {}
+                        content_blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:24]}"),
+                                "name": func.get("name", ""),
+                                "input": args,
+                            }
+                        )
+                    messages.append({"role": "assistant", "content": content_blocks})
+                else:
+                    messages.append({"role": "assistant", "content": content or ""})
+
+            elif role == "tool":
+                # Tool result message
+                tool_use_id = msg.tool_call_id or ""
+                tool_content = (
+                    content if isinstance(content, str) else json.dumps(content)
+                )
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": tool_use_id,
+                                "content": tool_content,
+                            }
+                        ],
+                    }
+                )
+
+        payload: dict[str, Any] = {
+            "model": request.model,
+            "messages": messages,
+            "stream": True,  # Always stream for SSE conversion
+        }
+
+        if system_parts:
+            payload["system"] = "\n\n".join(system_parts)
+
+        if request.max_tokens is not None:
+            payload["max_tokens"] = request.max_tokens
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        if request.top_p is not None:
+            payload["top_p"] = request.top_p
+        if request.stop is not None:
+            if isinstance(request.stop, list):
+                payload["stop_sequences"] = request.stop
+            else:
+                payload["stop_sequences"] = [request.stop]
+
+        # Convert tools
+        if request.tools:
+            anthropic_tools = []
+            for tool in request.tools:
+                func = tool.function
+                anthropic_tools.append(
+                    {
+                        "name": func.name,
+                        "description": func.description or "",
+                        "input_schema": func.parameters
+                        or {"type": "object", "properties": {}},
+                    }
+                )
+            payload["tools"] = anthropic_tools
+
+        # Convert tool_choice
+        if request.tool_choice is not None:
+            tc = request.tool_choice
+            if isinstance(tc, str):
+                if tc == "auto":
+                    payload["tool_choice"] = {"type": "auto"}
+                elif tc == "none":
+                    pass  # No tool_choice means no tools
+                elif tc == "required":
+                    payload["tool_choice"] = {"type": "any"}
+            elif isinstance(tc, dict):
+                tc_type = tc.get("type")
+                if tc_type == "function":
+                    payload["tool_choice"] = {
+                        "type": "tool",
+                        "name": tc.get("function", {}).get("name", ""),
+                    }
+                elif tc_type == "auto":
+                    payload["tool_choice"] = {"type": "auto"}
+
+        return payload

--- a/src/free_claude_code/core/chat_completions/models.py
+++ b/src/free_claude_code/core/chat_completions/models.py
@@ -1,0 +1,45 @@
+"""Pydantic models for the OpenAI Chat Completions protocol."""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ChatCompletionsMessage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | list[Any] | None = None
+    name: str | None = None
+    tool_calls: list[Any] | None = None
+    tool_call_id: str | None = None
+
+
+class ChatCompletionsToolFunction(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    description: str | None = None
+    parameters: dict[str, Any] | None = None
+
+
+class ChatCompletionsTool(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["function"] = "function"
+    function: ChatCompletionsToolFunction
+
+
+class ChatCompletionsRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    messages: list[ChatCompletionsMessage]
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    stream: bool | None = None
+    stop: str | list[str] | None = None
+    tools: list[ChatCompletionsTool] | None = None
+    tool_choice: Any = None
+    user: str | None = None

--- a/src/free_claude_code/core/chat_completions/stream.py
+++ b/src/free_claude_code/core/chat_completions/stream.py
@@ -1,0 +1,137 @@
+"""Convert Anthropic SSE stream to OpenAI Chat Completions SSE format."""
+
+import json
+import time
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+def _new_id(prefix: str = "chatcmpl") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:24]}"
+
+
+async def chat_completions_sse_from_anthropic(
+    anthropic_chunks: AsyncIterator[str],
+    model: str,
+) -> AsyncIterator[str]:
+    """Convert Anthropic SSE events to OpenAI Chat Completions SSE events."""
+    chunk_id = _new_id()
+    finish_reason: str | None = None
+    tool_call_index = 0
+    current_tool_call_id: str | None = None
+    current_tool_call_name: str | None = None
+    current_tool_call_args = ""
+    buffer = ""
+
+    async for raw_line in anthropic_chunks:
+        buffer += raw_line
+        lines = buffer.split("\n")
+        buffer = lines.pop()
+
+        for line in lines:
+            line = line.rstrip("\r")
+            if not line or not line.startswith("data:"):
+                continue
+            data_str = line[len("data:") :].strip()
+            if not data_str or data_str == "[DONE]":
+                continue
+            try:
+                data = json.loads(data_str)
+            except json.JSONDecodeError, TypeError:
+                continue
+
+            evt = data.get("type", "")
+
+            if evt == "message_start":
+                msg = data.get("message", {})
+                if msg.get("model"):
+                    model = msg["model"]
+                continue
+
+            if evt == "content_block_start":
+                cb = data.get("content_block", {})
+                bt = cb.get("type", "")
+                if bt == "text":
+                    yield _sse(chunk_id, model, 0, {"role": "assistant", "content": ""})
+                elif bt == "tool_use":
+                    current_tool_call_id = cb.get("id", "")
+                    current_tool_call_name = cb.get("name", "")
+                    current_tool_call_args = ""
+                    tc = {
+                        "index": tool_call_index,
+                        "id": current_tool_call_id,
+                        "type": "function",
+                        "function": {"name": current_tool_call_name, "arguments": ""},
+                    }
+                    yield _sse(chunk_id, model, 0, {"tool_calls": [tc]})
+                continue
+
+            if evt == "content_block_delta":
+                delta = data.get("delta", {})
+                dt = delta.get("type", "")
+                if dt == "text_delta":
+                    text = delta.get("text", "")
+                    if text:
+                        yield _sse(chunk_id, model, 0, {"content": text})
+                elif dt == "input_json_delta":
+                    pj = delta.get("partial_json", "")
+                    if pj and current_tool_call_id:
+                        current_tool_call_args += pj
+                        tc = {"index": tool_call_index, "function": {"arguments": pj}}
+                        yield _sse(chunk_id, model, 0, {"tool_calls": [tc]})
+                continue
+
+            if evt == "content_block_stop":
+                if current_tool_call_id:
+                    tool_call_index += 1
+                    current_tool_call_id = None
+                    current_tool_call_name = None
+                    current_tool_call_args = ""
+                continue
+
+            if evt == "message_delta":
+                sr = data.get("delta", {}).get("stop_reason")
+                if sr:
+                    finish_reason = {
+                        "end_turn": "stop",
+                        "stop_sequence": "stop",
+                        "max_tokens": "length",
+                        "tool_use": "tool_calls",
+                    }.get(sr, "stop")
+                continue
+
+            if evt == "message_stop":
+                yield _sse_final(chunk_id, model, finish_reason or "stop")
+                yield "data: [DONE]\n\n"
+                return
+
+            if evt == "error":
+                yield _sse_final(chunk_id, model, "error")
+                yield "data: [DONE]\n\n"
+                return
+
+    yield _sse_final(chunk_id, model, finish_reason or "stop")
+    yield "data: [DONE]\n\n"
+
+
+def _sse(chunk_id: str, model: str, index: int, delta: dict[str, Any]) -> str:
+    chunk = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": index, "delta": delta, "finish_reason": None}],
+    }
+    return f"data: {json.dumps(chunk)}\n\n"
+
+
+def _sse_final(chunk_id: str, model: str, finish_reason: str) -> str:
+    chunk = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+    }
+    return f"data: {json.dumps(chunk)}\n\n"


### PR DESCRIPTION
## Summary

Adds a `/v1/chat/completions` endpoint that accepts OpenAI Chat Completions requests, converts them to Anthropic Messages format, routes through the existing provider execution pipeline, and converts Anthropic SSE responses back to Chat Completions SSE format.

## What changed

**New files:**
- `core/chat_completions/__init__.py` — Module exports
- `core/chat_completions/models.py` — Pydantic models for Chat Completions requests
- `core/chat_completions/converter.py` — OpenAI Chat Completions → Anthropic Messages converter
- `core/chat_completions/stream.py` — Anthropic SSE → Chat Completions SSE stream converter
- `api/handlers/chat_completions.py` — Handler with proper lease management

**Modified:**
- `api/routes.py` — Added `POST /v1/chat/completions` with lease lifecycle

## Why

This enables any OpenAI Chat Completions client (Freebuff, LM Studio, etc.) to use free-claude-code's provider routing and model catalog. The existing `/v1/messages` (Anthropic) and `/v1/responses` (OpenAI Responses) endpoints remain unchanged.

## Testing

- All `ruff check` and `ruff format` checks pass
- All `ty` type checks pass
- Syntax validation passes for all new files

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds an OpenAI-compatible Chat Completions endpoint backed by the existing Anthropic Messages execution path. Four blocking behaviors remain: omitted `stream` requests return SSE instead of a JSON completion; non-streaming completions discard successful content and provider terminal errors; `tool_choice: "none"` can still leave provider tool invocation enabled; and malformed tool-call input reaches a server error rather than request validation.

The previous streaming lifetime-management failure is disproved: a real route execution with `stream: true` returned HTTP 200 SSE output and released the request lease successfully.

<h3>Confidence Score: 0/5</h3>

The endpoint is not ready to merge because normal client requests can receive the wrong response format, non-streaming results can be silently lost, tool restrictions can fail open, and malformed input produces server errors.

Four independently reproduced blocking failures remain, including a security-relevant failure to preserve an explicit tool-use prohibition.

**Files Needing Attention:** src/free_claude_code/api/handlers/chat_completions.py, src/free_claude_code/core/chat_completions/converter.py, src/free_claude_code/core/chat_completions/models.py

<details open><summary><h3>Security Review</h3></summary>

The `tool_choice: "none"` conversion is security-relevant because a caller can explicitly prohibit tool use while the provider still receives callable tools with its automatic selection behavior. This can permit tool execution outside the caller's requested authorization boundary.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding, including hermetic reproduction sources and an observed FastAPI TestClient response.
- T-Rex validated the aggregate probe for Chat Completions and captured both the probe source and the runtime output.
- T-Rex executed a focused Chat Completions validation script to exercise tool-choice-none behavior and captured the numbered reproduction script and payloads.
- T-Rex performed a real ASGI route validation for chat completions streaming, confirming 200 responses with SSE data and that lifetime tests passed.
- T-Rex captured regression and lifetime test artifacts for chat completions streaming, including before/after logs and regression test results.

<a href="https://app.greptile.com/trex/runs/20160954/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (6)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Streaming Chat Completions responses are rejected by the response-lifetime contract**

   - **Bug**
     - `POST /v1/chat/completions` with `stream: true` reaches the mocked provider but fails at the HTTP adapter boundary. The observed client response is HTTP 500 Internal Server Error with `Streaming API responses must use ManagedStreamingResponse.` instead of an SSE stream.
   - **Cause**
     - `src/free_claude_code/api/handlers/chat_completions.py:71-79` returns FastAPI's plain `StreamingResponse`. `src/free_claude_code/api/routes.py:285` unconditionally passes that response to `bind_response_lifetime`, and `src/free_claude_code/api/response_streams.py:158-172` explicitly raises `TypeError` for any `StreamingResponse` that is not `ManagedStreamingResponse`.
   - **Fix**
     - Construct the Chat Completions streaming result as `ManagedStreamingResponse` (or route it through the existing managed first-chunk streaming-response helper) so `bind_response_lifetime` can bind and release the runtime lease.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Non-stream chat completions converts the aggregate tuple instead of its message and ignores terminal SSE errors**

   - **Bug**
     - At `src/free_claude_code/api/handlers/chat_completions.py:62-63`, `aggregate_anthropic_sse_to_message(streamed)` returns `(message_dict, error_dict_or_none)`, but the complete tuple is passed to `_to_non_streaming_response`. Since the converter checks attributes such as `.content` and `.stop_reason`, which a tuple lacks, it emits an empty assistant response. A successful mocked provider SSE returned HTTP 200 with `choices[0].message.content = null` rather than the emitted text. A mocked terminal `overloaded_error` likewise returned HTTP 200 with an empty response, losing the provider error message.
   - **Cause**
     - The handler assigns the two-value aggregate result to one variable (`message`) rather than unpacking `message, error`; it also has no branch to translate a non-null terminal SSE error into an OpenAI-compatible error response.
   - **Fix**
     - Unpack the return at line 62 (`message, error = await ...`), pass only `message` to `_to_non_streaming_response`, and translate a non-null `error` to the endpoint's appropriate non-2xx OpenAI error response before constructing a completion.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Chat Completions tool_choice none is converted to provider auto**

   - **Bug**
     - A client request declaring a function tool and `tool_choice: "none"` does not suppress the tool. The Chat Completions converter preserves `payload["tools"]` while omitting `payload["tool_choice"]`; the downstream OpenAI-compatible provider request contract interprets that combination as implicit automatic tool use and emits `tool_choice: "auto"`.
   - **Cause**
     - `src/free_claude_code/core/chat_completions/converter.py:150-163` unconditionally serializes request tools before tool-choice processing. At lines `170-172`, the `"none"` branch performs only `pass`, despite the comment claiming no `tool_choice` means no tools. In this stack, absent tool choice with retained tools means auto, not disabled.
   - **Fix**
     - When `request.tool_choice == "none"`, omit/remove `tools` from the converted payload (and omit `tool_choice`), matching the existing OpenAI Responses conversion contract. Add a regression test through the Chat Completions converter and OpenAI-compatible provider request builder asserting that neither provider tools nor an auto tool choice is forwarded.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Omitted stream field defaults Chat Completions requests to SSE**

   - **Bug**
     - An OpenAI Chat Completions request without a `stream` member receives an SSE response instead of a JSON `chat.completion` completion envelope.
   - **Cause**
     - `ChatCompletionsHandler.create` checks only `if request_data.stream is False` before choosing aggregation. The Pydantic field defaults to `None`, so an omitted field follows the streaming fallback branch.
   - **Fix**
     - Make the streaming branch explicit (`if request_data.stream is True`) and make omitted/false stream requests use the non-streaming JSON aggregation branch; add a route-level TestClient regression test for omitted `stream`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


5. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Chat Completions non-streaming path passes aggregate tuple as a message and suppresses terminal provider errors**

   - **Bug**
     - `aggregate_anthropic_sse_to_message` produced a tuple with arity 2 for both test streams. On success, aggregation produced text `hello from provider`, but `ChatCompletionsHandler.create` returned a 200 completion whose `choices[0].message.content` was null. On the terminal provider-error stream, aggregation returned `{"type":"overloaded_error","message":"provider overloaded"}`, but the handler still returned the same 200 empty completion.
   - **Cause**
     - At `src/free_claude_code/api/handlers/chat_completions.py:65-66`, `message = await aggregate_anthropic_sse_to_message(streamed)` stores the `(message, error)` tuple and passes it to `_to_non_streaming_response`. That converter only reads attribute-style `content` and `stop_reason`, so it cannot convert the tuple (or the aggregated dict). The handler also contains no branch to map the returned terminal SSE error to an HTTP error response.
   - **Fix**
     - Unpack the aggregator result (`message, error = ...`). If `error` is present, return a protocol-appropriate non-2xx error response using the same terminal-error mapping approach as the Messages handler. For success, make `_to_non_streaming_response` consume the aggregate dict (or convert it to the expected message model) and map dict content blocks, stop reason, and usage.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


6. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Malformed Chat Completions tool calls cause a server error after request validation**

   - **Bug**
     - The public `/v1/chat/completions` request model accepts a string as an element of `messages[].tool_calls`; conversion then calls `.get()` on that string and the handler returns HTTP 500 instead of rejecting the request as invalid.
   - **Cause**
     - `ChatCompletionsMessage.tool_calls` is declared `list[Any] | None`, while `ChatCompletionsToAnthropicConverter.to_anthropic_payload()` treats every element as a dictionary with `function`, `id`, and related fields.
   - **Fix**
     - Replace `list[Any]` with a typed Pydantic tool-call model (including typed function/name/arguments fields), or add an explicit mapping/type validation before conversion; invalid elements should produce FastAPI's 422 validation response rather than a 500.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: use ManagedStreamingResponse for Ch..."](https://github.com/alishahryar1/free-claude-code/commit/10cbad5464a18949b1b115271614b709b8e7e96e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55831273)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->