### PR TITLE
Fix pre-output model fallback transitions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,7 +202,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 # MODEL_SONNET=<provider/model-id>
 # MODEL_HAIKU=<provider/model-id>
 MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
-# Optional ordered cross-client fallbacks after retryable provider failures exhaust.
+# Optional ordered cross-client fallbacks when a provider/model fails before output.
 # A request may reach and consume usage from more than one provider.
 # MODEL_FALLBACKS="groq/llama-3.3-70b-versatile,open_router/openrouter/free"
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -619,16 +619,18 @@ publish the private upstream model as the response model.
 Fallback execution is a bounded first-frame state machine in
 [application/execution.py](src/free_claude_code/application/execution.py). The
 executor opens the primary first and resolves each later provider lazily. It
-advances only when the current candidate raises a retryable `ExecutionFailure`
-before emitting any non-empty protocol chunk and another configured target
-exists. It closes the abandoned iterator before resolving the next provider and
-deep-copies the original routed request for every candidate, changing only the
-upstream model. Authentication, permission, billing, invalid request, context
-overflow, deterministic preflight, unexpected exceptions, empty completion,
-timeouts, cancellation, and disconnect do not advance. Once any protocol frame
-is emitted, the candidate is committed and existing terminal-error behavior is
-authoritative; this prevents duplicate lifecycles and output. Final exhaustion
-re-raises the last exact failure.
+advances when the current provider has finalized any `ExecutionFailure` before
+emitting a non-empty protocol chunk and another configured target exists.
+`retryable` remains provider-local recovery metadata; it does not control the
+application's forward transition to a different target. The executor closes the
+abandoned iterator before resolving the next provider and deep-copies the
+original routed request for every candidate, changing only the upstream model.
+Deterministic preflight or validation failures, unexpected exceptions, the
+application-owned progress deadline, cancellation, disconnect, and empty
+completion remain terminal. Once any protocol frame is emitted, the candidate
+is committed and existing terminal-error behavior is authoritative; this
+prevents duplicate lifecycles and output. Final exhaustion re-raises the last
+exact failure.
 
 Every candidate keeps the original request ID, public response model, input
 token count, reasoning policy, messages, system prompt, tools, and generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.5"
+version = "5.14.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -246,6 +246,10 @@ class ProviderExecutor:
                     except ExecutionFailure as failure:
                         candidate_failure = failure
 
+                    if provider_stream is None and candidate_failure is None:
+                        raise TypeError(
+                            "provider stream_response must return an async iterator"
+                        )
                     while provider_stream is not None:
                         if loop.time() >= progress_deadline:
                             raise self._progress_timeout_failure(
@@ -261,6 +265,11 @@ class ProviderExecutor:
                                 except ExecutionFailure as failure:
                                     read_failure = failure
                         except StopAsyncIteration:
+                            if progress_timeout.expired():
+                                raise self._progress_timeout_failure(
+                                    request_id=request_id,
+                                    provider_id=target.provider_id,
+                                ) from None
                             break
                         except TimeoutError as exc:
                             if not progress_timeout.expired():

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -211,7 +211,22 @@ class ProviderExecutor:
         async def provider_body() -> AsyncIterator[str]:
             loop = asyncio.get_running_loop()
             progress_deadline = loop.time() + self._progress_timeout_seconds
+
+            def raise_if_cancelled() -> None:
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise asyncio.CancelledError()
+
+            def raise_if_execution_stopped(provider_id: str) -> None:
+                raise_if_cancelled()
+                if loop.time() >= progress_deadline:
+                    raise self._progress_timeout_failure(
+                        request_id=request_id,
+                        provider_id=provider_id,
+                    )
+
             for index, target in enumerate(candidates):
+                raise_if_execution_stopped(target.provider_id)
                 provider = (
                     primary_provider
                     if index == 0
@@ -230,6 +245,7 @@ class ProviderExecutor:
                         candidate_request,
                         reasoning=routed.reasoning,
                     )
+                raise_if_execution_stopped(target.provider_id)
 
                 provider_stream: AsyncIterator[str] | None = None
                 candidate_committed = False
@@ -245,48 +261,51 @@ class ProviderExecutor:
                         )
                     except ExecutionFailure as failure:
                         candidate_failure = failure
+                    except Exception:
+                        raise_if_cancelled()
+                        raise
 
+                    raise_if_execution_stopped(target.provider_id)
                     if provider_stream is None and candidate_failure is None:
                         raise TypeError(
                             "provider stream_response must return an async iterator"
                         )
                     while provider_stream is not None:
-                        if loop.time() >= progress_deadline:
-                            raise self._progress_timeout_failure(
-                                request_id=request_id,
-                                provider_id=target.provider_id,
-                            )
+                        raise_if_execution_stopped(target.provider_id)
                         progress_timeout = asyncio.timeout_at(progress_deadline)
+                        chunk: object = None
                         read_failure: ExecutionFailure | None = None
+                        stream_finished = False
                         try:
                             async with progress_timeout:
                                 try:
                                     chunk = await anext(provider_stream)
+                                except StopAsyncIteration:
+                                    stream_finished = True
                                 except ExecutionFailure as failure:
                                     read_failure = failure
-                        except StopAsyncIteration:
-                            if progress_timeout.expired():
-                                raise self._progress_timeout_failure(
-                                    request_id=request_id,
-                                    provider_id=target.provider_id,
-                                ) from None
-                            break
+                                except Exception:
+                                    raise_if_cancelled()
+                                    raise
                         except TimeoutError as exc:
+                            raise_if_cancelled()
                             if not progress_timeout.expired():
                                 raise
                             raise self._progress_timeout_failure(
                                 request_id=request_id,
                                 provider_id=target.provider_id,
                             ) from exc
-                        if progress_timeout.expired():
-                            raise self._progress_timeout_failure(
-                                request_id=request_id,
-                                provider_id=target.provider_id,
-                            )
+                        raise_if_execution_stopped(target.provider_id)
+                        if stream_finished:
+                            break
                         if read_failure is not None:
                             candidate_failure = read_failure
                             break
