### PR TITLE
feat: add omlx local provider with API key support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,9 +189,14 @@ LLAMACPP_BASE_URL="http://localhost:8080/v1"
 OLLAMA_BASE_URL="http://localhost:11434"
 
 
+# OMLX Config (local OpenAI-compatible server with API key)
+OMLX_API_KEY="omlx"
+OMLX_BASE_URL="http://localhost:8001/v1"
+
+
 # Default model and optional Claude tier overrides
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "poolside"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "omlx" | "tokenrouter" | "nararoute" | "poolside"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -216,6 +221,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # FCC_SMOKE_MODEL_LMSTUDIO=<provider/model-id>
 # FCC_SMOKE_MODEL_LLAMACPP=<provider/model-id>
 # FCC_SMOKE_MODEL_OLLAMA=<provider/model-id>
+# FCC_SMOKE_MODEL_OMLX=<provider/model-id>
 # FCC_SMOKE_MODEL_KIMI=<provider/model-id>
 # FCC_SMOKE_MODEL_KIMI_CODE=<provider/model-id>
 # FCC_SMOKE_MODEL_WAFER=<provider/model-id>
@@ -292,6 +298,7 @@ REASONING_HAIKU=inherit
 # CODESTRAL_PROXY=<http-or-socks-url>
 # LMSTUDIO_PROXY=<http-or-socks-url>
 # LLAMACPP_PROXY=<http-or-socks-url>
