### PR TITLE
fix(providers): allow fallback for uncommitted mid-stream BAD_REQUEST errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.5"
+version = "5.14.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -192,14 +192,26 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
     )
 
 
-def is_retryable_stream_error(exc: BaseException) -> bool:
-    """Return whether an opened stream failure permits replay or recovery."""
+def is_retryable_stream_error(
+    exc: BaseException, *, stream_committed: bool = True
+) -> bool:
+    """Return whether an opened stream failure permits replay or recovery.
+
+    `stream_committed` should be False when no output has yet reached the
+    client. A BAD_REQUEST-shaped error can surface mid-stream, after HTTP 200,
+    reflecting the provider's internal state rather than a genuinely invalid
+    request; if nothing has been delivered yet, treating it as retryable so a
+    fallback candidate can be tried is safe (#1543). Defaults to the prior,
+    strict behavior for call sites that haven't been updated to pass this.
+    """
     if isinstance(exc, RetryableProviderProtocolError):
         return True
     if isinstance(exc, ExecutionFailure):
         return exc.retryable
-    if isinstance(exc, openai.AuthenticationError | openai.BadRequestError):
+    if isinstance(exc, openai.AuthenticationError):
         return False
+    if isinstance(exc, openai.BadRequestError):
+        return not stream_committed
     if retryable_transient_status(exc) is not None:
         return True
     return isinstance(

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -29,6 +29,7 @@ _OVERLOAD_MARKERS = frozenset(
     }
 )
 _INTERNAL_ERROR_MARKERS = frozenset({"internal_server_error", "internal server error"})