-                        if not chunk:
+                        if not isinstance(chunk, str):
+                            raise TypeError(
+                                "provider stream_response must yield string chunks"
+                            )
+                        if chunk == "":
                             await asyncio.sleep(0)
                             continue
                         if not candidate_committed:
@@ -310,6 +329,7 @@ class ProviderExecutor:
                             preserved_error=sys.exception(),
                         )
 
+                raise_if_cancelled()
                 if candidate_failure is None:
                     return
                 if candidate_committed or index + 1 >= len(candidates):

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -265,11 +265,6 @@ class ProviderExecutor:
                                 except ExecutionFailure as failure:
                                     read_failure = failure
                         except StopAsyncIteration:
-                            if progress_timeout.expired():
-                                raise self._progress_timeout_failure(
-                                    request_id=request_id,
-                                    provider_id=target.provider_id,
-                                ) from None
                             break
                         except TimeoutError as exc:
                             if not progress_timeout.expired():
@@ -303,12 +298,26 @@ class ProviderExecutor:
                         progress_deadline = loop.time() + self._progress_timeout_seconds
                 finally:
                     if provider_stream is not None:
-                        await close_stream_input(
-                            provider_stream,
-                            owner="provider_executor",
-                            source="api",
-                            preserved_error=sys.exception(),
+                        active_error = sys.exception()
+                        preserved_error = active_error or candidate_failure
+                        cleanup_timeout = asyncio.timeout_at(
+                            progress_deadline if active_error is None else None
                         )
+                        try:
+                            async with cleanup_timeout:
+                                await close_stream_input(
+                                    provider_stream,
+                                    owner="provider_executor",
+                                    source="api",
+                                    preserved_error=preserved_error,
+                                )
+                        except TimeoutError as exc:
+                            if not cleanup_timeout.expired():
+                                raise
+                            raise self._progress_timeout_failure(
+                                request_id=request_id,
+                                provider_id=target.provider_id,
+                            ) from exc
 
                 if candidate_failure is None:
                     return

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -100,7 +100,7 @@ class ProviderExecutor:
             "candidate_count": candidate_count,
             "failure_kind": failure.kind.value,
             "status_code": failure.status_code,
-            "provider_retryable": True,
+            "provider_retryable": failure.retryable,
         }
         if self._generation_id is not None:
             fields["generation_id"] = self._generation_id
@@ -233,25 +233,33 @@ class ProviderExecutor:
 
                 provider_stream: AsyncIterator[str] | None = None
                 candidate_committed = False
-                advance_failure: ExecutionFailure | None = None
+                candidate_failure: ExecutionFailure | None = None
                 try:
-                    provider_stream = provider.stream_response(
-                        candidate_request,
-                        input_tokens=input_tokens,
-                        request_id=request_id,
-                        response_model=gateway_model,
-                        reasoning=routed.reasoning,
-                    )
-                    while True:
+                    try:
+                        provider_stream = provider.stream_response(
+                            candidate_request,
+                            input_tokens=input_tokens,
+                            request_id=request_id,
+                            response_model=gateway_model,
+                            reasoning=routed.reasoning,
+                        )
+                    except ExecutionFailure as failure:
+                        candidate_failure = failure
+
+                    while provider_stream is not None:
                         if loop.time() >= progress_deadline:
                             raise self._progress_timeout_failure(
                                 request_id=request_id,
                                 provider_id=target.provider_id,
                             )
                         progress_timeout = asyncio.timeout_at(progress_deadline)
+                        read_failure: ExecutionFailure | None = None
                         try:
                             async with progress_timeout:
-                                chunk = await anext(provider_stream)
+                                try:
+                                    chunk = await anext(provider_stream)
+                                except ExecutionFailure as failure:
+                                    read_failure = failure
                         except StopAsyncIteration:
                             break
                         except TimeoutError as exc:
@@ -261,6 +269,14 @@ class ProviderExecutor:
                                 request_id=request_id,
                                 provider_id=target.provider_id,
                             ) from exc
+                        if progress_timeout.expired():
+                            raise self._progress_timeout_failure(
+                                request_id=request_id,
+                                provider_id=target.provider_id,
+                            )
+                        if read_failure is not None:
+                            candidate_failure = read_failure
+                            break
                         if not chunk:
                             await asyncio.sleep(0)
                             continue
@@ -276,14 +292,6 @@ class ProviderExecutor:
                                 )
                         yield chunk
                         progress_deadline = loop.time() + self._progress_timeout_seconds
-                except ExecutionFailure as failure:
-                    if (
-                        candidate_committed
-                        or not failure.retryable
-                        or index + 1 >= len(candidates)
-                    ):
-                        raise
-                    advance_failure = failure
                 finally:
                     if provider_stream is not None:
                         await close_stream_input(
@@ -293,15 +301,17 @@ class ProviderExecutor:
                             preserved_error=sys.exception(),
                         )
 
-                if advance_failure is None:
+                if candidate_failure is None:
                     return
+                if candidate_committed or index + 1 >= len(candidates):
+                    raise candidate_failure
                 next_target = candidates[index + 1]
                 self._trace_fallback_started(
                     request_id=request_id,
                     wire_api=wire_api,
                     failed=target,
                     selected=next_target,
-                    failure=advance_failure,
+                    failure=candidate_failure,
                     candidate_index=index + 2,
                     candidate_count=len(candidates),
                 )

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -211,22 +211,7 @@ class ProviderExecutor:
         async def provider_body() -> AsyncIterator[str]:
             loop = asyncio.get_running_loop()
             progress_deadline = loop.time() + self._progress_timeout_seconds
-
-            def raise_if_cancelled() -> None:
-                current = asyncio.current_task()
-                if current is not None and current.cancelling():
-                    raise asyncio.CancelledError()
-
-            def raise_if_execution_stopped(provider_id: str) -> None:
-                raise_if_cancelled()
-                if loop.time() >= progress_deadline:
-                    raise self._progress_timeout_failure(
-                        request_id=request_id,
-                        provider_id=provider_id,
-                    )
-
             for index, target in enumerate(candidates):
