### PR TITLE
Simplify coding harness installer verification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.8"
+version = "5.13.9"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -22,15 +22,10 @@ $ClaudeInstallUrl = "https://claude.ai/install.ps1"
 $CodexInstallUrl = "https://chatgpt.com/codex/install.ps1"
 $PiInstallUrl = "https://pi.dev/install.ps1"
 $OpenCodeReleaseBaseUrl = "https://github.com/anomalyco/opencode/releases/latest/download"
-$MinOpenCodeVersion = "1.18.18"
-$MinClineVersion = "3.0.55"
 $HermesInstallUrl = "https://hermes-agent.nousresearch.com/install.ps1"
-$MinHermesVersion = "0.20.4"
 $DshVersion = "0.1.0-rc.8"
 $DshPackage = "@deepseek-ai/dsh@$DshVersion"
 $GrokInstallUrl = "https://x.ai/cli/install.ps1"
-$MinGrokVersion = "1.0.5"
-$MinMuseVersion = "0.2.1"
 $RtkVersion = "0.44.2"
 $RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/download/v$RtkVersion"
 $RtkWindowsAssetName = "rtk-x86_64-pc-windows-msvc.zip"
@@ -688,34 +683,6 @@ function Test-SupportedStableVersion {
     return ([version] $normalizedVersion) -ge ([version] $normalizedMinimum)
 }
 