+# OMLX_PROXY=<http-or-socks-url>
 # KIMI_PROXY=<http-or-socks-url>
 # KIMI_CODE_PROXY=<http-or-socks-url>
 # WAFER_PROXY=<http-or-socks-url>

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -27,6 +27,7 @@ DEFAULT_TARGETS = frozenset(
         "lmstudio",
         "messaging",
         "ollama",
+        "omlx",
         "providers",
         "rate_limit",
         "tools",
@@ -57,6 +58,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "lmstudio": "lmstudio/local-model",
     "llamacpp": "llamacpp/local-model",
     "ollama": "ollama/llama3.1",
+    "omlx": "omlx/local-model",
     "kimi_code": "kimi_code/k3",
     "wafer": "wafer/DeepSeek-V4-Pro",
     "minimax": "minimax/MiniMax-M3",
@@ -127,6 +129,7 @@ TARGET_REQUIRED_ENV: dict[str, tuple[str, ...]] = {
     "lmstudio": ("LM_STUDIO_BASE_URL with a running LM Studio server",),
     "llamacpp": ("LLAMACPP_BASE_URL with a running llama-server",),
     "ollama": ("OLLAMA_BASE_URL with a running Ollama server",),
+    "omlx": ("OMLX_BASE_URL and OMLX_API_KEY with a running OMLX server",),
     "nvidia_nim_cli": (
         "NVIDIA_NIM_API_KEY",
         "FCC_SMOKE_CLAUDE_BIN or claude on PATH",

--- a/smoke/lib/local_providers.py
+++ b/smoke/lib/local_providers.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 import httpx
 import pytest
 
+from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
 from free_claude_code.providers.openai_chat import openai_v1_base_url
 
 LOCAL_PROVIDER_PROBE_TIMEOUT_S = 1.5
@@ -16,6 +17,7 @@ def first_local_provider_model_id(
     base_url: str,
     *,
     timeout_s: float,
+    api_key: str = "",
 ) -> str:
     """Return the first local model id, or skip when the local server is absent."""
     base_url = base_url.strip()
@@ -29,6 +31,7 @@ def first_local_provider_model_id(
         provider,
         base_url,
         timeout_s=timeout,
+        api_key=api_key,
     )
 
 
@@ -37,9 +40,12 @@ def _first_openai_compatible_model_id(
     base_url: str,
     *,
     timeout_s: float,
+    api_key: str = "",
 ) -> str:
     models_url = urljoin(base_url.rstrip("/") + "/", "models")
-    response = _get_local_provider_response(provider, models_url, timeout_s=timeout_s)
+    response = _get_local_provider_response(
+        provider, models_url, timeout_s=timeout_s, api_key=api_key
+    )
     assert response.status_code == 200, response.text
     payload = response.json()
     data = payload.get("data") if isinstance(payload, dict) else None
@@ -56,17 +62,33 @@ def _get_local_provider_response(
     url: str,
     *,
     timeout_s: float,
+    api_key: str = "",
 ) -> httpx.Response:
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
     try:
-        response = httpx.get(url, timeout=timeout_s)
+        response = httpx.get(url, timeout=timeout_s, headers=headers)
     except httpx.TimeoutException as exc:
         pytest.skip(f"missing_env: {provider} local server is not reachable: {exc}")
     except httpx.NetworkError as exc:
         pytest.skip(f"missing_env: {provider} local server is not running: {exc}")
 
+    if response.status_code in {401, 403}:
+        pytest.skip(
+            f"missing_env: {provider} local server rejected credentials: "
+            f"HTTP {response.status_code}"
+        )
     if response.status_code in {404, 405, 502, 503}:
         pytest.skip(
             f"missing_env: {provider} local server is not available at {url}: "
             f"HTTP {response.status_code}"
         )
     return response
+
+
+def local_provider_api_key(provider: str, settings: object) -> str:
+    """Return the credential value for an authed local provider, if any."""
+    descriptor = PROVIDER_CATALOG.get(provider)
+    if descriptor is None or descriptor.credential_attr is None:
+        return ""
+    value = getattr(settings, descriptor.credential_attr, None)
+    return value if isinstance(value, str) else ""

--- a/smoke/prereq/test_local_provider_endpoints_prereq_live.py
+++ b/smoke/prereq/test_local_provider_endpoints_prereq_live.py
@@ -1,7 +1,10 @@
 import pytest
 
 from smoke.lib.config import SmokeConfig
-from smoke.lib.local_providers import first_local_provider_model_id
+from smoke.lib.local_providers import (
+    first_local_provider_model_id,
+    local_provider_api_key,
+)
 
 
 @pytest.mark.live
@@ -31,4 +34,15 @@ def test_ollama_models_endpoint_when_available(smoke_config: SmokeConfig) -> Non
         "ollama",
         smoke_config.settings.ollama_base_url,
         timeout_s=smoke_config.timeout_s,
+    )
+
+
+@pytest.mark.live
+@pytest.mark.smoke_target("omlx")
+def test_omlx_models_endpoint_when_available(smoke_config: SmokeConfig) -> None:
+    first_local_provider_model_id(
+        "omlx",
+        smoke_config.settings.omlx_base_url,
+        timeout_s=smoke_config.timeout_s,
+        api_key=local_provider_api_key("omlx", smoke_config.settings),
     )

--- a/smoke/product/test_local_provider_product_live.py
+++ b/smoke/product/test_local_provider_product_live.py
@@ -2,7 +2,10 @@ import pytest
 
 from smoke.lib.config import SmokeConfig
 from smoke.lib.e2e import ConversationDriver, SmokeServerDriver, assert_product_stream
-from smoke.lib.local_providers import first_local_provider_model_id
+from smoke.lib.local_providers import (
+    first_local_provider_model_id,
+    local_provider_api_key,
+)
 
 pytestmark = [pytest.mark.live]
 
@@ -34,6 +37,15 @@ def test_ollama_openai_chat_e2e(smoke_config: SmokeConfig) -> None:
     )
 
 
+@pytest.mark.smoke_target("omlx")
+def test_omlx_openai_chat_e2e(smoke_config: SmokeConfig) -> None:
+    _local_provider_messages_e2e(
+        smoke_config,
+        provider="omlx",
+        base_url=smoke_config.settings.omlx_base_url,
+    )
+
+
 def _local_provider_messages_e2e(
     smoke_config: SmokeConfig,
     *,
@@ -44,6 +56,7 @@ def _local_provider_messages_e2e(
         provider,
         base_url,
         timeout_s=smoke_config.timeout_s,
+        api_key=local_provider_api_key(provider, smoke_config.settings),
     )
 
     with SmokeServerDriver(

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -24,6 +24,7 @@ from free_claude_code.config.provider_catalog import (
     ProviderAuthKind,
 )
 from free_claude_code.core.json_types import JsonObject, JsonValue
+from free_claude_code.core.urls import openai_v1_base_url
 
 from .dependencies import get_services
 from .ports import ApiServices
@@ -287,6 +288,20 @@ def _local_provider_api_key(provider_id: str, values: dict[str, str]) -> str:
     return values.get(descriptor.credential_env, "")
 
 
+def _local_provider_normalizes_v1(provider_id: str, path: str) -> bool:
+    """Whether the status probe should normalize the base URL to ``/v1``.
+
+    OpenAI-compatible local providers (e.g. omlx) expose models at
+    ``/v1/models``; a service-root base URL must be normalized so the probe
+    hits the versioned endpoint. Providers with non-OpenAI probe paths (e.g.
+    ollama ``/api/tags``) are left untouched.
+    """
+    if path != "/models":
+        return False
+    descriptor = PROVIDER_CATALOG.get(provider_id)
+    return descriptor is not None and descriptor.local_status_normalize_v1
+
+
 async def _check_local_provider(
     provider_id: str, base_url: str, path: str, *, api_key: str = ""
 ) -> JsonObject:
@@ -299,6 +314,8 @@ async def _check_local_provider(
             "base_url": base_url,
         }
 
+    if _local_provider_normalizes_v1(provider_id, path):
+        clean_url = openai_v1_base_url(clean_url)
     url = f"{clean_url}{path}"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
     try:

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -35,6 +35,7 @@ LOCAL_PROVIDER_PATHS = {
     "lmstudio": "/models",
     "llamacpp": "/models",
     "ollama": "/api/tags",
+    "omlx": "/models",
 }
 _LOCAL_PROVIDER_CHECK_FAILURE_MESSAGE = (
     "Could not connect. Verify the URL and that the local provider is running."
@@ -148,7 +149,10 @@ async def local_provider_status(request: Request):
     checks = []
     for provider_id, path in LOCAL_PROVIDER_PATHS.items():
         base_url = _local_provider_url(provider_id, values)
-        checks.append(await _check_local_provider(provider_id, base_url, path))
+        api_key = _local_provider_api_key(provider_id, values)
+        checks.append(
+            await _check_local_provider(provider_id, base_url, path, api_key=api_key)
+        )
     return {"providers": checks}
 
 
@@ -270,11 +274,21 @@ def _local_provider_url(provider_id: str, values: dict[str, str]) -> str:
         return values.get("LLAMACPP_BASE_URL", "")
     if provider_id == "ollama":
         return values.get("OLLAMA_BASE_URL", "")
+    if provider_id == "omlx":
+        return values.get("OMLX_BASE_URL", "")
     return ""
 
 
+def _local_provider_api_key(provider_id: str, values: dict[str, str]) -> str:
+    """Return the credential value for an authed local provider, if any."""
+    descriptor = PROVIDER_CATALOG.get(provider_id)
+    if descriptor is None or descriptor.credential_env is None:
+        return ""
+    return values.get(descriptor.credential_env, "")
+
+
 async def _check_local_provider(
-    provider_id: str, base_url: str, path: str
+    provider_id: str, base_url: str, path: str, *, api_key: str = ""
 ) -> JsonObject:
     clean_url = base_url.strip().rstrip("/")
     if not clean_url:
@@ -286,9 +300,10 @@ async def _check_local_provider(
         }
 
     url = f"{clean_url}{path}"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
     try:
         async with httpx.AsyncClient(timeout=1.5) as client:
-            response = await client.get(url)
+            response = await client.get(url, headers=headers)
         ok = 200 <= response.status_code < 300
         return {
             "provider_id": provider_id,

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -111,6 +111,7 @@ class ProviderDescriptor:
     base_url_attr: str | None = None
     proxy_attr: str | None = None
     required_settings_attrs: tuple[str, ...] = ()
+    local_status_normalize_v1: bool = False
 
     def configuration_attrs(self) -> tuple[str, ...]:
         """Return settings fields whose non-empty values configure this provider."""
@@ -583,6 +584,7 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         base_url_attr="omlx_base_url",
         proxy_attr="omlx_proxy",
         local=True,
+        local_status_normalize_v1=True,
     ),
 }
 

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -29,6 +29,7 @@ LMSTUDIO_DEFAULT_BASE = "http://localhost:1234/v1"
 LLAMACPP_DEFAULT_BASE = "http://localhost:8080/v1"
 OLLAMA_DEFAULT_BASE = "http://localhost:11434"
 OLLAMA_CLOUD_DEFAULT_BASE = "https://ollama.com/v1"
+OMLX_DEFAULT_BASE = "http://localhost:8001/v1"
 OPENCODE_ZEN_DEFAULT_BASE = "https://opencode.ai/zen/v1"
 OPENCODE_GO_DEFAULT_BASE = "https://opencode.ai/zen/go/v1"
 VERCEL_AI_GATEWAY_DEFAULT_BASE = "https://ai-gateway.vercel.sh/v1"
@@ -571,6 +572,16 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         static_credential="ollama",
         default_base_url=OLLAMA_DEFAULT_BASE,
         base_url_attr="ollama_base_url",
+        local=True,
+    ),
+    "omlx": ProviderDescriptor(
+        provider_id="omlx",
+        display_name="OMLX",
+        credential_env="OMLX_API_KEY",
+        credential_attr="omlx_api_key",
+        default_base_url=OMLX_DEFAULT_BASE,
+        base_url_attr="omlx_base_url",
+        proxy_attr="omlx_proxy",
         local=True,
     ),
 }

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -348,6 +348,16 @@ class Settings(BaseModel):
         validation_alias="OLLAMA_BASE_URL",
     )
 