-                raise_if_execution_stopped(target.provider_id)
                 provider = (
                     primary_provider
                     if index == 0
@@ -245,7 +230,6 @@ class ProviderExecutor:
                         candidate_request,
                         reasoning=routed.reasoning,
                     )
-                raise_if_execution_stopped(target.provider_id)
 
                 provider_stream: AsyncIterator[str] | None = None
                 candidate_committed = False
@@ -261,51 +245,48 @@ class ProviderExecutor:
                         )
                     except ExecutionFailure as failure:
                         candidate_failure = failure
-                    except Exception:
-                        raise_if_cancelled()
-                        raise
 
-                    raise_if_execution_stopped(target.provider_id)
                     if provider_stream is None and candidate_failure is None:
                         raise TypeError(
                             "provider stream_response must return an async iterator"
                         )
                     while provider_stream is not None:
-                        raise_if_execution_stopped(target.provider_id)
+                        if loop.time() >= progress_deadline:
+                            raise self._progress_timeout_failure(
+                                request_id=request_id,
+                                provider_id=target.provider_id,
+                            )
                         progress_timeout = asyncio.timeout_at(progress_deadline)
-                        chunk: object = None
                         read_failure: ExecutionFailure | None = None
-                        stream_finished = False
                         try:
                             async with progress_timeout:
                                 try:
                                     chunk = await anext(provider_stream)
-                                except StopAsyncIteration:
-                                    stream_finished = True
                                 except ExecutionFailure as failure:
                                     read_failure = failure
-                                except Exception:
-                                    raise_if_cancelled()
-                                    raise
+                        except StopAsyncIteration:
+                            if progress_timeout.expired():
+                                raise self._progress_timeout_failure(
+                                    request_id=request_id,
+                                    provider_id=target.provider_id,
+                                ) from None
+                            break
                         except TimeoutError as exc:
-                            raise_if_cancelled()
                             if not progress_timeout.expired():
                                 raise
                             raise self._progress_timeout_failure(
                                 request_id=request_id,
                                 provider_id=target.provider_id,
                             ) from exc
-                        raise_if_execution_stopped(target.provider_id)
-                        if stream_finished:
-                            break
+                        if progress_timeout.expired():
+                            raise self._progress_timeout_failure(
+                                request_id=request_id,
+                                provider_id=target.provider_id,
+                            )
                         if read_failure is not None:
                             candidate_failure = read_failure
                             break
-                        if not isinstance(chunk, str):
-                            raise TypeError(
-                                "provider stream_response must yield string chunks"
-                            )
-                        if chunk == "":
+                        if not chunk:
                             await asyncio.sleep(0)
                             continue
                         if not candidate_committed:
@@ -329,7 +310,6 @@ class ProviderExecutor:
                             preserved_error=sys.exception(),
                         )
 
-                raise_if_cancelled()
                 if candidate_failure is None:
                     return
                 if candidate_committed or index + 1 >= len(candidates):

--- a/src/free_claude_code/config/admin/manifest.py
+++ b/src/free_claude_code/config/admin/manifest.py
@@ -132,8 +132,8 @@ _NON_PROVIDER_FIELDS: tuple[ConfigFieldSpec, ...] = (
         "model_list",
         settings_attr="model_fallbacks",
         description=(
-            "Tried in order after the selected model exhausts retryable provider "
-            "failures. Applies to every client. One request may reach multiple "
+            "Tried in order when the selected provider/model fails before output "
+            "starts. Applies to every client. One request may reach multiple "
             "providers and consume usage at each."
         ),
     ),

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -467,6 +467,7 @@ def test_admin_config_masks_secrets_and_exposes_manifest(monkeypatch, tmp_path):
     assert fallback_field["value"] is None
     assert fallback_field["nullable"] is True
     assert fallback_field["restart_required"] is False
+    assert "fails before output" in fallback_field["description"]
     assert "every client" in fallback_field["description"]
     assert "multiple providers" in fallback_field["description"]
     reasoning_policy = next(

--- a/tests/api/test_model_fallback.py
+++ b/tests/api/test_model_fallback.py
@@ -68,6 +68,36 @@ def test_responses_fallback_emits_one_stable_response_lifecycle() -> None:
         ("/v1/responses", responses_payload()),
     ),
 )
