### PR TITLE
Prevent unintended Claude auto mode requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.7"
+version = "5.13.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/claude.py
+++ b/src/free_claude_code/cli/launchers/claude.py
@@ -15,6 +15,9 @@ from .common import preflight_proxy, resolve_client_binary, run_client_process
 
 _DISPLAY_NAME = "Claude Code"
 _INSTALL_HINT = "Install Claude Code with: npm install -g @anthropic-ai/claude-code"
+_DEFAULT_PERMISSION_MODE_ARGS = ("--permission-mode", "default")
+_PERMISSION_MODE_FLAG = "--permission-mode"
+_BYPASS_PERMISSIONS_FLAG = "--dangerously-skip-permissions"
 
 
 def launch(argv: Sequence[str] | None = None) -> None:
@@ -59,6 +62,25 @@ def claude_binary_name() -> str:
 def build_claude_launcher_command(
     *, binary_path: str, argv: Sequence[str]
 ) -> list[str]:
-    """Return the Claude wrapper command without changing user arguments."""
+    """Start Claude outside auto mode unless the user selected a mode."""
 
-    return [binary_path, *argv]
+    args = list(argv)
+    if not _has_explicit_permission_mode(args):
+        args[:0] = _DEFAULT_PERMISSION_MODE_ARGS
+
+    return [binary_path, *args]
+
+
+def _has_explicit_permission_mode(argv: Sequence[str]) -> bool:
+    """Return whether CLI arguments explicitly choose a permission mode."""
+
+    for arg in argv:
+        if arg == "--":
+            break
+        if arg in (
+            _PERMISSION_MODE_FLAG,
+            _BYPASS_PERMISSIONS_FLAG,
+        ) or arg.startswith(f"{_PERMISSION_MODE_FLAG}="):
+            return True
+
+    return False

--- a/tests/cli/test_claude_launcher.py
+++ b/tests/cli/test_claude_launcher.py
@@ -1,0 +1,55 @@
+import pytest
+
+from free_claude_code.cli.launchers.claude import build_claude_launcher_command
+
+
+def test_claude_launcher_defaults_to_non_auto_permission_mode() -> None:
+    assert build_claude_launcher_command(
+        binary_path="claude", argv=["fix the tests"]
+    ) == ["claude", "--permission-mode", "default", "fix the tests"]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--permission-mode", "auto", "fix the tests"],
+        ["--permission-mode=acceptEdits", "fix the tests"],
+        ["--dangerously-skip-permissions", "fix the tests"],
+    ],
+)
+def test_claude_launcher_preserves_explicit_permission_choice(
+    argv: list[str],
+) -> None:
+    assert build_claude_launcher_command(binary_path="claude", argv=argv) == [
+        "claude",
+        *argv,
+    ]
+
+
+@pytest.mark.parametrize("argv", [["--permission-mode"], ["--permission-mode="]])
+def test_claude_launcher_leaves_malformed_permission_options_to_claude(
+    argv: list[str],
+) -> None:
+    assert build_claude_launcher_command(binary_path="claude", argv=argv) == [
+        "claude",
+        *argv,
+    ]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["explain --permission-mode auto"],
+        ["--", "--permission-mode=auto"],
+        ["--", "--dangerously-skip-permissions"],
+    ],
+)
+def test_claude_launcher_does_not_treat_prompt_text_as_a_permission_choice(
+    argv: list[str],
+) -> None:
+    assert build_claude_launcher_command(binary_path="claude", argv=argv) == [
+        "claude",
+        "--permission-mode",
+        "default",
+        *argv,
+    ]

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -364,7 +364,13 @@ def test_launch_claude_passes_args_and_child_env(
 
     assert exc_info.value.code == 7
     popen.assert_called_once()
-    assert popen.call_args.args[0] == ["resolved-claude.cmd", "--model", "sonnet"]
+    assert popen.call_args.args[0] == [
+        "resolved-claude.cmd",
+        "--permission-mode",
+        "default",
+        "--model",
+        "sonnet",
+    ]
     child_env = popen.call_args.kwargs["env"]
     assert child_env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9191"
     assert child_env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.7"
+version = "5.13.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

`fcc-claude` left permission-mode selection to Claude Code. A saved or resumed Auto mode could send extra safety-classifier model requests through FCC without an explicit choice for that launch.

## Changes

| Before | After |
| --- | --- |
| Launches inherited Claude Code's effective permission mode. | Launches default to the documented `default` permission mode and avoid Auto classifier calls. |
| Permission options had no wrapper precedence contract. | Explicit `--permission-mode` and bypass selections remain authoritative. |
| Prompt text could be confused with an option by a naive check. | Argument scanning stops at `--` and leaves prompt text untouched. |
| Package version was 5.13.7. | Package version is 5.13.8. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes `fcc-claude` add `--permission-mode default` when the caller has not explicitly selected a Claude permission mode. Explicit `--permission-mode` values and `--dangerously-skip-permissions` remain unchanged, and permission-looking text after `--` is treated as prompt content.

A mocked invocation of the actual launcher exercised the default path, split and inline explicit permission modes, the bypass flag, and the end-of-options boundary. All five cases produced the expected child command. The focused Claude launcher and entrypoint tests also passed (46 tests).
</details>


<h3>Confidence Score: 5/5</h3>

The launcher change is safe to merge based on the exercised command-forwarding behavior.

The actual `launch()` path was exercised with mocked process dependencies across every changed permission-selection branch, including the end-of-options boundary. A before-and-after comparison confirmed that only the intended defaulting behavior changed, and focused regression tests passed.

**Files Needing Attention:** No files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused regression suite was executed to validate the PR against the Claude launcher behavior and it completed with 46 tests passed in 0.89s.
- Pre-PR versus post-PR comparison showed that before the PR, the parent commit produced no default mode for no-selection and -- prompt-text inputs, whereas after the PR the expected default mode was produced for those two inputs.
- The same comparison confirmed that all three explicit selections remained unchanged at the byte level after the PR.
- Artifacts documenting the validation were collected, including the offline permission validation source, the before/after launcher logs, and the focused regression test output.

<a href="https://app.greptile.com/trex/runs/20204762/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Avoid Claude auto mode by default"](https://github.com/alishahryar1/free-claude-code/commit/eea4a1068e55ced05b8b7030c286d7afe33a19c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55923659)</sub>

<!-- /greptile_comment -->