-function Get-OpenCodeVersion {
-    param([string] $OpenCodePath)
-
-    $output = Invoke-Utf8NativeCapture -FilePath $OpenCodePath -Arguments @("--version")
-    $version = Convert-SemanticVersionOutput $output
-    if ([string]::IsNullOrWhiteSpace($version)) {
-        throw "OpenCode is present, but 'opencode --version' did not return a valid semantic version."
-    }
-    return $version
-}
-
-function Confirm-OpenCodeApplication {
-    if ($DryRun) {
-        Write-Host "+ opencode --version"
-        return
-    }
-
-    $command = Get-ApplicationCommand "opencode"
-    if (-not $command) {
-        throw "OpenCode was installed, but 'opencode' is not available on PATH."
-    }
-    $version = Get-OpenCodeVersion $command.Source
-    if (-not (Test-SupportedStableVersion -Version $version -Minimum $MinOpenCodeVersion)) {
-        throw "Stable OpenCode V1 $MinOpenCodeVersion or newer is required; found OpenCode $version after installation."
-    }
-    Write-Host "Verified OpenCode $version."
-}
-
 function Get-OpenCodeWindowsAssetName {
     $architecture = $env:PROCESSOR_ARCHITEW6432
     if ([string]::IsNullOrWhiteSpace($architecture)) {
@@ -776,92 +743,24 @@ function Install-OpenCode {
 }
 
 function Ensure-OpenCode {
-    if ($DryRun) {
-        if (Get-ApplicationCommand "opencode") {
-            Write-Host "+ opencode --version"
-            Write-Host "A compatible OpenCode will be preserved; an older version will be upgraded with opencode upgrade."
-        }
-        else {
-            Install-OpenCode
-        }
-        Confirm-OpenCodeApplication
-        return
-    }
-
     $command = Get-ApplicationCommand "opencode"
     if ($command) {
-        $version = Get-OpenCodeVersion $command.Source
-        if (Test-SupportedStableVersion -Version $version -Minimum $MinOpenCodeVersion) {
-            Write-Host "OpenCode $version already satisfies >=$MinOpenCodeVersion; leaving it unchanged."
-            return
-        }
-        Write-Host "OpenCode $version does not satisfy stable V1 >=$MinOpenCodeVersion; upgrading it with OpenCode."
-        Invoke-NativeCommand -FilePath $command.Source -Arguments @("upgrade")
-        Add-KnownBinDirectories
+        Write-Host "OpenCode already found on PATH; verifying it."
     }
     else {
         Install-OpenCode
         Add-KnownBinDirectories
     }
 
-    Confirm-OpenCodeApplication
-}
-
-function Get-ClineVersion {
-    param([string] $ClinePath)
-
-    $output = Invoke-Utf8NativeCapture -FilePath $ClinePath -Arguments @("--version")
-    $version = Convert-SemanticVersionOutput $output
-    if ([string]::IsNullOrWhiteSpace($version)) {
-        throw "Cline is present, but 'cline --version' did not return a valid semantic version."
-    }
-    return $version
-}
-
-function Confirm-ClineApplication {
-    if ($DryRun) {
-        Write-Host "+ cline --version"
-        return
-    }
-
-    $command = Get-ApplicationCommand "cline"
-    if (-not $command) {
-        throw "Cline was installed, but 'cline' is not available on PATH."
-    }
-    $version = Get-ClineVersion $command.Source
-    if (-not (Test-SupportedStableVersion -Version $version -Minimum $MinClineVersion)) {
-        throw "Stable Cline $MinClineVersion or newer is required; found Cline $version after installation."
-    }
-    Write-Host "Verified Cline $version."
+    Confirm-Application -CommandName "opencode" -DisplayName "OpenCode"
 }
 
 function Ensure-Cline {
     Add-NpmBinDirectories
 
-    if ($DryRun) {
-        if (Get-ApplicationCommand "cline") {
-            Write-Host "+ cline --version"
-            Write-Host "A compatible Cline will be preserved; an older version will be upgraded with cline update."
-        }
-        elseif (Get-ApplicationCommand "npm") {
-            Write-Host "+ npm install -g cline"
-        }
-        else {
-            throw "Cline installation requires npm. Install Node.js from https://nodejs.org/en/download, then rerun the installer."
-        }
-        Confirm-ClineApplication
-        return
-    }
-
     $command = Get-ApplicationCommand "cline"
     if ($command) {
-        $version = Get-ClineVersion $command.Source
-        if (Test-SupportedStableVersion -Version $version -Minimum $MinClineVersion) {
-            Write-Host "Cline $version already satisfies >=$MinClineVersion; leaving it unchanged."
-            return
-        }
-        Write-Host "Cline $version does not satisfy stable >=$MinClineVersion; upgrading it with Cline."
-        Invoke-NativeCommand -FilePath $command.Source -Arguments @("update")
+        Write-Host "Cline already found on PATH; verifying it."
     }
     else {
         $npm = Get-ApplicationCommand "npm"
@@ -869,21 +768,10 @@ function Ensure-Cline {
             throw "Cline installation requires npm. Install Node.js from https://nodejs.org/en/download, then rerun the installer."
         }
         Invoke-NativeCommand -FilePath $npm.Source -Arguments @("install", "-g", "cline")
+        Add-NpmBinDirectories
     }
 
-    Add-NpmBinDirectories
-    Confirm-ClineApplication
-}
-
-function Get-HermesVersion {
-    param([string] $HermesPath)
-
-    $output = Invoke-Utf8NativeCapture -FilePath $HermesPath -Arguments @("--version")
-    if ($output -match '(?im)^\s*Hermes Agent\s+v?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?=\s|$)') {
-        return $Matches["version"]
-    }
-
-    throw "Hermes Agent is present, but 'hermes --version' did not return a valid semantic version."
+    Confirm-Application -CommandName "cline" -DisplayName "Cline"
 }
 
 function Confirm-HermesArchitecture {
@@ -899,23 +787,6 @@ function Confirm-HermesArchitecture {
     }
 }
 
-function Confirm-HermesApplication {
-    if ($DryRun) {
-        Write-Host "+ hermes --version"
-        return
-    }
-
-    $command = Get-ApplicationCommand "hermes"
-    if (-not $command) {
-        throw "Hermes Agent was installed, but 'hermes' is not available on PATH."
-    }
-    $version = Get-HermesVersion $command.Source
-    if (-not (Test-SupportedStableVersion -Version $version -Minimum $MinHermesVersion)) {
-        throw "Hermes Agent $MinHermesVersion or newer is required; found Hermes $version after installation."
-    }
-    Write-Host "Verified Hermes Agent $version."
-}
-
 function Install-Hermes {
     Confirm-HermesArchitecture
     Invoke-DownloadedPowerShellInstaller `
@@ -926,81 +797,15 @@ function Install-Hermes {
 }
 
 function Ensure-Hermes {
-    if ($DryRun) {
-        if (Get-ApplicationCommand "hermes") {
-            Write-Host "+ hermes --version"
-            Write-Host "A compatible Hermes Agent will be preserved; an older version will be upgraded with the official installer."
-        }
-        else {
-            Install-Hermes
-        }
-        Confirm-HermesApplication
-        return
-    }
-
     $command = Get-ApplicationCommand "hermes"
     if ($command) {
-        $version = Get-HermesVersion $command.Source
-        if (Test-SupportedStableVersion -Version $version -Minimum $MinHermesVersion) {
-            Write-Host "Hermes Agent $version already satisfies >=$MinHermesVersion; leaving it unchanged."
-            return
-        }
-        Write-Host "Hermes Agent $version does not satisfy >=$MinHermesVersion; upgrading it with the official installer."
+        Write-Host "Hermes Agent already found on PATH; verifying it."
+    }
+    else {
+        Install-Hermes
     }
 
-    Install-Hermes
-    Confirm-HermesApplication
-}
-
-function Get-GrokVersion {
-    param([string] $GrokPath)
-
-    $output = Invoke-Utf8NativeCapture -FilePath $GrokPath -Arguments @("version", "--json")
-    $invalidMetadata = "Grok Build is present, but 'grok version --json' did not return valid stable version metadata."
-    try {
-        $metadata = ConvertFrom-Json -InputObject $output -ErrorAction Stop
-    }
-    catch {
-        throw $invalidMetadata
-    }
-    if ($null -eq $metadata) {
-        throw $invalidMetadata
-    }
-
-    $currentVersionProperty = $metadata.PSObject.Properties["currentVersion"]
-    $channelProperty = $metadata.PSObject.Properties["channel"]
-    if (
-        ($null -eq $currentVersionProperty) -or
-        ($currentVersionProperty.Value -isnot [string]) -or
-        ($null -eq $channelProperty) -or
-        ($channelProperty.Value -isnot [string]) -or
-        ($channelProperty.Value -cne "stable")
-    ) {
-        throw $invalidMetadata
-    }
-
-    $currentVersion = $currentVersionProperty.Value.Trim()
-    if ($currentVersion -notmatch '^(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?:\s+\([^\r\n]*\))?$') {
-        throw $invalidMetadata
-    }
-    return $Matches["version"]
-}
-
-function Confirm-GrokApplication {
-    if ($DryRun) {
-        Write-Host "+ grok version --json"
-        return
-    }
-
-    $command = Get-ApplicationCommand "grok"
-    if (-not $command) {
-        throw "Grok Build was installed, but 'grok' is not available on PATH."
-    }
-    $version = Get-GrokVersion $command.Source
-    if (-not (Test-SupportedStableVersion -Version $version -Minimum $MinGrokVersion)) {
-        throw "Stable Grok Build $MinGrokVersion or newer is required; found Grok Build $version after installation."
-    }
-    Write-Host "Verified Grok Build $version."
+    Confirm-Application -CommandName "hermes" -DisplayName "Hermes Agent"
 }
 
 function Install-Grok {
@@ -1009,63 +814,27 @@ function Install-Grok {
 }
 
 function Ensure-Grok {
-    if ($DryRun) {
-        if (Get-ApplicationCommand "grok") {
-            Write-Host "+ grok version --json"
-            Write-Host "A compatible Grok Build will be preserved; an older version will be upgraded with the official installer."
-        }
-        else {
-            Install-Grok
-        }
-        Confirm-GrokApplication
-        return
-    }
-
     $command = Get-ApplicationCommand "grok"
     if ($command) {
-        $version = Get-GrokVersion $command.Source
-        if (Test-SupportedStableVersion -Version $version -Minimum $MinGrokVersion) {
-            Write-Host "Grok Build $version already satisfies >=$MinGrokVersion; leaving it unchanged."
-            return
-        }
-        Write-Host "Grok Build $version does not satisfy stable >=$MinGrokVersion; upgrading it with the official installer."
+        Write-Host "Grok Build already found on PATH; verifying it."
+    }
+    else {
+        Install-Grok
     }
 
-    Install-Grok
-    Confirm-GrokApplication
-}
-
-function Get-MuseVersion {
-    param([string] $MusePath)
-
-    $output = Invoke-Utf8NativeCapture -FilePath $MusePath -Arguments @("--version")
-    if ($output -match '(?m)^\s*Muse Code\s+(?<version>\d+\.\d+\.\d+)(?:\s+\([^\r\n]+\))?\s*$') {
-        return $Matches["version"]
-    }
-
-    throw "Muse Code is present, but 'muse --version' did not return the expected 'Muse Code x.y.z' version."
+    Confirm-Application -CommandName "grok" -DisplayName "Grok Build"
 }
 
 function Ensure-Muse {
     $script:MuseAvailable = $false
     $command = Get-ApplicationCommand "muse"
     if (-not $command) {
-        Write-Host "Muse Code is not installed. Meta does not currently publish an official Windows installer; fcc-muse will be ready when a compatible Muse binary is on PATH."
+        Write-Host "Muse Code is not installed. Meta does not currently publish an official Windows installer; fcc-muse will be ready when Muse Code is on PATH."
         return
     }
 
-    if ($DryRun) {
-        Write-Host "+ muse --version"
-        Write-Host "A compatible preinstalled Muse Code will be preserved; FCC does not update Muse on Windows."
-        $script:MuseAvailable = $true
-        return
-    }
-
-    $version = Get-MuseVersion $command.Source
-    if (-not (Test-SupportedStableVersion -Version $version -Minimum $MinMuseVersion)) {
-        throw "Muse Code $MinMuseVersion or newer is required; found Muse Code $version. Meta does not currently publish an official Windows updater."
-    }
-    Write-Host "Verified Muse Code $version."
+    Write-Host "Muse Code already found on PATH; verifying it."
+    Confirm-Application -CommandName "muse" -DisplayName "Muse Code"
     $script:MuseAvailable = $true
 }
 
@@ -1598,12 +1367,12 @@ else {
         Write-Host "Run Grok Build with: fcc-grok"
     }
     else {
-        Write-Host "The fcc-grok wrapper is ready after you install Grok Build $MinGrokVersion or newer."
+        Write-Host "The fcc-grok wrapper is ready after you install Grok Build."
     }
     if ($script:MuseAvailable) {
         Write-Host "Run Muse Code with: fcc-muse"
     }
     else {
-        Write-Host "The fcc-muse wrapper is ready after you install Muse Code $MinMuseVersion or newer."
+        Write-Host "The fcc-muse wrapper is ready after you install Muse Code."
     }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -662,7 +662,7 @@ function Convert-SemanticVersionOutput {
     if ([string]::IsNullOrWhiteSpace($Output)) {
         return ""
     }
-    if ($Output -match '(?m)^\s*(?:(?:uv|opencode|cline|dsh|grok|node)(?:\s+version)?\s+|Hermes Agent\s+v?|v)?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?:\s+\([^\r\n]*\))?\s*$') {
+    if ($Output -match '(?m)^\s*(?:(?:uv|opencode|cline|dsh|node)(?:\s+version)?\s+|Hermes Agent\s+v?|v)?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?:\s+\([^\r\n]*\))?\s*$') {
         return $Matches["version"]
     }
     return ""
@@ -955,17 +955,40 @@ function Ensure-Hermes {
 function Get-GrokVersion {
     param([string] $GrokPath)
 
-    $output = Invoke-Utf8NativeCapture -FilePath $GrokPath -Arguments @("--version")
-    $version = Convert-SemanticVersionOutput $output
-    if ([string]::IsNullOrWhiteSpace($version)) {
-        throw "Grok Build is present, but 'grok --version' did not return a valid semantic version."
+    $output = Invoke-Utf8NativeCapture -FilePath $GrokPath -Arguments @("version", "--json")
+    $invalidMetadata = "Grok Build is present, but 'grok version --json' did not return valid stable version metadata."
+    try {
+        $metadata = ConvertFrom-Json -InputObject $output -ErrorAction Stop
     }
-    return $version
+    catch {
+        throw $invalidMetadata
+    }
+    if ($null -eq $metadata) {
+        throw $invalidMetadata
+    }
+
+    $currentVersionProperty = $metadata.PSObject.Properties["currentVersion"]
+    $channelProperty = $metadata.PSObject.Properties["channel"]
+    if (
+        ($null -eq $currentVersionProperty) -or
+        ($currentVersionProperty.Value -isnot [string]) -or
+        ($null -eq $channelProperty) -or
+        ($channelProperty.Value -isnot [string]) -or
+        ($channelProperty.Value -cne "stable")
+    ) {
+        throw $invalidMetadata
+    }
+
+    $currentVersion = $currentVersionProperty.Value.Trim()
+    if ($currentVersion -notmatch '^(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?)(?:\s+\([^\r\n]*\))?$') {
+        throw $invalidMetadata
+    }
+    return $Matches["version"]
 }
 
 function Confirm-GrokApplication {
     if ($DryRun) {
-        Write-Host "+ grok --version"
+        Write-Host "+ grok version --json"
         return
     }
 
@@ -988,7 +1011,7 @@ function Install-Grok {
 function Ensure-Grok {
     if ($DryRun) {
         if (Get-ApplicationCommand "grok") {
-            Write-Host "+ grok --version"
+            Write-Host "+ grok version --json"
             Write-Host "A compatible Grok Build will be preserved; an older version will be upgraded with the official installer."
         }
         else {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -994,14 +994,18 @@ ensure_dsh() {
 }
 
 current_grok_version() {
-    if output=$(grok --version 2>/dev/null); then
+    if output=$(grok version --json 2>/dev/null); then
         :
     else
         return 1
     fi
 
-    version=$(printf '%s\n' "$output" | awk '
-        /^[[:space:]]*(grok[[:space:]]+|v)?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?([[:space:]]+\([^\r\n]*\))?[[:space:]]*$/ &&
+    current_version=$(printf '%s\n' "$output" | sed -n 's/.*"currentVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    channel=$(printf '%s\n' "$output" | sed -n 's/.*"channel"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    [ "$channel" = "stable" ] || return 1
+
+    version=$(printf '%s\n' "$current_version" | awk '
+        /^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z][0-9A-Za-z.-]*)?([[:space:]]+\([^\r\n]*\))?$/ &&
         match($0, /[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?/) {
             print substr($0, RSTART, RLENGTH)
             exit
@@ -1013,12 +1017,12 @@ current_grok_version() {
 
 verify_grok_command() {
     if [ "$dry_run" -eq 1 ]; then
-        print_command grok --version
+        print_command grok version --json
         return 0
     fi
 
     command -v grok >/dev/null 2>&1 || fail "Grok Build was installed, but 'grok' is not available on PATH."
-    version=$(current_grok_version) || fail "Grok Build is present, but 'grok --version' did not return a valid semantic version."
+    version=$(current_grok_version) || fail "Grok Build is present, but 'grok version --json' did not return valid stable version metadata."
     if ! stable_version_is_supported "$version" "$MIN_GROK_VERSION"; then
         fail "Stable Grok Build $MIN_GROK_VERSION or newer is required; found Grok Build $version after installation."
     fi
@@ -1033,7 +1037,7 @@ install_grok_build() {
 ensure_grok() {
     if [ "$dry_run" -eq 1 ]; then
         if command -v grok >/dev/null 2>&1; then
-            print_command grok --version
+            print_command grok version --json
             printf 'A compatible Grok Build will be preserved; an older version will be upgraded with the official installer.\n'
         else
             install_grok_build
@@ -1043,7 +1047,7 @@ ensure_grok() {
     fi
 
     if command -v grok >/dev/null 2>&1; then
-        version=$(current_grok_version) || fail "Grok Build is present, but 'grok --version' did not return a valid semantic version."
+        version=$(current_grok_version) || fail "Grok Build is present, but 'grok version --json' did not return valid stable version metadata."
         if stable_version_is_supported "$version" "$MIN_GROK_VERSION"; then
             printf 'Grok Build %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_GROK_VERSION"
             return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1000,9 +1000,10 @@ current_grok_version() {
         return 1
     fi
 
-    current_version=$(printf '%s\n' "$output" | sed -n 's/.*"currentVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    channel=$(printf '%s\n' "$output" | sed -n 's/.*"channel"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    [ "$channel" = "stable" ] || return 1
+    current_version=$(printf '%s\n' "$output" | sed -n \
+        -e 's/^[[:space:]]*{[[:space:]]*"currentVersion"[[:space:]]*:[[:space:]]*"\([^"\\]*\)"[[:space:]]*,[[:space:]]*"channel"[[:space:]]*:[[:space:]]*"stable"[[:space:]]*}[[:space:]]*$/\1/p' \
+        -e 's/^[[:space:]]*{[[:space:]]*"channel"[[:space:]]*:[[:space:]]*"stable"[[:space:]]*,[[:space:]]*"currentVersion"[[:space:]]*:[[:space:]]*"\([^"\\]*\)"[[:space:]]*}[[:space:]]*$/\1/p')
+    [ -n "$current_version" ] || return 1
 
     version=$(printf '%s\n' "$current_version" | awk '
         /^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z][0-9A-Za-z.-]*)?([[:space:]]+\([^\r\n]*\))?$/ &&

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,16 +8,11 @@ CLAUDE_INSTALL_URL="https://claude.ai/install.sh"
 CODEX_INSTALL_URL="https://chatgpt.com/codex/install.sh"
 PI_INSTALL_URL="https://pi.dev/install.sh"
 OPENCODE_INSTALL_URL="https://opencode.ai/install"
-MIN_OPENCODE_VERSION="1.18.18"
-MIN_CLINE_VERSION="3.0.55"
 HERMES_INSTALL_URL="https://hermes-agent.nousresearch.com/install.sh"
-MIN_HERMES_VERSION="0.20.4"
 DSH_VERSION="0.1.0-rc.8"
 DSH_PACKAGE="@deepseek-ai/dsh@$DSH_VERSION"
 GROK_INSTALL_URL="https://x.ai/cli/install.sh"
-MIN_GROK_VERSION="1.0.5"
 MUSE_INSTALL_URL="https://dev.meta.ai/install.sh"
-MIN_MUSE_VERSION="0.2.1"
 RTK_VERSION="0.44.2"
 RTK_RELEASE_BASE_URL="https://github.com/rtk-ai/rtk/releases/download/v$RTK_VERSION"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
@@ -673,161 +668,29 @@ ensure_pi() {
     pi_available=1
 }
 
-current_opencode_version() {
-    if output=$(opencode --version 2>/dev/null); then
-        :
-    else
-        return 1
-    fi
-
-    version=$(printf '%s\n' "$output" | awk '
-        /^[[:space:]]*((opencode( version)?[[:space:]]+)|v)?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?[[:space:]]*$/ &&
-        match($0, /[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?/) {
-            print substr($0, RSTART, RLENGTH)
-            exit
-        }
-    ')
-    [ -n "$version" ] || return 1
-    printf '%s\n' "$version"
-}
-
-verify_opencode_command() {
-    if [ "$dry_run" -eq 1 ]; then
-        print_command opencode --version
-        return 0
-    fi
-
-    command_path=$(command -v opencode 2>/dev/null) || fail "OpenCode was installed, but 'opencode' is not available on PATH."
-    version=$(current_opencode_version) || fail "OpenCode is present, but 'opencode --version' did not return a valid semantic version."
-    if ! stable_version_is_supported "$version" "$MIN_OPENCODE_VERSION"; then
-        fail "Stable OpenCode V1 $MIN_OPENCODE_VERSION or newer is required; found OpenCode $version after installation."
-    fi
-    printf 'Verified OpenCode %s.\n' "$version"
-}
-
 ensure_opencode() {
-    if [ "$dry_run" -eq 1 ]; then
-        if command -v opencode >/dev/null 2>&1; then
-            print_command opencode --version
-            printf 'A compatible OpenCode will be preserved; an older version will be upgraded with opencode upgrade.\n'
-        else
-            download_and_run "$OPENCODE_INSTALL_URL" bash "OpenCode"
-        fi
-        verify_opencode_command
-        return 0
-    fi
-
     if command -v opencode >/dev/null 2>&1; then
-        version=$(current_opencode_version) || fail "OpenCode is present, but 'opencode --version' did not return a valid semantic version."
-        if stable_version_is_supported "$version" "$MIN_OPENCODE_VERSION"; then
-            printf 'OpenCode %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_OPENCODE_VERSION"
-            return 0
-        fi
-        printf 'OpenCode %s does not satisfy stable V1 >=%s; upgrading it with OpenCode.\n' "$version" "$MIN_OPENCODE_VERSION"
-        run opencode upgrade
-        add_known_bin_directories
+        printf 'OpenCode already found on PATH; verifying it.\n'
     else
         download_and_run "$OPENCODE_INSTALL_URL" bash "OpenCode"
         add_known_bin_directories
     fi
 
-    verify_opencode_command
-}
-
-current_cline_version() {
-    if output=$(cline --version 2>/dev/null); then
-        :
-    else
-        return 1
-    fi
-
-    version=$(printf '%s\n' "$output" | awk '
-        /^[[:space:]]*((cline( version)?[[:space:]]+)|v)?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?[[:space:]]*$/ &&
-        match($0, /[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?/) {
-            print substr($0, RSTART, RLENGTH)
-            exit
-        }
-    ')
-    [ -n "$version" ] || return 1
-    printf '%s\n' "$version"
-}
-
-verify_cline_command() {
-    if [ "$dry_run" -eq 1 ]; then
-        print_command cline --version
-        return 0
-    fi
-
-    command -v cline >/dev/null 2>&1 || fail "Cline was installed, but 'cline' is not available on PATH."
-    version=$(current_cline_version) || fail "Cline is present, but 'cline --version' did not return a valid semantic version."
-    if ! stable_version_is_supported "$version" "$MIN_CLINE_VERSION"; then
-        fail "Stable Cline $MIN_CLINE_VERSION or newer is required; found Cline $version after installation."
-    fi
-    printf 'Verified Cline %s.\n' "$version"
+    verify_command opencode "OpenCode"
 }
 
 ensure_cline() {
     add_npm_bin_directories
 
-    if [ "$dry_run" -eq 1 ]; then
-        if command -v cline >/dev/null 2>&1; then
-            print_command cline --version
-            printf 'A compatible Cline will be preserved; an older version will be upgraded with cline update.\n'
-        elif command -v npm >/dev/null 2>&1; then
-            print_command npm install -g cline
-        else
-            fail "Cline installation requires npm. Install Node.js from https://nodejs.org/en/download, then rerun the installer."
-        fi
-        verify_cline_command
-        return 0
-    fi
-
     if command -v cline >/dev/null 2>&1; then
-        version=$(current_cline_version) || fail "Cline is present, but 'cline --version' did not return a valid semantic version."
-        if stable_version_is_supported "$version" "$MIN_CLINE_VERSION"; then
-            printf 'Cline %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_CLINE_VERSION"
-            return 0
-        fi
-        printf 'Cline %s does not satisfy stable >=%s; upgrading it with Cline.\n' "$version" "$MIN_CLINE_VERSION"
-        run cline update
+        printf 'Cline already found on PATH; verifying it.\n'
     else
         command -v npm >/dev/null 2>&1 || fail "Cline installation requires npm. Install Node.js from https://nodejs.org/en/download, then rerun the installer."
         run npm install -g cline
+        add_npm_bin_directories
     fi
 
-    add_npm_bin_directories
-    verify_cline_command
-}
-
-current_hermes_version() {
-    if output=$(hermes --version 2>/dev/null); then
-        :
-    else
-        return 1
-    fi
-
-    version=$(printf '%s\n' "$output" | awk '
-        match($0, /[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?/) {
-            print substr($0, RSTART, RLENGTH)
-            exit
-        }
-    ')
-    [ -n "$version" ] || return 1
-    printf '%s\n' "$version"
-}
-
-verify_hermes_command() {
-    if [ "$dry_run" -eq 1 ]; then
-        print_command hermes --version
-        return 0
-    fi
-
-    command -v hermes >/dev/null 2>&1 || fail "Hermes Agent was installed, but 'hermes' is not available on PATH."
-    version=$(current_hermes_version) || fail "Hermes Agent is present, but 'hermes --version' did not return a valid semantic version."
-    if ! stable_version_is_supported "$version" "$MIN_HERMES_VERSION"; then
-        fail "Hermes Agent $MIN_HERMES_VERSION or newer is required; found Hermes $version after installation."
-    fi
-    printf 'Verified Hermes Agent %s.\n' "$version"
+    verify_command cline "Cline"
 }
 
 hermes_platform_is_supported() {
@@ -857,28 +720,13 @@ install_hermes() {
 }
 
 ensure_hermes() {
-    if [ "$dry_run" -eq 1 ]; then
-        if command -v hermes >/dev/null 2>&1; then
-            print_command hermes --version
-            printf 'A compatible Hermes Agent will be preserved; an older version will be upgraded with the official installer.\n'
-        else
-            install_hermes
-        fi
-        verify_hermes_command
-        return 0
-    fi
-
     if command -v hermes >/dev/null 2>&1; then
-        version=$(current_hermes_version) || fail "Hermes Agent is present, but 'hermes --version' did not return a valid semantic version."
-        if stable_version_is_supported "$version" "$MIN_HERMES_VERSION"; then
-            printf 'Hermes Agent %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_HERMES_VERSION"
-            return 0
-        fi
-        printf 'Hermes Agent %s does not satisfy >=%s; upgrading it with the official installer.\n' "$version" "$MIN_HERMES_VERSION"
+        printf 'Hermes Agent already found on PATH; verifying it.\n'
+    else
+        install_hermes
     fi
 
-    install_hermes
-    verify_hermes_command
+    verify_command hermes "Hermes Agent"
 }
 
 current_dsh_version() {
@@ -993,103 +841,19 @@ ensure_dsh() {
     verify_dsh_command
 }
 
-current_grok_version() {
-    if output=$(grok version --json 2>/dev/null); then
-        :
-    else
-        return 1
-    fi
-
-    current_version=$(printf '%s\n' "$output" | sed -n \
-        -e 's/^[[:space:]]*{[[:space:]]*"currentVersion"[[:space:]]*:[[:space:]]*"\([^"\\]*\)"[[:space:]]*,[[:space:]]*"channel"[[:space:]]*:[[:space:]]*"stable"[[:space:]]*}[[:space:]]*$/\1/p' \
-        -e 's/^[[:space:]]*{[[:space:]]*"channel"[[:space:]]*:[[:space:]]*"stable"[[:space:]]*,[[:space:]]*"currentVersion"[[:space:]]*:[[:space:]]*"\([^"\\]*\)"[[:space:]]*}[[:space:]]*$/\1/p')
-    [ -n "$current_version" ] || return 1
-
-    version=$(printf '%s\n' "$current_version" | awk '
-        /^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z][0-9A-Za-z.-]*)?([[:space:]]+\([^\r\n]*\))?$/ &&
-        match($0, /[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?/) {
-            print substr($0, RSTART, RLENGTH)
-            exit
-        }
-    ')
-    [ -n "$version" ] || return 1
-    printf '%s\n' "$version"
-}
-
-verify_grok_command() {
-    if [ "$dry_run" -eq 1 ]; then
-        print_command grok version --json
-        return 0
-    fi
-
-    command -v grok >/dev/null 2>&1 || fail "Grok Build was installed, but 'grok' is not available on PATH."
-    version=$(current_grok_version) || fail "Grok Build is present, but 'grok version --json' did not return valid stable version metadata."
-    if ! stable_version_is_supported "$version" "$MIN_GROK_VERSION"; then
-        fail "Stable Grok Build $MIN_GROK_VERSION or newer is required; found Grok Build $version after installation."
-    fi
-    printf 'Verified Grok Build %s.\n' "$version"
-}
-
 install_grok_build() {
     download_and_run "$GROK_INSTALL_URL" bash "Grok Build"
     add_known_bin_directories
 }
 
 ensure_grok() {
-    if [ "$dry_run" -eq 1 ]; then
-        if command -v grok >/dev/null 2>&1; then
-            print_command grok version --json
-            printf 'A compatible Grok Build will be preserved; an older version will be upgraded with the official installer.\n'
-        else
-            install_grok_build
-        fi
-        verify_grok_command
-        return 0
-    fi
-
     if command -v grok >/dev/null 2>&1; then
-        version=$(current_grok_version) || fail "Grok Build is present, but 'grok version --json' did not return valid stable version metadata."
-        if stable_version_is_supported "$version" "$MIN_GROK_VERSION"; then
-            printf 'Grok Build %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_GROK_VERSION"
-            return 0
-        fi
-        printf 'Grok Build %s does not satisfy stable >=%s; upgrading it with the official installer.\n' "$version" "$MIN_GROK_VERSION"
-    fi
-
-    install_grok_build
-    verify_grok_command
-}
-
-current_muse_version() {
-    if output=$(muse --version 2>/dev/null); then
-        :
+        printf 'Grok Build already found on PATH; verifying it.\n'
     else
-        return 1
+        install_grok_build
     fi
 
-    version=$(printf '%s\n' "$output" | awk '
-        /^[[:space:]]*Muse Code[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+([[:space:]]+\([^\r\n]+\))?[[:space:]]*$/ &&
-        match($0, /[0-9]+\.[0-9]+\.[0-9]+/) {
-            print substr($0, RSTART, RLENGTH)
-            exit
-        }
-    ')
-    [ -n "$version" ] || return 1
-    printf '%s\n' "$version"
-}
-
-verify_muse_command() {
-    if [ "$dry_run" -eq 1 ]; then
-        print_command muse --version
-        return 0
-    fi
-
-    command -v muse >/dev/null 2>&1 || fail "Muse Code was installed, but 'muse' is not available on PATH."
-    version=$(current_muse_version) || fail "Muse Code is present, but 'muse --version' did not return the expected 'Muse Code x.y.z' version."
-    if ! stable_version_is_supported "$version" "$MIN_MUSE_VERSION"; then
-        fail "Muse Code $MIN_MUSE_VERSION or newer is required; found Muse Code $version after installation."
-    fi
-    printf 'Verified Muse Code %s.\n' "$version"
+    verify_command grok "Grok Build"
 }
 
 install_muse_code() {
@@ -1102,28 +866,13 @@ install_muse_code() {
 }
 
 ensure_muse() {
-    if [ "$dry_run" -eq 1 ]; then
-        if command -v muse >/dev/null 2>&1; then
-            print_command muse --version
-            printf 'A compatible Muse Code will be preserved; an older version will be upgraded with the official installer.\n'
-        else
-            install_muse_code
-        fi
-        verify_muse_command
-        return 0
-    fi
-
     if command -v muse >/dev/null 2>&1; then
-        version=$(current_muse_version) || fail "Muse Code is present, but 'muse --version' did not return the expected 'Muse Code x.y.z' version."
-        if stable_version_is_supported "$version" "$MIN_MUSE_VERSION"; then
-            printf 'Muse Code %s already satisfies >=%s; leaving it unchanged.\n' "$version" "$MIN_MUSE_VERSION"
-            return 0
-        fi
-        printf 'Muse Code %s does not satisfy >=%s; upgrading it with the official installer.\n' "$version" "$MIN_MUSE_VERSION"
+        printf 'Muse Code already found on PATH; verifying it.\n'
+    else
+        install_muse_code
     fi
 
-    install_muse_code
-    verify_muse_command
+    verify_command muse "Muse Code"
 }
 
 ensure_selected_coding_agents() {
@@ -1570,11 +1319,11 @@ else
     if [ "$install_grok" -eq 1 ]; then
         printf 'Run Grok Build with: fcc-grok\n'
     else
-        printf 'The fcc-grok wrapper is ready after you install Grok Build %s or newer.\n' "$MIN_GROK_VERSION"
+        printf 'The fcc-grok wrapper is ready after you install Grok Build.\n'
     fi
     if [ "$install_muse" -eq 1 ]; then
         printf 'Run Muse Code with: fcc-muse\n'
     else
-        printf 'The fcc-muse wrapper is ready after you install Muse Code %s or newer.\n' "$MIN_MUSE_VERSION"
+        printf 'The fcc-muse wrapper is ready after you install Muse Code.\n'
     fi
 fi

--- a/src/free_claude_code/cli/launchers/grok.py
+++ b/src/free_claude_code/cli/launchers/grok.py
@@ -13,6 +13,7 @@ from typing import Never
 from free_claude_code.cli.local_http import with_local_proxy_bypass
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
+from free_claude_code.core.json_types import JsonValue
 
 from .common import (
     preflight_proxy,
@@ -35,7 +36,8 @@ _INSTALL_HINT = (
 _MINIMUM_VERSION = (1, 0, 5)
 _VERSION_TIMEOUT_SECONDS = 5.0
 _VERSION_PATTERN = re.compile(
-    r"(?im)^\s*(?:grok\s+)?v?(\d+)\.(\d+)\.(\d+)(?:\s+\([^\r\n]*\))?\s*$"
+    r"^(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z.-]+)?"
+    r"(?:\s+\([^\r\n]*\))?$"
 )
 _PASSTHROUGH_COMMANDS = frozenset(
     {
@@ -268,11 +270,11 @@ def require_compatible_grok(binary_path: str) -> None:
 
 
 def grok_binary_version(binary_path: str) -> tuple[int, int, int] | None:
-    """Read a stable Grok Build version without invoking a shell."""
+    """Read Grok Build's machine-readable stable release metadata."""
 
     try:
         result = subprocess.run(
-            [binary_path, "--version"],
+            [binary_path, "version", "--json"],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -284,7 +286,17 @@ def grok_binary_version(binary_path: str) -> tuple[int, int, int] | None:
     if result.returncode != 0:
         return None
 
-    match = _VERSION_PATTERN.search(result.stdout)
+    try:
+        payload: JsonValue = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or payload.get("channel") != "stable":
+        return None
+
+    current_version = payload.get("currentVersion")
+    if not isinstance(current_version, str):
+        return None
+    match = _VERSION_PATTERN.fullmatch(current_version.strip())
     if match is None:
         return None
     return int(match.group(1)), int(match.group(2)), int(match.group(3))

--- a/tests/cli/test_grok_launcher.py
+++ b/tests/cli/test_grok_launcher.py
@@ -172,12 +172,18 @@ def test_route_bypass_flags_are_rejected_before_version_probe(argv: list[str]) -
 @pytest.mark.parametrize(
     ("output", "return_code", "expected"),
     [
-        ("1.0.5\n", 0, (1, 0, 5)),
-        ("grok 1.2.3\n", 0, (1, 2, 3)),
-        ("1.2.3 (abcdef)\n", 0, (1, 2, 3)),
-        ("1.2.3-alpha.1\n", 0, None),
-        ("unexpected 1.2.3\n", 0, None),
-        ("1.2.3\n", 1, None),
+        (
+            '{"currentVersion":"1.0.5 (5115b46bc9)","channel":"stable"}',
+            0,
+            (1, 0, 5),
+        ),
+        ('{"channel":"stable","currentVersion":"1.2.3+build.1"}', 0, (1, 2, 3)),
+        ('{"currentVersion":"1.2.3-alpha.1","channel":"stable"}', 0, None),
+        ('{"currentVersion":"1.2.3","channel":"preview"}', 0, None),
+        ('{"currentVersion":123,"channel":"stable"}', 0, None),
+        ('{"currentVersion":"1.2.3","channel":"stable"}', 1, None),
+        ("not-json", 0, None),
+        ("[]", 0, None),
     ],
 )
 def test_grok_version_probe(
@@ -191,8 +197,16 @@ def test_grok_version_probe(
         grok.subprocess,
         "run",
         return_value=SimpleNamespace(stdout=output, returncode=return_code),
-    ):
+    ) as run:
         assert grok.grok_binary_version("resolved-grok") == expected
+    run.assert_called_once_with(
+        ["resolved-grok", "version", "--json"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=5.0,
+    )
 
 
 def test_grok_version_probe_handles_timeout() -> None:

--- a/tests/cli/test_grok_launcher.py
+++ b/tests/cli/test_grok_launcher.py
@@ -182,6 +182,7 @@ def test_route_bypass_flags_are_rejected_before_version_probe(argv: list[str]) -
         ('{"currentVersion":"1.2.3","channel":"preview"}', 0, None),
         ('{"currentVersion":123,"channel":"stable"}', 0, None),
         ('{"currentVersion":"1.2.3","channel":"stable"}', 1, None),
+        ('{"currentVersion":"1.2.3\t(build)","channel":"stable"}', 0, None),
         ("not-json", 0, None),
         ("[]", 0, None),
     ],

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -52,7 +52,7 @@ def _braced_body(text: str, declaration: str) -> str:
     raise AssertionError(f"Unclosed function body for {declaration}")
 
 
-def _posix_command(name: str) -> str:
+def _posix_command(name: str, *, version_output: str | None = None) -> str:
     version = {
         "opencode": "1.18.18",
         "cline": "3.0.55",
@@ -62,18 +62,16 @@ def _posix_command(name: str) -> str:
         "muse": "0.2.1",
         "node": "22.19.0",
     }.get(name, "1.0.0")
-    if name == "grok":
-        version_command = f'''if [ "${{1:-}}" = "version" ] && [ "${{2:-}}" = "--json" ]; then
-    echo '{{"currentVersion":"{version} (5115b46bc9)","channel":"stable"}}'
-fi'''
-    else:
+    if version_output is None:
         if name == "hermes":
             version_output = f"Hermes Agent v{version} (test build)"
+        elif name == "grok":
+            version_output = f"grok {version} (5115b46bc9) [stable]"
         elif name == "muse":
             version_output = f"Muse Code {version} ({version}-R1215.1)"
         else:
             version_output = f"{name} {version}"
-        version_command = f'''if [ "${{1:-}}" = "--version" ]; then
+    version_command = f'''if [ "${{1:-}}" = "--version" ]; then
     echo "{version_output}"
 fi'''
     help_output = (
@@ -555,7 +553,7 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
     assert calls.index("npm:install -g @deepseek-ai/dsh@0.1.0-rc.8") < calls.index(
         "dsh:--version"
     )
-    assert calls.index("grok-install") < calls.index("grok:version --json")
+    assert calls.index("grok-install") < calls.index("grok:--version")
     assert calls.index("muse-install") < calls.index("muse:--version")
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
@@ -590,7 +588,7 @@ def test_install_sh_discovers_grok_in_custom_bin_directory(
     assert (custom_grok_bin / "grok").is_file()
     assert not (Path(posix_harness.env["HOME"]) / ".grok" / "bin" / "grok").exists()
     calls = posix_harness.calls()
-    assert calls.index("grok-install") < calls.index("grok:version --json")
+    assert calls.index("grok-install") < calls.index("grok:--version")
 
 
 def test_install_sh_installs_selected_hermes_without_setup(
@@ -639,81 +637,32 @@ def test_install_sh_rejects_unsupported_hermes_platform_before_download(
     )
 
 
-def test_install_sh_preserves_compatible_existing_hermes(
+@pytest.mark.parametrize(
+    ("client", "install_call"),
+    [
+        ("opencode", "opencode-install"),
+        ("cline", "npm:install -g cline"),
+        ("hermes", "hermes-install:--non-interactive --skip-setup"),
+        ("grok", "grok-install"),
+        ("muse", "muse-install"),
+    ],
+)
+def test_install_sh_preserves_upstream_managed_harness_without_parsing_version(
     posix_harness: PosixHarness,
-) -> None:
-    posix_harness.add_client("hermes")
-
-    result = posix_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    assert "Hermes Agent 0.20.4 already satisfies >=0.20.4" in result.stdout
-    assert not any(
-        "hermes-agent.nousresearch.com" in call for call in posix_harness.calls()
-    )
-
-
-def test_install_sh_preserves_compatible_existing_grok(
-    posix_harness: PosixHarness,
-) -> None:
-    posix_harness.add_client("grok")
-
-    result = posix_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    assert "Grok Build 1.0.5 already satisfies >=1.0.5" in result.stdout
-    assert not any("x.ai/cli" in call for call in posix_harness.calls())
-
-
-def test_install_sh_rejects_nonstable_grok_metadata(
-    posix_harness: PosixHarness,
+    client: str,
+    install_call: str,
 ) -> None:
     _write_executable(
-        posix_harness.bin_dir / "grok",
-        _posix_command("grok").replace('"channel":"stable"', '"channel":"preview"'),
-    )
-
-    result = posix_harness.run()
-
-    assert result.returncode != 0
-    assert "did not return valid stable version metadata" in result.stderr
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
-
-
-def test_install_sh_rejects_malformed_grok_metadata(
-    posix_harness: PosixHarness,
-) -> None:
-    _write_executable(
-        posix_harness.bin_dir / "grok",
-        _posix_command("grok").replace(
-            '{"currentVersion":"1.0.5 (5115b46bc9)","channel":"stable"}',
-            'not-json "currentVersion":"1.0.5 (5115b46bc9)" "channel":"stable"',
-        ),
-    )
-
-    result = posix_harness.run()
-
-    assert result.returncode != 0
-    assert "did not return valid stable version metadata" in result.stderr
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
-
-
-def test_install_sh_upgrades_old_grok_with_official_installer(
-    posix_harness: PosixHarness,
-) -> None:
-    _write_executable(
-        posix_harness.bin_dir / "grok",
-        _posix_command("grok").replace(
-            '"currentVersion":"1.0.5', '"currentVersion":"1.0.4'
-        ),
+        posix_harness.bin_dir / client,
+        _posix_command(client, version_output="opaque upstream version output"),
     )
 
     result = posix_harness.run()
 
     assert result.returncode == 0, result.stderr
-    assert "does not satisfy stable >=1.0.5" in result.stdout
-    assert "download:https://x.ai/cli/install.sh" in posix_harness.calls()
-    assert "grok-install" in posix_harness.calls()
+    calls = posix_harness.calls()
+    assert f"{client}:--version" in calls
+    assert install_call not in calls
 
 
 @pytest.mark.parametrize("failure", ["grok-download", "grok-install"])
@@ -728,37 +677,6 @@ def test_install_sh_stops_when_grok_install_fails(
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
     assert not any(call.startswith("uv:") for call in posix_harness.calls())
-
-
-def test_install_sh_preserves_compatible_existing_muse(
-    posix_harness: PosixHarness,
-) -> None:
-    posix_harness.add_client("muse")
-
-    result = posix_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    assert "Muse Code 0.2.1 already satisfies >=0.2.1" in result.stdout
-    assert not any("dev.meta.ai" in call for call in posix_harness.calls())
-
-
-def test_install_sh_upgrades_old_muse_with_official_installer(
-    posix_harness: PosixHarness,
-) -> None:
-    _write_executable(
-        posix_harness.bin_dir / "muse",
-        _posix_command("muse").replace(
-            "Muse Code 0.2.1 (0.2.1-R1215.1)",
-            "Muse Code 0.2.0 (0.2.0-R1200.1)",
-        ),
-    )
-
-    result = posix_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    assert "Muse Code 0.2.0 does not satisfy >=0.2.1" in result.stdout
-    assert "download:https://dev.meta.ai/install.sh" in posix_harness.calls()
-    assert "muse-install" in posix_harness.calls()
 
 
 @pytest.mark.parametrize("failure", ["muse-download", "muse-install"])
@@ -1563,7 +1481,7 @@ def _windows_shortcut_icon(
     return completed.stdout
 
 
-def _batch_client(name: str) -> str:
+def _batch_client(name: str, *, version_output: str | None = None) -> str:
     version = {
         "opencode": "1.18.18",
         "cline": "3.0.55",
@@ -1573,8 +1491,8 @@ def _batch_client(name: str) -> str:
         "muse": "0.2.1",
         "node": "22.19.0",
     }.get(name, "1.0.0")
-    if name == "grok":
-        version_command = f'if "%1 %2"=="version --json" echo {{"currentVersion":"{version} (5115b46bc9)","channel":"stable"}}'
+    if version_output is not None:
+        version_command = f'if "%1"=="--version" echo {version_output}'
     elif name == "hermes":
         version_command = (
             f'if "%1"=="--version" echo Hermes Agent v{version} '
@@ -1584,6 +1502,10 @@ def _batch_client(name: str) -> str:
             'if "%1"=="--version" echo Python: 3.12.11\n'
             'if "%1"=="--version" echo OpenAI SDK: 2.15.0\n'
             'if "%1"=="--version" echo Up to date'
+        )
+    elif name == "grok":
+        version_command = (
+            f'if "%1"=="--version" echo grok {version} (5115b46bc9) [stable]'
         )
     elif name == "muse":
         version_command = (
@@ -2027,7 +1949,7 @@ def test_install_ps1_fresh_install_is_verified(
     assert calls.index("npm:install -g @deepseek-ai/dsh@0.1.0-rc.8") < calls.index(
         "dsh:--version"
     )
-    assert calls.index("grok-install") < calls.index("grok:version --json")
+    assert calls.index("grok-install") < calls.index("grok:--version")
     assert "Muse Code is not installed" in result.stdout
     assert not any(call.startswith("muse:") for call in calls)
     assert not any("hermes:setup" in call for call in calls)
@@ -2088,130 +2010,35 @@ def test_install_ps1_discovers_grok_in_custom_bin_directory(
         Path(powershell_harness.env["USERPROFILE"]) / ".grok" / "bin" / "grok.cmd"
     ).exists()
     calls = powershell_harness.calls()
-    assert calls.index("grok-install") < calls.index("grok:version --json")
-
-
-def test_install_ps1_preserves_compatible_existing_hermes(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    powershell_harness.add_client("hermes")
-
-    result = powershell_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    assert "Hermes Agent 0.20.4 already satisfies >=0.20.4" in result.stdout
-    assert not any(
-        "hermes-agent.nousresearch.com" in call for call in powershell_harness.calls()
-    )
-
-
-@pytest.mark.parametrize("unrelated_version", ["3.12.11", "v3.12.11"])
-def test_install_ps1_rejects_unrelated_versions_in_hermes_output(
-    powershell_harness: PowerShellHarness,
-    unrelated_version: str,
-) -> None:
-    hermes_command = (
-        _batch_client("hermes")
-        .replace(
-            "echo Hermes Agent v0.20.4 (2026.8.18) · upstream deadbeef",
-            "echo Hermes Agent release unavailable",
-        )
-        .replace(
-            "echo Python: 3.12.11",
-            f"echo {unrelated_version}",
-        )
-    )
-    _write_executable(powershell_harness.bin_dir / "hermes.cmd", hermes_command)
-
-    result = powershell_harness.run()
-
-    assert result.returncode != 0
-    assert "did not return a valid semantic version" in result.stderr
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
-
-
-def test_install_ps1_preserves_compatible_existing_grok(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    powershell_harness.add_client("grok")
-
-    result = powershell_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    assert "Grok Build 1.0.5 already satisfies >=1.0.5" in result.stdout
-    assert not any("x.ai/cli" in call for call in powershell_harness.calls())
-
-
-def test_install_ps1_rejects_nonstable_grok_metadata(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    _write_executable(
-        powershell_harness.bin_dir / "grok.cmd",
-        _batch_client("grok").replace('"channel":"stable"', '"channel":"preview"'),
-    )
-
-    result = powershell_harness.run()
-
-    assert result.returncode != 0
-    assert "did not return valid stable version metadata" in result.stderr
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
-
-
-def test_install_ps1_preserves_compatible_existing_muse(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    powershell_harness.add_client("muse")
-
-    result = powershell_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    assert "Verified Muse Code 0.2.1" in result.stdout
-    assert "Run Muse Code with: fcc-muse" in result.stdout
-    assert not any("meta.ai" in call for call in powershell_harness.calls())
+    assert calls.index("grok-install") < calls.index("grok:--version")
 
 
 @pytest.mark.parametrize(
-    "version_output",
+    ("client", "install_call"),
     [
-        "Muse Code 0.2.0 (0.2.0-R1200.1)",
-        "Meta launcher build 0.2.1",
+        ("opencode", "anomalyco/opencode"),
+        ("cline", "npm:install -g cline"),
+        ("hermes", "hermes-install:True:True"),
+        ("grok", "grok-install"),
+        ("muse", "meta.ai"),
     ],
 )
-def test_install_ps1_rejects_incompatible_muse_without_inventing_an_updater(
+def test_install_ps1_preserves_upstream_managed_harness_without_parsing_version(
     powershell_harness: PowerShellHarness,
-    version_output: str,
+    client: str,
+    install_call: str,
 ) -> None:
     _write_executable(
-        powershell_harness.bin_dir / "muse.cmd",
-        _batch_client("muse").replace(
-            "Muse Code 0.2.1 (0.2.1-R1215.1)", version_output
-        ),
-    )
-
-    result = powershell_harness.run()
-
-    assert result.returncode != 0
-    assert "Muse Code" in result.stderr
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
-    assert not any("meta.ai" in call for call in powershell_harness.calls())
-
-
-def test_install_ps1_upgrades_old_grok_with_official_installer(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    (powershell_harness.bin_dir / "grok.cmd").write_text(
-        _batch_client("grok").replace(
-            '"currentVersion":"1.0.5', '"currentVersion":"1.0.4'
-        ),
-        encoding="utf-8",
+        powershell_harness.bin_dir / f"{client}.cmd",
+        _batch_client(client, version_output="opaque upstream version output"),
     )
 
     result = powershell_harness.run()
 
     assert result.returncode == 0, result.stderr
-    assert "does not satisfy stable >=1.0.5" in result.stdout
-    assert "download:https://x.ai/cli/install.ps1" in powershell_harness.calls()
-    assert "grok-install" in powershell_harness.calls()
+    calls = powershell_harness.calls()
+    assert f"{client}:--version" in calls
+    assert not any(install_call in call for call in calls)
 
 
 @pytest.mark.parametrize("failure", ["grok-download", "grok-install"])
@@ -2319,58 +2146,9 @@ def test_install_ps1_stops_when_selected_dsh_install_fails(
     assert not any(call.startswith("uv:") for call in powershell_harness.calls())
 
 
-def test_install_ps1_upgrades_old_hermes_with_noninteractive_setup_skipped(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    hermes_bin = (
-        Path(powershell_harness.env["LOCALAPPDATA"]) / "hermes" / "hermes-agent" / "bin"
-    )
-    hermes_bin.mkdir(parents=True)
-    (hermes_bin / "hermes.cmd").write_text(
-        _batch_client("hermes").replace("v0.20.4", "v0.19.9"),
-        encoding="utf-8",
-    )
-
-    result = powershell_harness.run()
-
-    assert result.returncode == 0, result.stderr
-    calls = powershell_harness.calls()
-    assert any("hermes-agent.nousresearch.com/install.ps1" in call for call in calls)
-    assert "hermes-install:True:True" in calls
-    assert not any("hermes:setup" in call for call in calls)
-    assert not any(call.startswith("rtk:init") for call in calls)
-
-
-def test_install_ps1_stops_when_hermes_upgrade_fails(
-    powershell_harness: PowerShellHarness,
-) -> None:
-    hermes_bin = (
-        Path(powershell_harness.env["LOCALAPPDATA"]) / "hermes" / "hermes-agent" / "bin"
-    )
-    hermes_bin.mkdir(parents=True)
-    (hermes_bin / "hermes.cmd").write_text(
-        _batch_client("hermes").replace("v0.20.4", "v0.19.9"),
-        encoding="utf-8",
-    )
-
-    result = powershell_harness.run(fail_step="hermes-install")
-
-    assert result.returncode != 0
-    assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any("astral.sh" in call for call in powershell_harness.calls())
-
-
 def test_install_ps1_rejects_unsupported_hermes_architecture_before_download(
     powershell_harness: PowerShellHarness,
 ) -> None:
-    hermes_bin = (
-        Path(powershell_harness.env["LOCALAPPDATA"]) / "hermes" / "hermes-agent" / "bin"
-    )
-    hermes_bin.mkdir(parents=True)
-    (hermes_bin / "hermes.cmd").write_text(
-        _batch_client("hermes").replace("v0.20.4", "v0.19.9"),
-        encoding="utf-8",
-    )
     powershell_harness.env["PROCESSOR_ARCHITECTURE"] = "MIPS"
     powershell_harness.env["PROCESSOR_ARCHITEW6432"] = "MIPS"
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -62,12 +62,20 @@ def _posix_command(name: str) -> str:
         "muse": "0.2.1",
         "node": "22.19.0",
     }.get(name, "1.0.0")
-    if name == "hermes":
-        version_output = f"Hermes Agent v{version} (test build)"
-    elif name == "muse":
-        version_output = f"Muse Code {version} ({version}-R1215.1)"
+    if name == "grok":
+        version_command = f'''if [ "${{1:-}}" = "version" ] && [ "${{2:-}}" = "--json" ]; then
+    echo '{{"currentVersion":"{version} (5115b46bc9)","channel":"stable"}}'
+fi'''
     else:
-        version_output = f"{name} {version}"
+        if name == "hermes":
+            version_output = f"Hermes Agent v{version} (test build)"
+        elif name == "muse":
+            version_output = f"Muse Code {version} ({version}-R1215.1)"
+        else:
+            version_output = f"{name} {version}"
+        version_command = f'''if [ "${{1:-}}" = "--version" ]; then
+    echo "{version_output}"
+fi'''
     help_output = (
         '    echo "  --extension, -e <path>  Load an extension"\n'
         '    echo "  --models <patterns>     Scope models"'
@@ -79,9 +87,7 @@ echo "{name}:$*" >> "$CALL_LOG"
 if [ "$FAIL_STEP" = "{name}-verify" ]; then
     exit 31
 fi
-if [ "${{1:-}}" = "--version" ]; then
-    echo "{version_output}"
-fi
+{version_command}
 if [ "${{1:-}}" = "--help" ]; then
 {help_output}
 fi
@@ -549,7 +555,7 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
     assert calls.index("npm:install -g @deepseek-ai/dsh@0.1.0-rc.8") < calls.index(
         "dsh:--version"
     )
-    assert calls.index("grok-install") < calls.index("grok:--version")
+    assert calls.index("grok-install") < calls.index("grok:version --json")
     assert calls.index("muse-install") < calls.index("muse:--version")
     assert calls.index("uv-install") < calls.index("uv:--version")
     assert any(
@@ -584,7 +590,7 @@ def test_install_sh_discovers_grok_in_custom_bin_directory(
     assert (custom_grok_bin / "grok").is_file()
     assert not (Path(posix_harness.env["HOME"]) / ".grok" / "bin" / "grok").exists()
     calls = posix_harness.calls()
-    assert calls.index("grok-install") < calls.index("grok:--version")
+    assert calls.index("grok-install") < calls.index("grok:version --json")
 
 
 def test_install_sh_installs_selected_hermes_without_setup(
@@ -659,12 +665,29 @@ def test_install_sh_preserves_compatible_existing_grok(
     assert not any("x.ai/cli" in call for call in posix_harness.calls())
 
 
+def test_install_sh_rejects_nonstable_grok_metadata(
+    posix_harness: PosixHarness,
+) -> None:
+    _write_executable(
+        posix_harness.bin_dir / "grok",
+        _posix_command("grok").replace('"channel":"stable"', '"channel":"preview"'),
+    )
+
+    result = posix_harness.run()
+
+    assert result.returncode != 0
+    assert "did not return valid stable version metadata" in result.stderr
+    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+
+
 def test_install_sh_upgrades_old_grok_with_official_installer(
     posix_harness: PosixHarness,
 ) -> None:
     _write_executable(
         posix_harness.bin_dir / "grok",
-        _posix_command("grok").replace("grok 1.0.5", "grok 1.0.4"),
+        _posix_command("grok").replace(
+            '"currentVersion":"1.0.5', '"currentVersion":"1.0.4'
+        ),
     )
 
     result = posix_harness.run()
@@ -1532,8 +1555,10 @@ def _batch_client(name: str) -> str:
         "muse": "0.2.1",
         "node": "22.19.0",
     }.get(name, "1.0.0")
-    version_output = (
-        (
+    if name == "grok":
+        version_command = f'if "%1 %2"=="version --json" echo {{"currentVersion":"{version} (5115b46bc9)","channel":"stable"}}'
+    elif name == "hermes":
+        version_command = (
             f'if "%1"=="--version" echo Hermes Agent v{version} '
             "(2026.8.18) · upstream deadbeef\n"
             'if "%1"=="--version" echo Install directory: C:\\fake-hermes\n'
@@ -1542,13 +1567,12 @@ def _batch_client(name: str) -> str:
             'if "%1"=="--version" echo OpenAI SDK: 2.15.0\n'
             'if "%1"=="--version" echo Up to date'
         )
-        if name == "hermes"
-        else (
+    elif name == "muse":
+        version_command = (
             f'if "%1"=="--version" echo Muse Code {version} ({version}-R1215.1)'
-            if name == "muse"
-            else f'if "%1"=="--version" echo {name} {version}'
         )
-    )
+    else:
+        version_command = f'if "%1"=="--version" echo {name} {version}'
     help_output = (
         "echo   --extension, -e ^<path^>  Load an extension\n"
         "echo   --models ^<patterns^>     Scope models"
@@ -1558,7 +1582,7 @@ def _batch_client(name: str) -> str:
     return f"""@echo off
 echo {name}:%*>>"%CALL_LOG%"
 if "%FAIL_STEP%"=="{name}-verify" exit /b 51
-{version_output}
+{version_command}
 if "%1"=="--help" (
 {help_output}
 )
@@ -1985,7 +2009,7 @@ def test_install_ps1_fresh_install_is_verified(
     assert calls.index("npm:install -g @deepseek-ai/dsh@0.1.0-rc.8") < calls.index(
         "dsh:--version"
     )
-    assert calls.index("grok-install") < calls.index("grok:--version")
+    assert calls.index("grok-install") < calls.index("grok:version --json")
     assert "Muse Code is not installed" in result.stdout
     assert not any(call.startswith("muse:") for call in calls)
     assert not any("hermes:setup" in call for call in calls)
@@ -2046,7 +2070,7 @@ def test_install_ps1_discovers_grok_in_custom_bin_directory(
         Path(powershell_harness.env["USERPROFILE"]) / ".grok" / "bin" / "grok.cmd"
     ).exists()
     calls = powershell_harness.calls()
-    assert calls.index("grok-install") < calls.index("grok:--version")
+    assert calls.index("grok-install") < calls.index("grok:version --json")
 
 
 def test_install_ps1_preserves_compatible_existing_hermes(
@@ -2100,6 +2124,21 @@ def test_install_ps1_preserves_compatible_existing_grok(
     assert not any("x.ai/cli" in call for call in powershell_harness.calls())
 
 
+def test_install_ps1_rejects_nonstable_grok_metadata(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    _write_executable(
+        powershell_harness.bin_dir / "grok.cmd",
+        _batch_client("grok").replace('"channel":"stable"', '"channel":"preview"'),
+    )
+
+    result = powershell_harness.run()
+
+    assert result.returncode != 0
+    assert "did not return valid stable version metadata" in result.stderr
+    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+
+
 def test_install_ps1_preserves_compatible_existing_muse(
     powershell_harness: PowerShellHarness,
 ) -> None:
@@ -2143,7 +2182,9 @@ def test_install_ps1_upgrades_old_grok_with_official_installer(
     powershell_harness: PowerShellHarness,
 ) -> None:
     (powershell_harness.bin_dir / "grok.cmd").write_text(
-        _batch_client("grok").replace("grok 1.0.5", "grok 1.0.4"),
+        _batch_client("grok").replace(
+            '"currentVersion":"1.0.5', '"currentVersion":"1.0.4'
+        ),
         encoding="utf-8",
     )
 

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -680,6 +680,24 @@ def test_install_sh_rejects_nonstable_grok_metadata(
     assert not any(call.startswith("uv:") for call in posix_harness.calls())
 
 
+def test_install_sh_rejects_malformed_grok_metadata(
+    posix_harness: PosixHarness,
+) -> None:
+    _write_executable(
+        posix_harness.bin_dir / "grok",
+        _posix_command("grok").replace(
+            '{"currentVersion":"1.0.5 (5115b46bc9)","channel":"stable"}',
+            'not-json "currentVersion":"1.0.5 (5115b46bc9)" "channel":"stable"',
+        ),
+    )
+
+    result = posix_harness.run()
+
+    assert result.returncode != 0
+    assert "did not return valid stable version metadata" in result.stderr
+    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+
+
 def test_install_sh_upgrades_old_grok_with_official_installer(
     posix_harness: PosixHarness,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.8"
+version = "5.13.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Installers duplicated external harness version parsing across shell, PowerShell, and Python. Grok Build's valid decorated version stopped installation, while attempts to duplicate its JSON contract in shell introduced malformed-metadata edge cases. Fixes #1521.

## Changes

| Before | After |
| --- | --- |
| Installers parsed and compared OpenCode, Cline, Hermes, Grok, and Muse versions independently. | Installers verify upstream-managed harnesses with their successful `--version` command. |
| Existing external harnesses could be automatically upgraded by FCC's installer. | Existing external harnesses remain untouched; their `fcc-*` launchers enforce compatibility when used. |
| Grok's human display output and shell JSON matching could block installation. | Grok installation uses generic command verification; the Python launcher alone validates stable JSON metadata. |
| uv, DeepSeek/Node, Pi, and RTK shared the same conceptual verification bucket. | FCC-owned, pinned, dependency, and identity contracts retain their specialized checks. |
| The package version was 5.13.8. | The package version is 5.13.9 with one patch bump. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Grok launcher now uses structured version metadata, but the POSIX installer can still retain an incompatible existing Grok installation. A preview or outdated executable can make installation complete successfully even though the advertised `fcc-grok` command cannot run with it.
</details>


<h3>Confidence Score: 4/5</h3>

Not ready to merge until the installer validates existing Grok installations against the same compatibility requirements as the launcher.

The installer accepts an existing Grok executable solely because `grok --version` exits successfully, while the launcher rejects that same executable when its structured metadata identifies it as an unsupported preview release.

**Files Needing Attention:** scripts/install.sh

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the P1 finding using the Focused Grok installer and launcher reproduction script.
- Observed that the installer accepts an old preview Grok while fcc-grok rejects it.
- Validated the final reproduction script's shell syntax.
- Ran the end-to-end contract validation script and confirmed the version checks pass and the launcher gate rejects the fake release.
- Noted there is an additional P1 finding proof without artifacts.

<a href="https://app.greptile.com/trex/runs/20220616/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Installer accepts Grok versions that fcc-grok rejects**

   - **Bug**
     - An existing Grok executable returning success from `grok --version` is treated as verified by the installer even when it is an old prerelease build. The installer completes and advertises `fcc-grok`, but the launcher rejects the same executable because it is not a stable release meeting the minimum supported version.
   - **Cause**
     - `ensure_grok` calls generic `verify_command` at `scripts/install.sh:856`; `verify_command` at lines 417-428 only resolves the command and executes `<path> --version`, without JSON parsing, stable-channel validation, prerelease rejection, or a minimum-version comparison. `fcc-grok` instead uses `grok version --json` and checks stable semantic version `>= 1.0.5` at `src/free_claude_code/cli/launchers/grok.py:255-302`.
   - **Fix**
     - Replace the generic Grok verification at `scripts/install.sh:856` with a Grok-specific verifier that executes `grok version --json`, requires a JSON object with `channel` equal to `stable`, rejects prerelease or malformed `currentVersion`, and enforces version `>= 1.0.5` to match `fcc-grok`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-grok-version-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-grok-version-contract%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231525%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=alishahryar1%2Ffree-claude-code&pr=1525&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-grok-version-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-grok-version-contract%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Finstall.sh%3A856%0A**Grok%20verification%20accepts%20unsupported%20installations**%0A%0A%60ensure_grok%60%20delegates%20an%20existing%20installation%20to%20%60verify_command%60%2C%20which%20only%20requires%20%60grok%20--version%60%20to%20exit%20successfully.%20An%20old%20preview%20build%20can%20therefore%20make%20the%20installer%20succeed%20and%20advertise%20%60fcc-grok%60%2C%20even%20though%20the%20launcher%20rejects%20that%20same%20binary%20because%20its%20JSON%20metadata%20is%20not%20a%20stable%20release%20at%20least%20version%201.0.5.%20Verify%20Grok%20with%20%60grok%20version%20--json%60%20and%20enforce%20the%20same%20stable-channel%20and%20minimum-version%20contract%20as%20the%20launcher.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Simplify upstream harness installer veri..."](https://github.com/alishahryar1/free-claude-code/commit/1fdae4f7588bd8c43c5c088cb35a818702224ba4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55935987)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->