### PR TITLE
Share Chat and Responses stream execution lifecycle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,8 +46,9 @@ flowchart LR
     Handlers --> Executor[application ProviderExecutor]
     Executor --> Lease[Provider Generation Lease]
     Lease --> Providers[ProviderRuntime]
-    Providers --> OpenAIChat[OpenAI Chat Provider Profiles And Specialized Adapters]
-    Providers --> OpenAIResponses[Standard OpenAI Responses Transport]
+    Providers --> StreamSupervisor[Shared Stream Execution Supervisor]
+    StreamSupervisor --> OpenAIChat[OpenAI Chat Provider Profiles And Specialized Adapters]
+    StreamSupervisor --> OpenAIResponses[Standard OpenAI Responses Transport]
     Providers --> NativeProviders[Native And Private Provider Adapters]
 ```
 
@@ -68,11 +69,11 @@ The installable wheel packages are declared in [pyproject.toml](pyproject.toml):
   management, and client adapter contracts.
 - [src/free_claude_code/config/](src/free_claude_code/config/) owns settings, provider metadata, filesystem paths,
   logging setup, constants, and provider ID catalogs.
-- [src/free_claude_code/core/](src/free_claude_code/core/) owns provider-neutral protocol logic: wire request and response
-  models, Anthropic conversion, SSE construction, OpenAI Responses conversion,
-  canonical execution-failure semantics, credential-safe diagnostics, token
-  counting, and structured trace helpers. It never classifies provider SDK or
-  HTTP client exceptions.
+- [src/free_claude_code/core/](src/free_claude_code/core/) owns provider-neutral inference requests and events plus
+  protocol logic: wire request and response models, ingress codecs, public
+  presenters, canonical execution-failure semantics, credential-safe
+  diagnostics, token counting, and structured trace helpers. It never
+  classifies provider SDK or HTTP client exceptions.
 - [src/free_claude_code/messaging/](src/free_claude_code/messaging/) owns optional platform adapters, incoming message
   handling, tree queues, transcript rendering, persistence, commands, and voice
   support.
@@ -228,14 +229,15 @@ new places to add unrelated behavior:
   thin, keep Claude-only behavior in the Messages handler, and use
   [application/execution.py](src/free_claude_code/application/execution.py) only for shared
   provider resolution, preflight, tracing, token counting, and streaming.
-- [providers/openai_chat/](src/free_claude_code/providers/openai_chat/) owns the common upstream provider
-  behavior. It separates immutable vendor profiles from per-request stream
-  execution, recovery, request policy, and tool-call assembly. Within one
-  request, the runner owns logical orchestration, a replaceable stream assembler
-  owns one replay epoch's ledger and parser state, the shared
-  `ProviderAttemptScope` owns each returned physical stream and attempt, and
-  `RecoveryController` alone owns downstream commit policy. Shared protocol
-  rules belong in [src/free_claude_code/core/](src/free_claude_code/core/).
+- [providers/streaming/](src/free_claude_code/providers/streaming/) owns the transport-neutral streamed-attempt
+  lifecycle for standard Responses and OpenAI Chat. `PublicationBuffer` owns
+  only reversible holdback and the irreversible provider publication boundary;
+  `StreamExecutionSupervisor` composes admitted attempts, first-raw acceptance,
+  active deadline publication, local replay, cancellation, and exact cleanup.
+  Transport sources and epochs retain request encoding, raw decoding, terminal
+  validation, and typed recovery snapshots. OpenAI Chat supplies its own typed
+  continuation/tool-repair strategy; standard Responses supplies none. Private
+  Codex retains its staged recovery controller until its separate migration.
 - [messaging/workflow.py](src/free_claude_code/messaging/workflow.py) coordinates messaging runtime
   dependencies. Inbound turn intake, queued node execution, slash command
   dependencies, and tree queue internals live in separate modules so new
@@ -535,7 +537,8 @@ than presenting a partial success.
 The public response chain follows a transitive close-ownership rule. A response
 owns its replay iterator; replay owns the active protocol adapter; each protocol
 adapter owns its direct input; tracing owns the executor body; the executor body
-owns the provider iterator; and the provider runner owns its upstream stream.
+owns the provider iterator; and the provider lifecycle owner owns its upstream
+stream.
 Each of these response-chain owners closes its direct input on normal completion,
 failure, cancellation, and early consumer close. Failures from those explicit
 cleanup calls are trace metadata and cannot replace an established wire outcome;
@@ -579,10 +582,11 @@ sequenceDiagram
 
 OpenAI Responses uses the same provider execution primitive without importing
 Claude-only message intercepts. `ResponsesHandler` delegates protocol work to
-the `OpenAIResponsesAdapter` in
-[src/free_claude_code/core/openai_responses/adapter.py](src/free_claude_code/core/openai_responses/adapter.py). The adapter
-converts the Responses payload into an Anthropic Messages payload before
-provider execution, then converts Anthropic SSE back to Responses SSE.
+the ingress codec and `ResponsesEventPresenter` in
+[src/free_claude_code/core/openai_responses/](src/free_claude_code/core/openai_responses/). Ingress produces the same
+`InferenceRequest` consumed by provider execution, and the presenter maps the
+resulting `InferenceEvent` stream directly to Responses SSE. Anthropic wire
+models and SSE are not an intermediate provider representation.
 
 ## Model Routing
 
@@ -757,6 +761,26 @@ New work fails fast during the provider-directed cooldown; once it expires,
 exactly one new caller becomes the next probe. There is no background retry
 worker, copied request queue, or second scheduling system.
 
+[providers/streaming/](src/free_claude_code/providers/streaming/) composes those admission primitives for streamed
+generation. A request-scoped source performs exactly one upstream call per
+`open()`, while every returned epoch owns a fresh decoder, ledger, parsers,
+usage state, tool assembler, and closeable raw stream. Receipt of the first raw
+upstream item calls `ProviderAttempt.accept()` before decoding it: failures
+before that point participate in provider-wide recovery, while decoder or read
+failures afterward remain request-local.
+
+The policy-free `PublicationBuffer` retains canonical events for at most 0.75
+seconds or 65,536 semantic bytes. Its first non-`ResponseStarted` event starts
+the monotonic deadline. The supervisor races that deadline against one
+already-started raw read; publication never cancels and recreates the read.
+Before publication, a retryable accepted failure may discard the complete epoch
+and consume another attempt from the same `ProviderExecution`. After
+publication, neither provider replay nor application fallback may replace the
+response. OpenAI Chat may append through its typed recovery strategy; standard
+Responses reports the terminal failure. Attempt resources and concurrency are
+released before terminal output or recovery is exposed to downstream
+backpressure.
+
 The one-call helper on `ProviderExecution` accepts only a callback that performs
 one quota-bearing provider call. Higher-level orchestration remains with its
 protocol owner: every model-catalog page receives a separate logical execution,
@@ -803,16 +827,19 @@ upstream. `OpenAIChatProfile` contains immutable request policy, an explicit
 reasoning encoder, an explicit history replay mode, its standard
 streamed-reasoning field, postprocessors, and base-URL normalization for
 ordinary vendors. Configuration differences therefore remain data rather than
-empty subclasses. The package also
-owns the exactly typed private per-request runner, recovery operations, tool-call
-assembly, and streamed usage handling. No obsolete generic transport namespace
-or untyped provider backchannel remains.
+empty subclasses. The package also owns its request-scoped attempt source,
+fresh per-attempt Chat epoch, typed continuation/tool-repair strategy,
+tool-call assembly, and streamed usage handling. Provider corrections persist
+across physical calls, but a discarded epoch cannot leak parser, tool, usage,
+or ledger state into its replacement.
 
 [providers/openai_responses/](src/free_claude_code/providers/openai_responses/)
 owns standard API-key `/responses` execution. Its transport borrows the owning
 provider's configured SDK client and admission controller, builds and parses the
-public protocol through `core.openai_responses`, and owns stream attempts,
-failure classification, recovery holdback, cancellation, and exact closure. It
+public protocol through `core.openai_responses`, and supplies a Responses
+attempt source and decoder epoch to the shared stream supervisor. It retains
+Responses failure classification and terminal validation but has no Chat
+continuation policy or post-publication replay. It
 owns no credentials, model discovery, provider configuration, or client
 lifecycle. This boundary is deliberately separate from the Codex subscription
 adapter's OAuth and private-backend contract.
@@ -1187,79 +1214,40 @@ same commit-state split but do not acquire provider retry semantics.
 
 [src/free_claude_code/core/openai_responses/](src/free_claude_code/core/openai_responses/) owns OpenAI Responses support:
 
-- the permissive `OpenAIResponsesRequest` ingress model used directly by the
-  FastAPI route and the protocol adapter;
-- the `OpenAIResponsesAdapter` facade used by the API layer;
+- the wire-facing `OpenAIResponsesRequest` ingress model and explicit field
+  policy used by the API handler;
+- conversion from supported Responses semantics into immutable
+  `InferenceRequest` values;
+- `ResponsesPresentationSnapshot` for validated fields echoed by public
+  response envelopes;
+- `ResponsesEventPresenter`, which maps `InferenceEvent` directly to Responses
+  lifecycle events;
 - streaming-only `/v1/responses` support for Codex/FCC workflows;
-- Responses request conversion into Anthropic Messages payloads;
-- Anthropic SSE conversion into Responses SSE;
 - OpenAI-compatible error envelopes.
 
 The package intentionally does not implement the full OpenAI Responses surface.
 FCC accepts omitted `stream` or `stream: true`; `stream: false` is rejected with
 an OpenAI-shaped client error because installed FCC/Codex workflows only need
-streaming. Request conversion, stream transformation, Anthropic SSE parsing,
-Responses SSE event formatting, output item construction, tool identity mapping,
-reasoning mapping, ID generation, and error envelope construction each live
-behind the adapter boundary. The concrete request object crosses that boundary
-unchanged; nested Responses input and tool data stays permissive and is
-interpreted by the conversion functions. `stream.py` is the public streaming
-entrypoint;
-[src/free_claude_code/core/openai_responses/streaming/](src/free_claude_code/core/openai_responses/streaming/) owns the
-block-indexed Responses stream assembler. The package separates Anthropic SSE
-dispatch, block state, output ledger ordering, block completion, SSE event
-builders, and error mapping. API code should depend on the adapter, not on
-those internal module owners directly. Responses output payloads stay
-OpenAI-shaped. Canonical execution failures enter the assembler directly, so
-Responses does not infer provider failure semantics by parsing an Anthropic
-terminal error.
-Post-start Responses failures are assembler-owned: the active
-`ResponsesStreamAssembler` emits `response.failed` so the terminal event keeps
-the same `response.id`, output ledger, and usage state as the earlier
-`response.created`.
-Provider completion reasons remain canonical until that same assembler chooses
-the Responses terminal event. Anthropic `max_tokens` becomes
-`response.incomplete` with `incomplete_details.reason=max_output_tokens` while
-preserving partial output and usage; normal terminal reasons remain
-`response.completed`.
+streaming. Known passive compatibility fields are normalized explicitly; active
+unsupported semantics and unknown top-level fields fail before provider I/O.
+Function/custom tools, reasoning, scoped opaque replay artifacts, tool identity,
+usage, completion reasons, and partial-output failure state remain canonical
+until the Responses presenter chooses their public wire shape.
 
-Responses custom tools are also boundary-owned. The adapter accepts native
-Responses `custom` tool declarations, represents them internally as Anthropic
-tools with a single string `input` field, and restores `custom_tool_call`,
-`custom_tool_call_output`, and `response.custom_tool_call_input.*` shapes at the
-Responses edge. Text or grammar format metadata is preserved as model guidance;
-FCC does not validate custom-tool grammars.
+The presenter owns Responses IDs, indexes, output ledger ordering, block
+completion, and terminal serialization. A post-start failure emits
+`response.failed` with the same public response identity; an output-limit finish
+emits `response.incomplete` with `max_output_tokens`; ordinary success emits
+`response.completed`. It consumes `ExecutionFailure` directly and never infers
+provider semantics by parsing Anthropic SSE.
 
-Client-facing Responses tool identity mapping is distinct from upstream wire
-portability. Namespaces and custom-tool identities are restored at the public
-Responses edge; the OpenAI tool-name codec operates beneath that mapping only
-while the canonical Anthropic request crosses an OpenAI upstream transport.
-
-Responses reasoning is handled as lossless protocol conversion before provider
-policy. The adapter preserves `reasoning.effort` in Anthropic `output_config`;
-the application reasoning boundary then interprets `none` as off and preserves
-all other named efforts. It never translates OpenAI effort names into Anthropic
-token budgets.
-Application-resolved source controls remain on the immutable canonical request;
-provider adapters consume the resolved `ReasoningPolicy` rather than parsing
-those controls again. A target converter validates only the unrepresented
-semantic remainder: it may omit an application-consumed control or an exact
-no-op, but must reject active or unknown behavior before upstream I/O. For the
-connected OpenAI Responses transport, `output_config.effort` is already
-represented by the policy and an empty context edit or exact
-`clear_thinking_20251015` edit with `keep: "all"` is inert. Structured-output
-configuration and any active, malformed, or extended context edit remain
-unsupported and fail preflight rather than being silently discarded.
-Prior Responses `reasoning` input items replay plaintext `reasoning_text`, or
-fallback `summary_text`, into assistant `reasoning_content`. Encrypted reasoning
-input is ignored because the proxy cannot decrypt it.
-
-Provider thinking output maps back to Responses reasoning in the same block
-order the upstream Anthropic stream produced. Anthropic `thinking` blocks become
-Responses `reasoning` output items and `response.reasoning_text.*` stream
-events. Anthropic `redacted_thinking` becomes a Responses `reasoning` item with
-`encrypted_content`; the opaque value is not exposed as visible text and FCC
-does not synthesize reasoning summaries.
+Client-facing Responses tool identity is distinct from upstream wire
+portability. Canonical function/custom tool values preserve namespaces, call
+IDs, schemas or formats, and string versus object input. The selected upstream
+codec alone applies reversible OpenAI-compatible name encoding. Reasoning intent
+is resolved once by the application, while typed replay artifacts remain opaque
+and are forwarded only when their exact compatibility scope matches the
+selected upstream route.
 
 Provider code should delegate protocol details to these modules. Avoid copying
 conversion code into individual providers, and avoid provider-to-provider imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.3"
+version = "5.14.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/admission.py
+++ b/src/free_claude_code/providers/admission.py
@@ -278,7 +278,7 @@ class ProviderAttempt:
         await self.aclose()
 
     async def accept(self) -> None:
-        """Record a valid upstream response and close a recovery episode if probing."""
+        """Record first upstream reachability and close a recovery episode if probing."""
         if self._resolved or self._closed:
             return
         await self._controller._attempt_accepted(self._execution, self._permit)

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -5,7 +5,6 @@ import sys
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import Any
 
 import httpx2
@@ -33,20 +32,18 @@ from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningP
 from free_claude_code.core.trace import provider_chat_body_snapshot, trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
-    ProviderAttempt,
-    ProviderCorrectionAction,
     ProviderExecution,
     ProviderOperationKind,
 )
 from free_claude_code.providers.base import BaseProvider, ProviderConfig
 from free_claude_code.providers.failure_policy import (
+    ProviderFailureOverride,
     RetryableToolProtocolError,
     classify_provider_failure,
     is_retryable_stream_error,
     underlying_provider_error,
 )
 from free_claude_code.providers.http import (
-    ProviderAttemptScope,
     close_provider_stream,
     maybe_await_aclose,
 )
@@ -70,10 +67,15 @@ from free_claude_code.providers.openai_compat import (
     OpenAIToolNameCodec,
     openai_replay_scope,
 )
-from free_claude_code.providers.stream_recovery import (
-    RecoveryController,
-    RecoveryFailureAction,
-    TruncatedProviderStreamError,
+from free_claude_code.providers.stream_recovery import TruncatedProviderStreamError
+from free_claude_code.providers.streaming import (
+    BoundAttemptOperations,
+    PublicationBuffer,
+    RecoveryContext,
+    RecoveryOutcome,
+    StreamExecutionSupervisor,
+    StreamFeed,
+    StreamTraceContext,
 )
 
 from .output_cap import clamp_output_tokens, parse_output_token_cap
@@ -226,19 +228,6 @@ def _estimated_recovery_usage(
     )
 
 
-class _OpenAIChatFailureOutcome(StrEnum):
-    RETRY = "retry"
-    COMPLETE = "complete"
-    RAISE = "raise"
-
-
-@dataclass(frozen=True, slots=True)
-class _OpenAIChatFailureResolution:
-    outcome: _OpenAIChatFailureOutcome
-    events: tuple[InferenceEvent, ...] = ()
-    failure: ExecutionFailure | None = None
-
-
 class _OpenAIChatStreamAssembler:
     """Own one discardable OpenAI-chat replay epoch."""
 
@@ -311,6 +300,10 @@ class _OpenAIChatStreamAssembler:
     @property
     def tool_argument_alias_buffers(self) -> Mapping[int, str]:
         return self._tool_argument_alias_buffers
+
+    @property
+    def tool_calls(self) -> OpenAIToolCallAssembler:
+        return self._tool_calls
 
     def start_events(self) -> Iterator[InferenceEvent]:
         if self._started:
@@ -542,6 +535,7 @@ class OpenAIChatProvider(BaseProvider):
         # later requests clamp proactively instead of paying the 400 each time.
         self._model_output_caps: dict[str, int] = {}
         self._admission = admission
+        self._supervisor = StreamExecutionSupervisor(admission)
         timeout = httpx2.Timeout(
             config.http_read_timeout,
             connect=config.http_connect_timeout,
@@ -735,60 +729,6 @@ class OpenAIChatProvider(BaseProvider):
         """Return provider-specific cumulative usage fields."""
         return {}
 
-    async def _create_stream(
-        self,
-        body: dict,
-        execution: ProviderExecution,
-        operation_kind: ProviderOperationKind,
-    ) -> tuple[Any, dict, ProviderAttempt]:
-        """Create a streaming chat completion with bounded request fallbacks."""
-        body = self._apply_learned_output_cap(body)
-        used_retry_kinds: set[str] = set()
-
-        while execution.can_attempt:
-            attempt = await execution.open_attempt(operation_kind)
-            stream: Any | None = None
-            retain_attempt = False
-            try:
-                create_body = self._prepare_create_body(body)
-                stream = await self._client.chat.completions.create(
-                    **create_body,
-                    stream=True,
-                )
-                stream = self._normalize_stream(stream, body)
-                retain_attempt = True
-                return stream, body, attempt
-            except asyncio.CancelledError:
-                raise
-            except Exception as error:
-                retry_body = self._next_create_retry_body(error, body, used_retry_kinds)
-                if retry_body is not None:
-                    correction = await attempt.correct(error)
-                    if correction is ProviderCorrectionAction.RETRY:
-                        body = retry_body
-                        continue
-                    raise
-                decision = await attempt.fail(
-                    error,
-                    provider_failure_override=self._provider_failure_override,
-                )
-                if not decision.retry_allowed:
-                    raise
-            finally:
-                if not retain_attempt:
-                    if stream is not None:
-                        await close_provider_stream(
-                            stream,
-                            active_error=sys.exception(),
-                            provider_name=self._provider_name,
-                            request_id=execution.request_id,
-                        )
-                    await attempt.aclose()
-
-        if execution.last_failure is not None:
-            raise execution.last_failure
-        raise RuntimeError("provider execution ended without a final error")
-
     def _normalize_stream(self, stream: Any, _body: Mapping[str, Any]) -> Any:
         """Return the provider-specific stream view consumed by the base runner."""
         return stream
@@ -864,7 +804,7 @@ class OpenAIChatProvider(BaseProvider):
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
     ) -> AsyncIterator[InferenceEvent]:
         """Stream provider-neutral inference events."""
-        runner = _OpenAIChatStreamRunner(
+        source = _OpenAIChatAttemptSource(
             self,
             request=request,
             provider_model=provider_model,
@@ -873,11 +813,298 @@ class OpenAIChatProvider(BaseProvider):
             response_model=response_model or request.model,
             reasoning=reasoning,
         )
-        return runner.run()
+        return self._supervisor.stream(
+            source,
+            publication=PublicationBuffer(),
+            recovery=_OpenAIChatRecoveryStrategy(source),
+        )
 
 
-class _OpenAIChatStreamRunner:
-    """Orchestrate one OpenAI-chat request and its recovery lifecycle."""
+class _OpenAIChatAttemptState:
+    """Persist one corrected Chat request across physical attempts."""
+
+    def __init__(
+        self,
+        provider: OpenAIChatProvider,
+        body: dict[str, Any],
+        *,
+        request_id: str | None,
+    ) -> None:
+        self._provider = provider
+        self._body = provider._apply_learned_output_cap(body)
+        self._request_id = request_id
+        self._used_retry_kinds: set[str] = set()
+
+    @property
+    def body(self) -> dict[str, Any]:
+        return self._body
+
+    async def open_stream(self) -> Any:
+        """Perform exactly one upstream call and normalize its stream."""
+        stream: Any | None = None
+        try:
+            create_body = self._provider._prepare_create_body(self._body)
+            stream = await self._provider._client.chat.completions.create(
+                **create_body,
+                stream=True,
+            )
+            return self._provider._normalize_stream(stream, self._body)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if stream is not None:
+                await close_provider_stream(
+                    stream,
+                    active_error=sys.exception(),
+                    provider_name=self._provider._provider_name,
+                    request_id=self._request_id,
+                )
+            raise
+
+    def apply_correction(self, error: Exception) -> bool:
+        retry_body = self._provider._next_create_retry_body(
+            error,
+            self._body,
+            self._used_retry_kinds,
+        )
+        if retry_body is None:
+            return False
+        self._body = retry_body
+        return True
+
+
+class _OpenAIChatStreamEpoch(AsyncIterator[object]):
+    """One Chat raw stream and its fresh semantic decoder state."""
+
+    def __init__(
+        self,
+        stream: Any,
+        *,
+        assembler: _OpenAIChatStreamAssembler,
+        provider: OpenAIChatProvider,
+        input_tokens: int,
+        request_id: str | None,
+    ) -> None:
+        self._stream = stream
+        self._iterator = aiter(stream)
+        self._assembler = assembler
+        self._provider = provider
+        self._input_tokens = input_tokens
+        self._request_id = request_id
+
+    def __aiter__(self) -> AsyncIterator[object]:
+        return self
+
+    async def __anext__(self) -> object:
+        return await anext(self._iterator)
+
+    async def aclose(self) -> None:
+        await maybe_await_aclose(self._stream)
+
+    @property
+    def recovery_snapshot(self) -> _OpenAIChatStreamAssembler:
+        return self._assembler
+
+    def start(self) -> StreamFeed:
+        return StreamFeed(tuple(self._assembler.start_events()))
+
+    def feed(self, raw: object) -> StreamFeed:
+        return StreamFeed(tuple(self._assembler.feed(raw)))
+
+    def finish(self) -> StreamFeed:
+        events = list(self._assembler.finish_upstream())
+        events.extend(self._assembler.prepare_completion())
+        events.extend(
+            self._assembler.terminal_events(
+                usage_fields=self._provider._usage_fields(self._assembler.usage_info)
+            )
+        )
+        return StreamFeed(tuple(events), terminal=True)
+
+    def failure_events(self) -> tuple[InferenceEvent, ...]:
+        return tuple(self._assembler.ledger.close_unclosed_blocks())
+
+    def trace_completed(self) -> None:
+        completion = self._assembler.completion
+        if completion.provider_input_tokens is not None:
+            logger.debug(
+                "TOKEN_ESTIMATE: our={} provider={} diff={:+d}",
+                self._input_tokens,
+                completion.provider_input_tokens,
+                completion.provider_input_tokens - self._input_tokens,
+            )
+        trace_event(
+            stage="provider",
+            event="provider.response.completed",
+            source="provider",
+            provider=self._provider._provider_name,
+            request_id=self._request_id,
+            finish_reason=(
+                None
+                if completion.finish_reason is None
+                else str(completion.finish_reason)
+            ),
+            output_tokens=completion.output_tokens,
+            prompt_tokens=completion.input_tokens,
+            prompt_tokens_estimate=self._input_tokens,
+        )
+
+
+class _OpenAIChatRecoveryEpoch(AsyncIterator[object]):
+    """Collect one private Chat continuation or tool-repair response."""
+
+    def __init__(
+        self,
+        stream: Any,
+        *,
+        provider: OpenAIChatProvider,
+        request: InferenceRequest,
+        tool_names: OpenAIToolNameCodec,
+        accepted_body: Mapping[str, Any],
+        include_reasoning: bool,
+    ) -> None:
+        self._stream = stream
+        self._iterator = aiter(stream)
+        self._provider = provider
+        self._request = request
+        self._tool_names = tool_names
+        self._accepted_body = accepted_body
+        self._include_reasoning = include_reasoning
+        self._text_parts: list[str] = []
+        self._thinking_parts: list[str] = []
+        self._tool_calls = OpenAIToolCallCollector()
+        self._terminal_seen = False
+
+    def __aiter__(self) -> AsyncIterator[object]:
+        return self
+
+    async def __anext__(self) -> object:
+        return await anext(self._iterator)
+
+    async def aclose(self) -> None:
+        await maybe_await_aclose(self._stream)
+
+    def feed(self, raw: object) -> None:
+        choices = getattr(raw, "choices", None)
+        if not choices:
+            return
+        choice = choices[0]
+        if choice.finish_reason is not None:
+            self._terminal_seen = True
+        delta = choice.delta
+        if delta is None:
+            return
+        if self._include_reasoning:
+            reasoning = self._provider._profile.reasoning_delta(delta)
+            if reasoning:
+                self._thinking_parts.append(reasoning)
+        content = getattr(delta, "content", None)
+        if isinstance(content, str) and content:
+            self._text_parts.append(content)
+        native_tool_calls = getattr(delta, "tool_calls", None)
+        if isinstance(native_tool_calls, list | tuple):
+            for tool_call in native_tool_calls:
+                self._tool_calls.add(tool_call)
+
+    def finish(self) -> _CollectedRecoveryOutput:
+        completed_tool_calls = self._tool_calls.completed_calls(
+            self._request,
+            tool_names=self._tool_names,
+            tool_argument_aliases=self._provider._tool_argument_aliases(
+                dict(self._accepted_body)
+            ),
+        )
+        if self._tool_calls.has_calls and completed_tool_calls is None:
+            raise TruncatedProviderStreamError(
+                "Recovery stream ended with an incomplete tool call."
+            )
+        if not self._terminal_seen and not completed_tool_calls:
+            raise TruncatedProviderStreamError(
+                "Recovery stream ended without finish_reason."
+            )
+        return _CollectedRecoveryOutput(
+            text="".join(self._text_parts),
+            thinking="".join(self._thinking_parts),
+            tool_calls=completed_tool_calls or (),
+        )
+
+
+class _OpenAIChatRecoverySource:
+    """One corrected private Chat recovery request on the shared attempt budget."""
+
+    def __init__(
+        self,
+        primary: _OpenAIChatAttemptSource,
+        body: dict[str, Any],
+        *,
+        include_reasoning: bool,
+    ) -> None:
+        self._primary = primary
+        self._state = _OpenAIChatAttemptState(
+            primary.provider,
+            body,
+            request_id=primary.request_id,
+        )
+        self._include_reasoning = include_reasoning
+
+    @property
+    def trace_context(self) -> StreamTraceContext:
+        return StreamTraceContext(
+            provider_name=self._primary.provider._provider_name,
+            request_id=self._primary.request_id,
+            recovery_kind="openai_text",
+        )
+
+    @property
+    def failure_override(self) -> ProviderFailureOverride:
+        return self._primary.provider._provider_failure_override
+
+    def trace_started(self, execution: ProviderExecution) -> None:
+        del execution
+
+    async def open(self) -> _OpenAIChatRecoveryEpoch:
+        stream = await self._state.open_stream()
+        try:
+            return _OpenAIChatRecoveryEpoch(
+                stream,
+                provider=self._primary.provider,
+                request=self._primary.request,
+                tool_names=self._primary.tool_names,
+                accepted_body=self._state.body,
+                include_reasoning=self._include_reasoning,
+            )
+        except Exception:
+            await close_provider_stream(
+                stream,
+                active_error=sys.exception(),
+                provider_name=self._primary.provider._provider_name,
+                request_id=self._primary.request_id,
+            )
+            raise
+
+    def apply_correction(self, error: Exception) -> bool:
+        return self._state.apply_correction(error)
+
+    def attempt_error(self, error: Exception) -> Exception:
+        return error
+
+    def is_retryable(self, error: Exception) -> bool:
+        return is_retryable_stream_error(error)
+
+    def classify_failure(self, error: Exception) -> ExecutionFailure:
+        return classify_provider_failure(
+            underlying_provider_error(error),
+            provider_name=self._primary.provider._provider_name,
+            read_timeout_s=self._primary.provider._config.http_read_timeout,
+            request_id=self._primary.request_id,
+            provider_failure_override=(
+                self._primary.provider._provider_failure_override
+            ),
+        )
+
+
+class _OpenAIChatAttemptSource:
+    """Request-scoped Chat connector, decoder factory, and failure policy."""
 
     def __init__(
         self,
@@ -904,55 +1131,61 @@ class _OpenAIChatStreamRunner:
             replay_format="chat-completions",
         )
         self._response_id = f"response_{uuid.uuid4().hex}"
-        self._tool_calls = OpenAIToolCallAssembler(
-            record_extra_content=provider._record_tool_call_extra_content,
-            replay_scope=self._replay_scope,
+        self._state: _OpenAIChatAttemptState | None = None
+
+    @property
+    def provider(self) -> OpenAIChatProvider:
+        return self._provider
+
+    @property
+    def request(self) -> InferenceRequest:
+        return self._request
+
+    @property
+    def request_id(self) -> str | None:
+        return self._request_id
+
+    @property
+    def tool_names(self) -> OpenAIToolNameCodec:
+        return self._tool_names
+
+    @property
+    def body(self) -> dict[str, Any]:
+        return self._ensure_state().body
+
+    @property
+    def trace_context(self) -> StreamTraceContext:
+        return StreamTraceContext(
+            provider_name=self._provider._provider_name,
+            request_id=self._request_id,
         )
 
-    async def run(self) -> AsyncIterator[InferenceEvent]:
-        """Convert the upstream OpenAI-chat stream into canonical events."""
-        execution = self._provider._admission.start_execution(
-            request_id=self._request_id
-        )
-        provider_stream = self._run_execution(execution)
-        try:
-            async for event in provider_stream:
-                yield event
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:
-            execution.fail(error)
-            raise
-        else:
-            execution.succeed()
-        finally:
-            await maybe_await_aclose(provider_stream)
-            execution.abandon()
+    @property
+    def failure_override(self) -> ProviderFailureOverride:
+        return self._provider._provider_failure_override
 
-    async def _run_execution(
-        self,
-        execution: ProviderExecution,
-    ) -> AsyncIterator[InferenceEvent]:
-        """Run one provider execution while retaining transport-owned state."""
-        tag = self._provider._provider_name
-        req_tag = f" request_id={self._request_id}" if self._request_id else ""
-        recovery = RecoveryController()
+    def _ensure_state(self) -> _OpenAIChatAttemptState:
+        if self._state is None:
+            body = self._provider._build_request_body(
+                self._request,
+                provider_model=self._provider_model,
+                reasoning=self._reasoning,
+            )
+            request_stream_usage(body)
+            self._state = _OpenAIChatAttemptState(
+                self._provider,
+                body,
+                request_id=self._request_id,
+            )
+        return self._state
 
-        def hold_event(event: InferenceEvent) -> Iterator[InferenceEvent]:
-            yield from recovery.push(event)
-
-        body = self._provider._build_request_body(
-            self._request,
-            provider_model=self._provider_model,
-            reasoning=self._reasoning,
-        )
-        request_stream_usage(body)
-        output_reasoning = self._reasoning.output_enabled
+    def trace_started(self, execution: ProviderExecution) -> None:
+        body = self.body
         trace_event(
             stage="provider",
             event="provider.request.sent",
             source="provider",
-            provider=tag,
+            provider=self._provider._provider_name,
             request_id=self._request_id,
             execution_id=execution.execution_id,
             gateway_model=self._response_model,
@@ -962,188 +1195,53 @@ class _OpenAIChatStreamRunner:
             body=provider_chat_body_snapshot(body),
         )
 
-        while True:
-            assembler = self._new_stream_assembler(output_reasoning=output_reasoning)
-            for event in assembler.start_events():
-                for out_event in hold_event(event):
-                    yield out_event
-            scope: ProviderAttemptScope | None = None
-            try:
-                stream, body, attempt = await self._provider._create_stream(
-                    body,
-                    execution,
-                    ProviderOperationKind.GENERATION,
-                )
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name=tag,
-                    request_id=self._request_id,
-                )
-                stream = scope.retain(stream)
-                assembler.bind_tool_argument_aliases(
-                    self._provider._tool_argument_aliases(body)
-                )
-                async for chunk in stream:
-                    if not scope.attempt.accepted:
-                        await scope.attempt.accept()
-                    for event in assembler.feed(chunk):
-                        for out_event in hold_event(event):
-                            yield out_event
-
-                for event in assembler.finish_upstream():
-                    for out_event in hold_event(event):
-                        yield out_event
-                break
-
-            except asyncio.CancelledError, GeneratorExit:
-                raise
-            except Exception as error:
-                resolution = await self._resolve_attempt_failure(
-                    error=error,
-                    scope=scope,
-                    assembler=assembler,
-                    body=body,
-                    execution=execution,
-                    recovery=recovery,
-                    req_tag=req_tag,
-                )
-                if resolution.outcome is _OpenAIChatFailureOutcome.RETRY:
-                    continue
-                for event in resolution.events:
-                    yield event
-                if resolution.outcome is _OpenAIChatFailureOutcome.COMPLETE:
-                    return
-                if resolution.failure is None:
-                    raise AssertionError(
-                        "raise resolution requires a failure"
-                    ) from error
-                raise resolution.failure from error
-            finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
-
-        for event in assembler.prepare_completion():
-            for out_event in hold_event(event):
-                yield out_event
-        completion = assembler.completion
-        if completion.provider_input_tokens is not None:
-            logger.debug(
-                "TOKEN_ESTIMATE: our={} provider={} diff={:+d}",
-                self._input_tokens,
-                completion.provider_input_tokens,
-                completion.provider_input_tokens - self._input_tokens,
+    async def open(self) -> _OpenAIChatStreamEpoch:
+        state = self._ensure_state()
+        stream = await state.open_stream()
+        try:
+            assembler = self._new_stream_assembler(
+                output_reasoning=self._reasoning.output_enabled
             )
-        trace_event(
-            stage="provider",
-            event="provider.response.completed",
-            source="provider",
-            provider=tag,
-            request_id=self._request_id,
-            finish_reason=(
-                None
-                if completion.finish_reason is None
-                else str(completion.finish_reason)
-            ),
-            output_tokens=completion.output_tokens,
-            prompt_tokens=completion.input_tokens,
-            prompt_tokens_estimate=self._input_tokens,
-        )
-        for event in assembler.terminal_events(
-            usage_fields=self._provider._usage_fields(assembler.usage_info)
-        ):
-            for out_event in hold_event(event):
-                yield out_event
-        for event in recovery.flush():
-            yield event
-
-    async def _resolve_attempt_failure(
-        self,
-        *,
-        error: Exception,
-        scope: ProviderAttemptScope | None,
-        assembler: _OpenAIChatStreamAssembler,
-        body: dict[str, Any],
-        execution: ProviderExecution,
-        recovery: RecoveryController,
-        req_tag: str,
-    ) -> _OpenAIChatFailureResolution:
-        """Resolve one failed generation attempt without owning retry policy."""
-        attempt_failure = None
-        if scope is not None and not scope.attempt.accepted:
-            attempt_failure = await scope.attempt.fail(
-                error,
-                provider_failure_override=self._provider._provider_failure_override,
+            assembler.bind_tool_argument_aliases(
+                self._provider._tool_argument_aliases(state.body)
             )
-
-        retryable = (
-            attempt_failure.retryable
-            if attempt_failure is not None
-            else is_retryable_stream_error(error)
-        )
-        generated_output = assembler.generated_output
-        complete_tool_salvageable = assembler.complete_tool_salvageable
-        decision = recovery.advance_failure(
-            retryable=retryable,
-            stream_opened=scope is not None,
-            generated_output=generated_output,
-            complete_tool_salvageable=complete_tool_salvageable,
-            attempts_remaining=execution.attempts_remaining,
-        )
-        tag = self._provider._provider_name
-        if decision.action == RecoveryFailureAction.EARLY_RETRY:
-            trace_event(
-                stage="provider",
-                event="provider.recovery.early_retry",
-                source="provider",
-                provider=tag,
+            return _OpenAIChatStreamEpoch(
+                stream,
+                assembler=assembler,
+                provider=self._provider,
+                input_tokens=self._input_tokens,
                 request_id=self._request_id,
-                attempts_started=execution.attempts_started,
-                max_attempts=execution.max_attempts,
-                retryable=True,
             )
-            return _OpenAIChatFailureResolution(outcome=_OpenAIChatFailureOutcome.RETRY)
+        except Exception:
+            await close_provider_stream(
+                stream,
+                active_error=sys.exception(),
+                provider_name=self._provider._provider_name,
+                request_id=self._request_id,
+            )
+            raise
 
-        if decision.action == RecoveryFailureAction.MIDSTREAM_RECOVERY:
-            if scope is not None:
-                await scope.aclose(active_error=error)
-            try:
-                recovery_events = await self._recovery_events(
-                    body=body,
-                    ledger=assembler.ledger,
-                    error=error,
-                    tool_argument_alias_buffers=(assembler.tool_argument_alias_buffers),
-                    output_reasoning=self._reasoning.output_enabled,
-                    execution=execution,
-                )
-            except Exception as recovery_error:
-                trace_event(
-                    stage="provider",
-                    event="provider.recovery.failed",
-                    source="provider",
-                    provider=tag,
-                    request_id=self._request_id,
-                    exc_type=type(recovery_error).__name__,
-                )
-                recovery_events = None
-            if recovery_events is not None:
-                return _OpenAIChatFailureResolution(
-                    outcome=_OpenAIChatFailureOutcome.COMPLETE,
-                    events=(
-                        *recovery.flush_uncommitted(decision),
-                        *recovery_events,
-                    ),
-                )
+    def apply_correction(self, error: Exception) -> bool:
+        return self._ensure_state().apply_correction(error)
 
+    def attempt_error(self, error: Exception) -> Exception:
+        return error
+
+    def is_retryable(self, error: Exception) -> bool:
+        return is_retryable_stream_error(error)
+
+    def classify_failure(self, error: Exception) -> ExecutionFailure:
         reported_error = underlying_provider_error(error)
+        req_tag = f" request_id={self._request_id}" if self._request_id else ""
         self._provider._log_stream_transport_error(
-            tag,
+            self._provider._provider_name,
             req_tag,
             reported_error,
             request_id=self._request_id,
         )
         failure = classify_provider_failure(
             reported_error,
-            provider_name=tag,
+            provider_name=self._provider._provider_name,
             read_timeout_s=self._provider._config.http_read_timeout,
             request_id=self._request_id,
             provider_failure_override=self._provider._provider_failure_override,
@@ -1152,7 +1250,7 @@ class _OpenAIChatStreamRunner:
             "stage": "provider",
             "event": "provider.response.error",
             "source": "provider",
-            "provider": tag,
+            "provider": self._provider._provider_name,
             "request_id": self._request_id,
             "exc_type": type(reported_error).__name__,
             "failure_kind": failure.kind.value,
@@ -1162,304 +1260,7 @@ class _OpenAIChatStreamRunner:
         if self._provider._config.log_api_error_tracebacks:
             error_trace["error_message"] = failure.message
         trace_event(**error_trace)
-
-        failure_events: list[InferenceEvent] = []
-        if (
-            not decision.committed
-            and decision.has_buffered
-            and complete_tool_salvageable
-        ):
-            failure_events.extend(recovery.flush())
-        elif not decision.committed:
-            recovery.discard()
-            return _OpenAIChatFailureResolution(
-                outcome=_OpenAIChatFailureOutcome.RAISE,
-                failure=failure,
-            )
-        failure_events.extend(assembler.ledger.close_unclosed_blocks())
-        return _OpenAIChatFailureResolution(
-            outcome=_OpenAIChatFailureOutcome.RAISE,
-            events=tuple(failure_events),
-            failure=failure,
-        )
-
-    async def _collect_recovery_output(
-        self,
-        body: dict[str, Any],
-        *,
-        include_reasoning: bool,
-        execution: ProviderExecution,
-        operation_kind: ProviderOperationKind,
-    ) -> _CollectedRecoveryOutput:
-        """Collect one complete buffered continuation response."""
-        last_error: Exception | None = None
-        while execution.can_attempt:
-            scope: ProviderAttemptScope | None = None
-            try:
-                stream, accepted_body, attempt = await self._provider._create_stream(
-                    body,
-                    execution,
-                    operation_kind,
-                )
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name=self._provider._provider_name,
-                    request_id=self._request_id,
-                )
-                stream = scope.retain(stream)
-                text_parts: list[str] = []
-                thinking_parts: list[str] = []
-                tool_calls = OpenAIToolCallCollector()
-                terminal_seen = False
-                async for chunk in stream:
-                    if not scope.attempt.accepted:
-                        await scope.attempt.accept()
-                    if not getattr(chunk, "choices", None):
-                        continue
-                    choice = chunk.choices[0]
-                    if choice.finish_reason is not None:
-                        terminal_seen = True
-                    delta = choice.delta
-                    if delta is None:
-                        continue
-                    if include_reasoning:
-                        reasoning = self._provider._profile.reasoning_delta(delta)
-                        if reasoning:
-                            thinking_parts.append(reasoning)
-                    content = getattr(delta, "content", None)
-                    if isinstance(content, str) and content:
-                        text_parts.append(content)
-                    native_tool_calls = getattr(delta, "tool_calls", None)
-                    if isinstance(native_tool_calls, list | tuple):
-                        for tool_call in native_tool_calls:
-                            tool_calls.add(tool_call)
-
-                completed_tool_calls = tool_calls.completed_calls(
-                    self._request,
-                    tool_names=self._tool_names,
-                    tool_argument_aliases=self._provider._tool_argument_aliases(
-                        accepted_body
-                    ),
-                )
-                if tool_calls.has_calls and completed_tool_calls is None:
-                    raise TruncatedProviderStreamError(
-                        "Recovery stream ended with an incomplete tool call."
-                    )
-                if not terminal_seen and not completed_tool_calls:
-                    raise TruncatedProviderStreamError(
-                        "Recovery stream ended without finish_reason."
-                    )
-                return _CollectedRecoveryOutput(
-                    text="".join(text_parts),
-                    thinking="".join(thinking_parts),
-                    tool_calls=completed_tool_calls or (),
-                )
-            except Exception as error:
-                last_error = error
-                retryable = is_retryable_stream_error(error)
-                if scope is not None and not scope.attempt.accepted:
-                    failure = await scope.attempt.fail(
-                        error,
-                        provider_failure_override=(
-                            self._provider._provider_failure_override
-                        ),
-                    )
-                    retryable = failure.retryable
-                if not retryable or not execution.can_attempt:
-                    raise
-                trace_event(
-                    stage="provider",
-                    event="provider.recovery.retry",
-                    source="provider",
-                    provider=self._provider._provider_name,
-                    recovery_kind="openai_text",
-                    attempts_started=execution.attempts_started,
-                    max_attempts=execution.max_attempts,
-                    exc_type=type(error).__name__,
-                )
-            finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
-        if last_error is not None:
-            raise last_error
-        return _CollectedRecoveryOutput(text="", thinking="", tool_calls=())
-
-    async def _recovery_events(
-        self,
-        *,
-        body: dict[str, Any],
-        ledger: InferenceStreamLedger,
-        error: Exception,
-        tool_argument_alias_buffers: Mapping[int, str],
-        output_reasoning: bool,
-        execution: ProviderExecution,
-    ) -> list[InferenceEvent] | None:
-        """Build terminal recovery events when the interrupted stream permits it."""
-        if ledger.has_emitted_tool_block():
-            if not all_emitted_tools_complete(ledger, self._request):
-                repair_events = await self._repair_tool_args(
-                    body=body,
-                    ledger=ledger,
-                    tool_argument_alias_buffers=tool_argument_alias_buffers,
-                    execution=execution,
-                )
-                if repair_events is None:
-                    return None
-            else:
-                repair_events = []
-            events: list[InferenceEvent] = list(repair_events)
-            events.extend(ledger.close_all_blocks())
-            events.extend(
-                ledger.finish_events(
-                    FinishReason.END_TURN,
-                    _estimated_recovery_usage(
-                        input_tokens=self._input_tokens,
-                        output_tokens=ledger.estimate_output_tokens(),
-                    ),
-                )
-            )
-            trace_event(
-                stage="provider",
-                event="provider.recovery.tool_salvaged",
-                source="provider",
-                provider=self._provider._provider_name,
-                request_id=self._request_id,
-            )
-            return events
-
-        partial_text = ledger.accumulated_text
-        partial_thinking = ledger.accumulated_reasoning
-        if not partial_text and not partial_thinking:
-            return None
-
-        if isinstance(error, RetryableToolProtocolError):
-            recovery_body = make_response_recovery_body(
-                body,
-                partial_text,
-                partial_thinking,
-            )
-        else:
-            recovery_body = make_text_recovery_body(
-                body,
-                partial_text,
-                partial_thinking,
-            )
-        recovered = await self._collect_recovery_output(
-            recovery_body,
-            include_reasoning=output_reasoning,
-            execution=execution,
-            operation_kind=ProviderOperationKind.CONTINUATION,
-        )
-        text_suffix = continuation_suffix(partial_text, recovered.text)
-        thinking_suffix = continuation_suffix(partial_thinking, recovered.thinking)
-        events: list[InferenceEvent] = []
-        if thinking_suffix:
-            events.extend(ledger.ensure_reasoning_block())
-            events.append(ledger.emit_reasoning_delta(thinking_suffix))
-        if text_suffix:
-            events.extend(ledger.ensure_text_block())
-            events.append(ledger.emit_text_delta(text_suffix))
-        if recovered.tool_calls:
-            events.extend(ledger.close_content_blocks())
-            for tool_call in recovered.tool_calls:
-                events.extend(
-                    self._tool_calls.process_tool_call(
-                        tool_call,
-                        ledger,
-                        tool_names=self._tool_names,
-                    )
-                )
-        if not events:
-            return None
-        events.extend(ledger.close_all_blocks())
-        events.extend(
-            ledger.finish_events(
-                FinishReason.END_TURN,
-                _estimated_recovery_usage(
-                    input_tokens=self._input_tokens,
-                    output_tokens=ledger.estimate_output_tokens(),
-                ),
-            )
-        )
-        trace_event(
-            stage="provider",
-            event="provider.recovery.continued",
-            source="provider",
-            provider=self._provider._provider_name,
-            request_id=self._request_id,
-        )
-        return events
-
-    async def _repair_tool_args(
-        self,
-        *,
-        body: dict[str, Any],
-        ledger: InferenceStreamLedger,
-        tool_argument_alias_buffers: Mapping[int, str],
-        execution: ProviderExecution,
-    ) -> list[InferenceEvent] | None:
-        schemas = tool_schemas_by_name(self._request)
-        events: list[InferenceEvent] = []
-        for tool_index, state in started_tool_states(ledger):
-            block = ledger.tool_block_for_tool_index(tool_index)
-            emitted_prefix = block.content if block is not None else ""
-            repair_prefix = emitted_prefix
-            if not repair_prefix and state.name == "Task":
-                repair_prefix = self._tool_calls.buffered_task_args(tool_index)
-            if not repair_prefix and tool_index in tool_argument_alias_buffers:
-                repair_prefix = tool_argument_alias_buffers[tool_index]
-            if (
-                parse_complete_tool_input(repair_prefix, state.name, schemas)
-                is not None
-            ):
-                if not emitted_prefix and repair_prefix:
-                    events.append(ledger.emit_tool_delta(tool_index, repair_prefix))
-                continue
-
-            schema = schemas.get(state.name)
-            recovery_body = make_tool_repair_body(
-                body,
-                tool_name=state.name,
-                prefix=repair_prefix,
-                input_schema=schema.input_schema if schema is not None else None,
-            )
-            accepted_suffix: str | None = None
-            repair_attempt = 0
-            while execution.can_attempt:
-                repair_attempt += 1
-                recovered = await self._collect_recovery_output(
-                    recovery_body,
-                    include_reasoning=False,
-                    execution=execution,
-                    operation_kind=ProviderOperationKind.TOOL_REPAIR,
-                )
-                repair = accept_tool_json_repair(
-                    repair_prefix,
-                    recovered.text,
-                    tool_name=state.name,
-                    schemas=schemas,
-                )
-                if repair is not None:
-                    accepted_suffix = repair.suffix
-                    trace_event(
-                        stage="provider",
-                        event="provider.recovery.tool_repaired",
-                        source="provider",
-                        provider=self._provider._provider_name,
-                        tool_name=state.name,
-                        attempt=repair_attempt,
-                    )
-                    break
-            if accepted_suffix is None:
-                return None
-            to_emit = (
-                accepted_suffix if emitted_prefix else repair_prefix + accepted_suffix
-            )
-            if to_emit:
-                events.append(ledger.emit_tool_delta(tool_index, to_emit))
-        if not all_emitted_tools_complete(ledger, self._request):
-            return None
-        return events
+        return failure
 
     def _new_stream_assembler(
         self, *, output_reasoning: bool
@@ -1484,7 +1285,258 @@ class _OpenAIChatStreamRunner:
             provider_name=self._provider._provider_name,
             output_reasoning=output_reasoning,
             tool_names=self._tool_names,
-            tool_calls=self._tool_calls,
+            tool_calls=OpenAIToolCallAssembler(
+                record_extra_content=self._provider._record_tool_call_extra_content,
+                replay_scope=self._replay_scope,
+            ),
             extra_reasoning_events=extra_reasoning_events,
             replay_scope=self._replay_scope,
         )
+
+
+class _OpenAIChatRecoveryStrategy:
+    """Chat-only continuation, tool salvage, and repair policy."""
+
+    def __init__(self, primary: _OpenAIChatAttemptSource) -> None:
+        self._primary = primary
+
+    def prefers_recovery(
+        self, context: RecoveryContext[_OpenAIChatStreamAssembler]
+    ) -> bool:
+        assembler = context.snapshot
+        return (
+            context.retryable
+            and assembler.generated_output
+            and (context.attempts_remaining > 0 or assembler.complete_tool_salvageable)
+            and (
+                context.published
+                or assembler.complete_tool_salvageable
+                or context.attempts_remaining == 1
+            )
+        )
+
+    async def resolve(
+        self,
+        context: RecoveryContext[_OpenAIChatStreamAssembler],
+        attempts: BoundAttemptOperations,
+    ) -> RecoveryOutcome | None:
+        assembler = context.snapshot
+        if self.prefers_recovery(context):
+            try:
+                recovery_events = await self._recovery_events(
+                    assembler=assembler,
+                    error=context.error,
+                    attempts=attempts,
+                )
+            except asyncio.CancelledError, GeneratorExit:
+                raise
+            except Exception as recovery_error:
+                trace_event(
+                    stage="provider",
+                    event="provider.recovery.failed",
+                    source="provider",
+                    provider=self._primary.provider._provider_name,
+                    request_id=self._primary.request_id,
+                    exc_type=type(recovery_error).__name__,
+                )
+            else:
+                if recovery_events is not None:
+                    return RecoveryOutcome(
+                        events=tuple(recovery_events),
+                        publish_buffer=(not context.published and context.has_buffered),
+                        completed=True,
+                    )
+
+        if (
+            not context.published
+            and context.has_buffered
+            and assembler.complete_tool_salvageable
+        ):
+            return RecoveryOutcome(
+                events=tuple(assembler.ledger.close_unclosed_blocks()),
+                publish_buffer=True,
+                completed=False,
+            )
+        return None
+
+    async def _recovery_events(
+        self,
+        *,
+        assembler: _OpenAIChatStreamAssembler,
+        error: Exception,
+        attempts: BoundAttemptOperations,
+    ) -> list[InferenceEvent] | None:
+        """Build terminal recovery events when the interrupted stream permits it."""
+        ledger = assembler.ledger
+        body = self._primary.body
+        if ledger.has_emitted_tool_block():
+            if not all_emitted_tools_complete(ledger, self._primary.request):
+                repair_events = await self._repair_tool_args(
+                    body=body,
+                    assembler=assembler,
+                    attempts=attempts,
+                )
+                if repair_events is None:
+                    return None
+            else:
+                repair_events = []
+            events: list[InferenceEvent] = list(repair_events)
+            events.extend(ledger.close_all_blocks())
+            events.extend(
+                ledger.finish_events(
+                    FinishReason.END_TURN,
+                    _estimated_recovery_usage(
+                        input_tokens=self._primary._input_tokens,
+                        output_tokens=ledger.estimate_output_tokens(),
+                    ),
+                )
+            )
+            trace_event(
+                stage="provider",
+                event="provider.recovery.tool_salvaged",
+                source="provider",
+                provider=self._primary.provider._provider_name,
+                request_id=self._primary.request_id,
+            )
+            return events
+
+        partial_text = ledger.accumulated_text
+        partial_thinking = ledger.accumulated_reasoning
+        if not partial_text and not partial_thinking:
+            return None
+
+        if isinstance(error, RetryableToolProtocolError):
+            recovery_body = make_response_recovery_body(
+                body,
+                partial_text,
+                partial_thinking,
+            )
+        else:
+            recovery_body = make_text_recovery_body(
+                body,
+                partial_text,
+                partial_thinking,
+            )
+        recovered = await attempts.collect(
+            _OpenAIChatRecoverySource(
+                self._primary,
+                recovery_body,
+                include_reasoning=self._primary._reasoning.output_enabled,
+            ),
+            operation_kind=ProviderOperationKind.CONTINUATION,
+        )
+        text_suffix = continuation_suffix(partial_text, recovered.text)
+        thinking_suffix = continuation_suffix(partial_thinking, recovered.thinking)
+        events: list[InferenceEvent] = []
+        if thinking_suffix:
+            events.extend(ledger.ensure_reasoning_block())
+            events.append(ledger.emit_reasoning_delta(thinking_suffix))
+        if text_suffix:
+            events.extend(ledger.ensure_text_block())
+            events.append(ledger.emit_text_delta(text_suffix))
+        if recovered.tool_calls:
+            events.extend(ledger.close_content_blocks())
+            for tool_call in recovered.tool_calls:
+                events.extend(
+                    assembler.tool_calls.process_tool_call(
+                        tool_call,
+                        ledger,
+                        tool_names=self._primary.tool_names,
+                    )
+                )
+        if not events:
+            return None
+        events.extend(ledger.close_all_blocks())
+        events.extend(
+            ledger.finish_events(
+                FinishReason.END_TURN,
+                _estimated_recovery_usage(
+                    input_tokens=self._primary._input_tokens,
+                    output_tokens=ledger.estimate_output_tokens(),
+                ),
+            )
+        )
+        trace_event(
+            stage="provider",
+            event="provider.recovery.continued",
+            source="provider",
+            provider=self._primary.provider._provider_name,
+            request_id=self._primary.request_id,
+        )
+        return events
+
+    async def _repair_tool_args(
+        self,
+        *,
+        body: dict[str, Any],
+        assembler: _OpenAIChatStreamAssembler,
+        attempts: BoundAttemptOperations,
+    ) -> list[InferenceEvent] | None:
+        ledger = assembler.ledger
+        schemas = tool_schemas_by_name(self._primary.request)
+        events: list[InferenceEvent] = []
+        for tool_index, state in started_tool_states(ledger):
+            block = ledger.tool_block_for_tool_index(tool_index)
+            emitted_prefix = block.content if block is not None else ""
+            repair_prefix = emitted_prefix
+            if not repair_prefix and state.name == "Task":
+                repair_prefix = assembler.tool_calls.buffered_task_args(tool_index)
+            if (
+                not repair_prefix
+                and tool_index in assembler.tool_argument_alias_buffers
+            ):
+                repair_prefix = assembler.tool_argument_alias_buffers[tool_index]
+            if (
+                parse_complete_tool_input(repair_prefix, state.name, schemas)
+                is not None
+            ):
+                if not emitted_prefix and repair_prefix:
+                    events.append(ledger.emit_tool_delta(tool_index, repair_prefix))
+                continue
+
+            schema = schemas.get(state.name)
+            recovery_body = make_tool_repair_body(
+                body,
+                tool_name=state.name,
+                prefix=repair_prefix,
+                input_schema=schema.input_schema if schema is not None else None,
+            )
+            accepted_suffix: str | None = None
+            repair_attempt = 0
+            while attempts.can_attempt:
+                repair_attempt += 1
+                recovered = await attempts.collect(
+                    _OpenAIChatRecoverySource(
+                        self._primary,
+                        recovery_body,
+                        include_reasoning=False,
+                    ),
+                    operation_kind=ProviderOperationKind.TOOL_REPAIR,
+                )
+                repair = accept_tool_json_repair(
+                    repair_prefix,
+                    recovered.text,
+                    tool_name=state.name,
+                    schemas=schemas,
+                )
+                if repair is not None:
+                    accepted_suffix = repair.suffix
+                    trace_event(
+                        stage="provider",
+                        event="provider.recovery.tool_repaired",
+                        source="provider",
+                        provider=self._primary.provider._provider_name,
+                        tool_name=state.name,
+                        attempt=repair_attempt,
+                    )
+                    break
+            if accepted_suffix is None:
+                return None
+            to_emit = (
+                accepted_suffix if emitted_prefix else repair_prefix + accepted_suffix
+            )
+            if to_emit:
+                events.append(ledger.emit_tool_delta(tool_index, to_emit))
+        if not all_emitted_tools_complete(ledger, self._primary.request):
+            return None
+        return events

--- a/src/free_claude_code/providers/openai_responses/transport.py
+++ b/src/free_claude_code/providers/openai_responses/transport.py
@@ -1,6 +1,5 @@
 """Standard API-key OpenAI Responses execution over the official SDK."""
 
-import asyncio
 import sys
 import uuid
 from collections.abc import AsyncIterator
@@ -26,21 +25,22 @@ from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
     ProviderExecution,
-    ProviderOperationKind,
 )
 from free_claude_code.providers.failure_policy import (
     RetryableProviderProtocolError,
     classify_provider_failure,
     is_retryable_stream_error,
 )
-from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
+from free_claude_code.providers.http import close_provider_stream
 from free_claude_code.providers.openai_compat import (
     OpenAIToolNameCodec,
     openai_replay_scope,
 )
-from free_claude_code.providers.stream_recovery import (
-    RecoveryController,
-    RecoveryFailureAction,
+from free_claude_code.providers.streaming import (
+    PublicationBuffer,
+    StreamExecutionSupervisor,
+    StreamFeed,
+    StreamTraceContext,
 )
 
 from .events import ResponsesEventDecoder, ResponsesStreamFailure
@@ -67,6 +67,173 @@ class _ClosableResponsesStream(AsyncIterator[ResponseStreamEvent]):
         await self._stream.close()
 
 
+class _ResponsesStreamEpoch(AsyncIterator[ResponseStreamEvent]):
+    """One Responses raw stream and its fresh decoder epoch."""
+
+    def __init__(
+        self,
+        stream: _ClosableResponsesStream,
+        *,
+        decoder: ResponsesEventDecoder,
+        provider_name: str,
+        request_id: str | None,
+    ) -> None:
+        self._stream = stream
+        self._decoder = decoder
+        self._provider_name = provider_name
+        self._request_id = request_id
+
+    def __aiter__(self) -> AsyncIterator[ResponseStreamEvent]:
+        return self
+
+    async def __anext__(self) -> ResponseStreamEvent:
+        return await anext(self._stream)
+
+    async def aclose(self) -> None:
+        await self._stream.aclose()
+
+    @property
+    def recovery_snapshot(self) -> None:
+        return None
+
+    def start(self) -> StreamFeed:
+        return StreamFeed(tuple(self._decoder.start()))
+
+    def feed(self, raw: ResponseStreamEvent) -> StreamFeed:
+        events = tuple(self._decoder.feed(raw.type, raw.to_dict(mode="json")))
+        return StreamFeed(events, terminal=self._decoder.completed)
+
+    def finish(self) -> StreamFeed:
+        if not self._decoder.completed:
+            raise _TruncatedResponsesStream(
+                "Provider Responses stream ended without a terminal event."
+            )
+        return StreamFeed(terminal=True)
+
+    def failure_events(self) -> tuple[InferenceEvent, ...]:
+        return tuple(self._decoder.ledger.close_unclosed_blocks())
+
+    def trace_completed(self) -> None:
+        trace_event(
+            stage="provider",
+            event="provider.response.completed",
+            source="provider",
+            provider=self._provider_name,
+            request_id=self._request_id,
+            transport="responses",
+        )
+
+
+class _ResponsesAttemptSource:
+    """Request-scoped standard Responses connector and failure policy."""
+
+    def __init__(
+        self,
+        *,
+        client: AsyncOpenAI,
+        body: ResponseCreateParamsStreaming,
+        provider_name: str,
+        read_timeout_s: float,
+        input_tokens: int,
+        request_id: str | None,
+        response_model: str,
+        tool_names: OpenAIToolNameCodec,
+        replay_scope: ReplayCompatibilityScope,
+    ) -> None:
+        self._client = client
+        self._body = body
+        self._provider_name = provider_name
+        self._read_timeout_s = read_timeout_s
+        self._input_tokens = input_tokens
+        self._request_id = request_id
+        self._response_model = response_model
+        self._tool_names = tool_names
+        self._replay_scope = replay_scope
+        self._response_id = f"response_{uuid.uuid4().hex}"
+
+    @property
+    def trace_context(self) -> StreamTraceContext:
+        return StreamTraceContext(
+            provider_name=self._provider_name,
+            request_id=self._request_id,
+            transport="responses",
+        )
+
+    @property
+    def failure_override(self) -> None:
+        return None
+
+    def trace_started(self, execution: ProviderExecution) -> None:
+        trace_event(
+            stage="provider",
+            event="provider.request.sent",
+            source="provider",
+            provider=self._provider_name,
+            request_id=self._request_id,
+            execution_id=execution.execution_id,
+            gateway_model=self._response_model,
+            downstream_model=self._body.get("model"),
+            transport="responses",
+        )
+
+    async def open(self) -> _ResponsesStreamEpoch:
+        sdk_stream = await self._client.responses.create(**self._body)
+        stream = _ClosableResponsesStream(sdk_stream)
+        try:
+            return _ResponsesStreamEpoch(
+                stream,
+                decoder=ResponsesEventDecoder(
+                    response_id=self._response_id,
+                    model=self._response_model,
+                    input_tokens=self._input_tokens,
+                    tool_names=self._tool_names,
+                    replay_scope=self._replay_scope,
+                ),
+                provider_name=self._provider_name,
+                request_id=self._request_id,
+            )
+        except Exception:
+            await close_provider_stream(
+                stream,
+                active_error=sys.exception(),
+                provider_name=self._provider_name,
+                request_id=self._request_id,
+            )
+            raise
+
+    def apply_correction(self, error: Exception) -> bool:
+        del error
+        return False
+
+    def attempt_error(self, error: Exception) -> Exception:
+        return _effective_error(error)
+
+    def is_retryable(self, error: Exception) -> bool:
+        return is_retryable_stream_error(_effective_error(error))
+
+    def classify_failure(self, error: Exception) -> ExecutionFailure:
+        effective_error = _effective_error(error)
+        failure = classify_provider_failure(
+            effective_error,
+            provider_name=self._provider_name,
+            read_timeout_s=self._read_timeout_s,
+            request_id=self._request_id,
+        )
+        trace_event(
+            stage="provider",
+            event="provider.response.error",
+            source="provider",
+            provider=self._provider_name,
+            request_id=self._request_id,
+            transport="responses",
+            exc_type=type(effective_error).__name__,
+            failure_kind=failure.kind.value,
+            status_code=failure.status_code,
+            provider_retryable=failure.retryable,
+        )
+        return failure
+
+
 class OpenAIResponsesTransport:
     """Execute public Responses requests with provider-owned retry semantics."""
 
@@ -82,6 +249,7 @@ class OpenAIResponsesTransport:
         self._admission = admission
         self._provider_name = provider_name
         self._read_timeout_s = read_timeout_s
+        self._supervisor = StreamExecutionSupervisor(admission)
 
     def preflight_stream(
         self,
@@ -113,14 +281,18 @@ class OpenAIResponsesTransport:
             provider_model,
             replay_format="responses",
         )
-        return self._run_stream(
-            body,
+        source = _ResponsesAttemptSource(
+            client=self._client,
+            body=body,
+            provider_name=self._provider_name,
+            read_timeout_s=self._read_timeout_s,
             input_tokens=input_tokens,
             request_id=request_id,
             response_model=response_model,
             tool_names=tool_names,
             replay_scope=replay_scope,
         )
+        return self._supervisor.stream(source, publication=PublicationBuffer())
 
     def _build_body(
         self,
@@ -147,183 +319,6 @@ class OpenAIResponsesTransport:
         except (ResponsesConversionError, ResponsesRequestEncodingError) as exc:
             raise InvalidRequestError(str(exc)) from exc
 
-    async def _run_stream(
-        self,
-        body: ResponseCreateParamsStreaming,
-        *,
-        input_tokens: int,
-        request_id: str | None,
-        response_model: str,
-        tool_names: OpenAIToolNameCodec,
-        replay_scope: ReplayCompatibilityScope,
-    ) -> AsyncIterator[InferenceEvent]:
-        execution = self._admission.start_execution(request_id=request_id)
-        provider_stream = self._run_execution(
-            body,
-            input_tokens=input_tokens,
-            request_id=request_id,
-            response_model=response_model,
-            tool_names=tool_names,
-            replay_scope=replay_scope,
-            execution=execution,
-        )
-        try:
-            async for event in provider_stream:
-                yield event
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:
-            execution.fail(error)
-            raise
-        else:
-            execution.succeed()
-        finally:
-            await maybe_await_aclose(provider_stream)
-            execution.abandon()
-
-    async def _run_execution(
-        self,
-        body: ResponseCreateParamsStreaming,
-        *,
-        input_tokens: int,
-        request_id: str | None,
-        response_model: str,
-        tool_names: OpenAIToolNameCodec,
-        replay_scope: ReplayCompatibilityScope,
-        execution: ProviderExecution,
-    ) -> AsyncIterator[InferenceEvent]:
-        recovery = RecoveryController()
-        response_id = f"response_{uuid.uuid4().hex}"
-        trace_event(
-            stage="provider",
-            event="provider.request.sent",
-            source="provider",
-            provider=self._provider_name,
-            request_id=request_id,
-            execution_id=execution.execution_id,
-            gateway_model=response_model,
-            downstream_model=body.get("model"),
-            transport="responses",
-        )
-
-        while execution.can_attempt:
-            stream_adapter = ResponsesEventDecoder(
-                response_id=response_id,
-                model=response_model,
-                input_tokens=input_tokens,
-                tool_names=tool_names,
-                replay_scope=replay_scope,
-            )
-            for event in stream_adapter.start():
-                for held in recovery.push(event):
-                    yield held
-
-            scope: ProviderAttemptScope | None = None
-            stream_opened = False
-            try:
-                attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name=self._provider_name,
-                    request_id=request_id,
-                )
-                sdk_stream = await self._client.responses.create(**body)
-                stream = scope.retain(_ClosableResponsesStream(sdk_stream))
-                stream_opened = True
-
-                async for upstream_event in stream:
-                    if not scope.attempt.accepted:
-                        await scope.attempt.accept()
-                    for event in stream_adapter.feed(
-                        upstream_event.type,
-                        upstream_event.to_dict(mode="json"),
-                    ):
-                        for held in recovery.push(event):
-                            yield held
-                if not stream_adapter.completed:
-                    raise _TruncatedResponsesStream(
-                        "Provider Responses stream ended without a terminal event."
-                    )
-                for event in recovery.flush():
-                    yield event
-                trace_event(
-                    stage="provider",
-                    event="provider.response.completed",
-                    source="provider",
-                    provider=self._provider_name,
-                    request_id=request_id,
-                    transport="responses",
-                )
-                return
-            except asyncio.CancelledError, GeneratorExit:
-                raise
-            except Exception as raw_error:
-                error = _effective_error(raw_error)
-                attempt_failure = None
-                if scope is not None and not scope.attempt.accepted:
-                    attempt_failure = await scope.attempt.fail(error)
-                if attempt_failure is not None and attempt_failure.retry_allowed:
-                    recovery.discard()
-                    _trace_early_retry(
-                        provider_name=self._provider_name,
-                        request_id=request_id,
-                        execution=execution,
-                    )
-                    continue
-
-                retryable = (
-                    attempt_failure.retryable
-                    if attempt_failure is not None
-                    else is_retryable_stream_error(error)
-                )
-                decision = recovery.advance_failure(
-                    retryable=retryable,
-                    stream_opened=stream_opened,
-                    generated_output=recovery.committed,
-                    complete_tool_salvageable=False,
-                    attempts_remaining=execution.attempts_remaining,
-                )
-                if decision.action is RecoveryFailureAction.EARLY_RETRY:
-                    recovery.discard()
-                    _trace_early_retry(
-                        provider_name=self._provider_name,
-                        request_id=request_id,
-                        execution=execution,
-                    )
-                    continue
-
-                failure = classify_provider_failure(
-                    error,
-                    provider_name=self._provider_name,
-                    read_timeout_s=self._read_timeout_s,
-                    request_id=request_id,
-                )
-                trace_event(
-                    stage="provider",
-                    event="provider.response.error",
-                    source="provider",
-                    provider=self._provider_name,
-                    request_id=request_id,
-                    transport="responses",
-                    exc_type=type(error).__name__,
-                    failure_kind=failure.kind.value,
-                    status_code=failure.status_code,
-                    provider_retryable=failure.retryable,
-                )
-                if not decision.committed:
-                    recovery.discard()
-                    raise failure from raw_error
-                for event in stream_adapter.ledger.close_unclosed_blocks():
-                    yield event
-                raise failure from raw_error
-            finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
-
-        if execution.last_failure is not None:
-            raise execution.last_failure
-        raise RuntimeError("Responses execution ended without a terminal result.")
-
 
 def _effective_error(error: Exception) -> Exception:
     if not isinstance(error, ResponsesStreamFailure):
@@ -341,21 +336,3 @@ def _effective_error(error: Exception) -> Exception:
         marker in code for marker in ("server", "internal", "unavailable", "timeout")
     )
     return ExecutionFailure(FailureKind.UPSTREAM, 502, message, retryable)
-
-
-def _trace_early_retry(
-    *,
-    provider_name: str,
-    request_id: str | None,
-    execution: ProviderExecution,
-) -> None:
-    trace_event(
-        stage="provider",
-        event="provider.recovery.early_retry",
-        source="provider",
-        provider=provider_name,
-        request_id=request_id,
-        transport="responses",
-        attempts_started=execution.attempts_started,
-        max_attempts=execution.max_attempts,
-    )

--- a/src/free_claude_code/providers/stream_recovery.py
+++ b/src/free_claude_code/providers/stream_recovery.py
@@ -1,20 +1,12 @@
-"""Provider-owned stream holdback and recovery decisions."""
+"""Legacy Codex stream recovery policy pending shared-supervisor migration."""
 
-import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 
-from free_claude_code.core.inference import (
-    InferenceEvent,
-    ResponseStarted,
-    inference_event_size,
-)
+from free_claude_code.core.inference import InferenceEvent
+from free_claude_code.providers.streaming.publication import PublicationBuffer
 
 from .failure_policy import RetryableProviderProtocolError
-
-EARLY_HOLDBACK_SECONDS = 0.75
-RECOVERY_BUFFER_MAX_BYTES = 65_536
 
 
 class TruncatedProviderStreamError(RetryableProviderProtocolError):
@@ -39,74 +31,25 @@ class RecoveryDecision:
     has_buffered: bool
 
 
-class RecoveryHoldbackBuffer:
-    """Briefly retain canonical output so early cutoffs retry invisibly."""
-
-    def __init__(
-        self,
-        *,
-        holdback_seconds: float = EARLY_HOLDBACK_SECONDS,
-        max_bytes: int = RECOVERY_BUFFER_MAX_BYTES,
-        now: Callable[[], float] | None = None,
-    ) -> None:
-        self._holdback_seconds = holdback_seconds
-        self._max_bytes = max_bytes
-        self._now = now or time.monotonic
-        self._events: list[InferenceEvent] = []
-        self._bytes = 0
-        self._started_at: float | None = None
-        self.committed = False
-
-    def push(self, event: InferenceEvent) -> list[InferenceEvent]:
-        if self.committed:
-            return [event]
-        if self._started_at is None and not isinstance(event, ResponseStarted):
-            self._started_at = self._now()
-        self._events.append(event)
-        self._bytes += inference_event_size(event)
-        if self._bytes >= self._max_bytes or (
-            self._started_at is not None
-            and self._now() - self._started_at >= self._holdback_seconds
-        ):
-            return self.flush()
-        return []
-
-    def flush(self) -> list[InferenceEvent]:
-        if self.committed:
-            return []
-        self.committed = True
-        events = self._events
-        self._events = []
-        self._bytes = 0
-        self._started_at = None
-        return events
-
-    def discard(self) -> None:
-        self._events = []
-        self._bytes = 0
-        self._started_at = None
-
-    @property
-    def has_buffered(self) -> bool:
-        return bool(self._events)
-
-
 class RecoveryController:
-    """Own commit-boundary holdback for one provider stream lifecycle."""
+    """Retain Codex's active recovery policy until its PR-4 migration."""
 
     def __init__(self) -> None:
-        self._holdback = RecoveryHoldbackBuffer()
+        self._holdback = PublicationBuffer()
 
     @property
     def committed(self) -> bool:
-        return self._holdback.committed
+        return self._holdback.published
 
     @property
     def has_buffered(self) -> bool:
         return self._holdback.has_buffered
 
     def push(self, event: InferenceEvent) -> list[InferenceEvent]:
-        return self._holdback.push(event)
+        publishable = self._holdback.push(event)
+        if publishable or self._holdback.seconds_until_deadline != 0:
+            return publishable
+        return self._holdback.flush()
 
     def flush(self) -> list[InferenceEvent]:
         return self._holdback.flush()
@@ -128,7 +71,7 @@ class RecoveryController:
         complete_tool_salvageable: bool,
         attempts_remaining: int,
     ) -> RecoveryDecision:
-        committed = self._holdback.committed
+        committed = self._holdback.published
         has_buffered = self._holdback.has_buffered
         retry_available = attempts_remaining > 0
         reserve_last_attempt_for_recovery = generated_output and attempts_remaining == 1
@@ -142,7 +85,6 @@ class RecoveryController:
             and not reserve_last_attempt_for_recovery
         ):
             self._holdback.discard()
-            self._holdback = RecoveryHoldbackBuffer()
             return RecoveryDecision(
                 action=RecoveryFailureAction.EARLY_RETRY,
                 retryable=True,

--- a/src/free_claude_code/providers/streaming/__init__.py
+++ b/src/free_claude_code/providers/streaming/__init__.py
@@ -1,0 +1,35 @@
+"""Shared provider streaming lifecycle owners."""
+
+from .publication import (
+    EARLY_HOLDBACK_SECONDS,
+    RECOVERY_BUFFER_MAX_BYTES,
+    PublicationBuffer,
+)
+from .supervisor import (
+    AttemptSource,
+    BoundAttemptOperations,
+    BufferedAttemptEpoch,
+    RecoveryContext,
+    RecoveryOutcome,
+    StreamAttemptEpoch,
+    StreamExecutionSupervisor,
+    StreamFeed,
+    StreamRecoveryStrategy,
+    StreamTraceContext,
+)
+
+__all__ = [
+    "EARLY_HOLDBACK_SECONDS",
+    "RECOVERY_BUFFER_MAX_BYTES",
+    "AttemptSource",
+    "BoundAttemptOperations",
+    "BufferedAttemptEpoch",
+    "PublicationBuffer",
+    "RecoveryContext",
+    "RecoveryOutcome",
+    "StreamAttemptEpoch",
+    "StreamExecutionSupervisor",
+    "StreamFeed",
+    "StreamRecoveryStrategy",
+    "StreamTraceContext",
+]

--- a/src/free_claude_code/providers/streaming/publication.py
+++ b/src/free_claude_code/providers/streaming/publication.py
@@ -1,0 +1,83 @@
+"""Policy-free canonical event holdback and publication state."""
+
+import time
+from collections.abc import Callable
+
+from free_claude_code.core.inference import (
+    InferenceEvent,
+    ResponseStarted,
+    inference_event_size,
+)
+
+EARLY_HOLDBACK_SECONDS = 0.75
+RECOVERY_BUFFER_MAX_BYTES = 65_536
+
+
+class PublicationBuffer:
+    """Briefly retain canonical output before its irreversible publication."""
+
+    def __init__(
+        self,
+        *,
+        holdback_seconds: float = EARLY_HOLDBACK_SECONDS,
+        max_bytes: int = RECOVERY_BUFFER_MAX_BYTES,
+        now: Callable[[], float] | None = None,
+    ) -> None:
+        if holdback_seconds < 0:
+            raise ValueError("holdback_seconds must be >= 0")
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be > 0")
+        self._holdback_seconds = holdback_seconds
+        self._max_bytes = max_bytes
+        self._now = now or time.monotonic
+        self._events: list[InferenceEvent] = []
+        self._bytes = 0
+        self._deadline: float | None = None
+        self._published = False
+
+    @property
+    def published(self) -> bool:
+        """Return whether canonical output has crossed the provider boundary."""
+        return self._published
+
+    @property
+    def has_buffered(self) -> bool:
+        return bool(self._events)
+
+    @property
+    def seconds_until_deadline(self) -> float | None:
+        """Return the remaining active holdback delay, if one has started."""
+        if self._published or self._deadline is None:
+            return None
+        return max(0.0, self._deadline - self._now())
+
+    def push(self, event: InferenceEvent) -> list[InferenceEvent]:
+        """Buffer one event or return events that are already publishable."""
+        if self._published:
+            return [event]
+        if self._deadline is None and not isinstance(event, ResponseStarted):
+            self._deadline = self._now() + self._holdback_seconds
+        self._events.append(event)
+        self._bytes += inference_event_size(event)
+        if self._bytes >= self._max_bytes:
+            return self.flush()
+        return []
+
+    def flush(self) -> list[InferenceEvent]:
+        """Publish every held event exactly once."""
+        if self._published:
+            return []
+        self._published = True
+        events = self._events
+        self._events = []
+        self._bytes = 0
+        self._deadline = None
+        return events
+
+    def discard(self) -> None:
+        """Discard an unpublished attempt epoch and reset its holdback clock."""
+        if self._published:
+            return
+        self._events.clear()
+        self._bytes = 0
+        self._deadline = None

--- a/src/free_claude_code/providers/streaming/supervisor.py
+++ b/src/free_claude_code/providers/streaming/supervisor.py
@@ -1,0 +1,569 @@
+"""Shared provider stream attempt, publication, and cleanup lifecycle."""
+
+import asyncio
+import sys
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Protocol
+
+from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.inference import InferenceEvent
+from free_claude_code.core.trace import trace_event
+from free_claude_code.providers.admission import (
+    ProviderAdmissionController,
+    ProviderCorrectionAction,
+    ProviderExecution,
+    ProviderOperationKind,
+)
+from free_claude_code.providers.failure_policy import ProviderFailureOverride
+from free_claude_code.providers.http import ProviderAttemptScope
+
+from .publication import PublicationBuffer
+
+
+@dataclass(frozen=True, slots=True)
+class StreamTraceContext:
+    """Safe common trace dimensions for one request-scoped attempt source."""
+
+    provider_name: str
+    request_id: str | None
+    transport: str | None = None
+    recovery_kind: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StreamFeed:
+    """Canonical events produced by one raw item or end-of-stream transition."""
+
+    events: tuple[InferenceEvent, ...] = ()
+    terminal: bool = False
+
+
+class StreamAttemptEpoch[RawT, SnapshotT](Protocol):
+    """One closeable raw stream and its fresh attempt-local decoder state."""
+
+    def __aiter__(self) -> AsyncIterator[RawT]: ...
+
+    async def __anext__(self) -> RawT: ...
+
+    async def aclose(self) -> None: ...
+
+    @property
+    def recovery_snapshot(self) -> SnapshotT: ...
+
+    def start(self) -> StreamFeed: ...
+
+    def feed(self, raw: RawT) -> StreamFeed: ...
+
+    def finish(self) -> StreamFeed: ...
+
+    def failure_events(self) -> tuple[InferenceEvent, ...]: ...
+
+    def trace_completed(self) -> None: ...
+
+
+class BufferedAttemptEpoch[RawT, ResultT](Protocol):
+    """One closeable recovery stream whose output stays private until complete."""
+
+    def __aiter__(self) -> AsyncIterator[RawT]: ...
+
+    async def __anext__(self) -> RawT: ...
+
+    async def aclose(self) -> None: ...
+
+    def feed(self, raw: RawT) -> None: ...
+
+    def finish(self) -> ResultT: ...
+
+
+class AttemptSource[EpochT](Protocol):
+    """Request-scoped owner of one-call opening and provider failure semantics."""
+
+    @property
+    def trace_context(self) -> StreamTraceContext: ...
+
+    @property
+    def failure_override(self) -> ProviderFailureOverride | None: ...
+
+    def trace_started(self, execution: ProviderExecution) -> None: ...
+
+    async def open(self) -> EpochT: ...
+
+    def apply_correction(self, error: Exception) -> bool: ...
+
+    def attempt_error(self, error: Exception) -> Exception: ...
+
+    def is_retryable(self, error: Exception) -> bool: ...
+
+    def classify_failure(self, error: Exception) -> ExecutionFailure: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryContext[SnapshotT]:
+    """Accepted stream failure state offered to optional transport recovery."""
+
+    error: Exception
+    retryable: bool
+    published: bool
+    has_buffered: bool
+    attempts_remaining: int
+    snapshot: SnapshotT
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryOutcome:
+    """Events and terminal state produced by a transport recovery strategy."""
+
+    events: tuple[InferenceEvent, ...]
+    publish_buffer: bool
+    completed: bool
+
+
+class StreamRecoveryStrategy[SnapshotT](Protocol):
+    """Optional transport policy for recovery after an accepted stream fails."""
+
+    def prefers_recovery(self, context: RecoveryContext[SnapshotT]) -> bool: ...
+
+    async def resolve(
+        self,
+        context: RecoveryContext[SnapshotT],
+        attempts: BoundAttemptOperations,
+    ) -> RecoveryOutcome | None: ...
+
+
+class BoundAttemptOperations:
+    """Run private recovery attempts on one supervisor-owned execution budget."""
+
+    def __init__(
+        self,
+        supervisor: StreamExecutionSupervisor,
+        execution: ProviderExecution,
+    ) -> None:
+        self._supervisor = supervisor
+        self._execution = execution
+
+    @property
+    def can_attempt(self) -> bool:
+        return self._execution.can_attempt
+
+    @property
+    def attempts_remaining(self) -> int:
+        return self._execution.attempts_remaining
+
+    async def collect[RawT, ResultT](
+        self,
+        source: AttemptSource[BufferedAttemptEpoch[RawT, ResultT]],
+        *,
+        operation_kind: ProviderOperationKind,
+    ) -> ResultT:
+        """Collect one complete private stream using the shared attempt lifecycle."""
+        last_error: Exception | None = None
+        while self._execution.can_attempt:
+            scope, epoch = await self._supervisor._open_epoch(
+                source,
+                self._execution,
+                operation_kind=operation_kind,
+            )
+            error: Exception | None = None
+            result: ResultT | None = None
+            try:
+                async for raw in epoch:
+                    if not scope.attempt.accepted:
+                        await scope.attempt.accept()
+                    epoch.feed(raw)
+                result = epoch.finish()
+            except asyncio.CancelledError, GeneratorExit:
+                await scope.aclose(active_error=sys.exception())
+                raise
+            except Exception as caught:
+                error = caught
+
+            if error is None:
+                await scope.aclose(active_error=None)
+                if result is None:
+                    raise RuntimeError("buffered attempt completed without a result")
+                return result
+
+            last_error = error
+            try:
+                effective_error = source.attempt_error(error)
+                if not scope.attempt.accepted:
+                    decision = await scope.attempt.fail(
+                        effective_error,
+                        provider_failure_override=source.failure_override,
+                    )
+                    retryable = decision.retryable
+                else:
+                    retryable = source.is_retryable(error)
+            except BaseException:
+                await scope.aclose(active_error=sys.exception())
+                raise
+            await scope.aclose(active_error=error)
+            if not retryable or not self._execution.can_attempt:
+                raise error
+            _trace_retry(
+                source.trace_context,
+                self._execution,
+                operation_kind=operation_kind,
+                error=error,
+            )
+
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("recovery collection ended without an attempt outcome")
+
+
+class StreamExecutionSupervisor:
+    """Compose admission attempts into one canonical provider stream lifecycle."""
+
+    def __init__(self, admission: ProviderAdmissionController) -> None:
+        self._admission = admission
+
+    async def stream[RawT, SnapshotT](
+        self,
+        source: AttemptSource[StreamAttemptEpoch[RawT, SnapshotT]],
+        *,
+        publication: PublicationBuffer,
+        recovery: StreamRecoveryStrategy[SnapshotT] | None = None,
+    ) -> AsyncIterator[InferenceEvent]:
+        """Run one request-scoped source through the shared logical lifecycle."""
+        execution = self._admission.start_execution(
+            request_id=source.trace_context.request_id
+        )
+        provider_stream: AsyncGenerator[InferenceEvent] | None = None
+        try:
+            source.trace_started(execution)
+            provider_stream = self._run_execution(
+                source,
+                publication=publication,
+                recovery=recovery,
+                execution=execution,
+            )
+            async for event in provider_stream:
+                yield event
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            execution.fail(error)
+            raise
+        else:
+            execution.succeed()
+        finally:
+            if provider_stream is not None:
+                await provider_stream.aclose()
+            execution.abandon()
+
+    async def _run_execution[RawT, SnapshotT](
+        self,
+        source: AttemptSource[StreamAttemptEpoch[RawT, SnapshotT]],
+        *,
+        publication: PublicationBuffer,
+        recovery: StreamRecoveryStrategy[SnapshotT] | None,
+        execution: ProviderExecution,
+    ) -> AsyncGenerator[InferenceEvent]:
+        while execution.can_attempt:
+            scope, epoch = await self._open_epoch(
+                source,
+                execution,
+                operation_kind=ProviderOperationKind.GENERATION,
+            )
+            pending_read: asyncio.Task[RawT] | None = None
+            terminal_events: list[InferenceEvent] = []
+            error: Exception | None = None
+            try:
+                for event in epoch.start().events:
+                    for publishable in publication.push(event):
+                        yield publishable
+                iterator = aiter(epoch)
+                while True:
+                    if pending_read is None:
+                        pending_read = asyncio.create_task(_read_next(iterator))
+                    remaining = publication.seconds_until_deadline
+                    if remaining is not None:
+                        if remaining == 0:
+                            for publishable in publication.flush():
+                                yield publishable
+                            continue
+                        done, _pending = await asyncio.wait(
+                            {pending_read},
+                            timeout=remaining,
+                        )
+                        if pending_read not in done:
+                            for publishable in publication.flush():
+                                yield publishable
+                            continue
+                    try:
+                        raw = await pending_read
+                    except StopAsyncIteration:
+                        pending_read = None
+                        break
+                    pending_read = None
+                    if not scope.attempt.accepted:
+                        await scope.attempt.accept()
+                    feed = epoch.feed(raw)
+                    if feed.terminal:
+                        terminal_events.extend(feed.events)
+                    else:
+                        for event in feed.events:
+                            for publishable in publication.push(event):
+                                yield publishable
+                finished = epoch.finish()
+                if not finished.terminal:
+                    raise RuntimeError("stream epoch finished without terminal events")
+                terminal_events.extend(finished.events)
+            except asyncio.CancelledError, GeneratorExit:
+                if pending_read is not None:
+                    if not pending_read.done():
+                        pending_read.cancel()
+                    with suppress(asyncio.CancelledError, Exception):
+                        await pending_read
+                    pending_read = None
+                await scope.aclose(active_error=sys.exception())
+                raise
+            except Exception as caught:
+                error = caught
+            finally:
+                if pending_read is not None:
+                    if not pending_read.done():
+                        pending_read.cancel()
+                    with suppress(asyncio.CancelledError, Exception):
+                        await pending_read
+
+            if error is None:
+                await scope.aclose(active_error=None)
+                epoch.trace_completed()
+                for event in terminal_events:
+                    for publishable in publication.push(event):
+                        yield publishable
+                for publishable in publication.flush():
+                    yield publishable
+                return
+
+            if not scope.attempt.accepted:
+                try:
+                    effective_error = source.attempt_error(error)
+                    decision = await scope.attempt.fail(
+                        effective_error,
+                        provider_failure_override=source.failure_override,
+                    )
+                except BaseException:
+                    await scope.aclose(active_error=sys.exception())
+                    raise
+                if decision.retry_allowed:
+                    await scope.aclose(active_error=error)
+                    publication.discard()
+                    _trace_retry(
+                        source.trace_context,
+                        execution,
+                        operation_kind=ProviderOperationKind.GENERATION,
+                        error=error,
+                    )
+                    continue
+                try:
+                    failure = source.classify_failure(error)
+                except BaseException:
+                    await scope.aclose(active_error=sys.exception())
+                    raise
+                await scope.aclose(active_error=failure)
+                publication.discard()
+                raise failure from error
+
+            try:
+                retryable = source.is_retryable(error)
+                context = RecoveryContext(
+                    error=error,
+                    retryable=retryable,
+                    published=publication.published,
+                    has_buffered=publication.has_buffered,
+                    attempts_remaining=execution.attempts_remaining,
+                    snapshot=epoch.recovery_snapshot,
+                )
+                prefer_recovery = recovery is not None and recovery.prefers_recovery(
+                    context
+                )
+            except BaseException:
+                await scope.aclose(active_error=sys.exception())
+                raise
+            if (
+                retryable
+                and not publication.published
+                and execution.can_attempt
+                and not prefer_recovery
+            ):
+                await scope.aclose(active_error=error)
+                publication.discard()
+                _trace_retry(
+                    source.trace_context,
+                    execution,
+                    operation_kind=ProviderOperationKind.GENERATION,
+                    error=error,
+                )
+                continue
+
+            failure: ExecutionFailure | None = None
+            if prefer_recovery:
+                await scope.aclose(active_error=error)
+            else:
+                try:
+                    failure = source.classify_failure(error)
+                except BaseException:
+                    await scope.aclose(active_error=sys.exception())
+                    raise
+                await scope.aclose(active_error=failure)
+
+            outcome: RecoveryOutcome | None = None
+            if recovery is not None:
+                try:
+                    outcome = await recovery.resolve(
+                        context,
+                        BoundAttemptOperations(self, execution),
+                    )
+                except asyncio.CancelledError, GeneratorExit:
+                    raise
+                except Exception as recovery_error:
+                    trace_event(
+                        stage="provider",
+                        event="provider.recovery.failed",
+                        source="provider",
+                        provider=source.trace_context.provider_name,
+                        request_id=source.trace_context.request_id,
+                        exc_type=type(recovery_error).__name__,
+                    )
+
+            if outcome is not None and outcome.completed:
+                if outcome.publish_buffer:
+                    for publishable in publication.flush():
+                        yield publishable
+                elif not publication.published:
+                    publication.discard()
+                for event in outcome.events:
+                    yield event
+                return
+
+            if failure is None:
+                failure = source.classify_failure(error)
+            if outcome is not None:
+                if outcome.publish_buffer:
+                    for publishable in publication.flush():
+                        yield publishable
+                elif not publication.published:
+                    publication.discard()
+                for event in outcome.events:
+                    yield event
+                raise failure from error
+
+            if not publication.published:
+                publication.discard()
+                raise failure from error
+            for event in epoch.failure_events():
+                yield event
+            raise failure from error
+
+        if execution.last_failure is not None:
+            raise execution.last_failure
+        raise RuntimeError("provider stream execution ended without a terminal result")
+
+    async def _open_epoch[EpochT](
+        self,
+        source: AttemptSource[EpochT],
+        execution: ProviderExecution,
+        *,
+        operation_kind: ProviderOperationKind,
+    ) -> tuple[ProviderAttemptScope, EpochT]:
+        while execution.can_attempt:
+            try:
+                attempt = await execution.open_attempt(operation_kind)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                raise source.classify_failure(error) from error
+            scope = ProviderAttemptScope(
+                attempt,
+                provider_name=source.trace_context.provider_name,
+                request_id=source.trace_context.request_id,
+            )
+            try:
+                epoch = await source.open()
+            except asyncio.CancelledError:
+                await scope.aclose(active_error=sys.exception())
+                raise
+            except Exception as error:
+                try:
+                    effective_error = source.attempt_error(error)
+                    if source.apply_correction(error):
+                        correction = await attempt.correct(effective_error)
+                        await scope.aclose(active_error=error)
+                        if correction is ProviderCorrectionAction.RETRY:
+                            continue
+                        raise source.classify_failure(error) from error
+                    decision = await attempt.fail(
+                        effective_error,
+                        provider_failure_override=source.failure_override,
+                    )
+                    await scope.aclose(active_error=error)
+                    if decision.retry_allowed:
+                        _trace_retry(
+                            source.trace_context,
+                            execution,
+                            operation_kind=operation_kind,
+                            error=error,
+                        )
+                        continue
+                    raise source.classify_failure(error) from error
+                except BaseException:
+                    await scope.aclose(active_error=sys.exception())
+                    raise
+            return scope, scope.retain(epoch)
+
+        if execution.last_failure is not None:
+            raise source.classify_failure(execution.last_failure)
+        raise RuntimeError("provider execution ended without a final error")
+
+
+def _trace_retry(
+    context: StreamTraceContext,
+    execution: ProviderExecution,
+    *,
+    operation_kind: ProviderOperationKind,
+    error: Exception,
+) -> None:
+    if operation_kind is ProviderOperationKind.GENERATION:
+        if context.transport is None:
+            trace_event(
+                stage="provider",
+                event="provider.recovery.early_retry",
+                source="provider",
+                provider=context.provider_name,
+                request_id=context.request_id,
+                attempts_started=execution.attempts_started,
+                max_attempts=execution.max_attempts,
+                retryable=True,
+            )
+        else:
+            trace_event(
+                stage="provider",
+                event="provider.recovery.early_retry",
+                source="provider",
+                provider=context.provider_name,
+                request_id=context.request_id,
+                transport=context.transport,
+                attempts_started=execution.attempts_started,
+                max_attempts=execution.max_attempts,
+                retryable=True,
+            )
+        return
+    trace_event(
+        stage="provider",
+        event="provider.recovery.retry",
+        source="provider",
+        provider=context.provider_name,
+        recovery_kind=context.recovery_kind or operation_kind.value,
+        attempts_started=execution.attempts_started,
+        max_attempts=execution.max_attempts,
+        exc_type=type(error).__name__,
+    )
+
+
+async def _read_next[RawT](iterator: AsyncIterator[RawT]) -> RawT:
+    return await anext(iterator)

--- a/src/free_claude_code/providers/streaming/supervisor.py
+++ b/src/free_claude_code/providers/streaming/supervisor.py
@@ -34,7 +34,12 @@ class StreamTraceContext:
 
 @dataclass(frozen=True, slots=True)
 class StreamFeed:
-    """Canonical events produced by one raw item or end-of-stream transition."""
+    """Canonical events produced by one raw item or end-of-stream transition.
+
+    A terminal feed is the logical end of the response. The supervisor must stop
+    pulling the raw transport immediately, even if the transport has not reached
+    physical EOF yet.
+    """
 
     events: tuple[InferenceEvent, ...] = ()
     terminal: bool = False
@@ -304,6 +309,7 @@ class StreamExecutionSupervisor:
                     feed = epoch.feed(raw)
                     if feed.terminal:
                         terminal_events.extend(feed.events)
+                        break
                     else:
                         for event in feed.events:
                             for publishable in publication.push(event):

--- a/tests/providers/test_groq_reasoning.py
+++ b/tests/providers/test_groq_reasoning.py
@@ -10,8 +10,8 @@ import pytest
 
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
-from free_claude_code.providers.admission import ProviderOperationKind
 from free_claude_code.providers.groq import GroqProvider
 from free_claude_code.providers.groq.client import (
     _parse_reasoning_vocabulary,
@@ -346,26 +346,22 @@ async def test_initial_reasoning_policy_reaches_sdk_wire(
 @pytest.mark.asyncio
 async def test_exact_issue_retries_with_default_and_learns_model() -> None:
     provider = _provider()
+    request = _request()
     policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
-    body = provider._build_request_body(
-        canonical_request(_request()),
-        reasoning=policy,
-        provider_model=(_request()).model,
-    )
-    create = AsyncMock(side_effect=[_vocabulary_error(), object()])
+    create = AsyncMock(side_effect=[_vocabulary_error(), _successful_stream()])
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
 
     assert create.await_count == 2
     assert create.await_args_list[0].kwargs["reasoning_effort"] == "high"
     assert create.await_args_list[1].kwargs["reasoning_effort"] == "default"
-    assert used_body["reasoning_effort"] == "default"
     assert provider._model_reasoning_vocabularies == {
         _MODEL: frozenset({"none", "default"})
     }
@@ -376,16 +372,18 @@ async def test_exact_issue_retries_with_default_and_learns_model() -> None:
         provider_model=(_request()).model,
     )
     assert next_body["reasoning_effort"] == "default"
-    next_create = AsyncMock(return_value=object())
+    next_create = AsyncMock(return_value=_successful_stream())
     with patch.object(provider._client.chat.completions, "create", next_create):
-        _stream, next_used_body, next_attempt = await provider._create_stream(
-            next_body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
-        await next_attempt.aclose()
     assert next_create.await_count == 1
-    assert next_used_body["reasoning_effort"] == "default"
+    assert next_create.await_args is not None
+    assert next_create.await_args.kwargs["reasoning_effort"] == "default"
 
 
 def test_cached_none_default_preserves_off() -> None:
@@ -445,28 +443,25 @@ def test_cached_named_vocabulary_omits_unrepresentable_off() -> None:
 @pytest.mark.asyncio
 async def test_unknown_vocabulary_retries_without_effort_and_negative_caches() -> None:
     provider = _provider()
-    body = provider._build_request_body(
-        canonical_request(_request()),
-        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
-        provider_model=(_request()).model,
-    )
+    request = _request()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
     create = AsyncMock(
         side_effect=[
             _vocabulary_error("`balanced` or `extreme`"),
-            object(),
+            _successful_stream(),
         ]
     )
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
 
     assert "reasoning_effort" not in create.await_args_list[1].kwargs
-    assert "reasoning_effort" not in used_body
     assert provider._model_reasoning_vocabularies[_MODEL] == frozenset()
     assert "reasoning_effort" not in provider._build_request_body(
         canonical_request(_request()),
@@ -499,18 +494,6 @@ def test_reasoning_cache_isolated_by_opaque_model_id() -> None:
 async def test_concurrent_first_requests_can_learn_without_state_corruption() -> None:
     provider = _provider()
     policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
-    bodies = [
-        provider._build_request_body(
-            canonical_request(_request()),
-            reasoning=policy,
-            provider_model=(_request()).model,
-        ),
-        provider._build_request_body(
-            canonical_request(_request()),
-            reasoning=policy,
-            provider_model=(_request()).model,
-        ),
-    ]
     initial_calls = 0
     release_initial_errors = asyncio.Event()
     sent_efforts: list[str | None] = []
@@ -525,25 +508,30 @@ async def test_concurrent_first_requests_can_learn_without_state_corruption() ->
                 release_initial_errors.set()
             await release_initial_errors.wait()
             raise _vocabulary_error()
-        return object()
+        return _successful_stream()
 
-    async def execute(body: dict):
-        _stream, used_body, attempt = await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+    async def execute():
+        request = _request()
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
-        return used_body
 
     mock_create = AsyncMock(side_effect=create)
     with patch.object(provider._client.chat.completions, "create", mock_create):
-        used_bodies = await asyncio.gather(*(execute(body) for body in bodies))
+        await asyncio.gather(execute(), execute())
 
     assert mock_create.await_count == 4
     assert sent_efforts.count("high") == 2
     assert sent_efforts.count("default") == 2
-    assert all(body["reasoning_effort"] == "default" for body in used_bodies)
+    assert all(
+        call.kwargs["reasoning_effort"] == "default"
+        for call in mock_create.await_args_list
+        if call.kwargs.get("reasoning_effort") != "high"
+    )
     assert provider._model_reasoning_vocabularies == {
         _MODEL: frozenset({"none", "default"})
     }
@@ -554,6 +542,7 @@ async def test_stale_cache_self_heals_without_guessing_original_effort() -> None
     provider = _provider()
     policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
     provider._model_reasoning_vocabularies[_MODEL] = frozenset({"none", "default"})
+    request = _request()
     cached_body = provider._build_request_body(
         canonical_request(_request()),
         reasoning=policy,
@@ -563,19 +552,20 @@ async def test_stale_cache_self_heals_without_guessing_original_effort() -> None
     create = AsyncMock(
         side_effect=[
             _vocabulary_error("`low`, `medium`, or `high`", current="default"),
-            object(),
+            _successful_stream(),
         ]
     )
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, corrected_body, attempt = await provider._create_stream(
-            cached_body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
 
-    assert "reasoning_effort" not in corrected_body
+    assert "reasoning_effort" not in create.await_args_list[1].kwargs
     assert provider._model_reasoning_vocabularies[_MODEL] == frozenset(
         {"low", "medium", "high"}
     )
@@ -590,21 +580,20 @@ async def test_stale_cache_self_heals_without_guessing_original_effort() -> None
 @pytest.mark.asyncio
 async def test_unrelated_400_propagates_without_cache_poisoning() -> None:
     provider = _provider()
-    body = provider._build_request_body(
-        canonical_request(_request()),
-        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
-        provider_model=(_request()).model,
-    )
+    request = _request()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
     create = AsyncMock(side_effect=_BadRequest("messages: invalid role 'wizard'"))
 
     with (
         patch.object(provider._client.chat.completions, "create", create),
-        pytest.raises(_BadRequest, match="wizard"),
+        pytest.raises(ExecutionFailure),
     ):
-        await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
 
     assert create.await_count == 1
@@ -614,11 +603,8 @@ async def test_unrelated_400_propagates_without_cache_poisoning() -> None:
 @pytest.mark.asyncio
 async def test_nested_unrelated_allow_list_cannot_retry_or_poison_cache() -> None:
     provider = _provider()
-    body = provider._build_request_body(
-        canonical_request(_request()),
-        reasoning=ReasoningPolicy.off(),
-        provider_model=(_request()).model,
-    )
+    request = _request()
+    policy = ReasoningPolicy.off()
     error = _BadRequest(
         "invalid request",
         body={
@@ -630,12 +616,14 @@ async def test_nested_unrelated_allow_list_cannot_retry_or_poison_cache() -> Non
 
     with (
         patch.object(provider._client.chat.completions, "create", create),
-        pytest.raises(_BadRequest),
+        pytest.raises(ExecutionFailure),
     ):
-        await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
 
     assert create.await_count == 1
@@ -646,21 +634,20 @@ async def test_nested_unrelated_allow_list_cannot_retry_or_poison_cache() -> Non
 @pytest.mark.asyncio
 async def test_advertised_current_value_does_not_retry_or_cache() -> None:
     provider = _provider()
-    body = provider._build_request_body(
-        canonical_request(_request()),
-        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
-        provider_model=(_request()).model,
-    )
+    request = _request()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
     create = AsyncMock(side_effect=_vocabulary_error("`low`, `medium`, or `high`"))
 
     with (
         patch.object(provider._client.chat.completions, "create", create),
-        pytest.raises(_BadRequest),
+        pytest.raises(ExecutionFailure),
     ):
-        await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
 
     assert create.await_count == 1
@@ -670,22 +657,20 @@ async def test_advertised_current_value_does_not_retry_or_cache() -> None:
 @pytest.mark.asyncio
 async def test_last_attempt_learns_but_does_not_exceed_budget() -> None:
     provider = _provider(max_attempts=1)
+    request = _request()
     policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
-    body = provider._build_request_body(
-        canonical_request(_request()),
-        reasoning=policy,
-        provider_model=(_request()).model,
-    )
     create = AsyncMock(side_effect=_vocabulary_error())
 
     with (
         patch.object(provider._client.chat.completions, "create", create),
-        pytest.raises(_BadRequest),
+        pytest.raises(ExecutionFailure),
     ):
-        await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
 
     assert create.await_count == 1
@@ -705,51 +690,46 @@ async def test_last_attempt_learns_but_does_not_exceed_budget() -> None:
 @pytest.mark.asyncio
 async def test_output_cap_and_reasoning_corrections_share_one_session() -> None:
     provider = _provider()
-    body = provider._build_request_body(
-        canonical_request(make_messages_request(_MODEL, max_tokens=64_000)),
-        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
-        provider_model=(make_messages_request(_MODEL, max_tokens=64_000)).model,
-    )
+    request = make_messages_request(_MODEL, max_tokens=64_000)
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
     cap_error = _BadRequest("max_completion_tokens must be less than or equal to 40960")
-    create = AsyncMock(side_effect=[cap_error, _vocabulary_error(), object()])
-    execution = provider._admission.start_execution()
+    create = AsyncMock(
+        side_effect=[cap_error, _vocabulary_error(), _successful_stream()]
+    )
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await provider._create_stream(
-            body,
-            execution,
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
 
     assert create.await_count == 3
-    assert execution.attempts_started == 3
     assert create.await_args_list[1].kwargs["max_completion_tokens"] == 40_960
     assert create.await_args_list[1].kwargs["reasoning_effort"] == "high"
     assert create.await_args_list[2].kwargs["max_completion_tokens"] == 40_960
     assert create.await_args_list[2].kwargs["reasoning_effort"] == "default"
-    assert used_body["max_completion_tokens"] == 40_960
-    assert used_body["reasoning_effort"] == "default"
 
 
 @pytest.mark.asyncio
 async def test_corrected_request_cannot_enter_vocabulary_retry_loop() -> None:
     provider = _provider()
-    body = provider._build_request_body(
-        canonical_request(_request()),
-        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
-        provider_model=(_request()).model,
-    )
+    request = _request()
+    policy = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
     create = AsyncMock(side_effect=[_vocabulary_error(), _vocabulary_error()])
 
     with (
         patch.object(provider._client.chat.completions, "create", create),
-        pytest.raises(_BadRequest),
+        pytest.raises(ExecutionFailure),
     ):
-        await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                reasoning=policy,
+                provider_model=request.model,
+            )
         )
 
     assert create.await_count == 2

--- a/tests/providers/test_nvidia_nim.py
+++ b/tests/providers/test_nvidia_nim.py
@@ -14,7 +14,7 @@ from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from free_claude_code.providers.nvidia_nim.tool_schema import (
     NIM_TOOL_ARGUMENT_ALIASES_KEY,
 )
-from free_claude_code.providers.stream_recovery import RecoveryHoldbackBuffer
+from free_claude_code.providers.streaming import PublicationBuffer
 from tests.inference_support import collect_anthropic
 from tests.providers.request_factory import canonical_request, make_messages_request
 from tests.providers.support import (
@@ -897,7 +897,7 @@ async def test_midstream_native_tool_suffix_failure_recovers_without_duplication
         yield _content_chunk(recovered, finish_reason="tool_calls")
 
     def immediate_holdback():
-        return RecoveryHoldbackBuffer(holdback_seconds=0.0)
+        return PublicationBuffer(holdback_seconds=0.0)
 
     with (
         patch.object(
@@ -906,7 +906,7 @@ async def test_midstream_native_tool_suffix_failure_recovers_without_duplication
             new_callable=AsyncMock,
         ) as mock_create,
         patch(
-            "free_claude_code.providers.stream_recovery.RecoveryHoldbackBuffer",
+            "free_claude_code.providers.openai_chat.provider.PublicationBuffer",
             side_effect=immediate_holdback,
         ),
     ):

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -5,17 +5,19 @@ Covers the pure parse/clamp helpers and the provider behavior that clamps
 and learns the cap so later requests clamp proactively.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
-from free_claude_code.providers.admission import ProviderOperationKind
+from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.providers.groq import GroqProvider
 from free_claude_code.providers.openai_chat.output_cap import (
     clamp_output_tokens,
     parse_output_token_cap,
 )
+from tests.inference_support import collect_anthropic
 from tests.providers.request_factory import canonical_request, make_messages_request
 from tests.providers.support import (
     immediate_admission,
@@ -30,6 +32,27 @@ class _BadRequest(Exception):
         super().__init__(message)
         self.status_code = 400
         self.body = body
+
+
+async def _stream(chunks):
+    for chunk in chunks:
+        yield chunk
+
+
+def _chunk(*, finish_reason: str | None = None):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=None,
+                    reasoning_content=None,
+                    tool_calls=None,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -240,21 +263,14 @@ def groq_provider():
 
 @pytest.mark.asyncio
 async def test_create_stream_clamps_and_learns_on_cap_rejection(groq_provider):
+    request = make_messages_request(
+        "llama-3.3-70b-versatile",
+        max_tokens=64000,
+        thinking={"enabled": False},
+    )
     body = groq_provider._build_request_body(
-        canonical_request(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=64000,
-                thinking={"enabled": False},
-            )
-        ),
-        provider_model=(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=64000,
-                thinking={"enabled": False},
-            )
-        ).model,
+        canonical_request(request),
+        provider_model=request.model,
     )
     assert body["max_completion_tokens"] == 64000
     model = body["model"]
@@ -271,85 +287,66 @@ async def test_create_stream_clamps_and_learns_on_cap_rejection(groq_provider):
             "param": "max_completion_tokens",
         },
     )
-    create = AsyncMock(side_effect=[error, object()])
+    create = AsyncMock(side_effect=[error, _stream([_chunk(finish_reason="stop")])])
 
     with patch.object(groq_provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await groq_provider._create_stream(
-            body,
-            groq_provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            groq_provider.stream_response(
+                canonical_request(request),
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
 
     assert create.call_count == 2
     assert create.call_args_list[1].kwargs["max_completion_tokens"] == 16384
-    assert used_body["max_completion_tokens"] == 16384
     assert groq_provider._model_output_caps[model] == 16384
 
 
 @pytest.mark.asyncio
 async def test_learned_cap_clamps_next_request_without_a_400(groq_provider):
+    request = make_messages_request(
+        "llama-3.3-70b-versatile",
+        max_tokens=64000,
+        thinking={"enabled": False},
+    )
     body = groq_provider._build_request_body(
-        canonical_request(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=64000,
-                thinking={"enabled": False},
-            )
-        ),
-        provider_model=(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=64000,
-                thinking={"enabled": False},
-            )
-        ).model,
+        canonical_request(request),
+        provider_model=request.model,
     )
     model = body["model"]
     groq_provider._model_output_caps[model] = 40960
 
-    create = AsyncMock(return_value=object())
+    create = AsyncMock(return_value=_stream([_chunk(finish_reason="stop")]))
     with patch.object(groq_provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await groq_provider._create_stream(
-            body,
-            groq_provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            groq_provider.stream_response(
+                canonical_request(request),
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
 
     assert create.call_count == 1
     assert create.call_args.kwargs["max_completion_tokens"] == 40960
-    assert used_body["max_completion_tokens"] == 40960
 
 
 @pytest.mark.asyncio
 async def test_unrelated_400_is_not_clamped_and_propagates(groq_provider):
-    body = groq_provider._build_request_body(
-        canonical_request(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=100,
-                thinking={"enabled": False},
-            )
-        ),
-        provider_model=(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=100,
-                thinking={"enabled": False},
-            )
-        ).model,
+    request = make_messages_request(
+        "llama-3.3-70b-versatile",
+        max_tokens=100,
+        thinking={"enabled": False},
     )
     create = AsyncMock(side_effect=_BadRequest("messages: invalid role 'wizard'"))
 
     with (
         patch.object(groq_provider._client.chat.completions, "create", create),
-        pytest.raises(Exception, match="wizard"),
+        pytest.raises(ExecutionFailure),
     ):
-        await groq_provider._create_stream(
-            body,
-            groq_provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            groq_provider.stream_response(
+                canonical_request(request),
+                provider_model=request.model,
+            )
         )
 
     assert create.call_count == 1
@@ -358,21 +355,10 @@ async def test_unrelated_400_is_not_clamped_and_propagates(groq_provider):
 
 @pytest.mark.asyncio
 async def test_mixed_field_400_does_not_retry_or_poison_learned_cap(groq_provider):
-    body = groq_provider._build_request_body(
-        canonical_request(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=64000,
-                thinking={"enabled": False},
-            )
-        ),
-        provider_model=(
-            make_messages_request(
-                "llama-3.3-70b-versatile",
-                max_tokens=64000,
-                thinking={"enabled": False},
-            )
-        ).model,
+    request = make_messages_request(
+        "llama-3.3-70b-versatile",
+        max_tokens=64000,
+        thinking={"enabled": False},
     )
     error_body = {
         "param": "temperature",
@@ -387,12 +373,13 @@ async def test_mixed_field_400_does_not_retry_or_poison_learned_cap(groq_provide
 
     with (
         patch.object(groq_provider._client.chat.completions, "create", create),
-        pytest.raises(Exception, match="temperature"),
+        pytest.raises(ExecutionFailure),
     ):
-        await groq_provider._create_stream(
-            body,
-            groq_provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            groq_provider.stream_response(
+                canonical_request(request),
+                provider_model=request.model,
+            )
         )
 
     assert create.call_count == 1

--- a/tests/providers/test_openai_chat_usage.py
+++ b/tests/providers/test_openai_chat_usage.py
@@ -11,7 +11,6 @@ from httpx2 import Request, Response
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.core.inference import InferenceRequest
 from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
-from free_claude_code.providers.admission import ProviderOperationKind
 from free_claude_code.providers.openai_chat import (
     OpenAIChatProfile,
     OpenAIChatProvider,
@@ -244,27 +243,25 @@ async def test_openai_chat_stream_keeps_response_model_separate_from_upstream_mo
 @pytest.mark.asyncio
 async def test_openai_chat_stream_retries_without_usage_when_option_is_rejected():
     provider = _UsageTestProvider()
-    body = {"model": "m", "messages": [{"role": "user", "content": "x"}]}
-    request_stream_usage(body)
+    request = make_messages_request(model="m")
     create = AsyncMock(
         side_effect=[
             _bad_request(
                 "stream_options is unsupported",
                 {"error": {"message": "stream_options is unsupported"}},
             ),
-            object(),
+            _stream([_chunk(finish_reason="stop")]),
         ]
     )
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream_obj, used_body, attempt = await provider._create_stream(
-            body,
-            provider._admission.start_execution(),
-            ProviderOperationKind.GENERATION,
+        await collect_anthropic(
+            provider.stream_response(
+                canonical_request(request),
+                provider_model=request.model,
+            )
         )
-        await attempt.aclose()
 
     assert create.await_count == 2
     assert create.await_args_list[0].kwargs["stream_options"] == {"include_usage": True}
     assert "stream_options" not in create.await_args_list[1].kwargs
-    assert "stream_options" not in used_body

--- a/tests/providers/test_openai_responses_transport.py
+++ b/tests/providers/test_openai_responses_transport.py
@@ -390,11 +390,14 @@ async def test_post_commit_truncation_is_not_replayed() -> None:
 
 
 class _BlockingBody(httpx2.AsyncByteStream):
-    def __init__(self) -> None:
+    def __init__(self, *prefix: bytes) -> None:
+        self._prefix = prefix
         self.entered = asyncio.Event()
         self.closed = asyncio.Event()
 
     async def __aiter__(self):
+        for chunk in self._prefix:
+            yield chunk
         self.entered.set()
         await asyncio.Event().wait()
         yield b""
@@ -422,6 +425,29 @@ async def test_cancellation_closes_the_sdk_stream() -> None:
         await asyncio.wait_for(body.closed.wait(), timeout=3)
     finally:
         await client.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_closes_sdk_stream_without_waiting_for_eof() -> None:
+    body = _BlockingBody(
+        _sse(_text_delta("complete"), _completed_event()).encode(),
+    )
+    client = _client(
+        lambda _request: httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=body,
+        )
+    )
+    try:
+        chunks = await asyncio.wait_for(_collect(_transport(client)), timeout=3)
+        await asyncio.wait_for(body.closed.wait(), timeout=3)
+    finally:
+        await client.close()
+
+    parsed = parse_sse_text("".join(chunks))
+    assert text_content(parsed) == "complete"
+    assert_anthropic_stream_contract(parsed)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_openai_responses_transport.py
+++ b/tests/providers/test_openai_responses_transport.py
@@ -414,12 +414,12 @@ async def test_cancellation_closes_the_sdk_stream() -> None:
         )
     )
     task = asyncio.create_task(_collect(_transport(client)))
-    await asyncio.wait_for(body.entered.wait(), timeout=1)
+    await asyncio.wait_for(body.entered.wait(), timeout=3)
     task.cancel()
     try:
         with pytest.raises(asyncio.CancelledError):
             await task
-        await asyncio.wait_for(body.closed.wait(), timeout=1)
+        await asyncio.wait_for(body.closed.wait(), timeout=3)
     finally:
         await client.close()
 

--- a/tests/providers/test_provider_transport_logging.py
+++ b/tests/providers/test_provider_transport_logging.py
@@ -25,7 +25,7 @@ def _provider(*, verbose: bool = False) -> NvidiaNimProvider:
             log_api_error_tracebacks=verbose,
         ),
         nim_settings=NimSettings(),
-        admission=immediate_admission(),
+        admission=immediate_admission(max_attempts=1),
     )
 
 
@@ -34,8 +34,8 @@ async def test_stream_failure_default_logs_exclude_exception_text(caplog) -> Non
     provider = _provider()
     with (
         patch.object(
-            provider,
-            "_create_stream",
+            provider._client.chat.completions,
+            "create",
             new_callable=AsyncMock,
             side_effect=RuntimeError("SECRET_OPENAI_COMPAT"),
         ),
@@ -64,8 +64,8 @@ async def test_stream_failure_default_logs_cause_types_only(caplog) -> None:
     error.__cause__ = httpx2.ConnectError("SECRET_CAUSE_DETAIL")
     with (
         patch.object(
-            provider,
-            "_create_stream",
+            provider._client.chat.completions,
+            "create",
             new_callable=AsyncMock,
             side_effect=error,
         ),
@@ -91,8 +91,8 @@ async def test_stream_failure_verbose_traceback_redacts_credentials(caplog) -> N
     provider = _provider(verbose=True)
     with (
         patch.object(
-            provider,
-            "_create_stream",
+            provider._client.chat.completions,
+            "create",
             new_callable=AsyncMock,
             side_effect=RuntimeError(
                 "api_key=SECRET_OPENAI_COMPAT useful traceback detail"

--- a/tests/providers/test_stream_recovery.py
+++ b/tests/providers/test_stream_recovery.py
@@ -8,8 +8,8 @@ from free_claude_code.core.inference import (
 from free_claude_code.providers.stream_recovery import (
     RecoveryController,
     RecoveryFailureAction,
-    RecoveryHoldbackBuffer,
 )
+from free_claude_code.providers.streaming import PublicationBuffer
 
 
 def _event(label: str) -> TextDelta:
@@ -150,9 +150,9 @@ def test_non_retryable_error_is_final() -> None:
     assert not decision.retryable
 
 
-def test_holdback_buffers_until_delay_then_commits() -> None:
+def test_holdback_records_deadline_until_supervisor_commits() -> None:
     now = [10.0]
-    holdback = RecoveryHoldbackBuffer(holdback_seconds=0.75, now=lambda: now[0])
+    holdback = PublicationBuffer(holdback_seconds=0.75, now=lambda: now[0])
 
     started = _event("started")
     delta = _event("delta")
@@ -162,11 +162,13 @@ def test_holdback_buffers_until_delay_then_commits() -> None:
     assert holdback.push(started) == []
     now[0] += 0.74
     assert holdback.push(delta) == []
-    assert not holdback.committed
+    assert not holdback.published
 
     now[0] += 0.01
-    assert holdback.push(completed) == [started, delta, completed]
-    assert holdback.committed
+    assert holdback.push(completed) == []
+    assert holdback.seconds_until_deadline == 0
+    assert holdback.flush() == [started, delta, completed]
+    assert holdback.published
     assert holdback.push(terminal) == [terminal]
 
 
@@ -174,30 +176,30 @@ def test_synthetic_response_start_does_not_age_holdback_before_provider_output()
     None
 ):
     now = [10.0]
-    holdback = RecoveryHoldbackBuffer(holdback_seconds=0.75, now=lambda: now[0])
+    holdback = PublicationBuffer(holdback_seconds=0.75, now=lambda: now[0])
     started = ResponseStarted("response_test", "test-model")
 
     assert holdback.push(started) == []
     now[0] += 10.0
     assert holdback.push(_event("first-provider-output")) == []
-    assert not holdback.committed
+    assert not holdback.published
 
 
 def test_holdback_flushes_at_internal_buffer_cap() -> None:
     first = _event("ab")
     second = _event("cde")
-    holdback = RecoveryHoldbackBuffer(
+    holdback = PublicationBuffer(
         max_bytes=inference_event_size(first) + inference_event_size(second),
         now=lambda: 1.0,
     )
 
     assert holdback.push(first) == []
     assert holdback.push(second) == [first, second]
-    assert holdback.committed
+    assert holdback.published
 
 
 def test_holdback_discard_drops_uncommitted_events() -> None:
-    holdback = RecoveryHoldbackBuffer(now=lambda: 1.0)
+    holdback = PublicationBuffer(now=lambda: 1.0)
 
     assert holdback.push(_event("hidden")) == []
     holdback.discard()

--- a/tests/providers/test_stream_supervisor.py
+++ b/tests/providers/test_stream_supervisor.py
@@ -357,6 +357,24 @@ async def test_terminal_events_publish_only_after_attempt_scope_closes() -> None
 
 
 @pytest.mark.asyncio
+async def test_terminal_feed_stops_raw_reads_and_closes_attempt_scope() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=1)
+    epoch = _Epoch("terminal", block_after=1)
+    source = _Source(epoch)
+
+    events, execution = await asyncio.wait_for(
+        _collect(admission, source),
+        timeout=1,
+    )
+
+    assert epoch.read_calls == 1
+    assert epoch.closed
+    assert not epoch.blocked.is_set()
+    assert sum(isinstance(event, ResponseCompleted) for event in events) == 1
+    assert execution.state is ProviderExecutionState.SUCCEEDED
+
+
+@pytest.mark.asyncio
 async def test_active_deadline_publishes_without_restarting_blocked_read() -> None:
     admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
     epoch = _Epoch("content", block_after=1)

--- a/tests/providers/test_stream_supervisor.py
+++ b/tests/providers/test_stream_supervisor.py
@@ -1,0 +1,453 @@
+"""Transport-neutral contracts for the shared provider stream supervisor."""
+
+import asyncio
+from collections.abc import AsyncIterator
+from unittest.mock import patch
+
+import pytest
+
+from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.inference import (
+    FinishReason,
+    InferenceEvent,
+    InferenceUsage,
+    ResponseCompleted,
+    ResponseStarted,
+    TextBlockStarted,
+    TextDelta,
+)
+from free_claude_code.providers.admission import (
+    ProviderAdmissionController,
+    ProviderExecution,
+    ProviderExecutionState,
+)
+from free_claude_code.providers.failure_policy import (
+    classify_provider_failure,
+    is_retryable_stream_error,
+)
+from free_claude_code.providers.streaming import (
+    BoundAttemptOperations,
+    PublicationBuffer,
+    RecoveryContext,
+    RecoveryOutcome,
+    StreamExecutionSupervisor,
+    StreamFeed,
+    StreamTraceContext,
+)
+from tests.providers.support import immediate_admission
+
+
+class _CorrectionError(ValueError):
+    pass
+
+
+class _Epoch(AsyncIterator[str]):
+    """Scripted raw stream with observable read and close ownership."""
+
+    def __init__(
+        self,
+        *items: str,
+        block_after: int | None = None,
+        block_error: Exception | None = None,
+    ) -> None:
+        self._items = items
+        self._index = 0
+        self._block_after = block_after
+        self._block_error = block_error
+        self._terminal = False
+        self.read_calls = 0
+        self.closed = False
+        self.blocked = asyncio.Event()
+        self.release = asyncio.Event()
+
+    def __aiter__(self) -> AsyncIterator[str]:
+        return self
+
+    async def __anext__(self) -> str:
+        self.read_calls += 1
+        if self._block_after is not None and self._index >= self._block_after:
+            self.blocked.set()
+            await self.release.wait()
+            if self._block_error is not None:
+                raise self._block_error
+            raise StopAsyncIteration
+        if self._index >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._index]
+        self._index += 1
+        return item
+
+    async def aclose(self) -> None:
+        self.closed = True
+        self.release.set()
+
+    @property
+    def recovery_snapshot(self) -> str:
+        return "content" if self._index else "empty"
+
+    def start(self) -> StreamFeed:
+        return StreamFeed((ResponseStarted("response_test", "model"),))
+
+    def feed(self, raw: str) -> StreamFeed:
+        if raw == "decode_error":
+            raise TimeoutError("decoder failed after first raw item")
+        if raw == "noop":
+            return StreamFeed()
+        if raw == "content":
+            return StreamFeed(
+                (
+                    TextBlockStarted("item_test", "block_test"),
+                    TextDelta("block_test", "visible"),
+                )
+            )
+        if raw == "terminal":
+            self._terminal = True
+            return StreamFeed(
+                (
+                    ResponseCompleted(
+                        FinishReason.END_TURN,
+                        InferenceUsage(),
+                    ),
+                ),
+                terminal=True,
+            )
+        raise AssertionError(f"unknown raw item: {raw}")
+
+    def finish(self) -> StreamFeed:
+        if not self._terminal:
+            raise TimeoutError("stream ended before its terminal event")
+        return StreamFeed(terminal=True)
+
+    def failure_events(self) -> tuple[InferenceEvent, ...]:
+        return ()
+
+    def trace_completed(self) -> None:
+        pass
+
+
+class _Source:
+    """Scripted request source that records the request revision per call."""
+
+    def __init__(self, *actions: _Epoch | Exception) -> None:
+        self._actions = list(actions)
+        self.opens = 0
+        self.corrected = False
+        self.opened_revisions: list[str] = []
+        self.classifications = 0
+
+    @property
+    def trace_context(self) -> StreamTraceContext:
+        return StreamTraceContext("TEST_STREAM", "req_test")
+
+    @property
+    def failure_override(self) -> None:
+        return None
+
+    def trace_started(self, execution: ProviderExecution) -> None:
+        assert execution.state is ProviderExecutionState.ACTIVE
+
+    async def open(self) -> _Epoch:
+        self.opens += 1
+        self.opened_revisions.append("corrected" if self.corrected else "original")
+        action = self._actions.pop(0)
+        if isinstance(action, Exception):
+            raise action
+        return action
+
+    def apply_correction(self, error: Exception) -> bool:
+        if not isinstance(error, _CorrectionError) or self.corrected:
+            return False
+        self.corrected = True
+        return True
+
+    def attempt_error(self, error: Exception) -> Exception:
+        return error
+
+    def is_retryable(self, error: Exception) -> bool:
+        return is_retryable_stream_error(error)
+
+    def classify_failure(self, error: Exception) -> ExecutionFailure:
+        self.classifications += 1
+        return classify_provider_failure(
+            error,
+            provider_name="TEST_STREAM",
+            read_timeout_s=1.0,
+            request_id="req_test",
+        )
+
+
+class _ReserveFinalAttempt:
+    """Minimal Chat-like policy that recovers instead of replaying partial output."""
+
+    def __init__(self, epoch: _Epoch) -> None:
+        self._epoch = epoch
+        self.resolved = False
+
+    def prefers_recovery(self, context: RecoveryContext[str]) -> bool:
+        return context.has_buffered and context.attempts_remaining == 1
+
+    async def resolve(
+        self,
+        context: RecoveryContext[str],
+        attempts: BoundAttemptOperations,
+    ) -> RecoveryOutcome | None:
+        assert context.snapshot == "content"
+        assert attempts.attempts_remaining == 1
+        assert self._epoch.closed
+        self.resolved = True
+        return RecoveryOutcome(
+            events=(ResponseCompleted(FinishReason.END_TURN, InferenceUsage()),),
+            publish_buffer=True,
+            completed=True,
+        )
+
+
+async def _collect(
+    admission: ProviderAdmissionController,
+    source: _Source,
+    *,
+    publication: PublicationBuffer | None = None,
+    recovery: _ReserveFinalAttempt | None = None,
+) -> tuple[list[InferenceEvent], ProviderExecution]:
+    execution = admission.start_execution(request_id="req_test")
+    supervisor = StreamExecutionSupervisor(admission)
+    with patch.object(admission, "start_execution", return_value=execution):
+        events = [
+            event
+            async for event in supervisor.stream(
+                source,
+                publication=publication or PublicationBuffer(),
+                recovery=recovery,
+            )
+        ]
+    return events, execution
+
+
+@pytest.mark.asyncio
+async def test_preaccept_open_failure_uses_admission_retry() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
+    source = _Source(TimeoutError("open failed"), _Epoch("terminal"))
+
+    with patch("free_claude_code.providers.admission.trace_event") as trace:
+        events, execution = await _collect(admission, source)
+
+    outcomes = [
+        call.kwargs["outcome"]
+        for call in trace.call_args_list
+        if call.kwargs.get("event") == "provider.attempt.resolved"
+    ]
+    assert outcomes == ["retryable_failure", "accepted"]
+    assert source.opens == 2
+    assert execution.attempts_started == 2
+    assert execution.state is ProviderExecutionState.SUCCEEDED
+    assert sum(isinstance(event, ResponseStarted) for event in events) == 1
+    assert sum(isinstance(event, ResponseCompleted) for event in events) == 1
+
+
+@pytest.mark.asyncio
+async def test_preaccept_eof_uses_admission_retry() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
+    source = _Source(_Epoch(), _Epoch("terminal"))
+
+    with patch("free_claude_code.providers.admission.trace_event") as trace:
+        events, execution = await _collect(admission, source)
+
+    outcomes = [
+        call.kwargs["outcome"]
+        for call in trace.call_args_list
+        if call.kwargs.get("event") == "provider.attempt.resolved"
+    ]
+    assert outcomes == ["retryable_failure", "accepted"]
+    assert source.opens == 2
+    assert execution.attempts_started == 2
+    assert execution.state is ProviderExecutionState.SUCCEEDED
+    assert sum(isinstance(event, ResponseStarted) for event in events) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("first_raw", ["noop", "decode_error"])
+async def test_postaccept_failure_retries_locally_while_unpublished(
+    first_raw: str,
+) -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
+    source = _Source(_Epoch(first_raw), _Epoch("terminal"))
+
+    with patch("free_claude_code.providers.admission.trace_event") as trace:
+        events, execution = await _collect(admission, source)
+
+    outcomes = [
+        call.kwargs["outcome"]
+        for call in trace.call_args_list
+        if call.kwargs.get("event") == "provider.attempt.resolved"
+    ]
+    assert outcomes == ["accepted", "accepted"]
+    assert source.opens == 2
+    assert execution.attempts_started == 2
+    assert execution.state is ProviderExecutionState.SUCCEEDED
+    assert sum(isinstance(event, ResponseStarted) for event in events) == 1
+    assert sum(isinstance(event, ResponseCompleted) for event in events) == 1
+
+
+@pytest.mark.asyncio
+async def test_correction_and_early_retry_keep_the_corrected_request() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=3)
+    source = _Source(
+        _CorrectionError("unsupported deterministic field"),
+        _Epoch("noop"),
+        _Epoch("terminal"),
+    )
+
+    events, execution = await _collect(admission, source)
+
+    assert source.opened_revisions == ["original", "corrected", "corrected"]
+    assert execution.attempts_started == 3
+    assert execution.state is ProviderExecutionState.SUCCEEDED
+    assert sum(isinstance(event, ResponseStarted) for event in events) == 1
+
+
+@pytest.mark.asyncio
+async def test_standard_stream_consumes_its_final_prepublication_attempt() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
+    source = _Source(_Epoch("content"), _Epoch("terminal"))
+
+    events, execution = await _collect(admission, source)
+
+    assert source.opens == 2
+    assert execution.attempts_started == 2
+    assert not any(isinstance(event, TextDelta) for event in events)
+    assert sum(isinstance(event, ResponseStarted) for event in events) == 1
+
+
+@pytest.mark.asyncio
+async def test_typed_recovery_reserves_final_attempt_after_scope_close() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
+    failed_epoch = _Epoch("content")
+    source = _Source(failed_epoch)
+    recovery = _ReserveFinalAttempt(failed_epoch)
+
+    events, execution = await _collect(admission, source, recovery=recovery)
+
+    assert recovery.resolved
+    assert failed_epoch.closed
+    assert source.opens == 1
+    assert source.classifications == 0
+    assert execution.attempts_started == 1
+    assert execution.state is ProviderExecutionState.SUCCEEDED
+    assert sum(isinstance(event, TextDelta) for event in events) == 1
+    assert sum(isinstance(event, ResponseCompleted) for event in events) == 1
+
+
+@pytest.mark.asyncio
+async def test_terminal_events_publish_only_after_attempt_scope_closes() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=1)
+    epoch = _Epoch("terminal")
+    source = _Source(epoch)
+    execution = admission.start_execution(request_id="req_test")
+    supervisor = StreamExecutionSupervisor(admission)
+
+    with patch.object(admission, "start_execution", return_value=execution):
+        stream = supervisor.stream(source, publication=PublicationBuffer())
+        first = await anext(stream)
+        assert isinstance(first, ResponseStarted)
+        assert epoch.closed
+        remaining = [event async for event in stream]
+
+    assert any(isinstance(event, ResponseCompleted) for event in remaining)
+    assert execution.state is ProviderExecutionState.SUCCEEDED
+
+
+@pytest.mark.asyncio
+async def test_active_deadline_publishes_without_restarting_blocked_read() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
+    epoch = _Epoch("content", block_after=1)
+    source = _Source(epoch)
+    execution = admission.start_execution(request_id="req_test")
+    supervisor = StreamExecutionSupervisor(admission)
+
+    with patch.object(admission, "start_execution", return_value=execution):
+        stream = supervisor.stream(
+            source,
+            publication=PublicationBuffer(holdback_seconds=0),
+        )
+        first = await anext(stream)
+        second = await anext(stream)
+        await asyncio.wait_for(epoch.blocked.wait(), timeout=1)
+        assert isinstance(first, ResponseStarted)
+        assert isinstance(second, TextBlockStarted)
+        third = await anext(stream)
+        assert isinstance(third, TextDelta)
+        assert epoch.read_calls == 2
+
+        resumed = asyncio.Event()
+
+        async def consume_next() -> InferenceEvent:
+            resumed.set()
+            return await anext(stream)
+
+        pending = asyncio.create_task(consume_next())
+        await resumed.wait()
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+    assert epoch.closed
+    assert epoch.read_calls == 2
+    assert execution.state is ProviderExecutionState.ABANDONED
+
+
+@pytest.mark.asyncio
+async def test_failure_after_deadline_publication_is_not_replayed() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=2)
+    epoch = _Epoch(
+        "content",
+        block_after=1,
+        block_error=TimeoutError("failed after publication"),
+    )
+    source = _Source(epoch, _Epoch("terminal"))
+    execution = admission.start_execution(request_id="req_test")
+    supervisor = StreamExecutionSupervisor(admission)
+
+    with patch.object(admission, "start_execution", return_value=execution):
+        stream = supervisor.stream(
+            source,
+            publication=PublicationBuffer(holdback_seconds=0),
+        )
+        visible = [await anext(stream), await anext(stream), await anext(stream)]
+        await asyncio.wait_for(epoch.blocked.wait(), timeout=1)
+        epoch.release.set()
+        with pytest.raises(ExecutionFailure):
+            await anext(stream)
+
+    assert source.opens == 1
+    assert source.classifications == 1
+    assert sum(isinstance(event, TextDelta) for event in visible) == 1
+    assert execution.state is ProviderExecutionState.FAILED
+
+
+@pytest.mark.asyncio
+async def test_failure_policy_exception_still_closes_attempt_scope() -> None:
+    admission = immediate_admission(provider_name="TEST_STREAM", max_attempts=1)
+    epoch = _Epoch("decode_error")
+    source = _Source(epoch)
+    execution = admission.start_execution(request_id="req_test")
+    supervisor = StreamExecutionSupervisor(admission)
+
+    with (
+        patch.object(admission, "start_execution", return_value=execution),
+        patch.object(
+            source,
+            "is_retryable",
+            side_effect=RuntimeError("failure policy failed"),
+        ),
+        pytest.raises(RuntimeError, match="failure policy failed"),
+    ):
+        _ = [
+            event
+            async for event in supervisor.stream(
+                source,
+                publication=PublicationBuffer(),
+            )
+        ]
+
+    assert epoch.closed
+    assert execution.state is ProviderExecutionState.FAILED

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -30,7 +30,9 @@ from free_claude_code.providers.admission import (
 )
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from free_claude_code.providers.openai_chat.provider import (
-    _OpenAIChatStreamRunner,
+    _OpenAIChatAttemptSource,
+    _OpenAIChatAttemptState,
+    _OpenAIChatRecoverySource,
 )
 from free_claude_code.providers.openai_chat.recovery import (
     make_response_recovery_body,
@@ -44,6 +46,7 @@ from free_claude_code.providers.openai_chat.tool_calls import (
 )
 from free_claude_code.providers.openai_compat import OpenAIToolNameCodec
 from free_claude_code.providers.stream_recovery import TruncatedProviderStreamError
+from free_claude_code.providers.streaming import BoundAttemptOperations
 from tests.providers.request_factory import canonical_request, make_messages_request
 from tests.providers.support import (
     REASONING_OFF,
@@ -154,14 +157,14 @@ def _make_request(model: str = "test-model", stream: bool = True, **overrides: o
     return make_messages_request(model, **request_overrides)
 
 
-def _make_stream_runner(
+def _make_stream_source(
     provider: NvidiaNimProvider,
     *,
     request=None,
     request_id: str | None = None,
-) -> _OpenAIChatStreamRunner:
+) -> _OpenAIChatAttemptSource:
     effective_request = request or _make_request()
-    return _OpenAIChatStreamRunner(
+    return _OpenAIChatAttemptSource(
         provider,
         request=effective_request,
         provider_model=effective_request.model,
@@ -169,6 +172,27 @@ def _make_stream_runner(
         request_id=request_id,
         response_model=effective_request.model,
         reasoning=DEFAULT_REASONING_POLICY,
+    )
+
+
+async def _collect_recovery_output(
+    source: _OpenAIChatAttemptSource,
+    body: dict,
+    *,
+    include_reasoning: bool,
+    execution,
+    operation_kind: ProviderOperationKind,
+):
+    return await BoundAttemptOperations(
+        source.provider._supervisor,
+        execution,
+    ).collect(
+        _OpenAIChatRecoverySource(
+            source,
+            body,
+            include_reasoning=include_reasoning,
+        ),
+        operation_kind=operation_kind,
     )
 
 
@@ -312,7 +336,11 @@ class TestStreamingExceptionHandling:
     async def test_stream_normalization_failure_closes_raw_stream(self):
         provider = _make_provider()
         stream = ClosableAsyncStreamMock([])
-        execution = provider._admission.start_execution()
+        state = _OpenAIChatAttemptState(
+            provider,
+            {"messages": []},
+            request_id=None,
+        )
 
         with (
             patch.object(
@@ -328,11 +356,7 @@ class TestStreamingExceptionHandling:
             ),
             pytest.raises(ValueError, match="invalid stream wrapper"),
         ):
-            await provider._create_stream(
-                {"messages": []},
-                execution,
-                ProviderOperationKind.GENERATION,
-            )
+            await state.open_stream()
 
         assert stream.closed
 
@@ -1304,21 +1328,22 @@ class TestStreamingExceptionHandling:
         """A truncated text stream is continued and duplicate overlap is trimmed."""
         provider = _make_provider()
         request = _make_request()
-        stream_mock = AsyncStreamMock([_make_chunk(content="hello wor")])
+        initial_streams = [
+            AsyncStreamMock([_make_chunk(content="hello wor")])
+            for _ in range(UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS - 1)
+        ]
+        recovery_stream = AsyncStreamMock(
+            [
+                _make_chunk(content="world"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
-        with (
-            patch.object(
-                provider._client.chat.completions,
-                "create",
-                new_callable=AsyncMock,
-                return_value=stream_mock,
-            ),
-            patch.object(
-                _OpenAIChatStreamRunner,
-                "_collect_recovery_output",
-                new_callable=AsyncMock,
-                return_value=_recovery_output(text="world"),
-            ),
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[*initial_streams, recovery_stream],
         ):
             events = await _collect_stream(provider, request)
 
@@ -1384,7 +1409,7 @@ class TestStreamingExceptionHandling:
             for index in range(UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS)
         ]
         provider = _make_provider()
-        runner = _make_stream_runner(provider)
+        source = _make_stream_source(provider)
         execution = provider._admission.start_execution()
 
         with (
@@ -1396,7 +1421,8 @@ class TestStreamingExceptionHandling:
             ) as create,
             pytest.raises(TruncatedProviderStreamError),
         ):
-            await runner._collect_recovery_output(
+            await _collect_recovery_output(
+                source,
                 {"messages": []},
                 include_reasoning=True,
                 execution=execution,
@@ -1417,7 +1443,7 @@ class TestStreamingExceptionHandling:
             for index in range(UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS)
         ]
         provider = _make_provider()
-        runner = _make_stream_runner(provider)
+        source = _make_stream_source(provider)
         execution = provider._admission.start_execution()
 
         with (
@@ -1429,7 +1455,8 @@ class TestStreamingExceptionHandling:
             ) as create,
             pytest.raises(TimeoutError),
         ):
-            await runner._collect_recovery_output(
+            await _collect_recovery_output(
+                source,
                 {"messages": []},
                 include_reasoning=True,
                 execution=execution,
@@ -1449,7 +1476,7 @@ class TestStreamingExceptionHandling:
             ]
         )
         provider = _make_provider()
-        runner = _make_stream_runner(provider)
+        source = _make_stream_source(provider)
         execution = provider._admission.start_execution()
 
         with patch.object(
@@ -1458,7 +1485,8 @@ class TestStreamingExceptionHandling:
             new_callable=AsyncMock,
             return_value=stream,
         ):
-            result = await runner._collect_recovery_output(
+            result = await _collect_recovery_output(
+                source,
                 {"messages": []},
                 include_reasoning=True,
                 execution=execution,
@@ -1481,7 +1509,7 @@ class TestStreamingExceptionHandling:
             close_error=RuntimeError("cleanup failed"),
         )
         provider = _make_provider()
-        runner = _make_stream_runner(provider, request_id="req_recovery_success")
+        source = _make_stream_source(provider, request_id="req_recovery_success")
         execution = provider._admission.start_execution(
             request_id="req_recovery_success"
         )
@@ -1492,7 +1520,8 @@ class TestStreamingExceptionHandling:
             new_callable=AsyncMock,
             return_value=stream,
         ):
-            result = await runner._collect_recovery_output(
+            result = await _collect_recovery_output(
+                source,
                 {"messages": []},
                 include_reasoning=True,
                 execution=execution,
@@ -1519,7 +1548,7 @@ class TestStreamingExceptionHandling:
             ]
         )
         provider = _make_provider()
-        runner = _make_stream_runner(provider)
+        source = _make_stream_source(provider)
         execution = provider._admission.start_execution()
 
         with patch.object(
@@ -1528,7 +1557,8 @@ class TestStreamingExceptionHandling:
             new_callable=AsyncMock,
             side_effect=[failed, recovered],
         ) as create:
-            result = await runner._collect_recovery_output(
+            result = await _collect_recovery_output(
+                source,
                 {"messages": []},
                 include_reasoning=True,
                 execution=execution,
@@ -1549,7 +1579,7 @@ class TestStreamingExceptionHandling:
             close_error=RuntimeError("cleanup failed"),
         )
         provider = _make_provider()
-        runner = _make_stream_runner(provider)
+        source = _make_stream_source(provider)
         execution = provider._admission.start_execution()
 
         with (
@@ -1561,7 +1591,8 @@ class TestStreamingExceptionHandling:
             ),
             pytest.raises(ValueError, match="original terminal failure"),
         ):
-            await runner._collect_recovery_output(
+            await _collect_recovery_output(
+                source,
                 {"messages": []},
                 include_reasoning=True,
                 execution=execution,
@@ -1577,7 +1608,7 @@ class TestStreamingExceptionHandling:
             close_error=RuntimeError("cleanup failed")
         )
         provider = _make_provider()
-        runner = _make_stream_runner(provider)
+        source = _make_stream_source(provider)
         execution = provider._admission.start_execution()
 
         with patch.object(
@@ -1587,7 +1618,8 @@ class TestStreamingExceptionHandling:
             return_value=stream,
         ):
             task = asyncio.create_task(
-                runner._collect_recovery_output(
+                _collect_recovery_output(
+                    source,
                     {"messages": []},
                     include_reasoning=True,
                     execution=execution,
@@ -1607,7 +1639,7 @@ class TestStreamingExceptionHandling:
     async def test_recovery_collect_text_honors_provider_retry_classification(self):
         """Provider semantics apply before the first recovery chunk as well."""
         provider = _make_provider()
-        runner = _make_stream_runner(provider)
+        source = _make_stream_source(provider)
         execution = provider._admission.start_execution()
         request = httpx2.Request(
             "POST", "https://test.api.nvidia.com/v1/chat/completions"
@@ -1636,7 +1668,8 @@ class TestStreamingExceptionHandling:
             new_callable=AsyncMock,
             side_effect=[rejected, recovered],
         ) as create:
-            result = await runner._collect_recovery_output(
+            result = await _collect_recovery_output(
+                source,
                 {"messages": []},
                 include_reasoning=True,
                 execution=execution,
@@ -1695,39 +1728,36 @@ class TestStreamingExceptionHandling:
     @pytest.mark.asyncio
     async def test_openai_text_recovery_passes_thinking_context(self):
         """OpenAI-chat recovery call sites seed emitted thinking in the prompt."""
-        runner = _make_stream_runner(
-            _make_provider(), request=_make_request(), request_id="req_recovery"
+        provider = _make_provider()
+        request = _make_request()
+        initial_streams = [
+            AsyncStreamMock(
+                [
+                    _make_chunk(reasoning_content="hidden reasoning"),
+                    _make_chunk(content="visible answer"),
+                ]
+            )
+            for _ in range(UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS - 1)
+        ]
+        recovery_stream = AsyncStreamMock(
+            [
+                _make_chunk(content="visible answer done"),
+                _make_chunk(finish_reason="stop"),
+            ]
         )
-        ledger = _test_ledger()
-        ledger.start_reasoning_block()
-        ledger.emit_reasoning_delta("hidden reasoning")
-        list(ledger.ensure_text_block())
-        ledger.emit_text_delta("visible answer")
 
         with patch.object(
-            runner,
-            "_collect_recovery_output",
+            provider._client.chat.completions,
+            "create",
             new_callable=AsyncMock,
-            return_value=_recovery_output(
-                text="visible answer done",
-                thinking="hidden reasoning more",
-            ),
-        ) as mock_collect:
-            execution = runner._provider._admission.start_execution()
-            events = await runner._recovery_events(
-                body={"messages": [{"role": "user", "content": "hello"}]},
-                ledger=ledger,
-                error=TimeoutError("cutoff"),
-                tool_argument_alias_buffers={},
-                output_reasoning=True,
-                execution=execution,
-            )
+            side_effect=[*initial_streams, recovery_stream],
+        ) as create:
+            events = await _collect_stream(provider, request)
 
-        assert events is not None
-        assert mock_collect.await_args is not None
-        recovery_body = mock_collect.await_args.args[0]
+        assert events
+        assert create.await_count == UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS
+        recovery_body = create.await_args_list[-1].kwargs
         assert "hidden reasoning" in recovery_body["messages"][-1]["content"]
-        assert mock_collect.await_args.kwargs["include_reasoning"] is True
 
     @pytest.mark.asyncio
     async def test_primary_stream_closes_when_iteration_fails(self):
@@ -1757,28 +1787,21 @@ class TestStreamingExceptionHandling:
         request = _make_request()
         original_text = "hello wor" + ("x" * 70_000)
         original_stream = AsyncStreamMock([_make_chunk(content=original_text)])
+        recovery_streams = [
+            AsyncStreamMock([_make_chunk(content=f"world {index}")])
+            for index in range(UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS - 1)
+        ]
 
-        with (
-            patch.object(
-                provider._client.chat.completions,
-                "create",
-                new_callable=AsyncMock,
-                return_value=original_stream,
-            ) as mock_create,
-            patch.object(
-                _OpenAIChatStreamRunner,
-                "_collect_recovery_output",
-                new_callable=AsyncMock,
-                side_effect=TruncatedProviderStreamError(
-                    "Recovery stream ended without finish_reason."
-                ),
-            ) as mock_collect,
-        ):
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[original_stream, *recovery_streams],
+        ) as mock_create:
             events, error = await _collect_stream_and_error(provider, request)
 
         event_text = "".join(events)
-        assert mock_create.await_count == 1
-        assert mock_collect.await_count == 1
+        assert mock_create.await_count == UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS
         assert original_text in event_text
         assert "world" not in event_text
         assert "Provider stream ended without finish_reason." in error.message
@@ -1814,21 +1837,22 @@ class TestStreamingExceptionHandling:
         tool_chunk = _make_tool_calls_chunk(
             name="echo_smoke", arguments='{"message":', tool_id="call_repair"
         )
-        stream_mock = AsyncStreamMock([tool_chunk])
+        initial_streams = [
+            AsyncStreamMock([tool_chunk])
+            for _ in range(UPSTREAM_TRANSIENT_TOTAL_ATTEMPTS - 1)
+        ]
+        repair_stream = AsyncStreamMock(
+            [
+                _make_chunk(content='"ok"}'),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
 
-        with (
-            patch.object(
-                provider._client.chat.completions,
-                "create",
-                new_callable=AsyncMock,
-                return_value=stream_mock,
-            ),
-            patch.object(
-                _OpenAIChatStreamRunner,
-                "_collect_recovery_output",
-                new_callable=AsyncMock,
-                return_value=_recovery_output(text='"ok"}'),
-            ),
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[*initial_streams, repair_stream],
         ):
             events = await _collect_stream(provider, request)
 

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.3"
+version = "5.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

OpenAI Chat and standard Responses duplicated stream-attempt scheduling, holdback, retry, cancellation, and cleanup. Their separate lifecycle loops made ownership drift and duplicate or leaked output more likely during retries.

## Changes

| Before | After |
| --- | --- |
| Chat and Responses each orchestrated provider executions and physical attempts. | One provider-layer stream supervisor composes admission-owned attempts for both transports. |
| Holdback and Chat continuation policy were coupled in RecoveryController. | PublicationBuffer owns only publication state; Chat supplies typed recovery policy and Responses supplies none. |
| Retry epochs could retain transport-local state through separate lifecycle implementations. | Every physical attempt receives a fresh decoder, ledger, parser, usage state, and tool assembler while corrected request state persists. |
| Deadline publication depended on another upstream event. | The supervisor races one active raw read against the 0.75-second deadline without restarting the read. |
| Cleanup ordering was transport-specific. | Attempt resources and concurrency close before terminal publication or Chat recovery, including cancellation and policy failures. |
| Lifecycle verification was transport-specific. | Shared lifecycle regressions, 3,758 tests, 9 Playwright tests, six live provider paths through both public APIs, and a Claude harness control pass. |
| Version 5.14.3 contained the duplicated lifecycle. | Version 5.14.4 contains the behavior-preserving shared lifecycle. |



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change unifies provider stream lifecycle handling, including retries, buffering, cancellation, and cleanup. Focused stream tests confirm that a Responses stream completes and closes promptly after `response.completed` even if the provider connection remains open, disproving the earlier report that terminal events leave the stream waiting for another raw item.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The terminal-event completion path and pre-accept retry isolation both passed focused deterministic checks against the shared streaming supervisor.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran two terminal-related tests to validate terminal feed behavior: test\_terminal\_feed\_stops\_raw\_reads\_and\_closes\_attempt\_scope and test\_terminal\_event\_closes\_sdk\_stream\_without\_waiting\_for\_eof, and both passed as expected.
- I executed a deterministic stream epoch retry harness against the real supervisor and ran focused pre-accept retry tests; the first epoch failed to accept, the second fresh epoch completed, and the harness reported published\_response\_ids\_after\_retry: \["response-retried"\], with the pre-accept/open-failure retries also passing, confirming isolation of epoch and decoder state.
- I reviewed test-run logs that show the targeted test commands exited as expected and reported successful results (the two invocations showed 1 passed in the described durations).
- I documented the implementation notes in the supervisor code that show where epoch-start events are buffered, where failed pre-accept attempts are discarded, and where a new epoch is opened for retries.

<a href="https://app.greptile.com/trex/runs/20458651/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: stop reading terminal provider stre..."](https://github.com/alishahryar1/free-claude-code/commit/6b247397cf3d87d9637c5e5d83cfcc721cadcf42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56403581)</sub>

<!-- /greptile_comment -->