+_BAD_REQUEST_MARKERS = frozenset({"bad_request", "bad request"})
 _AUTHENTICATION_MESSAGE = "Provider authentication failed. Check API key."
 _PERMISSION_MESSAGE = (
     "Provider denied access. Check credential permissions and model access."
@@ -210,7 +211,7 @@ def is_retryable_stream_error(
         return exc.retryable
     if isinstance(exc, openai.AuthenticationError):
         return False
-    if isinstance(exc, openai.BadRequestError):
+    if _is_bad_request_shaped(exc):
         return not stream_committed
     if retryable_transient_status(exc) is not None:
         return True
@@ -454,6 +455,19 @@ def _body_to_text(body: Any) -> str:
 
 def _has_marker(text: str, markers: frozenset[str]) -> bool:
     return any(marker in text for marker in markers)
+
+
+def _is_bad_request_shaped(exc: BaseException) -> bool:
+    """Return whether an exception represents a BAD_REQUEST-classified failure.
+
+    Covers both `openai.BadRequestError` (bound to an actual HTTP 400
+    response) and the statusless `openai.APIError` shape reported in #1543,
+    where a mid-stream SSE error event carries no HTTP response at all but
+    a body with `type: "BAD_REQUEST"`.
+    """
+    if isinstance(exc, openai.BadRequestError):
+        return True
+    return _has_marker(transient_error_text(exc), _BAD_REQUEST_MARKERS)
 
 
 def underlying_provider_error(exc: Exception) -> Exception:

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -976,10 +976,25 @@ class _OpenAIChatStreamRunner:
             )
 
         generated_output = assembler.generated_output
+        # generated_output means the ledger has assembled *any* output,
+        # which can still be sitting in the holdback buffer rather than
+        # actually flushed to the client (recovery.committed is the
+        # narrower, literal-flush signal) -- but test_error_after_native_tool_call_failure_includes_body
+        # requires that once a complete tool call has been assembled, a
+        # subsequent BAD_REQUEST-shaped error raises as final rather than
+        # attempting recovery, regardless of literal flush timing. Gating on
+        # generated_output (true as soon as anything is assembled, not only
+        # once physically flushed) satisfies that guarantee while still
+        # covering #1543's reported scenario, where nothing had been
+        # generated at all yet. A stream that never opened has no
+        # meaningful commit state either way; treat it the same as
+        # generated, since a create-time BAD_REQUEST is a genuine client
+        # error, not a mid-stream provider hiccup.
+        stream_committed = scope is None or generated_output
         retryable = (
             attempt_failure.retryable
             if attempt_failure is not None
-            else is_retryable_stream_error(error, stream_committed=generated_output)
+            else is_retryable_stream_error(error, stream_committed=stream_committed)
         )
         complete_tool_salvageable = assembler.complete_tool_salvageable
         decision = recovery.advance_failure(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -975,12 +975,12 @@ class _OpenAIChatStreamRunner:
                 provider_failure_override=self._provider._provider_failure_override,
             )
 
+        generated_output = assembler.generated_output
         retryable = (
             attempt_failure.retryable
             if attempt_failure is not None
-            else is_retryable_stream_error(error)
+            else is_retryable_stream_error(error, stream_committed=generated_output)
         )
-        generated_output = assembler.generated_output
         complete_tool_salvageable = assembler.complete_tool_salvageable
         decision = recovery.advance_failure(
             retryable=retryable,

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -220,6 +220,10 @@ class _OpenAIChatStreamAssembler:
         return has_committed_sse_output(self._ledger)
 
     @property
+    def has_started_tool_block(self) -> bool:
+        return self._ledger.has_emitted_tool_block()
+
+    @property
     def complete_tool_salvageable(self) -> bool:
         return (
             self.generated_output
@@ -976,21 +980,23 @@ class _OpenAIChatStreamRunner:
             )
 
         generated_output = assembler.generated_output
-        # generated_output means the ledger has assembled *any* output,
-        # which can still be sitting in the holdback buffer rather than
-        # actually flushed to the client (recovery.committed is the
-        # narrower, literal-flush signal) -- but test_error_after_native_tool_call_failure_includes_body
-        # requires that once a complete tool call has been assembled, a
-        # subsequent BAD_REQUEST-shaped error raises as final rather than
-        # attempting recovery, regardless of literal flush timing. Gating on
-        # generated_output (true as soon as anything is assembled, not only
-        # once physically flushed) satisfies that guarantee while still
-        # covering #1543's reported scenario, where nothing had been
-        # generated at all yet. A stream that never opened has no
+        # recovery.committed is the literal "holdback buffer has flushed to
+        # the client" signal. Buffered *text* alone isn't enough to force
+        # non-retryable: it can still be sitting in the holdback buffer,
+        # unseen by the client, and safely discarded by an early retry --
+        # this is #1543's exact scenario (buffered text only, nothing
+        # committed). A *started tool block* is different: it's a semantic
+        # commitment regardless of flush timing (a fallback attempt could
+        # produce a different tool call, corrupting what's already been
+        # assembled), which is what
+        # test_error_after_native_tool_call_failure_includes_body requires
+        # to stay non-retryable. A stream that never opened has no
         # meaningful commit state either way; treat it the same as
-        # generated, since a create-time BAD_REQUEST is a genuine client
+        # committed, since a create-time BAD_REQUEST is a genuine client
         # error, not a mid-stream provider hiccup.
-        stream_committed = scope is None or generated_output
+        stream_committed = (
+            scope is None or recovery.committed or assembler.has_started_tool_block
+        )
         retryable = (
             attempt_failure.retryable
             if attempt_failure is not None

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -105,13 +105,42 @@ def test_stream_retry_classification_accepts_statusless_transients(
 
 
 def test_stream_retry_classification_rejects_openai_bad_request() -> None:
-    assert not is_retryable_stream_error(
-        _openai_status_error(
-            openai.BadRequestError,
-            status_code=400,
-            message="bad request",
-        )
+    error = _openai_status_error(
+        openai.BadRequestError,
+        status_code=400,
+        message="bad request",
     )
+    assert not is_retryable_stream_error(error)
+    assert not is_retryable_stream_error(error, stream_committed=True)
+
+
+def test_stream_retry_classification_accepts_uncommitted_mid_stream_bad_request() -> (
+    None
+):
+    # A BAD_REQUEST-shaped error can surface mid-stream, after HTTP 200,
+    # reflecting the provider's internal state rather than a genuinely
+    # invalid request. If nothing has reached the client yet, retrying
+    # against another candidate is safe (#1543).
+    error = _openai_status_error(
+        openai.BadRequestError,
+        status_code=400,
+        message="bad request",
+    )
+    assert is_retryable_stream_error(error, stream_committed=False)
+
+
+def test_stream_retry_classification_still_rejects_uncommitted_authentication_error() -> (
+    None
+):
+    # Unlike BAD_REQUEST, an authentication failure is about the credentials
+    # themselves, not the provider's stream state -- it must stay
+    # non-retryable regardless of whether anything has been committed yet.
+    error = _openai_status_error(
+        openai.AuthenticationError,
+        status_code=401,
+        message="unauthorized",
+    )
+    assert not is_retryable_stream_error(error, stream_committed=False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -129,6 +129,22 @@ def test_stream_retry_classification_accepts_uncommitted_mid_stream_bad_request(
     assert is_retryable_stream_error(error, stream_committed=False)
 
 
+def test_stream_retry_classification_accepts_uncommitted_statusless_bad_request() -> (
+    None
+):
+    # The mid-stream failure actually reported in #1543: no HTTP response at
+    # all (the SSE connection stayed open), just a statusless openai.APIError
+    # whose body carries type: "BAD_REQUEST". This must be recognized the
+    # same way as the HTTP-status-bound openai.BadRequestError case above.
+    error = _statusless_openai_error(
+        "stream embedded error",
+        {"error": {"message": "stream embedded error", "type": "BAD_REQUEST"}},
+    )
+    assert not is_retryable_stream_error(error)
+    assert not is_retryable_stream_error(error, stream_committed=True)
+    assert is_retryable_stream_error(error, stream_committed=False)
+
+
 def test_stream_retry_classification_still_rejects_uncommitted_authentication_error() -> (
     None
 ):

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -706,6 +706,48 @@ class TestStreamingExceptionHandling:
         _assert_error_not_in_text_deltas_after_tool(events, "bad after tool")
 
     @pytest.mark.asyncio
+    async def test_statusless_bad_request_before_any_tool_block_retries_silently(self):
+        """A mid-stream BAD_REQUEST with only buffered text (#1543) is retried, not raised.
+
+        Distinguishes this from test_error_after_native_tool_call_failure_includes_body:
+        that test has a *complete tool call* already assembled, which must stay
+        non-retryable regardless of flush timing. Here nothing but plain text has
+        been buffered -- the exact shape reported in #1543 -- so the holdback is
+        safely discardable and the candidate should retry invisibly to the client.
+        """
+        provider = _make_provider()
+        request = _make_request()
+        statusless_bad_request = openai.APIError(
+            "stream embedded error",
+            request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+            body={"error": {"message": "stream embedded error", "type": "BAD_REQUEST"}},
+        )
+        first_stream = AsyncStreamMock(
+            [_make_chunk(content="hidden")],
+            error=statusless_bad_request,
+        )
+        second_stream = AsyncStreamMock(
+            [
+                _make_chunk(content="visible"),
+                _make_chunk(finish_reason="stop"),
+            ]
+        )
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[first_stream, second_stream],
+        ) as mock_create:
+            events = await _collect_stream(provider, request)
+
+        event_text = "".join(events)
+        assert mock_create.await_count == 2
+        assert "hidden" not in event_text
+        assert "visible" in event_text
+        assert "event: error\n" not in event_text
+
+    @pytest.mark.asyncio
     async def test_clean_eof_after_complete_tool_call_salvages_tool_use(self):
         """A complete tool JSON payload missing finish_reason is committed as tool_use."""
         provider = _make_provider()

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.5"
+version = "5.14.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

`is_retryable_stream_error()` unconditionally classified `openai.BadRequestError` as non-retryable, regardless of when it occurred. Per #1543, this error can surface **mid-stream** — after the provider already returned HTTP 200 — via an SSE error event whose `type` is `BAD_REQUEST`. That reflects the provider's internal state at that moment, not a genuinely invalid request. Since nothing has been delivered to the client yet in that case, falling back to another candidate model is safe — but the hard-coded `False` classification meant `execution.py`'s outer fallback loop never got a chance to try, even though its own `candidate_committed` check would otherwise have allowed it.

## Change

- `is_retryable_stream_error()` gains a `stream_committed: bool = True` keyword-only parameter. `BadRequestError` is now retryable exactly when `stream_committed` is `False`. The default preserves the prior strict behavior for any call site that doesn't pass it explicitly.
- `AuthenticationError` is **not** affected — it stays unconditionally non-retryable, since an auth failure is about the credentials themselves, not the stream's commit state.
- Wired up in `openai_chat/provider.py`'s `_resolve_attempt_failure`, which already computes `assembler.generated_output` (→ `has_committed_sse_output`) right after this call site — reordered so it's computed first and passed through.

## Scope note

I intentionally left `openai_codex/provider.py` and `openai_responses/transport.py` untouched in this PR. Both also call `is_retryable_stream_error`, but I didn't find an equally direct "has anything reached the client yet" signal at their call sites, and didn't want to guess at one for a change to core retry logic. Happy to extend this once those call sites' semantics are confirmed, if that's wanted.

Fixes #1543.

## Test plan

- [x] Extended `tests/providers/test_failure_policy.py`: the existing `test_stream_retry_classification_rejects_openai_bad_request` now also asserts the explicit `stream_committed=True` case; added `test_stream_retry_classification_accepts_uncommitted_mid_stream_bad_request` (the new behavior) and `test_stream_retry_classification_still_rejects_uncommitted_authentication_error` (confirming `AuthenticationError` is unaffected).
- [x] Ran the full local CI sequence (`scripts/ci.ps1 -Skip playwright`): `ruff format`, `ruff check --fix`, `ty check`, and `pytest -v --tb=short` (playwright/e2e skipped as it's unrelated browser testing). All green — **3688 passed, 131 skipped, 0 failed**.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update allows provider fallback when a BAD_REQUEST-shaped stream failure occurs before any response is delivered, while preserving final error handling after a native tool block begins. Focused stream tests disproved the earlier reports that buffered text prevents fallback or that the tool-call error contract regresses. The package and lockfile metadata consistently identify version 5.14.6.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

Focused mocked-stream checks passed for both the invisible buffered-text fallback path and the started native-tool final-error path. Recovery state coverage and package lock consistency checks also passed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran focused mocked async-provider stream tests for statusless BAD\_REQUEST after buffered text and for BAD\_REQUEST after a native tool call began, and verified that the buffered-text fallback path and the final native-tool error path pass.
- Ran the retry-policy and recovery-holdback suite; all 13 tests passed.
- Validated version and lock consistency, confirming package metadata and uv.lock both report 5.14.6 and the lock check succeeds.

<a href="https://app.greptile.com/trex/runs/20530229/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Address greptile follow-up: distinguish ..."](https://github.com/alishahryar1/free-claude-code/commit/92881aa0d97ecc3dab185f75873da2f42b61603b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56534544)</sub>

<!-- /greptile_comment -->