+def test_nonretryable_provider_failure_uses_fallback_before_output(
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    primary = ControlledFallbackProvider(
+        failure=ExecutionFailure(
+            kind=FailureKind.PERMISSION,
+            status_code=403,
+            message="primary quota exhausted",
+            retryable=False,
+        )
+    )
+    fallback = ControlledFallbackProvider(text="fallback worked")
+
+    with fallback_client(primary, fallback) as client:
+        response = client.post(path, json=payload)
+
+    assert response.status_code == 200
+    assert "fallback worked" in response.text
+    assert "primary quota exhausted" not in response.text
+    assert primary.close_calls == fallback.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    (
+        ("/v1/messages", messages_payload(stream=True)),
+        ("/v1/responses", responses_payload()),
+    ),
+)
 def test_final_failure_uses_last_candidate_typed_error(
     path: str,
     payload: dict[str, object],

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -1,9 +1,7 @@
 """Application-owned provider execution contracts."""
 
 import asyncio
-import time
 from collections.abc import AsyncIterator
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -193,11 +191,6 @@ class ExecutionFailureStreamConstructionProvider(FakeProvider):
 
 
 class CancellationSuppressingProvider(FakeProvider):
-    def __init__(self, replacement_failure: ExecutionFailure | None = None) -> None:
-        super().__init__()
-        self.started = asyncio.Event()
-        self._replacement_failure = replacement_failure
-
     async def stream_response(
         self,
         request: MessagesRequest,
@@ -216,99 +209,10 @@ class CancellationSuppressingProvider(FakeProvider):
         )
         try:
             try:
-                self.started.set()
                 await asyncio.Event().wait()
             except asyncio.CancelledError:
-                if self._replacement_failure is not None:
-                    raise self._replacement_failure from None
                 return
             yield "unreachable"
-        finally:
-            self.stream_close_calls += 1
-
-
-class BlockingProvider(FakeProvider):
-    def __init__(
-        self,
-        outcome: str | ExecutionFailure | None,
-        *,
-        delay_seconds: float,
-    ) -> None:
-        super().__init__()
-        self._outcome = outcome
-        self._delay_seconds = delay_seconds
-
-    async def stream_response(
-        self,
-        request: MessagesRequest,
-        input_tokens: int = 0,
-        *,
-        request_id: str | None = None,
-        response_model: str | None = None,
-        reasoning: ReasoningPolicy,
-    ) -> AsyncIterator[str]:
-        self._record_stream_call(
-            request,
-            input_tokens=input_tokens,
-            request_id=request_id,
-            response_model=response_model,
-            reasoning=reasoning,
-        )
-        try:
-            time.sleep(self._delay_seconds)
-            if isinstance(self._outcome, ExecutionFailure):
-                raise self._outcome
-            if self._outcome is not None:
-                yield self._outcome
-        finally:
-            self.stream_close_calls += 1
-
-
-class BlockingStreamConstructionProvider(FakeProvider):
-    def __init__(self, failure: ExecutionFailure, *, delay_seconds: float) -> None:
-        super().__init__()
-        self._failure = failure
-        self._delay_seconds = delay_seconds
-
-    def stream_response(
-        self,
-        request: MessagesRequest,
-        input_tokens: int = 0,
-        *,
-        request_id: str | None = None,
-        response_model: str | None = None,
-        reasoning: ReasoningPolicy,
-    ) -> AsyncIterator[str]:
-        del request, input_tokens, request_id, response_model, reasoning
-        time.sleep(self._delay_seconds)
-        raise self._failure
-
-
-class InvalidChunkProvider(FakeProvider):
-    def __init__(self, chunk: object, failure: ExecutionFailure) -> None:
-        super().__init__()
-        self._chunk = chunk
-        self._failure = failure
-
-    async def stream_response(
-        self,
-        request: MessagesRequest,
-        input_tokens: int = 0,
-        *,
-        request_id: str | None = None,
-        response_model: str | None = None,
-        reasoning: ReasoningPolicy,
-    ) -> AsyncIterator[str]:
-        self._record_stream_call(
-            request,
-            input_tokens=input_tokens,
-            request_id=request_id,
-            response_model=response_model,
-            reasoning=reasoning,
-        )
-        try:
-            yield cast(str, self._chunk)
-            raise self._failure
         finally:
             self.stream_close_calls += 1
 
@@ -637,37 +541,6 @@ async def test_invalid_none_stream_remains_terminal() -> None:
             await anext(stream)
 
     assert resolved_ids == ["provider"]
-    assert fallback.stream_calls == []
-
-
-@pytest.mark.parametrize("invalid_chunk", [None, False, 0, b"", b"frame"])
-@pytest.mark.asyncio
-async def test_invalid_provider_chunk_remains_terminal(invalid_chunk: object) -> None:
-    primary = InvalidChunkProvider(
-        invalid_chunk,
-        _execution_failure("failure after invalid chunk", retryable=False),
-    )
-    fallback = FakeProvider()
-    resolved_ids: list[str] = []
-
-    def resolve(provider_id: str) -> FakeProvider:
-        resolved_ids.append(provider_id)
-        return {"provider": primary, "fallback": fallback}[provider_id]
-
-    executor = ProviderExecutor(resolve, progress_timeout_seconds=60.0)
-    stream = executor.stream(
-        _routed_request(_target("fallback", "model")),
-        wire_api="messages",
-        raw_log_label="FULL_PAYLOAD",
-        raw_log_payload={},
-        request_id="req_invalid_chunk",
-    )
-
-    with pytest.raises(TypeError, match="must yield string chunks"):
-        await anext(stream)
-
-    assert resolved_ids == ["provider"]
-    assert primary.stream_close_calls == 1
     assert fallback.stream_calls == []
 
 
@@ -1027,120 +900,6 @@ async def test_progress_timeout_wins_when_provider_suppresses_cancellation() -> 
     assert exc_info.value.status_code == 504
     assert resolved_ids == ["provider"]
     assert primary.stream_close_calls == 1
-    assert fallback.stream_calls == []
-
-
-@pytest.mark.parametrize(
-    "replacement_failure", [None, _execution_failure("translated")]
-)
-@pytest.mark.asyncio
-async def test_caller_cancellation_wins_when_provider_suppresses_it(
-    replacement_failure: ExecutionFailure | None,
-) -> None:
-    primary = CancellationSuppressingProvider(replacement_failure)
-    fallback = FakeProvider()
-    resolved_ids: list[str] = []
-
-    def resolve(provider_id: str) -> FakeProvider:
-        resolved_ids.append(provider_id)
-        return {"provider": primary, "fallback": fallback}[provider_id]
-
-    executor = ProviderExecutor(resolve, progress_timeout_seconds=1.0)
-    stream = executor.stream(
-        _routed_request(_target("fallback", "model")),
-        wire_api="messages",
-        raw_log_label="FULL_PAYLOAD",
-        raw_log_payload={},
-        request_id="req_suppressed_caller_cancel",
-    )
-    with (
-        patch("free_claude_code.application.execution.trace_event") as trace_mock,
-        patch("free_claude_code.core.trace.trace_event") as stream_trace_mock,
-    ):
-        task = asyncio.ensure_future(anext(stream))
-        await primary.started.wait()
-
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-    assert resolved_ids == ["provider"]
-    assert primary.stream_close_calls == 1
-    assert fallback.stream_calls == []
-    stream_events = {
-        call.kwargs.get("event") for call in stream_trace_mock.call_args_list
-    }
-    fallback_events = {call.kwargs.get("event") for call in trace_mock.call_args_list}
-    assert "free_claude_code.api.response.stream_interrupted" in stream_events
-    assert "free_claude_code.api.response.stream_completed" not in stream_events
-    assert "free_claude_code.model_fallback.started" not in fallback_events
-    assert "free_claude_code.model_fallback.selected" not in fallback_events
-
-
-@pytest.mark.parametrize(
-    "outcome",
-    ["late-frame", None, _execution_failure("late failure", retryable=False)],
-    ids=["frame", "completion", "execution-failure"],
-)
-@pytest.mark.asyncio
-async def test_absolute_progress_deadline_wins_over_late_stream_outcome(
-    outcome: str | ExecutionFailure | None,
-) -> None:
-    primary = BlockingProvider(outcome, delay_seconds=0.05)
-    fallback = FakeProvider()
-    resolved_ids: list[str] = []
-
-    def resolve(provider_id: str) -> FakeProvider:
-        resolved_ids.append(provider_id)
-        return {"provider": primary, "fallback": fallback}[provider_id]
-
-    executor = ProviderExecutor(resolve, progress_timeout_seconds=0.01)
-    stream = executor.stream(
-        _routed_request(_target("fallback", "model")),
-        wire_api="messages",
-        raw_log_label="FULL_PAYLOAD",
-        raw_log_payload={},
-        request_id="req_late_stream_outcome",
-    )
-
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await anext(stream)
-
-    assert exc_info.value.kind is FailureKind.TIMEOUT
-    assert exc_info.value.status_code == 504
-    assert resolved_ids == ["provider"]
-    assert primary.stream_close_calls == 1
-    assert fallback.stream_calls == []
-
-
-@pytest.mark.asyncio
-async def test_absolute_progress_deadline_wins_over_late_construction_failure() -> None:
-    primary = BlockingStreamConstructionProvider(
-        _execution_failure("late construction failure", retryable=False),
-        delay_seconds=0.05,
-    )
-    fallback = FakeProvider()
-    resolved_ids: list[str] = []
-
-    def resolve(provider_id: str) -> FakeProvider:
-        resolved_ids.append(provider_id)
-        return {"provider": primary, "fallback": fallback}[provider_id]
-
-    executor = ProviderExecutor(resolve, progress_timeout_seconds=0.01)
-    stream = executor.stream(
-        _routed_request(_target("fallback", "model")),
-        wire_api="messages",
-        raw_log_label="FULL_PAYLOAD",
-        raw_log_payload={},
-        request_id="req_late_construction_failure",
-    )
-
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await anext(stream)
-
-    assert exc_info.value.kind is FailureKind.TIMEOUT
-    assert exc_info.value.status_code == 504
-    assert resolved_ids == ["provider"]
     assert fallback.stream_calls == []
 
 

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -190,6 +190,33 @@ class ExecutionFailureStreamConstructionProvider(FakeProvider):
         raise self._failure
 
 
+class CancellationSuppressingProvider(FakeProvider):
+    async def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy,
+    ) -> AsyncIterator[str]:
+        self._record_stream_call(
+            request,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            response_model=response_model,
+            reasoning=reasoning,
+        )
+        try:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                return
+            yield "unreachable"
+        finally:
+            self.stream_close_calls += 1
+
+
 def _target(provider_id: str, provider_model: str) -> ProviderModelTarget:
     return ProviderModelTarget(
         provider_id=provider_id,
@@ -489,6 +516,32 @@ async def test_unexpected_primary_failure_does_not_select_fallback() -> None:
 
     assert resolved_ids == ["provider"]
     assert primary.stream_close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_none_stream_remains_terminal() -> None:
+    primary = FakeProvider()
+    fallback = FakeProvider()
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {"provider": primary, "fallback": fallback}[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=60.0)
+    with patch.object(primary, "stream_response", return_value=None):
+        stream = executor.stream(
+            _routed_request(_target("fallback", "model")),
+            wire_api="messages",
+            raw_log_label="FULL_PAYLOAD",
+            raw_log_payload={},
+            request_id="req_invalid_stream",
+        )
+        with pytest.raises(TypeError):
+            await anext(stream)
+
+    assert resolved_ids == ["provider"]
+    assert fallback.stream_calls == []
 
 
 @pytest.mark.parametrize("failure_kind", tuple(FailureKind))
@@ -816,6 +869,35 @@ async def test_application_progress_timeout_never_resolves_fallback() -> None:
     assert exc_info.value.kind is FailureKind.TIMEOUT
     assert exc_info.value.status_code == 504
     assert exc_info.value.retryable is False
+    assert resolved_ids == ["provider"]
+    assert primary.stream_close_calls == 1
+    assert fallback.stream_calls == []
+
+
+@pytest.mark.asyncio
+async def test_progress_timeout_wins_when_provider_suppresses_cancellation() -> None:
+    primary = CancellationSuppressingProvider()
+    fallback = FakeProvider()
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {"provider": primary, "fallback": fallback}[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=0.02)
+    stream = executor.stream(
+        _routed_request(_target("fallback", "model")),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_suppressed_timeout",
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        _ = [chunk async for chunk in stream]
+
+    assert exc_info.value.kind is FailureKind.TIMEOUT
+    assert exc_info.value.status_code == 504
     assert resolved_ids == ["provider"]
     assert primary.stream_close_calls == 1
     assert fallback.stream_calls == []

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -1,7 +1,9 @@
 """Application-owned provider execution contracts."""
 
 import asyncio
+import time
 from collections.abc import AsyncIterator
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -191,6 +193,11 @@ class ExecutionFailureStreamConstructionProvider(FakeProvider):
 
 
 class CancellationSuppressingProvider(FakeProvider):
+    def __init__(self, replacement_failure: ExecutionFailure | None = None) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self._replacement_failure = replacement_failure
+
     async def stream_response(
         self,
         request: MessagesRequest,
@@ -209,10 +216,99 @@ class CancellationSuppressingProvider(FakeProvider):
         )
         try:
             try:
+                self.started.set()
                 await asyncio.Event().wait()
             except asyncio.CancelledError:
+                if self._replacement_failure is not None:
+                    raise self._replacement_failure from None
                 return
             yield "unreachable"
+        finally:
+            self.stream_close_calls += 1
+
+
+class BlockingProvider(FakeProvider):
+    def __init__(
+        self,
+        outcome: str | ExecutionFailure | None,
+        *,
+        delay_seconds: float,
+    ) -> None:
+        super().__init__()
+        self._outcome = outcome
+        self._delay_seconds = delay_seconds
+
+    async def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy,
+    ) -> AsyncIterator[str]:
+        self._record_stream_call(
+            request,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            response_model=response_model,
+            reasoning=reasoning,
+        )
+        try:
+            time.sleep(self._delay_seconds)
+            if isinstance(self._outcome, ExecutionFailure):
+                raise self._outcome
+            if self._outcome is not None:
+                yield self._outcome
+        finally:
+            self.stream_close_calls += 1
+
+
+class BlockingStreamConstructionProvider(FakeProvider):
+    def __init__(self, failure: ExecutionFailure, *, delay_seconds: float) -> None:
+        super().__init__()
+        self._failure = failure
+        self._delay_seconds = delay_seconds
+
+    def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy,
+    ) -> AsyncIterator[str]:
+        del request, input_tokens, request_id, response_model, reasoning
+        time.sleep(self._delay_seconds)
+        raise self._failure
+
+
+class InvalidChunkProvider(FakeProvider):
+    def __init__(self, chunk: object, failure: ExecutionFailure) -> None:
+        super().__init__()
+        self._chunk = chunk
+        self._failure = failure
+
+    async def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy,
+    ) -> AsyncIterator[str]:
+        self._record_stream_call(
+            request,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            response_model=response_model,
+            reasoning=reasoning,
+        )
+        try:
+            yield cast(str, self._chunk)
+            raise self._failure
         finally:
             self.stream_close_calls += 1
 
