### PR TITLE
feat: add picker alias engine for Claude Desktop model discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.15.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -25,8 +25,8 @@ dependencies = [
     "jsonschema>=4.25.0",
     "google-auth[requests]>=2.56.3",
     "requests[socks]>=2.34.2",
-    "pystray>=0.19.5; sys_platform == 'win32' or sys_platform == 'darwin'",
-    "Pillow>=12.0.0; sys_platform == 'win32' or sys_platform == 'darwin'",
+    "pystray>=0.19.5",
+    "Pillow>=12.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.11"
+version = "5.19.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -26,8 +26,8 @@ dependencies = [
     "jsonschema>=4.25.0",
     "google-auth[requests]>=2.56.3",
     "requests[socks]>=2.34.2",
-    "pystray>=0.19.5; sys_platform == 'win32' or sys_platform == 'darwin'",
-    "Pillow>=12.0.0; sys_platform == 'win32' or sys_platform == 'darwin'",
+    "pystray>=0.19.5",
+    "Pillow>=12.0.0",
 ]
 
 [project.scripts]

--- a/src/free_claude_code/api/app.py
+++ b/src/free_claude_code/api/app.py
@@ -52,6 +52,12 @@ def create_app(services: ApiServices) -> FastAPI:
     app.include_router(admin_router)
     app.include_router(chat_router)
     app.include_router(router)
+    # Claude Desktop-only alias mount: same handlers under the desktop path
+    # prefix; the models handler serves picker aliases only on this mount.
+    app.include_router(
+        router,
+        prefix=f"/{services.requests.current_settings().desktop_gateway_prefix}",
+    )
 
     @app.exception_handler(ChatError)
     async def chat_error_handler(request: Request, exc: ChatError):

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -13,6 +13,7 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.core.gateway_model_ids import (
     gateway_model_id,
     no_thinking_gateway_model_id,
+    picker_alias_for,
 )
 from free_claude_code.core.model_capabilities import ModelInputModality
 
@@ -133,15 +134,26 @@ def build_models_list_response(
     runtime: RequestRuntimePort,
     *,
     view: ModelCatalogView = ModelCatalogView.CLAUDE,
+    picker_aliases: bool = False,
 ) -> ModelsListResponse:
-    """Return the application model inventory in the requested client view."""
+    """Return the application model inventory in the requested client view.
+
+    ``picker_aliases`` opts into Claude Desktop picker alias ids; only the
+    desktop-scoped API mount enables it, so every other FCC client sees raw
+    provider refs regardless of seeded alias state.
+    """
     if view is ModelCatalogView.CLAUDE:
-        return _build_claude_models_response(settings, runtime)
+        return _build_claude_models_response(
+            settings, runtime, picker_aliases=picker_aliases
+        )
     return _build_direct_models_response(settings, runtime, view=view)
 
 
 def _build_claude_models_response(
-    settings: Settings, runtime: RequestRuntimePort
+    settings: Settings,
+    runtime: RequestRuntimePort,
+    *,
+    picker_aliases: bool,
 ) -> ModelsListResponse:
     """Preserve the established Claude-compatible catalog exactly."""
     models: list[ModelResponse] = []
@@ -156,6 +168,7 @@ def _build_claude_models_response(
             supports_thinking=(
                 model_info.supports_thinking if model_info is not None else None
             ),
+            picker_aliases=picker_aliases,
         )
 
     for model_info in runtime.cached_prefixed_model_infos():
@@ -164,6 +177,7 @@ def _build_claude_models_response(
             seen,
             model_info.model_id,
             supports_thinking=model_info.supports_thinking,
+            picker_aliases=picker_aliases,
         )
 
     for model in SUPPORTED_CLAUDE_MODELS:
@@ -319,13 +333,22 @@ def _append_provider_model_variants(
     provider_model_ref: str,
     *,
     supports_thinking: bool | None = None,
+    picker_aliases: bool = False,
 ) -> None:
+    thinking_id = (
+        picker_alias_for(provider_model_ref) if picker_aliases else None
+    ) or gateway_model_id(provider_model_ref)
+    no_thinking_id = (
+        picker_alias_for(provider_model_ref, force_reasoning_off=True)
+        if picker_aliases
+        else None
+    ) or no_thinking_gateway_model_id(provider_model_ref)
     if supports_thinking is not False:
         _append_unique_model(
             models,
             seen,
             _discovered_model_response(
-                gateway_model_id(provider_model_ref),
+                thinking_id,
                 display_name=provider_model_ref,
             ),
         )
@@ -333,7 +356,7 @@ def _append_provider_model_variants(
         models,
         seen,
         _discovered_model_response(
-            no_thinking_gateway_model_id(provider_model_ref),
+            no_thinking_id,
             display_name=f"{provider_model_ref} (no thinking)",
         ),
     )

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -197,14 +197,31 @@ async def probe_health():
     response_model_exclude_none=True,
 )
 async def list_models(
+    request: Request,
     view: ModelCatalogView = ModelCatalogView.CLAUDE,
     services: ApiServices = Depends(get_services),
     settings: Settings = Depends(get_settings),
     _auth=Depends(require_proxy_auth),
 ):
-    """List the model ids this proxy advertises to compatible clients."""
+    """List the model ids this proxy advertises to compatible clients.
+
+    Served both bare and under the desktop path prefix. Picker aliases are
+    emitted only on the prefixed mount so Claude Code, Codex, Pi and every
+    other FCC client keep seeing raw provider refs. The mount is identified
+    by exact path equality, not by a prefix sniff: a
+    ``DESKTOP_GATEWAY_PREFIX`` of ``v1`` would otherwise make the bare
+    ``/v1/models`` path satisfy a ``startswith`` check and leak Desktop-only
+    aliases to every client.
+    """
     trace_event(stage="ingress", event="free_claude_code.api.models.list", source="api")
