### PR TITLE
fix(gemini): strip unsupported metadata key from requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.6"
+version = "5.14.7"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/gemini/client.py
+++ b/src/free_claude_code/providers/gemini/client.py
@@ -18,6 +18,10 @@ _REQUEST_POLICY = OpenAIChatRequestPolicy(
     reasoning_replay=ReasoningReplayMode.REASONING_CONTENT,
     include_extra_body=True,
     extra_body_validator=validate_google_extra_body,
+    # Google's OpenAI-compatible endpoint rejects the whole request with
+    # "Unknown name 'metadata': Cannot find field" if this key is present,
+    # whether at the top level or inside a caller-supplied extra_body (#1548).
+    unsupported_body_keys=frozenset({"metadata"}),
 )
 _PROFILE = OpenAIChatProfile(
     _REQUEST_POLICY,

--- a/src/free_claude_code/providers/openai_chat/request_policy.py
+++ b/src/free_claude_code/providers/openai_chat/request_policy.py
@@ -155,6 +155,15 @@ def _apply_common_openai_chat_policy(
     for key in policy.unsupported_body_keys:
         body.pop(key, None)
 
+    # unsupported_body_keys must also be stripped from a caller-supplied
+    # extra_body: it becomes the SDK's own extra_body= kwarg and gets merged
+    # into the wire-level JSON verbatim, so a key unsupported at the top
+    # level is equally unsupported when it arrives this way (#1548).
+    extra_body = body.get("extra_body")
+    if isinstance(extra_body, dict):
+        for key in policy.unsupported_body_keys:
+            extra_body.pop(key, None)
+
     if policy.max_tokens_field == "max_completion_tokens":
         _normalize_max_completion_tokens(body)
 

--- a/tests/providers/test_gemini.py
+++ b/tests/providers/test_gemini.py
@@ -199,25 +199,42 @@ def test_gemini_adaptive_thinking_with_effort_does_not_emit_custom_config(
 
 
 def test_build_request_body_preserves_caller_extra_body(gemini_provider):
-    req = make_request(extra_body={"metadata": {"user": "u1"}})
+    # This opaque sentinel verifies FCC's pass-through contract only; it does not
+    # imply that Gemini accepts an undocumented "custom_tag" wire field.
+    req = make_request(extra_body={"custom_tag": {"user": "u1"}})
 
     body = gemini_provider._build_request_body(req, reasoning=reasoning_for(req))
 
     assert "reasoning_effort" not in body
     eb = body.get("extra_body")
     assert isinstance(eb, dict)
-    assert eb.get("metadata") == {"user": "u1"}
+    assert eb.get("custom_tag") == {"user": "u1"}
     literal_extra_body = eb.get("extra_body")
     assert isinstance(literal_extra_body, dict)
     google = literal_extra_body.get("google")
     assert isinstance(google, dict)
 
 
+def test_build_request_body_strips_unsupported_metadata_key(gemini_provider):
+    """Regression for #1548: Gemini's OpenAI-compat endpoint hard-rejects the
+    whole request with "Unknown name 'metadata': Cannot find field" if this
+    key is present -- whether the caller sends it as a top-level extra_body
+    entry or FCC would otherwise forward it verbatim via the SDK merge.
+    """
+    req = make_request(extra_body={"metadata": {"user_id": "u1"}})
+
+    body = gemini_provider._build_request_body(req, reasoning=reasoning_for(req))
+    wire_json = _simulate_openai_sdk_wire_json(body)
+
+    assert "metadata" not in body
+    assert "metadata" not in body.get("extra_body", {})
+    assert "metadata" not in wire_json
+
+
 def test_build_request_body_merges_caller_nested_google(gemini_provider):
     req = make_request(
         thinking=None,
         extra_body={
-            "metadata": {"user": "u1"},
             "extra_body": {
                 "google": {
                     "thinking_config": {
@@ -235,7 +252,6 @@ def test_build_request_body_merges_caller_nested_google(gemini_provider):
     assert "reasoning_effort" not in body
     eb = body.get("extra_body")
     assert isinstance(eb, dict)
-    assert eb.get("metadata") == {"user": "u1"}
     literal_extra_body = eb.get("extra_body")
     assert isinstance(literal_extra_body, dict)
     google = literal_extra_body.get("google")

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.6"
+version = "5.14.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

FCC 5.14.4's since-reverted canonical Chat encoder forwarded native Claude request metadata to Gemini, whose OpenAI-compatible endpoint rejects the top-level field with HTTP 400. Current main drops native Messages metadata, but caller `extra_body` could still reintroduce the same wire field. Fixes #1548.

## Changes

| Before | After |
| --- | --- |
| Gemini had no explicit policy for unsupported `metadata`. | Gemini declares `metadata` unsupported at the provider boundary. |
| Shared sanitization removed unsupported keys only from the normal request body. | Shared sanitization also removes them from the SDK `extra_body` container before its wire-level merge. |
| Provider tests used `metadata` as an arbitrary pass-through sentinel. | A focused regression proves `metadata` cannot reach the wire, while opaque pass-through coverage explicitly makes no upstream-support claim. |
| The contributor branch preceded the current `main` release. | The branch is rebased and carries the single PR patch bump to `5.14.7`. |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update prevents unsupported Gemini `metadata` from being reintroduced through OpenAI SDK `extra_body` merging. The request path now removes that field while preserving supported nested Google configuration and unrelated provider-specific options.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the Gemini request body omits unsupported metadata before serialization and retains supported request options.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I executed a runtime probe against GeminiProvider.\_build\_request\_body and captured a real AsyncOpenAI.chat.completions.create call using httpx.MockTransport to record wire JSON.
- I ran the Gemini-focused request-construction tests with pytest and confirmed all 24 tests passed.
- I reviewed policy alignment by comparing the observed PR behavior against the policy files and concluded the behavior satisfied the stated hypotheses; the authored policy sources and outputs were uploaded for review.

<a href="https://app.greptile.com/trex/runs/20542502/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(gemini): strip unsupported metadata ..."](https://github.com/alishahryar1/free-claude-code/commit/bacb90e53e08435f8f140708fa3ad799bb544b37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56551597)</sub>

<!-- /greptile_comment -->