### PR TITLE
Normalize NVIDIA NIM top-p sampling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.6"
+version = "5.13.7"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/nim.py
+++ b/src/free_claude_code/config/nim.py
@@ -12,7 +12,10 @@ class NimSettings(BaseModel):
         1.0, ge=0.0, le=2.0, description="Sampling temperature, must be >=0 and <=2."
     )
     top_p: float = Field(
-        1.0, ge=0.0, le=1.0, description="Nucleus sampling probability. [0,1]"
+        0.95,
+        ge=0.95,
+        le=0.95,
+        description="FCC's fixed NVIDIA NIM nucleus sampling probability.",
     )
     top_k: int = -1
     max_tokens: int = Field(
@@ -61,7 +64,7 @@ class NimSettings(BaseModel):
     def validate_float_fields(cls, v, info: ValidationInfo):
         field_defaults = {
             "temperature": 1.0,
-            "top_p": 1.0,
+            "top_p": 0.95,
             "min_p": 0.0,
             "presence_penalty": 0.0,
             "frequency_penalty": 0.0,

--- a/src/free_claude_code/providers/nvidia_nim/request_options.py
+++ b/src/free_claude_code/providers/nvidia_nim/request_options.py
@@ -58,8 +58,7 @@ def apply_nim_request_options(
 
     if body.get("temperature") is None and nim.temperature is not None:
         body["temperature"] = nim.temperature
-    if body.get("top_p") is None and nim.top_p is not None:
-        body["top_p"] = nim.top_p
+    body["top_p"] = nim.top_p
 
     if "stop" not in body and nim.stop:
         body["stop"] = nim.stop

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -334,8 +334,10 @@ def test_nim_settings_keep_request_local_validation() -> None:
     assert settings.seed == 7
     assert settings.stop is None
     assert NimSettings().max_tokens == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
-    with pytest.raises(ValidationError):
-        NimSettings(top_p=1.1)
+    assert NimSettings().top_p == 0.95
+    for unsupported_top_p in (0.0, 0.9, 1.0):
+        with pytest.raises(ValidationError):
+            NimSettings(top_p=unsupported_top_p)
 
 
 def test_settings_defaults_do_not_contain_empty_enum_strings() -> None:

--- a/tests/providers/test_nvidia_nim_request.py
+++ b/tests/providers/test_nvidia_nim_request.py
@@ -163,6 +163,14 @@ class TestBuildRequestBody:
         body = build_request_body(req, nim, reasoning=REASONING_ON)
         assert body["max_tokens"] == 4096
 
+    @pytest.mark.parametrize("client_top_p", (None, 0.0, 0.5, 0.95, 1.0))
+    def test_top_p_always_uses_nim_policy(self, req, client_top_p):
+        req.top_p = client_top_p
+
+        body = build_request_body(req, NimSettings(), reasoning=REASONING_ON)
+
+        assert body["top_p"] == 0.95
+
     def test_presence_penalty_included_when_nonzero(self, req):
         nim = NimSettings(presence_penalty=0.5)
         body = build_request_body(req, nim, reasoning=REASONING_ON)

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.6"
+version = "5.13.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

NVIDIA NIM requests preserved or defaulted to `top_p=1.0`. NVIDIA's hosted Kimi K3 requires `0.95`, causing every request to fail with HTTP 400. Fixes #1515.

## Changes

| Before | After |
| --- | --- |
| NIM preserved client `top_p` values or defaulted them to `1.0`. | NIM normalizes every request to the fixed `top_p=0.95` policy. |
| Internal NIM settings accepted arbitrary nucleus-sampling values. | Internal NIM settings enforce the single supported policy value. |
| Request coverage did not exercise conflicting client sampling values. | Request coverage proves omitted and explicit client values all become `0.95`. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update fixes NVIDIA NIM sampling behavior at a consistent `top_p=0.95` policy value, regardless of whether callers omit or supply a different request value. It also rejects NIM configuration values outside that policy and updates the package patch version.

The possible regression where an omitted or client-provided `top_p` could remain in the generated request body was disproved by an executable probe: `None`, `0`, `0.5`, `0.95`, and `1` all produced `top_p=0.95`. The same check confirmed unsupported configuration values are rejected, and the focused configuration and NIM request-builder tests passed.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised NIM configuration and request-construction behavior.

Executable checks covered omitted, valid, and conflicting request values as well as valid and invalid configuration values; all resulting request bodies and validation outcomes matched the intended fixed policy.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an executable Python contract probe against both the prior revision and the updated code to validate top-p handling.
- Executed focused NVIDIA NIM top-p pytest coverage and confirmed all six parameterized checks passed.
- Compared pre- and post-change captures to verify old revision preserved client request values and accepted unsupported configuration values, while the new revision uses top\_p=0.95 for generated requests and rejects unsupported values.
- Uploaded and organized artifacts documenting the contract probe, pre/post-change behavior, and pytest results for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/20198977/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Normalize NVIDIA NIM top-p sampling"](https://github.com/alishahryar1/free-claude-code/commit/0cd969bdd7c5726f8e09700c0cf46b0ea42536b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55911031)</sub>

<!-- /greptile_comment -->