-    return build_models_list_response(settings, services.requests, view=view)
+    desktop_mount_path = f"/{settings.desktop_gateway_prefix}/v1/models"
+    picker_aliases = request.url.path == desktop_mount_path
+    return build_models_list_response(
+        settings,
+        services.requests,
+        view=view,
+        picker_aliases=picker_aliases,
+    )
 
 
 @router.get(

--- a/src/free_claude_code/application/routing.py
+++ b/src/free_claude_code/application/routing.py
@@ -13,7 +13,10 @@ from free_claude_code.config.provider_catalog import (
 from free_claude_code.config.reasoning import ReasoningPreference
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest, TokenCountRequest
-from free_claude_code.core.gateway_model_ids import decode_gateway_model_id
+from free_claude_code.core.gateway_model_ids import (
+    decode_gateway_model_id,
+    resolve_picker_alias,
+)
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import ReasoningPolicy
 
@@ -146,6 +149,18 @@ class ModelRouter:
     def _direct_provider_model(
         self, model_name: str
     ) -> tuple[str | None, str | None, bool]:
+        alias_resolution = resolve_picker_alias(model_name)
+        if alias_resolution is not None:
+            aliased_ref, force_reasoning_off = alias_resolution
+            provider_id, separator, provider_model = aliased_ref.partition("/")
+            if (
+                not separator
+                or provider_id not in SUPPORTED_PROVIDER_IDS
+                or not provider_model
+            ):
+                return None, None, False
+            return provider_id, provider_model, force_reasoning_off
+
         decoded = decode_gateway_model_id(model_name)
         if decoded is not None:
             if decoded.provider_id not in SUPPORTED_PROVIDER_IDS:

--- a/src/free_claude_code/cli/desktop_console.py
+++ b/src/free_claude_code/cli/desktop_console.py
@@ -3,7 +3,6 @@
 import threading
 
 from free_claude_code.cli.desktop import DesktopController, launch_desktop
-from free_claude_code.cli.desktop_tray import PystrayDesktopTray, tray_is_available
 
 
 class ConsoleDesktopTray:
@@ -24,13 +23,7 @@ class ConsoleDesktopTray:
         self._stop_event.set()
 
 
-def launch() -> None:
-    """Launch the tray when available, otherwise fall back to console mode."""
-
-    available, reason = tray_is_available()
-    if available:
-        launch_desktop(PystrayDesktopTray)
-        return
+def _print_console_notice(reason: str) -> None:
     print(
         "Native system tray is unavailable on this session; "
         "running in console mode instead.",
@@ -42,4 +35,24 @@ def launch() -> None:
         "installed; launch it from your app launcher as usual.",
         flush=True,
     )
+
+
+def launch() -> None:
+    """Launch the tray when available, otherwise fall back to console mode."""
+    # The import selects pystray's platform backend; on a headless Linux
+    # session that raises before any probe can run, so a failed import is
+    # reported as an unavailable tray rather than crashing the fallback.
+    try:
+        from free_claude_code.cli.desktop_tray import (
+            PystrayDesktopTray,
+            tray_is_available,
+        )
+    except Exception as exc:
+        _print_console_notice(f"the native tray adapter failed to load: {exc}")
+    else:
+        available, reason = tray_is_available()
+        if available:
+            launch_desktop(PystrayDesktopTray)
+            return
+        _print_console_notice(reason)
     launch_desktop(ConsoleDesktopTray)

--- a/src/free_claude_code/cli/desktop_console.py
+++ b/src/free_claude_code/cli/desktop_console.py
@@ -1,0 +1,58 @@
+"""Tray-less desktop mode for Linux sessions without a status-area backend."""
+
+import threading
+
+from free_claude_code.cli.desktop import DesktopController, launch_desktop
+
+
+class ConsoleDesktopTray:
+    """Null tray that keeps the controller lifecycle intact without UI.
+
+    ``run()`` blocks until ``stop()`` (or SIGINT interrupts the wait), so
+    ``DesktopController.run()`` starts and drains the server exactly as it
+    does behind a native tray.
+    """
+
+    def __init__(self, controller: DesktopController) -> None:
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        self._stop_event.wait()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+def _print_console_notice(reason: str) -> None:
+    print(
+        "Native system tray is unavailable on this session; "
+        "running in console mode instead.",
+        flush=True,
+    )
+    print(f"Reason: {reason}", flush=True)
+    print(
+        "Claude Desktop is routed through this server automatically when "
+        "installed; launch it from your app launcher as usual.",
+        flush=True,
+    )
+
+
+def launch() -> None:
+    """Launch the tray when available, otherwise fall back to console mode."""
+    # The import selects pystray's platform backend; on a headless Linux
+    # session that raises before any probe can run, so a failed import is
+    # reported as an unavailable tray rather than crashing the fallback.
+    try:
+        from free_claude_code.cli.desktop_tray import (
+            PystrayDesktopTray,
+            tray_is_available,
+        )
+    except Exception as exc:
+        _print_console_notice(f"the native tray adapter failed to load: {exc}")
+    else:
+        available, reason = tray_is_available()
+        if available:
+            launch_desktop(PystrayDesktopTray)
+            return
+        _print_console_notice(reason)
+    launch_desktop(ConsoleDesktopTray)

--- a/src/free_claude_code/cli/desktop_console.py
+++ b/src/free_claude_code/cli/desktop_console.py
@@ -1,0 +1,45 @@
+"""Tray-less desktop mode for Linux sessions without a status-area backend."""
+
+import threading
+
+from free_claude_code.cli.desktop import DesktopController, launch_desktop
+from free_claude_code.cli.desktop_tray import PystrayDesktopTray, tray_is_available
+
+
+class ConsoleDesktopTray:
+    """Null tray that keeps the controller lifecycle intact without UI.
+
+    ``run()`` blocks until ``stop()`` (or SIGINT interrupts the wait), so
+    ``DesktopController.run()`` starts and drains the server exactly as it
+    does behind a native tray.
+    """
+
+    def __init__(self, controller: DesktopController) -> None:
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        self._stop_event.wait()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+def launch() -> None:
+    """Launch the tray when available, otherwise fall back to console mode."""
+
+    available, reason = tray_is_available()
+    if available:
+        launch_desktop(PystrayDesktopTray)
+        return
+    print(
+        "Native system tray is unavailable on this session; "
+        "running in console mode instead.",
+        flush=True,
+    )
+    print(f"Reason: {reason}", flush=True)
+    print(
+        "Claude Desktop is routed through this server automatically when "
+        "installed; launch it from your app launcher as usual.",
+        flush=True,
+    )
+    launch_desktop(ConsoleDesktopTray)

--- a/src/free_claude_code/cli/desktop_entrypoint.py
+++ b/src/free_claude_code/cli/desktop_entrypoint.py
@@ -4,6 +4,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+from free_claude_code.cli import desktop_console
 from free_claude_code.cli.desktop_assets import export_app_icon
 
 
@@ -17,10 +18,17 @@ def launch(argv: Sequence[str] | None = None) -> None:
     if args:
         print("Usage: fcc-desktop [--export-icon PATH]", file=sys.stderr)
         raise SystemExit(2)
-    if sys.platform not in {"darwin", "win32"}:
-        print("FCC Desktop is supported on Windows and macOS.", file=sys.stderr)
+    if sys.platform not in {"darwin", "win32", "linux"}:
+        print("FCC Desktop is supported on Windows, macOS, and Linux.", file=sys.stderr)
         raise SystemExit(1)
 
-    from free_claude_code.cli.desktop_tray import launch as launch_tray
+    if sys.platform == "linux":
+        desktop_console.launch()
+        return
 
-    launch_tray()
+    # Import lazily so a headless Linux session without a pystray backend
+    # can still run ``--export-icon`` and the console-mode fallback; the
+    # tray adapter is only needed on this native-tray branch.
+    from free_claude_code.cli import desktop_tray
+
+    desktop_tray.launch()

--- a/src/free_claude_code/cli/desktop_entrypoint.py
+++ b/src/free_claude_code/cli/desktop_entrypoint.py
@@ -17,9 +17,15 @@ def launch(argv: Sequence[str] | None = None) -> None:
     if args:
         print("Usage: fcc-desktop [--export-icon PATH]", file=sys.stderr)
         raise SystemExit(2)
-    if sys.platform not in {"darwin", "win32"}:
-        print("FCC Desktop is supported on Windows and macOS.", file=sys.stderr)
+    if sys.platform not in {"darwin", "win32", "linux"}:
+        print("FCC Desktop is supported on Windows, macOS, and Linux.", file=sys.stderr)
         raise SystemExit(1)
+
+    if sys.platform == "linux":
+        from free_claude_code.cli.desktop_console import launch as launch_console
+
+        launch_console()
+        return
 
     from free_claude_code.cli.desktop_tray import launch as launch_tray
 

--- a/src/free_claude_code/cli/desktop_tray.py
+++ b/src/free_claude_code/cli/desktop_tray.py
@@ -1,4 +1,4 @@
-"""pystray adapter for the Windows tray and macOS menu bar."""
+"""pystray adapter for the Windows tray, macOS menu bar, and Linux status area."""
 
 from io import BytesIO
 
@@ -54,6 +54,37 @@ def _create_icon() -> Image.Image:
 
     with Image.open(BytesIO(app_icon_bytes(".png"))) as image:
         return image.convert("RGBA")
+
+
+_TRAY_BACKEND_HINT = (
+    "no supported tray backend is available; install "
+    "'gir1.2-ayatanaappindicator3-0.1' (Debian/Ubuntu) or "
+    "'libappindicator-gtk3' (Fedora), or use an X11 session"
+)
+
+
+def tray_is_available() -> tuple[bool, str]:
+    """Probe whether a native tray icon can be constructed on this desktop.
+
+    Constructing the pystray ``Icon`` resolves the platform backend module;
+    on Linux that import fails when no AppIndicator/GTK/X11 backend exists.
+    The probe discards the constructed icon without ever showing it.
+
+    Returns ``(True, "")`` when a tray can run, otherwise ``(False, reason)``
+    with an actionable message for console fallback mode.
+    """
+
+    try:
+        image = _create_icon()
+    except Exception as exc:
+        return False, f"tray icon artwork failed to load: {exc}"
+    try:
+        Icon("free-claude-code", image, "Free Claude Code")
+    except Exception as exc:
+        if isinstance(exc, ImportError):
+            return False, _TRAY_BACKEND_HINT
+        return False, str(exc)
+    return True, ""
 
 
 def launch() -> None:

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -703,6 +703,19 @@ class Settings(BaseModel):
         default="freecc",
         validation_alias="ANTHROPIC_AUTH_TOKEN",
     )
+    desktop_gateway_prefix: NonEmptyString = Field(
+        default="claude-desktop",
+        validation_alias="DESKTOP_GATEWAY_PREFIX",
+    )
+
+    @field_validator("desktop_gateway_prefix")
+    @classmethod
+    def normalize_desktop_gateway_prefix(cls, v: str) -> str:
+        """Strip boundary slashes so the prefix mounts as a single ``/{prefix}``."""
+        prefix = v.strip("/")
+        if not prefix:
+            raise ValueError("DESKTOP_GATEWAY_PREFIX must contain a path segment")
+        return prefix
 
     @field_validator("max_message_log_entries_per_chat", mode="before")
     @classmethod

--- a/src/free_claude_code/core/gateway_model_ids.py
+++ b/src/free_claude_code/core/gateway_model_ids.py
@@ -1,5 +1,6 @@
 """Gateway-safe model ID encoding shared by API and CLI adapters."""
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 GATEWAY_MODEL_ID_PREFIX = "anthropic"
@@ -8,6 +9,47 @@ GATEWAY_MODEL_ID_PREFIX = "anthropic"
 # supporting thinking. This intentionally uses that client-side capability
 # heuristic while keeping the real provider/model ref reversible for routing.
 NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
+
+PICKER_ALIAS_PREFIX = "claude-sonnet-nim"
+_PICKER_ALIAS_NO_THINKING_SUFFIX = "-no-thinking"
+_PICKER_ALIAS_WIDTH = 4
+
+
+@dataclass(frozen=True, slots=True)
+class _PickerAliasMaps:
+    """Immutable alias snapshot shared by catalog output and request routing.
+
+    Published as a single module-global assignment so concurrent readers can
+    never observe a torn state mixing refs from two different inventories.
+    """
+
+    alias_to_ref: Mapping[str, str]
+    alias_to_ref_no_thinking: Mapping[str, str]
+    ref_to_alias: Mapping[str, str]
+    ref_to_alias_no_thinking: Mapping[str, str]
+
+
+_EMPTY_PICKER_ALIAS_MAPS = _PickerAliasMaps({}, {}, {}, {})
+
+# Seeded at startup with the sorted refs from the runtime cached model catalog,
+# then republished whenever the model cache is mutated. Tests call
+# ``clear_picker_aliases()`` between runs to restore the inert empty snapshot.
+_picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+
+# Sticky ref-to-alias assignments that survive reseeds: once an alias has been
+# advertised for a ref, that alias is never re-pointed to a different ref, so
+# a desktop picker holding a stale catalog cannot silently route to another
+# model. Numbers of retired refs stay consumed; a returning ref regains its
+# previous alias. Reset only by ``clear_picker_aliases()``.
+_sticky_ref_to_alias: dict[str, str] = {}
+_used_alias_numbers: set[int] = set()
+
+
+def _next_unused_alias_number(used_numbers: set[int]) -> int:
+    candidate = 1
+    while candidate in used_numbers:
+        candidate += 1
+    return candidate
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,3 +91,96 @@ def decode_gateway_model_id(model_name: str) -> DecodedGatewayModelId | None:
         provider_model=provider_model,
         force_reasoning_off=force_reasoning_off,
     )