+    # ==================== OMLX Config (local OpenAI-compatible server) ====================
+    omlx_api_key: NonEmptyString = Field(
+        default="omlx",
+        validation_alias="OMLX_API_KEY",
+    )
+    omlx_base_url: NonEmptyString = Field(
+        default="http://localhost:8001/v1",
+        validation_alias="OMLX_BASE_URL",
+    )
+
     # ==================== Model ====================
     # All Claude model requests are mapped to this single model (fallback)
     # Format: provider_type/model/name
@@ -435,6 +445,9 @@ class Settings(BaseModel):
     )
     llamacpp_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="LLAMACPP_PROXY"
+    )
+    omlx_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="OMLX_PROXY"
     )
     kimi_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="KIMI_PROXY"

--- a/src/free_claude_code/core/urls.py
+++ b/src/free_claude_code/core/urls.py
@@ -1,0 +1,9 @@
+"""Shared URL normalization helpers."""
+
+__all__ = ["openai_v1_base_url"]
+
+
+def openai_v1_base_url(base_url: str) -> str:
+    """Return the canonical ``/v1`` API base for a server root or API base."""
+    normalized = base_url.rstrip("/")
+    return normalized if normalized.endswith("/v1") else f"{normalized}/v1"

--- a/src/free_claude_code/providers/openai_chat/base_url.py
+++ b/src/free_claude_code/providers/openai_chat/base_url.py
@@ -1,7 +1,9 @@
-"""OpenAI-compatible API base URL policy."""
+"""OpenAI-compatible API base URL policy.
 
+Re-exports the shared URL normalization helper from :mod:`free_claude_code.core.urls`
+so provider adapters and external consumers share one canonical implementation.
+"""
 
-def openai_v1_base_url(base_url: str) -> str:
-    """Return the canonical ``/v1`` API base for a server root or API base."""
-    normalized = base_url.rstrip("/")
-    return normalized if normalized.endswith("/v1") else f"{normalized}/v1"
+from free_claude_code.core.urls import openai_v1_base_url
+
+__all__ = ["openai_v1_base_url"]

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -672,5 +672,6 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             ReasoningReplayMode.DISABLED,
         ),
         NO_REASONING,
+        normalize_base_url=True,
     ),
 }

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -666,4 +666,11 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         normalize_base_url=True,
         reasoning_delta_field="reasoning",
     ),
