### PR TITLE
Add LLM7.io as the 50th provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,11 @@ NARAROUTE_BASE_URL="https://router.bynara.id/v1"
 # Poolside AI (OpenAI-compatible Chat Completions at inference.poolside.ai/v1)
 # POOLSIDE_API_KEY=<your-token>
 
+
+# LLM7.io (OpenAI-compatible Chat Completions at api.llm7.io/v1)
+# LLM7_API_KEY=<your-token>
+
+
 # Fireworks AI Config (OpenAI-compatible Chat Completions at api.fireworks.ai/inference/v1)
 # FIREWORKS_API_KEY=<your-token>
 
@@ -191,7 +196,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # Default model and optional Claude tier overrides
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "poolside"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "poolside" | "llm7"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -232,6 +237,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # FCC_SMOKE_MODEL_TOKENROUTER=<your-token>
 # FCC_SMOKE_MODEL_NARAROUTE=<provider/model-id>
 # FCC_SMOKE_MODEL_POOLSIDE=<provider/model-id>
+# FCC_SMOKE_MODEL_LLM7=<provider/model-id>
 # FCC_SMOKE_MODEL_FIREWORKS=<provider/model-id>
 # FCC_SMOKE_MODEL_NOVITA=<provider/model-id>
 # FCC_SMOKE_MODEL_CLOUDFLARE=<provider/model-id>
@@ -308,6 +314,7 @@ REASONING_HAIKU=inherit
 # TOKENROUTER_PROXY=<http-or-socks-url>
 # NARAROUTE_PROXY=<http-or-socks-url>
 # POOLSIDE_PROXY=<http-or-socks-url>
+# LLM7_PROXY=<http-or-socks-url>
 # FIREWORKS_PROXY=<http-or-socks-url>
 # NOVITA_PROXY=<http-or-socks-url>
 # CLOUDFLARE_PROXY=<http-or-socks-url>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## What You Get
 