+
+
+def _format_picker_alias(index: int, *, no_thinking: bool) -> str:
+    suffix = _PICKER_ALIAS_NO_THINKING_SUFFIX if no_thinking else ""
+    return f"{PICKER_ALIAS_PREFIX}-{index:0{_PICKER_ALIAS_WIDTH}d}{suffix}"
+
+
+def seed_picker_aliases(provider_model_refs: Iterable[str]) -> None:
+    """Publish a fresh immutable alias snapshot built from the supplied refs.
+
+    Aliases are stable across reseeds: a ref that already holds an alias keeps
+    it, and new refs take previously unused numbers, so an alias already shown
+    in a client picker can never silently resolve to a different model.
+    Numbering is deterministic on restart when starting from the same initial
+    inventory (counters assigned by ``sorted(refs)`` order).
+
+    An empty inventory publishes the inert empty snapshot so a cold-start
+    ``/v1/models`` request still falls back to the canonical
+    ``gateway_model_id`` wrappers, while sticky assignments and consumed
+    alias numbers are preserved so a later refresh can never re-point a
+    previously advertised alias.
+    """
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+
+    wanted = [ref for ref in sorted(set(provider_model_refs)) if ref]
+    if not wanted:
+        _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+        return
+
+    thinking_aliases: dict[str, str] = {}
+    no_thinking_aliases: dict[str, str] = {}
+    ref_to_thinking: dict[str, str] = {}
+    ref_to_no_thinking: dict[str, str] = {}
+    used_numbers = set(_used_alias_numbers)
+
+    for ref in wanted:
+        alias = _sticky_ref_to_alias.get(ref)
+        if alias is None:
+            number = _next_unused_alias_number(used_numbers)
+            used_numbers.add(number)
+            alias = _format_picker_alias(number, no_thinking=False)
+        thinking_aliases[alias] = ref
+        alias_no_thinking = f"{alias}{_PICKER_ALIAS_NO_THINKING_SUFFIX}"
+        no_thinking_aliases[alias_no_thinking] = ref
+        ref_to_thinking[ref] = alias
+        ref_to_no_thinking[ref] = alias_no_thinking
+
+    _sticky_ref_to_alias = {**_sticky_ref_to_alias, **ref_to_thinking}
+    _used_alias_numbers = used_numbers
+    _picker_aliases = _PickerAliasMaps(
+        alias_to_ref=thinking_aliases,
+        alias_to_ref_no_thinking=no_thinking_aliases,
+        ref_to_alias=ref_to_thinking,
+        ref_to_alias_no_thinking=ref_to_no_thinking,
+    )
+
+
+def picker_alias_for(
+    provider_model_ref: str, *, force_reasoning_off: bool = False
+) -> str | None:
+    """Return the picker alias for ``provider_model_ref``, if seeded."""
+    maps = _picker_aliases
+    if force_reasoning_off:
+        return maps.ref_to_alias_no_thinking.get(provider_model_ref)
+    return maps.ref_to_alias.get(provider_model_ref)
+
+
+def resolve_picker_alias(model_name: str) -> tuple[str, bool] | None:
+    """Reverse-lookup alias. Returns ``(provider_ref, force_reasoning_off)``."""
+    if not model_name:
+        return None
+    maps = _picker_aliases
+    ref = maps.alias_to_ref_no_thinking.get(model_name)
+    if ref is not None:
+        return ref, True
+    ref = maps.alias_to_ref.get(model_name)
+    if ref is not None:
+        return ref, False
+    return None
+
+
+def has_picker_aliases() -> bool:
+    """Whether ``seed_picker_aliases`` has populated the snapshot."""
+    maps = _picker_aliases
+    return bool(maps.alias_to_ref) or bool(maps.alias_to_ref_no_thinking)
+
+
+def clear_picker_aliases() -> None:
+    """Drop every alias entry and sticky assignment. Tests and hardening."""
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+    _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+    _sticky_ref_to_alias = {}
+    _used_alias_numbers = set()

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -147,6 +147,7 @@ class ApplicationRuntime:
             self.provider_manager.start_model_list_refresh()
             if self._chat_service is not None:
                 await self._chat_service.start()
+            self._seed_picker_aliases_from_cache()
             await self._start_messaging_if_configured()
             logging.getLogger("uvicorn.error").info(
                 "Admin UI: %s (local-only)",
@@ -341,6 +342,14 @@ class ApplicationRuntime:
             "admin_url": local_admin_url(settings) if automatic else None,
             "fields": list(fields),
         }
+
+    def _seed_picker_aliases_from_cache(self) -> None:
+        """Publish picker aliases for exactly the cached model inventory.
+
+        Delegates to the provider manager so startup seeding and every later
+        model-catalog republication share one ownership path.
+        """
+        self.provider_manager.refresh_picker_aliases()
 
     async def _start_messaging_if_configured(self) -> None:
         try:

--- a/src/free_claude_code/runtime/provider_manager.py
+++ b/src/free_claude_code/runtime/provider_manager.py
@@ -13,7 +13,9 @@ from free_claude_code.application.model_metadata import (
     ProviderModelRefreshResult,
 )
 from free_claude_code.application.ports import RequestRuntimePort
+from free_claude_code.config.model_refs import configured_chat_model_refs
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.gateway_model_ids import seed_picker_aliases
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.runtime import ProviderRuntime
@@ -366,7 +368,27 @@ class ProviderRuntimeManager:
             return
         self._run_model_catalog_publication(publisher.ensure_exists)
 
+    def refresh_picker_aliases(self) -> None:
+        """Re-point the process-global picker aliases at the current inventory.
+
+        Seeds the union of configured chat model refs and cached discovery
+        refs so a configured model absent from the discovery cache (cold or
+        incomplete provider discovery) still gets a picker alias instead of
+        being advertised as a raw gateway identifier.
+
+        Sticky ref-to-alias assignments make reseeds stable: already
+        advertised aliases keep routing to the same model, newly discovered
+        refs gain aliases immediately, and refs removed from the inventory
+        retire instead of routing to stale targets.
+        """
+        configured = (
+            ref.model_ref for ref in configured_chat_model_refs(self.current_settings())
+        )
+        cached = (info.model_id for info in self.cached_prefixed_model_infos())
+        seed_picker_aliases((*configured, *cached))
+
     def _publish_model_catalog(self) -> None:
+        self.refresh_picker_aliases()
         publisher = self._model_catalog_publisher
         if publisher is None:
             return