+    "omlx": OpenAIChatProfile(
+        _policy(
+            "OMLX",
+            ReasoningReplayMode.DISABLED,
+        ),
+        NO_REASONING,
+    ),
 }

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1544,7 +1544,7 @@ def test_admin_local_provider_status_reports_reachable(monkeypatch, tmp_path):
         async def __aexit__(self, *args):
             return None
 
-        async def get(self, url: str):
+        async def get(self, url: str, *, headers=None):
             return httpx.Response(200, json={"data": []})
 
     with patch("free_claude_code.api.admin_routes.httpx.AsyncClient", FakeAsyncClient):
@@ -1552,7 +1552,12 @@ def test_admin_local_provider_status_reports_reachable(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     providers = response.json()["providers"]
-    assert {provider["status"] for provider in providers} == {"reachable"}
+    by_id = {p["provider_id"]: p for p in providers}
+    # All local providers have default base URLs -> all reachable
+    assert by_id["lmstudio"]["status"] == "reachable"
+    assert by_id["llamacpp"]["status"] == "reachable"
+    assert by_id["ollama"]["status"] == "reachable"
+    assert by_id["omlx"]["status"] == "reachable"
 
 
 def test_admin_config_exposes_structured_provider_configuration_targets(
@@ -1591,7 +1596,7 @@ def test_admin_local_provider_failure_does_not_return_exception_text(
         async def __aexit__(self, *args):
             return None
 
-        async def get(self, url: str):
+        async def get(self, url: str, *, headers=None):
             raise RuntimeError(
                 "Provider rejected credential CREDENTIAL[unrecognized-format-987654321]"
             )
@@ -1604,6 +1609,7 @@ def test_admin_local_provider_failure_does_not_return_exception_text(
 
     assert response.status_code == 200
     providers = response.json()["providers"]
+    # All local providers have default base URLs -> all attempt HTTP and fail
     assert {provider["status"] for provider in providers} == {"offline"}
     for provider in providers:
         assert provider["message"] == (
@@ -1612,6 +1618,76 @@ def test_admin_local_provider_failure_does_not_return_exception_text(
         assert "CREDENTIAL[unrecognized-format-987654321]" not in provider["message"]
         assert "RuntimeError" not in provider["message"]
         assert "error_type" not in provider
+
+
+def test_admin_local_provider_status_sends_auth_header_for_omlx(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    monkeypatch.setenv("OMLX_BASE_URL", "http://localhost:8001/v1")
+    monkeypatch.setenv("OMLX_API_KEY", "sk-test-omlx-key")
+    app = create_test_app()
+
+    captured_headers: dict[str, str] = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url: str, *, headers=None):
+            if headers:
+                captured_headers.update(headers)
+            return httpx.Response(200, json={"data": [{"id": "test-model"}]})
+
+    with patch("free_claude_code.api.admin_routes.httpx.AsyncClient", FakeAsyncClient):
+        response = _local_client(app).get("/admin/api/providers/local-status")
+
+    assert response.status_code == 200
+    by_id = {p["provider_id"]: p for p in response.json()["providers"]}
+    assert by_id["omlx"]["status"] == "reachable"
+    assert captured_headers.get("Authorization") == "Bearer sk-test-omlx-key"
+
+
+def test_admin_local_provider_status_omits_auth_header_for_keyless_local(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+
+    captured: list[tuple[str, dict[str, str] | None]] = []
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url: str, *, headers=None):
+            captured.append((url, headers))
+            return httpx.Response(200, json={"data": []})
+
+    with patch("free_claude_code.api.admin_routes.httpx.AsyncClient", FakeAsyncClient):
+        _local_client(app).get("/admin/api/providers/local-status")
+
+    # omlx has credential_env -> sends auth header (default key "omlx")
+    omlx_calls = [(url, h) for url, h in captured if ":8001" in url]
+    assert len(omlx_calls) == 1
+    assert omlx_calls[0][1] is not None
+    assert omlx_calls[0][1]["Authorization"] == "Bearer omlx"
+    # keyless local providers (lmstudio/llamacpp/ollama) -> no auth header
+    keyless_calls = [(url, h) for url, h in captured if ":8001" not in url]
+    for _url, h in keyless_calls:
+        assert h is None
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -42,6 +42,8 @@ def _clear_process_config(monkeypatch) -> None:
         "BEDROCK_BASE_URL",
         "BEDROCK_PROXY",
         "OLLAMA_API_KEY",
+        "OMLX_API_KEY",
+        "OMLX_BASE_URL",
         "ANTHROPIC_AUTH_TOKEN",
         "PROXY_AUTH_ENABLED",
         "TELEGRAM_PROXY_URL",

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1692,6 +1692,35 @@ def test_admin_local_provider_status_omits_auth_header_for_keyless_local(
         assert h is None
 
 
+def test_admin_local_provider_status_normalizes_omlx_root_url(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    monkeypatch.setenv("OMLX_BASE_URL", "http://localhost:8001")
+    monkeypatch.setenv("OMLX_API_KEY", "sk-test-omlx-key")
+    app = create_test_app()
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url: str, *, headers=None):
+            if url.endswith("/v1/models"):
+                return httpx.Response(200, json={"data": [{"id": "test-model"}]})
+            return httpx.Response(404)
+
+    with patch("free_claude_code.api.admin_routes.httpx.AsyncClient", FakeAsyncClient):
+        response = _local_client(app).get("/admin/api/providers/local-status")
+
+    by_id = {p["provider_id"]: p for p in response.json()["providers"]}
+    assert by_id["omlx"]["status"] == "reachable"
+
+
 @pytest.mark.parametrize(
     "result",
     (

--- a/tests/config/test_provider_catalog.py
+++ b/tests/config/test_provider_catalog.py
@@ -32,7 +32,7 @@ def test_catalog_local_assignments_are_exact() -> None:
         provider_id
         for provider_id, descriptor in PROVIDER_CATALOG.items()
         if descriptor.local
-    } == {"lmstudio", "llamacpp", "ollama"}
+    } == {"lmstudio", "llamacpp", "ollama", "omlx"}
 
 
 def test_ollama_cloud_is_remote_and_distinct_from_local_ollama() -> None:

--- a/tests/contracts/test_local_provider_smoke.py
+++ b/tests/contracts/test_local_provider_smoke.py
@@ -19,7 +19,7 @@ class FakeResponse:
 def test_local_provider_openai_models_returns_first_id(monkeypatch) -> None:
     calls: list[tuple[str, float]] = []
 
-    def fake_get(url: str, *, timeout: float) -> FakeResponse:
+    def fake_get(url: str, *, timeout: float, headers=None) -> FakeResponse:
         calls.append((url, timeout))
         return FakeResponse(200, {"data": [{"id": "local-model"}]})
 
@@ -38,7 +38,7 @@ def test_local_provider_openai_models_returns_first_id(monkeypatch) -> None:
 def test_omlx_provider_targets_v1_models_directly(monkeypatch) -> None:
     calls: list[str] = []
 
-    def fake_get(url: str, *, timeout: float) -> FakeResponse:
+    def fake_get(url: str, *, timeout: float, headers=None) -> FakeResponse:
         calls.append(url)
         return FakeResponse(200, {"data": [{"id": "omlx-model"}]})
 
@@ -64,7 +64,7 @@ def test_omlx_provider_targets_v1_models_directly(monkeypatch) -> None:
 def test_local_provider_root_url_targets_openai_v1_models(
     monkeypatch, provider: str, port: int, model_id: str
 ) -> None:
-    def fake_get(url: str, *, timeout: float) -> FakeResponse:
+    def fake_get(url: str, *, timeout: float, headers=None) -> FakeResponse:
         assert url == f"http://127.0.0.1:{port}/v1/models"
         assert timeout == 1.5
         return FakeResponse(200, {"data": [{"id": model_id}]})
@@ -82,7 +82,7 @@ def test_local_provider_root_url_targets_openai_v1_models(
 
 
 def test_local_provider_not_running_is_missing_env_skip(monkeypatch) -> None:
-    def fake_get(url: str, *, timeout: float) -> FakeResponse:
+    def fake_get(url: str, *, timeout: float, headers=None) -> FakeResponse:
         raise httpx.ConnectError("refused")
 
     monkeypatch.setattr("smoke.lib.local_providers.httpx.get", fake_get)
@@ -98,7 +98,7 @@ def test_local_provider_not_running_is_missing_env_skip(monkeypatch) -> None:
 
 
 def test_local_provider_empty_model_list_is_missing_env_skip(monkeypatch) -> None:
-    def fake_get(url: str, *, timeout: float) -> FakeResponse:
+    def fake_get(url: str, *, timeout: float, headers=None) -> FakeResponse:
         return FakeResponse(200, {"data": []})
 
     monkeypatch.setattr("smoke.lib.local_providers.httpx.get", fake_get)
@@ -113,3 +113,58 @@ def test_local_provider_empty_model_list_is_missing_env_skip(monkeypatch) -> Non
     assert "missing_env: lmstudio local server has no loaded models" in str(
         excinfo.value
     )
+
+
+def test_omlx_provider_sends_auth_header_when_api_key_provided(monkeypatch) -> None:
+    captured_headers: dict[str, str] = {}
+
+    def fake_get(url: str, *, timeout: float, headers=None) -> FakeResponse:
+        if headers:
+            captured_headers.update(headers)
+        return FakeResponse(200, {"data": [{"id": "omlx-model"}]})
+
+    monkeypatch.setattr("smoke.lib.local_providers.httpx.get", fake_get)
+
+    first_local_provider_model_id(
+        "omlx",
+        "http://127.0.0.1:8001/v1",
+        timeout_s=45,
+        api_key="sk-test-key",
+    )
+
+    assert captured_headers.get("Authorization") == "Bearer sk-test-key"
+
+
+def test_local_provider_401_is_missing_env_skip(monkeypatch) -> None:
+    def fake_get(url: str, *, timeout: float, headers=None) -> FakeResponse:
+        return FakeResponse(401, {"error": "Invalid API key"})
+
+    monkeypatch.setattr("smoke.lib.local_providers.httpx.get", fake_get)
+
+    with pytest.raises(pytest.skip.Exception) as excinfo:
+        first_local_provider_model_id(
+            "omlx",
+            "http://127.0.0.1:8001/v1",
+            timeout_s=45,
+            api_key="wrong-key",
+        )
+
+    assert "missing_env: omlx local server rejected credentials" in str(excinfo.value)
+
+
+def test_local_provider_api_key_returns_credential_for_omlx() -> None:
+    from types import SimpleNamespace
+
+    from smoke.lib.local_providers import local_provider_api_key
+
+    settings = SimpleNamespace(omlx_api_key="sk-test-omlx")
+    assert local_provider_api_key("omlx", settings) == "sk-test-omlx"
+
+
+def test_local_provider_api_key_returns_empty_for_keyless_provider() -> None:
+    from types import SimpleNamespace
+
+    from smoke.lib.local_providers import local_provider_api_key
+
+    settings = SimpleNamespace()
+    assert local_provider_api_key("lmstudio", settings) == ""

--- a/tests/contracts/test_local_provider_smoke.py
+++ b/tests/contracts/test_local_provider_smoke.py
@@ -35,6 +35,25 @@ def test_local_provider_openai_models_returns_first_id(monkeypatch) -> None:
     assert calls == [("http://127.0.0.1:1234/v1/models", 1.5)]
 
 
+def test_omlx_provider_targets_v1_models_directly(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_get(url: str, *, timeout: float) -> FakeResponse:
+        calls.append(url)
+        return FakeResponse(200, {"data": [{"id": "omlx-model"}]})
+
+    monkeypatch.setattr("smoke.lib.local_providers.httpx.get", fake_get)
+
+    model = first_local_provider_model_id(
+        "omlx",
+        "http://127.0.0.1:8001/v1",
+        timeout_s=45,
+    )
+
+    assert model == "omlx-model"
+    assert calls == ["http://127.0.0.1:8001/v1/models"]
+
+
 @pytest.mark.parametrize(
     ("provider", "port", "model_id"),
     [

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -55,6 +55,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "lmstudio",
     "llamacpp",
     "ollama",
+    "omlx",
 )
 
 

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -75,6 +75,8 @@ def _settings(**overrides):
         "lm_studio_base_url": "",
         "llamacpp_base_url": "",
         "ollama_base_url": "http://localhost:11434",
+        "omlx_api_key": "",
+        "omlx_base_url": "http://localhost:8001/v1",
     }
     values.update(overrides)
     return SimpleNamespace(**values)

--- a/tests/providers/test_omlx.py
+++ b/tests/providers/test_omlx.py
@@ -52,6 +52,26 @@ def test_init_uses_openai_chat_client() -> None:
     assert (timeout.read, timeout.write, timeout.connect) == (600.0, 15.0, 5.0)
 
 
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("http://localhost:8001", "http://localhost:8001/v1"),
+        ("http://localhost:8001/", "http://localhost:8001/v1"),
+        ("http://localhost:8001/v1", "http://localhost:8001/v1"),
+        ("http://localhost:8001/v1/", "http://localhost:8001/v1"),
+    ],
+)
+def test_init_normalizes_openai_base_url(configured: str, expected: str) -> None:
+    config = make_provider_config(api_key="test-omlx-key", base_url=configured)
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI"
+    ) as openai_client:
+        provider = profiled_provider("omlx", config, admission=immediate_admission())
+
+    assert provider._base_url == expected
+    assert openai_client.call_args.kwargs["base_url"] == expected
+
+
 def test_build_request_body_uses_openai_chat_shape(
     provider: OpenAIChatProvider,
 ) -> None:

--- a/tests/providers/test_omlx.py
+++ b/tests/providers/test_omlx.py
@@ -1,0 +1,130 @@
+"""Tests for the OMLX OpenAI-compatible local provider."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from free_claude_code.config.provider_catalog import OMLX_DEFAULT_BASE
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.request_factory import make_messages_request
+from tests.providers.support import (
+    REASONING_OFF,
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+    reasoning_for,
+)
+
+OMLX_MODEL = "omlx/local-model"
+
+
+@pytest.fixture
+def provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "omlx",
+        make_provider_config(api_key="test-omlx-key", base_url=OMLX_DEFAULT_BASE),
+        admission=immediate_admission(),
+    )
+
+
+def test_default_base_url_constant() -> None:
+    assert OMLX_DEFAULT_BASE == "http://localhost:8001/v1"
+
+
+def test_init_uses_openai_chat_client() -> None:
+    config = make_provider_config(
+        api_key="test-omlx-key",
+        base_url="http://localhost:8001/v1/",
+        http_read_timeout=600.0,
+        http_write_timeout=15.0,
+        http_connect_timeout=5.0,
+    )
+    with patch(
+        "free_claude_code.providers.openai_chat.provider.AsyncOpenAI"
+    ) as openai_client:
+        provider = profiled_provider("omlx", config, admission=immediate_admission())
+
+    assert provider._provider_name == "OMLX"
+    assert provider._base_url == "http://localhost:8001/v1"
+    assert provider._api_key == "test-omlx-key"
+    timeout = openai_client.call_args.kwargs["timeout"]
+    assert (timeout.read, timeout.write, timeout.connect) == (600.0, 15.0, 5.0)
+
+
+def test_build_request_body_uses_openai_chat_shape(
+    provider: OpenAIChatProvider,
+) -> None:
+    request = make_messages_request(OMLX_MODEL, max_tokens=None)
+
+    body = provider._build_request_body(request, reasoning=reasoning_for(request))
+
+    assert body["model"] == OMLX_MODEL
+    assert "max_tokens" not in body
+    assert body["messages"][0]["role"] == "system"
+    assert "thinking" not in body
+
+
+def test_replay_strips_thinking_blocks_when_disabled(
+    provider: OpenAIChatProvider,
+) -> None:
+    request = make_messages_request(
+        OMLX_MODEL,
+        system=None,
+        messages=[
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "private", "signature": "s"},
+                    {"type": "text", "text": "visible"},
+                ],
+            },
+        ],
+    )
+
+    body = provider._build_request_body(request, reasoning=REASONING_OFF)
+
+    assert body["messages"][1]["content"] == "visible"
+    assert "extra_body" not in body
+
+
+@pytest.mark.asyncio
+async def test_stream_response_uses_shared_openai_chat_provider(
+    provider: OpenAIChatProvider,
+) -> None:
+    chunk = MagicMock()
+    chunk.choices = [
+        MagicMock(
+            delta=MagicMock(
+                content="Hello from OMLX",
+                reasoning_content=None,
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    chunk.usage = MagicMock(prompt_tokens=8, completion_tokens=4)
+
+    async def stream():
+        yield chunk
+
+    with patch.object(
+        provider._client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=stream(),
+    ) as create:
+        output = "".join(
+            [
+                event
+                async for event in provider.stream_response(
+                    make_messages_request(OMLX_MODEL)
+                )
+            ]
+        )
+
+    assert create.call_args.kwargs["stream"] is True
+    assert create.call_args.kwargs["model"] == OMLX_MODEL
+    assert "Hello from OMLX" in output
+    assert parse_sse_text(output)[-1].event == "message_stop"

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -108,11 +108,14 @@ def _make_settings(**overrides):
     mock.llamacpp_base_url = "http://localhost:8080/v1"
     mock.ollama_base_url = "http://localhost:11434"
     mock.ollama_api_key = "test_ollama_cloud_key"
+    mock.omlx_api_key = "test_omlx_key"
+    mock.omlx_base_url = "http://localhost:8001/v1"
     mock.poolside_api_key = "test_poolside_key"
     mock.nvidia_nim_proxy = None
     mock.open_router_proxy = None
     mock.lmstudio_proxy = None
     mock.llamacpp_proxy = None
+    mock.omlx_proxy = None
     mock.mistral_proxy = None
     mock.codestral_proxy = None
     mock.kimi_proxy = None
@@ -603,6 +606,21 @@ def test_local_provider_factory_resolves_catalog_static_credential(
     assert provider._api_key == expected_api_key
 
 
+def test_omlx_factory_resolves_credential_from_settings() -> None:
+    descriptor = PROVIDER_CATALOG["omlx"]
+    settings = _make_settings()
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("omlx", settings)
+
+    assert config.api_key == "test_omlx_key"
+    assert config.base_url == "http://localhost:8001/v1"
+    assert isinstance(provider, OpenAIChatProvider)
+    assert provider._api_key == "test_omlx_key"
+    assert provider._provider_name == "OMLX"
+
+
 def test_zai_coding_descriptor_uses_fixed_cloud_base_url():
     descriptor = PROVIDER_CATALOG["zai"]
 
@@ -867,6 +885,7 @@ def test_create_provider_instantiates_each_builtin():
         "lmstudio": LMStudioProvider,
         "llamacpp": OpenAIChatProvider,
         "ollama": OpenAIChatProvider,
+        "omlx": OpenAIChatProvider,
         "ollama_cloud": OpenAIChatProvider,
         "wafer": OpenAIChatProvider,
         "opencode_zen": OpenAIChatProvider,


### PR DESCRIPTION
## Summary

- Add `omlx` as a new local OpenAI-compatible provider that requires an API key (e.g. a local OMLX service on `http://localhost:8001/v1`)
- Register `omlx` in `PROVIDER_CATALOG` with `credential_env`, `credential_attr`, `base_url_attr`, `proxy_attr`, and `local=True`; add `omlx_api_key` / `omlx_base_url` / `omlx_proxy` fields to `Settings`; add `omlx` profile (`ReasoningReplayMode.DISABLED` + `NO_REASONING`) to `OPENAI_CHAT_PROFILES`
- Extend admin `/admin/api/providers/local-status` to send an `Authorization: Bearer` header when a local provider has a `credential_env` (DRY via `PROVIDER_CATALOG`); add `omlx` to `LOCAL_PROVIDER_PATHS` so it appears in the Admin UI local-provider status panel
- Extend smoke test helper `first_local_provider_model_id` with an `api_key` parameter and a `local_provider_api_key()` helper (DRY via `PROVIDER_CATALOG.credential_attr`); skip on 401/403 instead of failing; add omlx prereq + product smoke tests
- Update `.env.example` with `OMLX_API_KEY` / `OMLX_BASE_URL` / `OMLX_PROXY` / `FCC_SMOKE_MODEL_OMLX` and the valid-providers list
- Bump version `5.13.6` → `5.14.0` (MINOR: new provider) → `5.14.1` (PATCH: admin local-status + smoke auth fix)

### Files Changed

**Production (`src/`, `.env.example`, `pyproject.toml`)**
- `src/free_claude_code/config/provider_catalog.py` — `OMLX_DEFAULT_BASE` + `omlx` `ProviderDescriptor`
- `src/free_claude_code/config/settings.py` — `omlx_api_key`, `omlx_base_url`, `omlx_proxy` fields
- `src/free_claude_code/providers/openai_chat/profiles.py` — `omlx` profile
- `src/free_claude_code/api/admin_routes.py` — `omlx` in `LOCAL_PROVIDER_PATHS`; `_local_provider_api_key()` (DRY); `_check_local_provider` sends auth header
- `.env.example` — OMLX config entries, valid providers list, smoke model override, proxy
- `pyproject.toml` / `uv.lock` — version bump

**Smoke (`smoke/`)**
- `smoke/lib/config.py` — `omlx` in `DEFAULT_TARGETS`, `PROVIDER_SMOKE_DEFAULT_MODELS`, `TARGET_REQUIRED_ENV`
- `smoke/lib/local_providers.py` — `api_key` param on `first_local_provider_model_id` / `_get_local_provider_response`; `local_provider_api_key()` helper; 401/403 skip
- `smoke/prereq/test_local_provider_endpoints_prereq_live.py` — `test_omlx_models_endpoint_when_available`
- `smoke/product/test_local_provider_product_live.py` — `test_omlx_openai_chat_e2e`; all local providers now pass `api_key`

**Tests (`tests/`)**
- `tests/providers/test_omlx.py` — NEW: 5 tests (base URL, init, request body, thinking strip, stream)
- `tests/providers/test_provider_runtime.py` — `test_omlx_factory_resolves_credential_from_settings` + omlx in `test_create_provider_instantiates_each_builtin`
- `tests/api/test_admin.py` — 2 new tests (auth header for omlx, no auth for keyless) + 2 updated + `_clear_process_config` clears OMLX env vars
- `tests/contracts/test_local_provider_smoke.py` — 4 new tests (auth header, 401 skip, `local_provider_api_key` for omlx/keyless) + 5 updated fake_get signatures
- `tests/config/test_provider_catalog.py` — omlx in local assignments
- `tests/contracts/test_provider_catalog_order.py` — omlx in expected order
- `tests/contracts/test_smoke_config.py` — omlx settings mock

### Logic Altered

- **Provider registration**: `omlx` is a local provider that uses `OpenAIChatProvider` (shared, no provider-specific code). Model discovery uses the default `OpenAIModelListing()` → `GET /v1/models` with API key via OpenAI SDK.
- **Admin local-status**: `_local_provider_api_key()` derives the credential from `PROVIDER_CATALOG[provider_id].credential_env` — no hardcoded mapping. Keyless providers (`credential_env=None`: lmstudio/llamacpp/ollama) send `headers=None`; omlx sends `Authorization: Bearer <key>`.
- **Smoke auth**: `local_provider_api_key()` derives the credential from `PROVIDER_CATALOG[provider_id].credential_attr` via `getattr(settings, attr)` — symmetric to the admin helper but uses settings-attr lookup (different data source).
- **Reasoning**: omlx uses `ReasoningReplayMode.DISABLED` (thinking blocks stripped from replay) + `NO_REASONING` (no reasoning encoding in request body), matching the `cline_pass` pattern for local servers without native reasoning support.
- **max_tokens**: omlx has no `default_max_tokens` — `max_tokens` is only set when the caller provides it, letting the local server default apply otherwise.

### Verification Method

- `uv run ruff format --check src/ tests/ smoke/` — 520 files already formatted
- `uv run ruff check src/ tests/ smoke/` — All checks passed
- `uv run ty check src/` — All checks passed
- `uv run pytest tests/ --ignore=tests/scripts/test_installers.py` — 3548 passed, 27 skipped (2 pre-existing macOS `chflags` PermissionError failures in `tests/scripts/test_uninstallers.py` are unrelated to this PR; confirmed by reproducing on clean upstream `main`)
- Admin UI verified live: `curl http://localhost:8082/admin/api/providers/local-status` returns `omlx: reachable` with correct base URL
- OMLX model discovery verified live: `Provider model discovery cached: provider=omlx models=5`

#### Test plan

- [x] ruff format --check passes
- [x] ruff check passes
- [x] ty check passes
- [x] suppression grep passes (no `type: ignore` / `ty: ignore` / `noqa` / `from __future__`)
- [x] pytest passes (3548 passed, excluding 2 pre-existing macOS failures)
- [x] Admin UI local-status shows omlx as reachable
- [x] OMLX model discovery works (5 models found)
- [ ] CI playwright (will run on PR)
 









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds authenticated OMLX support across provider configuration, model discovery, local status checks, and smoke coverage. The previously reported OMLX request-path and Admin status-path failures are disproved: service-root URLs send provider traffic to `/v1/chat/completions`, and the Admin check requests `/v1/models` with the configured bearer credential. The change is safe to merge.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain. Runtime checks confirmed the OMLX provider and Admin status endpoint use the intended versioned URLs and authentication behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the OMLX path-auth runtime script and it completed successfully while exercising the OMLX provider against both a service-root URL and an already-versioned URL, plus the Admin local-status endpoint on a local HTTP server.
- The script showed that the provider posted /v1/chat/completions for both configurations, and Admin local-status retrieved /v1/models with the configured bearer credential and reported OMLX as reachable.
- I also ran the script with --before to establish a baseline, and it exited 0, showing that an unnormalized raw OpenAI client at a service root requests /chat/completions.
- Running the focused OMLX provider and Admin regression selection completed with all 11 tests passing.
- Artifacts containing the runtime script and logs were uploaded to support review.

<a href="https://app.greptile.com/trex/runs/20303778/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into main"](https://github.com/alishahryar1/free-claude-code/commit/4db94069b9c71dec6a8be198253fd5999b196773) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55905346)</sub>

<!-- /greptile_comment -->