@@ -541,6 +637,37 @@ async def test_invalid_none_stream_remains_terminal() -> None:
             await anext(stream)
 
     assert resolved_ids == ["provider"]
+    assert fallback.stream_calls == []
+
+
+@pytest.mark.parametrize("invalid_chunk", [None, False, 0, b"", b"frame"])
+@pytest.mark.asyncio
+async def test_invalid_provider_chunk_remains_terminal(invalid_chunk: object) -> None:
+    primary = InvalidChunkProvider(
+        invalid_chunk,
+        _execution_failure("failure after invalid chunk", retryable=False),
+    )
+    fallback = FakeProvider()
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {"provider": primary, "fallback": fallback}[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=60.0)
+    stream = executor.stream(
+        _routed_request(_target("fallback", "model")),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_invalid_chunk",
+    )
+
+    with pytest.raises(TypeError, match="must yield string chunks"):
+        await anext(stream)
+
+    assert resolved_ids == ["provider"]
+    assert primary.stream_close_calls == 1
     assert fallback.stream_calls == []
 
 
@@ -900,6 +1027,120 @@ async def test_progress_timeout_wins_when_provider_suppresses_cancellation() -> 
     assert exc_info.value.status_code == 504
     assert resolved_ids == ["provider"]
     assert primary.stream_close_calls == 1