-- **49 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
+- **50 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
 - **9 coding agents. One model catalog.** Run [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://github.com/openai/codex), [Pi](https://github.com/earendil-works/pi), [OpenCode](https://github.com/anomalyco/opencode), [Cline](https://github.com/cline/cline), [Hermes](https://github.com/NousResearch/hermes-agent), [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), [Grok Build](https://github.com/xai-org/grok-build), or [Muse Code](https://research.meta.ai/blog/introducing-muse-code-and-muse-spark-1-2/) with your FCC models.
 - **Keep coding through provider outages.** After retries are exhausted, FCC automatically tries your next configured model without making you restart the turn—across every client.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.
@@ -225,6 +225,7 @@ from more than one provider before succeeding.
 | [TokenRouter](https://www.tokenrouter.com/) | `TOKENROUTER_API_KEY` | `tokenrouter/moonshotai/kimi-k3-free` |
 | [NaraRoute](https://router.bynara.id/) | `NARAROUTE_API_KEY` | `nararoute/kimi-k3-free` |
 | [Poolside AI](https://platform.poolside.ai/) | `POOLSIDE_API_KEY` | `poolside/poolside/laguna-s-2.1` |
+| [LLM7.io](https://dash.llm7.io/) | `LLM7_API_KEY` | `llm7/default` |
 | [Ollama Cloud](https://ollama.com/settings/keys) | `OLLAMA_API_KEY` | `ollama_cloud/qwen3-coder:480b` |
 | [LM Studio](https://lmstudio.ai/) | `LM_STUDIO_BASE_URL` | `lmstudio/<model-id>` |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | `LLAMACPP_BASE_URL` | `llamacpp/<model-id>` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.13.10"
+version = "5.14.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -90,6 +90,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "tokenrouter": "tokenrouter/moonshotai/kimi-k3-free",
     "nararoute": "nararoute/kimi-k3-free",
     "poolside": "poolside/poolside/laguna-s-2.1",
+    "llm7": "llm7/default",
     "agnes": "agnes/agnes-2.0-flash",
     "zenmux": "zenmux/deepseek/deepseek-v4-flash-free",
     "wandb": "wandb/openai/gpt-oss-20b",

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -79,6 +79,8 @@ TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 NARAROUTE_DEFAULT_BASE = "https://router.bynara.id/v1"
 # Poolside AI OpenAI-compatible Chat Completions API.
 POOLSIDE_DEFAULT_BASE = "https://inference.poolside.ai/v1"
+# LLM7.io OpenAI-compatible Chat Completions API.
+LLM7_DEFAULT_BASE = "https://api.llm7.io/v1"
 # Agnes AI OpenAI-compatible Chat Completions API.
 AGNES_DEFAULT_BASE = "https://apihub.agnes-ai.com/v1"
 # ZenMux OpenAI-compatible Chat Completions gateway.
@@ -537,6 +539,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="poolside_api_key",
         default_base_url=POOLSIDE_DEFAULT_BASE,
         proxy_attr="poolside_proxy",
+    ),
+    "llm7": ProviderDescriptor(
+        provider_id="llm7",
+        display_name="LLM7.io",
+        credential_env="LLM7_API_KEY",
+        credential_url="https://dash.llm7.io/",
+        credential_attr="llm7_api_key",
+        default_base_url=LLM7_DEFAULT_BASE,
+        proxy_attr="llm7_proxy",
     ),
     "ollama_cloud": ProviderDescriptor(
         provider_id="ollama_cloud",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -201,6 +201,11 @@ class Settings(BaseModel):
         default=None, validation_alias="POOLSIDE_API_KEY"
     )
 
+    # ==================== LLM7.io (OpenAI-compatible) ====================
+    llm7_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="LLM7_API_KEY"
+    )
+
     # ==================== Fireworks AI Config ====================
     fireworks_api_key: OptionalNonEmptyString = Field(
         default=None, validation_alias="FIREWORKS_API_KEY"
@@ -489,6 +494,9 @@ class Settings(BaseModel):
     )
     poolside_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="POOLSIDE_PROXY"
+    )
+    llm7_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="LLM7_PROXY"
     )
     fireworks_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="FIREWORKS_PROXY"

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -627,7 +627,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
     "llm7": OpenAIChatProfile(
         _policy(
             "LLM7",
-            ReasoningReplayMode.DISABLED,
+            ReasoningReplayMode.REASONING_CONTENT,
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
         NO_REASONING,

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -85,6 +85,7 @@ class OpenAIModelListing:
     collection_field: str | None = "data"
     id_field: str = "id"
     aliases_field: str | None = None
+    additional_model_ids: tuple[str, ...] = ()
     required_path_values: RequiredPathValues = ()
     required_null_field: str | None = None
     required_sequence_items: tuple[tuple[str, str], ...] = ()
@@ -622,6 +623,24 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
         ),
         ChatTemplateReasoning(field="enable_thinking"),
+    ),
+    "llm7": OpenAIChatProfile(
+        _policy(
+            "LLM7",
+            ReasoningReplayMode.DISABLED,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NO_REASONING,
+        model_listing=OpenAIModelListing(
+            path="/models",
+            additional_model_ids=("default", "fast", "pro"),
+            required_path_values=(
+                (("model_type",), ("chat",)),
+                (("stream",), (True,)),
+                (("tools_calling",), (True,)),
+            ),
+            thinking_boolean_path=("reasoning",),
+        ),
     ),
     "ollama_cloud": OpenAIChatProfile(
         _policy(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -57,6 +57,7 @@ from free_claude_code.providers.http import (
 from free_claude_code.providers.model_listing import (
     extract_openai_model_infos,
     merge_model_list_pages,
+    model_infos_from_ids,
     validate_model_list_page,
 )
 from free_claude_code.providers.stream_recovery import (
@@ -496,7 +497,7 @@ class OpenAIChatProvider(BaseProvider):
         if not self._profile.model_ids_are_routable:
             return frozenset()
         listing = self._profile.model_listing
-        return extract_openai_model_infos(
+        live_model_infos = extract_openai_model_infos(
             payload,
             provider_name=self._provider_name,
             collection_field=listing.collection_field,
@@ -511,6 +512,12 @@ class OpenAIChatProvider(BaseProvider):
             non_thinking_tag=listing.non_thinking_tag,
             thinking_boolean_path=listing.thinking_boolean_path,
         )
+        model_infos_by_id = {
+            model_info.model_id: model_info for model_info in live_model_infos
+        }
+        for model_info in model_infos_from_ids(listing.additional_model_ids):
+            model_infos_by_id.setdefault(model_info.model_id, model_info)
+        return frozenset(model_infos_by_id.values())
 
     async def _list_models_payload(self) -> Any:
         """Fetch one OpenAI-compatible model-list payload with shared retries."""

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -51,6 +51,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "tokenrouter",
     "nararoute",
     "poolside",
+    "llm7",
     "ollama_cloud",
     "lmstudio",
     "llamacpp",

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -68,6 +68,7 @@ def _settings(**overrides):
         "cerebras_api_key": "",
         "ollama_api_key": "",
         "poolside_api_key": "",
+        "llm7_api_key": "",
         "fireworks_api_key": "",
         "novita_api_key": "",
         "cloudflare_api_token": "",
@@ -180,6 +181,53 @@ def test_poolside_provider_configuration_uses_documented_default_model(
     assert [model.provider for model in models] == ["poolside"]
     assert models[0].full_model == "poolside/poolside/laguna-s-2.1"
     assert models[0].source == "provider_default"
+
+
+def test_llm7_provider_configuration_uses_stable_default_selector(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_LLM7", raising=False)
+    config = _smoke_config(
+        settings=_settings(
+            model="ollama/llama3.1",
+            ollama_base_url="",
+            llm7_api_key="llm7-key",
+        )
+    )
+
+    assert config.has_provider_configuration("llm7")
+    models = config.provider_smoke_models()
+    assert [model.provider for model in models] == ["llm7"]
+    assert models[0].full_model == "llm7/default"
+    assert models[0].source == "provider_default"
+
+
+def test_llm7_smoke_override_accepts_selector_with_or_without_prefix(
+    monkeypatch,
+) -> None:
+    settings = _settings(
+        model="ollama/llama3.1",
+        ollama_base_url="",
+        llm7_api_key="llm7-key",
+    )
+    for override in ("fast", "llm7/fast"):
+        monkeypatch.setenv("FCC_SMOKE_MODEL_LLM7", override)
+        models = _smoke_config(settings=settings).provider_smoke_models()
+
+        assert [model.provider for model in models] == ["llm7"]
+        assert models[0].full_model == "llm7/fast"
+        assert models[0].source == "FCC_SMOKE_MODEL_LLM7"
+
+
+def test_llm7_is_not_enabled_without_explicit_credential(monkeypatch) -> None:
+    monkeypatch.delenv("FCC_SMOKE_MODEL_LLM7", raising=False)
+    config = _smoke_config(
+        provider_matrix=frozenset({"llm7"}),
+        settings=_settings(ollama_base_url="", llm7_api_key=""),
+    )
+
+    assert not config.has_provider_configuration("llm7")
+    assert config.provider_smoke_models() == []
 
 
 def test_xai_provider_smoke_uses_current_grok_model(monkeypatch) -> None:

--- a/tests/providers/test_llm7.py
+++ b/tests/providers/test_llm7.py
@@ -109,7 +109,7 @@ def test_preserves_provider_reasoning_default_and_standard_request_fields(
     assert "extra_body" not in body
 
 
-def test_drops_thinking_replay_but_preserves_tool_history(
+def test_replays_reasoning_content_with_tool_history(
     llm7_provider: OpenAIChatProvider,
 ) -> None:
     request = _request(
@@ -149,6 +149,7 @@ def test_drops_thinking_replay_but_preserves_tool_history(
     assert body["messages"][1] == {
         "role": "assistant",
         "content": "I will inspect it.",
+        "reasoning_content": "Read it first.",
         "tool_calls": [
             {
                 "id": "toolu_1",

--- a/tests/providers/test_llm7.py
+++ b/tests/providers/test_llm7.py
@@ -1,0 +1,285 @@
+"""Tests for the LLM7.io OpenAI-chat provider profile."""
+
+from unittest.mock import AsyncMock
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import LLM7_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.json_types import JsonObject, JsonValue
+from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers.model_listing import ModelListResponseError
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_DEFAULT,
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+    reasoning_for,
+)
+
+_MODEL = "openai/gpt-oss-120b"
+_SELECTOR_IDS = frozenset({"default", "fast", "pro"})
+
+
+@pytest.fixture
+def llm7_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "llm7",
+        make_provider_config(
+            api_key="test-llm7-key",
+            base_url=LLM7_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="llm7", max_attempts=1),
+    )
+
+
+def _request(**overrides: JsonValue) -> MessagesRequest:
+    payload: JsonObject = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "Inspect the file."}],
+        "tools": [
+            {
+                "name": "read_file",
+                "description": "Read a file",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }
+        ],
+    }
+    payload.update(overrides)
+    return MessagesRequest.model_validate(payload)
+
+
+def _catalog_model(
+    model_id: str = _MODEL,
+    *,
+    model_type: object = "chat",
+    stream: object = True,
+    tools_calling: object = True,
+    reasoning: bool | None = None,
+) -> dict[str, object]:
+    model: dict[str, object] = {
+        "id": model_id,
+        "model_type": model_type,
+        "stream": stream,
+        "tools_calling": tools_calling,
+    }
+    if reasoning is not None:
+        model["reasoning"] = reasoning
+    return model
+
+
+def test_constructs_standard_openai_chat_provider(
+    llm7_provider: OpenAIChatProvider,
+) -> None:
+    assert isinstance(llm7_provider, OpenAIChatProvider)
+    assert llm7_provider._provider_name == "LLM7"
+    assert llm7_provider._api_key == "test-llm7-key"
+    assert llm7_provider._base_url == LLM7_DEFAULT_BASE
+
+
+@pytest.mark.parametrize(
+    "reasoning",
+    [REASONING_DEFAULT, REASONING_ON, REASONING_OFF],
+)
+def test_preserves_provider_reasoning_default_and_standard_request_fields(
+    llm7_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+) -> None:
+    body = llm7_provider._build_request_body(_request(), reasoning=reasoning)
+
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+    assert body["model"] == _MODEL
+    assert body["tools"][0]["function"]["name"] == "read_file"
+    assert "reasoning" not in body
+    assert "reasoning_effort" not in body
+    assert "thinking" not in body
+    assert "extra_body" not in body
+
+
+def test_drops_thinking_replay_but_preserves_tool_history(
+    llm7_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(
+        messages=[
+            {"role": "user", "content": "Inspect the file."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Read it first."},
+                    {"type": "text", "text": "I will inspect it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "read_file",
+                        "input": {"path": "example.py"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "print('hello')",
+                    }
+                ],
+            },
+        ]
+    )
+
+    body = llm7_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "I will inspect it.",
+        "tool_calls": [
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": '{"path": "example.py"}',
+                },
+            }
+        ],
+    }
+    assert body["messages"][2] == {
+        "role": "tool",
+        "tool_call_id": "toolu_1",
+        "content": "print('hello')",
+    }
+
+
+@pytest.mark.asyncio
+async def test_filters_catalog_and_adds_live_authoritative_selectors(
+    llm7_provider: OpenAIChatProvider,
+) -> None:
+    llm7_provider._client.get = AsyncMock(
+        return_value={
+            "data": [
+                _catalog_model("reasoning-model", reasoning=True),
+                _catalog_model("plain-model", reasoning=False),
+                _catalog_model("unknown-reasoning-model"),
+                _catalog_model("default", reasoning=True),
+                _catalog_model("image-generator", model_type="image"),
+                _catalog_model("video-generator", model_type="video"),
+                _catalog_model("nonstreaming-chat", stream=False),
+                _catalog_model("chat-without-tools", tools_calling=False),
+            ]
+        }
+    )
+
+    model_infos = await llm7_provider.list_model_infos()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("reasoning-model", supports_thinking=True),
+            ProviderModelInfo("plain-model", supports_thinking=False),
+            ProviderModelInfo("unknown-reasoning-model"),
+            ProviderModelInfo("default", supports_thinking=True),
+            ProviderModelInfo("fast"),
+            ProviderModelInfo("pro"),
+        }
+    )
+    assert {info.model_id for info in model_infos} & _SELECTOR_IDS == _SELECTOR_IDS
+    assert sum(info.model_id == "default" for info in model_infos) == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("model_type", None),
+        ("model_type", 7),
+        ("stream", None),
+        ("stream", "true"),
+        ("tools_calling", None),
+        ("tools_calling", "true"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rejects_missing_or_wrongly_typed_required_catalog_metadata(
+    llm7_provider: OpenAIChatProvider,
+    field: str,
+    value: object,
+) -> None:
+    item = _catalog_model()
+    if value is None:
+        item.pop(field)
+    else:
+        item[field] = value
+    llm7_provider._client.get = AsyncMock(return_value={"data": [item]})
+
+    with pytest.raises(ModelListResponseError, match=f"include {field} as"):
+        await llm7_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_rejects_wrongly_typed_reasoning_metadata(
+    llm7_provider: OpenAIChatProvider,
+) -> None:
+    item = _catalog_model()
+    item["reasoning"] = "true"
+    llm7_provider._client.get = AsyncMock(return_value={"data": [item]})
+
+    with pytest.raises(ModelListResponseError, match="reasoning to be boolean"):
+        await llm7_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_selectors_do_not_mask_wholly_ineligible_catalog(
+    llm7_provider: OpenAIChatProvider,
+) -> None:
+    llm7_provider._client.get = AsyncMock(
+        return_value={"data": [_catalog_model(model_type="image")]}
+    )
+
+    with pytest.raises(ModelListResponseError, match="did not include any model ids"):
+        await llm7_provider.list_model_infos()
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_documented_url_and_bearer_auth(
+    llm7_provider: OpenAIChatProvider,
+) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, json={"data": [_catalog_model()]})
+
+    await llm7_provider._client.close()
+    llm7_provider._client = AsyncOpenAI(
+        api_key="wire-llm7-key",
+        base_url=LLM7_DEFAULT_BASE,
+        max_retries=0,
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
+    )
+    try:
+        model_infos = await llm7_provider.list_model_infos()
+    finally:
+        await llm7_provider.cleanup()
+
+    assert model_infos == frozenset(
+        {ProviderModelInfo(_MODEL)}
+        | {ProviderModelInfo(selector) for selector in _SELECTOR_IDS}
+    )
+    assert len(requests) == 1
+    assert str(requests[0].url) == "https://api.llm7.io/v1/models"
+    assert requests[0].headers["authorization"] == "Bearer wire-llm7-key"

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -21,6 +21,7 @@ from free_claude_code.config.provider_catalog import (
     GITHUB_MODELS_DEFAULT_BASE,
     HUGGINGFACE_DEFAULT_BASE,
     KIMI_CODE_DEFAULT_BASE,
+    LLM7_DEFAULT_BASE,
     MINIMAX_DEFAULT_BASE,
     NARAROUTE_DEFAULT_BASE,
     NEBIUS_DEFAULT_BASE,
@@ -109,6 +110,7 @@ def _make_settings(**overrides):
     mock.ollama_base_url = "http://localhost:11434"
     mock.ollama_api_key = "test_ollama_cloud_key"
     mock.poolside_api_key = "test_poolside_key"
+    mock.llm7_api_key = "test_llm7_key"
     mock.nvidia_nim_proxy = None
     mock.open_router_proxy = None
     mock.lmstudio_proxy = None
@@ -155,6 +157,7 @@ def _make_settings(**overrides):
     mock.cerebras_proxy = None
     mock.ollama_cloud_proxy = None
     mock.poolside_proxy = None
+    mock.llm7_proxy = None
     mock.kilo_api_key = "test_kilo_key"
     mock.kilo_proxy = None
     mock.openai_proxy = None
@@ -256,6 +259,30 @@ def test_poolside_provider_config_uses_key_base_and_proxy() -> None:
     assert descriptor.proxy_attr == "poolside_proxy"
     assert config.api_key == "poolside-token"
     assert config.base_url == POOLSIDE_DEFAULT_BASE
+    assert config.proxy == "http://proxy.test:8080"
+    assert isinstance(provider, OpenAIChatProvider)
+
+
+def test_llm7_provider_config_uses_key_base_and_proxy() -> None:
+    descriptor = PROVIDER_CATALOG["llm7"]
+    settings = _make_settings(
+        llm7_api_key="llm7-token",
+        llm7_proxy="http://proxy.test:8080",
+    )
+
+    config = build_provider_config(descriptor, settings)
+    with patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"):
+        provider = create_provider("llm7", settings)
+
+    assert descriptor.display_name == "LLM7.io"
+    assert descriptor.credential_env == "LLM7_API_KEY"
+    assert descriptor.credential_attr == "llm7_api_key"
+    assert descriptor.credential_url == "https://dash.llm7.io/"
+    assert descriptor.default_base_url == LLM7_DEFAULT_BASE
+    assert descriptor.base_url_attr is None
+    assert descriptor.proxy_attr == "llm7_proxy"
+    assert config.api_key == "llm7-token"
+    assert config.base_url == LLM7_DEFAULT_BASE
     assert config.proxy == "http://proxy.test:8080"
     assert isinstance(provider, OpenAIChatProvider)
 
@@ -871,6 +898,7 @@ def test_create_provider_instantiates_each_builtin():
         "wafer": OpenAIChatProvider,
         "opencode_zen": OpenAIChatProvider,
         "poolside": OpenAIChatProvider,
+        "llm7": OpenAIChatProvider,
         "opencode_go": OpenAIChatProvider,
         "vercel": OpenAIChatProvider,
         "bedrock": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.13.10"
+version = "5.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

LLM7.io was not available in FCC, and its mixed media catalog could not be exposed safely to coding agents. LLM7 also publishes stable selectors alongside dynamic concrete model IDs.

## Changes

| Before | After |
| --- | --- |
| FCC exposed 49 providers without LLM7 configuration. | FCC exposes LLM7.io as provider 50 with explicit key and optional proxy settings. |
| Dynamic LLM7 records and stable routing selectors had no shared catalog contract. | Live chat, streaming, and tool-capable records are strictly filtered, then `default`, `fast`, and `pro` are added with live metadata taking precedence. |
| LLM7 reasoning replay compatibility was unverified. | FCC replays `reasoning_content` with text and tool history after anonymous concrete, `default`, and `fast` routes accepted the exact wire shape. |
| The package version was 5.13.10. | The package version is 5.14.0 for the backward-compatible provider addition. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds LLM7.io as an OpenAI-compatible provider with configuration, catalog discovery, stable `default`/`fast`/`pro` selectors, and smoke-test support.

Offline provider checks confirmed correct filtering of streaming, tool-capable chat models, preservation of reasoning metadata, rejection of entirely ineligible catalogs, and correct replay of reasoning and tool-call history. No blocking failure remains.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge based on the completed provider and configuration checks.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a deterministic offline harness against mocked GET /v1/models and POST /v1/chat/completions before and after the change, and both runs returned HTTP 200.
- Verified that the current implementation retained only eligible catalog models, added the stable selectors, and serialized assistant reasoning, tool calls, and tool results as expected.
- Ran the focused LLM7 provider and smoke-selector test suite; all 80 tests passed.
- Compared before and after harness captures; the prior commit was archived for the before run and the current tree supplied the after run, with reasoning content exposure consistent with archived behavior.

<a href="https://app.greptile.com/trex/runs/20303339/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: replay LLM7 reasoning content"](https://github.com/alishahryar1/free-claude-code/commit/31cfccee60dd58b26175b698ab64a561f37e05ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56116710)</sub>

<!-- /greptile_comment -->