### PR TITLE
Escape Telegram MarkdownV2 image fallback as plain text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.8"
+version = "5.13.9"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.9"
+version = "5.13.10"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/messaging/rendering/telegram_markdown.py
+++ b/src/free_claude_code/messaging/rendering/telegram_markdown.py
@@ -128,10 +128,14 @@ def render_markdown_to_mdv2(text: str) -> str:
                             if key == "src":
                                 href = val
                                 break
+                # MarkdownV2 has no image entity, so an image degrades to plain
+                # text. Escape it as text: escape_md_v2_link_url only covers the
+                # link-destination set and would leave '(', ')', '.', '_' bare,
+                # which Telegram rejects with "can't parse entities".
                 if alt:
-                    out.append(f"{escape_md_v2(alt)} ({escape_md_v2_link_url(href)})")
+                    out.append(escape_md_v2(f"{alt} ({href})"))
                 else:
-                    out.append(escape_md_v2_link_url(href))
+                    out.append(escape_md_v2(href))
             else:
                 out.append(escape_md_v2(tok.content or ""))
             i += 1

--- a/tests/messaging/test_handler_markdown_and_status_edges.py
+++ b/tests/messaging/test_handler_markdown_and_status_edges.py
@@ -7,6 +7,7 @@ from free_claude_code.messaging.command_context import StopOutcome
 from free_claude_code.messaging.models import IncomingMessage, MessageScope
 from free_claude_code.messaging.node_event_pipeline import process_parsed_cli_event
 from free_claude_code.messaging.rendering.telegram_markdown import (
+    escape_md_v2,
     render_markdown_to_mdv2,
 )
 from free_claude_code.messaging.trees import (
@@ -85,8 +86,32 @@ def test_render_markdown_to_mdv2_covers_common_structures():
     assert "3\\." in out
     assert "> quote" in out
     assert "[link]" in out
-    assert "alt (http://example.com/img.png)" in out
+    assert escape_md_v2("alt (http://example.com/img.png)") in out
     assert "```" in out
+
+
+def test_render_markdown_to_mdv2_escapes_image_fallback_as_plain_text():
+    out = render_markdown_to_mdv2("![alt](http://x.com/a_b.png)")
+
+    assert out == escape_md_v2("alt (http://x.com/a_b.png)")
+    assert "(" not in out.replace("\\(", "")
+    assert ")" not in out.replace("\\)", "")
+    assert "." not in out.replace("\\.", "")
+    assert "_" not in out.replace("\\_", "")
+
+
+def test_render_markdown_to_mdv2_escapes_image_without_alt_text():
+    out = render_markdown_to_mdv2("![](http://x.com/a-b.png)")
+
+    assert out == escape_md_v2("http://x.com/a-b.png")
+    assert "." not in out.replace("\\.", "")
+    assert "-" not in out.replace("\\-", "")
+
+
+def test_render_markdown_to_mdv2_escapes_image_embedded_in_text():
+    out = render_markdown_to_mdv2("see ![d](https://e.com/d-1.png) here")
+
+    assert escape_md_v2("d (https://e.com/d-1.png)") in out
 
 
 def test_render_markdown_to_mdv2_renders_table_as_code_block():

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.8"
+version = "5.13.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.9"
+version = "5.13.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

A Markdown image in assistant output renders to **invalid Telegram MarkdownV2**, so Telegram rejects the request with `400 Bad Request: can't parse entities` and the **entire message fails to send** — not just the image.

`render_markdown_to_mdv2` has no MarkdownV2 image entity to emit, so an image degrades to plain text. The image branch escaped that plain text with `escape_md_v2_link_url`, which by design only escapes the link-destination set (`\` and `)`). Everything else Telegram reserves in ordinary text is left bare:

```python
>>> render_markdown_to_mdv2("![alt](http://x.com/a_b.png)")
'alt (http://x.com/a_b.png)'
```

`(`, `)`, `.` and `_` are all unescaped, and none of them sits inside a link or code entity. Any assistant reply containing an image — a diagram, a screenshot link, a badge — takes the whole message down.

## Changes

| Before | After |
| --- | --- |
| Image fallback text escaped with `escape_md_v2_link_url` (link-destination set only). | Image fallback text escaped with `escape_md_v2`, matching how it is actually emitted: plain text. |
| `![alt](http://x.com/a_b.png)` → `alt (http://x.com/a_b.png)` (Telegram 400). | → `alt \(http://x\.com/a\_b\.png\)` (accepted). |
| No test covered the image path for Telegram. | Three focused tests cover alt, no-alt, and inline-in-text forms. |
| Package version was 5.13.9. | Package version is 5.13.10. |

The alt-text and URL are now escaped together as one plain-text run, since that is exactly what they are once the image entity is gone.

## Note on the changed assertion

`test_render_markdown_to_mdv2_covers_common_structures` asserted the unescaped output:

```python
assert "alt (http://example.com/img.png)" in out
```

That assertion encoded the bug — the string it pinned is the one Telegram rejects. It is now:

```python
assert escape_md_v2("alt (http://example.com/img.png)") in out
```

This matches how the sibling truncation-marker assertions in `tests/messaging/test_transcript.py` already express expected MarkdownV2 (`assert escape_md_v2("... (truncated)") in out`).

## Verification

Reproduced against `main` before the change and confirmed fixed after, for alt / no-alt / inline / heading / list-item forms. Each output was checked by walking it the way Telegram's parser does — honouring backslash escapes, code spans and fenced blocks — and asserting no reserved character survives unescaped outside an entity.

`./scripts/ci.sh --skip playwright` passes: ruff format, ruff check, ty, and 3650 tests (119 skipped). Playwright was skipped locally as it only drives the Admin UI, which this change does not touch; CI will run it.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Telegram image fallbacks now render alt text and image URLs as escaped MarkdownV2 plain text, so image-containing responses remain parseable by Telegram. Focused renderer tests pass, and the project version and lockfile are synchronized at 5.13.10.

<h3>Confidence Score: 5/5</h3>

Safe to merge: image fallback output correctly escapes Telegram MarkdownV2 plain-text syntax.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a Python 3.14 renderer probe with uv run against the PR parent and current revision to verify image text escaping for alt text, empty alt text, embedded prose, and special characters.
- I observed that the parent renderer left MarkdownV2-special characters bare, while the current output showed unescaped\_plain\_text\_specials: \[\] for every case, indicating the fix updated escaping behavior.
- I executed the focused Telegram MarkdownV2 tests with pytest and all 20 tests passed, confirming the escaping and messaging behavior are preserved.
- I reviewed the post-fix changes in the escape branch (lines 135-138) that apply escape\_md\_v2 to alt text and href, and verified the after-state shows unescaped\_plain\_text\_specials: \[\], matching the intended behavior.

<a href="https://app.greptile.com/trex/runs/20227952/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Bump version to 5.13.10"](https://github.com/alishahryar1/free-claude-code/commit/d9184a311ab724a626a5adcce6094f2ea59f69d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55968342)</sub>

<!-- /greptile_comment -->