+    assert fallback.stream_calls == []
+
+
+@pytest.mark.parametrize(
+    "replacement_failure", [None, _execution_failure("translated")]
+)
+@pytest.mark.asyncio
+async def test_caller_cancellation_wins_when_provider_suppresses_it(
+    replacement_failure: ExecutionFailure | None,
+) -> None:
+    primary = CancellationSuppressingProvider(replacement_failure)
+    fallback = FakeProvider()
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {"provider": primary, "fallback": fallback}[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=1.0)
+    stream = executor.stream(
+        _routed_request(_target("fallback", "model")),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_suppressed_caller_cancel",
+    )
+    with (
+        patch("free_claude_code.application.execution.trace_event") as trace_mock,
+        patch("free_claude_code.core.trace.trace_event") as stream_trace_mock,
+    ):
+        task = asyncio.ensure_future(anext(stream))
+        await primary.started.wait()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert resolved_ids == ["provider"]
+    assert primary.stream_close_calls == 1
+    assert fallback.stream_calls == []
+    stream_events = {
+        call.kwargs.get("event") for call in stream_trace_mock.call_args_list
+    }
+    fallback_events = {call.kwargs.get("event") for call in trace_mock.call_args_list}
+    assert "free_claude_code.api.response.stream_interrupted" in stream_events
+    assert "free_claude_code.api.response.stream_completed" not in stream_events
+    assert "free_claude_code.model_fallback.started" not in fallback_events
+    assert "free_claude_code.model_fallback.selected" not in fallback_events
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    ["late-frame", None, _execution_failure("late failure", retryable=False)],
+    ids=["frame", "completion", "execution-failure"],
+)
+@pytest.mark.asyncio
+async def test_absolute_progress_deadline_wins_over_late_stream_outcome(
+    outcome: str | ExecutionFailure | None,
+) -> None:
+    primary = BlockingProvider(outcome, delay_seconds=0.05)
+    fallback = FakeProvider()
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {"provider": primary, "fallback": fallback}[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=0.01)
+    stream = executor.stream(
+        _routed_request(_target("fallback", "model")),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_late_stream_outcome",
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await anext(stream)
+
+    assert exc_info.value.kind is FailureKind.TIMEOUT
+    assert exc_info.value.status_code == 504
+    assert resolved_ids == ["provider"]
+    assert primary.stream_close_calls == 1
+    assert fallback.stream_calls == []
+
+
+@pytest.mark.asyncio
+async def test_absolute_progress_deadline_wins_over_late_construction_failure() -> None:
+    primary = BlockingStreamConstructionProvider(
+        _execution_failure("late construction failure", retryable=False),
+        delay_seconds=0.05,
+    )
+    fallback = FakeProvider()
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {"provider": primary, "fallback": fallback}[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=0.01)
+    stream = executor.stream(
+        _routed_request(_target("fallback", "model")),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_late_construction_failure",
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await anext(stream)
+
+    assert exc_info.value.kind is FailureKind.TIMEOUT
+    assert exc_info.value.status_code == 504
+    assert resolved_ids == ["provider"]
     assert fallback.stream_calls == []
 
 

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -172,6 +172,24 @@ class FailingStreamConstructionProvider(FakeProvider):
         raise RuntimeError("stream construction failed")
 
 
+class ExecutionFailureStreamConstructionProvider(FakeProvider):
+    def __init__(self, failure: ExecutionFailure) -> None:
+        super().__init__()
+        self._failure = failure
+
+    def stream_response(
+        self,
+        request: MessagesRequest,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+        response_model: str | None = None,
+        reasoning: ReasoningPolicy,
+    ) -> AsyncIterator[str]:
+        del request, input_tokens, request_id, response_model, reasoning
+        raise self._failure
+
+
 def _target(provider_id: str, provider_model: str) -> ProviderModelTarget:
     return ProviderModelTarget(
         provider_id=provider_id,
@@ -473,11 +491,19 @@ async def test_unexpected_primary_failure_does_not_select_fallback() -> None:
     assert primary.stream_close_calls == 1
 
 
+@pytest.mark.parametrize("failure_kind", tuple(FailureKind))
 @pytest.mark.asyncio
-async def test_nonretryable_failure_never_resolves_fallback() -> None:
-    primary_failure = _execution_failure("rejected", retryable=False)
+async def test_nonretryable_provider_failure_selects_fallback_before_first_frame(
+    failure_kind: FailureKind,
+) -> None:
+    primary_failure = ExecutionFailure(
+        kind=failure_kind,
+        status_code=500,
+        message="provider rejected candidate",
+        retryable=False,
+    )
     primary = ControlledProvider([primary_failure])
-    fallback = FakeProvider()
+    fallback = ControlledProvider(["fallback-frame"])
     resolved_ids: list[str] = []
 
     def resolve(provider_id: str) -> FakeProvider:
@@ -493,11 +519,45 @@ async def test_nonretryable_failure_never_resolves_fallback() -> None:
         request_id="req_rejected",
     )
 
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await anext(stream)
+    with patch("free_claude_code.application.execution.trace_event") as trace_mock:
+        chunks = [chunk async for chunk in stream]
 
-    assert exc_info.value is primary_failure
-    assert resolved_ids == ["provider"]
+    assert chunks == ["fallback-frame"]
+    assert resolved_ids == ["provider", "fallback"]
+    fallback_started = next(
+        call.kwargs
+        for call in trace_mock.call_args_list
+        if call.kwargs.get("event") == "free_claude_code.model_fallback.started"
+    )
+    assert fallback_started["failure_kind"] == failure_kind.value
+    assert fallback_started["provider_retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_nonretryable_stream_construction_failure_selects_fallback() -> None:
+    primary_failure = ExecutionFailure(
+        kind=FailureKind.PERMISSION,
+        status_code=403,
+        message="provider denied candidate",
+        retryable=False,
+    )
+    primary = ExecutionFailureStreamConstructionProvider(primary_failure)
+    fallback = ControlledProvider(["fallback-frame"])
+    providers = {"provider": primary, "fallback": fallback}
+    executor = ProviderExecutor(
+        providers.__getitem__,
+        progress_timeout_seconds=60.0,
+    )
+    stream = executor.stream(
+        _routed_request(_target("fallback", "model")),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_construction_failure",
+    )
+
+    assert [chunk async for chunk in stream] == ["fallback-frame"]
+    assert fallback.stream_calls[0]["request_id"] == "req_construction_failure"
 
 
 @pytest.mark.asyncio
@@ -729,6 +789,36 @@ async def test_progress_timeout_before_first_chunk_is_canonical_and_correlated()
             "timeout_seconds": 0.02,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_application_progress_timeout_never_resolves_fallback() -> None:
+    primary = ControlledProvider([WaitStep()])
+    fallback = FakeProvider()
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {"provider": primary, "fallback": fallback}[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=0.02)
+    stream = executor.stream(
+        _routed_request(_target("fallback", "model")),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_terminal_progress_timeout",
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await anext(stream)
+
+    assert exc_info.value.kind is FailureKind.TIMEOUT
+    assert exc_info.value.status_code == 504
+    assert exc_info.value.retryable is False
+    assert resolved_ids == ["provider"]
+    assert primary.stream_close_calls == 1
+    assert fallback.stream_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -190,8 +190,21 @@ class ExecutionFailureStreamConstructionProvider(FakeProvider):
         raise self._failure
 
 
-class CancellationSuppressingProvider(FakeProvider):
-    async def stream_response(
+class CloseControlledProvider(FakeProvider):
+    def __init__(
+        self,
+        failure: ExecutionFailure,
+        *,
+        close_delay_seconds: float = 0.0,
+        close_error: Exception | None = None,
+    ) -> None:
+        super().__init__()
+        self._failure = failure
+        self._close_delay_seconds = close_delay_seconds
+        self._close_error = close_error
+        self._read = False
+
+    def stream_response(
         self,
         request: MessagesRequest,
         input_tokens: int = 0,
@@ -207,14 +220,23 @@ class CancellationSuppressingProvider(FakeProvider):
             response_model=response_model,
             reasoning=reasoning,
         )
-        try:
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                return
-            yield "unreachable"
-        finally:
-            self.stream_close_calls += 1
+        return self
+
+    def __aiter__(self) -> AsyncIterator[str]:
+        return self
+
+    async def __anext__(self) -> str:
+        if self._read:
+            raise StopAsyncIteration
+        self._read = True
+        raise self._failure
+
+    async def aclose(self) -> None:
+        self.stream_close_calls += 1
+        if self._close_delay_seconds:
+            await asyncio.sleep(self._close_delay_seconds)
+        if self._close_error is not None:
+            raise self._close_error
 
 
 def _target(provider_id: str, provider_model: str) -> ProviderModelTarget:
@@ -875,8 +897,11 @@ async def test_application_progress_timeout_never_resolves_fallback() -> None:
 
 
 @pytest.mark.asyncio
-async def test_progress_timeout_wins_when_provider_suppresses_cancellation() -> None:
-    primary = CancellationSuppressingProvider()
+async def test_provider_cleanup_cannot_delay_fallback_past_progress_deadline() -> None:
+    primary = CloseControlledProvider(
+        _execution_failure("primary overloaded"),
+        close_delay_seconds=0.05,
+    )
     fallback = FakeProvider()
     resolved_ids: list[str] = []
 
@@ -890,17 +915,53 @@ async def test_progress_timeout_wins_when_provider_suppresses_cancellation() -> 
         wire_api="messages",
         raw_log_label="FULL_PAYLOAD",
         raw_log_payload={},
-        request_id="req_suppressed_timeout",
+        request_id="req_cleanup_timeout",
     )
 
-    with pytest.raises(ExecutionFailure) as exc_info:
-        _ = [chunk async for chunk in stream]
+    with (
+        patch("free_claude_code.application.execution.trace_event") as trace_mock,
+        pytest.raises(ExecutionFailure) as exc_info,
+    ):
+        await anext(stream)
 
     assert exc_info.value.kind is FailureKind.TIMEOUT
     assert exc_info.value.status_code == 504
     assert resolved_ids == ["provider"]
     assert primary.stream_close_calls == 1
     assert fallback.stream_calls == []
+    assert all(
+        call.kwargs.get("event") != "free_claude_code.model_fallback.started"
+        for call in trace_mock.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_trace_names_preserved_provider_failure() -> None:
+    failure = _execution_failure("primary overloaded")
+    provider = CloseControlledProvider(
+        failure,
+        close_error=RuntimeError("close failed"),
+    )
+    stream = _executor_stream(
+        provider,
+        timeout_seconds=1.0,
+        request_id="req_close_failure_trace",
+    )
+
+    with (
+        patch("free_claude_code.core.trace.trace_event") as trace_mock,
+        pytest.raises(ExecutionFailure) as exc_info,
+    ):
+        await anext(stream)
+
+    assert exc_info.value is failure
+    close_trace = next(
+        call.kwargs
+        for call in trace_mock.call_args_list
+        if call.kwargs.get("event") == "stream.input.close_failed"
+    )
+    assert close_trace["close_exc_type"] == "RuntimeError"
+    assert close_trace["preserved_exc_type"] == "ExecutionFailure"
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -256,6 +256,42 @@ _CASES = (
         False,
     ),
     _ClassificationCase(
+        "statusless_openai_tokenrouter_bad_request",
+        lambda: _statusless_openai_error(
+            "stream embedded error",
+            {
+                "object": "error",
+                "message": (
+                    "Invalid request: Disaggregated request received without "
+                    "bootstrap room id"
+                ),
+                "type": "BAD_REQUEST",
+                "param": None,
+                "code": 400,
+            },
+        ),
+        FailureKind.UPSTREAM,
+        500,
+        False,
+    ),
+    _ClassificationCase(
+        "openai_insufficient_user_quota",
+        lambda: _openai_status_error(
+            openai.PermissionDeniedError,
+            status_code=403,
+            message="insufficient user quota",
+            body={
+                "error": {
+                    "message": "insufficient user quota",
+                    "code": "insufficient_user_quota",
+                }
+            },
+        ),
+        FailureKind.PERMISSION,
+        403,
+        False,
+    ),
+    _ClassificationCase(
         "http_401_maps_authentication",
         lambda: _http_status_error(401, "Unauthorized"),
         FailureKind.AUTHENTICATION,

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.5"
+version = "5.14.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Configured model fallbacks were gated by provider retryability, so safe pre-output failures such as TokenRouter's statusless SSE error and quota exhaustion stopped the request instead of advancing. That mixed provider-owned same-model retry classification with application-owned cross-model fallback eligibility. Closes #1543.

## Changes

| Before | After |
| --- | --- |
| Only provider failures marked retryable could advance | Any provider-finalized `ExecutionFailure` may advance while no output has been emitted |
| Provider retry classification controlled cross-model routing | Providers retain same-model retry ownership; the application owns fallback after a provider finalizes a failure |
| Broad exception handling could also catch FCC's own timeout | Lexical provider boundaries keep preflight errors, unexpected exceptions, and FCC's progress timeout terminal |
| Abandoned stream cleanup was outside the fallback lifecycle | The failed stream closes before fallback, cooperative cleanup shares the progress deadline, and cleanup traces retain the preserved provider failure |
| Fallback trace always claimed retryable | Trace reports the provider failure's actual retryability |
| The reported TokenRouter and quota paths lacked contracts | Added exact classifier characterizations, both public API paths, lifecycle tests, and updated fallback wording |
| Release remained 5.14.5 | Bumped once to 5.14.6 and refreshed the lockfile |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update makes configured model fallbacks available when a provider fails before producing response output. It preserves terminal behavior after output begins and keeps application-owned deadlines and cancellation from starting another provider.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised provider fallback and stream-lifecycle behavior.

No blocking failure remains. The focused checks confirmed fallback for pre-output provider failures while preserving cleanup, deadline, cancellation, and first-output commitment behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a standalone pytest validation against the base revision and the PR revision using uv run --group dev pytest -n 0.
- I observed that the base revision did not fall back for the two pre-output ExecutionFailure paths, while the PR revision passed all five checks covering construction-time failure, iterator-time failure and cleanup, first-output commitment, progress deadline, and cancellation.
- I executed tests/application/test\_execution.py with pytest -n 0; all 37 tests passed, confirming the tested terminal stream behavior and the fallback boundary.
- I reviewed the Focused ProviderExecutor fallback lifecycle validation source to ground the validation work.
- I validated the disproved scenarios from proof 1, confirming that pre-output ExecutionFailure is not suppressed and the PR HEAD falls back with the correct provider\_retryable=False trace; I also confirmed that iterator-advancement failures do not bypass cleanup or trigger fallback, that fallback does not start after first non-empty output, after the progress deadline, or on cancellation, and that there is no security impact identified.

<a href="https://app.greptile.com/trex/runs/20538724/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Bound supported fallback cleanup"](https://github.com/alishahryar1/free-claude-code/commit/7686ff34e0ff1f82498f9525f6730356d0ccebf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56554579)</sub>

<!-- /greptile_comment -->