--- a/tests/api/test_desktop_scoped_models.py
+++ b/tests/api/test_desktop_scoped_models.py
@@ -1,0 +1,191 @@
+"""End-to-end scoping of picker aliases to the desktop-only API mount."""
+
+from fastapi.testclient import TestClient
+
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from tests.api.support import create_test_app
+
+
+def _settings() -> Settings:
+    settings = Settings()
+    settings.model = "deepseek/deepseek-chat"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    return settings
+
+
+def setup_function(_: object) -> None:
+    gmi.seed_picker_aliases(["deepseek/deepseek-chat"])
+
+
+def teardown_function(_: object) -> None:
+    gmi.clear_picker_aliases()
+
+
+def test_bare_models_route_never_serves_aliases() -> None:
+    app = create_test_app(_settings())
+
+    ids = [m["id"] for m in TestClient(app).get("/v1/models").json()["data"]]
+
+    assert all(not i.startswith("claude-sonnet-nim") for i in ids)
+    assert "anthropic/deepseek/deepseek-chat" in ids
+
+
+def test_prefixed_models_route_serves_aliases() -> None:
+    app = create_test_app(_settings())
+
+    response = TestClient(app).get("/claude-desktop/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = [m["id"] for m in data["data"]]
+    # The alias replaces the wrapper id for the same ref.
+    assert "claude-sonnet-nim-0001" in ids
+    assert "anthropic/deepseek/deepseek-chat" not in ids
+    labels = {
+        m["display_name"]
+        for m in data["data"]
+        if m["id"].startswith("claude-sonnet-nim")
+    }
+    assert "deepseek/deepseek-chat" in labels
+
+
+def test_custom_prefix_is_honored_from_settings() -> None:
+    app = create_test_app(
+        Settings.model_construct(
+            desktop_gateway_prefix="my-gateway",
+            model="deepseek/deepseek-chat",
+            model_fable=None,
+            model_opus=None,
+            model_sonnet=None,
+            model_haiku=None,
+        )
+    )
+
+    bare = TestClient(app).get("/v1/models")
+    prefixed = TestClient(app).get("/my-gateway/v1/models")
+
+    assert all(not m["id"].startswith("claude-sonnet-nim") for m in bare.json()["data"])
+    assert any(m["id"].startswith("claude-sonnet-nim") for m in prefixed.json()["data"])
+
+
+def test_prefix_with_boundary_slashes_is_normalized() -> None:
+    """FastAPI rejects router prefixes ending in '/', so a configured value
+    like '/desktop/' must be normalized or app startup crashes."""
+    settings = Settings(desktop_gateway_prefix="/desktop/")
+    settings.model = "deepseek/deepseek-chat"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+
+    response = TestClient(create_test_app(settings)).get("/desktop/v1/models")
+
+    assert response.status_code == 200
+    assert any(m["id"].startswith("claude-sonnet-nim") for m in response.json()["data"])
+
+
+def test_lookalike_prefixed_path_does_not_serve_aliases() -> None:
+    """Only the exact desktop prefix mount emits aliases; paths that merely
+    start with the same text must never leak picker aliases."""
+    app = create_test_app(_settings())
+
+    response = TestClient(app).get("/claude-desktop-evil/v1/models")
+
+    assert response.status_code == 404
+
+
+def test_prefix_equal_to_bare_v1_does_not_leak_aliases() -> None:
+    """A ``DESKTOP_GATEWAY_PREFIX`` of ``v1`` must not capture the bare catalog.
+
+    The bare ``/v1/models`` path starts with ``/v1/`` — a prefix-sniffing
+    check would treat it as the desktop mount and serve Desktop-only aliases
+    to Claude Code, Codex, Pi and every other client. Alias emission must be
+    gated on the exact mounted path instead.
+    """
+    app = create_test_app(
+        Settings.model_construct(
+            desktop_gateway_prefix="v1",
+            model="deepseek/deepseek-chat",
+            model_fable=None,
+            model_opus=None,
+            model_sonnet=None,
+            model_haiku=None,
+        )
+    )
+
+    client = TestClient(app)
+    bare = [m["id"] for m in client.get("/v1/models").json()["data"]]
+    mounted = [m["id"] for m in client.get("/v1/v1/models").json()["data"]]
+
+    assert all(not i.startswith("claude-sonnet-nim") for i in bare)
+    assert "anthropic/deepseek/deepseek-chat" in bare
+    assert any(i.startswith("claude-sonnet-nim") for i in mounted)
+
+
+def test_messages_round_trip_works_under_desktop_prefix() -> None:
+    """Claude Desktop chats against the prefixed base URL, so the full API
+    surface must exist under the prefix too."""
+    from unittest.mock import patch
+
+    app = create_test_app()
+
+    with (
+        patch(
+            "free_claude_code.api.routes.get_token_count",
+            return_value=1,
+        ),
+    ):
+        response = TestClient(app).post(
+            "/claude-desktop/v1/messages/count_tokens",
+            json={
+                "model": "claude-3-sonnet",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+
+
+def test_advertised_alias_routes_through_prefixed_api() -> None:
+    """An alias served by the desktop catalog must be routable end to end."""
+    from unittest.mock import patch
+
+    from free_claude_code.application.routing import (
+        ModelRouter,
+        RoutedTokenCountRequest,
+    )
+    from free_claude_code.core.anthropic import TokenCountRequest
+
+    app = create_test_app(_settings())
+    routed_refs: list[str] = []
+    original_resolver = ModelRouter.resolve_token_count_request
+
+    def spy(self: ModelRouter, request: TokenCountRequest) -> RoutedTokenCountRequest:
+        routed = original_resolver(self, request)
+        routed_refs.append(routed.resolved.primary.provider_model_ref)
+        return routed
+
+    with (
+        patch("free_claude_code.api.routes.get_token_count", return_value=1),
+        patch.object(
+            ModelRouter,
+            "resolve_token_count_request",
+            autospec=True,
+            side_effect=spy,
+        ),
+    ):
+        response = TestClient(app).post(
+            "/claude-desktop/v1/messages/count_tokens",
+            json={
+                "model": "claude-sonnet-nim-0001",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+    # The advertised alias reached the router and resolved to its seeded ref.
+    assert routed_refs == ["deepseek/deepseek-chat"]

--- a/tests/api/test_desktop_startup_aliases.py
+++ b/tests/api/test_desktop_startup_aliases.py
@@ -1,0 +1,84 @@
+"""Production startup path: the desktop mount serves seeded picker aliases.
+
+Regression guard for the Greptile P1 "picker aliases remain inactive"
+finding: ``ApplicationRuntime.start()`` seeds the process-global alias
+snapshot from the warmed model cache, and the desktop-prefixed
+``/v1/models`` mount serves those aliases while the bare mount keeps raw
+provider refs for every other FCC client.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from free_claude_code.api.app import create_app
+from free_claude_code.api.ports import ApiServices
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.application import ApplicationRuntime
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _settings() -> Settings:
+    return Settings().model_copy(
+        update={
+            "model": "nvidia_nim/meta/llama-3.3-70b-instruct",
+            "nvidia_nim_api_key": "test-key",
+            "messaging_platform": "none",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_startup_seeds_aliases_served_by_desktop_mount() -> None:
+    settings = _settings()
+    manager = ProviderRuntimeManager(settings)
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    manager.cache_model_infos(
+        "nvidia_nim",
+        [
+            ProviderModelInfo(
+                model_id="meta/llama-3.3-70b-instruct", supports_thinking=None
+            )
+        ],
+    )
+    # Drop the publication side effect so only ``start()`` can reseed.
+    gmi.clear_picker_aliases()
+    assert gmi.has_picker_aliases() is False
+
+    with (
+        patch.object(manager, "warm_referenced_model_cache", new=AsyncMock()),
+        patch.object(manager, "start_model_list_refresh"),
+        patch.object(manager, "close", new=AsyncMock()),
+    ):
+        await runtime.start()
+        try:
+            assert gmi.has_picker_aliases() is True
+
+            app = create_app(
+                ApiServices(requests=manager, admin=runtime, tasks=runtime)
+            )
+            client = TestClient(app)
+
+            desktop = client.get("/claude-desktop/v1/models")
+            assert desktop.status_code == 200
+            desktop_ids = [m["id"] for m in desktop.json()["data"]]
+            assert "claude-sonnet-nim-0001" in desktop_ids
+            assert "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct" not in desktop_ids
+
+            bare = client.get("/v1/models")
+            assert bare.status_code == 200
+            bare_ids = [m["id"] for m in bare.json()["data"]]
+            assert "claude-sonnet-nim-0001" not in bare_ids
+            assert "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct" in bare_ids
+        finally:
+            await runtime.close()

--- a/tests/api/test_model_catalog_aliases.py
+++ b/tests/api/test_model_catalog_aliases.py
@@ -1,0 +1,129 @@
+"""Picker alias selection in ``free_claude_code.api.model_catalog``."""
+
+import pytest
+
+from free_claude_code.api import model_catalog
+from free_claude_code.application.ports import RequestRuntimeLease
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+class _StubRuntime:
+    async def acquire(
+        self, *, include_model_infos: bool = False
+    ) -> RequestRuntimeLease:
+        raise NotImplementedError("catalog construction never acquires a lease")
+
+    def current_settings(self) -> Settings:
+        raise NotImplementedError
+
+    def cached_model_info(self, provider_id: str, model_id: str):
+        return None
+
+    def cached_prefixed_model_infos(self):
+        return ()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+_MODEL_SLOTS = ("model", "model_fable", "model_opus", "model_sonnet", "model_haiku")
+
+
+def _settings_with_refs(*refs):
+    slots = {
+        slot: (refs[index] if index < len(refs) else None)
+        for index, slot in enumerate(_MODEL_SLOTS)
+    }
+    return Settings.model_construct(
+        **slots,
+        reasoning_policy=ReasoningPreference.CLIENT,
+    )
+
+
+def _ids(response: model_catalog.ModelsListResponse) -> list[str]:
+    return [item.id for item in response.data]
+
+
+def test_unseeded_state_uses_gateway_wrapper_ids():
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    picker_ids = [
+        item.id for item in response.data if item.id.startswith("claude-sonnet-nim")
+    ]
+    assert picker_ids == []
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in _ids(response)
+    assert "claude-3-freecc-no-thinking/nvidia_nim/01-ai/yi-large" in _ids(response)
+
+
+def test_seeded_state_prefers_alias_for_thinking_variant():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    ids = _ids(response)
+    assert "claude-sonnet-nim-0001" in ids
+    assert "claude-sonnet-nim-0001-no-thinking" in ids
+    # Wrapper id is suppressed because the alias covers the same slot.
+    assert "anthropic/nvidia_nim/01-ai/yi-large" not in ids
+
+
+def test_seed_only_nim_uses_wrapper_for_other_providers():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("openai_chat/anthropic/claude-3-5-sonnet-20241022")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    # Non-NIM ref falls through to the original wrapper ids.
+    assert "anthropic/openai_chat/anthropic/claude-3-5-sonnet-20241022" in ids
+    assert (
+        "claude-3-freecc-no-thinking/openai_chat/anthropic/claude-3-5-sonnet-20241022"
+        in ids
+    )
+    # And no alias leaked from the seeded NIM ref into the unrelated entry.
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+
+
+def test_display_name_is_provider_model_ref_when_using_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    alias_entries = [
+        item for item in response.data if item.id.startswith("claude-sonnet-nim-0001")
+    ]
+    # Thinking entry exposes the canonical provider ref; the no-thinking
+    # variant keeps the established "(no thinking)" label suffix.
+    assert {item.display_name for item in alias_entries} == {
+        "nvidia_nim/01-ai/yi-large",
+        "nvidia_nim/01-ai/yi-large (no thinking)",
+    }
+
+
+def test_seeded_aliases_are_hidden_without_opt_in():
+    """Claude Code / Codex / Pi path: aliases must never leak, even when seeded."""
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in ids

--- a/tests/application/test_routing_aliases.py
+++ b/tests/application/test_routing_aliases.py
@@ -1,0 +1,108 @@
+"""Picker alias decoding routed through ``application.routing.ModelRouter``."""
+
+import pytest
+
+from free_claude_code.application.routing import ModelRouter
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture
+def settings():
+    settings = Settings()
+    settings.model = "nvidia_nim/fallback-model"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    settings.reasoning_policy = ReasoningPreference.CLIENT
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_resolves_alias_before_gateway_prefix(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.original_model == "claude-sonnet-nim-0001"
+    assert resolved.reasoning_preference is ReasoningPreference.CLIENT
+
+
+def test_resolves_alias_no_thinking_variant_forces_reasoning_off(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001-no-thinking")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.reasoning_preference is ReasoningPreference.OFF
+
+
+def test_alias_takes_priority_over_anthropic_prefix(settings):
+    # The same underlying ref exists both as an alias and as an
+    # ``anthropic/<ref>`` gateway id. The alias must win on the picker shape,
+    # and both code paths resolve to the same upstream model.
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    alias_resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+    gateway_resolved = ModelRouter(settings).resolve(
+        "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct"
+    )
+
+    assert (
+        alias_resolved.primary.provider_id
+        == gateway_resolved.primary.provider_id
+        == "nvidia_nim"
+    )
+    assert (
+        alias_resolved.primary.provider_model
+        == gateway_resolved.primary.provider_model
+        == "meta/llama-3.3-70b-instruct"
+    )
+
+
+def test_alias_for_unknown_provider_falls_through_to_existing_chain(settings):
+    # An alias pointing at an unsupported provider must not silently match;
+    # the alias resolver returns the ref and routing layer validates it.
+    # After validation, ``resolve`` falls through to the existing route
+    # table, so ``claude-sonnet-nim-NNNN`` lands on the configured fallback.
+    gmi.seed_picker_aliases(["bogus_provider/some-model"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    # Not the bogus provider we accidentally aliased to.
+    assert resolved.primary.provider_id != "bogus_provider"
+    # Falls through to the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"
+
+
+def test_unknown_alias_falls_through_to_existing_routing(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-9999")
+
+    # 9999 is not a seeded alias; the routing layer should fall through.
+    # With no alias match, unknown alias falls back to model name parsing,
+    # which raises because ``claude-sonnet-nim-9999`` doesn't match a route.
+    assert resolved.original_model == "claude-sonnet-nim-9999"
+
+
+def test_unseeded_alias_returns_none_from_resolver(settings):
+    # Cold-start path: no aliases seeded, alias-shaped id should not produce
+    # a routing hit. Falls through to the existing fallback chain.
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0500")
+
+    # Falls through and lands on the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -80,7 +80,7 @@ def test_console_tray_run_blocks_until_stop():
 
 def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
     with (
-        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):
         probe.return_value = (False, "backend missing")
@@ -93,9 +93,32 @@ def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
     assert "backend missing" in output
 
 
+class _RaisingModule:
+    """Stands in for ``desktop_tray`` when its pystray import would raise."""
+
+    def __getattr__(self, name: str):
+        raise RuntimeError("no display")
+
+
+def test_launch_falls_back_to_console_when_native_adapter_import_raises(capsys):
+    with (
+        patch.dict(
+            sys.modules, {"free_claude_code.cli.desktop_tray": _RaisingModule()}
+        ),
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        launch()
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "failed to load" in output
+    assert "no display" in output
+
+
 def test_console_launch_uses_native_tray_when_probe_succeeds():
     with (
-        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):
         probe.return_value = (True, "")
@@ -120,7 +143,7 @@ def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
 def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
     with (
         patch.object(sys, "platform", "linux"),
-        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):
         probe.return_value = (False, "backend missing")

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -1,0 +1,179 @@
+"""Linux desktop shell: tray probe, console fallback, and entrypoint routing."""
+
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from free_claude_code.cli.commands import ServerStatus
+from free_claude_code.cli.desktop import DesktopController
+from free_claude_code.cli.desktop_console import ConsoleDesktopTray, launch
+from free_claude_code.cli.desktop_entrypoint import launch as entrypoint_launch
+from free_claude_code.cli.desktop_tray import tray_is_available
+
+
+def test_tray_is_available_true_when_icon_constructs():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock()),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is True
+    assert reason == ""
+
+
+def test_tray_is_available_reports_backend_import_error():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch(
+            "free_claude_code.cli.desktop_tray.Icon",
+            MagicMock(side_effect=ImportError("gir bindings missing")),
+        ),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "appindicator" in reason
+
+
+def test_tray_is_available_reports_other_construction_errors_verbatim():
+    error = RuntimeError("no display")
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock(side_effect=error)),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert reason == "no display"
+
+
+def test_tray_is_available_reports_artwork_load_failure():
+    with patch(
+        "free_claude_code.cli.desktop_tray._create_icon",
+        MagicMock(side_effect=OSError("missing asset")),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "artwork" in reason
+
+
+def test_console_tray_run_blocks_until_stop():
+    tray = ConsoleDesktopTray(MagicMock(spec=DesktopController))
+    finished = threading.Event()
+
+    def run_tray():
+        tray.run()
+        finished.set()
+
+    worker = threading.Thread(target=run_tray)
+    worker.start()
+    assert not finished.wait(timeout=0.2)
+    tray.stop()
+    assert finished.wait(timeout=5)
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+
+
+def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
+    with (
+        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        launch()
+
+    factory = start.call_args.args[0]
+    assert factory is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "backend missing" in output
+
+
+def test_console_launch_uses_native_tray_when_probe_succeeds():
+    with (
+        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (True, "")
+        launch()
+
+    from free_claude_code.cli.desktop_tray import PystrayDesktopTray
+
+    assert start.call_args.args[0] is PystrayDesktopTray
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
+    with (
+        patch.object(sys, "platform", platform),
+        patch("free_claude_code.cli.desktop_tray.launch") as tray_launch,
+    ):
+        entrypoint_launch([])
+
+    tray_launch.assert_called_once()
+
+
+def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        entrypoint_launch([])
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+
+
+def test_entrypoint_still_rejects_unsupported_platforms(capsys):
+    with (
+        patch.object(sys, "platform", "freebsd"),
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        entrypoint_launch([])
+
+    assert exit_info.value.code == 1
+    assert "Linux" in capsys.readouterr().err
+
+
+def test_console_tray_lifecycle_drives_controller_to_clean_stop():
+    events: list[str] = []
+    server_started = threading.Event()
+
+    class FakeSupervisor:
+        status = ServerStatus.STOPPED
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            events.append("server-run")
+            server_started.set()
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            events.append("server-stop")
+
+    controller = DesktopController(
+        FakeSupervisor(),
+        lambda controller: ConsoleDesktopTray(controller),
+        lambda: None,
+    )
+
+    worker = threading.Thread(target=controller.run, daemon=True)
+    worker.start()
+    assert server_started.wait(timeout=5)
+    controller.quit()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    # quit() stops the server, then controller.run()'s finally chain repeats
+    # the idempotent stop; the null tray must survive both.
+    assert events[0] == "server-run"
+    assert events.count("server-stop") >= 1

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -1,0 +1,266 @@
+"""Linux desktop shell: tray probe, console fallback, and entrypoint routing."""
+
+import contextlib
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    import pystray  # noqa: F401
+except Exception:
+    # Headless session: pystray's Linux backend connects to the display at
+    # import time, which would break collection of this whole module before
+    # any console-fallback behavior can be exercised. Stub the package so
+    # the tray adapter imports; every test below replaces the tray symbols
+    # it actually uses.
+    sys.modules["pystray"] = MagicMock()
+
+from free_claude_code.cli.commands import ServerStatus
+from free_claude_code.cli.desktop import DesktopController
+from free_claude_code.cli.desktop_assets import app_icon_bytes
+from free_claude_code.cli.desktop_console import ConsoleDesktopTray, launch
+from free_claude_code.cli.desktop_entrypoint import launch as entrypoint_launch
+from free_claude_code.cli.desktop_tray import tray_is_available
+
+
+def test_tray_is_available_true_when_icon_constructs():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock()),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is True
+    assert reason == ""
+
+
+def test_tray_is_available_reports_backend_import_error():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch(
+            "free_claude_code.cli.desktop_tray.Icon",
+            MagicMock(side_effect=ImportError("gir bindings missing")),
+        ),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "appindicator" in reason
+
+
+def test_tray_is_available_reports_other_construction_errors_verbatim():
+    error = RuntimeError("no display")
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock(side_effect=error)),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert reason == "no display"
+
+
+def test_tray_is_available_reports_artwork_load_failure():
+    with patch(
+        "free_claude_code.cli.desktop_tray._create_icon",
+        MagicMock(side_effect=OSError("missing asset")),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "artwork" in reason
+
+
+def test_console_tray_run_blocks_until_stop():
+    tray = ConsoleDesktopTray(MagicMock(spec=DesktopController))
+    finished = threading.Event()
+
+    def run_tray():
+        tray.run()
+        finished.set()
+
+    worker = threading.Thread(target=run_tray)
+    worker.start()
+    assert not finished.wait(timeout=0.2)
+    tray.stop()
+    assert finished.wait(timeout=5)
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+
+
+def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
+    with (
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        launch()
+
+    factory = start.call_args.args[0]
+    assert factory is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "backend missing" in output
+
+
+class _RaisingModule:
+    """Stands in for ``desktop_tray`` when its pystray import would raise."""
+
+    def __getattr__(self, name: str):
+        raise RuntimeError("no display")
+
+
+def test_launch_falls_back_to_console_when_native_adapter_import_raises(capsys):
+    with (
+        patch.dict(
+            sys.modules, {"free_claude_code.cli.desktop_tray": _RaisingModule()}
+        ),
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        launch()
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "failed to load" in output
+    assert "no display" in output
+
+
+def test_console_launch_uses_native_tray_when_probe_succeeds():
+    with (
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (True, "")
+        launch()
+
+    from free_claude_code.cli.desktop_tray import PystrayDesktopTray
+
+    assert start.call_args.args[0] is PystrayDesktopTray
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
+    with (
+        patch.object(sys, "platform", platform),
+        patch("free_claude_code.cli.desktop_tray.launch") as tray_launch,
+    ):
+        entrypoint_launch([])
+
+    tray_launch.assert_called_once()
+
+
+def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        entrypoint_launch([])
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+
+
+def test_entrypoint_still_rejects_unsupported_platforms(capsys):
+    with (
+        patch.object(sys, "platform", "freebsd"),
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        entrypoint_launch([])
+
+    assert exit_info.value.code == 1
+    assert "Linux" in capsys.readouterr().err
+
+
+def test_console_tray_lifecycle_drives_controller_to_clean_stop():
+    events: list[str] = []
+    server_started = threading.Event()
+
+    class FakeSupervisor:
+        status = ServerStatus.STOPPED
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            events.append("server-run")
+            server_started.set()
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            events.append("server-stop")
+
+    controller = DesktopController(
+        FakeSupervisor(),
+        lambda controller: ConsoleDesktopTray(controller),
+        lambda: None,
+    )
+
+    worker = threading.Thread(target=controller.run, daemon=True)
+    worker.start()
+    assert server_started.wait(timeout=5)
+    controller.quit()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    # quit() stops the server, then controller.run()'s finally chain repeats
+    # the idempotent stop; the null tray must survive both.
+    assert events[0] == "server-run"
+    assert events.count("server-stop") >= 1
+
+
+@contextlib.contextmanager
+def _headless_entrypoint():
+    """Import ``desktop_entrypoint`` as if the tray backend were broken.
+
+    Drops the cached entrypoint and tray modules, then makes the tray
+    module raise on import the way pystray does on a headless Linux
+    session without an X11/appindicator backend.
+    """
+    saved_entrypoint = sys.modules.pop("free_claude_code.cli.desktop_entrypoint", None)
+    saved_tray = sys.modules.pop("free_claude_code.cli.desktop_tray", None)
+    try:
+        with patch.dict(
+            sys.modules,
+            {"free_claude_code.cli.desktop_tray": _RaisingModule()},
+        ):
+            import free_claude_code.cli.desktop_entrypoint as fresh_entrypoint
+
+            yield fresh_entrypoint
+    finally:
+        sys.modules.pop("free_claude_code.cli.desktop_entrypoint", None)
+        if saved_entrypoint is not None:
+            sys.modules["free_claude_code.cli.desktop_entrypoint"] = saved_entrypoint
+        if saved_tray is not None:
+            sys.modules["free_claude_code.cli.desktop_tray"] = saved_tray
+
+
+def test_headless_entrypoint_import_survives_broken_tray_backend():
+    with _headless_entrypoint() as fresh_entrypoint:
+        assert callable(fresh_entrypoint.launch)
+
+
+def test_headless_entrypoint_still_exports_icon(tmp_path):
+    destination = tmp_path / "icons" / "app-icon.png"
+
+    with _headless_entrypoint() as fresh_entrypoint:
+        fresh_entrypoint.launch(["--export-icon", str(destination)])
+
+    assert destination.read_bytes() == app_icon_bytes(".png")
+
+
+def test_headless_entrypoint_routes_linux_to_console_mode(capsys):
+    with (
+        _headless_entrypoint() as fresh_entrypoint,
+        patch.object(sys, "platform", "linux"),
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        fresh_entrypoint.launch([])
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+    assert "failed to load" in capsys.readouterr().out

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -500,3 +500,25 @@ def test_settings_defaults_do_not_contain_empty_enum_strings() -> None:
     for _name, value in Settings():
         if isinstance(value, Enum):
             assert value.value
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("claude-desktop", "claude-desktop"),
+        ("/claude-desktop", "claude-desktop"),
+        ("claude-desktop/", "claude-desktop"),
+        ("/claude-desktop/", "claude-desktop"),
+        ("//gateway//", "gateway"),
+    ],
+)
+def test_desktop_gateway_prefix_strips_boundary_slashes(
+    value: str, expected: str
+) -> None:
+    assert Settings(desktop_gateway_prefix=value).desktop_gateway_prefix == expected
+
+
+@pytest.mark.parametrize("value", ["/", "//", "///"])
+def test_desktop_gateway_prefix_requires_a_path_segment(value: str) -> None:
+    with pytest.raises(ValidationError):
+        Settings(desktop_gateway_prefix=value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,3 +241,13 @@ def _propagate_loguru_to_caplog():
         loguru_logger.remove(
             handler_id
         )  # Handler already removed (e.g. by test_logging_config)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_picker_alias_state():
+    """Keep the process-global picker alias maps inert between tests."""
+    from free_claude_code.core import gateway_model_ids as gmi
+
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()

--- a/tests/core/test_gateway_model_ids_aliases.py
+++ b/tests/core/test_gateway_model_ids_aliases.py
@@ -1,0 +1,251 @@
+"""Tests for picker aliasing in ``free_claude_code.core.gateway_model_ids``."""
+
+import pytest
+
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    """Reset module-scope alias maps before/after each test."""
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_picker_alias_prefix_is_anthropic_safe():
+    assert gmi.PICKER_ALIAS_PREFIX == "claude-sonnet-nim"
+
+
+def test_has_picker_aliases_false_before_seed():
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_populates_maps_and_marks_seeded():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    assert gmi.has_picker_aliases() is True
+
+
+def test_alias_counter_is_deterministic_from_sorted_input():
+    first = ["nvidia_nim/z-provider/z-model", "nvidia_nim/a-provider/a-model"]
+    second = list(reversed(first))
+
+    gmi.seed_picker_aliases(first)
+    a_first = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    gmi.seed_picker_aliases(second)
+    a_second = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert a_first == a_second == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/z-provider/z-model")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_reseed_keeps_existing_refs_on_their_alias():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    # A refresh that adds a ref must not renumber the advertised ones.
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+            "openai/gpt-x",
+        ]
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == (
+        "claude-sonnet-nim-0001"
+    )
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+    assert gmi.picker_alias_for("openai/gpt-x") == "claude-sonnet-nim-0003"
+
+
+def test_alias_lookup_thinking_and_no_thinking_variants():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+
+
+def test_alias_lookup_unknown_ref_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/missing/model") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/missing/model", force_reasoning_off=True)
+        is None
+    )
+
+
+def test_resolve_picker_alias_round_trip():
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        False,
+    )
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001-no-thinking") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        True,
+    )
+
+
+def test_resolve_picker_alias_unknown_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999-no-thinking") is None
+    assert gmi.resolve_picker_alias("claude-haiku-nim-0001") is None
+
+
+def test_resolve_picker_alias_for_prefix_only_when_seeded_empty():
+    # Maps are empty by default (cold-start window).
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_clear_resets_state():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.has_picker_aliases() is True
+
+    gmi.clear_picker_aliases()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_empty_iterable_keeps_state_empty():
+    gmi.seed_picker_aliases([])
+
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_replaces_previous_aliases_without_slot_reuse():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    # The removed ref's alias is retired, never recycled onto the new ref.
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_returning_ref_regains_its_previous_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    original = gmi.picker_alias_for("nvidia_nim/01-ai/yi-large")
+    assert original is not None
+
+    gmi.seed_picker_aliases(["openai/gpt-x"])
+    assert gmi.resolve_picker_alias(original) is None
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large", "openai/gpt-x"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == original
+
+
+def test_empty_refresh_keeps_retired_numbers_consumed():
+    """Disconnect-everything must not recycle aliases on the next refresh."""
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+    assert advertised is not None
+
+    # Inventory drains to empty (final provider disconnected)...
+    gmi.seed_picker_aliases([])
+    assert gmi.has_picker_aliases() is False
+    assert gmi.resolve_picker_alias(advertised) is None
+
+    # ...and a different model arrives later.
+    gmi.seed_picker_aliases(["openai/new/model"])
+
+    new_alias = gmi.picker_alias_for("openai/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(advertised) is None
+
+
+def test_aliases_are_four_digit_zero_padded():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(15)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [
+        alias for ref in refs if (alias := gmi.picker_alias_for(ref)) is not None
+    ]
+
+    assert len(aliases) == 15
+    for alias in aliases:
+        # All aliases share the same prefix and 4-digit counter width.
+        assert alias.startswith("claude-sonnet-nim-")
+        counter = alias.removeprefix("claude-sonnet-nim-").split("-")[0]
+        assert len(counter) == 4
+        assert counter.isdigit()
+
+
+def test_seed_assigns_unique_aliases_per_ref():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(10)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [gmi.picker_alias_for(ref) for ref in refs]
+
+    assert len(set(aliases)) == len(refs)
+    assert all(alias is not None for alias in aliases)
+
+
+def test_reseed_publishes_one_consistent_snapshot():
+    """Catalog output and routing must agree after an inventory swap.
+
+    Regression guard for torn publication: a reader binding the snapshot
+    before a reseed sees one self-consistent inventory, and a reader binding
+    it afterwards sees the other — never a mix of old and new maps. Sticky
+    assignments additionally guarantee the pre-reseed alias keeps resolving
+    to the same ref it advertised (or retires entirely).
+    """
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+
+    gmi.seed_picker_aliases(["nvidia_nim/new/model"])
+
+    assert advertised is not None
+    # The previously advertised alias either still routes to its original ref
+    # or is retired outright; it can never re-point to another model.
+    assert gmi.resolve_picker_alias(advertised) in {
+        ("nvidia_nim/old/model", False),
+        None,
+    }
+    # Both directions of the new snapshot are aligned with each other.
+    new_alias = gmi.picker_alias_for("nvidia_nim/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(new_alias) == ("nvidia_nim/new/model", False)
+    no_thinking_alias = gmi.picker_alias_for(
+        "nvidia_nim/new/model", force_reasoning_off=True
+    )
+    assert no_thinking_alias is not None
+    assert gmi.resolve_picker_alias(no_thinking_alias) == (
+        "nvidia_nim/new/model",
+        True,
+    )

--- a/tests/runtime/test_application_runtime_picker_aliases.py
+++ b/tests/runtime/test_application_runtime_picker_aliases.py
@@ -1,0 +1,97 @@
+"""Runtime seeding for picker aliases via ``ApplicationRuntime``."""
+
+from typing import cast
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.application import ApplicationRuntime
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+class _SeedingProviderManager:
+    """Stand-in honoring the manager's alias-refresh contract."""
+
+    def __init__(self, model_ids: list[str]) -> None:
+        self._model_ids = model_ids
+        self.refresh_calls = 0
+
+    def refresh_picker_aliases(self) -> None:
+        self.refresh_calls += 1
+        infos = tuple(
+            ProviderModelInfo(model_id=model_id, supports_thinking=None)
+            for model_id in self._model_ids
+        )
+        gmi.seed_picker_aliases(info.model_id for info in infos)
+
+
+def _make_runtime_with_models(
+    model_ids: list[str],
+) -> tuple[ApplicationRuntime, _SeedingProviderManager]:
+    provider_manager = _SeedingProviderManager(model_ids)
+    return (
+        ApplicationRuntime(
+            cast(ProviderRuntimeManager, provider_manager), transcriber=None
+        ),
+        provider_manager,
+    )
+
+
+def test_seed_picker_aliases_from_cache_populates_maps():
+    runtime, _manager = _make_runtime_with_models(
+        ["nvidia_nim/01-ai/yi-large", "nvidia_nim/meta/llama-3.3-70b-instruct"]
+    )
+
+    runtime._seed_picker_aliases_from_cache()
+
+    assert gmi.has_picker_aliases() is True
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_seed_picker_aliases_with_empty_cache_leaves_state_inert():
+    runtime, _manager = _make_runtime_with_models([])
+
+    runtime._seed_picker_aliases_from_cache()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_picker_aliases_uses_sorted_input_for_counter_stability():
+    first_runtime, first_manager = _make_runtime_with_models(
+        [
+            "nvidia_nim/z-provider/z-model",
+            "nvidia_nim/a-provider/a-model",
+        ]
+    )
+    first_runtime._seed_picker_aliases_from_cache()
+    assert first_manager.refresh_calls == 1
+    first_alias_for_a = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    second_runtime, _manager = _make_runtime_with_models(
+        [
+            "nvidia_nim/a-provider/a-model",
+            "nvidia_nim/z-provider/z-model",
+        ]
+    )
+    second_runtime._seed_picker_aliases_from_cache()
+    second_alias_for_a = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert first_alias_for_a == second_alias_for_a == "claude-sonnet-nim-0001"

--- a/tests/runtime/test_provider_manager_picker_aliases.py
+++ b/tests/runtime/test_provider_manager_picker_aliases.py
@@ -1,0 +1,87 @@
+"""Picker-alias reseeding on model-catalog republication."""
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _manager(model: str) -> ProviderRuntimeManager:
+    settings = Settings().model_copy(
+        update={"model": model, "nvidia_nim_api_key": "test-key"}
+    )
+    return ProviderRuntimeManager(settings)
+
+
+def _info(model_id: str) -> ProviderModelInfo:
+    return ProviderModelInfo(model_id=model_id, supports_thinking=None)
+
+
+def test_refresh_picker_aliases_seeds_current_cache_snapshot() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0001"
+    )
+    gmi.clear_picker_aliases()
+
+
+def test_cache_publication_reseeds_aliases_atomically() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    first_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+
+    # A refreshed inventory keeps the sticky assignment and adds new refs.
+    manager.cache_model_infos(
+        "nvidia_nim",
+        [
+            _info("meta/llama-3.3-70b-instruct"),
+            _info("01-ai/yi-large"),
+        ],
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct") == first_alias
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is not None
+
+
+def test_configured_ref_gets_alias_without_discovery_cache() -> None:
+    manager = _manager("nvidia_nim/one")
+
+    # No discovery cache yet: the configured model still gains a picker alias
+    # so a cold /v1/models request never advertises a raw gateway identifier.
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert gmi.picker_alias_for("nvidia_nim/one") is not None
+
+
+def test_empty_cache_retires_discovery_only_aliases_but_keeps_configured() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    configured_alias = gmi.picker_alias_for("nvidia_nim/one")
+    discovery_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+    assert configured_alias is not None
+    assert discovery_alias is not None
+
+    manager.cache_model_infos("nvidia_nim", [])
+
+    # The discovery-only ref retires; the configured ref keeps its alias.
+    assert gmi.has_picker_aliases() is True
+    assert gmi.resolve_picker_alias(discovery_alias) is None
+    assert gmi.picker_alias_for("nvidia_nim/one") == configured_alias

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -620,9 +620,9 @@ dependencies = [
     { name = "loguru" },
     { name = "markdown-it-py" },
     { name = "openai" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pillow" },
     { name = "pydantic" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pystray" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "requests", extra = ["socks"] },
@@ -671,9 +671,9 @@ requires-dist = [
     { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "nvidia-riva-client", marker = "extra == 'voice'", specifier = ">=2.26.0" },
     { name = "openai", specifier = ">=3.2.0" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=12.0.0" },
+    { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=0.19.5" },
+    { name = "pystray", specifier = ">=0.19.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-telegram-bot", specifier = ">=22.8" },
     { name = "requests", extras = ["socks"], specifier = ">=2.34.2" },
@@ -1553,11 +1553,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
     { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
     { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
     { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
     { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
     { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
     { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
     { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
     { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
     { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
     { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
@@ -1566,11 +1574,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
     { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
     { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
     { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
     { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
     { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
     { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
     { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
@@ -1900,7 +1916,8 @@ version = "0.19.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
     { name = "six" },
 ]
 wheels = [
@@ -2031,6 +2048,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
+]
+
+[[package]]
+name = "python-xlib"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -449,6 +449,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -598,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.11"
+version = "5.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -612,9 +621,9 @@ dependencies = [
     { name = "loguru" },
     { name = "markdown-it-py" },
     { name = "openai" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pillow" },
     { name = "pydantic" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pystray" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "requests", extra = ["socks"] },
@@ -664,9 +673,9 @@ requires-dist = [
     { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "nvidia-riva-client", marker = "extra == 'voice'", specifier = ">=2.26.0" },
     { name = "openai", specifier = ">=3.2.0" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=12.0.0" },
+    { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=0.19.5" },
+    { name = "pystray", specifier = ">=0.19.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-telegram-bot", specifier = ">=22.8" },
     { name = "requests", extras = ["socks"], specifier = ">=2.34.2" },
@@ -1030,38 +1039,35 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.16.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
-    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
-    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
-    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
-    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
-    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
-    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
-    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
-    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
-    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
-    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
 ]
 
 [[package]]
@@ -1513,19 +1519,20 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "3.3.1"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "distro" },
     { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/9c/ba0c292b4032ede74c249ca314ad64eb1bb5a03a843f6e01facb02f80cd8/openai-3.3.1.tar.gz", hash = "sha256:6f22807de1a976c932cecda620e8172a8c3fdbaeed29c7f21564e0c2410edf56", size = 1282113, upload-time = "2026-08-19T16:31:35.006Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/6c/670271205379061112bf5ed900b78a68e21bf11733de829772c5322f92aa/openai-3.3.0.tar.gz", hash = "sha256:28f904a9fbff15288e9dd67bc0f7020d4f576d37786383a480db02fe5d8139d3", size = 1166178, upload-time = "2026-08-18T21:17:53.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/db/2b7a1b3de659bb82aef979116c74e809982b13e42c057759767552b5155f/openai-3.3.1-py3-none-any.whl", hash = "sha256:9652df7fdf8ee6f5bd58e0a12f2b1d414a18e0f06bb7a9a57c8643a5f5469bd3", size = 1690337, upload-time = "2026-08-19T16:31:32.812Z" },
+    { url = "https://files.pythonhosted.org/packages/82/83/d44980712bf51dddaca090cd772b3102e75377ddac877eaa4b2cb58d886a/openai-3.3.0-py3-none-any.whl", hash = "sha256:ded6b2112e6d299c7a2573ff6f165dc92fb64ceaa4d7daa42345f091157bd373", size = 1690265, upload-time = "2026-08-18T21:17:51.351Z" },
 ]
 
 [[package]]
@@ -1548,11 +1555,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
     { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
     { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
     { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
     { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
     { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
     { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
     { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
     { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
     { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
     { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
@@ -1561,11 +1576,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
     { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
     { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
     { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
     { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
     { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
     { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
     { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
@@ -1895,7 +1918,8 @@ version = "0.19.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
     { name = "six" },
 ]
 wheels = [
@@ -2026,6 +2050,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
+]
+
+[[package]]
+name = "python-xlib"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
 ]
 
 [[package]]
@@ -2260,27 +2296,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.4"
+version = "0.16.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
-    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
-    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
-    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
-    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]
@@ -2617,7 +2653,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.15.1"
+version = "5.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2630,9 +2666,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/92/c50c61da7046bbb59a4d011291aeadcfb4d7980ab36fdb31e93823a3fb93/transformers-5.15.1.tar.gz", hash = "sha256:27c996bd9075ddc82d40f8590dfdc81ea45f611bfca477e0db5d7fd257a482f7", size = 9378434, upload-time = "2026-08-19T11:28:20.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/3f/d89353267d511e18f137dfd7769d07837350c11b88408ce1dfe2e93e56c7/transformers-5.15.0.tar.gz", hash = "sha256:bbf98f57b2ddd7c4ecbccfa2c0069017aa6fd01cc204bd50cbc0eeadcf2a13b8", size = 9377983, upload-time = "2026-08-10T10:27:23.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/c4/a12e1d9b387fb0c40a57116db82b457e8c771cb419163cda29204d74a595/transformers-5.15.1-py3-none-any.whl", hash = "sha256:b7cdf238ff583e3a58dbc7fa34da1aaf091ce063141f65a30538160bd5afe93f", size = 11749582, upload-time = "2026-08-19T11:28:16.726Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/43/81355710a4c84e9420e11a86d41a5364deb561f2ef36dfdf254a07371bbb/transformers-5.15.0-py3-none-any.whl", hash = "sha256:d7f007736f67749ae9490c4f8cb5d30b452ae2d68c8675e50ba8d63ea7feb107", size = 11749280, upload-time = "2026-08-10T10:27:20.416Z" },
 ]
 
 [[package]]
@@ -2657,27 +2693,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.74"
+version = "0.0.72"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/0f/c767853e88567a2ec7e996dd95e3105b1bc62c95d103689311ef0f4a603c/ty-0.0.74.tar.gz", hash = "sha256:da14344fc8625fc9ff359bafb856ad575636ea86d9bb6a629b146bff27b380e6", size = 6786318, upload-time = "2026-08-22T15:05:54.054Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/df/656e684bafb13c1d146e7d5b5f3e7978ca177232acc84998ff36427e9462/ty-0.0.72.tar.gz", hash = "sha256:ec2b8066b618df18cab4cb8e992f8da45d360332acb23fa34df7fa29cd1b9d3a", size = 6654939, upload-time = "2026-08-14T21:35:42.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/95/6ded58bc97885c6d88fa1f9cd815031489200738f961cbf0466663213f80/ty-0.0.74-py3-none-linux_armv6l.whl", hash = "sha256:8969ef4e508debf00cf58f9ea85a539f799b1732c59cdfcecd037630b9755b30", size = 12790043, upload-time = "2026-08-22T15:05:05.015Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/8a/5e323603b6ab8731144421877ee8a0f8ac5a5511e67857127caa09f6730e/ty-0.0.74-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51fb6cf5b98e1e1140825b2430943f78d744876a735231656eafbb4c3f7eca3c", size = 12371748, upload-time = "2026-08-22T15:05:08.609Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/44/ee72e08cb705281e8d8c42917dd577aa598a8a098008495fda5176ee3f6e/ty-0.0.74-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ebe60b1f0a948c793d6c77fc9e9ddda599e4f023c04ab16e8e03bcb428c3fa0", size = 12282403, upload-time = "2026-08-22T15:05:11.448Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b3/fd935b694ff68bc278af50f7ad04770b36ce6306399baef7e1847b553a9d/ty-0.0.74-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa97f407a695c890a53615966a663c7d2167e2cabe88db7ca1a24d62635cdfc8", size = 12345164, upload-time = "2026-08-22T15:05:14.19Z" },
-    { url = "https://files.pythonhosted.org/packages/54/5c/5b5825268e029ebb164c909780103dbbae367f069801410068bf1cef29b3/ty-0.0.74-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:673ddb733d4a0db31385ba1ed9ff1f6bd9dc5565413ce57b1ca5ac4c7803da5d", size = 12556646, upload-time = "2026-08-22T15:05:16.994Z" },
-    { url = "https://files.pythonhosted.org/packages/56/e7/515914e571d62ce0101744fed3f881936eeb1b30dc37beb72b4f7ca1e289/ty-0.0.74-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1028e7c6b4f6145e9704552f43a5fffdcd51b42263ffdcd9c9677762bc395a4a", size = 13311653, upload-time = "2026-08-22T15:05:20.254Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/07/d1452babb6f9266c2122cabc095180b70ed306fb770b2996753814d2237d/ty-0.0.74-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79841a8890493021fb308772474983316eb91f7b56cb227a6a05a06b262a36f0", size = 13768284, upload-time = "2026-08-22T15:05:23.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/60/8d4a2fc7842a47210a1cb0a16a187d9de39ad5d509a00fb74c1c073afcde/ty-0.0.74-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94859d321f3c6a6c8f7bfc3f40e8319cda7e6e012e613440f3dfd145d5010e2e", size = 13422306, upload-time = "2026-08-22T15:05:26.248Z" },
-    { url = "https://files.pythonhosted.org/packages/de/76/ebbc269a8c4efcc4d44624993bd188145f20d60ebda9680b15aaec42cc50/ty-0.0.74-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:970a8b2c09ff3be04c8a1c6767332d861be4fce85efe7bb205e4ade7c8655274", size = 12970637, upload-time = "2026-08-22T15:05:29.15Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/dd/b99f7236acbf856780ca1779a48143d2d9f2c24d7f531a0ce15a022b8a87/ty-0.0.74-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:795f763b3ded85574c2c2846a6fb8acf2aa76e9e83d761143e92b1f0c7ffa2cd", size = 13344891, upload-time = "2026-08-22T15:05:32.033Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/d7/9ff7449a4c7e6428f2c6f298e74cf24b70668f29d45c249507a723ff3782/ty-0.0.74-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dc086db5367d912c31c0cc872deb7387290e779a4b9b54fcb944673a7cd52c7b", size = 12395272, upload-time = "2026-08-22T15:05:34.702Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/dd/b23a5b6b35d37df89dc8dc5daa09efd9245a668b50c4c81c25de21567dc1/ty-0.0.74-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0314d7b391cf684e47c2fa093d2ce4c597cfc9b01d9a315fe204aed6359b271b", size = 12573079, upload-time = "2026-08-22T15:05:37.683Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c5/ccba16239d6129533c8b3603458d0f4dd2ba69478e47059073968e74261d/ty-0.0.74-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4a45dd2e991e8bdae82ba78c8cd051b253f60bc71a6536598fa3ef580b4fc9b", size = 12832506, upload-time = "2026-08-22T15:05:40.505Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/1c/2390912634dff4f341f97b397f2aee341ff062be0a66cda37d59375454f2/ty-0.0.74-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:210e2eac6b018fb934e2b8dac3956a0ba076a3fb1fa6f135058c825e5b759b81", size = 13154752, upload-time = "2026-08-22T15:05:43.355Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/33/a8c12188227e6f74f91853a7374e01ed81d6ad21c16c8b70e92dbebfe46a/ty-0.0.74-py3-none-win32.whl", hash = "sha256:db0bb6a8f098ef9bd1be861f73b4f7c0320d40d4c05c7ae0a8677d4e7aa4f6e5", size = 12130002, upload-time = "2026-08-22T15:05:46.058Z" },
-    { url = "https://files.pythonhosted.org/packages/21/5c/064f28ccb9c234cfce5a2f7aa69a256663d5ae5bb0290b3a9706cc4d1e4c/ty-0.0.74-py3-none-win_amd64.whl", hash = "sha256:bebff181515255b3c78bd2e7693ae66fab6064ad4feea2065c68bc01022aa678", size = 12771435, upload-time = "2026-08-22T15:05:48.811Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/06/d6becdaca0315346c26b6df97cb0eafa81de4f870945d6989e88704374ed/ty-0.0.74-py3-none-win_arm64.whl", hash = "sha256:1a3469eaaf8c85b1c0a15bede25d36daea4b09fce1d913e965b24e24b3f1d6c6", size = 12558299, upload-time = "2026-08-22T15:05:51.543Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3b/f51461239a4e66565d4b362f97a3b55fe7fdba2e944068341f87c62f6743/ty-0.0.72-py3-none-linux_armv6l.whl", hash = "sha256:fda86db153ffd85ee52000cf175d6a3f1c0223772cf7c5b6f726200bf92c7b44", size = 12621989, upload-time = "2026-08-14T21:35:01.676Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/79ddf683affc679ca856f3510b5640ec3a88a842ba5f654f5d4bc78f1786/ty-0.0.72-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ceb944c612529b9023acfdc9cf4c0dcbb722549f9d17d46baecd1141baf01d7f", size = 12233910, upload-time = "2026-08-14T21:35:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/45/10562a0d84802158db8fa4ec46de54aa9fdcecdeeaabbfe3639ae7042b66/ty-0.0.72-py3-none-macosx_11_0_arm64.whl", hash = "sha256:108d76218333d6c092e5f1cebf8e9b06f25738613a0236a28e2dd47c936ee52c", size = 12084108, upload-time = "2026-08-14T21:35:06.686Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/dc/1fe1aef8d697e3509face271a5331700c7aa1d1e44a4b622707bdfa41d4b/ty-0.0.72-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f3943f186f741a2499a31053872169250c9264a9a49684920e48d8fcf4ef4f5", size = 12132640, upload-time = "2026-08-14T21:35:09.305Z" },
+    { url = "https://files.pythonhosted.org/packages/14/46/41ceb265e96969487311a2014bd0e53abb4fbc1395efb2ebe411fcb4db62/ty-0.0.72-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf283c07dc3cc52ca48a3ad8ab100fb5aec3aebbd03ef6a12d5f910b8e596fc5", size = 12402489, upload-time = "2026-08-14T21:35:11.555Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/45/30bf43cb4fd505c5c2dd30fda27dde5f05208686cd21217adec77c954204/ty-0.0.72-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:95f3b6462c38f9f115d10cee21f47fedf715fcf2040daf36eef210359300bc7c", size = 13130835, upload-time = "2026-08-14T21:35:13.746Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2f/03bba754d2613f640df168335c41f83f41db150bb515839c60d80e3a7880/ty-0.0.72-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30caf658feb8ffb250d9e9e47107657a78f5f3425c227df1664d8df2ebe38880", size = 13590392, upload-time = "2026-08-14T21:35:16.839Z" },
+    { url = "https://files.pythonhosted.org/packages/04/c7/03c67f00e63005ec41585653dc3096064570b1e6273742baae2798cd242f/ty-0.0.72-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:27bdc012ddfbeec8948e4a6036c0dc39ac7cf2c8ec7c7d48dc7d2fd56d57b399", size = 13309629, upload-time = "2026-08-14T21:35:19.169Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/df/102d3b264eb7f2a58dd11952f229bb5150bb5668d176a6154976a6675981/ty-0.0.72-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:802c5970a77d7739e6f499921fbb6984fb7ad8a31d95e1ff42fd46f3642e4f3b", size = 12734028, upload-time = "2026-08-14T21:35:22.099Z" },
+    { url = "https://files.pythonhosted.org/packages/61/85/d0737c8c54d0ba67366ddfb9f31d88edf0b02299e65923e6945ae60ebcb5/ty-0.0.72-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:47dce65114fdc615c68ca0edb393b433df0956447e4267df0e264137a789598d", size = 13174832, upload-time = "2026-08-14T21:35:24.71Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/31/497f5a96c36d9b586ab6afe0574986835c6fd5b835a89773d2bec4711b49/ty-0.0.72-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:325144fa07e2675d0faa337fcc864213c272a499eb0cfe5bde2fdc62282d27bc", size = 12215005, upload-time = "2026-08-14T21:35:26.892Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7d/46e65b17b4966c7cd0140f134380d33d8e84fe6efccd761533ce793dc502/ty-0.0.72-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a5c9f15d0f58e43707d8848274be1821a0ef408eccb8aa7dda28a4a9eddf7640", size = 12421298, upload-time = "2026-08-14T21:35:29.301Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2a/12ada4ec17700b3cb1d4fd3bc3e5b1852df9e6885288429318cade87b3c1/ty-0.0.72-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ee508d64b381871529cc22c412b41071bf5e908b7aa5d66a38f3f6b2573a806", size = 12669242, upload-time = "2026-08-14T21:35:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/4692536880790fb550ed6d44a6096778dc71bb112f2c6d615cebb01a57e5/ty-0.0.72-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3699e2ec7921d44da79d6b089f7bf239b2cc53c4e45a5a38430adc34ee9e9a55", size = 12988199, upload-time = "2026-08-14T21:35:33.749Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0d/f5e5a50322e9c45865e7b7a428ba6cd6527387cf0f2472492ac3cf746243/ty-0.0.72-py3-none-win32.whl", hash = "sha256:f25f72a67bd36cd247707c4784e52fad0b6b4f42a1b7dd14804110fa95c486ed", size = 11939708, upload-time = "2026-08-14T21:35:36.006Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4e/8af3534b2e4214e6184a5a59c34101e94a68d578f081f97b995866bab1bf/ty-0.0.72-py3-none-win_amd64.whl", hash = "sha256:cdeee869341717e1736cea2e2d7856738c6957c320f584ed2f68c8f90100d2f5", size = 12643876, upload-time = "2026-08-14T21:35:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ea/a2606e654c7276bd08586391a2525b0af3f3bf60228a8c57b2d248f273f9/ty-0.0.72-py3-none-win_arm64.whl", hash = "sha256:1bd3ac3ed4424a6d6990a85dc388556aea012bd752de21349a84b685951de0d8", size = 12394857, upload-time = "2026-08-14T21:35:40.277Z" },
 ]
 
 [[package]]
@@ -2727,15 +2763,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.4"
+version = "0.52.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Part 2 of 7 — splits the closed #1545 into reviewable pieces (≤750 lines each).
Each part is a separate PR against `main` and should be merged in order (after Part 1); until earlier parts merge, this diff against `main` also shows them.

## What this PR does

Adds the picker alias engine so Claude Desktop's model picker can surface every provider model under a Claude-shaped id.

- New `seed_picker_aliases` / `picker_alias_for` / `resolve_picker_alias` in `gateway_model_ids.py`, producing stable `claude-sonnet-nim-NNNN` aliases.
- Aliases are published as one immutable snapshot (single module-global assignment) so concurrent readers never see a torn state.
- Sticky ref→alias assignments survive reseeds: an advertised alias is never re-pointed to another model, and retired numbers are never reused.
- Wires aliases into the model catalog (opt-in `picker_aliases` flag) and the request router (reverse-lookup before gateway-id decode).

## Verification

- `ruff format --check`, `ruff check`, `ty check` clean
- Full pytest suite passes








## Review feedback addressed

- Greptile P1 (aliases inactive in production): the router is now mounted under the configurable desktop gateway prefix (`DESKTOP_GATEWAY_PREFIX`), emits picker aliases only on that prefixed mount, and `ApplicationRuntime` seeds the alias snapshot from the warmed model cache at startup. Claude Code, Codex, Pi and every other client keep seeing raw provider refs on the bare paths.
- Greptile review summary (refresh drift): alias state is now refreshed inside `ProviderRuntimeManager` on every model-catalog republication, so refreshed inventories gain aliases immediately, sticky assignments never re-point advertised aliases, and removed refs retire instead of routing to stale targets.
- Greptile P2 (local import): desktop entrypoint launchers are top-level module imports per repo convention.
























<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The Desktop integration now publishes stable picker aliases only from the Desktop-scoped model endpoint, routes those aliases to configured provider models, and preserves Linux console startup when a native tray backend is unavailable.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The configured-model catalog path, bare-path alias isolation, alias routing, icon export, and headless Linux console behavior all complete successfully.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the configured-cache model-catalog probe before and after the PR to verify alias exposure and routing, confirming the Desktop catalog shows both aliases for deepseek/deepseek-chat while bare /v1/models remains alias-free, and that a posted alias token count to /v1/v1/messages/count\_tokens returns input\_tokens:1 and routes to deepseek/deepseek-chat; the focused regression suite for alias seeding, Desktop route scoping, and model routing passed all 18 tests.
- Performed an import-guarded executable check for the Linux desktop entrypoint to block pystray during import, verified icon export and that Linux launch selects desktop\_console without importing desktop\_tray; ran the focused headless Linux desktop tests and all 16 tests passed, with no changes to tracked configuration.
- Compared pre-PR and current HEAD probe results to confirm alias routing is now active: before, the probe found no emitted alias and desktop path returned 404 for /v1/v1/models; after, bare /v1/models returns 200, desktop /v1/v1/models returns 200 with both aliases, and input\_tokens:1 is returned and routed to the chat model.
- Documented the exact authored probe sources and captured command outputs for the model-catalog and Linux-desktop checks, including focused headless test collections and post-run integrity verifications.

<a href="https://app.greptile.com/trex/runs/21705894/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (15): Last reviewed commit: ["feat: add picker alias engine for deskto..."](https://github.com/alishahryar1/free-claude-code/commit/f0a2f3767e0402b6a44fbb103db65aeb7dd4d9b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56607869)</sub>

<!-- /greptile_comment -->