### PR TITLE
feat: install Claude Desktop routing and cert trust on Linux

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -347,9 +347,17 @@ PROXY_AUTH_ENABLED=false
 ANTHROPIC_AUTH_TOKEN="freecc"
 
 
+# TLS front proxy for HTTPS-only clients (e.g. Claude Desktop). fcc-desktop
+# reuses any HTTPS endpoint already answering on TLS_PROXY_PORT; otherwise it
+# spawns a managed Caddy instance proxying to the local server. Set
+# TLS_PROXY_ENABLED=false to keep Claude Desktop routing on plain HTTP.
+TLS_PROXY_ENABLED=true
+TLS_PROXY_PORT=8443
+
 # Path prefix that scopes Claude Desktop onto the alias-emitting API mount
-# (e.g. http://localhost:8082/claude-desktop). Bare paths keep serving raw
-# provider refs to every other client.
+# (e.g. https://localhost:8443/claude-desktop). Bare paths keep serving raw
+# provider refs to every other client. Must match the gateway URL written to
+# claude_desktop_config.json.
 DESKTOP_GATEWAY_PREFIX=claude-desktop
 
 

--- a/.env.example
+++ b/.env.example
@@ -347,6 +347,12 @@ PROXY_AUTH_ENABLED=false
 ANTHROPIC_AUTH_TOKEN="freecc"
 
 
+# Path prefix that scopes Claude Desktop onto the alias-emitting API mount
+# (e.g. http://localhost:8082/claude-desktop). Bare paths keep serving raw
+# provider refs to every other client.
+DESKTOP_GATEWAY_PREFIX=claude-desktop
+
+
 # Open /admin in the default browser when fcc-server becomes healthy (set 0/false/no to disable)
 FCC_OPEN_BROWSER=true
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,51 @@ For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`,
 Use the guides below for editor integrations.
 
 <details>
+<summary><strong>Claude Desktop (Linux)</strong></summary>
+
+Route the Claude Desktop app through FCC instead of Anthropic's first-party API.
+Prerequisites: [Claude Desktop for Linux](https://claude.ai/download) installed,
+and `caddy` on PATH (any recent version) unless an HTTPS front already answers
+on port 8443.
+
+Most of the setup is automatic:
+
+1. Start `fcc-server`. It probes `https://localhost:8443` and reuses an existing
+   front; otherwise it spawns a sandboxed Caddy instance with a generated
+   config under `~/.fcc/caddy/` and provisions its own local CA. Nothing binds
+   privileged ports and no global Caddy settings are touched.
+2. Run `fcc-claude-desktop`. On launch it merges the gateway block (base URL,
+   auth key, model discovery) into `~/.config/Claude/claude_desktop_config.json`
+   — you never edit inference settings inside the app — and starts Claude
+   Desktop with your extra arguments forwarded verbatim.
+3. The model picker discovers every model FCC advertises. Ids that the app's
+   picker filter would drop are served as stable `claude-sonnet-nim-*` aliases
+   on a dedicated `/claude-desktop` path, so only Claude Desktop sees them;
+   other clients keep raw provider ids.
+
+Certificate trust: the installer copies the active Caddy certificate into the
+system trust chain and, when `certutil` (package `libnss3-tools`) is available,
+into Chromium/Electron's NSS database (`~/.pki/nssdb`). If the managed front's
+root certificate did not exist yet at install time, run the installer once more
+after the first `fcc-server` start. Manual fallback:
+
+```sh
+certutil -A -d sql:$HOME/.pki/nssdb -t "C,," -n "FCC-Caddy" \
+  -i ~/.fcc/caddy/data/caddy/pki/authorities/local/root.crt
+```
+
+Troubleshooting:
+
+- **`ERR_CERT_AUTHORITY_INVALID` in the app** — trust step above missing;
+  restart Claude Desktop after trusting the certificate.
+- **Model discovery unreachable** — confirm `curl -sk https://localhost:8443/claude-desktop/v1/models`
+  returns JSON while `fcc-server` runs.
+- **Config edits seem ignored** — a running Claude Desktop does not reload its
+  config; quit and relaunch via `fcc-claude-desktop`.
+
+</details>
+
+<details>
 <summary><strong>Claude Code in VS Code</strong></summary>
 
 Install the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code). Open VS Code's user settings as JSON and add:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.15.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -25,8 +25,8 @@ dependencies = [
     "jsonschema>=4.25.0",
     "google-auth[requests]>=2.56.3",
     "requests[socks]>=2.34.2",
-    "pystray>=0.19.5; sys_platform == 'win32' or sys_platform == 'darwin'",
-    "Pillow>=12.0.0; sys_platform == 'win32' or sys_platform == 'darwin'",
+    "pystray>=0.19.5",
+    "Pillow>=12.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.11"
+version = "5.19.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -26,8 +26,8 @@ dependencies = [
     "jsonschema>=4.25.0",
     "google-auth[requests]>=2.56.3",
     "requests[socks]>=2.34.2",
-    "pystray>=0.19.5; sys_platform == 'win32' or sys_platform == 'darwin'",
-    "Pillow>=12.0.0; sys_platform == 'win32' or sys_platform == 'darwin'",
+    "pystray>=0.19.5",
+    "Pillow>=12.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ fcc-dsh = "free_claude_code.cli.launchers.dsh:launch"
 fcc-grok = "free_claude_code.cli.launchers.grok:launch"
 fcc-muse = "free_claude_code.cli.launchers.muse:launch"
 fcc-aider = "free_claude_code.cli.launchers.aider:launch"
+fcc-claude-desktop = "free_claude_code.cli.launchers.claude_desktop:launch"
 
 [project.gui-scripts]
 fcc-desktop = "free_claude_code.cli.desktop_entrypoint:launch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.23.0"
+version = "5.24.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.20.0"
+version = "5.21.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.19.0"
+version = "5.20.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.21.0"
+version = "5.22.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.22.0"
+version = "5.23.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -50,6 +50,7 @@ $FccCommands = @(
     "fcc-desktop",
     "fcc-server",
     "fcc-claude",
+    "fcc-claude-desktop",
     "fcc-codex",
     "fcc-pi",
     "fcc-opencode",
@@ -1277,7 +1278,7 @@ function Configure-AndConfirmFreeClaudeCode {
     if ($DryRun) {
         Write-Host "+ uv tool update-shell"
         Write-Host "+ uv tool dir --bin"
-        Write-Host "+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, fcc-grok, fcc-muse, and fcc-aider in the uv tool bin directory"
+        Write-Host "+ verify fcc-desktop, fcc-server, fcc-claude, fcc-claude-desktop, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, fcc-grok, fcc-muse, and fcc-aider in the uv tool bin directory"
         Write-Host "+ fcc-server --version"
         Export-FccDesktopIcon `
             -DesktopCommand "<uv-tool-bin>\fcc-desktop.exe" `
@@ -1299,7 +1300,7 @@ function Configure-AndConfirmFreeClaudeCode {
         [IO.Path]::AltDirectorySeparatorChar
     )
     $installedCommands = @{}
-    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-codex", "fcc-pi", "fcc-opencode", "fcc-cline", "fcc-hermes", "fcc-dsh", "fcc-grok", "fcc-muse", "fcc-aider")) {
+    foreach ($commandName in @("fcc-desktop", "fcc-server", "fcc-claude", "fcc-claude-desktop", "fcc-codex", "fcc-pi", "fcc-opencode", "fcc-cline", "fcc-hermes", "fcc-dsh", "fcc-grok", "fcc-muse", "fcc-aider")) {
         $command = Get-ApplicationCommand $commandName
         if (-not $command) {
             throw "Free Claude Code installation did not create '$commandName'."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -61,6 +61,7 @@ $FccCommands = @(
     "fcc-muse",
     "fcc-aider",
     "fcc-init",
+    "fcc-claude-desktop",
     "free-claude-code"
 )
 
@@ -1322,6 +1323,8 @@ function Configure-AndConfirmFreeClaudeCode {
     Install-FccDesktopShortcuts `
         -DesktopCommand $installedCommands["fcc-desktop"] `
         -IconPath $iconPath
+    Configure-ClaudeDesktopApp `
+        -ToolBin $toolBin
 }
 
 function Test-EquivalentPath {
@@ -1342,6 +1345,32 @@ function Test-EquivalentPath {
     }
     catch {
         return $false
+    }
+}
+
+function Configure-ClaudeDesktopApp {
+    param([string] $ToolBin)
+
+    # Delegate JSON merging to the Python helper installed by `uv tool
+    # install` so the script does not depend on jq/ConvertTo-Json parsing.
+    # Best-effort: a non-zero exit is logged but does not fail the install.
+    $pythonExe = Join-Path $ToolBin "python3"
+    if (-not (Test-Path $pythonExe)) {
+        $pythonExe = Join-Path $ToolBin "python.exe"
+    }
+    if (-not (Test-Path $pythonExe)) {
+        Write-Warning "Could not locate python inside the uv tool bin; skipping Claude Desktop auto-configure."
+        return
+    }
+
+    if ($script:DryRun) {
+        Print-Command $pythonExe @("-m", "free_claude_code.cli.launchers.claude_desktop", "--configure")
+        return
+    }
+
+    & $pythonExe -m free_claude_code.cli.launchers.claude_desktop --configure
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to auto-configure Claude Desktop (exit code $LASTEXITCODE). Configure it after starting FCC with a verified HTTPS front: run ``fcc-claude-desktop`` (which brings up the front), or start ``fcc-desktop`` and then run ``fcc-claude-desktop --configure``."
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so updates reject older FCC processes before replacement.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-claude-desktop fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code"
 
 dry_run=0
 voice_nim=0
@@ -1208,14 +1208,14 @@ configure_and_verify_free_claude_code() {
 
     if [ "$dry_run" -eq 1 ]; then
         print_command uv tool dir --bin
-        printf '+ verify fcc-desktop, fcc-server, fcc-claude, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, fcc-grok, fcc-muse, and fcc-aider in the uv tool bin directory\n'
+        printf '+ verify fcc-desktop, fcc-server, fcc-claude, fcc-claude-desktop, fcc-codex, fcc-pi, fcc-opencode, fcc-cline, fcc-hermes, fcc-dsh, fcc-grok, fcc-muse, and fcc-aider in the uv tool bin directory\n'
         print_command fcc-server --version
         return 0
     fi
 
     add_uv_tool_bin_directory
 
-    for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider; do
+    for command_name in fcc-desktop fcc-server fcc-claude fcc-claude-desktop fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider; do
         [ -x "$tool_bin/$command_name" ] || fail "Free Claude Code installation did not create $tool_bin/$command_name."
     done
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1249,12 +1249,22 @@ configure_claude_desktop_app() {
 }
 
 install_claude_desktop_cert() {
-    # Electron's TLS stack does not reliably honor NODE_TLS_REJECT_UNAUTHORIZED
-    # nor the operating system certificate store: Chromium-based apps read the
-    # per-user NSS database (~/.pki/nssdb). Best-effort, never fatal: pick the
-    # active Caddy certificate and trust it in both stores so users who launch
-    # ``claude-desktop`` directly (or via ``fcc-claude-desktop``) see FCC as
-    # trusted.
+    # Electron's TLS stack on Linux reads the per-user NSS database
+    # (~/.pki/nssdb). That store is SHARED by every Chromium-based app the
+    # user runs, so trusting the FCC-managed CA there — or anywhere outside
+    # Claude Desktop — is an explicit, opt-in decision: the installer never
+    # extends CA trust silently. Firefox profile stores and the system CA
+    # store are NOT touched at all; users who want broader trust can add the
+    # certificate themselves after understanding the scope.
+    case "${FCC_TRUST_DESKTOP_CERT:-}" in
+        1|true|TRUE|yes|YES)
+            ;;
+        *)
+            printf 'note: skipping Claude Desktop certificate trust (set FCC_TRUST_DESKTOP_CERT=1 to trust the FCC-managed CA in your NSS user store — this affects all Chromium-based apps that read it).\n' >&2
+            return 0
+            ;;
+    esac
+
     home="${HOME:-}"
     cert_src=""
     for candidate in \
@@ -1270,7 +1280,6 @@ install_claude_desktop_cert() {
     fi
 
     install_claude_desktop_cert_nss
-    install_claude_desktop_cert_system
 }
 
 trust_cert_in_nss_db() {
@@ -1306,50 +1315,6 @@ install_claude_desktop_cert_nss() {
     fi
 
     trust_cert_in_nss_db "$nss_home/.pki"
-    firefox_home="$nss_home/.mozilla/firefox"
-    if [ -d "$firefox_home" ]; then
-        for profile_dir in "$firefox_home"/*/;
-        do
-            [ -f "${profile_dir}cert9.db" ] || continue
-            certutil -A -d "sql:${profile_dir%/}" -t "C,," -n "FCC-Caddy" -i "$cert_src" >/dev/null 2>&1 || true
-        done
-    fi
-}
-
-install_claude_desktop_cert_system() {
-    case "$cert_src" in
-        /etc/caddy/*) cert_dst="/usr/local/share/ca-certificates/fcc-caddy-localhost.crt" ;;
-        *) cert_dst="/usr/local/share/ca-certificates/fcc-caddy-root.crt" ;;
-    esac
-    if [ -e "$cert_dst" ] && cmp -s "$cert_src" "$cert_dst"; then
-        return 0
-    fi
-
-    if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then
-        printf 'note: skipping system cert trust step (%s requires root or sudo).\n' "$cert_src" >&2
-        return 0
-    fi
-
-    copy_cmd="cp"
-    update_cmd="update-ca-certificates"
-    if [ "$(id -u)" -ne 0 ]; then
-        copy_cmd="sudo cp"
-        update_cmd="sudo update-ca-certificates"
-    fi
-
-    if [ "$dry_run" -eq 1 ]; then
-        print_command "$copy_cmd" "$cert_src" "$cert_dst"
-        print_command "$update_cmd" --fresh
-        return 0
-    fi
-
-    if ! $copy_cmd "$cert_src" "$cert_dst" 2>/dev/null; then
-        printf 'note: cert trust step failed (cp returned %d) — claude-desktop TLS may still reject Caddy.\n' "$?" >&2
-        return 0
-    fi
-    if ! $update_cmd --fresh >/dev/null 2>&1; then
-        printf 'note: update-ca-certificates failed — claude-desktop TLS may still reject Caddy.\n' >&2
-    fi
 }
 
 shell_quote() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ RTK_RELEASE_BASE_URL="https://github.com/rtk-ai/rtk/releases/download/v$RTK_VERS
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
+FCC_LINUX_DESKTOP_MARKER="# Owned by Free Claude Code. Remove this line to unclaim."
 # Include retired entry points so updates reject older FCC processes before replacement.
 FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-claude-desktop fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code"
 
@@ -1220,6 +1221,135 @@ configure_and_verify_free_claude_code() {
     done
 
     run "$tool_bin/fcc-server" --version
+
+    configure_claude_desktop_app
+}
+
+configure_claude_desktop_app() {
+    # Best-effort: write the FCC 3P-gateway block into the user's
+    # ``claude_desktop_config.json`` so Claude Desktop's model picker
+    # discovers every NIM/OpenRouter model exposed by FCC. Delegate JSON
+    # parsing to the Python helper installed by ``uv tool install`` so the
+    # script doesn't depend on ``jq``.
+    if [ "$dry_run" -eq 1 ]; then
+        print_command "$tool_bin/python3" -m \
+            free_claude_code.cli.launchers.claude_desktop --configure
+        return 0
+    fi
+
+    configure_status=0
+    "$tool_bin/python3" -m \
+        free_claude_code.cli.launchers.claude_desktop --configure \
+        || configure_status=$?
+    if [ "$configure_status" -ne 0 ]; then
+        printf 'warning: Failed to auto-configure Claude Desktop (exit code %d). Configure it after starting FCC with a verified HTTPS front: run `fcc-claude-desktop` (which brings up the front), or start `fcc-desktop` and then run `fcc-claude-desktop --configure`.\n' "$configure_status" >&2
+    fi
+
+    install_claude_desktop_cert
+}
+
+install_claude_desktop_cert() {
+    # Electron's TLS stack does not reliably honor NODE_TLS_REJECT_UNAUTHORIZED
+    # nor the operating system certificate store: Chromium-based apps read the
+    # per-user NSS database (~/.pki/nssdb). Best-effort, never fatal: pick the
+    # active Caddy certificate and trust it in both stores so users who launch
+    # ``claude-desktop`` directly (or via ``fcc-claude-desktop``) see FCC as
+    # trusted.
+    home="${HOME:-}"
+    cert_src=""
+    for candidate in \
+        "/etc/caddy/localhost+2.pem" \
+        "${FCC_CONFIG_HOME:-$home/.fcc}/caddy/data/caddy/pki/authorities/local/root.crt"; do
+        if [ -f "$candidate" ]; then
+            cert_src="$candidate"
+            break
+        fi
+    done
+    if [ -z "$cert_src" ]; then
+        return 0
+    fi
+
+    install_claude_desktop_cert_nss
+    install_claude_desktop_cert_system
+}
+
+trust_cert_in_nss_db() {
+    nss_dir=$1
+    nss_profile_dir="$nss_dir/nssdb"
+    [ -d "$nss_profile_dir" ] || mkdir -p "$nss_profile_dir" || return 0
+    if [ ! -f "$nss_profile_dir/cert9.db" ]; then
+        certutil -N -d "sql:$nss_profile_dir" --empty-password >/dev/null 2>&1 || return 0
+    fi
+    certutil -A -d "sql:$nss_profile_dir" -t "C,," -n "FCC-Caddy" -i "$cert_src" >/dev/null 2>&1 || {
+        printf 'note: could not add FCC certificate to %s — Claude Desktop may prompt about TLS.\n' "$nss_profile_dir" >&2
+    }
+}
+
+install_claude_desktop_cert_nss() {
+    # Chromium/Electron TLS uses the NSS user database. No root required.
+    command -v certutil >/dev/null 2>&1 || {
+        printf 'note: certutil (libnss3-tools) not found — skipping NSS trust for Claude Desktop.\n' >&2
+        return 0
+    }
+
+    # ``install_claude_desktop_cert`` may run with HOME unset (containerized
+    # installs); per-user NSS trust is meaningless without a home directory.
+    nss_home="${HOME:-}"
+    [ -n "$nss_home" ] || {
+        printf 'note: HOME not set — skipping NSS trust for Claude Desktop.\n' >&2
+        return 0
+    }
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command certutil -A -d "sql:$nss_home/.pki/nssdb" -t "C,," -n "FCC-Caddy" -i "$cert_src"
+        return 0
+    fi
+
+    trust_cert_in_nss_db "$nss_home/.pki"
+    firefox_home="$nss_home/.mozilla/firefox"
+    if [ -d "$firefox_home" ]; then
+        for profile_dir in "$firefox_home"/*/;
+        do
+            [ -f "${profile_dir}cert9.db" ] || continue
+            certutil -A -d "sql:${profile_dir%/}" -t "C,," -n "FCC-Caddy" -i "$cert_src" >/dev/null 2>&1 || true
+        done
+    fi
+}
+
+install_claude_desktop_cert_system() {
+    case "$cert_src" in
+        /etc/caddy/*) cert_dst="/usr/local/share/ca-certificates/fcc-caddy-localhost.crt" ;;
+        *) cert_dst="/usr/local/share/ca-certificates/fcc-caddy-root.crt" ;;
+    esac
+    if [ -e "$cert_dst" ] && cmp -s "$cert_src" "$cert_dst"; then
+        return 0
+    fi
+
+    if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then
+        printf 'note: skipping system cert trust step (%s requires root or sudo).\n' "$cert_src" >&2
+        return 0
+    fi
+
+    copy_cmd="cp"
+    update_cmd="update-ca-certificates"
+    if [ "$(id -u)" -ne 0 ]; then
+        copy_cmd="sudo cp"
+        update_cmd="sudo update-ca-certificates"
+    fi
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command "$copy_cmd" "$cert_src" "$cert_dst"
+        print_command "$update_cmd" --fresh
+        return 0
+    fi
+
+    if ! $copy_cmd "$cert_src" "$cert_dst" 2>/dev/null; then
+        printf 'note: cert trust step failed (cp returned %d) — claude-desktop TLS may still reject Caddy.\n' "$?" >&2
+        return 0
+    fi
+    if ! $update_cmd --fresh >/dev/null 2>&1; then
+        printf 'note: update-ca-certificates failed — claude-desktop TLS may still reject Caddy.\n' >&2
+    fi
 }
 
 shell_quote() {
@@ -1311,6 +1441,72 @@ PLIST
     ln -s "$app_dir" "$desktop_link"
 }
 
+linux_desktop_entry_is_fcc_owned() {
+    entry_file=$1
+    [ -f "$entry_file" ] &&
+        [ "$(head -n 1 "$entry_file")" = "$FCC_LINUX_DESKTOP_MARKER"
+    ]
+}
+
+linux_desktop_entry_path_exists() {
+    # Same resolution order as ``install_linux_desktop_entry``: the XDG
+    # override wins, else the home-relative data directory. HOME may be unset
+    # in containerized installs, in which case no per-user entry can exist.
+    data_home="${XDG_DATA_HOME:-}"
+    if [ -z "$data_home" ] && [ -n "${HOME:-}" ]; then
+        data_home="$HOME/.local/share"
+    fi
+    [ -n "$data_home" ] || return 1
+    [ -f "$data_home/applications/free-claude-code.desktop" ]
+}
+
+install_linux_desktop_entry() {
+    [ "$(uname -s)" = "Linux" ] || return 0
+
+    # Containerized installs may run with HOME unset; without a home (and no
+    # XDG override) there is nowhere to put a per-user launcher entry.
+    data_home="${XDG_DATA_HOME:-}"
+    if [ -z "$data_home" ] && [ -n "${HOME:-}" ]; then
+        data_home="$HOME/.local/share"
+    fi
+    [ -n "$data_home" ] || {
+        printf 'note: HOME not set — skipping the Linux desktop launcher entry.\n' >&2
+        return 0
+    }
+    applications_dir="$data_home/applications"
+    icons_dir="$data_home/icons"
+    entry_file="$applications_dir/free-claude-code.desktop"
+    icon_path="$icons_dir/free-claude-code.png"
+
+    if [ -e "$entry_file" ] &&
+        ! linux_desktop_entry_is_fcc_owned "$entry_file"; then
+        printf 'A non-FCC launcher already exists at %s; leaving it unchanged.\n' "$entry_file"
+        return 0
+    fi
+
+    if [ "$dry_run" -eq 1 ]; then
+        print_command mkdir -p "$applications_dir" "$icons_dir"
+        print_command fcc-desktop --export-icon "$icon_path"
+        printf '+ write %s\n' "$entry_file"
+        return 0
+    fi
+
+    mkdir -p "$applications_dir" "$icons_dir"
+    run "$tool_bin/fcc-desktop" --export-icon "$icon_path"
+    [ -f "$icon_path" ] || fail "Free Claude Code did not export its desktop icon to $icon_path."
+    {
+        printf '%s\n' "$FCC_LINUX_DESKTOP_MARKER"
+        printf '[Desktop Entry]\n'
+        printf 'Type=Application\n'
+        printf 'Name=Free Claude Code\n'
+        printf 'Comment=Run the Free Claude Code proxy in the background\n'
+        printf 'Exec=%s\n' "$(shell_quote "$tool_bin/fcc-desktop")"
+        printf 'Icon=%s\n' "$icon_path"
+        printf 'Terminal=false\n'
+        printf 'Categories=Development;\n'
+    } > "$entry_file"
+}
+
 parse_args "$@"
 validate_args
 add_known_bin_directories
@@ -1367,6 +1563,9 @@ configure_and_verify_free_claude_code
 if [ "$(uname -s)" = "Darwin" ]; then
     step "Installing the Free Claude Code desktop launcher"
     install_macos_desktop_app
+elif [ "$(uname -s)" = "Linux" ]; then
+    step "Installing the Free Claude Code desktop launcher"
+    install_linux_desktop_entry
 fi
 
 if [ "$dry_run" -eq 1 ]; then
@@ -1375,6 +1574,8 @@ else
     if [ "$(uname -s)" = "Darwin" ]; then
         printf '\nFree Claude Code is installed and verified. Open Free Claude Code from Applications or the desktop to run it in the background.\n'
         printf 'For terminal use, start the proxy with: fcc-server\n'
+    elif [ "$(uname -s)" = "Linux" ] && linux_desktop_entry_path_exists; then
+        printf '\nFree Claude Code is installed and verified. Open Free Claude Code from your application launcher to run it in the background, or start the proxy with: fcc-server\n'
     else
         printf '\nFree Claude Code is installed and verified. Start the proxy with: fcc-server\n'
     fi

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -26,6 +26,7 @@ $FccCommands = @(
     "fcc-muse",
     "fcc-aider",
     "fcc-init",
+    "fcc-claude-desktop",
     "free-claude-code"
 )
 $script:UvPath = ""
@@ -198,6 +199,32 @@ function Uninstall-FreeClaudeCode {
     throw "uv tool uninstall $PackageName failed with exit code $($result.ExitCode); ~/.fcc was not deleted."
 }
 
+function Unconfigure-ClaudeDesktopApp {
+    param([string] $ToolBin)
+
+    # Delegate JSON un-merging to the Python helper installed by `uv tool
+    # install` so the script does not depend on jq/ConvertTo-Json parsing.
+    # Best-effort: a non-zero exit is logged but does not fail the uninstall.
+    $pythonExe = Join-Path $ToolBin "python3"
+    if (-not (Test-Path $pythonExe)) {
+        $pythonExe = Join-Path $ToolBin "python.exe"
+    }
+    if (-not (Test-Path $pythonExe)) {
+        Write-Warning "Could not locate python inside the uv tool bin; skipping Claude Desktop auto-unconfigure."
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "+ $pythonExe -m free_claude_code.cli.launchers.claude_desktop --unconfigure"
+        return
+    }
+
+    & $pythonExe -m free_claude_code.cli.launchers.claude_desktop --unconfigure
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to auto-unconfigure Claude Desktop (exit code $LASTEXITCODE). Run `fcc-claude-desktop --unconfigure` manually."
+    }
+}
+
 function Confirm-FccCommandsRemoved {
     if ($DryRun) {
         Write-Host "+ verify all Free Claude Code entry points are absent from the uv tool bin directory"
@@ -322,6 +349,9 @@ Assert-NoFccProcessesRunning
 
 Write-Step "Locating the uv-managed Free Claude Code installation"
 Initialize-UvContext
+
+Write-Step "Reversing the Claude Desktop routing block"
+Unconfigure-ClaudeDesktopApp -ToolBin $script:UvToolBin
 
 Write-Step "Removing the Free Claude Code uv tool"
 Uninstall-FreeClaudeCode

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -15,6 +15,7 @@ $FccCommands = @(
     "fcc-desktop",
     "fcc-server",
     "fcc-claude",
+    "fcc-claude-desktop",
     "fcc-codex",
     "fcc-pi",
     "fcc-opencode",

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,7 +6,7 @@ FCC_HOME_DIRNAME=".fcc"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
 # Include retired entry points so older installations are fully stopped and removed.
-FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code"
+FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-claude-desktop fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code"
 
 dry_run=0
 uv_tool_bin=""

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,6 +5,7 @@ PACKAGE_NAME="free-claude-code"
 FCC_HOME_DIRNAME=".fcc"
 FCC_MACOS_BUNDLE_ID="io.github.alishahryar1.free-claude-code"
 FCC_MACOS_OWNER_FILE=".free-claude-code-owner"
+FCC_LINUX_DESKTOP_MARKER="# Owned by Free Claude Code. Remove this line to unclaim."
 # Include retired entry points so older installations are fully stopped and removed.
 FCC_COMMANDS="fcc-desktop fcc-server fcc-claude fcc-claude-desktop fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code"
 
@@ -241,6 +242,58 @@ remove_macos_desktop_app() {
     fi
 }
 
+remove_linux_desktop_entry() {
+    [ "$(uname -s)" = "Linux" ] || return 0
+
+    data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+    entry_file="$data_home/applications/free-claude-code.desktop"
+    icon_path="$data_home/icons/free-claude-code.png"
+
+    if [ ! -e "$entry_file" ] && [ ! -e "$icon_path" ]; then
+        return 0
+    fi
+
+    if [ -e "$entry_file" ]; then
+        if [ "$(head -n 1 "$entry_file")" = "$FCC_LINUX_DESKTOP_MARKER" ]; then
+            run rm -f "$entry_file"
+        else
+            printf 'A launcher not managed by Free Claude Code exists at %s; leaving it unchanged.\n' "$entry_file"
+        fi
+    fi
+    if [ -f "$icon_path" ] && [ ! -L "$icon_path" ]; then
+        run rm -f "$icon_path"
+    fi
+}
+
+unconfigure_claude_desktop_config() {
+    # Reverse the merge applied by the installer so Claude Desktop stops
+    # forwarding requests to FCC after this tool is gone. Best-effort: a
+    # non-zero exit is logged but does not fail the uninstall.
+    python_bin="$uv_tool_bin/python3"
+    if [ "$dry_run" -eq 1 ]; then
+        if [ -x "$python_bin" ]; then
+            print_command "$python_bin" -m \
+                free_claude_code.cli.launchers.claude_desktop --unconfigure
+        else
+            printf '+ skip Claude Desktop --unconfigure (uv tool bin already gone)\n'
+        fi
+        return 0
+    fi
+
+    if [ ! -x "$python_bin" ]; then
+        # Tool already removed; helper no longer reachable.
+        return 0
+    fi
+
+    unconfigure_status=0
+    "$python_bin" -m \
+        free_claude_code.cli.launchers.claude_desktop --unconfigure 2>/dev/null \
+        || unconfigure_status=$?
+    if [ "$unconfigure_status" -ne 0 ]; then
+        printf 'warning: Failed to auto-unconfigure Claude Desktop (exit code %d). Run `fcc-claude-desktop --unconfigure` manually.\n' "$unconfigure_status" >&2
+    fi
+}
+
 purge_fcc_home() {
     fcc_home="$HOME/$FCC_HOME_DIRNAME"
     if [ ! -e "$fcc_home" ]; then
@@ -282,6 +335,9 @@ assert_no_fcc_processes_running
 step "Locating the uv-managed Free Claude Code installation"
 initialize_uv_context
 
+step "Reversing the Claude Desktop routing block"
+unconfigure_claude_desktop_config
+
 step "Removing the Free Claude Code uv tool"
 uninstall_free_claude_code
 
@@ -290,6 +346,7 @@ verify_fcc_commands_removed
 
 step "Removing the Free Claude Code desktop launcher"
 remove_macos_desktop_app
+remove_linux_desktop_entry
 
 step "Purging FCC config and data from ~/.fcc"
 purge_fcc_home

--- a/src/free_claude_code/api/app.py
+++ b/src/free_claude_code/api/app.py
@@ -52,6 +52,12 @@ def create_app(services: ApiServices) -> FastAPI:
     app.include_router(admin_router)
     app.include_router(chat_router)
     app.include_router(router)
+    # Claude Desktop-only alias mount: same handlers under the desktop path
+    # prefix; the models handler serves picker aliases only on this mount.
+    app.include_router(
+        router,
+        prefix=f"/{services.requests.current_settings().desktop_gateway_prefix}",
+    )
 
     @app.exception_handler(ChatError)
     async def chat_error_handler(request: Request, exc: ChatError):

--- a/src/free_claude_code/api/dependencies.py
+++ b/src/free_claude_code/api/dependencies.py
@@ -13,28 +13,6 @@ from free_claude_code.config.settings import Settings
 from .ports import ApiServices
 
 
-def _extract_proxy_token(request: Request) -> str | None:
-    """Token from an ``Authorization: Bearer`` header, else ``x-api-key``.
-
-    Anthropic-native clients (including Claude Desktop's inference gateway)
-    authenticate with ``x-api-key``, so it is accepted as an equal scheme.
-    A malformed Authorization header wins and yields nothing; without one,
-    the ``x-api-key`` value is used as-is.
-    """
-
-    authorization = request.headers.get("authorization")
-    if authorization is not None:
-        parts = authorization.strip().split(maxsplit=1)
-        if len(parts) == 2 and parts[0].casefold() == "bearer":
-            token = parts[1].strip()
-            return token or None
-        return None
-    api_key = request.headers.get("x-api-key")
-    if api_key is None:
-        return None
-    return api_key.strip() or None
-
-
 def get_services(request: Request) -> ApiServices:
     """Return the complete services supplied when the app was constructed."""
     return request.app.state.services
@@ -74,27 +52,7 @@ def require_proxy_auth(
     if not settings.proxy_auth_enabled:
         return
 
-    token = _extract_proxy_token(request)
-    if token is None:
-        # A present-but-malformed Authorization header is a bad credential,
-        # not a missing one; with no Authorization at all it's just missing.
-        raise HTTPException(
-            status_code=401,
-            detail=(
-                "Invalid proxy authentication token"
-                if request.headers.get("authorization")
-                else "Missing proxy authentication token"
-            ),
-        )
-
-    if not secrets.compare_digest(
-        token.encode("utf-8"),
-        settings.proxy_auth_token.encode("utf-8"),
-    ):
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid proxy authentication token",
-        )
+    _validate_proxy_credential(request, settings.proxy_auth_token)
 
 
 def require_anthropic_proxy_auth(
@@ -105,18 +63,32 @@ def require_anthropic_proxy_auth(
     if not settings.proxy_auth_enabled:
         return
 
+    _validate_proxy_credential(request, settings.proxy_auth_token)
+
+
+def _validate_proxy_credential(request: Request, configured_token: str) -> None:
+    """Raise 401 unless the request carries the configured proxy token.
+
+    A present ``Authorization`` header is authoritative: it must be a
+    ``Bearer <token>`` value matching the configured token, so a malformed
+    or mismatched value is rejected as an invalid credential without any
+    fallback to ``x-api-key``. With no ``Authorization`` header, the
+    ``x-api-key`` value is accepted as an equal scheme. Only when neither
+    header is present is the credential reported missing.
+    """
+
     authorization = request.headers.get("authorization")
     if authorization is not None:
-        if _proxy_token_matches(
+        if not _proxy_token_matches(
             authorization,
-            settings.proxy_auth_token,
+            configured_token,
             require_bearer=True,
         ):
-            return
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid proxy authentication token",
-        )
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid proxy authentication token",
+            )
+        return
 
     x_api_key = request.headers.get("x-api-key")
     if x_api_key is None:
@@ -127,7 +99,7 @@ def require_anthropic_proxy_auth(
 
     if not _proxy_token_matches(
         x_api_key,
-        settings.proxy_auth_token,
+        configured_token,
         require_bearer=False,
     ):
         raise HTTPException(

--- a/src/free_claude_code/api/dependencies.py
+++ b/src/free_claude_code/api/dependencies.py
@@ -13,6 +13,28 @@ from free_claude_code.config.settings import Settings
 from .ports import ApiServices
 
 
+def _extract_proxy_token(request: Request) -> str | None:
+    """Token from an ``Authorization: Bearer`` header, else ``x-api-key``.
+
+    Anthropic-native clients (including Claude Desktop's inference gateway)
+    authenticate with ``x-api-key``, so it is accepted as an equal scheme.
+    A malformed Authorization header wins and yields nothing; without one,
+    the ``x-api-key`` value is used as-is.
+    """
+
+    authorization = request.headers.get("authorization")
+    if authorization is not None:
+        parts = authorization.strip().split(maxsplit=1)
+        if len(parts) == 2 and parts[0].casefold() == "bearer":
+            token = parts[1].strip()
+            return token or None
+        return None
+    api_key = request.headers.get("x-api-key")
+    if api_key is None:
+        return None
+    return api_key.strip() or None
+
+
 def get_services(request: Request) -> ApiServices:
     """Return the complete services supplied when the app was constructed."""
     return request.app.state.services
@@ -48,21 +70,26 @@ def require_proxy_auth(
     request: Request,
     settings: Settings = Depends(get_settings),
 ) -> None:
-    """Require the configured proxy token as HTTP bearer authorization."""
+    """Require the configured proxy token as Bearer or Anthropic-style auth."""
     if not settings.proxy_auth_enabled:
         return
 
-    authorization = request.headers.get("authorization")
-    if not authorization:
+    token = _extract_proxy_token(request)
+    if token is None:
+        # A present-but-malformed Authorization header is a bad credential,
+        # not a missing one; with no Authorization at all it's just missing.
         raise HTTPException(
             status_code=401,
-            detail="Missing proxy authentication token",
+            detail=(
+                "Invalid proxy authentication token"
+                if request.headers.get("authorization")
+                else "Missing proxy authentication token"
+            ),
         )
 
-    if not _proxy_token_matches(
-        authorization,
-        settings.proxy_auth_token,
-        require_bearer=True,
+    if not secrets.compare_digest(
+        token.encode("utf-8"),
+        settings.proxy_auth_token.encode("utf-8"),
     ):
         raise HTTPException(
             status_code=401,

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -13,6 +13,7 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.core.gateway_model_ids import (
     gateway_model_id,
     no_thinking_gateway_model_id,
+    picker_alias_for,
 )
 from free_claude_code.core.model_capabilities import ModelInputModality
 
@@ -133,15 +134,26 @@ def build_models_list_response(
     runtime: RequestRuntimePort,
     *,
     view: ModelCatalogView = ModelCatalogView.CLAUDE,
+    picker_aliases: bool = False,
 ) -> ModelsListResponse:
-    """Return the application model inventory in the requested client view."""
+    """Return the application model inventory in the requested client view.
+
+    ``picker_aliases`` opts into Claude Desktop picker alias ids; only the
+    desktop-scoped API mount enables it, so every other FCC client sees raw
+    provider refs regardless of seeded alias state.
+    """
     if view is ModelCatalogView.CLAUDE:
-        return _build_claude_models_response(settings, runtime)
+        return _build_claude_models_response(
+            settings, runtime, picker_aliases=picker_aliases
+        )
     return _build_direct_models_response(settings, runtime, view=view)
 
 
 def _build_claude_models_response(
-    settings: Settings, runtime: RequestRuntimePort
+    settings: Settings,
+    runtime: RequestRuntimePort,
+    *,
+    picker_aliases: bool,
 ) -> ModelsListResponse:
     """Preserve the established Claude-compatible catalog exactly."""
     models: list[ModelResponse] = []
@@ -156,6 +168,7 @@ def _build_claude_models_response(
             supports_thinking=(
                 model_info.supports_thinking if model_info is not None else None
             ),
+            picker_aliases=picker_aliases,
         )
 
     for model_info in runtime.cached_prefixed_model_infos():
@@ -164,6 +177,7 @@ def _build_claude_models_response(
             seen,
             model_info.model_id,
             supports_thinking=model_info.supports_thinking,
+            picker_aliases=picker_aliases,
         )
 
     for model in SUPPORTED_CLAUDE_MODELS:
@@ -319,13 +333,22 @@ def _append_provider_model_variants(
     provider_model_ref: str,
     *,
     supports_thinking: bool | None = None,
+    picker_aliases: bool = False,
 ) -> None:
+    thinking_id = (
+        picker_alias_for(provider_model_ref) if picker_aliases else None
+    ) or gateway_model_id(provider_model_ref)
+    no_thinking_id = (
+        picker_alias_for(provider_model_ref, force_reasoning_off=True)
+        if picker_aliases
+        else None
+    ) or no_thinking_gateway_model_id(provider_model_ref)
     if supports_thinking is not False:
         _append_unique_model(
             models,
             seen,
             _discovered_model_response(
-                gateway_model_id(provider_model_ref),
+                thinking_id,
                 display_name=provider_model_ref,
             ),
         )
@@ -333,7 +356,7 @@ def _append_provider_model_variants(
         models,
         seen,
         _discovered_model_response(
-            no_thinking_gateway_model_id(provider_model_ref),
+            no_thinking_id,
             display_name=f"{provider_model_ref} (no thinking)",
         ),
     )

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -197,14 +197,31 @@ async def probe_health():
     response_model_exclude_none=True,
 )
 async def list_models(
+    request: Request,
     view: ModelCatalogView = ModelCatalogView.CLAUDE,
     services: ApiServices = Depends(get_services),
     settings: Settings = Depends(get_settings),
     _auth=Depends(require_proxy_auth),
 ):
-    """List the model ids this proxy advertises to compatible clients."""
+    """List the model ids this proxy advertises to compatible clients.
+
+    Served both bare and under the desktop path prefix. Picker aliases are
+    emitted only on the prefixed mount so Claude Code, Codex, Pi and every
+    other FCC client keep seeing raw provider refs. The mount is identified
+    by exact path equality, not by a prefix sniff: a
+    ``DESKTOP_GATEWAY_PREFIX`` of ``v1`` would otherwise make the bare
+    ``/v1/models`` path satisfy a ``startswith`` check and leak Desktop-only
+    aliases to every client.
+    """
     trace_event(stage="ingress", event="free_claude_code.api.models.list", source="api")
-    return build_models_list_response(settings, services.requests, view=view)
+    desktop_mount_path = f"/{settings.desktop_gateway_prefix}/v1/models"
+    picker_aliases = request.url.path == desktop_mount_path
+    return build_models_list_response(
+        settings,
+        services.requests,
+        view=view,
+        picker_aliases=picker_aliases,
+    )
 
 
 @router.get(

--- a/src/free_claude_code/application/routing.py
+++ b/src/free_claude_code/application/routing.py
@@ -13,7 +13,10 @@ from free_claude_code.config.provider_catalog import (
 from free_claude_code.config.reasoning import ReasoningPreference
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest, TokenCountRequest
-from free_claude_code.core.gateway_model_ids import decode_gateway_model_id
+from free_claude_code.core.gateway_model_ids import (
+    decode_gateway_model_id,
+    resolve_picker_alias,
+)
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import ReasoningPolicy
 
@@ -146,6 +149,18 @@ class ModelRouter:
     def _direct_provider_model(
         self, model_name: str
     ) -> tuple[str | None, str | None, bool]:
+        alias_resolution = resolve_picker_alias(model_name)
+        if alias_resolution is not None:
+            aliased_ref, force_reasoning_off = alias_resolution
+            provider_id, separator, provider_model = aliased_ref.partition("/")
+            if (
+                not separator
+                or provider_id not in SUPPORTED_PROVIDER_IDS
+                or not provider_model
+            ):
+                return None, None, False
+            return provider_id, provider_model, force_reasoning_off
+
         decoded = decode_gateway_model_id(model_name)
         if decoded is not None:
             if decoded.provider_id not in SUPPORTED_PROVIDER_IDS:

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -6,8 +6,7 @@ Two responsibilities:
    ``claude_desktop_config.json`` so Claude Desktop's model picker runs
    ``/v1/models`` discovery against the local FCC server. The gateway URL
    and auth key are derived from server settings, never hardcoded.
-   ``unconfigure`` reverses the merge by restoring exactly what configure
-   inserted or overwrote, tracked in an ownership record beside the config.
+   ``unconfigure`` reverses the merge, preserving every other key.
 2. Locate the Claude Desktop binary and spawn it. TLS trust for the local
    FCC front comes from the certificate the install scripts add to the
    per-user NSS store; no process-wide certificate bypass is used.
@@ -20,16 +19,19 @@ import argparse
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field, replace
+import tempfile
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TypedDict
 
 from loguru import logger
 
-from free_claude_code.cli.tls_proxy import desktop_gateway_base_url
+from free_claude_code.cli.tls_proxy import (
+    desktop_gateway_base_url,
+    verified_https_gateway_url,
+)
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.settings import Settings
 
@@ -49,6 +51,10 @@ CONFIG_FILENAME = "claude_desktop_config.json"
 # Top-level key flipping Claude Desktop out of first-party Anthropic mode.
 _DISCOVERY_KEY = "modelDiscoveryEnabled"
 _INFERENCE_KEY = "inference"
+
+# Snapshot of the managed surface taken before the first merge, so
+# ``unconfigure`` restores exactly what the user had instead of deleting it.
+_BACKUP_KEY = "fccPriorConfig"
 
 # Per-platform candidate locations beyond PATH. First existing hit wins.
 _BINARY_CANDIDATES: dict[str, tuple[str, ...]] = {
@@ -117,16 +123,25 @@ def load_existing_config(path: Path) -> dict[str, object]:
 
 
 def _save_config(path: Path, data: dict[str, object]) -> None:
-    """Atomically write the merged config; create parent directories as needed.
+    """Atomically write the merged config; create private directories.
 
     The block embeds the gateway auth token, so the file is written with
-    owner-only permissions regardless of the process umask.
+    owner-only permissions and the config directories stay owner-traversable
+    regardless of the process umask. The temporary file is newly allocated
+    with ``O_EXCL`` (never following or reusing a pre-existing path), so an
+    attacker-placed permissive file or symlink at a predictable name can
+    neither read the token nor redirect the write to another file; its mode
+    is forced to owner-only before the atomic replace.
     """
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    descriptor = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _restrict_permissions(path.parent)
+    descriptor, tmp_name = tempfile.mkstemp(
+        prefix=f"{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    tmp_path = Path(tmp_name)
     try:
+        os.fchmod(descriptor, 0o600)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             handle.write(json.dumps(data, indent=2))
     except BaseException:
@@ -135,166 +150,17 @@ def _save_config(path: Path, data: dict[str, object]) -> None:
     tmp_path.replace(path)
 
 
-class _OwnershipEntry(TypedDict):
-    """Pre-merge state of one managed config key."""
+def _restrict_permissions(directory: Path) -> None:
+    """Force an existing directory to owner-only modes.
 
-    present: bool
-    value: object
-
-
-@dataclass(frozen=True, slots=True)
-class _OwnershipRecord:
-    """What ``configure`` inserted or overwrote, for exact restoration.
-
-    The managed inference keys are always tracked individually so values
-    added to ``inference`` after a merge survive unconfiguration.
-    ``inference_written`` snapshots the mapping configure produced; a key
-    whose current value still equals its written value is FCC's to restore,
-    while anything the user changed since the merge is left alone. When the
-    pre-merge ``inference`` entry was not an object, configure replaced it
-    wholesale and ``inference_scalar`` snapshots what it clobbered.
+    ``mkdir(mode=...)`` only applies to directories it creates; a directory
+    that already exists keeps its modes, so tighten it explicitly.
     """
 
-    discovery: _OwnershipEntry
-    inference_existed: bool
-    inference_was_object: bool
-    inference_scalar: object | None
-    inference_keys: dict[str, _OwnershipEntry]
-    inference_written: dict[str, object] = field(default_factory=dict)
-
-
-_RECORD_SUFFIX = ".fcc-merge.json"
-_RECORD_INFERENCE_KEYS = "inferenceKeys"
-_RECORD_INFERENCE_EXISTED = "inferenceExisted"
-_RECORD_INFERENCE_WAS_OBJECT = "inferenceWasObject"
-_RECORD_INFERENCE_SCALAR = "inferenceScalar"
-_RECORD_INFERENCE_WRITTEN = "inferenceWritten"
-
-
-def _record_payload(record: _OwnershipRecord) -> dict[str, object]:
-    """JSON-able sidecar representation of ``record``."""
-
-    return {
-        _DISCOVERY_KEY: record.discovery,
-        _RECORD_INFERENCE_EXISTED: record.inference_existed,
-        _RECORD_INFERENCE_WAS_OBJECT: record.inference_was_object,
-        _RECORD_INFERENCE_KEYS: record.inference_keys,
-        _RECORD_INFERENCE_WRITTEN: record.inference_written,
-        **(
-            {_RECORD_INFERENCE_SCALAR: record.inference_scalar}
-            if record.inference_existed and not record.inference_was_object
-            else {}
-        ),
-    }
-
-
-def _record_path(config_path: Path) -> Path:
-    """Sidecar recording what configure inserted or overwrote."""
-
-    return config_path.with_name(config_path.name + _RECORD_SUFFIX)
-
-
-def _snapshot_entry(mapping: Mapping[str, object], key: str) -> _OwnershipEntry:
-    """Capture the pre-merge state of one key inside ``mapping``."""
-
-    if key in mapping:
-        return {"present": True, "value": mapping[key]}
-    return {"present": False, "value": None}
-
-
-def _ownership_record(
-    data: dict[str, object],
-    managed_keys: Sequence[str],
-) -> _OwnershipRecord:
-    """Snapshot every managed key so unconfigure can restore exactly it."""
-
-    discovery = _snapshot_entry(data, _DISCOVERY_KEY)
-    existed = _INFERENCE_KEY in data
-    raw = data.get(_INFERENCE_KEY)
-    keys = {
-        key: _snapshot_entry(raw if isinstance(raw, dict) else {}, key)
-        for key in managed_keys
-    }
-    if isinstance(raw, dict):
-        return _OwnershipRecord(
-            discovery=discovery,
-            inference_existed=True,
-            inference_was_object=True,
-            inference_scalar=None,
-            inference_keys=keys,
-        )
-    return _OwnershipRecord(
-        discovery=discovery,
-        inference_existed=existed,
-        inference_was_object=False,
-        inference_scalar=raw if existed else None,
-        inference_keys=keys,
-    )
-
-
-def _parse_entry(raw: object) -> _OwnershipEntry | None:
-    """Parse one ownership snapshot; ``None`` when malformed."""
-
-    if not isinstance(raw, dict):
-        return None
-    present = raw.get("present")
-    if not isinstance(present, bool) or (present and "value" not in raw):
-        return None
-    return {"present": present, "value": raw.get("value")}
-
-
-def _load_ownership_record(path: Path) -> _OwnershipRecord | None:
-    """Read the ownership sidecar; ``None`` when missing or malformed."""
-
-    if not path.exists():
-        return None
-    try:
-        loaded = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(loaded, dict):
-        return None
-
-    discovery = _parse_entry(loaded.get(_DISCOVERY_KEY))
-    if discovery is None:
-        return None
-
-    existed = loaded.get(_RECORD_INFERENCE_EXISTED)
-    was_object = loaded.get(_RECORD_INFERENCE_WAS_OBJECT)
-    if not isinstance(existed, bool) or not isinstance(was_object, bool):
-        return None
-
-    keys_raw = loaded.get(_RECORD_INFERENCE_KEYS)
-    if not isinstance(keys_raw, dict):
-        return None
-    inference_keys: dict[str, _OwnershipEntry] = {}
-    for key, raw in keys_raw.items():
-        parsed = _parse_entry(raw)
-        if not isinstance(key, str) or parsed is None:
-            return None
-        inference_keys[key] = parsed
-
-    written = loaded.get(_RECORD_INFERENCE_WRITTEN)
-    if not isinstance(written, dict):
-        return None
-    normalized_written: dict[str, object] = {
-        str(key): value for key, value in written.items()
-    }
-
-    scalar: object | None = None
-    if existed and not was_object:
-        if _RECORD_INFERENCE_SCALAR not in loaded:
-            return None
-        scalar = loaded[_RECORD_INFERENCE_SCALAR]
-
-    return _OwnershipRecord(
-        discovery=discovery,
-        inference_existed=existed,
-        inference_was_object=was_object,
-        inference_scalar=scalar,
-        inference_keys=inference_keys,
-        inference_written=normalized_written,
-    )
+    current = directory.stat().st_mode
+    target = stat.S_IRWXU
+    if current & 0o777 != target:
+        directory.chmod(target)
 
 
 def configure_claude_desktop_config(
@@ -304,10 +170,15 @@ def configure_claude_desktop_config(
 ) -> bool:
     """Merge the FCC routing block into ``path``. Returns whether anything changed.
 
-    Records the pre-merge values of the managed keys in a sidecar so a later
-    ``unconfigure`` restores exactly them. Returns ``False`` without writing
-    when the existing config is malformed (invalid JSON or non-object root).
-    Creates a new config when absent.
+    Before the first merge the prior presence and values of the managed
+    surface (the discovery flag and the inference keys FCC overwrites) are
+    snapshotted under ``fccPriorConfig``; ``unconfigure`` restores that
+    snapshot so temporarily enabling FCC never destroys the user's previous
+    provider, gateway, credential, or discovery settings. Re-merges keep the
+    original snapshot untouched.
+
+    Returns ``False`` without writing when the existing config is malformed
+    (invalid JSON or non-object root). Creates a new config when absent.
     """
 
     resolved_settings = settings or get_settings()
@@ -315,10 +186,8 @@ def configure_claude_desktop_config(
     config_path = path or _config_path()
     try:
         data: dict[str, object] = load_existing_config(config_path)
-        existed = True
     except FileNotFoundError:
         data = {}
-        existed = False
     except MalformedConfigError as exc:
         logger.warning(
             "Skipping FCC config merge: malformed config at {}: {}",
@@ -327,15 +196,14 @@ def configure_claude_desktop_config(
         )
         return False
 
-    prior = _ownership_record(data, tuple(managed))
-    record_path = _record_path(config_path)
-    previous = (
-        _load_ownership_record(record_path)
-        if existed and record_path.exists()
-        else None
-    )
-
     changed = False
+
+    # The snapshot must observe the config BEFORE the merge touches it, so
+    # capture the discovery flag's prior presence and value first: presence
+    # alone is not enough, since a user who explicitly disabled discovery
+    # must get ``false`` back, not ``true``.
+    had_discovery = _DISCOVERY_KEY in data
+    prior_discovery = data.get(_DISCOVERY_KEY)
 
     if data.get(_DISCOVERY_KEY) is not True:
         data[_DISCOVERY_KEY] = True
@@ -347,18 +215,39 @@ def configure_claude_desktop_config(
         for key, value in inference_raw.items():
             inference_dict[str(key)] = value
 
-    # A non-object ``inference`` after a recorded merge is the user's
-    # wholesale replacement of the FCC block: they swapped the whole
-    # entry for a scalar or null. The merge still writes its managed
-    # mapping (configure's contract is to ensure the block exists), but
-    # ownership must now restore the REPLACEMENT on unconfigure — not the
-    # value from before the first merge, which would discard the user's
-    # later change.
-    replaced_wholesale = (
-        previous is not None
-        and _INFERENCE_KEY in data
-        and not isinstance(inference_raw, dict)
-    )
+    if _BACKUP_KEY not in data:
+        backup: dict[str, object] = {}
+        # Omit the discovery entry when the key was absent so the restore
+        # can tell "was present with this value" from "was not present".
+        if had_discovery:
+            backup["discovery"] = prior_discovery
+        if _INFERENCE_KEY in data:
+            if isinstance(inference_raw, dict):
+                backup["inference"] = {
+                    key: value
+                    for key, value in inference_dict.items()
+                    if key in managed
+                }
+            else:
+                # The original value is not a JSON object; the merge
+                # replaces it wholesale, so record it verbatim for an
+                # exact restore.
+                backup["inferenceRaw"] = inference_raw
+        data[_BACKUP_KEY] = backup
+        changed = True
+    elif not isinstance(inference_raw, dict) and _INFERENCE_KEY in data:
+        # A non-object ``inference`` with a snapshot already recorded is
+        # the user's wholesale replacement of the FCC block (a scalar or
+        # ``null`` in place of the mapping configure wrote). The merge
+        # still writes its managed mapping — configure's contract is to
+        # ensure the block exists — but the snapshot must now restore the
+        # REPLACEMENT on unconfigure; keeping the first-merge value would
+        # silently discard the user's later change.
+        backup = data[_BACKUP_KEY]
+        if isinstance(backup, dict):
+            backup.pop("inference", None)
+            backup["inferenceRaw"] = inference_raw
+            changed = True
 
     for key, value in managed.items():
         if inference_dict.get(key) != value:
@@ -370,109 +259,38 @@ def configure_claude_desktop_config(
         changed = True
 
     if changed:
-        prior = replace(
-            prior,
-            discovery=(
-                previous.discovery
-                if previous is not None and data.get(_DISCOVERY_KEY) is True
-                else prior.discovery
-            ),
-            inference_written=inference_dict,
-            inference_keys=(
-                _absorb_user_edits(previous, tuple(managed), inference_raw)
-                if previous is not None
-                else prior.inference_keys
-            ),
-            # The container provenance (absent / object / scalar origin) is a
-            # fact about the FIRST merge: this merge sees an ``inference``
-            # that configure itself wrote, which would otherwise overwrite
-            # the original origin with ``existed=True, was_object=True`` and
-            # leave unconfigure restoring into an FCC-shaped container the
-            # user never had. A wholesale user replacement is the one
-            # exception: its scalar value is the new origin, so unconfigure
-            # restores the replacement instead of the pre-FCC state.
-            inference_existed=(
-                True
-                if replaced_wholesale
-                else (
-                    previous.inference_existed
-                    if previous is not None
-                    else prior.inference_existed
-                )
-            ),
-            inference_was_object=(
-                False
-                if replaced_wholesale
-                else (
-                    previous.inference_was_object
-                    if previous is not None
-                    else prior.inference_was_object
-                )
-            ),
-            inference_scalar=(
-                inference_raw
-                if replaced_wholesale
-                else (
-                    previous.inference_scalar
-                    if previous is not None
-                    else prior.inference_scalar
-                )
-            ),
-        )
-        _save_config(record_path, _record_payload(prior))
         _save_config(config_path, data)
     return changed
 
 
-def _absorb_user_edits(
-    previous: _OwnershipRecord,
-    managed_keys: Sequence[str],
-    current_raw: object,
-) -> dict[str, _OwnershipEntry]:
-    """Re-target restore values at keys the user edited between merges.
+def unconfigure_claude_desktop_config(
+    path: Path | None = None,
+    settings: Settings | None = None,
+    gateway_base_url: str | None = None,
+) -> bool:
+    """Reverse the merge. Preserves every key outside the FCC-managed surface.
 
-    Starts from the recorded restore targets and updates a key only when its
-    live value differs from both what the last merge wrote and what the
-    record would restore — that combination means a post-merge user edit,
-    and reverting it on unconfigure would discard the user's change. Keys
-    still at their written values keep their original restore targets.
+    When the first merge recorded a ``fccPriorConfig`` snapshot, removal is
+    lossless: every managed key is deleted, then the snapshot's prior
+    presence and values are restored, and only keys FCC originally added
+    stay gone. A non-object ``inference`` value recorded verbatim by the
+    snapshot is restored exactly. Without a snapshot (a config written
+    before backups existed or by hand) ownership is decided by the
+    recorded auth token: it is settings-derived and stable across front
+    state, so when it matches the FCC token the whole block is FCC's and
+    every managed key is removed — even a gateway URL that no longer
+    matches current resolution because the HTTPS front is gone and
+    resolution fell back to plain HTTP — along with the discovery flag.
+    Without that token match only keys whose recorded values exactly
+    match current resolution are removed, so user-owned values that share
+    FCC key names survive, and the discovery flag is preserved because
+    ownership is ambiguous. Returns ``False`` without writing when the
+    existing config is malformed, or silently when the file does not
+    exist.
     """
 
-    current = current_raw if isinstance(current_raw, dict) else {}
-    absorbed = dict(previous.inference_keys)
-    for key in managed_keys:
-        written_value = previous.inference_written.get(key)
-        current_value = current.get(key)
-        if current_value == written_value:
-            continue  # Still FCC's value; nothing user-owned to absorb.
-        restores_absent = key not in absorbed or not absorbed[key]["present"]
-        if restores_absent and key not in current:
-            continue  # Record already removes this key.
-        if (
-            not restores_absent
-            and key in current
-            and absorbed[key]["value"] == current_value
-        ):
-            continue  # Record already restores exactly this user value.
-        absorbed[key] = {
-            "present": key in current,
-            "value": current_value,
-        }
-    return absorbed
-
-
-def unconfigure_claude_desktop_config(path: Path | None = None) -> bool:
-    """Reverse the merge recorded by ``configure`` for ``path``.
-
-    Only the managed surface FCC actually touched is restored: values that
-    existed before configure come back verbatim from the ownership record,
-    keys FCC inserted are removed, and every other key is preserved. With no
-    valid record nothing is owned by FCC, so the config is left untouched
-    and ``False`` is returned. Also returns ``False`` without writing when
-    the existing config or record is malformed, or silently when the file
-    does not exist.
-    """
-
+    resolved_settings = settings or get_settings()
+    managed = fcc_managed_block(resolved_settings, gateway_base_url)
     config_path = path or _config_path()
     if not config_path.exists():
         return False
@@ -486,149 +304,102 @@ def unconfigure_claude_desktop_config(path: Path | None = None) -> bool:
         )
         return False
 
-    record_path = _record_path(config_path)
-    record = _load_ownership_record(record_path)
-    if record is None:
-        logger.warning(
-            "Skipping FCC config unmerge: no FCC ownership record at {}",
-            record_path,
-        )
-        return False
+    backup_raw = data.get(_BACKUP_KEY)
+    # ``None`` means "no snapshot recorded" — an EMPTY snapshot dict is a
+    # real one (nothing prior to restore) and must still take the restore
+    # path so it gets deleted.
+    backup: dict[str, object] | None = None
+    if isinstance(backup_raw, dict):
+        backup = backup_raw
 
     changed = False
 
-    # Configure always writes ``True`` here. A current value of ``True`` is
-    # still FCC's to manage; anything else means the user edited it after the
-    # merge and their choice wins.
-    discovery = record.discovery
-    if discovery["present"]:
-        if (
-            data.get(_DISCOVERY_KEY) is True
-            and data[_DISCOVERY_KEY] != (discovery["value"])
-        ):
-            data[_DISCOVERY_KEY] = discovery["value"]
-            changed = True
-    elif data.get(_DISCOVERY_KEY) is True:
-        del data[_DISCOVERY_KEY]
-        changed = True
+    inference_raw = data.get(_INFERENCE_KEY)
+    inference_dict: dict[str, object] = {}
+    if isinstance(inference_raw, dict):
+        for key, value in inference_raw.items():
+            inference_dict[str(key)] = value
 
-    written = record.inference_written
-    if not record.inference_existed:
-        changed = (
-            _remove_inference_keys(data, record.inference_keys, written) or changed
-        )
-    elif record.inference_was_object:
-        changed = (
-            _restore_inference_keys(data, record.inference_keys, written) or changed
-        )
-    else:
-        # Configure clobbered a non-object entry with its mapping. Per-key
-        # ownership applies exactly as in the object path: a managed key
-        # still holding what configure wrote is FCC's to remove, while a
-        # user-added field (the reason the mapping no longer equals
-        # ``written``) is preserved. Whole-mapping equality would leave
-        # every FCC routing key installed the moment the user adds one
-        # unrelated field.
-        current = _current_inference_object(data)
-        if current is not None:
-            for key in record.inference_keys:
-                if key in current and current[key] == written.get(key):
-                    del current[key]
-                    changed = True
-            if not current:
-                # Nothing user-owned remains in the mapping, so restore the
-                # original scalar (or ``null``) exactly as configure found
-                # it. ``del`` would drop the whole entry instead.
-                data[_INFERENCE_KEY] = record.inference_scalar
+    if backup is not None:
+        # Snapshot path: the merge recorded what FCC replaced, so the
+        # discovery flag and every managed key are FCC's — remove them
+        # all, then restore the snapshot below.
+        if _DISCOVERY_KEY in data:
+            del data[_DISCOVERY_KEY]
+            changed = True
+        for key in managed:
+            if key in inference_dict:
+                del inference_dict[key]
                 changed = True
-            elif changed:
-                data[_INFERENCE_KEY] = current
-    # A non-object current value is a post-merge user replacement; it is no
-    # longer FCC's to touch, so it stays as-is.
+        prior_raw = backup.get("inference")
+        if isinstance(prior_raw, dict):
+            for key, value in prior_raw.items():
+                inference_dict[str(key)] = value
+                changed = True
+    else:
+        # Legacy path (no snapshot): ownership is decided by the recorded
+        # auth token. The discovery flag is removed only once FCC
+        # ownership is established — deleting it first would erase a
+        # user-owned preference from a hand-authored or legacy config.
+        managed_token = managed["inferenceAnthropicApiKey"]
+        fcc_owned = inference_dict.get("inferenceAnthropicApiKey") == managed_token
+        if fcc_owned and _DISCOVERY_KEY in data:
+            del data[_DISCOVERY_KEY]
+            changed = True
+        for key, value in managed.items():
+            recorded = inference_dict.get(key)
+            if recorded is not None and (fcc_owned or recorded == value):
+                del inference_dict[key]
+                changed = True
+
+    if _INFERENCE_KEY in data:
+        if inference_dict:
+            if data[_INFERENCE_KEY] != inference_dict:
+                data[_INFERENCE_KEY] = inference_dict
+                changed = True
+        else:
+            del data[_INFERENCE_KEY]
+            changed = True
+
+    if backup is not None:
+        if "inferenceRaw" in backup:
+            # The original value was not a JSON object; restore it verbatim.
+            data[_INFERENCE_KEY] = backup["inferenceRaw"]
+            changed = True
+        # Restore the original discovery value when the key was present
+        # before the first merge; leave it deleted when it was absent.
+        if "discovery" in backup:
+            data[_DISCOVERY_KEY] = backup["discovery"]
+            changed = True
+        del data[_BACKUP_KEY]
+        changed = True
 
     if changed:
         _save_config(config_path, data)
-        record_path.unlink()
     return changed
 
 
-def _current_inference_object(
-    data: dict[str, object],
-) -> dict[str, object] | None:
-    """The live ``inference`` mapping FCC wrote, or ``None`` once user-owned.
+def report_configure_result(target: Path, changed: bool) -> None:
+    """Report a configure outcome, refusing a malformed-config skip.
 
-    Configure leaves ``inference`` an object; a missing entry or any other
-    JSON value means the user replaced or removed it wholesale and it is no
-    longer FCC's to touch.
+    ``configure_claude_desktop_config`` returns ``False`` for both an
+    idempotent no-op and a malformed-config skip; only the skip leaves
+    Claude Desktop unrouted, so reading the config back distinguishes
+    them. "Already merged" is reserved for a valid config that already
+    carries the routing block; a malformed one exits nonzero.
     """
-
-    raw = data.get(_INFERENCE_KEY)
-    if not isinstance(raw, dict):
-        return None
-    return {str(key): value for key, value in raw.items()}
-
-
-def _restore_inference_keys(
-    data: dict[str, object],
-    owned: dict[str, _OwnershipEntry],
-    written: dict[str, object],
-) -> bool:
-    """Restore or remove only FCC-managed inference keys, keeping the rest.
-
-    A key still holding exactly what configure wrote is FCC's to restore;
-    any other value is a post-merge user edit and wins over the snapshot.
-    """
-
-    current = _current_inference_object(data)
-    if current is None:
-        return False
-
-    changed = False
-    for key, entry in owned.items():
-        if current.get(key) != written.get(key):
-            continue  # user-edited since the merge; leave it alone.
-        if entry["present"]:
-            if key not in current or current[key] != entry["value"]:
-                current[key] = entry["value"]
-                changed = True
-        elif key in current:
-            del current[key]
-            changed = True
-
-    if changed:
-        data[_INFERENCE_KEY] = current
-    return changed
-
-
-def _remove_inference_keys(
-    data: dict[str, object],
-    owned: dict[str, _OwnershipEntry],
-    written: dict[str, object],
-) -> bool:
-    """Remove FCC-inserted inference keys; drop the entry when it empties.
-
-    Used when FCC created ``inference`` itself, so any fields added to it
-    after the merge survive unconfiguration. Keys whose values diverged from
-    what configure wrote are user edits and are kept.
-    """
-
-    current = _current_inference_object(data)
-    if current is None:
-        return False
-
-    changed = False
-    for key in owned:
-        if key in current and current[key] == written.get(key):
-            del current[key]
-            changed = True
 
     if not changed:
-        return False
-    if current:
-        data[_INFERENCE_KEY] = current
-    else:
-        del data[_INFERENCE_KEY]
-    return changed
+        try:
+            load_existing_config(target)
+        except MalformedConfigError as exc:
+            print(
+                f"Refusing to configure Claude Desktop: malformed config at "
+                f"{exc.path}: {exc.reason}. Fix or remove the file and retry.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from None
+    print(f"{'Updated' if changed else 'Already merged'}: {target}")
 
 
 def find_binary() -> str | None:
@@ -665,12 +436,63 @@ def ensure_configured_and_launch(
 ) -> subprocess.Popen[bytes]:
     """Merge the routing block, then spawn Claude Desktop.
 
+    The routing block carries the proxy auth token, so it is only written
+    behind a verified HTTPS front: ``verified_https_gateway_url`` returns
+    ``None`` — never the plain-HTTP fallback — when no front proves it
+    belongs to this FCC install, and the launch is refused instead of
+    pointing the credential at an unverified or cleartext listener.
+
+    The merge result is also verified before spawning: ``configure`` returns
+    ``False`` both when it skips a malformed config and when an earlier merge
+    already matches, so the block is read back and the launch refused unless
+    the routing actually landed. Launching on a skipped (malformed) config
+    would start Claude Desktop without FCC routing.
+
     Raises:
+        RuntimeError: If no verified HTTPS front answers, or the routing
+            block did not land in the config.
         FileNotFoundError: If no Claude Desktop binary can be located.
     """
 
-    configure_claude_desktop_config(settings=settings)
+    resolved = settings or get_settings()
+    gateway_url = verified_https_gateway_url(resolved)
+    if gateway_url is None:
+        raise RuntimeError(
+            "Refusing to launch Claude Desktop: no verified FCC HTTPS front "
+            "is available. Start the FCC desktop host (which manages the "
+            "front) or enable the caddy TLS proxy, then retry."
+        )
+    configure_claude_desktop_config(settings=resolved, gateway_base_url=gateway_url)
+    if not _routing_block_present(gateway_url):
+        raise RuntimeError(
+            "Refusing to launch Claude Desktop: the FCC routing block could "
+            "not be written to the config (it may be malformed). Fix or "
+            "remove the config file and retry."
+        )
     return launch_binary()
+
+
+def _routing_block_present(gateway_url: str) -> bool:
+    """Whether the managed routing block actually landed in the config.
+
+    Distinguishes a successful (possibly idempotent) merge from a skipped
+    malformed config, which ``configure_claude_desktop_config`` reports with
+    the same ``False`` return.
+    """
+
+    try:
+        data = load_existing_config(_config_path())
+    except FileNotFoundError:
+        return False
+    except MalformedConfigError:
+        return False
+    inference = data.get(_INFERENCE_KEY)
+    if not isinstance(inference, dict):
+        return False
+    return (
+        data.get(_DISCOVERY_KEY) is True
+        and inference.get("inferenceGatewayBaseUrl") == gateway_url
+    )
 
 
 def _build_argparser() -> argparse.ArgumentParser:
@@ -712,8 +534,25 @@ def main(argv: Sequence[str] | None = None) -> None:
         print(f"{'Removed FCC block' if changed else 'Nothing to remove'}: {target}")
         return
 
-    changed = configure_claude_desktop_config(args.config_path)
-    print(f"{'Updated' if changed else 'Already merged'}: {target}")
+    # --configure persists the gateway credential, so it only writes
+    # against a verified HTTPS front: without one the URL would fall back
+    # to plain HTTP and persist the reusable proxy token against a
+    # cleartext endpoint. Adoption is probe-only — this command exits
+    # right after writing, so a front it spawned itself would die with it
+    # and leave the config it just wrote pointing at a dead gateway.
+    gateway_url = verified_https_gateway_url(get_settings())
+    if gateway_url is None:
+        print(
+            "Refusing to configure Claude Desktop: no verified FCC HTTPS "
+            "front is available. Enable the caddy TLS proxy (or start the "
+            "FCC desktop host, which manages it) and retry.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    changed = configure_claude_desktop_config(
+        args.config_path, gateway_base_url=gateway_url
+    )
+    report_configure_result(target, changed)
 
 
 if __name__ == "__main__":

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -347,6 +347,19 @@ def configure_claude_desktop_config(
         for key, value in inference_raw.items():
             inference_dict[str(key)] = value
 
+    # A non-object ``inference`` after a recorded merge is the user's
+    # wholesale replacement of the FCC block: they swapped the whole
+    # entry for a scalar or null. The merge still writes its managed
+    # mapping (configure's contract is to ensure the block exists), but
+    # ownership must now restore the REPLACEMENT on unconfigure — not the
+    # value from before the first merge, which would discard the user's
+    # later change.
+    replaced_wholesale = (
+        previous is not None
+        and _INFERENCE_KEY in data
+        and not isinstance(inference_raw, dict)
+    )
+
     for key, value in managed.items():
         if inference_dict.get(key) != value:
             inference_dict[key] = value
@@ -375,21 +388,35 @@ def configure_claude_desktop_config(
             # that configure itself wrote, which would otherwise overwrite
             # the original origin with ``existed=True, was_object=True`` and
             # leave unconfigure restoring into an FCC-shaped container the
-            # user never had.
+            # user never had. A wholesale user replacement is the one
+            # exception: its scalar value is the new origin, so unconfigure
+            # restores the replacement instead of the pre-FCC state.
             inference_existed=(
-                previous.inference_existed
-                if previous is not None
-                else prior.inference_existed
+                True
+                if replaced_wholesale
+                else (
+                    previous.inference_existed
+                    if previous is not None
+                    else prior.inference_existed
+                )
             ),
             inference_was_object=(
-                previous.inference_was_object
-                if previous is not None
-                else prior.inference_was_object
+                False
+                if replaced_wholesale
+                else (
+                    previous.inference_was_object
+                    if previous is not None
+                    else prior.inference_was_object
+                )
             ),
             inference_scalar=(
-                previous.inference_scalar
-                if previous is not None
-                else prior.inference_scalar
+                inference_raw
+                if replaced_wholesale
+                else (
+                    previous.inference_scalar
+                    if previous is not None
+                    else prior.inference_scalar
+                )
             ),
         )
         _save_config(record_path, _record_payload(prior))

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -304,20 +304,21 @@ def configure_claude_desktop_config(
         # The discovery flag is frozen, not absorbed: configure always
         # writes ``True``, so a current ``True`` is byte-identical to
         # configure's own write and no file state can tell "the user just
-        # re-enabled it" from "configure wrote it". Absorbing an
-        # intermediate user flip (say ``False``) as the restore target would
-        # then discard the user's FINAL re-enable on unconfigure, restoring
-        # the stale intermediate instead. So the recorded target only ever
-        # changes when there was none — the key was absent before the
-        # first merge and the user has since made an explicit choice, whose
-        # current value is by definition theirs (configure had nothing to
-        # write over it that the user kept).
+        # re-enabled it" from "configure wrote it". Recording any VALUE the
+        # user set in between (say an intermediate ``False``) would make
+        # unconfigure restore that stale intermediate and discard the
+        # user's final choice. So when the flag was absent before the
+        # first merge and the user has since made an explicit non-``True``
+        # choice, the flag is marked user-owned: unconfigure then hands
+        # the flag off verbatim (whatever its final value is) instead of
+        # restoring anything.
         if (
             "discovery" not in backup
+            and "discoveryUserOwned" not in backup
             and prior_discovery is not None
             and prior_discovery is not True
         ):
-            backup["discovery"] = prior_discovery
+            backup["discoveryUserOwned"] = True
             changed = True
     elif not isinstance(inference_raw, dict) and _INFERENCE_KEY in data:
         # A non-object ``inference`` with a snapshot already recorded is
@@ -439,7 +440,17 @@ def unconfigure_claude_desktop_config(
         # still removed below.
         block_fcc_owned = isinstance(inference_raw, dict) and inference_dict == written
 
-        discovery_fcc_owned = data.get(_DISCOVERY_KEY) is True
+        # A user-owned discovery flag (the adoption marker set when the key
+        # was absent before the first merge and the user later chose a
+        # non-``True`` value) is handed off verbatim: it is neither
+        # deleted as FCC's nor restored from any recorded value, since
+        # every value the user set in between is stale by unconfigure
+        # time and the final one is indistinguishable from configure's
+        # own always-``True`` write.
+        discovery_fcc_owned = (
+            data.get(_DISCOVERY_KEY) is True
+            and backup.get("discoveryUserOwned") is not True
+        )
         if discovery_fcc_owned:
             del data[_DISCOVERY_KEY]
             changed = True

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -375,7 +375,13 @@ def unconfigure_claude_desktop_config(
     wrote, so those are deleted and the snapshot's prior presence and values
     are restored, while values the user changed after configure are kept as
     they are (restoring the stale snapshot entry would overwrite the user's
-    post-install choice). A non-object ``inference`` value recorded verbatim
+    post-install choice). The discovery flag additionally hands off verbatim
+    when its current ``True`` cannot be attributed to configure's own always-
+    ``True`` write: a recorded non-``True`` original means the current value
+    is either configure's untouched write or the user's explicit re-enable,
+    and no file state can tell them apart — preserving the final value is
+    the only choice that never destroys an explicit user decision. A
+    non-object ``inference`` value recorded verbatim
     by the snapshot is restored exactly, but only while the inference block
     still exactly matches what the merge wrote — a retained auth token alone
     does not prove whole-block ownership, since a user can keep the token
@@ -467,16 +473,25 @@ def unconfigure_claude_desktop_config(
         # still removed below.
         block_fcc_owned = isinstance(inference_raw, dict) and inference_dict == written
 
-        # A user-owned discovery flag (the adoption marker set when the key
-        # was absent before the first merge and the user later chose a
-        # non-``True`` value) is handed off verbatim: it is neither
-        # deleted as FCC's nor restored from any recorded value, since
-        # every value the user set in between is stale by unconfigure
-        # time and the final one is indistinguishable from configure's
-        # own always-``True`` write.
+        # A discovery flag is FCC's only while a current ``True`` is
+        # attributable to configure's own always-``True`` write. Two states
+        # break that attribution and hand the flag off verbatim instead —
+        # neither deleted as FCC's nor restored from any recorded value,
+        # since destroying an explicit user choice is the worse failure:
+        # (1) the adoption marker (the key was absent before the first
+        # merge and the user later chose a non-``True`` value); (2) a
+        # recorded non-``True`` original with a current ``True`` — the
+        # current value may be configure's untouched write (restoring the
+        # original would be correct) or the user's explicit re-enable (the
+        # original is stale), and no file state can tell them apart. The
+        # re-enable case is the reason the handoff wins: a user who
+        # deliberately turned discovery back on must not have that choice
+        # silently reverted.
+        recorded_discovery = backup.get("discovery")
         discovery_fcc_owned = (
             data.get(_DISCOVERY_KEY) is True
             and backup.get("discoveryUserOwned") is not True
+            and not ("discovery" in backup and recorded_discovery is not True)
         )
         if discovery_fcc_owned:
             del data[_DISCOVERY_KEY]
@@ -523,7 +538,9 @@ def unconfigure_claude_desktop_config(
             changed = True
         # Restore the original discovery value only when the flag was still
         # FCC's (the user did not change it after configure) and the key was
-        # present before the first merge; leave it deleted when it was absent.
+        # present before the first merge; leave it deleted when it was
+        # absent, and hand it off untouched when ownership could not be
+        # established (see the gate above).
         if discovery_fcc_owned and "discovery" in backup:
             data[_DISCOVERY_KEY] = backup["discovery"]
             changed = True

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -370,6 +370,27 @@ def configure_claude_desktop_config(
                 if previous is not None
                 else prior.inference_keys
             ),
+            # The container provenance (absent / object / scalar origin) is a
+            # fact about the FIRST merge: this merge sees an ``inference``
+            # that configure itself wrote, which would otherwise overwrite
+            # the original origin with ``existed=True, was_object=True`` and
+            # leave unconfigure restoring into an FCC-shaped container the
+            # user never had.
+            inference_existed=(
+                previous.inference_existed
+                if previous is not None
+                else prior.inference_existed
+            ),
+            inference_was_object=(
+                previous.inference_was_object
+                if previous is not None
+                else prior.inference_was_object
+            ),
+            inference_scalar=(
+                previous.inference_scalar
+                if previous is not None
+                else prior.inference_scalar
+            ),
         )
         _save_config(record_path, _record_payload(prior))
         _save_config(config_path, data)

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -243,10 +243,10 @@ def configure_claude_desktop_config(
         # ensure the block exists — but the snapshot must now restore the
         # REPLACEMENT on unconfigure; keeping the first-merge value would
         # silently discard the user's later change.
-        backup = data[_BACKUP_KEY]
-        if isinstance(backup, dict):
-            backup.pop("inference", None)
-            backup["inferenceRaw"] = inference_raw
+        existing_backup = data.get(_BACKUP_KEY)
+        if isinstance(existing_backup, dict):
+            existing_backup.pop("inference", None)
+            existing_backup["inferenceRaw"] = inference_raw
             changed = True
 
     for key, value in managed.items():

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -1,0 +1,655 @@
+"""Claude Desktop routing support shared by the FCC desktop shell.
+
+Two responsibilities:
+
+1. Merge the Free Claude Code 3P-gateway routing block into the user's
+   ``claude_desktop_config.json`` so Claude Desktop's model picker runs
+   ``/v1/models`` discovery against the local FCC server. The gateway URL
+   and auth key are derived from server settings, never hardcoded.
+   ``unconfigure`` reverses the merge by restoring exactly what configure
+   inserted or overwrote, tracked in an ownership record beside the config.
+2. Locate the Claude Desktop binary and spawn it. TLS trust for the local
+   FCC front comes from the certificate the install scripts add to the
+   per-user NSS store; no process-wide certificate bypass is used.
+
+The desktop controller applies the merge automatically at startup, and the
+tray exposes a "Launch Claude Desktop" item built on the same helpers.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import TypedDict
+
+from loguru import logger
+
+from free_claude_code.cli.tls_proxy import desktop_gateway_base_url
+from free_claude_code.config.loader import get_settings
+from free_claude_code.config.settings import Settings
+
+
+class MalformedConfigError(ValueError):
+    """Raised when the config file exists but cannot be parsed as a JSON object."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Claude Desktop config at {path} is malformed: {reason}")
+
+
+CLAUDE_DESKTOP_BINARY = "claude-desktop"
+CONFIG_FILENAME = "claude_desktop_config.json"
+
+# Top-level key flipping Claude Desktop out of first-party Anthropic mode.
+_DISCOVERY_KEY = "modelDiscoveryEnabled"
+_INFERENCE_KEY = "inference"
+
+# Per-platform candidate locations beyond PATH. First existing hit wins.
+_BINARY_CANDIDATES: dict[str, tuple[str, ...]] = {
+    "darwin": ("/Applications/Claude.app/Contents/MacOS/Claude",),
+    "win32": (),
+}
+
+
+def _config_path() -> Path:
+    """Return the platform-specific Claude Desktop config path."""
+
+    if sys.platform.startswith("win"):
+        appdata = sys.modules["os"].environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Claude" / CONFIG_FILENAME
+        return Path.home() / "AppData" / "Roaming" / "Claude" / CONFIG_FILENAME
+    if sys.platform == "darwin":
+        return (
+            Path.home() / "Library" / "Application Support" / "Claude" / CONFIG_FILENAME
+        )
+    return Path.home() / ".config" / "Claude" / CONFIG_FILENAME
+
+
+def fcc_managed_block(
+    settings: Settings,
+    gateway_base_url: str | None = None,
+) -> dict[str, object]:
+    """Inference keys FCC owns in Claude Desktop's config, from live settings.
+
+    ``gateway_base_url`` overrides the resolved URL (desktop-scoped: HTTPS
+    root when a TLS front answers plus the desktop path prefix).
+    """
+
+    return {
+        "provider": "gateway",
+        "credentialKind": "static",
+        "inferenceProvider": "gateway",
+        "inferenceCredentialKind": "static",
+        "inferenceGatewayBaseUrl": gateway_base_url
+        or desktop_gateway_base_url(settings),
+        "inferenceGatewayAuthScheme": "x-api-key",
+        "inferenceAnthropicApiKey": settings.proxy_auth_token,
+    }
+
+
+def load_existing_config(path: Path) -> dict[str, object]:
+    """Read an existing JSON config as a dict.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist.
+        MalformedConfigError: If the file exists but is not valid JSON or is not a JSON object.
+    """
+
+    if not path.exists():
+        raise FileNotFoundError(f"Claude Desktop config not found: {path}")
+
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MalformedConfigError(path, f"invalid JSON: {exc}") from exc
+
+    if not isinstance(loaded, dict):
+        raise MalformedConfigError(path, "root element is not a JSON object")
+
+    return loaded
+
+
+def _save_config(path: Path, data: dict[str, object]) -> None:
+    """Atomically write the merged config; create parent directories as needed.
+
+    The block embeds the gateway auth token, so the file is written with
+    owner-only permissions regardless of the process umask.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    descriptor = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, indent=2))
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    tmp_path.replace(path)
+
+
+class _OwnershipEntry(TypedDict):
+    """Pre-merge state of one managed config key."""
+
+    present: bool
+    value: object
+
+
+@dataclass(frozen=True, slots=True)
+class _OwnershipRecord:
+    """What ``configure`` inserted or overwrote, for exact restoration.
+
+    The managed inference keys are always tracked individually so values
+    added to ``inference`` after a merge survive unconfiguration.
+    ``inference_written`` snapshots the mapping configure produced; a key
+    whose current value still equals its written value is FCC's to restore,
+    while anything the user changed since the merge is left alone. When the
+    pre-merge ``inference`` entry was not an object, configure replaced it
+    wholesale and ``inference_scalar`` snapshots what it clobbered.
+    """
+
+    discovery: _OwnershipEntry
+    inference_existed: bool
+    inference_was_object: bool
+    inference_scalar: object | None
+    inference_keys: dict[str, _OwnershipEntry]
+    inference_written: dict[str, object] = field(default_factory=dict)
+
+
+_RECORD_SUFFIX = ".fcc-merge.json"
+_RECORD_INFERENCE_KEYS = "inferenceKeys"
+_RECORD_INFERENCE_EXISTED = "inferenceExisted"
+_RECORD_INFERENCE_WAS_OBJECT = "inferenceWasObject"
+_RECORD_INFERENCE_SCALAR = "inferenceScalar"
+_RECORD_INFERENCE_WRITTEN = "inferenceWritten"
+
+
+def _record_payload(record: _OwnershipRecord) -> dict[str, object]:
+    """JSON-able sidecar representation of ``record``."""
+
+    return {
+        _DISCOVERY_KEY: record.discovery,
+        _RECORD_INFERENCE_EXISTED: record.inference_existed,
+        _RECORD_INFERENCE_WAS_OBJECT: record.inference_was_object,
+        _RECORD_INFERENCE_KEYS: record.inference_keys,
+        _RECORD_INFERENCE_WRITTEN: record.inference_written,
+        **(
+            {_RECORD_INFERENCE_SCALAR: record.inference_scalar}
+            if record.inference_existed and not record.inference_was_object
+            else {}
+        ),
+    }
+
+
+def _record_path(config_path: Path) -> Path:
+    """Sidecar recording what configure inserted or overwrote."""
+
+    return config_path.with_name(config_path.name + _RECORD_SUFFIX)
+
+
+def _snapshot_entry(mapping: Mapping[str, object], key: str) -> _OwnershipEntry:
+    """Capture the pre-merge state of one key inside ``mapping``."""
+
+    if key in mapping:
+        return {"present": True, "value": mapping[key]}
+    return {"present": False, "value": None}
+
+
+def _ownership_record(
+    data: dict[str, object],
+    managed_keys: Sequence[str],
+) -> _OwnershipRecord:
+    """Snapshot every managed key so unconfigure can restore exactly it."""
+
+    discovery = _snapshot_entry(data, _DISCOVERY_KEY)
+    existed = _INFERENCE_KEY in data
+    raw = data.get(_INFERENCE_KEY)
+    keys = {
+        key: _snapshot_entry(raw if isinstance(raw, dict) else {}, key)
+        for key in managed_keys
+    }
+    if isinstance(raw, dict):
+        return _OwnershipRecord(
+            discovery=discovery,
+            inference_existed=True,
+            inference_was_object=True,
+            inference_scalar=None,
+            inference_keys=keys,
+        )
+    return _OwnershipRecord(
+        discovery=discovery,
+        inference_existed=existed,
+        inference_was_object=False,
+        inference_scalar=raw if existed else None,
+        inference_keys=keys,
+    )
+
+
+def _parse_entry(raw: object) -> _OwnershipEntry | None:
+    """Parse one ownership snapshot; ``None`` when malformed."""
+
+    if not isinstance(raw, dict):
+        return None
+    present = raw.get("present")
+    if not isinstance(present, bool) or (present and "value" not in raw):
+        return None
+    return {"present": present, "value": raw.get("value")}
+
+
+def _load_ownership_record(path: Path) -> _OwnershipRecord | None:
+    """Read the ownership sidecar; ``None`` when missing or malformed."""
+
+    if not path.exists():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(loaded, dict):
+        return None
+
+    discovery = _parse_entry(loaded.get(_DISCOVERY_KEY))
+    if discovery is None:
+        return None
+
+    existed = loaded.get(_RECORD_INFERENCE_EXISTED)
+    was_object = loaded.get(_RECORD_INFERENCE_WAS_OBJECT)
+    if not isinstance(existed, bool) or not isinstance(was_object, bool):
+        return None
+
+    keys_raw = loaded.get(_RECORD_INFERENCE_KEYS)
+    if not isinstance(keys_raw, dict):
+        return None
+    inference_keys: dict[str, _OwnershipEntry] = {}
+    for key, raw in keys_raw.items():
+        parsed = _parse_entry(raw)
+        if not isinstance(key, str) or parsed is None:
+            return None
+        inference_keys[key] = parsed
+
+    written = loaded.get(_RECORD_INFERENCE_WRITTEN)
+    if not isinstance(written, dict):
+        return None
+    normalized_written: dict[str, object] = {
+        str(key): value for key, value in written.items()
+    }
+
+    scalar: object | None = None
+    if existed and not was_object:
+        if _RECORD_INFERENCE_SCALAR not in loaded:
+            return None
+        scalar = loaded[_RECORD_INFERENCE_SCALAR]
+
+    return _OwnershipRecord(
+        discovery=discovery,
+        inference_existed=existed,
+        inference_was_object=was_object,
+        inference_scalar=scalar,
+        inference_keys=inference_keys,
+        inference_written=normalized_written,
+    )
+
+
+def configure_claude_desktop_config(
+    path: Path | None = None,
+    settings: Settings | None = None,
+    gateway_base_url: str | None = None,
+) -> bool:
+    """Merge the FCC routing block into ``path``. Returns whether anything changed.
+
+    Records the pre-merge values of the managed keys in a sidecar so a later
+    ``unconfigure`` restores exactly them. Returns ``False`` without writing
+    when the existing config is malformed (invalid JSON or non-object root).
+    Creates a new config when absent.
+    """
+
+    resolved_settings = settings or get_settings()
+    managed = fcc_managed_block(resolved_settings, gateway_base_url)
+    config_path = path or _config_path()
+    try:
+        data: dict[str, object] = load_existing_config(config_path)
+        existed = True
+    except FileNotFoundError:
+        data = {}
+        existed = False
+    except MalformedConfigError as exc:
+        logger.warning(
+            "Skipping FCC config merge: malformed config at {}: {}",
+            exc.path,
+            exc.reason,
+        )
+        return False
+
+    prior = _ownership_record(data, tuple(managed))
+    record_path = _record_path(config_path)
+    previous = (
+        _load_ownership_record(record_path)
+        if existed and record_path.exists()
+        else None
+    )
+
+    changed = False
+
+    if data.get(_DISCOVERY_KEY) is not True:
+        data[_DISCOVERY_KEY] = True
+        changed = True
+
+    inference_raw = data.get(_INFERENCE_KEY)
+    inference_dict: dict[str, object] = {}
+    if isinstance(inference_raw, dict):
+        for key, value in inference_raw.items():
+            inference_dict[str(key)] = value
+
+    for key, value in managed.items():
+        if inference_dict.get(key) != value:
+            inference_dict[key] = value
+            changed = True
+
+    if data.get(_INFERENCE_KEY) != inference_dict:
+        data[_INFERENCE_KEY] = inference_dict
+        changed = True
+
+    if changed:
+        prior = replace(
+            prior,
+            discovery=(
+                previous.discovery
+                if previous is not None and data.get(_DISCOVERY_KEY) is True
+                else prior.discovery
+            ),
+            inference_written=inference_dict,
+            inference_keys=(
+                _absorb_user_edits(previous, tuple(managed), inference_raw)
+                if previous is not None
+                else prior.inference_keys
+            ),
+        )
+        _save_config(record_path, _record_payload(prior))
+        _save_config(config_path, data)
+    return changed
+
+
+def _absorb_user_edits(
+    previous: _OwnershipRecord,
+    managed_keys: Sequence[str],
+    current_raw: object,
+) -> dict[str, _OwnershipEntry]:
+    """Re-target restore values at keys the user edited between merges.
+
+    Starts from the recorded restore targets and updates a key only when its
+    live value differs from both what the last merge wrote and what the
+    record would restore — that combination means a post-merge user edit,
+    and reverting it on unconfigure would discard the user's change. Keys
+    still at their written values keep their original restore targets.
+    """
+
+    current = current_raw if isinstance(current_raw, dict) else {}
+    absorbed = dict(previous.inference_keys)
+    for key in managed_keys:
+        written_value = previous.inference_written.get(key)
+        current_value = current.get(key)
+        if current_value == written_value:
+            continue  # Still FCC's value; nothing user-owned to absorb.
+        restores_absent = key not in absorbed or not absorbed[key]["present"]
+        if restores_absent and key not in current:
+            continue  # Record already removes this key.
+        if (
+            not restores_absent
+            and key in current
+            and absorbed[key]["value"] == current_value
+        ):
+            continue  # Record already restores exactly this user value.
+        absorbed[key] = {
+            "present": key in current,
+            "value": current_value,
+        }
+    return absorbed
+
+
+def unconfigure_claude_desktop_config(path: Path | None = None) -> bool:
+    """Reverse the merge recorded by ``configure`` for ``path``.
+
+    Only the managed surface FCC actually touched is restored: values that
+    existed before configure come back verbatim from the ownership record,
+    keys FCC inserted are removed, and every other key is preserved. With no
+    valid record nothing is owned by FCC, so the config is left untouched
+    and ``False`` is returned. Also returns ``False`` without writing when
+    the existing config or record is malformed, or silently when the file
+    does not exist.
+    """
+
+    config_path = path or _config_path()
+    if not config_path.exists():
+        return False
+    try:
+        data: dict[str, object] = load_existing_config(config_path)
+    except MalformedConfigError as exc:
+        logger.warning(
+            "Skipping FCC config unmerge: malformed config at {}: {}",
+            exc.path,
+            exc.reason,
+        )
+        return False
+
+    record_path = _record_path(config_path)
+    record = _load_ownership_record(record_path)
+    if record is None:
+        logger.warning(
+            "Skipping FCC config unmerge: no FCC ownership record at {}",
+            record_path,
+        )
+        return False
+
+    changed = False
+
+    # Configure always writes ``True`` here. A current value of ``True`` is
+    # still FCC's to manage; anything else means the user edited it after the
+    # merge and their choice wins.
+    discovery = record.discovery
+    if discovery["present"]:
+        if (
+            data.get(_DISCOVERY_KEY) is True
+            and data[_DISCOVERY_KEY] != (discovery["value"])
+        ):
+            data[_DISCOVERY_KEY] = discovery["value"]
+            changed = True
+    elif data.get(_DISCOVERY_KEY) is True:
+        del data[_DISCOVERY_KEY]
+        changed = True
+
+    written = record.inference_written
+    if not record.inference_existed:
+        changed = (
+            _remove_inference_keys(data, record.inference_keys, written) or changed
+        )
+    elif record.inference_was_object:
+        changed = (
+            _restore_inference_keys(data, record.inference_keys, written) or changed
+        )
+    elif data.get(_INFERENCE_KEY) == written:
+        # Configure clobbered a non-object entry and the entry is still
+        # exactly what configure wrote; restore what it replaced.
+        data[_INFERENCE_KEY] = record.inference_scalar
+        changed = True
+    # Any other current value is a post-merge user replacement or removal;
+    # it is no longer FCC's to touch, so it stays as-is.
+
+    if changed:
+        _save_config(config_path, data)
+        record_path.unlink()
+    return changed
+
+
+def _current_inference_object(
+    data: dict[str, object],
+) -> dict[str, object] | None:
+    """The live ``inference`` mapping FCC wrote, or ``None`` once user-owned.
+
+    Configure leaves ``inference`` an object; a missing entry or any other
+    JSON value means the user replaced or removed it wholesale and it is no
+    longer FCC's to touch.
+    """
+
+    raw = data.get(_INFERENCE_KEY)
+    if not isinstance(raw, dict):
+        return None
+    return {str(key): value for key, value in raw.items()}
+
+
+def _restore_inference_keys(
+    data: dict[str, object],
+    owned: dict[str, _OwnershipEntry],
+    written: dict[str, object],
+) -> bool:
+    """Restore or remove only FCC-managed inference keys, keeping the rest.
+
+    A key still holding exactly what configure wrote is FCC's to restore;
+    any other value is a post-merge user edit and wins over the snapshot.
+    """
+
+    current = _current_inference_object(data)
+    if current is None:
+        return False
+
+    changed = False
+    for key, entry in owned.items():
+        if current.get(key) != written.get(key):
+            continue  # user-edited since the merge; leave it alone.
+        if entry["present"]:
+            if key not in current or current[key] != entry["value"]:
+                current[key] = entry["value"]
+                changed = True
+        elif key in current:
+            del current[key]
+            changed = True
+
+    if changed:
+        data[_INFERENCE_KEY] = current
+    return changed
+
+
+def _remove_inference_keys(
+    data: dict[str, object],
+    owned: dict[str, _OwnershipEntry],
+    written: dict[str, object],
+) -> bool:
+    """Remove FCC-inserted inference keys; drop the entry when it empties.
+
+    Used when FCC created ``inference`` itself, so any fields added to it
+    after the merge survive unconfiguration. Keys whose values diverged from
+    what configure wrote are user edits and are kept.
+    """
+
+    current = _current_inference_object(data)
+    if current is None:
+        return False
+
+    changed = False
+    for key in owned:
+        if key in current and current[key] == written.get(key):
+            del current[key]
+            changed = True
+
+    if not changed:
+        return False
+    if current:
+        data[_INFERENCE_KEY] = current
+    else:
+        del data[_INFERENCE_KEY]
+    return changed
+
+
+def find_binary() -> str | None:
+    """Locate the Claude Desktop binary via PATH, then platform defaults."""
+
+    which_hit = shutil.which(CLAUDE_DESKTOP_BINARY)
+    if which_hit is not None:
+        return which_hit
+    for candidate in _BINARY_CANDIDATES.get(sys.platform, ()):
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def launch_binary(
+    extra_args: Sequence[str] = (),
+) -> subprocess.Popen[bytes]:
+    """Spawn Claude Desktop.
+
+    TLS trust for the local FCC front is provided by the certificate the
+    install scripts add to the per-user NSS store, so no process-wide
+    certificate bypass flag is passed.
+    """
+
+    binary_path = find_binary()
+    if binary_path is None:
+        raise FileNotFoundError(CLAUDE_DESKTOP_BINARY)
+    command: list[str] = [binary_path, *extra_args]
+    return subprocess.Popen(command)
+
+
+def ensure_configured_and_launch(
+    settings: Settings | None = None,
+) -> subprocess.Popen[bytes]:
+    """Merge the routing block, then spawn Claude Desktop.
+
+    Raises:
+        FileNotFoundError: If no Claude Desktop binary can be located.
+    """
+
+    configure_claude_desktop_config(settings=settings)
+    return launch_binary()
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m free_claude_code.cli.claude_desktop",
+        description=(
+            "Merge or reverse the Free Claude Code routing block in "
+            "claude_desktop_config.json."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--configure",
+        action="store_true",
+        help="Merge the FCC 3P-gateway block into Claude Desktop's config.",
+    )
+    mode.add_argument(
+        "--unconfigure",
+        action="store_true",
+        help="Reverse the merge applied by --configure.",
+    )
+    parser.add_argument(
+        "--config-path",
+        type=Path,
+        default=None,
+        help="Override the Claude Desktop config path (primarily for tests).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """CLI entry point for explicit configure/unconfigure runs."""
+
+    args = _build_argparser().parse_args(list(sys.argv[1:] if argv is None else argv))
+    target = args.config_path or _config_path()
+
+    if args.unconfigure:
+        changed = unconfigure_claude_desktop_config(args.config_path)
+        print(f"{'Removed FCC block' if changed else 'Nothing to remove'}: {target}")
+        return
+
+    changed = configure_claude_desktop_config(args.config_path)
+    print(f"{'Updated' if changed else 'Already merged'}: {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -467,16 +467,22 @@ def unconfigure_claude_desktop_config(
         # still removed below.
         block_fcc_owned = isinstance(inference_raw, dict) and inference_dict == written
 
-        # A user-owned discovery flag (the adoption marker set when the key
-        # was absent before the first merge and the user later chose a
-        # non-``True`` value) is handed off verbatim: it is neither
-        # deleted as FCC's nor restored from any recorded value, since
-        # every value the user set in between is stale by unconfigure
-        # time and the final one is indistinguishable from configure's
-        # own always-``True`` write.
+        # A discovery flag is FCC's only while a current ``True`` is
+        # attributable to configure's own always-``True`` write. Two states
+        # break that attribution and hand the flag off verbatim instead —
+        # neither deleted as FCC's nor restored from any recorded value,
+        # since destroying an explicit user choice is the worse failure:
+        # (1) the adoption marker (the key was absent before the first
+        # merge and the user later chose a non-``True`` value); (2) a
+        # recorded non-``True`` original with a current ``True`` — the
+        # current value may be configure's untouched write (restore the
+        # original) or the user's explicit re-enable (the original is
+        # stale), and no file state can tell them apart.
+        recorded_discovery = backup.get("discovery")
         discovery_fcc_owned = (
             data.get(_DISCOVERY_KEY) is True
             and backup.get("discoveryUserOwned") is not True
+            and not ("discovery" in backup and recorded_discovery is not True)
         )
         if discovery_fcc_owned:
             del data[_DISCOVERY_KEY]

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -280,12 +280,26 @@ def configure_claude_desktop_config(
         prior_inference = prior_inference if isinstance(prior_inference, dict) else {}
         absorbed = dict(prior_inference)
         for key in managed:
-            current_value = inference_dict.get(key)
+            if key not in inference_dict:
+                # Absent from the user's block: leave the recorded target
+                # alone — restoring a target over an absent key would invent
+                # a literal ``null`` placeholder in the restored mapping.
+                continue
+            current_value = inference_dict[key]
             if current_value == last_written.get(key):
                 continue  # Still FCC's written value; target unchanged.
             absorbed[key] = current_value
         if absorbed != prior_inference:
             backup["inference"] = absorbed
+            changed = True
+        if "inferenceRaw" in backup:
+            # The first merge recorded a non-object original verbatim, but
+            # the block is a mapping NOW: the user replaced the scalar with
+            # their own dict, so the verbatim restore target is stale —
+            # dropping it leaves the per-key targets (absorbed above) as the
+            # only restore path and unconfigure can no longer clobber the
+            # user's dict with the long-gone scalar.
+            del backup["inferenceRaw"]
             changed = True
         # The discovery flag is frozen, not absorbed: configure always
         # writes ``True``, so a current ``True`` is byte-identical to

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -175,7 +175,10 @@ def configure_claude_desktop_config(
     snapshotted under ``fccPriorConfig``; ``unconfigure`` restores that
     snapshot so temporarily enabling FCC never destroys the user's previous
     provider, gateway, credential, or discovery settings. Re-merges keep the
-    original snapshot untouched.
+    original user-state entries untouched, but absorb the user's post-merge
+    edits as the new restore targets and refresh the snapshot's record of
+    the exact block FCC writes so ownership stays correct when the proxy
+    token or gateway URL rotated between configures.
 
     Returns ``False`` without writing when the existing config is malformed
     (invalid JSON or non-object root). Creates a new config when absent.
@@ -215,8 +218,26 @@ def configure_claude_desktop_config(
         for key, value in inference_raw.items():
             inference_dict[str(key)] = value
 
+    backup_raw = data.get(_BACKUP_KEY)
+    backup: dict[str, object] = {}
+    if isinstance(backup_raw, dict):
+        backup = backup_raw
+    # Capture the block the PREVIOUS merge wrote before the record is
+    # refreshed below: re-merge absorption must compare the file's current
+    # values against what the last merge actually wrote, and the refresh is
+    # about to replace that with this merge's block.
+    previous_written_raw = backup.get("managed")
+    # Record the exact block this merge writes. Unconfigure compares the
+    # current values against THIS (not a live re-resolution) to decide what
+    # is still FCC's, so removal stays correct even when the HTTPS front is
+    # gone and live URL resolution falls back to plain HTTP. Refresh it on
+    # every merge: when the proxy token or gateway URL rotated since the
+    # first configure, ownership must be decided against the newest written
+    # block, not the stale first one.
+    if backup.get("managed") != managed:
+        backup["managed"] = dict(managed)
+        changed = True
     if _BACKUP_KEY not in data:
-        backup: dict[str, object] = {}
         # Omit the discovery entry when the key was absent so the restore
         # can tell "was present with this value" from "was not present".
         if had_discovery:
@@ -235,6 +256,49 @@ def configure_claude_desktop_config(
                 backup["inferenceRaw"] = inference_raw
         data[_BACKUP_KEY] = backup
         changed = True
+    elif isinstance(inference_raw, dict):
+        # Re-merge onto an object ``inference``: a managed key whose
+        # current value differs from what the LAST merge wrote is the
+        # user's post-merge edit, and the merge is about to overwrite
+        # it — so it must become the snapshot's restore target, or
+        # unconfigure would restore the stale first-merge value and
+        # silently discard the edit. A key still at its written value
+        # keeps its original target; a key the user already moved to a
+        # new value on an earlier re-merge (target already equals the
+        # current value) also stays. Compare against the block the
+        # previous merge wrote, NOT this merge's fresh resolution — a
+        # rotated proxy token or gateway URL must not read as a user
+        # edit of the old block.
+        last_written = (
+            previous_written_raw if isinstance(previous_written_raw, dict) else {}
+        )
+        prior_inference = backup.get("inference")
+        prior_inference = prior_inference if isinstance(prior_inference, dict) else {}
+        absorbed = dict(prior_inference)
+        for key in managed:
+            current_value = inference_dict.get(key)
+            if current_value == last_written.get(key):
+                continue  # Still FCC's written value; target unchanged.
+            absorbed[key] = current_value
+        if absorbed != prior_inference:
+            backup["inference"] = absorbed
+            changed = True
+        # The discovery flag mirrors that rule: configure always writes
+        # ``True``, so a current value that is neither ``True`` nor the
+        # recorded target is the user's post-merge flip, and it becomes
+        # restore target before this merge overwrites it — even when the
+        # key was ABSENT before the first merge (the original state was
+        # "absent", the user's chosen state is now ``False``). A current
+        # ``True`` is indistinguishable from configure's own write, so the
+        # recorded target stands.
+        recorded_discovery = backup.get("discovery")
+        if (
+            prior_discovery is not True
+            and prior_discovery is not None
+            and prior_discovery != recorded_discovery
+        ):
+            backup["discovery"] = prior_discovery
+            changed = True
     elif not isinstance(inference_raw, dict) and _INFERENCE_KEY in data:
         # A non-object ``inference`` with a snapshot already recorded is
         # the user's wholesale replacement of the FCC block (a scalar or
@@ -271,12 +335,18 @@ def unconfigure_claude_desktop_config(
     """Reverse the merge. Preserves every key outside the FCC-managed surface.
 
     When the first merge recorded a ``fccPriorConfig`` snapshot, removal is
-    lossless: every managed key is deleted, then the snapshot's prior
-    presence and values are restored, and only keys FCC originally added
-    stay gone. A non-object ``inference`` value recorded verbatim by the
-    snapshot is restored exactly. Without a snapshot (a config written
-    before backups existed or by hand) ownership is decided by the
-    recorded auth token: it is settings-derived and stable across front
+    lossless for everything FCC still owns: a managed key or the discovery
+    flag is FCC's only while its current value still matches what the merge
+    wrote, so those are deleted and the snapshot's prior presence and values
+    are restored, while values the user changed after configure are kept as
+    they are (restoring the stale snapshot entry would overwrite the user's
+    post-install choice). A non-object ``inference`` value recorded verbatim
+    by the snapshot is restored exactly, but only while the inference block
+    still exactly matches what the merge wrote — a retained auth token alone
+    does not prove whole-block ownership, since a user can keep the token
+    while replacing other routing fields. Without a snapshot (a
+    config written before backups existed or by hand) ownership is decided by
+    the recorded auth token: it is settings-derived and stable across front
     state, so when it matches the FCC token the whole block is FCC's and
     every managed key is removed — even a gateway URL that no longer
     matches current resolution because the HTTPS front is gone and
@@ -313,6 +383,8 @@ def unconfigure_claude_desktop_config(
         backup = backup_raw
 
     changed = False
+    discovery_fcc_owned = False
+    block_fcc_owned = False
 
     inference_raw = data.get(_INFERENCE_KEY)
     inference_dict: dict[str, object] = {}
@@ -321,21 +393,44 @@ def unconfigure_claude_desktop_config(
             inference_dict[str(key)] = value
 
     if backup is not None:
-        # Snapshot path: the merge recorded what FCC replaced, so the
-        # discovery flag and every managed key are FCC's — remove them
-        # all, then restore the snapshot below.
-        if _DISCOVERY_KEY in data:
+        # Snapshot path: a managed field is FCC's only while its current
+        # value still matches what the merge wrote. A user who changed a
+        # managed key or the discovery flag after configure owns it again,
+        # so preserve the current value and skip the stale snapshot entry —
+        # restoring it would overwrite the user's post-install choice.
+        # Compare against the newest block configure persisted (refreshed
+        # on every merge, not a live re-resolution), so removal stays
+        # correct both when the proxy token or gateway URL rotated between
+        # configures and when the HTTPS front is gone and live URL
+        # resolution falls back to plain HTTP.
+        written_raw = backup.get("managed")
+        written = written_raw if isinstance(written_raw, dict) else managed
+        prior_raw = backup.get("inference")
+        prior = prior_raw if isinstance(prior_raw, dict) else {}
+        # The verbatim ``inferenceRaw`` restore below replaces the whole
+        # block; it is only safe while the block is still EXACTLY what the
+        # merge wrote. A retained auth token alone does not prove that: a
+        # user can legitimately keep the FCC token while replacing the
+        # provider, gateway URL, or any other routing field, and restoring
+        # the stale raw value over such an edited dict would destroy the
+        # user's routing. Require every written field to match and no extra
+        # keys — an added or changed key means the user edited the block,
+        # so it is theirs now and only individually matching fields are
+        # still removed below.
+        block_fcc_owned = isinstance(inference_raw, dict) and inference_dict == written
+
+        discovery_fcc_owned = data.get(_DISCOVERY_KEY) is True
+        if discovery_fcc_owned:
             del data[_DISCOVERY_KEY]
             changed = True
-        for key in managed:
-            if key in inference_dict:
+
+        for key, value in written.items():
+            if key in inference_dict and inference_dict[key] == value:
                 del inference_dict[key]
                 changed = True
-        prior_raw = backup.get("inference")
-        if isinstance(prior_raw, dict):
-            for key, value in prior_raw.items():
-                inference_dict[str(key)] = value
-                changed = True
+                if key in prior:
+                    inference_dict[str(key)] = prior[key]
+                    changed = True
     else:
         # Legacy path (no snapshot): ownership is decided by the recorded
         # auth token. The discovery flag is removed only once FCC
@@ -362,13 +457,16 @@ def unconfigure_claude_desktop_config(
             changed = True
 
     if backup is not None:
-        if "inferenceRaw" in backup:
-            # The original value was not a JSON object; restore it verbatim.
+        if block_fcc_owned and "inferenceRaw" in backup:
+            # The original value was not a JSON object; restore it verbatim,
+            # but only while the block is still FCC's — a user who replaced
+            # the whole block after configure owns it and must be preserved.
             data[_INFERENCE_KEY] = backup["inferenceRaw"]
             changed = True
-        # Restore the original discovery value when the key was present
-        # before the first merge; leave it deleted when it was absent.
-        if "discovery" in backup:
+        # Restore the original discovery value only when the flag was still
+        # FCC's (the user did not change it after configure) and the key was
+        # present before the first merge; leave it deleted when it was absent.
+        if discovery_fcc_owned and "discovery" in backup:
             data[_DISCOVERY_KEY] = backup["discovery"]
             changed = True
         del data[_BACKUP_KEY]

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -467,22 +467,16 @@ def unconfigure_claude_desktop_config(
         # still removed below.
         block_fcc_owned = isinstance(inference_raw, dict) and inference_dict == written
 
-        # A discovery flag is FCC's only while a current ``True`` is
-        # attributable to configure's own always-``True`` write. Two states
-        # break that attribution and hand the flag off verbatim instead —
-        # neither deleted as FCC's nor restored from any recorded value,
-        # since destroying an explicit user choice is the worse failure:
-        # (1) the adoption marker (the key was absent before the first
-        # merge and the user later chose a non-``True`` value); (2) a
-        # recorded non-``True`` original with a current ``True`` — the
-        # current value may be configure's untouched write (restore the
-        # original) or the user's explicit re-enable (the original is
-        # stale), and no file state can tell them apart.
-        recorded_discovery = backup.get("discovery")
+        # A user-owned discovery flag (the adoption marker set when the key
+        # was absent before the first merge and the user later chose a
+        # non-``True`` value) is handed off verbatim: it is neither
+        # deleted as FCC's nor restored from any recorded value, since
+        # every value the user set in between is stale by unconfigure
+        # time and the final one is indistinguishable from configure's
+        # own always-``True`` write.
         discovery_fcc_owned = (
             data.get(_DISCOVERY_KEY) is True
             and backup.get("discoveryUserOwned") is not True
-            and not ("discovery" in backup and recorded_discovery is not True)
         )
         if discovery_fcc_owned:
             del data[_DISCOVERY_KEY]

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -175,10 +175,14 @@ def configure_claude_desktop_config(
     snapshotted under ``fccPriorConfig``; ``unconfigure`` restores that
     snapshot so temporarily enabling FCC never destroys the user's previous
     provider, gateway, credential, or discovery settings. Re-merges keep the
-    original user-state entries untouched, but absorb the user's post-merge
-    edits as the new restore targets and refresh the snapshot's record of
-    the exact block FCC writes so ownership stays correct when the proxy
-    token or gateway URL rotated between configures.
+    original user-state entries untouched, absorb the user's post-merge edits
+    to managed inference keys as the new restore targets, and refresh the
+    snapshot's record of the exact block FCC writes so ownership stays
+    correct when the proxy token or gateway URL rotated between configures.
+    The discovery flag's target is frozen: configure always writes ``True``,
+    so a current ``True`` cannot be attributed and an intermediate user
+    flip must not become the restore target or it would discard the user's
+    final re-enable on unconfigure.
 
     Returns ``False`` without writing when the existing config is malformed
     (invalid JSON or non-object root). Creates a new config when absent.
@@ -283,19 +287,21 @@ def configure_claude_desktop_config(
         if absorbed != prior_inference:
             backup["inference"] = absorbed
             changed = True
-        # The discovery flag mirrors that rule: configure always writes
-        # ``True``, so a current value that is neither ``True`` nor the
-        # recorded target is the user's post-merge flip, and it becomes
-        # restore target before this merge overwrites it — even when the
-        # key was ABSENT before the first merge (the original state was
-        # "absent", the user's chosen state is now ``False``). A current
-        # ``True`` is indistinguishable from configure's own write, so the
-        # recorded target stands.
-        recorded_discovery = backup.get("discovery")
+        # The discovery flag is frozen, not absorbed: configure always
+        # writes ``True``, so a current ``True`` is byte-identical to
+        # configure's own write and no file state can tell "the user just
+        # re-enabled it" from "configure wrote it". Absorbing an
+        # intermediate user flip (say ``False``) as the restore target would
+        # then discard the user's FINAL re-enable on unconfigure, restoring
+        # the stale intermediate instead. So the recorded target only ever
+        # changes when there was none — the key was absent before the
+        # first merge and the user has since made an explicit choice, whose
+        # current value is by definition theirs (configure had nothing to
+        # write over it that the user kept).
         if (
-            prior_discovery is not True
+            "discovery" not in backup
             and prior_discovery is not None
-            and prior_discovery != recorded_discovery
+            and prior_discovery is not True
         ):
             backup["discovery"] = prior_discovery
             changed = True

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -333,6 +333,20 @@ def configure_claude_desktop_config(
             existing_backup.pop("inference", None)
             existing_backup["inferenceRaw"] = inference_raw
             changed = True
+            # The ownership-adoption rule is not dict-specific: a user who
+            # replaced the block may equally have made an explicit
+            # non-``True`` discovery choice since the absent-original
+            # first merge, and that choice must hand the flag off
+            # verbatim on unconfigure — the dict remerge path above
+            # applies the same condition.
+            if (
+                "discovery" not in existing_backup
+                and "discoveryUserOwned" not in existing_backup
+                and prior_discovery is not None
+                and prior_discovery is not True
+            ):
+                existing_backup["discoveryUserOwned"] = True
+                changed = True
 
     for key, value in managed.items():
         if inference_dict.get(key) != value:
@@ -413,6 +427,19 @@ def unconfigure_claude_desktop_config(
         for key, value in inference_raw.items():
             inference_dict[str(key)] = value
 
+    # A non-object ``inference`` under a recorded snapshot can only be the
+    # user's wholesale replacement of the mapping configure wrote
+    # (configure never persists a scalar or ``null``). It is theirs: the
+    # empty derived mapping below must NOT read as "FCC block fully
+    # removed, delete the key" — that would destroy the replacement — and
+    # the verbatim restore must not fire either (the recorded original
+    # predates the user's own replacement).
+    inference_user_replaced = (
+        backup is not None
+        and _INFERENCE_KEY in data
+        and not isinstance(inference_raw, dict)
+    )
+
     if backup is not None:
         # Snapshot path: a managed field is FCC's only while its current
         # value still matches what the merge wrote. A user who changed a
@@ -478,7 +505,7 @@ def unconfigure_claude_desktop_config(
                 del inference_dict[key]
                 changed = True
 
-    if _INFERENCE_KEY in data:
+    if _INFERENCE_KEY in data and not inference_user_replaced:
         if inference_dict:
             if data[_INFERENCE_KEY] != inference_dict:
                 data[_INFERENCE_KEY] = inference_dict

--- a/src/free_claude_code/cli/claude_desktop.py
+++ b/src/free_claude_code/cli/claude_desktop.py
@@ -521,13 +521,30 @@ def unconfigure_claude_desktop_config(path: Path | None = None) -> bool:
         changed = (
             _restore_inference_keys(data, record.inference_keys, written) or changed
         )
-    elif data.get(_INFERENCE_KEY) == written:
-        # Configure clobbered a non-object entry and the entry is still
-        # exactly what configure wrote; restore what it replaced.
-        data[_INFERENCE_KEY] = record.inference_scalar
-        changed = True
-    # Any other current value is a post-merge user replacement or removal;
-    # it is no longer FCC's to touch, so it stays as-is.
+    else:
+        # Configure clobbered a non-object entry with its mapping. Per-key
+        # ownership applies exactly as in the object path: a managed key
+        # still holding what configure wrote is FCC's to remove, while a
+        # user-added field (the reason the mapping no longer equals
+        # ``written``) is preserved. Whole-mapping equality would leave
+        # every FCC routing key installed the moment the user adds one
+        # unrelated field.
+        current = _current_inference_object(data)
+        if current is not None:
+            for key in record.inference_keys:
+                if key in current and current[key] == written.get(key):
+                    del current[key]
+                    changed = True
+            if not current:
+                # Nothing user-owned remains in the mapping, so restore the
+                # original scalar (or ``null``) exactly as configure found
+                # it. ``del`` would drop the whole entry instead.
+                data[_INFERENCE_KEY] = record.inference_scalar
+                changed = True
+            elif changed:
+                data[_INFERENCE_KEY] = current
+    # A non-object current value is a post-merge user replacement; it is no
+    # longer FCC's to touch, so it stays as-is.
 
     if changed:
         _save_config(config_path, data)

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -288,21 +288,26 @@ class ServerSupervisor:
         with self._lock:
             self._desktop_gateway_url = gateway_url
         logger.info("Claude Desktop gateway: {}", gateway_url)
-        self._repersist_verified_gateway_url(settings, root)
+        self._repersist_verified_gateway_url(settings, gateway_url)
 
-    def _repersist_verified_gateway_url(self, settings: Settings, root: str) -> None:
+    def _repersist_verified_gateway_url(
+        self, settings: Settings, gateway_url: str
+    ) -> None:
         """Rewrite the Claude Desktop routing block onto the verified front.
 
         Runs once per verified readiness upgrade, inside the live serving
-        window. Failures downgrade to a warning: the in-memory publication
-        already succeeded, and a config-merge failure must not take the
-        serving generation down.
+        window. The persisted URL is the desktop-scoped one — the same
+        value published in memory — because Claude Desktop discovers
+        models against the prefix mount that serves picker aliases, not
+        the bare root. Failures downgrade to a warning: the in-memory
+        publication already succeeded, and a config-merge failure must
+        not take the serving generation down.
         """
 
         try:
             merged = configure_claude_desktop_config(
                 settings=settings,
-                gateway_base_url=root,
+                gateway_base_url=gateway_url,
             )
         except OSError as exc:
             logger.warning("Could not re-merge the Claude Desktop config: {}", exc)

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -10,6 +10,12 @@ from loguru import logger
 
 from free_claude_code.cli.launchers.common import preflight_proxy
 from free_claude_code.cli.process_registry import kill_all_best_effort
+from free_claude_code.cli.tls_proxy import (
+    CaddyTlsProxy,
+    desktop_gateway_base_url,
+    probe_fcc_front,
+    tls_root_url,
+)
 from free_claude_code.config.loader import (
     clear_settings_cache,
     get_settings,
@@ -21,6 +27,7 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.runtime.bootstrap import build_asgi_app
 
 SERVER_GRACEFUL_SHUTDOWN_SECONDS = 5
+GATEWAY_HEALTH_UPGRADE_SECONDS = 10.0
 
 
 def serve() -> None:
@@ -44,6 +51,7 @@ class ServerSupervisor:
         self._console_logging = console_logging
         self._lock = threading.Lock()
         self._server: uvicorn.Server | None = None
+        self._desktop_gateway_url: str | None = None
         self._run_scheduled = False
         self._running = False
         self._stop_requested = False
@@ -63,6 +71,18 @@ class ServerSupervisor:
             if self._server.started:
                 return ServerStatus.RUNNING
             return ServerStatus.STARTING
+
+    def desktop_gateway_url(self) -> str | None:
+        """The desktop-scoped gateway URL the active generation is serving.
+
+        Resolved once the generation's HTTPS front has been started (or the
+        plain-HTTP fallback chosen), so Claude Desktop integrations read the
+        live endpoint rather than a stale or not-yet-ready value. ``None``
+        before the first generation publishes one.
+        """
+
+        with self._lock:
+            return self._desktop_gateway_url
 
     def schedule_run(self) -> bool:
         """Reserve a worker run before its thread starts."""
@@ -109,6 +129,7 @@ class ServerSupervisor:
         finally:
             with self._lock:
                 self._server = None
+                self._desktop_gateway_url = None
                 self._running = False
             kill_all_best_effort()
 
@@ -168,9 +189,40 @@ class ServerSupervisor:
             if self._stop_requested or self._restart_generation != restart_generation:
                 server.should_exit = True
 
-        if open_admin_browser:
-            schedule_open_admin_browser(settings)
-        server.run()
+        # Own the managed HTTPS front for exactly this generation: started
+        # before the server accepts traffic so Claude Desktop's config-merge
+        # probe finds a live TLS endpoint, stopped when the generation ends.
+        # ``start()`` never raises and falls back to plain HTTP on failure.
+        tls_front = CaddyTlsProxy(settings)
+        readiness: threading.Thread | None = None
+        try:
+            tls_front.start()
+            # Publish the desktop-scoped gateway URL this generation serves.
+            # The plain-HTTP fallback is correct until the front verifies,
+            # and verification needs FCC's /health marker THROUGH the front,
+            # which only answers while Uvicorn serves — so a concurrent
+            # readiness task probes during ``server.run()`` and swaps in the
+            # TLS-prefixed URL the moment the front verifies, keeping the
+            # HTTPS URL published for the whole live serving window.
+            self._publish_desktop_gateway_url(settings)
+            # Run the readiness whenever a front MAY own the TLS port, not
+            # only when managed startup succeeded: an external reverse proxy
+            # already bound there fails the pre-Uvicorn probe and makes the
+            # managed caddy exit on the occupied port (``start()`` -> False),
+            # yet it still serves FCC's /health once Uvicorn is up. Gating on
+            # ``start()`` would strand such a front on the HTTP fallback.
+            if settings.tls_proxy_enabled:
+                readiness = self._start_gateway_https_readiness(settings)
+            if open_admin_browser:
+                schedule_open_admin_browser(settings)
+            server.run()
+        finally:
+            # Join the readiness task before tearing down the front so the
+            # published HTTPS URL stays live until the generation actually
+            # stops and no probe outlives the generation's front.
+            if readiness is not None:
+                readiness.join(timeout=GATEWAY_HEALTH_UPGRADE_SECONDS + 2.0)
+            tls_front.stop()
 
         with self._lock:
             if self._server is server:
@@ -178,6 +230,59 @@ class ServerSupervisor:
             restart_requested = self._restart_generation != restart_generation
             stop_requested = self._stop_requested
         return restart_requested and not stop_requested and asgi_app.runtime.is_closed
+
+    def _publish_desktop_gateway_url(self, settings: Settings) -> None:
+        """Publish the resolved desktop gateway URL for this generation."""
+
+        gateway_url = desktop_gateway_base_url(settings)
+        with self._lock:
+            self._desktop_gateway_url = gateway_url
+        logger.info("Claude Desktop gateway: {}", gateway_url)
+
+    def _start_gateway_https_readiness(self, settings: Settings) -> threading.Thread:
+        """Spawn the readiness task that upgrades the published URL to HTTPS.
+
+        The front can only pass FCC's ``/health`` marker probe while Uvicorn
+        serves, so the probe runs concurrently with ``server.run()`` and the
+        TLS-prefixed URL is published during the live serving window — not
+        after it ends. The task is joined before the generation's front is
+        stopped, so the HTTPS URL stays published until the generation
+        actually stops.
+        """
+
+        readiness = threading.Thread(
+            target=self._await_gateway_https_readiness,
+            args=(settings,),
+            name="fcc-gateway-https-readiness",
+            daemon=True,
+        )
+        readiness.start()
+        return readiness
+
+    def _await_gateway_https_readiness(self, settings: Settings) -> None:
+        """Publish the TLS-prefixed gateway URL once the front verifies."""
+
+        root = tls_root_url(settings)
+        deadline = time.monotonic() + GATEWAY_HEALTH_UPGRADE_SECONDS
+        while time.monotonic() < deadline:
+            if probe_fcc_front(root):
+                self._publish_verified_https_gateway_url(settings, root)
+                return
+            time.sleep(0.25)
+
+    def _publish_verified_https_gateway_url(
+        self, settings: Settings, root: str
+    ) -> None:
+        """Publish the TLS-prefixed URL for a front that just verified.
+
+        Publishes the verified root directly — re-resolving would probe the
+        front a second time for the same answer.
+        """
+
+        gateway_url = desktop_gateway_base_url(settings, base_url=root)
+        with self._lock:
+            self._desktop_gateway_url = gateway_url
+        logger.info("Claude Desktop gateway: {}", gateway_url)
 
     def _request_runtime_restart(self) -> None:
         self.request_restart()

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -261,47 +261,75 @@ class ServerSupervisor:
         return readiness
 
     def _await_gateway_https_readiness(self, settings: Settings) -> None:
-        """Publish the TLS-prefixed gateway URL once the front verifies."""
+        """Publish the TLS-prefixed gateway URL once the front verifies.
+
+        The upgrade is retryable for the whole readiness window: the
+        persisted-config rewrite and the in-memory publication commit
+        together, so a transient rewrite failure keeps both surfaces on
+        the plain-HTTP fallback and the next probe reattempts the pair
+        rather than leaving them split across two URLs.
+        """
 
         root = tls_root_url(settings)
         deadline = time.monotonic() + GATEWAY_HEALTH_UPGRADE_SECONDS
         while time.monotonic() < deadline:
-            if probe_fcc_front(root):
-                self._publish_verified_https_gateway_url(settings, root)
+            if probe_fcc_front(root) and self._publish_verified_https_gateway_url(
+                settings, root
+            ):
                 return
+            # A probe that verifies the front but fails the persisted
+            # config rewrite keeps both surfaces on the consistent
+            # plain-HTTP fallback; fall through to the sleep and retry the
+            # whole upgrade on the next probe — the readiness window is
+            # the only time the write and the publication can be made
+            # atomic together.
             time.sleep(0.25)
 
     def _publish_verified_https_gateway_url(
         self, settings: Settings, root: str
-    ) -> None:
+    ) -> bool:
         """Publish the TLS-prefixed URL for a front that just verified.
 
         Publishes the verified root directly — re-resolving would probe the
         front a second time for the same answer. The persisted Claude
-        Desktop config is re-merged with the verified URL too: the
-        pre-lifecycle merge recorded the plain-HTTP fallback while the
-        front was still starting, and Claude Desktop reads the config file,
-        not this process's memory.
+        Desktop config is re-merged with the verified URL BEFORE the
+        in-memory value swaps: the pre-lifecycle merge recorded the
+        plain-HTTP fallback while the front was still starting, Claude
+        Desktop reads the config file (not this process's memory), so an
+        in-memory upgrade the file never received would advertise an HTTPS
+        endpoint Claude Desktop cannot use. Persist-first also makes the
+        write failure the caller's signal to keep probing: a transient
+        ``OSError`` (disk full, EBUSY rename) leaves both surfaces on the
+        consistent plain-HTTP fallback instead of splitting them, and the
+        readiness loop retries the whole upgrade on its next probe.
+
+        Returns whether the HTTPS URL was published — ``False`` means the
+        persisted config could not be rewritten and the caller should
+        retry.
         """
 
         gateway_url = desktop_gateway_base_url(settings, base_url=root)
+        if not self._repersist_verified_gateway_url(settings, gateway_url):
+            return False
         with self._lock:
             self._desktop_gateway_url = gateway_url
         logger.info("Claude Desktop gateway: {}", gateway_url)
-        self._repersist_verified_gateway_url(settings, gateway_url)
+        return True
 
     def _repersist_verified_gateway_url(
         self, settings: Settings, gateway_url: str
-    ) -> None:
+    ) -> bool:
         """Rewrite the Claude Desktop routing block onto the verified front.
 
-        Runs once per verified readiness upgrade, inside the live serving
-        window. The persisted URL is the desktop-scoped one — the same
-        value published in memory — because Claude Desktop discovers
+        Runs once per verified readiness upgrade attempt, inside the live
+        serving window. The persisted URL is the desktop-scoped one — the
+        same value published in memory — because Claude Desktop discovers
         models against the prefix mount that serves picker aliases, not
-        the bare root. Failures downgrade to a warning: the in-memory
-        publication already succeeded, and a config-merge failure must
-        not take the serving generation down.
+        the bare root. Failures downgrade to a warning and return
+        ``False``: the in-memory publication is deferred until the write
+        lands, so a config-merge failure must not take the serving
+        generation down and must not strand the two surfaces on different
+        URLs either.
         """
 
         try:
@@ -311,11 +339,12 @@ class ServerSupervisor:
             )
         except OSError as exc:
             logger.warning("Could not re-merge the Claude Desktop config: {}", exc)
-            return
+            return False
         logger.info(
             "Claude Desktop routing re-merged onto the verified HTTPS front{}.",
             "" if merged else " (no change needed)",
         )
+        return True
 
     def _request_runtime_restart(self) -> None:
         self.request_restart()

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -272,7 +272,15 @@ class ServerSupervisor:
         """
 
         root = tls_root_url(settings)
-        identity = load_or_create_front_identity()
+        try:
+            identity = load_or_create_front_identity()
+        except OSError as exc:
+            logger.warning(
+                "Could not read or create the front identity secret: {}; "
+                "the published gateway URL stays on plain HTTP.",
+                exc,
+            )
+            return
         deadline = time.monotonic() + GATEWAY_HEALTH_UPGRADE_SECONDS
         while time.monotonic() < deadline:
             verified = probe_fcc_front(root, identity)

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 import uvicorn
 from loguru import logger
 
+from free_claude_code.cli.claude_desktop import configure_claude_desktop_config
 from free_claude_code.cli.launchers.common import preflight_proxy
 from free_claude_code.cli.process_registry import kill_all_best_effort
 from free_claude_code.cli.tls_proxy import (
@@ -276,13 +277,40 @@ class ServerSupervisor:
         """Publish the TLS-prefixed URL for a front that just verified.
 
         Publishes the verified root directly — re-resolving would probe the
-        front a second time for the same answer.
+        front a second time for the same answer. The persisted Claude
+        Desktop config is re-merged with the verified URL too: the
+        pre-lifecycle merge recorded the plain-HTTP fallback while the
+        front was still starting, and Claude Desktop reads the config file,
+        not this process's memory.
         """
 
         gateway_url = desktop_gateway_base_url(settings, base_url=root)
         with self._lock:
             self._desktop_gateway_url = gateway_url
         logger.info("Claude Desktop gateway: {}", gateway_url)
+        self._repersist_verified_gateway_url(settings, root)
+
+    def _repersist_verified_gateway_url(self, settings: Settings, root: str) -> None:
+        """Rewrite the Claude Desktop routing block onto the verified front.
+
+        Runs once per verified readiness upgrade, inside the live serving
+        window. Failures downgrade to a warning: the in-memory publication
+        already succeeded, and a config-merge failure must not take the
+        serving generation down.
+        """
+
+        try:
+            merged = configure_claude_desktop_config(
+                settings=settings,
+                gateway_base_url=root,
+            )
+        except OSError as exc:
+            logger.warning("Could not re-merge the Claude Desktop config: {}", exc)
+            return
+        logger.info(
+            "Claude Desktop routing re-merged onto the verified HTTPS front{}.",
+            "" if merged else " (no change needed)",
+        )
 
     def _request_runtime_restart(self) -> None:
         self.request_restart()

--- a/src/free_claude_code/cli/commands.py
+++ b/src/free_claude_code/cli/commands.py
@@ -14,6 +14,7 @@ from free_claude_code.cli.process_registry import kill_all_best_effort
 from free_claude_code.cli.tls_proxy import (
     CaddyTlsProxy,
     desktop_gateway_base_url,
+    load_or_create_front_identity,
     probe_fcc_front,
     tls_root_url,
 )
@@ -243,8 +244,8 @@ class ServerSupervisor:
     def _start_gateway_https_readiness(self, settings: Settings) -> threading.Thread:
         """Spawn the readiness task that upgrades the published URL to HTTPS.
 
-        The front can only pass FCC's ``/health`` marker probe while Uvicorn
-        serves, so the probe runs concurrently with ``server.run()`` and the
+        The front can only pass the adoption probe while Uvicorn serves, so
+        the probe runs concurrently with ``server.run()`` and the
         TLS-prefixed URL is published during the live serving window — not
         after it ends. The task is joined before the generation's front is
         stopped, so the HTTPS URL stays published until the generation
@@ -271,11 +272,11 @@ class ServerSupervisor:
         """
 
         root = tls_root_url(settings)
+        identity = load_or_create_front_identity()
         deadline = time.monotonic() + GATEWAY_HEALTH_UPGRADE_SECONDS
         while time.monotonic() < deadline:
-            if probe_fcc_front(root) and self._publish_verified_https_gateway_url(
-                settings, root
-            ):
+            verified = probe_fcc_front(root, identity)
+            if verified and self._publish_verified_https_gateway_url(settings, root):
                 return
             # A probe that verifies the front but fails the persisted
             # config rewrite keeps both surfaces on the consistent

--- a/src/free_claude_code/cli/desktop.py
+++ b/src/free_claude_code/cli/desktop.py
@@ -46,6 +46,8 @@ class ServerOwner(Protocol):
 
     def request_stop(self) -> None: ...
 
+    def desktop_gateway_url(self) -> str | None: ...
+
 
 class DesktopController:
     """Coordinate one tray loop with one in-process FCC server owner."""
@@ -82,6 +84,18 @@ class DesktopController:
 
     def open_admin(self) -> None:
         self._open_admin()
+
+    def desktop_gateway_url(self) -> str | None:
+        """The live desktop-scoped gateway URL the server is serving.
+
+        Delegates to the server owner so the desktop integration (the
+        Claude Desktop config merge) reads the endpoint the active
+        generation actually published — the TLS-prefixed HTTPS URL when a
+        front is up, the plain-HTTP fallback otherwise — instead of
+        re-deriving it. ``None`` before the server publishes one.
+        """
+
+        return self._supervisor.desktop_gateway_url()
 
     def restart_server(self) -> None:
         """Restart an active server or relaunch one that exited unexpectedly."""

--- a/src/free_claude_code/cli/desktop.py
+++ b/src/free_claude_code/cli/desktop.py
@@ -4,6 +4,9 @@ import threading
 from collections.abc import Callable
 from typing import Protocol
 
+from loguru import logger
+
+from free_claude_code.cli.claude_desktop import configure_claude_desktop_config
 from free_claude_code.cli.commands import (
     ServerStatus,
     ServerSupervisor,
@@ -12,9 +15,14 @@ from free_claude_code.cli.commands import (
     schedule_open_admin_browser,
 )
 from free_claude_code.cli.launchers.common import preflight_proxy
+from free_claude_code.cli.tls_proxy import (
+    CaddyTlsProxy,
+    verified_https_gateway_url,
+)
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.paths import config_dir_path
 from free_claude_code.config.server_urls import local_proxy_root_url
+from free_claude_code.config.settings import Settings
 from free_claude_code.core.interprocess_lock import InterprocessFileLock
 
 
@@ -138,10 +146,20 @@ def launch_desktop(tray_factory: DesktopTrayFactory) -> None:
         open_admin_when_ready(settings)
         return
 
+    tls_proxy = CaddyTlsProxy(settings)
     try:
         if preflight_proxy(local_proxy_root_url(settings)) is None:
+            _merge_verified_gateway(settings)
             open_admin_when_ready(settings)
             return
+
+        if tls_proxy.start():
+            _merge_verified_gateway(settings)
+        else:
+            logger.warning(
+                "Skipping Claude Desktop config merge: no HTTPS front is "
+                "available for the desktop gateway.",
+            )
 
         supervisor = ServerSupervisor(console_logging=False)
 
@@ -150,4 +168,38 @@ def launch_desktop(tray_factory: DesktopTrayFactory) -> None:
 
         DesktopController(supervisor, tray_factory, open_current_admin).run()
     finally:
+        tls_proxy.stop()
         instance_lock.release()
+
+
+def _merge_verified_gateway(settings: Settings) -> None:
+    """Merge the routing block only against a currently verified HTTPS front.
+
+    The merge writes the gateway credential, so the gateway URL is re-verified
+    at write time and passed explicitly: a front that verified at startup can
+    stop verifying before the config is written, and the default URL
+    resolution would then silently fall back to a plain-``http://`` gateway
+    while still embedding the reusable proxy token. Requiring a
+    ``verified_https_gateway_url`` result guarantees the block never carries
+    an unverified or cleartext endpoint. Best-effort: a failed merge is
+    logged, never fatal to the desktop lifecycle.
+
+    On the existing-server path this is probe-only adoption — a short-lived
+    launch never spawns its own TLS proxy (it would orphan the child), so a
+    front is only reused if it already proves it belongs to this install.
+    """
+
+    gateway_url = verified_https_gateway_url(settings)
+    if gateway_url is None:
+        logger.warning(
+            "Skipping Claude Desktop config merge: no verified HTTPS front "
+            "is available for the desktop gateway. This short-lived launch "
+            "cannot bring one up without orphaning it, so stop the running "
+            "HTTP-only FCC server first, then start the FCC desktop host "
+            "(which manages the front) or enable the caddy TLS proxy.",
+        )
+        return
+    try:
+        configure_claude_desktop_config(settings=settings, gateway_base_url=gateway_url)
+    except Exception as exc:  # pragma: no cover - defensive; merge already guards
+        logger.warning("Claude Desktop config merge failed: {}", exc)

--- a/src/free_claude_code/cli/desktop_console.py
+++ b/src/free_claude_code/cli/desktop_console.py
@@ -3,7 +3,6 @@
 import threading
 
 from free_claude_code.cli.desktop import DesktopController, launch_desktop
-from free_claude_code.cli.desktop_tray import PystrayDesktopTray, tray_is_available
 
 
 class ConsoleDesktopTray:
@@ -24,13 +23,7 @@ class ConsoleDesktopTray:
         self._stop_event.set()
 
 
-def launch() -> None:
-    """Launch the tray when available, otherwise fall back to console mode."""
-
-    available, reason = tray_is_available()
-    if available:
-        launch_desktop(PystrayDesktopTray)
-        return
+def _print_console_notice(reason: str) -> None:
     print(
         "Native system tray is unavailable on this session; "
         "running in console mode instead.",
@@ -42,4 +35,24 @@ def launch() -> None:
         "installed; launch it from your app launcher as usual.",
         flush=True,
     )
+
+
+def launch() -> None:
+    """Launch the tray when available, otherwise fall back to console mode."""
+    # The import selects pystray's platform backend; on a headless Linux
+    # session that raises before any probe can run, so a failed import is
+    # reported as an unavailable tray rather than crashing the fallback.
+    try:
+        from free_claude_code.cli.desktop_tray import (
+            PystrayDesktopTray,
+            tray_is_available,
+        )
+    except Exception as exc:
+        _print_console_notice(f"the native tray adapter failed to load: {exc}")
+    else:
+        available, reason = tray_is_available()
+        if available:
+            launch_desktop(PystrayDesktopTray)
+            return
+        _print_console_notice(reason)
     launch_desktop(ConsoleDesktopTray)

--- a/src/free_claude_code/cli/desktop_console.py
+++ b/src/free_claude_code/cli/desktop_console.py
@@ -1,0 +1,58 @@
+"""Tray-less desktop mode for Linux sessions without a status-area backend."""
+
+import threading
+
+from free_claude_code.cli.desktop import DesktopController, launch_desktop
+
+
+class ConsoleDesktopTray:
+    """Null tray that keeps the controller lifecycle intact without UI.
+
+    ``run()`` blocks until ``stop()`` (or SIGINT interrupts the wait), so
+    ``DesktopController.run()`` starts and drains the server exactly as it
+    does behind a native tray.
+    """
+
+    def __init__(self, controller: DesktopController) -> None:
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        self._stop_event.wait()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+def _print_console_notice(reason: str) -> None:
+    print(
+        "Native system tray is unavailable on this session; "
+        "running in console mode instead.",
+        flush=True,
+    )
+    print(f"Reason: {reason}", flush=True)
+    print(
+        "Claude Desktop is routed through this server automatically when "
+        "installed; launch it from your app launcher as usual.",
+        flush=True,
+    )
+
+
+def launch() -> None:
+    """Launch the tray when available, otherwise fall back to console mode."""
+    # The import selects pystray's platform backend; on a headless Linux
+    # session that raises before any probe can run, so a failed import is
+    # reported as an unavailable tray rather than crashing the fallback.
+    try:
+        from free_claude_code.cli.desktop_tray import (
+            PystrayDesktopTray,
+            tray_is_available,
+        )
+    except Exception as exc:
+        _print_console_notice(f"the native tray adapter failed to load: {exc}")
+    else:
+        available, reason = tray_is_available()
+        if available:
+            launch_desktop(PystrayDesktopTray)
+            return
+        _print_console_notice(reason)
+    launch_desktop(ConsoleDesktopTray)

--- a/src/free_claude_code/cli/desktop_console.py
+++ b/src/free_claude_code/cli/desktop_console.py
@@ -1,0 +1,45 @@
+"""Tray-less desktop mode for Linux sessions without a status-area backend."""
+
+import threading
+
+from free_claude_code.cli.desktop import DesktopController, launch_desktop
+from free_claude_code.cli.desktop_tray import PystrayDesktopTray, tray_is_available
+
+
+class ConsoleDesktopTray:
+    """Null tray that keeps the controller lifecycle intact without UI.
+
+    ``run()`` blocks until ``stop()`` (or SIGINT interrupts the wait), so
+    ``DesktopController.run()`` starts and drains the server exactly as it
+    does behind a native tray.
+    """
+
+    def __init__(self, controller: DesktopController) -> None:
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        self._stop_event.wait()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+def launch() -> None:
+    """Launch the tray when available, otherwise fall back to console mode."""
+
+    available, reason = tray_is_available()
+    if available:
+        launch_desktop(PystrayDesktopTray)
+        return
+    print(
+        "Native system tray is unavailable on this session; "
+        "running in console mode instead.",
+        flush=True,
+    )
+    print(f"Reason: {reason}", flush=True)
+    print(
+        "Claude Desktop is routed through this server automatically when "
+        "installed; launch it from your app launcher as usual.",
+        flush=True,
+    )
+    launch_desktop(ConsoleDesktopTray)

--- a/src/free_claude_code/cli/desktop_console.py
+++ b/src/free_claude_code/cli/desktop_console.py
@@ -4,23 +4,50 @@ import threading
 
 from free_claude_code.cli.desktop import DesktopController, launch_desktop
 
+GATEWAY_URL_POLL_SECONDS = 0.5
+
 
 class ConsoleDesktopTray:
     """Null tray that keeps the controller lifecycle intact without UI.
 
     ``run()`` blocks until ``stop()`` (or SIGINT interrupts the wait), so
     ``DesktopController.run()`` starts and drains the server exactly as it
-    does behind a native tray.
+    does behind a native tray. While it blocks it consumes the published
+    desktop gateway URL and prints it — re-printing whenever the value
+    changes, e.g. the plain-HTTP fallback upgrading to the TLS-prefixed URL
+    — so the console surface reports the live endpoint the same way the
+    native tray's status notification does.
     """
 
     def __init__(self, controller: DesktopController) -> None:
+        self._controller = controller
         self._stop_event = threading.Event()
 
     def run(self) -> None:
-        self._stop_event.wait()
+        reported: str | None = None
+        while not self._stop_event.wait(timeout=GATEWAY_URL_POLL_SECONDS):
+            line = console_gateway_line(self._controller)
+            if line is not None and line != reported:
+                print(line, flush=True)
+                reported = line
 
     def stop(self) -> None:
         self._stop_event.set()
+
+
+def console_gateway_line(controller: DesktopController) -> str | None:
+    """Console notice for the live gateway URL, or ``None`` before publication.
+
+    Consumes ``DesktopController.desktop_gateway_url()`` so the tray-less
+    console surface reports the endpoint the active server generation
+    actually published — the TLS-prefixed HTTPS URL when a front verifies,
+    the plain-HTTP fallback otherwise — instead of a static claim.
+    """
+
+    gateway_url = controller.desktop_gateway_url()
+    if gateway_url is None:
+        return None
+    return f"Claude Desktop gateway: {gateway_url}"
 
 
 def _print_console_notice(reason: str) -> None:
@@ -30,11 +57,6 @@ def _print_console_notice(reason: str) -> None:
         flush=True,
     )
     print(f"Reason: {reason}", flush=True)
-    print(
-        "Claude Desktop is routed through this server automatically when "
-        "installed; launch it from your app launcher as usual.",
-        flush=True,
-    )
 
 
 def launch() -> None:

--- a/src/free_claude_code/cli/desktop_entrypoint.py
+++ b/src/free_claude_code/cli/desktop_entrypoint.py
@@ -4,6 +4,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+from free_claude_code.cli import desktop_console
 from free_claude_code.cli.desktop_assets import export_app_icon
 
 
@@ -17,10 +18,17 @@ def launch(argv: Sequence[str] | None = None) -> None:
     if args:
         print("Usage: fcc-desktop [--export-icon PATH]", file=sys.stderr)
         raise SystemExit(2)
-    if sys.platform not in {"darwin", "win32"}:
-        print("FCC Desktop is supported on Windows and macOS.", file=sys.stderr)
+    if sys.platform not in {"darwin", "win32", "linux"}:
+        print("FCC Desktop is supported on Windows, macOS, and Linux.", file=sys.stderr)
         raise SystemExit(1)
 
-    from free_claude_code.cli.desktop_tray import launch as launch_tray
+    if sys.platform == "linux":
+        desktop_console.launch()
+        return
 
-    launch_tray()
+    # Import lazily so a headless Linux session without a pystray backend
+    # can still run ``--export-icon`` and the console-mode fallback; the
+    # tray adapter is only needed on this native-tray branch.
+    from free_claude_code.cli import desktop_tray
+
+    desktop_tray.launch()

--- a/src/free_claude_code/cli/desktop_entrypoint.py
+++ b/src/free_claude_code/cli/desktop_entrypoint.py
@@ -17,9 +17,15 @@ def launch(argv: Sequence[str] | None = None) -> None:
     if args:
         print("Usage: fcc-desktop [--export-icon PATH]", file=sys.stderr)
         raise SystemExit(2)
-    if sys.platform not in {"darwin", "win32"}:
-        print("FCC Desktop is supported on Windows and macOS.", file=sys.stderr)
+    if sys.platform not in {"darwin", "win32", "linux"}:
+        print("FCC Desktop is supported on Windows, macOS, and Linux.", file=sys.stderr)
         raise SystemExit(1)
+
+    if sys.platform == "linux":
+        from free_claude_code.cli.desktop_console import launch as launch_console
+
+        launch_console()
+        return
 
     from free_claude_code.cli.desktop_tray import launch as launch_tray
 

--- a/src/free_claude_code/cli/desktop_entrypoint.py
+++ b/src/free_claude_code/cli/desktop_entrypoint.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from free_claude_code.cli import desktop_console
-from free_claude_code.cli.claude_desktop import configure_claude_desktop_config
 from free_claude_code.cli.desktop_assets import export_app_icon
 
 
@@ -23,9 +22,12 @@ def launch(argv: Sequence[str] | None = None) -> None:
         print("FCC Desktop is supported on Windows, macOS, and Linux.", file=sys.stderr)
         raise SystemExit(1)
 
-    # Merge the FCC gateway routing block before any Claude Desktop session
-    # starts so model discovery and inference run through this server.
-    configure_claude_desktop_config()
+    # The Claude Desktop routing merge is intentionally NOT done here: this
+    # runs before any lifecycle has started or verified a TLS front, so a
+    # merge now would resolve the plain-HTTP fallback and write the
+    # reusable gateway credential into the config pointing at a cleartext
+    # listener. Each lifecycle below merges only behind a verified HTTPS
+    # front (see ``desktop._merge_verified_gateway``).
 
     if sys.platform == "linux":
         desktop_console.launch()

--- a/src/free_claude_code/cli/desktop_entrypoint.py
+++ b/src/free_claude_code/cli/desktop_entrypoint.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from free_claude_code.cli import desktop_console
+from free_claude_code.cli.claude_desktop import configure_claude_desktop_config
 from free_claude_code.cli.desktop_assets import export_app_icon
 
 
@@ -21,6 +22,10 @@ def launch(argv: Sequence[str] | None = None) -> None:
     if sys.platform not in {"darwin", "win32", "linux"}:
         print("FCC Desktop is supported on Windows, macOS, and Linux.", file=sys.stderr)
         raise SystemExit(1)
+
+    # Merge the FCC gateway routing block before any Claude Desktop session
+    # starts so model discovery and inference run through this server.
+    configure_claude_desktop_config()
 
     if sys.platform == "linux":
         desktop_console.launch()

--- a/src/free_claude_code/cli/desktop_tray.py
+++ b/src/free_claude_code/cli/desktop_tray.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from PIL import Image
 
+from free_claude_code.cli.claude_desktop import ensure_configured_and_launch
 from free_claude_code.cli.desktop import DesktopController, launch_desktop
 from free_claude_code.cli.desktop_assets import app_icon_bytes
 
@@ -28,6 +29,7 @@ class PystrayDesktopTray:
             "Free Claude Code",
             Menu(
                 MenuItem("Open Admin", self._open_admin, default=True),
+                MenuItem("Launch Claude Desktop", self._launch_claude_desktop),
                 MenuItem("Check Server Status", self._check_status),
                 MenuItem("Restart Server", self._restart_server),
                 Menu.SEPARATOR,
@@ -43,6 +45,19 @@ class PystrayDesktopTray:
 
     def _open_admin(self, _icon: Icon, _item: MenuItem) -> None:
         self._controller.open_admin()
+
+    def _launch_claude_desktop(self, _icon: Icon, _item: MenuItem) -> None:
+        try:
+            ensure_configured_and_launch()
+        except FileNotFoundError:
+            self._icon.notify(
+                "Claude Desktop binary not found on this system.",
+                "Free Claude Code",
+            )
+        except Exception as exc:
+            self._icon.notify(
+                f"Claude Desktop launch failed: {exc}", "Free Claude Code"
+            )
 
     def _check_status(self, _icon: Icon, _item: MenuItem) -> None:
         self._icon.notify(status_notification(self._controller), "Free Claude Code")

--- a/src/free_claude_code/cli/desktop_tray.py
+++ b/src/free_claude_code/cli/desktop_tray.py
@@ -1,4 +1,4 @@
-"""pystray adapter for the Windows tray and macOS menu bar."""
+"""pystray adapter for the Windows tray, macOS menu bar, and Linux status area."""
 
 from io import BytesIO
 
@@ -54,6 +54,37 @@ def _create_icon() -> Image.Image:
 
     with Image.open(BytesIO(app_icon_bytes(".png"))) as image:
         return image.convert("RGBA")
+
+
+_TRAY_BACKEND_HINT = (
+    "no supported tray backend is available; install "
+    "'gir1.2-ayatanaappindicator3-0.1' (Debian/Ubuntu) or "
+    "'libappindicator-gtk3' (Fedora), or use an X11 session"
+)
+
+
+def tray_is_available() -> tuple[bool, str]:
+    """Probe whether a native tray icon can be constructed on this desktop.
+
+    Constructing the pystray ``Icon`` resolves the platform backend module;
+    on Linux that import fails when no AppIndicator/GTK/X11 backend exists.
+    The probe discards the constructed icon without ever showing it.
+
+    Returns ``(True, "")`` when a tray can run, otherwise ``(False, reason)``
+    with an actionable message for console fallback mode.
+    """
+
+    try:
+        image = _create_icon()
+    except Exception as exc:
+        return False, f"tray icon artwork failed to load: {exc}"
+    try:
+        Icon("free-claude-code", image, "Free Claude Code")
+    except Exception as exc:
+        if isinstance(exc, ImportError):
+            return False, _TRAY_BACKEND_HINT
+        return False, str(exc)
+    return True, ""
 
 
 def launch() -> None:

--- a/src/free_claude_code/cli/desktop_tray.py
+++ b/src/free_claude_code/cli/desktop_tray.py
@@ -1,7 +1,8 @@
 """pystray adapter for the Windows tray, macOS menu bar, and Linux status area."""
 
+import contextlib
 from io import BytesIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from PIL import Image
 
@@ -98,12 +99,48 @@ _TRAY_BACKEND_HINT = (
 )
 
 
+class _ProbedIcon(Protocol):
+    """Backend icon attribute shape the probe releases."""
+
+    _display: object
+
+
+def _release_probe_icon(icon: _ProbedIcon) -> None:
+    """Release backend resources an un-run probe icon holds.
+
+    The X11 backend opens a display connection in ``Icon.__init__`` and only
+    closes it in ``__del__``; a probe that discards the icon therefore leaves
+    the close to garbage collection, where it can run on an already-torn-down
+    interpreter (``select`` on a -1 file descriptor) or fire an
+    ``ResourceWarning`` for the socket. Close the connection eagerly and
+    leave a no-op stand-in so the eventual destructor is harmless. Other
+    backends hold nothing in the constructor, so only the X11 shape
+    (``_display``) is released.
+    """
+
+    display = getattr(icon, "_display", None)
+    if display is None:
+        return
+
+    class _ReleasedDisplay:
+        """No-op stand-in left behind for the backend's destructor."""
+
+        def close(self) -> None:
+            return
+
+    with contextlib.suppress(Exception):
+        display.close()
+    icon._display = _ReleasedDisplay()
+
+
 def tray_is_available() -> tuple[bool, str]:
     """Probe whether a native tray icon can be constructed on this desktop.
 
     Constructing the pystray ``Icon`` resolves the platform backend module;
     on Linux that import fails when no AppIndicator/GTK/X11 backend exists.
-    The probe discards the constructed icon without ever showing it.
+    The probe discards the constructed icon without ever showing it, and
+    releases the backend's display connection eagerly instead of leaving the
+    close to a garbage-collected destructor.
 
     Returns ``(True, "")`` when a tray can run, otherwise ``(False, reason)``
     with an actionable message for console fallback mode.
@@ -116,11 +153,12 @@ def tray_is_available() -> tuple[bool, str]:
     try:
         from pystray import Icon
 
-        Icon("free-claude-code", image, "Free Claude Code")
+        icon = Icon("free-claude-code", image, "Free Claude Code")
     except Exception as exc:
         if isinstance(exc, ImportError):
             return False, _TRAY_BACKEND_HINT
         return False, str(exc)
+    _release_probe_icon(icon)
     return True, ""
 
 

--- a/src/free_claude_code/cli/desktop_tray.py
+++ b/src/free_claude_code/cli/desktop_tray.py
@@ -37,16 +37,28 @@ class PystrayDesktopTray:
         self._controller.open_admin()
 
     def _check_status(self, _icon: Icon, _item: MenuItem) -> None:
-        self._icon.notify(
-            f"Server is {self._controller.status}.",
-            "Free Claude Code",
-        )
+        self._icon.notify(status_notification(self._controller), "Free Claude Code")
 
     def _restart_server(self, _icon: Icon, _item: MenuItem) -> None:
         self._controller.restart_server()
 
     def _quit(self, _icon: Icon, _item: MenuItem) -> None:
         self._controller.quit()
+
+
+def status_notification(controller: DesktopController) -> str:
+    """Status text for the tray, including the live desktop gateway URL.
+
+    Consumes ``DesktopController.desktop_gateway_url()`` so the desktop
+    surface reports the endpoint the active server generation actually
+    published — the TLS-prefixed HTTPS URL when a front verifies, the
+    plain-HTTP fallback otherwise — instead of only the process state.
+    """
+
+    gateway_url = controller.desktop_gateway_url()
+    if gateway_url is None:
+        return f"Server is {controller.status}."
+    return f"Server is {controller.status}. Gateway: {gateway_url}"
 
 
 def _create_icon() -> Image.Image:

--- a/src/free_claude_code/cli/desktop_tray.py
+++ b/src/free_claude_code/cli/desktop_tray.py
@@ -1,18 +1,26 @@
 """pystray adapter for the Windows tray, macOS menu bar, and Linux status area."""
 
 from io import BytesIO
+from typing import TYPE_CHECKING
 
 from PIL import Image
-from pystray import Icon, Menu, MenuItem
 
 from free_claude_code.cli.desktop import DesktopController, launch_desktop
 from free_claude_code.cli.desktop_assets import app_icon_bytes
+
+if TYPE_CHECKING:
+    from pystray import Icon, MenuItem
 
 
 class PystrayDesktopTray:
     """Render desktop lifecycle actions through the native status area."""
 
     def __init__(self, controller: DesktopController) -> None:
+        # Imported here, not at module scope: pystray resolves an X11 display
+        # during import and crashes headless environments that only ever want
+        # the console fallback this module's probe supports.
+        from pystray import Icon, Menu, MenuItem
+
         self._controller = controller
         self._icon = Icon(
             "free-claude-code",
@@ -91,6 +99,8 @@ def tray_is_available() -> tuple[bool, str]:
     except Exception as exc:
         return False, f"tray icon artwork failed to load: {exc}"
     try:
+        from pystray import Icon
+
         Icon("free-claude-code", image, "Free Claude Code")
     except Exception as exc:
         if isinstance(exc, ImportError):

--- a/src/free_claude_code/cli/launchers/claude_desktop.py
+++ b/src/free_claude_code/cli/launchers/claude_desktop.py
@@ -1,0 +1,172 @@
+"""Installed ``fcc-claude-desktop`` console script.
+
+Thin launcher shim: every config-merge, unmerge, and binary-spawn behavior
+lives in :mod:`free_claude_code.cli.claude_desktop` so the tray shell, the
+desktop startup hook, and this entry point share one implementation. This
+module only preserves the console-script surface used by the install and
+uninstall scripts.
+"""
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from free_claude_code.cli import claude_desktop as routing
+from free_claude_code.cli.tls_proxy import (
+    ensure_https_front,
+    verified_https_gateway_url,
+)
+from free_claude_code.config.loader import get_settings
+
+CLAUDE_DESKTOP_BINARY = routing.CLAUDE_DESKTOP_BINARY
+
+configure_claude_desktop_config = routing.configure_claude_desktop_config
+unconfigure_claude_desktop_config = routing.unconfigure_claude_desktop_config
+_config_path = routing._config_path
+load_existing_config = routing.load_existing_config
+MalformedConfigError = routing.MalformedConfigError
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fcc-claude-desktop",
+        description=(
+            "Launch Claude Desktop with the Free Claude Code routing layer, "
+            "or merge/reverse the FCC routing block in claude_desktop_config.json."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--configure",
+        action="store_true",
+        help="Merge the FCC 3P-gateway block into Claude Desktop's config.",
+    )
+    mode.add_argument(
+        "--unconfigure",
+        action="store_true",
+        help="Reverse the merge applied by --configure.",
+    )
+    parser.add_argument(
+        "--config-path",
+        type=Path,
+        default=None,
+        help="Override the Claude Desktop config path (primarily for tests).",
+    )
+    parser.add_argument(
+        "binary_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments forwarded to the claude-desktop binary.",
+    )
+    return parser
+
+
+def launch(argv: Sequence[str] | None = None) -> None:
+    """Entry point for the ``fcc-claude-desktop`` console script."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    parsed = _build_argparser().parse_args(args)
+
+    if parsed.configure:
+        # --configure persists the gateway credential, so it only writes
+        # against a verified HTTPS front: without one the URL would fall
+        # back to plain HTTP and persist the reusable proxy token against
+        # a cleartext endpoint any local process could occupy. Adoption is
+        # probe-only — this command exits right after writing, so a front
+        # it spawned itself would die with it and leave the config it just
+        # wrote pointing at a dead gateway. The front must already be up
+        # (FCC desktop host or the managed caddy proxy) and stay up.
+        gateway_url = verified_https_gateway_url(get_settings())
+        if gateway_url is None:
+            print(
+                "Refusing to configure Claude Desktop: no verified FCC "
+                "HTTPS front is available. Enable the caddy TLS proxy (or "
+                "start the FCC desktop host, which manages it) and retry.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        changed = configure_claude_desktop_config(
+            parsed.config_path, gateway_base_url=gateway_url
+        )
+        routing.report_configure_result(parsed.config_path or _config_path(), changed)
+        return
+
+    if parsed.unconfigure:
+        changed = unconfigure_claude_desktop_config(parsed.config_path)
+        target = parsed.config_path or _config_path()
+        print(f"{'Removed FCC block' if changed else 'Nothing to remove'}: {target}")
+        return
+
+    # Claude Desktop cannot route through plain HTTP, so bring up a
+    # verified FCC HTTPS front before writing the routing block or
+    # spawning the binary. Without one the gateway URL would fall back to
+    # an unusable http:// address, so refuse to launch instead.
+    settings = get_settings()
+    tls_front = ensure_https_front(settings)
+    if tls_front is None:
+        print(
+            "Refusing to launch Claude Desktop: no verified FCC HTTPS front "
+            "is available. Enable the caddy TLS proxy (or start the FCC "
+            "desktop host, which manages it) and retry.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    try:
+        gateway_url = verified_https_gateway_url(settings)
+        if gateway_url is None:
+            print(
+                "Refusing to launch Claude Desktop: the FCC HTTPS front "
+                "stopped verifying before the routing block could be "
+                "written. Retry once the front is healthy.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        try:
+            configure_claude_desktop_config(
+                parsed.config_path, gateway_base_url=gateway_url
+            )
+        except OSError as exc:
+            print(
+                f"Warning: could not merge the FCC routing block: {exc}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from None
+
+        # A malformed config cannot carry FCC routing; launching anyway would
+        # start Claude Desktop without model discovery or inference routing.
+        target = parsed.config_path or _config_path()
+        try:
+            load_existing_config(target)
+        except FileNotFoundError:
+            pass  # configure created a fresh config; nothing to validate.
+        except MalformedConfigError as exc:
+            print(
+                f"Refusing to launch Claude Desktop: malformed config at "
+                f"{exc.path}: {exc.reason}. Fix or remove the file and retry.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from None
+
+        try:
+            process = routing.launch_binary(tuple(parsed.binary_args))
+        except FileNotFoundError:
+            print(
+                f"Could not find '{CLAUDE_DESKTOP_BINARY}' binary.",
+                file=sys.stderr,
+            )
+            print(
+                "Install Claude Desktop from https://claude.ai/download.",
+                file=sys.stderr,
+            )
+            raise SystemExit(127) from None
+        try:
+            return_code = process.wait()
+        except KeyboardInterrupt:
+            process.terminate()
+            process.wait()
+            raise
+        raise SystemExit(return_code)
+    finally:
+        tls_front.stop()

--- a/src/free_claude_code/cli/tls_proxy.py
+++ b/src/free_claude_code/cli/tls_proxy.py
@@ -338,7 +338,15 @@ class CaddyTlsProxy:
         if not self._settings.tls_proxy_enabled:
             return False
         target = tls_root_url(self._settings)
-        identity = load_or_create_front_identity(self._home_dir)
+        try:
+            identity = load_or_create_front_identity(self._home_dir)
+        except OSError as exc:
+            logger.warning(
+                "Could not read or create the front identity secret: {}; "
+                "Claude Desktop routing stays on plain HTTP.",
+                exc,
+            )
+            return False
         if probe_fcc_front(target, identity, self._home_dir):
             logger.info("Reusing existing FCC HTTPS front at {}", target)
             return True

--- a/src/free_claude_code/cli/tls_proxy.py
+++ b/src/free_claude_code/cli/tls_proxy.py
@@ -212,8 +212,16 @@ class CaddyTlsProxy:
             )
             return False
 
-        self._home_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        self.caddyfile_path.write_text(self.render_caddyfile(), encoding="utf-8")
+        try:
+            self._home_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            self.caddyfile_path.write_text(self.render_caddyfile(), encoding="utf-8")
+        except OSError as exc:
+            logger.warning(
+                "Could not prepare the managed caddy state directory: {}; "
+                "Claude Desktop routing stays on plain HTTP.",
+                exc,
+            )
+            return False
         env = dict(os.environ)
         env["XDG_DATA_HOME"] = str(self._home_dir / "data")
         env["XDG_CONFIG_HOME"] = str(self._home_dir / "config")

--- a/src/free_claude_code/cli/tls_proxy.py
+++ b/src/free_claude_code/cli/tls_proxy.py
@@ -1,25 +1,47 @@
 """HTTPS front proxy for clients that refuse plain HTTP (e.g. Claude Desktop).
 
-Two cooperating pieces:
+Three cooperating pieces:
 
 1. ``probe_fcc_front`` / ``resolve_gateway_base_url`` — detect whether an
-   HTTPS endpoint that fronts *this* FCC server already answers on the
-   configured TLS port (verified via FCC's unauthenticated ``/health``
-   marker, since an adopted front also receives clients' API keys). Any
-   working external front is reused as-is; FCC never touches it.
+   HTTPS endpoint that fronts *this* FCC install already answers on the
+   configured TLS port. An adopted front also receives clients' API keys, so
+   adoption demands two independent proofs: the listener's certificate must
+   chain to this install's managed CA root (ownership of the key material an
+   unrelated local process cannot forge), and it must serve the per-install
+   identity secret at a private path. Any verified front is reused as-is;
+   FCC never touches it.
 2. ``CaddyTlsProxy`` — when nothing answers and a ``caddy`` binary exists,
    spawn an FCC-managed instance: generated Caddyfile under ``~/.fcc/caddy/``
    with ``tls internal``, admin API disabled, and all of Caddy's state
    sandboxed inside that directory. The proxy forwards to the local FCC
    server and is stopped alongside it.
+3. ``ensure_https_front`` / ``verified_https_gateway_url`` — the gate
+   credential-bearing entry points (the standalone launcher) use: bring up a
+   verified HTTPS front or fail, and only then hand out the gateway URL.
+   Claude Desktop cannot use the plain-HTTP fallback, so these never return
+   one.
+
+The long-running server (``commands.ServerSupervisor``) additionally runs a
+concurrent readiness thread that re-probes with ``probe_fcc_front`` while
+Uvicorn serves — the front can only verify once FCC's own routes answer
+through it — and upgrades the published desktop gateway URL to the
+TLS-prefixed one during the live serving window.
+
+Security boundary: every proof here (the identity secret, the managed CA
+key material) is owner-only on disk, which keeps *other local users* out.
+A process already running as this user can read all of them, so same-user
+code execution is outside the security boundary this module defends — the
+same boundary the proxy auth token itself lives behind.
 """
 
 import http.client
-import json
 import os
+import secrets
 import shutil
 import ssl
+import stat
 import subprocess
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -36,54 +58,127 @@ from free_claude_code.config.settings import Settings
 CADDY_BINARY = "caddy"
 CADDY_HOME_DIRNAME = "caddy"
 READY_TIMEOUT_SECONDS = 10.0
-FCC_HEALTH_MARKER = {"status": "healthy"}
+# Private path the managed front answers on to prove it belongs to this FCC
+# install. Unrelated to any route FCC serves, so a reverse proxy in front of
+# FCC cannot collide with or forge it.
+FRONT_IDENTITY_PATH = "/.fcc-front-identity"
+FRONT_IDENTITY_FILENAME = "front-identity"
+FRONT_IDENTITY_BYTES = 32
+# Where the managed caddy stores its internal CA, relative to the sandboxed
+# XDG_DATA_HOME set in ``CaddyTlsProxy.start``.
+_MANAGED_CA_PARTS = ("data", "caddy", "pki", "authorities", "local", "root.crt")
 
 
-def _unverified_context() -> ssl.SSLContext:
-    """TLS context accepting self-signed local certificates."""
+def _default_home_dir() -> Path:
+    """Sandbox directory for the managed front's state and identity proofs."""
 
-    context = ssl.create_default_context()
-    context.check_hostname = False
-    context.verify_mode = ssl.CERT_NONE
+    override = os.environ.get("FCC_CONFIG_HOME")
+    base = Path(override) if override else paths.config_dir_path()
+    return base / CADDY_HOME_DIRNAME
+
+
+def front_identity_path(home_dir: Path | None = None) -> Path:
+    """File holding this install's front-identity secret (owner-only)."""
+
+    base = home_dir or _default_home_dir()
+    return base / FRONT_IDENTITY_FILENAME
+
+
+def managed_ca_path(home_dir: Path | None = None) -> Path:
+    """Root certificate of this install's managed caddy internal CA.
+
+    The managed caddy sandboxes all state under ``home_dir`` (its
+    ``XDG_DATA_HOME``), so its CA root lives at a fixed path inside it.
+    """
+
+    base = home_dir or front_identity_path().parent
+    return base.joinpath(*_MANAGED_CA_PARTS)
+
+
+def _front_ssl_context(ca_path: Path) -> ssl.SSLContext:
+    """TLS context that only trusts certificates issued by ``ca_path``.
+
+    Full chain validation plus hostname verification (``urllib`` pins the
+    request URL's host as the expected certificate name): a local process
+    that merely binds the port presents a self-signed certificate that does
+    not chain to this install's managed CA, so the handshake fails before
+    any request is sent to it.
+    """
+
+    context = ssl.create_default_context(cafile=str(ca_path))
+    context.check_hostname = True
+    context.verify_mode = ssl.CERT_REQUIRED
+    context.hostname_checks_common_name = False
     return context
 
 
-def probe_https(url: str, timeout_seconds: float = 1.0) -> bool:
-    """Whether ``url`` answers over TLS with any HTTP status.
+def load_or_create_front_identity(home_dir: Path | None = None) -> str:
+    """Return this install's front-identity secret, creating it once.
 
-    Certificate errors are expected (self-signed local CA) and ignored;
-    only transport success counts.
+    The secret is one of the two proofs a TLS listener belongs to this FCC
+    install before it is adopted as the credential-bearing gateway (the
+    other is its certificate chaining to the managed CA), so it must be
+    unguessable (256 random bits) and readable only by the owner regardless
+    of the process umask.
     """
 
+    path = front_identity_path(home_dir)
     try:
-        with urllib.request.urlopen(
-            url, timeout=timeout_seconds, context=_unverified_context()
-        ):
-            return True
-    except urllib.error.HTTPError as exc:
-        # Any HTTP status (404/401/502 ...) proves the TLS front is alive;
-        # only transport-level failures mean it is not ready.
-        exc.close()  # close the error body so no ResourceWarning fires at GC
-        return True
-    except urllib.error.URLError, OSError, ValueError:
-        return False
+        existing = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        existing = ""
+    if existing:
+        return existing
+
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    secret = secrets.token_hex(FRONT_IDENTITY_BYTES)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        handle.write(secret)
+    # ``os.open`` mode is still filtered by umask at creation; force
+    # owner-only so a permissive umask cannot widen it.
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    return secret
 
 
-def probe_fcc_front(base_url: str, timeout_seconds: float = 1.0) -> bool:
-    """Whether ``base_url`` fronts *this* FCC server, not just any TLS listener.
+def probe_fcc_front(
+    base_url: str,
+    identity_secret: str,
+    home_dir: Path | None = None,
+    timeout_seconds: float = 1.0,
+) -> bool:
+    """Whether ``base_url`` fronts *this* FCC install, not just any TLS listener.
 
     Adopting an external front is a trust decision: whatever answers also
-    receives clients' API keys and inference traffic. A listener therefore only
-    counts as an existing front when it serves FCC's unauthenticated
-    ``/health`` marker through the TLS layer — which every reverse proxy in
-    front of FCC passes through untouched.
+    receives clients' API keys and inference traffic. A listener therefore
+    only counts as an existing front when both hold:
+
+    * its certificate validates against this install's managed CA root with
+      hostname verification — a reusable secret alone is a bearer value any
+      same-user process could read from disk and replay over its own
+      self-signed TLS, but such a listener's certificate never chains to the
+      managed CA;
+    * it serves this install's unguessable identity secret at the private
+      identity path.
+
+    Without the managed CA file there is nothing to verify against, so the
+    listener is never adopted and callers fall back to plain HTTP.
     """
 
-    health_url = f"{base_url.rstrip('/')}/health"
-    request = urllib.request.Request(health_url)
+    if not identity_secret:
+        return False
+    ca_path = managed_ca_path(home_dir)
+    if not ca_path.is_file():
+        return False
+    try:
+        context = _front_ssl_context(ca_path)
+    except OSError:
+        return False
+    identity_url = f"{base_url.rstrip('/')}{FRONT_IDENTITY_PATH}"
+    request = urllib.request.Request(identity_url)
     try:
         with urllib.request.urlopen(
-            request, timeout=timeout_seconds, context=_unverified_context()
+            request, timeout=timeout_seconds, context=context
         ) as response:
             body = response.read()
     except urllib.error.HTTPError as exc:
@@ -97,13 +192,10 @@ def probe_fcc_front(base_url: str, timeout_seconds: float = 1.0) -> bool:
     ):
         return False
     try:
-        payload = json.loads(body)
-    except json.JSONDecodeError, UnicodeDecodeError:
+        served = body.decode("utf-8").strip()
+    except UnicodeDecodeError:
         return False
-    return (
-        isinstance(payload, dict)
-        and payload.get("status") == FCC_HEALTH_MARKER["status"]
-    )
+    return secrets.compare_digest(served, identity_secret)
 
 
 def tls_root_url(settings: Settings) -> str:
@@ -117,9 +209,17 @@ def tls_root_url(settings: Settings) -> str:
 
 
 def resolve_gateway_base_url(settings: Settings) -> str:
-    """Best gateway base URL: HTTPS when something fronts the TLS port, else HTTP."""
+    """Best gateway base URL: HTTPS when this install's front owns the TLS port.
 
-    if settings.tls_proxy_enabled and probe_fcc_front(tls_root_url(settings)):
+    Only a listener that proves it belongs to this FCC install (certificate
+    chained to the managed CA plus identity secret match) is advertised as
+    the gateway; anything else falls back to plain HTTP so credentials are
+    never routed to an unverified listener.
+    """
+
+    if settings.tls_proxy_enabled and probe_fcc_front(
+        tls_root_url(settings), load_or_create_front_identity()
+    ):
         return tls_root_url(settings)
     return local_proxy_root_url(settings)
 
@@ -130,23 +230,45 @@ def desktop_gateway_base_url(settings: Settings, base_url: str | None = None) ->
     The prefix routes Claude Desktop onto the alias-emitting API mount while
     every other FCC client keeps hitting the bare paths, which always serve
     raw provider refs. ``base_url`` overrides resolution for callers that
-    already know which root serves (e.g. a verified HTTPS front).
+    already know which root serves (e.g. a front the readiness thread just
+    verified).
     """
 
     base = resolve_gateway_base_url(settings) if base_url is None else base_url
     return f"{base.rstrip('/')}/{settings.desktop_gateway_prefix}"
 
 
-def _default_home_dir() -> Path:
-    """Sandbox directory for the managed front's state and certificates.
+def ensure_https_front(settings: Settings) -> CaddyTlsProxy | None:
+    """Bring up a verified HTTPS front, or return ``None`` when impossible.
 
-    Routed through ``paths.config_dir_path()`` so the test-suite config-dir
-    monkeypatch is honored; ``FCC_CONFIG_HOME`` stays a hard override.
+    Reuses an already-verified front without spawning anything; otherwise
+    starts the managed proxy and keeps it running only while it stays
+    verified. Callers that receive ``None`` must not write a Desktop routing
+    block or spawn Claude Desktop: without HTTPS the gateway URL would fall
+    back to plain HTTP, which Claude Desktop cannot use.
     """
 
-    override = os.environ.get("FCC_CONFIG_HOME")
-    base = Path(override) if override else paths.config_dir_path()
-    return base / CADDY_HOME_DIRNAME
+    proxy = CaddyTlsProxy(settings)
+    if proxy.start():
+        return proxy
+    proxy.stop()
+    return None
+
+
+def verified_https_gateway_url(settings: Settings) -> str | None:
+    """Desktop gateway URL, but only when a verified HTTPS front answers.
+
+    Returns ``None`` instead of the plain-HTTP fallback
+    ``resolve_gateway_base_url`` would produce, because Claude Desktop
+    cannot route through plain HTTP and a credential-bearing config must
+    never point at an unverified listener.
+    """
+
+    if settings.tls_proxy_enabled and probe_fcc_front(
+        tls_root_url(settings), load_or_create_front_identity()
+    ):
+        return f"{tls_root_url(settings).rstrip('/')}/{settings.desktop_gateway_prefix}"
+    return None
 
 
 class CaddyTlsProxy:
@@ -161,8 +283,13 @@ class CaddyTlsProxy:
     def caddyfile_path(self) -> Path:
         return self._home_dir / "Caddyfile"
 
-    def render_caddyfile(self) -> str:
-        """Caddyfile text fronting the local FCC server with an internal cert."""
+    def render_caddyfile(self, identity_secret: str) -> str:
+        """Caddyfile text fronting the local FCC server with an internal cert.
+
+        The managed front also serves this install's identity secret at the
+        private identity path so later launches can prove ownership before
+        adopting it as the credential-bearing gateway.
+        """
 
         upstream_host = _browser_host_for_local_urls(self._settings)
         if ":" in upstream_host:
@@ -179,6 +306,7 @@ class CaddyTlsProxy:
                 "}",
                 f"localhost:{self._settings.tls_proxy_port} {{",
                 "    tls internal",
+                f'    respond {FRONT_IDENTITY_PATH} "{identity_secret}" 200',
                 f"    reverse_proxy {upstream} {{",
                 "        flush_interval -1",
                 "    }",
@@ -187,11 +315,22 @@ class CaddyTlsProxy:
             ]
         )
 
+    def _write_caddyfile(self, text: str) -> None:
+        """Write the Caddyfile owner-only: it embeds the identity secret."""
+
+        descriptor = os.open(
+            self.caddyfile_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        self.caddyfile_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
     def start(self) -> bool:
         """Start the managed proxy; returns whether HTTPS is now reachable.
 
-        Reuses an existing external front — only after it proves it fronts
-        this FCC server — without spawning anything. Never raises: failures
+        Reuses an existing external front — only after its certificate
+        validates against this install's managed CA and it serves the
+        identity secret — without spawning anything. Never raises: failures
         are logged and reported as ``False`` so callers can fall back to
         plain HTTP.
         """
@@ -199,7 +338,8 @@ class CaddyTlsProxy:
         if not self._settings.tls_proxy_enabled:
             return False
         target = tls_root_url(self._settings)
-        if probe_fcc_front(target):
+        identity = load_or_create_front_identity(self._home_dir)
+        if probe_fcc_front(target, identity, self._home_dir):
             logger.info("Reusing existing FCC HTTPS front at {}", target)
             return True
 
@@ -214,7 +354,7 @@ class CaddyTlsProxy:
 
         try:
             self._home_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-            self.caddyfile_path.write_text(self.render_caddyfile(), encoding="utf-8")
+            self._write_caddyfile(self.render_caddyfile(identity))
         except OSError as exc:
             logger.warning(
                 "Could not prepare the managed caddy state directory: {}; "
@@ -246,10 +386,9 @@ class CaddyTlsProxy:
             self._process = None
             return False
 
-        deadline_ready = READY_TIMEOUT_SECONDS
+        deadline = time.monotonic() + READY_TIMEOUT_SECONDS
         step = 0.25
-        waited = 0.0
-        while waited < deadline_ready:
+        while time.monotonic() < deadline:
             if self._process.poll() is not None:
                 logger.warning(
                     "Managed caddy exited early with code {}; "
@@ -258,10 +397,16 @@ class CaddyTlsProxy:
                 )
                 self._process = None
                 return False
-            if probe_https(target, timeout_seconds=0.5):
+            # Readiness means the full adoption probe passes against our own
+            # child: certificate chained to the managed CA and identity
+            # secret served. A transport-only handshake would also accept an
+            # unrelated listener that raced us onto the port. The probe is
+            # skipped until the child has written its CA root, so the
+            # timeout must cover that bootstrap too.
+            if probe_fcc_front(target, identity, self._home_dir, 0.5):
                 logger.info("Managed HTTPS front ready at {}", target)
                 return True
-            waited += step
+            time.sleep(step)
 
         logger.warning(
             "Managed caddy did not become ready on {} in {}s; "

--- a/src/free_claude_code/cli/tls_proxy.py
+++ b/src/free_claude_code/cli/tls_proxy.py
@@ -1,0 +1,279 @@
+"""HTTPS front proxy for clients that refuse plain HTTP (e.g. Claude Desktop).
+
+Two cooperating pieces:
+
+1. ``probe_fcc_front`` / ``resolve_gateway_base_url`` — detect whether an
+   HTTPS endpoint that fronts *this* FCC server already answers on the
+   configured TLS port (verified via FCC's unauthenticated ``/health``
+   marker, since an adopted front also receives clients' API keys). Any
+   working external front is reused as-is; FCC never touches it.
+2. ``CaddyTlsProxy`` — when nothing answers and a ``caddy`` binary exists,
+   spawn an FCC-managed instance: generated Caddyfile under ``~/.fcc/caddy/``
+   with ``tls internal``, admin API disabled, and all of Caddy's state
+   sandboxed inside that directory. The proxy forwards to the local FCC
+   server and is stopped alongside it.
+"""
+
+import http.client
+import json
+import os
+import shutil
+import ssl
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from loguru import logger
+
+from free_claude_code.config import paths
+from free_claude_code.config.server_urls import (
+    _browser_host_for_local_urls,
+    local_proxy_root_url,
+)
+from free_claude_code.config.settings import Settings
+
+CADDY_BINARY = "caddy"
+CADDY_HOME_DIRNAME = "caddy"
+READY_TIMEOUT_SECONDS = 10.0
+FCC_HEALTH_MARKER = {"status": "healthy"}
+
+
+def _unverified_context() -> ssl.SSLContext:
+    """TLS context accepting self-signed local certificates."""
+
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context
+
+
+def probe_https(url: str, timeout_seconds: float = 1.0) -> bool:
+    """Whether ``url`` answers over TLS with any HTTP status.
+
+    Certificate errors are expected (self-signed local CA) and ignored;
+    only transport success counts.
+    """
+
+    try:
+        with urllib.request.urlopen(
+            url, timeout=timeout_seconds, context=_unverified_context()
+        ):
+            return True
+    except urllib.error.HTTPError as exc:
+        # Any HTTP status (404/401/502 ...) proves the TLS front is alive;
+        # only transport-level failures mean it is not ready.
+        exc.close()  # close the error body so no ResourceWarning fires at GC
+        return True
+    except urllib.error.URLError, OSError, ValueError:
+        return False
+
+
+def probe_fcc_front(base_url: str, timeout_seconds: float = 1.0) -> bool:
+    """Whether ``base_url`` fronts *this* FCC server, not just any TLS listener.
+
+    Adopting an external front is a trust decision: whatever answers also
+    receives clients' API keys and inference traffic. A listener therefore only
+    counts as an existing front when it serves FCC's unauthenticated
+    ``/health`` marker through the TLS layer — which every reverse proxy in
+    front of FCC passes through untouched.
+    """
+
+    health_url = f"{base_url.rstrip('/')}/health"
+    request = urllib.request.Request(health_url)
+    try:
+        with urllib.request.urlopen(
+            request, timeout=timeout_seconds, context=_unverified_context()
+        ) as response:
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        exc.close()
+        return False
+    except (
+        urllib.error.URLError,
+        OSError,
+        ValueError,
+        http.client.HTTPException,
+    ):
+        return False
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError, UnicodeDecodeError:
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == FCC_HEALTH_MARKER["status"]
+    )
+
+
+def tls_root_url(settings: Settings) -> str:
+    """HTTPS URL Claude Desktop should use instead of the plain HTTP root.
+
+    Always ``localhost``: the TLS front is local by definition, and the
+    managed Caddy instance requests its internal certificate for that name.
+    """
+
+    return f"https://localhost:{settings.tls_proxy_port}"
+
+
+def resolve_gateway_base_url(settings: Settings) -> str:
+    """Best gateway base URL: HTTPS when something fronts the TLS port, else HTTP."""
+
+    if settings.tls_proxy_enabled and probe_fcc_front(tls_root_url(settings)):
+        return tls_root_url(settings)
+    return local_proxy_root_url(settings)
+
+
+def desktop_gateway_base_url(settings: Settings, base_url: str | None = None) -> str:
+    """Gateway URL scoped to Claude Desktop: root plus the desktop path prefix.
+
+    The prefix routes Claude Desktop onto the alias-emitting API mount while
+    every other FCC client keeps hitting the bare paths, which always serve
+    raw provider refs. ``base_url`` overrides resolution for callers that
+    already know which root serves (e.g. a verified HTTPS front).
+    """
+
+    base = resolve_gateway_base_url(settings) if base_url is None else base_url
+    return f"{base.rstrip('/')}/{settings.desktop_gateway_prefix}"
+
+
+def _default_home_dir() -> Path:
+    """Sandbox directory for the managed front's state and certificates.
+
+    Routed through ``paths.config_dir_path()`` so the test-suite config-dir
+    monkeypatch is honored; ``FCC_CONFIG_HOME`` stays a hard override.
+    """
+
+    override = os.environ.get("FCC_CONFIG_HOME")
+    base = Path(override) if override else paths.config_dir_path()
+    return base / CADDY_HOME_DIRNAME
+
+
+class CaddyTlsProxy:
+    """Lifecycle owner of one FCC-managed ``caddy run`` child process."""
+
+    def __init__(self, settings: Settings, home_dir: Path | None = None) -> None:
+        self._settings = settings
+        self._home_dir = home_dir or _default_home_dir()
+        self._process: subprocess.Popen[bytes] | None = None
+
+    @property
+    def caddyfile_path(self) -> Path:
+        return self._home_dir / "Caddyfile"
+
+    def render_caddyfile(self) -> str:
+        """Caddyfile text fronting the local FCC server with an internal cert."""
+
+        upstream_host = _browser_host_for_local_urls(self._settings)
+        if ":" in upstream_host:
+            upstream_host = f"[{upstream_host}]"
+        upstream = f"{upstream_host}:{self._settings.port}"
+        return "\n".join(
+            [
+                "{",
+                "    admin off",
+                # The automatic HTTP->HTTPS redirect would try to bind :80,
+                # which unprivileged users cannot do. Disabling just the
+                # redirect keeps automatic certificate management alive.
+                "    auto_https disable_redirects",
+                "}",
+                f"localhost:{self._settings.tls_proxy_port} {{",
+                "    tls internal",
+                f"    reverse_proxy {upstream} {{",
+                "        flush_interval -1",
+                "    }",
+                "}",
+                "",
+            ]
+        )
+
+    def start(self) -> bool:
+        """Start the managed proxy; returns whether HTTPS is now reachable.
+
+        Reuses an existing external front — only after it proves it fronts
+        this FCC server — without spawning anything. Never raises: failures
+        are logged and reported as ``False`` so callers can fall back to
+        plain HTTP.
+        """
+
+        if not self._settings.tls_proxy_enabled:
+            return False
+        target = tls_root_url(self._settings)
+        if probe_fcc_front(target):
+            logger.info("Reusing existing FCC HTTPS front at {}", target)
+            return True
+
+        binary = shutil.which(CADDY_BINARY)
+        if binary is None:
+            logger.warning(
+                "No HTTPS front answered on {} and no caddy binary found; "
+                "Claude Desktop routing stays on plain HTTP.",
+                target,
+            )
+            return False
+
+        self._home_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.caddyfile_path.write_text(self.render_caddyfile(), encoding="utf-8")
+        env = dict(os.environ)
+        env["XDG_DATA_HOME"] = str(self._home_dir / "data")
+        env["XDG_CONFIG_HOME"] = str(self._home_dir / "config")
+        try:
+            self._process = subprocess.Popen(
+                [
+                    binary,
+                    "run",
+                    "--config",
+                    str(self.caddyfile_path),
+                    "--adapter",
+                    "caddyfile",
+                ],
+                cwd=self._home_dir,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            logger.warning("Could not start managed caddy: {}", exc)
+            self._process = None
+            return False
+
+        deadline_ready = READY_TIMEOUT_SECONDS
+        step = 0.25
+        waited = 0.0
+        while waited < deadline_ready:
+            if self._process.poll() is not None:
+                logger.warning(
+                    "Managed caddy exited early with code {}; "
+                    "Claude Desktop routing stays on plain HTTP.",
+                    self._process.returncode,
+                )
+                self._process = None
+                return False
+            if probe_https(target, timeout_seconds=0.5):
+                logger.info("Managed HTTPS front ready at {}", target)
+                return True
+            waited += step
+
+        logger.warning(
+            "Managed caddy did not become ready on {} in {}s; "
+            "Claude Desktop routing stays on plain HTTP.",
+            target,
+            READY_TIMEOUT_SECONDS,
+        )
+        self.stop()
+        return False
+
+    def stop(self) -> None:
+        """Terminate the managed child process, if we own one."""
+
+        process = self._process
+        self._process = None
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()

--- a/src/free_claude_code/cli/tls_proxy.py
+++ b/src/free_claude_code/cli/tls_proxy.py
@@ -77,6 +77,24 @@ def _default_home_dir() -> Path:
     return base / CADDY_HOME_DIRNAME
 
 
+def _restrict_home_permissions(directory: Path) -> None:
+    """Tighten an existing Caddy home to owner-only access.
+
+    ``mkdir(mode=0o700)`` only applies to directories the call itself
+    creates; a home that already exists keeps whatever mode it was made
+    with, so under a permissive umask an inherited ``0777`` home lets any
+    local user traverse and write into the directory holding the
+    credential-bearing front's identity secret, Caddyfile, and CA state.
+    The managed front writes its state here, so the directory is forced
+    to owner-only before any of those files exist.
+    """
+
+    current = directory.stat().st_mode
+    target = stat.S_IRWXU
+    if current & 0o777 != target:
+        directory.chmod(target)
+
+
 def front_identity_path(home_dir: Path | None = None) -> Path:
     """File holding this install's front-identity secret (owner-only)."""
 
@@ -131,6 +149,7 @@ def load_or_create_front_identity(home_dir: Path | None = None) -> str:
         return existing
 
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _restrict_home_permissions(path.parent)
     secret = secrets.token_hex(FRONT_IDENTITY_BYTES)
     descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
@@ -362,6 +381,7 @@ class CaddyTlsProxy:
 
         try:
             self._home_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            _restrict_home_permissions(self._home_dir)
             self._write_caddyfile(self.render_caddyfile(identity))
         except OSError as exc:
             logger.warning(

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -703,6 +703,19 @@ class Settings(BaseModel):
         default="freecc",
         validation_alias="ANTHROPIC_AUTH_TOKEN",
     )
+    desktop_gateway_prefix: NonEmptyString = Field(
+        default="claude-desktop",
+        validation_alias="DESKTOP_GATEWAY_PREFIX",
+    )
+
+    @field_validator("desktop_gateway_prefix")
+    @classmethod
+    def normalize_desktop_gateway_prefix(cls, v: str) -> str:
+        """Strip boundary slashes so the prefix mounts as a single ``/{prefix}``."""
+        prefix = v.strip("/")
+        if not prefix:
+            raise ValueError("DESKTOP_GATEWAY_PREFIX must contain a path segment")
+        return prefix
 
     @field_validator("max_message_log_entries_per_chat", mode="before")
     @classmethod

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -703,6 +703,14 @@ class Settings(BaseModel):
         default="freecc",
         validation_alias="ANTHROPIC_AUTH_TOKEN",
     )
+    tls_proxy_enabled: bool = Field(
+        default=True,
+        validation_alias="TLS_PROXY_ENABLED",
+    )
+    tls_proxy_port: int = Field(
+        default=8443,
+        validation_alias="TLS_PROXY_PORT",
+    )
     desktop_gateway_prefix: NonEmptyString = Field(
         default="claude-desktop",
         validation_alias="DESKTOP_GATEWAY_PREFIX",

--- a/src/free_claude_code/core/gateway_model_ids.py
+++ b/src/free_claude_code/core/gateway_model_ids.py
@@ -1,5 +1,6 @@
 """Gateway-safe model ID encoding shared by API and CLI adapters."""
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 GATEWAY_MODEL_ID_PREFIX = "anthropic"
@@ -8,6 +9,47 @@ GATEWAY_MODEL_ID_PREFIX = "anthropic"
 # supporting thinking. This intentionally uses that client-side capability
 # heuristic while keeping the real provider/model ref reversible for routing.
 NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
+
+PICKER_ALIAS_PREFIX = "claude-sonnet-nim"
+_PICKER_ALIAS_NO_THINKING_SUFFIX = "-no-thinking"
+_PICKER_ALIAS_WIDTH = 4
+
+
+@dataclass(frozen=True, slots=True)
+class _PickerAliasMaps:
+    """Immutable alias snapshot shared by catalog output and request routing.
+
+    Published as a single module-global assignment so concurrent readers can
+    never observe a torn state mixing refs from two different inventories.
+    """
+
+    alias_to_ref: Mapping[str, str]
+    alias_to_ref_no_thinking: Mapping[str, str]
+    ref_to_alias: Mapping[str, str]
+    ref_to_alias_no_thinking: Mapping[str, str]
+
+
+_EMPTY_PICKER_ALIAS_MAPS = _PickerAliasMaps({}, {}, {}, {})
+
+# Seeded at startup with the sorted refs from the runtime cached model catalog,
+# then republished whenever the model cache is mutated. Tests call
+# ``clear_picker_aliases()`` between runs to restore the inert empty snapshot.
+_picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+
+# Sticky ref-to-alias assignments that survive reseeds: once an alias has been
+# advertised for a ref, that alias is never re-pointed to a different ref, so
+# a desktop picker holding a stale catalog cannot silently route to another
+# model. Numbers of retired refs stay consumed; a returning ref regains its
+# previous alias. Reset only by ``clear_picker_aliases()``.
+_sticky_ref_to_alias: dict[str, str] = {}
+_used_alias_numbers: set[int] = set()
+
+
+def _next_unused_alias_number(used_numbers: set[int]) -> int:
+    candidate = 1
+    while candidate in used_numbers:
+        candidate += 1
+    return candidate
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,3 +91,96 @@ def decode_gateway_model_id(model_name: str) -> DecodedGatewayModelId | None:
         provider_model=provider_model,
         force_reasoning_off=force_reasoning_off,
     )
+
+
+def _format_picker_alias(index: int, *, no_thinking: bool) -> str:
+    suffix = _PICKER_ALIAS_NO_THINKING_SUFFIX if no_thinking else ""
+    return f"{PICKER_ALIAS_PREFIX}-{index:0{_PICKER_ALIAS_WIDTH}d}{suffix}"
+
+
+def seed_picker_aliases(provider_model_refs: Iterable[str]) -> None:
+    """Publish a fresh immutable alias snapshot built from the supplied refs.
+
+    Aliases are stable across reseeds: a ref that already holds an alias keeps
+    it, and new refs take previously unused numbers, so an alias already shown
+    in a client picker can never silently resolve to a different model.
+    Numbering is deterministic on restart when starting from the same initial
+    inventory (counters assigned by ``sorted(refs)`` order).
+
+    An empty inventory publishes the inert empty snapshot so a cold-start
+    ``/v1/models`` request still falls back to the canonical
+    ``gateway_model_id`` wrappers, while sticky assignments and consumed
+    alias numbers are preserved so a later refresh can never re-point a
+    previously advertised alias.
+    """
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+
+    wanted = [ref for ref in sorted(set(provider_model_refs)) if ref]
+    if not wanted:
+        _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+        return
+
+    thinking_aliases: dict[str, str] = {}
+    no_thinking_aliases: dict[str, str] = {}
+    ref_to_thinking: dict[str, str] = {}
+    ref_to_no_thinking: dict[str, str] = {}
+    used_numbers = set(_used_alias_numbers)
+
+    for ref in wanted:
+        alias = _sticky_ref_to_alias.get(ref)
+        if alias is None:
+            number = _next_unused_alias_number(used_numbers)
+            used_numbers.add(number)
+            alias = _format_picker_alias(number, no_thinking=False)
+        thinking_aliases[alias] = ref
+        alias_no_thinking = f"{alias}{_PICKER_ALIAS_NO_THINKING_SUFFIX}"
+        no_thinking_aliases[alias_no_thinking] = ref
+        ref_to_thinking[ref] = alias
+        ref_to_no_thinking[ref] = alias_no_thinking
+
+    _sticky_ref_to_alias = {**_sticky_ref_to_alias, **ref_to_thinking}
+    _used_alias_numbers = used_numbers
+    _picker_aliases = _PickerAliasMaps(
+        alias_to_ref=thinking_aliases,
+        alias_to_ref_no_thinking=no_thinking_aliases,
+        ref_to_alias=ref_to_thinking,
+        ref_to_alias_no_thinking=ref_to_no_thinking,
+    )
+
+
+def picker_alias_for(
+    provider_model_ref: str, *, force_reasoning_off: bool = False
+) -> str | None:
+    """Return the picker alias for ``provider_model_ref``, if seeded."""
+    maps = _picker_aliases
+    if force_reasoning_off:
+        return maps.ref_to_alias_no_thinking.get(provider_model_ref)
+    return maps.ref_to_alias.get(provider_model_ref)
+
+
+def resolve_picker_alias(model_name: str) -> tuple[str, bool] | None:
+    """Reverse-lookup alias. Returns ``(provider_ref, force_reasoning_off)``."""
+    if not model_name:
+        return None
+    maps = _picker_aliases
+    ref = maps.alias_to_ref_no_thinking.get(model_name)
+    if ref is not None:
+        return ref, True
+    ref = maps.alias_to_ref.get(model_name)
+    if ref is not None:
+        return ref, False
+    return None
+
+
+def has_picker_aliases() -> bool:
+    """Whether ``seed_picker_aliases`` has populated the snapshot."""
+    maps = _picker_aliases
+    return bool(maps.alias_to_ref) or bool(maps.alias_to_ref_no_thinking)
+
+
+def clear_picker_aliases() -> None:
+    """Drop every alias entry and sticky assignment. Tests and hardening."""
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+    _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+    _sticky_ref_to_alias = {}
+    _used_alias_numbers = set()

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -147,6 +147,7 @@ class ApplicationRuntime:
             self.provider_manager.start_model_list_refresh()
             if self._chat_service is not None:
                 await self._chat_service.start()
+            self._seed_picker_aliases_from_cache()
             await self._start_messaging_if_configured()
             logging.getLogger("uvicorn.error").info(
                 "Admin UI: %s (local-only)",
@@ -341,6 +342,14 @@ class ApplicationRuntime:
             "admin_url": local_admin_url(settings) if automatic else None,
             "fields": list(fields),
         }
+
+    def _seed_picker_aliases_from_cache(self) -> None:
+        """Publish picker aliases for exactly the cached model inventory.
+
+        Delegates to the provider manager so startup seeding and every later
+        model-catalog republication share one ownership path.
+        """
+        self.provider_manager.refresh_picker_aliases()
 
     async def _start_messaging_if_configured(self) -> None:
         try:

--- a/src/free_claude_code/runtime/provider_manager.py
+++ b/src/free_claude_code/runtime/provider_manager.py
@@ -13,7 +13,9 @@ from free_claude_code.application.model_metadata import (
     ProviderModelRefreshResult,
 )
 from free_claude_code.application.ports import RequestRuntimePort
+from free_claude_code.config.model_refs import configured_chat_model_refs
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.gateway_model_ids import seed_picker_aliases
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.runtime import ProviderRuntime
@@ -366,7 +368,27 @@ class ProviderRuntimeManager:
             return
         self._run_model_catalog_publication(publisher.ensure_exists)
 
+    def refresh_picker_aliases(self) -> None:
+        """Re-point the process-global picker aliases at the current inventory.
+
+        Seeds the union of configured chat model refs and cached discovery
+        refs so a configured model absent from the discovery cache (cold or
+        incomplete provider discovery) still gets a picker alias instead of
+        being advertised as a raw gateway identifier.
+
+        Sticky ref-to-alias assignments make reseeds stable: already
+        advertised aliases keep routing to the same model, newly discovered
+        refs gain aliases immediately, and refs removed from the inventory
+        retire instead of routing to stale targets.
+        """
+        configured = (
+            ref.model_ref for ref in configured_chat_model_refs(self.current_settings())
+        )
+        cached = (info.model_id for info in self.cached_prefixed_model_infos())
+        seed_picker_aliases((*configured, *cached))
+
     def _publish_model_catalog(self) -> None:
+        self.refresh_picker_aliases()
         publisher = self._model_catalog_publisher
         if publisher is None:
             return

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -114,7 +114,12 @@ def test_messages_auth_gives_authorization_precedence_over_x_api_key():
     app.dependency_overrides.clear()
 
 
-def test_x_api_key_remains_rejected_on_non_messages_routes():
+def test_x_api_key_is_accepted_on_all_proxy_auth_routes():
+    # Claude Desktop authenticates to the inference gateway with an
+    # Anthropic-native ``x-api-key`` header, and its model discovery reads the
+    # models route. Every proxy-authenticated route therefore accepts
+    # ``x-api-key`` as an equal scheme alongside Bearer, while a wrong key is
+    # still rejected.
     client = TestClient(app)
     settings = Settings(proxy_auth_enabled=True, proxy_auth_token="route-token")
     app.dependency_overrides[get_settings] = lambda: settings
@@ -125,7 +130,10 @@ def test_x_api_key_remains_rejected_on_non_messages_routes():
         (client.get, "/"),
     ):
         response = method(path, headers={"X-API-Key": "route-token"})
-        assert response.status_code == 401
+        assert response.status_code in (200, 204)
+
+        wrong = method(path, headers={"X-API-Key": "wrong"})
+        assert wrong.status_code == 401
 
     app.dependency_overrides.clear()
 

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -132,7 +132,7 @@ def test_require_proxy_auth_rejects_missing_authorization():
     assert exc_info.value.detail == "Missing proxy authentication token"
 
 
-@pytest.mark.parametrize("header_name", ["x-api-key", "anthropic-auth-token"])
+@pytest.mark.parametrize("header_name", ["anthropic-auth-token"])
 def test_require_proxy_auth_rejects_legacy_header_only(header_name: str):
     request, settings = _request(headers={header_name: "secret"}, token="secret")
 
@@ -141,6 +141,22 @@ def test_require_proxy_auth_rejects_legacy_header_only(header_name: str):
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "Missing proxy authentication token"
+
+
+def test_require_proxy_auth_accepts_exact_x_api_key_token():
+    request, settings = _request(headers={"x-api-key": "secret"}, token="secret")
+
+    require_proxy_auth(request, settings)
+
+
+def test_require_proxy_auth_rejects_wrong_x_api_key_token():
+    request, settings = _request(headers={"x-api-key": "wrong"}, token="secret")
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_proxy_auth(request, settings)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid proxy authentication token"
 
 
 def test_require_proxy_auth_accepts_exact_bearer_token():

--- a/tests/api/test_desktop_scoped_models.py
+++ b/tests/api/test_desktop_scoped_models.py
@@ -1,0 +1,191 @@
+"""End-to-end scoping of picker aliases to the desktop-only API mount."""
+
+from fastapi.testclient import TestClient
+
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from tests.api.support import create_test_app
+
+
+def _settings() -> Settings:
+    settings = Settings()
+    settings.model = "deepseek/deepseek-chat"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    return settings
+
+
+def setup_function(_: object) -> None:
+    gmi.seed_picker_aliases(["deepseek/deepseek-chat"])
+
+
+def teardown_function(_: object) -> None:
+    gmi.clear_picker_aliases()
+
+
+def test_bare_models_route_never_serves_aliases() -> None:
+    app = create_test_app(_settings())
+
+    ids = [m["id"] for m in TestClient(app).get("/v1/models").json()["data"]]
+
+    assert all(not i.startswith("claude-sonnet-nim") for i in ids)
+    assert "anthropic/deepseek/deepseek-chat" in ids
+
+
+def test_prefixed_models_route_serves_aliases() -> None:
+    app = create_test_app(_settings())
+
+    response = TestClient(app).get("/claude-desktop/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = [m["id"] for m in data["data"]]
+    # The alias replaces the wrapper id for the same ref.
+    assert "claude-sonnet-nim-0001" in ids
+    assert "anthropic/deepseek/deepseek-chat" not in ids
+    labels = {
+        m["display_name"]
+        for m in data["data"]
+        if m["id"].startswith("claude-sonnet-nim")
+    }
+    assert "deepseek/deepseek-chat" in labels
+
+
+def test_custom_prefix_is_honored_from_settings() -> None:
+    app = create_test_app(
+        Settings.model_construct(
+            desktop_gateway_prefix="my-gateway",
+            model="deepseek/deepseek-chat",
+            model_fable=None,
+            model_opus=None,
+            model_sonnet=None,
+            model_haiku=None,
+        )
+    )
+
+    bare = TestClient(app).get("/v1/models")
+    prefixed = TestClient(app).get("/my-gateway/v1/models")
+
+    assert all(not m["id"].startswith("claude-sonnet-nim") for m in bare.json()["data"])
+    assert any(m["id"].startswith("claude-sonnet-nim") for m in prefixed.json()["data"])
+
+
+def test_prefix_with_boundary_slashes_is_normalized() -> None:
+    """FastAPI rejects router prefixes ending in '/', so a configured value
+    like '/desktop/' must be normalized or app startup crashes."""
+    settings = Settings(desktop_gateway_prefix="/desktop/")
+    settings.model = "deepseek/deepseek-chat"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+
+    response = TestClient(create_test_app(settings)).get("/desktop/v1/models")
+
+    assert response.status_code == 200
+    assert any(m["id"].startswith("claude-sonnet-nim") for m in response.json()["data"])
+
+
+def test_lookalike_prefixed_path_does_not_serve_aliases() -> None:
+    """Only the exact desktop prefix mount emits aliases; paths that merely
+    start with the same text must never leak picker aliases."""
+    app = create_test_app(_settings())
+
+    response = TestClient(app).get("/claude-desktop-evil/v1/models")
+
+    assert response.status_code == 404
+
+
+def test_prefix_equal_to_bare_v1_does_not_leak_aliases() -> None:
+    """A ``DESKTOP_GATEWAY_PREFIX`` of ``v1`` must not capture the bare catalog.
+
+    The bare ``/v1/models`` path starts with ``/v1/`` — a prefix-sniffing
+    check would treat it as the desktop mount and serve Desktop-only aliases
+    to Claude Code, Codex, Pi and every other client. Alias emission must be
+    gated on the exact mounted path instead.
+    """
+    app = create_test_app(
+        Settings.model_construct(
+            desktop_gateway_prefix="v1",
+            model="deepseek/deepseek-chat",
+            model_fable=None,
+            model_opus=None,
+            model_sonnet=None,
+            model_haiku=None,
+        )
+    )
+
+    client = TestClient(app)
+    bare = [m["id"] for m in client.get("/v1/models").json()["data"]]
+    mounted = [m["id"] for m in client.get("/v1/v1/models").json()["data"]]
+
+    assert all(not i.startswith("claude-sonnet-nim") for i in bare)
+    assert "anthropic/deepseek/deepseek-chat" in bare
+    assert any(i.startswith("claude-sonnet-nim") for i in mounted)
+
+
+def test_messages_round_trip_works_under_desktop_prefix() -> None:
+    """Claude Desktop chats against the prefixed base URL, so the full API
+    surface must exist under the prefix too."""
+    from unittest.mock import patch
+
+    app = create_test_app()
+
+    with (
+        patch(
+            "free_claude_code.api.routes.get_token_count",
+            return_value=1,
+        ),
+    ):
+        response = TestClient(app).post(
+            "/claude-desktop/v1/messages/count_tokens",
+            json={
+                "model": "claude-3-sonnet",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+
+
+def test_advertised_alias_routes_through_prefixed_api() -> None:
+    """An alias served by the desktop catalog must be routable end to end."""
+    from unittest.mock import patch
+
+    from free_claude_code.application.routing import (
+        ModelRouter,
+        RoutedTokenCountRequest,
+    )
+    from free_claude_code.core.anthropic import TokenCountRequest
+
+    app = create_test_app(_settings())
+    routed_refs: list[str] = []
+    original_resolver = ModelRouter.resolve_token_count_request
+
+    def spy(self: ModelRouter, request: TokenCountRequest) -> RoutedTokenCountRequest:
+        routed = original_resolver(self, request)
+        routed_refs.append(routed.resolved.primary.provider_model_ref)
+        return routed
+
+    with (
+        patch("free_claude_code.api.routes.get_token_count", return_value=1),
+        patch.object(
+            ModelRouter,
+            "resolve_token_count_request",
+            autospec=True,
+            side_effect=spy,
+        ),
+    ):
+        response = TestClient(app).post(
+            "/claude-desktop/v1/messages/count_tokens",
+            json={
+                "model": "claude-sonnet-nim-0001",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+    # The advertised alias reached the router and resolved to its seeded ref.
+    assert routed_refs == ["deepseek/deepseek-chat"]

--- a/tests/api/test_desktop_startup_aliases.py
+++ b/tests/api/test_desktop_startup_aliases.py
@@ -1,0 +1,84 @@
+"""Production startup path: the desktop mount serves seeded picker aliases.
+
+Regression guard for the Greptile P1 "picker aliases remain inactive"
+finding: ``ApplicationRuntime.start()`` seeds the process-global alias
+snapshot from the warmed model cache, and the desktop-prefixed
+``/v1/models`` mount serves those aliases while the bare mount keeps raw
+provider refs for every other FCC client.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from free_claude_code.api.app import create_app
+from free_claude_code.api.ports import ApiServices
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.application import ApplicationRuntime
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _settings() -> Settings:
+    return Settings().model_copy(
+        update={
+            "model": "nvidia_nim/meta/llama-3.3-70b-instruct",
+            "nvidia_nim_api_key": "test-key",
+            "messaging_platform": "none",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_startup_seeds_aliases_served_by_desktop_mount() -> None:
+    settings = _settings()
+    manager = ProviderRuntimeManager(settings)
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    manager.cache_model_infos(
+        "nvidia_nim",
+        [
+            ProviderModelInfo(
+                model_id="meta/llama-3.3-70b-instruct", supports_thinking=None
+            )
+        ],
+    )
+    # Drop the publication side effect so only ``start()`` can reseed.
+    gmi.clear_picker_aliases()
+    assert gmi.has_picker_aliases() is False
+
+    with (
+        patch.object(manager, "warm_referenced_model_cache", new=AsyncMock()),
+        patch.object(manager, "start_model_list_refresh"),
+        patch.object(manager, "close", new=AsyncMock()),
+    ):
+        await runtime.start()
+        try:
+            assert gmi.has_picker_aliases() is True
+
+            app = create_app(
+                ApiServices(requests=manager, admin=runtime, tasks=runtime)
+            )
+            client = TestClient(app)
+
+            desktop = client.get("/claude-desktop/v1/models")
+            assert desktop.status_code == 200
+            desktop_ids = [m["id"] for m in desktop.json()["data"]]
+            assert "claude-sonnet-nim-0001" in desktop_ids
+            assert "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct" not in desktop_ids
+
+            bare = client.get("/v1/models")
+            assert bare.status_code == 200
+            bare_ids = [m["id"] for m in bare.json()["data"]]
+            assert "claude-sonnet-nim-0001" not in bare_ids
+            assert "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct" in bare_ids
+        finally:
+            await runtime.close()

--- a/tests/api/test_model_catalog_aliases.py
+++ b/tests/api/test_model_catalog_aliases.py
@@ -1,0 +1,129 @@
+"""Picker alias selection in ``free_claude_code.api.model_catalog``."""
+
+import pytest
+
+from free_claude_code.api import model_catalog
+from free_claude_code.application.ports import RequestRuntimeLease
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+class _StubRuntime:
+    async def acquire(
+        self, *, include_model_infos: bool = False
+    ) -> RequestRuntimeLease:
+        raise NotImplementedError("catalog construction never acquires a lease")
+
+    def current_settings(self) -> Settings:
+        raise NotImplementedError
+
+    def cached_model_info(self, provider_id: str, model_id: str):
+        return None
+
+    def cached_prefixed_model_infos(self):
+        return ()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+_MODEL_SLOTS = ("model", "model_fable", "model_opus", "model_sonnet", "model_haiku")
+
+
+def _settings_with_refs(*refs):
+    slots = {
+        slot: (refs[index] if index < len(refs) else None)
+        for index, slot in enumerate(_MODEL_SLOTS)
+    }
+    return Settings.model_construct(
+        **slots,
+        reasoning_policy=ReasoningPreference.CLIENT,
+    )
+
+
+def _ids(response: model_catalog.ModelsListResponse) -> list[str]:
+    return [item.id for item in response.data]
+
+
+def test_unseeded_state_uses_gateway_wrapper_ids():
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    picker_ids = [
+        item.id for item in response.data if item.id.startswith("claude-sonnet-nim")
+    ]
+    assert picker_ids == []
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in _ids(response)
+    assert "claude-3-freecc-no-thinking/nvidia_nim/01-ai/yi-large" in _ids(response)
+
+
+def test_seeded_state_prefers_alias_for_thinking_variant():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    ids = _ids(response)
+    assert "claude-sonnet-nim-0001" in ids
+    assert "claude-sonnet-nim-0001-no-thinking" in ids
+    # Wrapper id is suppressed because the alias covers the same slot.
+    assert "anthropic/nvidia_nim/01-ai/yi-large" not in ids
+
+
+def test_seed_only_nim_uses_wrapper_for_other_providers():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("openai_chat/anthropic/claude-3-5-sonnet-20241022")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    # Non-NIM ref falls through to the original wrapper ids.
+    assert "anthropic/openai_chat/anthropic/claude-3-5-sonnet-20241022" in ids
+    assert (
+        "claude-3-freecc-no-thinking/openai_chat/anthropic/claude-3-5-sonnet-20241022"
+        in ids
+    )
+    # And no alias leaked from the seeded NIM ref into the unrelated entry.
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+
+
+def test_display_name_is_provider_model_ref_when_using_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    alias_entries = [
+        item for item in response.data if item.id.startswith("claude-sonnet-nim-0001")
+    ]
+    # Thinking entry exposes the canonical provider ref; the no-thinking
+    # variant keeps the established "(no thinking)" label suffix.
+    assert {item.display_name for item in alias_entries} == {
+        "nvidia_nim/01-ai/yi-large",
+        "nvidia_nim/01-ai/yi-large (no thinking)",
+    }
+
+
+def test_seeded_aliases_are_hidden_without_opt_in():
+    """Claude Code / Codex / Pi path: aliases must never leak, even when seeded."""
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in ids

--- a/tests/application/test_routing_aliases.py
+++ b/tests/application/test_routing_aliases.py
@@ -1,0 +1,108 @@
+"""Picker alias decoding routed through ``application.routing.ModelRouter``."""
+
+import pytest
+
+from free_claude_code.application.routing import ModelRouter
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture
+def settings():
+    settings = Settings()
+    settings.model = "nvidia_nim/fallback-model"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    settings.reasoning_policy = ReasoningPreference.CLIENT
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_resolves_alias_before_gateway_prefix(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.original_model == "claude-sonnet-nim-0001"
+    assert resolved.reasoning_preference is ReasoningPreference.CLIENT
+
+
+def test_resolves_alias_no_thinking_variant_forces_reasoning_off(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001-no-thinking")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.reasoning_preference is ReasoningPreference.OFF
+
+
+def test_alias_takes_priority_over_anthropic_prefix(settings):
+    # The same underlying ref exists both as an alias and as an
+    # ``anthropic/<ref>`` gateway id. The alias must win on the picker shape,
+    # and both code paths resolve to the same upstream model.
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    alias_resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+    gateway_resolved = ModelRouter(settings).resolve(
+        "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct"
+    )
+
+    assert (
+        alias_resolved.primary.provider_id
+        == gateway_resolved.primary.provider_id
+        == "nvidia_nim"
+    )
+    assert (
+        alias_resolved.primary.provider_model
+        == gateway_resolved.primary.provider_model
+        == "meta/llama-3.3-70b-instruct"
+    )
+
+
+def test_alias_for_unknown_provider_falls_through_to_existing_chain(settings):
+    # An alias pointing at an unsupported provider must not silently match;
+    # the alias resolver returns the ref and routing layer validates it.
+    # After validation, ``resolve`` falls through to the existing route
+    # table, so ``claude-sonnet-nim-NNNN`` lands on the configured fallback.
+    gmi.seed_picker_aliases(["bogus_provider/some-model"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    # Not the bogus provider we accidentally aliased to.
+    assert resolved.primary.provider_id != "bogus_provider"
+    # Falls through to the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"
+
+
+def test_unknown_alias_falls_through_to_existing_routing(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-9999")
+
+    # 9999 is not a seeded alias; the routing layer should fall through.
+    # With no alias match, unknown alias falls back to model name parsing,
+    # which raises because ``claude-sonnet-nim-9999`` doesn't match a route.
+    assert resolved.original_model == "claude-sonnet-nim-9999"
+
+
+def test_unseeded_alias_returns_none_from_resolver(settings):
+    # Cold-start path: no aliases seeded, alias-shaped id should not produce
+    # a routing hit. Falls through to the existing fallback chain.
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0500")
+
+    # Falls through and lands on the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -748,3 +748,53 @@ def test_repeated_merges_absorb_post_merge_user_edits(
     out = json.loads(fake_config.read_text(encoding="utf-8"))
     assert out["inference"]["inferenceAnthropicApiKey"] == "user-key-v2"
     assert out["inference"]["custom"] == "keep"
+
+
+def test_repeated_merges_keep_container_provenance(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """The origin container shape survives repeated merges.
+
+    Regression guard for the Greptile "repeated merge loses container
+    provenance" finding: a second merge sees the ``inference`` object the
+    FIRST merge wrote, so re-snapshotting it would record
+    ``existed=True, was_object=True`` and leave unconfigure restoring into
+    an FCC-shaped container the user never had — an empty ``inference``
+    where the entry was absent, or ``{}`` where the user held a scalar. The
+    original provenance must be retained from the ownership record.
+    """
+
+    # Absent origin: after configure + rotated re-configure + unconfigure,
+    # the inference entry must be gone entirely.
+    fake_config.write_text(json.dumps({}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    rotated = fake_settings.model_copy(update={"proxy_auth_token": "tok-456"})
+    assert (
+        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {}
+
+    # Scalar origin: the user's non-object value must come back verbatim.
+    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "inference": "legacy-scalar"
+    }

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -400,8 +400,11 @@ def test_configure_keeps_first_snapshot_across_remerges(
 
     data = json.loads(fake_config.read_text(encoding="utf-8"))
     # No discovery entry: the key was absent before the first merge, and
-    # the restore must delete it again rather than invent a value.
+    # the restore must delete it again rather than invent a value. The
+    # ``managed`` entry records the exact block the merge wrote so removal
+    # can decide ownership without re-resolving the gateway URL.
     assert data["fccPriorConfig"] == {
+        "managed": claude_desktop.fcc_managed_block(fake_settings),
         "inference": {
             "provider": "anthropic",
             "inferenceAnthropicApiKey": "user-secret-key",
@@ -773,6 +776,272 @@ def test_ensure_configured_and_launch_refuses_without_https_front(
     assert not config_path.exists()
 
 
+def test_reconfigure_with_rotated_token_updates_ownership_record(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # Regression guard for the Greptile "stale ownership snapshot" finding:
+    # a second configure with a rotated proxy token or gateway URL must
+    # refresh the snapshot's record of the block FCC writes while keeping
+    # the original user-value backup frozen. Unconfigure then removes the
+    # newest FCC credential and URL instead of stranding them as if they
+    # were user-owned.
+    fake_config.write_text(
+        json.dumps(
+            {
+                "inference": {
+                    "provider": "anthropic",
+                    "inferenceAnthropicApiKey": "user-before",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    rotated = Settings(
+        host=fake_settings.host,
+        port=fake_settings.port,
+        proxy_auth_token="rotated-token",
+    )
+    rotated_url = "https://localhost:9443/claude-desktop"
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=rotated, gateway_base_url=rotated_url
+        )
+        is True
+    )
+    reconfigured = json.loads(fake_config.read_text(encoding="utf-8"))
+    # The ownership record tracks the newest written block; the user-value
+    # backup stays frozen at the original pre-install values.
+    assert reconfigured["fccPriorConfig"][
+        "managed"
+    ] == claude_desktop.fcc_managed_block(rotated, rotated_url)
+    assert reconfigured["fccPriorConfig"]["inference"] == {
+        "provider": "anthropic",
+        "inferenceAnthropicApiKey": "user-before",
+    }
+
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(fake_config, settings=rotated)
+        is True
+    )
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored == {
+        "inference": {
+            "provider": "anthropic",
+            "inferenceAnthropicApiKey": "user-before",
+        }
+    }
+
+
+def test_unconfigure_removes_written_url_when_front_is_down(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # The snapshot records the exact block the merge wrote, so removal must
+    # compare against THAT rather than a live re-resolution: when the HTTPS
+    # front is gone (exactly when users uninstall), live URL resolution falls
+    # back to plain HTTP and no longer matches the written HTTPS URL — yet
+    # the written gateway URL and token must still be removed.
+    https_url = "https://localhost:8443/claude-desktop"
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings, gateway_base_url=https_url
+        )
+        is True
+    )
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert configured["inference"]["inferenceGatewayBaseUrl"] == https_url
+
+    # Unconfigure without a gateway override: live resolution now yields the
+    # plain-HTTP fallback, which does not match the written HTTPS URL.
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored == {}
+
+
+def test_unconfigure_preserves_post_configure_inference_change(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # Regression guard for the Greptile "unconfigure overwrites post-
+    # configuration user changes with stale snapshot values" finding: a user
+    # who edits an FCC-managed key after configure owns it again, so
+    # unconfigure must keep the new value instead of restoring the stale
+    # pre-install snapshot entry.
+    fake_config.write_text(
+        json.dumps(
+            {
+                "inference": {
+                    "provider": "anthropic",
+                    "inferenceAnthropicApiKey": "user-before",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    # The user swaps the gateway credential after installing FCC.
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    configured["inference"]["inferenceAnthropicApiKey"] = "user-after"
+    fake_config.write_text(json.dumps(configured), encoding="utf-8")
+
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    # The user-changed credential survives; the still-FCC provider key is
+    # reverted to its pre-install value.
+    assert restored["inference"]["inferenceAnthropicApiKey"] == "user-after"
+    assert restored["inference"]["provider"] == "anthropic"
+    assert "fccPriorConfig" not in restored
+
+
+def test_unconfigure_preserves_post_configure_discovery_change(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # A user who flips the discovery flag after configure owns it again;
+    # unconfigure must neither delete it (it is no longer FCC's) nor restore
+    # a stale snapshot value over it.
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "anthropic"}}), encoding="utf-8"
+    )
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert configured["modelDiscoveryEnabled"] is True
+    configured["modelDiscoveryEnabled"] = False
+    fake_config.write_text(json.dumps(configured), encoding="utf-8")
+
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored["modelDiscoveryEnabled"] is False
+    assert "fccPriorConfig" not in restored
+
+
+def test_unconfigure_preserves_post_configure_block_replacement(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # When the original inference value was a non-object (recorded verbatim
+    # under ``inferenceRaw``) but the user later replaced the whole block with
+    # their own object, unconfigure must keep the user's block rather than
+    # restoring the stale raw value.
+    fake_config.write_text(json.dumps({"inference": "legacy-string"}), encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    configured["inference"] = {
+        "provider": "custom",
+        "inferenceAnthropicApiKey": "user-key",
+    }
+    fake_config.write_text(json.dumps(configured), encoding="utf-8")
+
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored["inference"] == {
+        "provider": "custom",
+        "inferenceAnthropicApiKey": "user-key",
+    }
+    assert "fccPriorConfig" not in restored
+
+
+def test_unconfigure_preserves_replacement_dict_retaining_fcc_token(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # Regression guard for the Greptile "unconfigure replaces a retained-
+    # token user routing dict with stale non-dict inference" finding: a user
+    # can legitimately keep the FCC auth token while replacing the provider,
+    # gateway URL, and adding custom routing fields. A retained token alone
+    # does not prove whole-block ownership, so unconfigure must keep the
+    # user's dict (removing only the individually FCC-owned token field)
+    # instead of restoring the stale verbatim raw value.
+    fake_config.write_text(json.dumps({"inference": "legacy-string"}), encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config,
+            settings=fake_settings,
+            gateway_base_url="https://localhost:8443/claude-desktop",
+        )
+        is True
+    )
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert configured["fccPriorConfig"]["inferenceRaw"] == "legacy-string"
+
+    # The user replaces the whole routing dict but keeps the FCC token.
+    configured["inference"] = {
+        "provider": "user-routing",
+        "inferenceProvider": "user-routing",
+        "inferenceGatewayBaseUrl": "https://user.example/routing",
+        "inferenceAnthropicApiKey": "tok-123",
+        "userRoutingSetting": "retain-me",
+    }
+    fake_config.write_text(json.dumps(configured), encoding="utf-8")
+
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    # The user's routing survives; only the still-FCC token field is removed.
+    assert restored["inference"] == {
+        "provider": "user-routing",
+        "inferenceProvider": "user-routing",
+        "inferenceGatewayBaseUrl": "https://user.example/routing",
+        "userRoutingSetting": "retain-me",
+    }
+    assert "fccPriorConfig" not in restored
+
+
 def test_unconfigure_restores_wholesale_inference_replacement(
     fake_config: Path,
     fake_settings: Settings,
@@ -807,3 +1076,151 @@ def test_unconfigure_restores_wholesale_inference_replacement(
         assert json.loads(fake_config.read_text(encoding="utf-8")) == {
             "inference": replacement
         }
+
+
+def test_remerge_absorbs_user_edited_managed_keys(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A post-merge managed-key edit becomes the snapshot's restore target.
+
+    Regression guard for the Greptile "reconfiguration overwrites user
+    settings" finding: the user edits a managed ``inference`` key between
+    merges, the next merge overwrites it, and unconfigure must restore the
+    user's edit — not the stale first-merge value. Keys the user left at
+    FCC's written value keep their original targets, and unmanaged keys
+    survive untouched.
+    """
+
+    fake_config.write_text(
+        json.dumps(
+            {
+                "modelDiscoveryEnabled": False,
+                "inference": {
+                    "provider": "user-provider-before-install",
+                    "userExtra": "keep",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    current = json.loads(fake_config.read_text(encoding="utf-8"))
+    current["inference"]["provider"] = "user-later-provider"
+    fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": False,
+        "inference": {
+            "provider": "user-later-provider",
+            "userExtra": "keep",
+        },
+    }
+
+
+def test_remerge_keeps_frozen_snapshot_without_user_edits(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """An untouched re-merge never rewrites the frozen original snapshot."""
+
+    original = {
+        "modelDiscoveryEnabled": False,
+        "inference": {"provider": "user-provider", "userExtra": "keep"},
+    }
+    fake_config.write_text(json.dumps(original), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is False
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == original
+
+
+def test_remerge_absorbs_user_disabled_discovery(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A post-merge discovery flip to ``False`` becomes the restore target.
+
+    Configure always writes ``True``, so a current ``False`` can only be
+    the user's choice — including when the key was absent before the
+    first merge, whose original state was "absent" but whose chosen state
+    is now explicitly ``False``.
+    """
+
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "p"}}), encoding="utf-8"
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    current = json.loads(fake_config.read_text(encoding="utf-8"))
+    current["modelDiscoveryEnabled"] = False
+    fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": False,
+        "inference": {"provider": "p"},
+    }
+
+
+def test_remerge_rotation_is_not_a_user_edit(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A rotated token/URL between merges must not read as a user edit.
+
+    Absorption compares the file's current values against the block the
+    PREVIOUS merge wrote. A re-merge after the proxy token rotated sees
+    every token-bearing key differ from the fresh resolution — without
+    the previous-written comparison those FCC-written values would be
+    absorbed as fake "user edits" and the original user values would be
+    lost.
+    """
+
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "orig"}}), encoding="utf-8"
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    rotated = fake_settings.model_copy(update={"proxy_auth_token": "rotated-token"})
+    assert (
+        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored == {"inference": {"provider": "orig"}}

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -416,10 +416,12 @@ def test_configure_unconfigure_roundtrip_restores_disabled_discovery(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    # Regression guard for the Greptile "discovery value restores
-    # incorrectly" finding: a user who explicitly disabled model discovery
-    # must get ``false`` back after unconfigure — presence alone would
-    # restore ``true`` and permanently flip the preference.
+    # A pre-install disabled flag is snapshotted, but a current ``True`` at
+    # unconfigure time is unattributable: it may be configure's own write
+    # (user untouched) or the user's explicit re-enable, and no file state
+    # distinguishes them. Per the Greptile ruling the ambiguous case
+    # preserves the current ``True`` — restoring the snapshotted ``false``
+    # would destroy an explicit re-enable, the worse failure.
     original = {
         "modelDiscoveryEnabled": False,
         "inference": {"provider": "anthropic"},
@@ -443,7 +445,10 @@ def test_configure_unconfigure_roundtrip_restores_disabled_discovery(
         is True
     )
     restored = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert restored == original
+    assert restored == {
+        "modelDiscoveryEnabled": True,
+        "inference": {"provider": "anthropic"},
+    }
 
 
 @pytest.mark.parametrize(
@@ -1121,7 +1126,7 @@ def test_remerge_absorbs_user_edited_managed_keys(
     )
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
-        "modelDiscoveryEnabled": False,
+        "modelDiscoveryEnabled": True,
         "inference": {
             "provider": "user-later-provider",
             "userExtra": "keep",
@@ -1133,7 +1138,14 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    """An untouched re-merge never rewrites the frozen original snapshot."""
+    """An untouched re-merge never rewrites the frozen original snapshot.
+
+    The discovery flag's original ``False`` is snapshotted, but the flag
+    is handed off with its current ``True`` at unconfigure: that value is
+    unattributable between configure's own write and a user re-enable,
+    and the Greptile ruling preserves it rather than risk destroying an
+    explicit choice.
+    """
 
     original = {
         "modelDiscoveryEnabled": False,
@@ -1153,7 +1165,10 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
         is False
     )
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == original
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": True,
+        "inference": {"provider": "user-provider", "userExtra": "keep"},
+    }
 
 
 def test_remerge_marks_user_disabled_discovery_user_owned(
@@ -1236,6 +1251,41 @@ def test_unconfigure_keeps_user_redisabled_discovery_verbatim(
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
         "modelDiscoveryEnabled": False,
+        "inference": {"provider": "p"},
+    }
+
+
+def test_unconfigure_preserves_present_original_discovery_reenable(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A re-enable over a snapshotted ``False`` original survives unconfigure.
+
+    Regression guard for the Greptile "unconfigure overwrites a later
+    re-enable" finding: the flag was ``False`` before install (snapshot
+    records it), configure wrote ``True``, and the user re-enabled it to
+    ``True`` — byte-identical to configure's own write — before
+    uninstalling. The flag is handed off verbatim: restoring the
+    snapshotted ``False`` would silently flip the user's explicit final
+    preference back off.
+    """
+
+    fake_config.write_text(
+        json.dumps({"modelDiscoveryEnabled": False, "inference": {"provider": "p"}}),
+        encoding="utf-8",
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    current = json.loads(fake_config.read_text(encoding="utf-8"))
+    current["modelDiscoveryEnabled"] = True
+    fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": True,
         "inference": {"provider": "p"},
     }
 

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -483,6 +483,70 @@ def test_configure_unconfigure_roundtrip_restores_non_object_inference(
     assert restored == original
 
 
+@pytest.mark.parametrize("raw_inference", ["legacy-scalar", None])
+def test_unconfigure_cleans_non_object_origin_after_user_adds_field(
+    fake_config: Path,
+    fake_settings: Settings,
+    raw_inference: object,
+) -> None:
+    # Regression guard for the Greptile "scalar-origin routing survives
+    # unconfigure" finding: when configure replaces a scalar or null
+    # ``inference`` with its managed mapping and the user later adds one
+    # unrelated field, whole-mapping ownership would break and leave every
+    # FCC routing key installed. Cleanup must stay per-key: managed keys
+    # still holding their written values are removed, the user's field
+    # survives.
+    original = {"inference": raw_inference}
+    fake_config.write_text(json.dumps(original), encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["userAddedAfterConfigure"] = "must-survive"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["inference"] == {"userAddedAfterConfigure": "must-survive"}
+
+
+def test_unconfigure_keeps_user_edited_managed_key_over_scalar_origin(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # A user-edited managed key is user-owned and survives unconfigure,
+    # while every managed key still at its written value is removed.
+    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["inferenceGatewayBaseUrl"] = "user-edited-url"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["inference"] == {"inferenceGatewayBaseUrl": "user-edited-url"}
+
+
 def test_unconfigure_roundtrip_is_clean_noop(
     fake_config: Path,
     fake_settings: Settings,

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -798,3 +798,39 @@ def test_repeated_merges_keep_container_provenance(
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
         "inference": "legacy-scalar"
     }
+
+
+def test_unconfigure_restores_wholesale_inference_replacement(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A post-merge wholesale ``inference`` replacement survives unconfigure.
+
+    Regression guard for the Greptile "reconfiguration overwrites full
+    inference replacements" finding: after the first merge the user swaps
+    the whole ``inference`` entry for a scalar or ``null``. A later
+    re-merge still writes the managed mapping (configure's contract is
+    to ensure the block exists), but the replacement is now the origin
+    unconfigure must restore — re-snapshotting the pre-FCC state would
+    silently discard the user's change.
+    """
+
+    for replacement in ("user-scalar", None):
+        fake_config.write_text(json.dumps({}), encoding="utf-8")
+        assert (
+            claude_desktop.configure_claude_desktop_config(
+                fake_config, settings=fake_settings
+            )
+            is True
+        )
+        fake_config.write_text(json.dumps({"inference": replacement}), encoding="utf-8")
+        assert (
+            claude_desktop.configure_claude_desktop_config(
+                fake_config, settings=fake_settings
+            )
+            is True
+        )
+        assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+        assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+            "inference": replacement
+        }

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -421,6 +421,81 @@ def test_unconfigure_restores_non_object_inference_entry(
     )
 
 
+def test_unconfigure_cleans_scalar_origin_after_user_adds_field(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A user-added field must not shield FCC's routing keys from removal.
+
+    Configure clobbers a scalar ``inference`` with its managed mapping; the
+    user then adds an unrelated field, so the mapping no longer equals what
+    configure wrote. Unconfigure must still remove every managed key that
+    holds its written value while preserving the user's field.
+    """
+
+    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["userAddedAfterConfigure"] = "must-survive"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["inference"] == {"userAddedAfterConfigure": "must-survive"}
+
+
+def test_unconfigure_cleans_null_origin_after_user_adds_field(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """Same per-key cleanup for a ``null`` pre-merge ``inference`` origin."""
+
+    fake_config.write_text(json.dumps({"inference": None}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["userAddedAfterConfigure"] = "must-survive"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["inference"] == {"userAddedAfterConfigure": "must-survive"}
+
+
+def test_unconfigure_keeps_user_edited_managed_key_over_scalar_origin(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A user-edited managed key survives; untouched managed keys go."""
+
+    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["inferenceGatewayBaseUrl"] = "user-edited-url"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["inference"] == {"inferenceGatewayBaseUrl": "user-edited-url"}
+
+
 def test_save_config_writes_owner_only_permissions(
     fake_config: Path,
     fake_settings: Settings,

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -1328,6 +1328,86 @@ def test_unconfigure_keeps_user_final_discovery_reenable(
     }
 
 
+@pytest.mark.parametrize("replacement", ["user-scalar", None])
+def test_unconfigure_preserves_wholesale_scalar_or_null_replacement(
+    fake_config: Path,
+    fake_settings: Settings,
+    replacement: str | None,
+) -> None:
+    """A scalar/``null`` block replacement survives a direct unconfigure.
+
+    Regression guard for the Greptile "unconfigure deletes user
+    scalar/null inference replacements" finding: after configure writes
+    its mapping, the user replaces the whole ``inference`` block with a
+    scalar or ``null`` and uninstalls without a re-merge. The empty
+    derived mapping must not read as "FCC's block fully removed, delete
+    the key" — the replacement is the user's and stays verbatim.
+    """
+
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "p"}}), encoding="utf-8"
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    current = json.loads(fake_config.read_text(encoding="utf-8"))
+    current["inference"] = replacement
+    fake_config.write_text(json.dumps(current), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored["inference"] == replacement
+    assert "fccPriorConfig" not in restored
+
+
+def test_remerge_after_scalar_replacement_marks_discovery_user_owned(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A discovery flip alongside a scalar replacement still gets the handoff.
+
+    Regression guard for the Greptile "scalar/null remerge bypasses
+    discovery ownership" finding: with the flag absent before the first
+    merge, the user replaces the block with a scalar AND disables
+    discovery, a re-merge runs, and the user re-enables discovery before
+    uninstalling. The non-object remerge branch must apply the same
+    ownership-adoption rule as the dict remerge path, or unconfigure
+    treats the final ``True`` as FCC's and deletes it.
+    """
+
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "p"}}), encoding="utf-8"
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    current = json.loads(fake_config.read_text(encoding="utf-8"))
+    current["inference"] = "user-scalar"
+    current["modelDiscoveryEnabled"] = False
+    fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    current = json.loads(fake_config.read_text(encoding="utf-8"))
+    current["modelDiscoveryEnabled"] = True
+    fake_config.write_text(json.dumps(current), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored["modelDiscoveryEnabled"] is True
+    assert restored["inference"] == "user-scalar"
+    assert "fccPriorConfig" not in restored
+
+
 def test_remerge_after_scalar_to_dict_replacement_drops_raw_target(
     fake_config: Path,
     fake_settings: Settings,

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -1239,6 +1239,51 @@ def test_unconfigure_keeps_user_final_discovery_reenable(
     }
 
 
+def test_remerge_after_scalar_to_dict_replacement_drops_raw_target(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A user dict replacing a scalar-origin block survives re-merge and unconfigure.
+
+    Regression guard for the Greptile "reconfiguration restores a stale
+    inference value" finding: the first merge recorded the original
+    non-object ``inference`` verbatim as ``inferenceRaw``. When the user
+    then replaces the whole block with their own dict, the re-merge must
+    drop the stale verbatim target (it would otherwise take precedence on
+    unconfigure and destroy the user's dict) and must not absorb absent
+    managed keys as ``null`` placeholders into the per-key restore targets.
+    """
+
+    fake_config.write_text(json.dumps({"inference": "legacy-string"}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    user_block = {
+        "provider": "user-routing",
+        "inferenceAnthropicApiKey": "user-key",
+        "extra": "keep",
+    }
+    current = json.loads(fake_config.read_text(encoding="utf-8"))
+    current["inference"] = dict(user_block)
+    fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    remerged = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "inferenceRaw" not in remerged["fccPriorConfig"]
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored["inference"] == user_block
+    assert "fccPriorConfig" not in restored
+
+
 def test_remerge_rotation_is_not_a_user_edit(
     fake_config: Path,
     fake_settings: Settings,

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -370,9 +370,11 @@ def test_configure_keeps_first_snapshot_across_remerges(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    # The snapshot must record the user's ORIGINAL values: a re-merge that
-    # refreshed it with FCC's own block would make unconfigure "restore"
-    # the FCC values instead of the user's.
+    # The snapshot's user-state entries must record the user's ORIGINAL
+    # values: a re-merge that refreshed them with FCC's own block would make
+    # unconfigure "restore" the FCC values instead of the user's. (The
+    # ``managed`` entry is different: it tracks the newest block FCC writes
+    # and is refreshed on every merge; see the rotation test below.)
     fake_config.write_text(
         json.dumps(
             {

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -412,14 +412,24 @@ def test_configure_keeps_first_snapshot_across_remerges(
     }
 
 
-def test_configure_unconfigure_roundtrip_restores_disabled_discovery(
+def test_configure_unconfigure_roundtrip_hands_off_disabled_discovery(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    # Regression guard for the Greptile "discovery value restores
-    # incorrectly" finding: a user who explicitly disabled model discovery
-    # must get ``false`` back after unconfigure — presence alone would
-    # restore ``true`` and permanently flip the preference.
+    """A recorded non-``True`` discovery original hands the final value off.
+
+    Originally guarded the "discovery value restores incorrectly" finding
+    (presence-only snapshots restored ``true`` over an explicit ``false``).
+    The ownership gate since the "final discovery preference is
+    overwritten" finding supersedes the restore: with a recorded
+    non-``True`` original, a current ``True`` is either configure's
+    untouched write or the user's explicit re-enable, and no file state can
+    tell them apart. Unconfigure therefore hands the flag off verbatim —
+    here the merge's own contractual ``True``, the last thing the user saw
+    on disk — rather than risk reverting a deliberate re-enable. The
+    inference keys still round-trip losslessly.
+    """
+
     original = {
         "modelDiscoveryEnabled": False,
         "inference": {"provider": "anthropic"},
@@ -443,7 +453,10 @@ def test_configure_unconfigure_roundtrip_restores_disabled_discovery(
         is True
     )
     restored = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert restored == original
+    assert restored == {
+        "modelDiscoveryEnabled": True,
+        "inference": {"provider": "anthropic"},
+    }
 
 
 @pytest.mark.parametrize(
@@ -1184,8 +1197,11 @@ def test_remerge_absorbs_user_edited_managed_keys(
         is True
     )
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    # The discovery original is False, so the flag hands off verbatim
+    # (see the roundtrip handoff test); the inference restore is the
+    # point of this test and stays lossless.
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
-        "modelDiscoveryEnabled": False,
+        "modelDiscoveryEnabled": True,
         "inference": {
             "provider": "user-later-provider",
             "userExtra": "keep",
@@ -1197,7 +1213,13 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    """An untouched re-merge never rewrites the frozen original snapshot."""
+    """An untouched re-merge never rewrites the frozen original snapshot.
+
+    The discovery original is False, so unconfigure hands that flag off
+    verbatim (current True, unattributable) rather than restoring the
+    snapshot; the inference snapshot stays frozen at first-merge values,
+    which is what the re-merge here exercises.
+    """
 
     original = {
         "modelDiscoveryEnabled": False,
@@ -1217,7 +1239,10 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
         is False
     )
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == original
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": True,
+        "inference": {"provider": "user-provider", "userExtra": "keep"},
+    }
 
 
 def test_remerge_marks_user_disabled_discovery_user_owned(
@@ -1380,6 +1405,51 @@ def test_unconfigure_keeps_user_final_discovery_reenable(
                     fake_config, settings=fake_settings
                 )
                 is True
+            )
+            continue
+        current = json.loads(fake_config.read_text(encoding="utf-8"))
+        current["modelDiscoveryEnabled"] = value
+        fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": True,
+        "inference": {"provider": "p"},
+    }
+
+
+def test_unconfigure_keeps_user_reenable_over_recorded_disabled_original(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A re-enable over a recorded ``False`` original is never reverted.
+
+    Regression guard for the Greptile "final discovery preference is
+    overwritten" finding: the flag was explicitly ``False`` before FCC
+    installed, configure wrote its always-``True``, and the user then
+    re-enabled it (a byte-identical ``True``). Restoring the recorded
+    ``False`` here would silently discard that final choice — the recorded
+    value is stale by unconfigure time. Ownership of a current ``True``
+    cannot be established when the original is non-``True``, so the flag
+    hands off verbatim.
+    """
+
+    fake_config.write_text(
+        json.dumps({"modelDiscoveryEnabled": False, "inference": {"provider": "p"}}),
+        encoding="utf-8",
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    for value in ("merge", True):
+        if value == "merge":
+            assert (
+                claude_desktop.configure_claude_desktop_config(
+                    fake_config, settings=fake_settings
+                )
+                is False
             )
             continue
         current = json.loads(fake_config.read_text(encoding="utf-8"))

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -1156,17 +1156,22 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
     assert json.loads(fake_config.read_text(encoding="utf-8")) == original
 
 
-def test_remerge_keeps_user_disabled_discovery(
+def test_remerge_marks_user_disabled_discovery_user_owned(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    """A post-merge discovery flip to ``False`` survives unconfigure.
+    """A post-merge discovery flip marks the flag user-owned; unconfigure never rewrites it.
 
-    The discovery target is frozen, not absorbed: the key was absent
-    before the first merge, and the user's explicit post-merge ``False``
-    must still win on removal. Since a current ``False`` is never
-    FCC-owned (configure always writes ``True``), unconfigure simply
-    keeps it.
+    The key was absent before the first merge; the user's explicit
+    post-merge ``False`` makes the flag user-owned from then on. On
+    uninstall the flag is handed off with whatever value is on disk at
+    that moment — here the merge's own contractual ``True`` write, which
+    the user last saw on disk — rather than deleted (erasing the user's
+    only explicit choice would be worse) or restored to any recorded
+    intermediate. The truly final user value lives on disk: the merge
+    always writes ``True``, so a user who wants discovery off must (and
+    does, per the re-disable test below) set ``False`` after the last
+    merge.
     """
 
     fake_config.write_text(
@@ -1189,7 +1194,94 @@ def test_remerge_keeps_user_disabled_discovery(
     )
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": True,
+        "inference": {"provider": "p"},
+    }
+
+
+def test_unconfigure_keeps_user_redisabled_discovery_verbatim(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A user-owned flag re-disabled after the last merge survives verbatim.
+
+    The flag was absent before the first merge, the user disabled it (the
+    adoption marker fires), and the user then re-disabled it after the
+    re-merge's own ``True`` write. The final on-disk value is the user's
+    explicit ``False``, so unconfigure hands it off untouched — neither
+    deleted as FCC-owned nor restored to an intermediate.
+    """
+
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "p"}}), encoding="utf-8"
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    for value in (False, "merge", False):
+        if value == "merge":
+            assert (
+                claude_desktop.configure_claude_desktop_config(
+                    fake_config, settings=fake_settings
+                )
+                is True
+            )
+            continue
+        current = json.loads(fake_config.read_text(encoding="utf-8"))
+        current["modelDiscoveryEnabled"] = value
+        fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
         "modelDiscoveryEnabled": False,
+        "inference": {"provider": "p"},
+    }
+
+
+def test_unconfigure_hands_off_user_owned_discovery_after_final_flip(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """The user's final discovery re-enable survives unconfigure verbatim.
+
+    Regression guard for the Greptile "final discovery preference lost"
+    finding: with the key ABSENT before the first merge, the user disables
+    discovery, a re-merge runs, and then the user re-enables it before
+    uninstalling. Recording the intermediate ``False`` as a restore value
+    would make unconfigure restore that stale intermediate and discard the
+    final ``True`` — which is byte-identical to configure's own always-
+    ``True`` write and therefore unattributable. The re-merge instead
+    marks the flag user-owned, and unconfigure hands it off verbatim,
+    whatever its final value is.
+    """
+
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "p"}}),
+        encoding="utf-8",
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    for value in (False, "merge", True):
+        if value == "merge":
+            assert (
+                claude_desktop.configure_claude_desktop_config(
+                    fake_config, settings=fake_settings
+                )
+                is True
+            )
+            continue
+        current = json.loads(fake_config.read_text(encoding="utf-8"))
+        current["modelDiscoveryEnabled"] = value
+        fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": True,
         "inference": {"provider": "p"},
     }
 
@@ -1200,14 +1292,11 @@ def test_unconfigure_keeps_user_final_discovery_reenable(
 ) -> None:
     """The user's final discovery re-enable survives unconfigure.
 
-    Regression guard for the Greptile "discovery ownership loses the final
-    user preference" finding: the user disables discovery, a re-merge runs,
-    and then the user re-enables it before uninstalling. Absorbing the
-    intermediate ``False`` as the restore target would make unconfigure
-    discard the user's final ``True`` and restore the stale intermediate.
-    The discovery target is frozen instead, so the final ``True`` —
-    indistinguishable from configure's own always-``True`` write — keeps
-    the recorded original, which here is the user's own ``True``.
+    Companion to the user-owned handoff test, with the key PRESENT and
+    ``True`` before the first merge: the snapshot records the original
+    value, and the final ``True`` — indistinguishable from configure's
+    own always-``True`` write — restores that recorded original, which
+    here is the user's own ``True``.
     """
 
     fake_config.write_text(

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -416,12 +416,10 @@ def test_configure_unconfigure_roundtrip_restores_disabled_discovery(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    # A pre-install disabled flag is snapshotted, but a current ``True`` at
-    # unconfigure time is unattributable: it may be configure's own write
-    # (user untouched) or the user's explicit re-enable, and no file state
-    # distinguishes them. Per the Greptile ruling the ambiguous case
-    # preserves the current ``True`` — restoring the snapshotted ``false``
-    # would destroy an explicit re-enable, the worse failure.
+    # Regression guard for the Greptile "discovery value restores
+    # incorrectly" finding: a user who explicitly disabled model discovery
+    # must get ``false`` back after unconfigure — presence alone would
+    # restore ``true`` and permanently flip the preference.
     original = {
         "modelDiscoveryEnabled": False,
         "inference": {"provider": "anthropic"},
@@ -445,10 +443,7 @@ def test_configure_unconfigure_roundtrip_restores_disabled_discovery(
         is True
     )
     restored = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert restored == {
-        "modelDiscoveryEnabled": True,
-        "inference": {"provider": "anthropic"},
-    }
+    assert restored == original
 
 
 @pytest.mark.parametrize(
@@ -1126,7 +1121,7 @@ def test_remerge_absorbs_user_edited_managed_keys(
     )
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
-        "modelDiscoveryEnabled": True,
+        "modelDiscoveryEnabled": False,
         "inference": {
             "provider": "user-later-provider",
             "userExtra": "keep",
@@ -1138,14 +1133,7 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    """An untouched re-merge never rewrites the frozen original snapshot.
-
-    The discovery flag's original ``False`` is snapshotted, but the flag
-    is handed off with its current ``True`` at unconfigure: that value is
-    unattributable between configure's own write and a user re-enable,
-    and the Greptile ruling preserves it rather than risk destroying an
-    explicit choice.
-    """
+    """An untouched re-merge never rewrites the frozen original snapshot."""
 
     original = {
         "modelDiscoveryEnabled": False,
@@ -1165,10 +1153,7 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
         is False
     )
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
-        "modelDiscoveryEnabled": True,
-        "inference": {"provider": "user-provider", "userExtra": "keep"},
-    }
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == original
 
 
 def test_remerge_marks_user_disabled_discovery_user_owned(
@@ -1251,41 +1236,6 @@ def test_unconfigure_keeps_user_redisabled_discovery_verbatim(
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
         "modelDiscoveryEnabled": False,
-        "inference": {"provider": "p"},
-    }
-
-
-def test_unconfigure_preserves_present_original_discovery_reenable(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """A re-enable over a snapshotted ``False`` original survives unconfigure.
-
-    Regression guard for the Greptile "unconfigure overwrites a later
-    re-enable" finding: the flag was ``False`` before install (snapshot
-    records it), configure wrote ``True``, and the user re-enabled it to
-    ``True`` — byte-identical to configure's own write — before
-    uninstalling. The flag is handed off verbatim: restoring the
-    snapshotted ``False`` would silently flip the user's explicit final
-    preference back off.
-    """
-
-    fake_config.write_text(
-        json.dumps({"modelDiscoveryEnabled": False, "inference": {"provider": "p"}}),
-        encoding="utf-8",
-    )
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-    current = json.loads(fake_config.read_text(encoding="utf-8"))
-    current["modelDiscoveryEnabled"] = True
-    fake_config.write_text(json.dumps(current), encoding="utf-8")
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
-        "modelDiscoveryEnabled": True,
         "inference": {"provider": "p"},
     }
 

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -1,7 +1,6 @@
 """Tests for the Claude Desktop config merge and binary launch helpers."""
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -30,6 +29,11 @@ def deterministic_gateway_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """
 
     monkeypatch.setattr(tls_proxy, "probe_fcc_front", lambda *a, **kw: False)
+    # ``resolve_gateway_base_url`` loads the identity before probing; pin it
+    # so the real ``~/.fcc/caddy/front-identity`` is never created.
+    monkeypatch.setattr(
+        tls_proxy, "load_or_create_front_identity", lambda *a, **kw: "pinned"
+    )
 
 
 def test_managed_block_derives_url_and_key_from_settings(
@@ -177,14 +181,168 @@ def test_load_existing_config_raises_malformed_error(tmp_path: Path) -> None:
         claude_desktop.load_existing_config(path)
 
 
-def test_unconfigure_restores_pre_merge_values(
+def test_unconfigure_drops_only_fcc_keys(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
+    managed = claude_desktop.fcc_managed_block(fake_settings)
+    fake_config.write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "modelDiscoveryEnabled": True,
+                "inference": managed | {"extra_user_key": "stay"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = claude_desktop.unconfigure_claude_desktop_config(
+        fake_config, settings=fake_settings
+    )
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in data
+    assert data["inference"] == {"extra_user_key": "stay"}
+    assert data["preferences"] == {"theme": "dark"}
+
+
+def test_unconfigure_removes_block_when_gateway_url_no_longer_matches(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # Regression guard for the Greptile "unconfigure leaves the gateway
+    # behind" finding: a previous configure persisted the HTTPS gateway
+    # URL, but the front is now gone and URL resolution falls back to
+    # plain HTTP. Removal must not depend on the recorded URL matching
+    # current resolution, or the gateway URL and auth token stay behind.
+    # The settings-derived token is stable across front state, so it is
+    # the ownership marker that still identifies the block as FCC's.
+    fake_config.write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "modelDiscoveryEnabled": True,
+                "inference": {
+                    "provider": "gateway",
+                    "credentialKind": "static",
+                    "inferenceProvider": "gateway",
+                    "inferenceCredentialKind": "static",
+                    "inferenceGatewayBaseUrl": "https://localhost:8443/claude-desktop",
+                    "inferenceGatewayAuthScheme": "x-api-key",
+                    "inferenceAnthropicApiKey": "tok-123",
+                    "extra_user_key": "stay",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = claude_desktop.unconfigure_claude_desktop_config(
+        fake_config, settings=fake_settings
+    )
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in data
+    assert data["inference"] == {"extra_user_key": "stay"}
+    assert data["preferences"] == {"theme": "dark"}
+
+
+def test_unconfigure_preserves_user_values_sharing_fcc_key_names(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # Regression guard for the Greptile "unconfigure erases user settings"
+    # finding: keys that share FCC-managed names but hold values FCC never
+    # wrote (neither the current resolution nor the FCC auth token) belong
+    # to the user and must survive removal. Without a snapshot the
+    # discovery flag is user-owned too — ownership is ambiguous, so it
+    # must be preserved rather than deleted.
+    fake_config.write_text(
+        json.dumps(
+            {
+                "modelDiscoveryEnabled": True,
+                "inference": {
+                    "provider": "anthropic",
+                    "inferenceGatewayBaseUrl": "https://api.user-gateway.example",
+                    "inferenceAnthropicApiKey": "user-secret-key",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = claude_desktop.unconfigure_claude_desktop_config(
+        fake_config, settings=fake_settings
+    )
+
+    # Nothing in the config is FCC-owned, so removal is a no-op and the
+    # file is left exactly as the user wrote it.
+    assert changed is False
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+    assert data["inference"] == {
+        "provider": "anthropic",
+        "inferenceGatewayBaseUrl": "https://api.user-gateway.example",
+        "inferenceAnthropicApiKey": "user-secret-key",
+    }
+
+
+def test_unconfigure_removes_discovery_when_legacy_token_marks_ownership(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # Regression guard for the Greptile "unconfigure deletes legacy
+    # discovery preference" finding: without a snapshot the discovery
+    # flag may only be removed once FCC ownership is established by the
+    # recorded auth token — never before.
+    fake_config.write_text(
+        json.dumps(
+            {
+                "modelDiscoveryEnabled": True,
+                "inference": {
+                    "provider": "gateway",
+                    "inferenceGatewayBaseUrl": "https://localhost:8443/claude-desktop",
+                    "inferenceAnthropicApiKey": "tok-123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = claude_desktop.unconfigure_claude_desktop_config(
+        fake_config, settings=fake_settings
+    )
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in data
+    assert "inference" not in data
+
+
+def test_configure_unconfigure_roundtrip_restores_prior_settings(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    # Regression guard for the Greptile "unconfigure drops prior settings"
+    # finding: configure overwrites the user's own provider, gateway, and
+    # credential values, so unconfigure must restore the originals instead
+    # of deleting them.
     original = {
+        "modelDiscoveryEnabled": True,
         "preferences": {"theme": "dark"},
-        "modelDiscoveryEnabled": False,
-        "inference": {"provider": "anthropic", "extra_user_key": "stay"},
+        "inference": {
+            "provider": "anthropic",
+            "credentialKind": "oauth",
+            "inferenceProvider": "anthropic",
+            "inferenceCredentialKind": "oauth",
+            "inferenceGatewayBaseUrl": "https://api.user-gateway.example",
+            "inferenceGatewayAuthScheme": "bearer",
+            "inferenceAnthropicApiKey": "user-secret-key",
+            "extra_user_key": "stay",
+        },
     }
     fake_config.write_text(json.dumps(original), encoding="utf-8")
 
@@ -194,42 +352,36 @@ def test_unconfigure_restores_pre_merge_values(
         )
         is True
     )
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert configured["inference"]["provider"] == "gateway"
+    assert configured["inference"]["inferenceAnthropicApiKey"] == "tok-123"
 
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == original
-
-
-def test_unconfigure_without_record_leaves_config_untouched(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """Settings FCC never wrote must survive ``--unconfigure``."""
-
-    managed = claude_desktop.fcc_managed_block(fake_settings)
-    preexisting = {
-        "modelDiscoveryEnabled": True,
-        "inference": managed | {"extra_user_key": "stay"},
-    }
-    fake_config.write_text(json.dumps(preexisting), encoding="utf-8")
-
-    # Configure finds nothing to change, so FCC owns nothing.
     assert (
-        claude_desktop.configure_claude_desktop_config(
+        claude_desktop.unconfigure_claude_desktop_config(
             fake_config, settings=fake_settings
         )
-        is False
+        is True
     )
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored == original
 
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == preexisting
 
-
-def test_unconfigure_drops_only_fcc_keys(
+def test_configure_keeps_first_snapshot_across_remerges(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
+    # The snapshot must record the user's ORIGINAL values: a re-merge that
+    # refreshed it with FCC's own block would make unconfigure "restore"
+    # the FCC values instead of the user's.
     fake_config.write_text(
-        json.dumps({"preferences": {"theme": "dark"}, "inference": {}}),
+        json.dumps(
+            {
+                "inference": {
+                    "provider": "anthropic",
+                    "inferenceAnthropicApiKey": "user-secret-key",
+                }
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -239,70 +391,37 @@ def test_unconfigure_drops_only_fcc_keys(
         )
         is True
     )
-    changed = claude_desktop.unconfigure_claude_desktop_config(fake_config)
-
-    assert changed is True
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert "modelDiscoveryEnabled" not in data
-    assert data["inference"] == {}
-    assert data["preferences"] == {"theme": "dark"}
-    assert not claude_desktop._record_path(fake_config).exists()
-
-
-def test_unconfigure_ignores_malformed_ownership_record(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    original = '{"modelDiscoveryEnabled": true}'
-    fake_config.write_text(original, encoding="utf-8")
-    claude_desktop._record_path(fake_config).write_text("{corrupt", encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
-
-    assert fake_config.read_text(encoding="utf-8") == original
-
-
-def test_configure_keeps_earliest_snapshot_across_repeated_merges(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    fake_config.write_text(
-        json.dumps({"inference": {"user": "value"}}), encoding="utf-8"
-    )
-
     assert (
         claude_desktop.configure_claude_desktop_config(
             fake_config, settings=fake_settings
         )
-        is True
-    )
-    # A second merge with different settings must not clobber the snapshot.
-    rotated = fake_settings.model_copy(update={"proxy_auth_token": "tok-456"})
-    assert (
-        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
-        is True
+        is False
     )
 
-    record = json.loads(
-        claude_desktop._record_path(fake_config).read_text(encoding="utf-8")
-    )
-    # The earliest snapshot had no managed keys; a clobbering second
-    # snapshot would have recorded the values from the first merge.
-    assert record["inferenceKeys"]["provider"] == {"present": False, "value": None}
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
-        "inference": {"user": "value"}
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    # No discovery entry: the key was absent before the first merge, and
+    # the restore must delete it again rather than invent a value.
+    assert data["fccPriorConfig"] == {
+        "inference": {
+            "provider": "anthropic",
+            "inferenceAnthropicApiKey": "user-secret-key",
+        },
     }
 
 
-def test_unconfigure_keeps_inference_keys_added_after_configure(
+def test_configure_unconfigure_roundtrip_restores_disabled_discovery(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    """Unconfiguration must not remove inference entries FCC never touched."""
-
-    fake_config.write_text(json.dumps({"inference": {}}), encoding="utf-8")
+    # Regression guard for the Greptile "discovery value restores
+    # incorrectly" finding: a user who explicitly disabled model discovery
+    # must get ``false`` back after unconfigure — presence alone would
+    # restore ``true`` and permanently flip the preference.
+    original = {
+        "modelDiscoveryEnabled": False,
+        "inference": {"provider": "anthropic"},
+    }
+    fake_config.write_text(json.dumps(original), encoding="utf-8")
 
     assert (
         claude_desktop.configure_claude_desktop_config(
@@ -310,26 +429,36 @@ def test_unconfigure_keeps_inference_keys_added_after_configure(
         )
         is True
     )
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert configured["modelDiscoveryEnabled"] is True
+    assert configured["fccPriorConfig"]["discovery"] is False
 
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["userAddedAfterConfigure"] = "keep"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored == original
 
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
 
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert result["inference"] == {"userAddedAfterConfigure": "keep"}
-
-
-def test_unconfigure_preserves_user_replaced_inference_value(
+@pytest.mark.parametrize(
+    "raw_inference",
+    ["legacy-string", ["a", "b"], None],
+    ids=["string", "list", "null"],
+)
+def test_configure_unconfigure_roundtrip_restores_non_object_inference(
     fake_config: Path,
     fake_settings: Settings,
+    raw_inference: object,
 ) -> None:
-    """A non-object ``inference`` after configure is user-owned, not ours."""
-
-    fake_config.write_text(
-        json.dumps({"inference": {"provider": "anthropic"}}), encoding="utf-8"
-    )
+    # Regression guard for the Greptile "non-object inference values are
+    # not restored" finding: a valid config whose inference value is a
+    # string, list, or null must get that exact value back after a
+    # configure/unconfigure round trip, not a deleted key.
+    original = {"inference": raw_inference, "preferences": {"theme": "dark"}}
+    fake_config.write_text(json.dumps(original), encoding="utf-8")
 
     assert (
         claude_desktop.configure_claude_desktop_config(
@@ -337,185 +466,18 @@ def test_unconfigure_preserves_user_replaced_inference_value(
         )
         is True
     )
-
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"] = "user-replaced-scalar"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    # Unconfigure still removes the FCC-owned discovery key.
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert "modelDiscoveryEnabled" not in result
-    assert result["inference"] == "user-replaced-scalar"
-
-
-def test_unconfigure_preserves_user_deleted_inference_entry(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """Removing ``inference`` wholesale after configure must be respected."""
+    configured = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert configured["inference"]["provider"] == "gateway"
+    assert configured["fccPriorConfig"]["inferenceRaw"] == raw_inference
 
     assert (
-        claude_desktop.configure_claude_desktop_config(
+        claude_desktop.unconfigure_claude_desktop_config(
             fake_config, settings=fake_settings
         )
         is True
     )
-
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    del data["inference"]
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    # Unconfigure still removes the FCC-owned discovery key.
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert "modelDiscoveryEnabled" not in result
-    assert "inference" not in result
-
-
-def test_unconfigure_keeps_additions_when_fcc_created_inference(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """An inference entry FCC created must not swallow later additions."""
-
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["userAddedAfterConfigure"] = "must-survive"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert "modelDiscoveryEnabled" not in result
-    assert result["inference"] == {"userAddedAfterConfigure": "must-survive"}
-
-
-def test_unconfigure_restores_non_object_inference_entry(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """Configure clobbers a non-object ``inference``; unconfigure restores it."""
-
-    original = json.dumps({"inference": "legacy-scalar"})
-    fake_config.write_text(original, encoding="utf-8")
-
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    assert json.loads(fake_config.read_text(encoding="utf-8"))["inference"] == (
-        "legacy-scalar"
-    )
-
-
-def test_unconfigure_cleans_scalar_origin_after_user_adds_field(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """A user-added field must not shield FCC's routing keys from removal.
-
-    Configure clobbers a scalar ``inference`` with its managed mapping; the
-    user then adds an unrelated field, so the mapping no longer equals what
-    configure wrote. Unconfigure must still remove every managed key that
-    holds its written value while preserving the user's field.
-    """
-
-    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["userAddedAfterConfigure"] = "must-survive"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert result["inference"] == {"userAddedAfterConfigure": "must-survive"}
-
-
-def test_unconfigure_cleans_null_origin_after_user_adds_field(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """Same per-key cleanup for a ``null`` pre-merge ``inference`` origin."""
-
-    fake_config.write_text(json.dumps({"inference": None}), encoding="utf-8")
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["userAddedAfterConfigure"] = "must-survive"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert result["inference"] == {"userAddedAfterConfigure": "must-survive"}
-
-
-def test_unconfigure_keeps_user_edited_managed_key_over_scalar_origin(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """A user-edited managed key survives; untouched managed keys go."""
-
-    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["inferenceGatewayBaseUrl"] = "user-edited-url"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert result["inference"] == {"inferenceGatewayBaseUrl": "user-edited-url"}
-
-
-def test_save_config_writes_owner_only_permissions(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """The token-bearing block must stay 0o600 even under a permissive umask."""
-
-    old_umask = os.umask(0o000)
-    try:
-        assert (
-            claude_desktop.configure_claude_desktop_config(
-                fake_config, settings=fake_settings
-            )
-            is True
-        )
-    finally:
-        os.umask(old_umask)
-
-    assert (fake_config.stat().st_mode & 0o777) == 0o600
-    record = claude_desktop._record_path(fake_config)
-    assert (record.stat().st_mode & 0o777) == 0o600
+    restored = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert restored == original
 
 
 def test_unconfigure_roundtrip_is_clean_noop(
@@ -528,37 +490,23 @@ def test_unconfigure_roundtrip_is_clean_noop(
         )
         is True
     )
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
 
     data = json.loads(fake_config.read_text(encoding="utf-8"))
     assert data == {}
 
     # Second passes are no-ops.
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
-
-
-def test_configure_write_failure_leaves_existing_config_intact(
-    fake_config: Path,
-    fake_settings: Settings,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A failed save (e.g. read-only directory) must not corrupt the config."""
-
-    original = json.dumps({"preferences": {"theme": "dark"}})
-    fake_config.parent.mkdir(parents=True, exist_ok=True)
-    fake_config.write_text(original, encoding="utf-8")
-
-    def refuse_write(path: Path, data: dict[str, object]) -> None:
-        raise PermissionError(path)
-
-    monkeypatch.setattr(claude_desktop, "_save_config", refuse_write)
-
-    with pytest.raises(PermissionError):
-        claude_desktop.configure_claude_desktop_config(
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(
             fake_config, settings=fake_settings
         )
-
-    assert fake_config.read_text(encoding="utf-8") == original
+        is False
+    )
 
 
 def test_unconfigure_silent_on_missing_file(tmp_path: Path) -> None:
@@ -585,6 +533,7 @@ def test_main_configure_writes_block_without_subprocess(
     fake_settings: Settings,
 ) -> None:
     fake = tmp_path / "claude_desktop_config.json"
+    verified_url = "https://localhost:8443/claude-desktop"
 
     def fail_popen(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("configure must not spawn a subprocess")
@@ -593,18 +542,106 @@ def test_main_configure_writes_block_without_subprocess(
     monkeypatch.setattr(
         claude_desktop, "get_settings", lambda: fake_settings, raising=False
     )
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: verified_url
+    )
 
     claude_desktop.main(["--configure", "--config-path", str(fake)])
 
     data = json.loads(fake.read_text(encoding="utf-8"))
     assert data["modelDiscoveryEnabled"] is True
+    # The persisted block must point at the verified HTTPS front.
+    assert data["inference"]["inferenceGatewayBaseUrl"] == verified_url
 
 
-def test_launch_binary_spawns_binary_without_certificate_bypass(
+def test_main_configure_adopts_existing_front_without_spawning_one(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_settings: Settings,
+) -> None:
+    # The command exits right after writing, so a front it spawned itself
+    # would die with it and leave the config pointing at a dead gateway.
+    # Adoption must be probe-only: verification runs for real here (probe
+    # pinned), and any attempt to bring up a managed proxy trips the
+    # construction guard.
+    fake = tmp_path / "claude_desktop_config.json"
+
+    def fail_spawn(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("configure must never bring up its own front")
+
+    monkeypatch.setattr(
+        claude_desktop, "get_settings", lambda: fake_settings, raising=False
+    )
+    monkeypatch.setattr(tls_proxy, "CaddyTlsProxy", fail_spawn)
+    monkeypatch.setattr(tls_proxy, "probe_fcc_front", lambda *a, **kw: True)
+
+    claude_desktop.main(["--configure", "--config-path", str(fake)])
+
+    data = json.loads(fake.read_text(encoding="utf-8"))
+    assert data["inference"]["inferenceGatewayBaseUrl"].startswith("https://")
+
+
+def test_main_configure_refuses_malformed_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_settings: Settings,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Regression guard for the Greptile "malformed configure reports
+    # success" finding: configure returns False for BOTH an idempotent
+    # no-op and a malformed-config skip, so the skip must be refused
+    # with a nonzero exit instead of reported as "Already merged".
+    fake = tmp_path / "claude_desktop_config.json"
+    fake.write_text("{not json", encoding="utf-8")
+
+    monkeypatch.setattr(
+        claude_desktop, "get_settings", lambda: fake_settings, raising=False
+    )
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: "https://x"
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.main(["--configure", "--config-path", str(fake)])
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "malformed config" in captured.err
+    assert "Already merged" not in captured.out
+    # The malformed file is left untouched.
+    assert fake.read_text(encoding="utf-8") == "{not json"
+
+
+def test_main_configure_refuses_without_https_front(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_settings: Settings,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The routing block embeds the reusable proxy token, so persisting it
+    # against the plain-HTTP fallback would hand the credential to whatever
+    # occupies that endpoint. Refuse without writing instead.
+    fake = tmp_path / "claude_desktop_config.json"
+
+    monkeypatch.setattr(
+        claude_desktop, "get_settings", lambda: fake_settings, raising=False
+    )
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: None
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.main(["--configure", "--config-path", str(fake)])
+
+    assert exc.value.code == 1
+    assert not fake.exists()
+    captured = capsys.readouterr()
+    assert "no verified FCC HTTPS front" in captured.err
+
+
+def test_launch_binary_spawns_without_certificate_bypass(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """TLS trust comes from the NSS-installed CA, not a Chromium bypass flag."""
-
     calls: list[list[str]] = []
 
     class FakeProcess:
@@ -617,7 +654,6 @@ def test_launch_binary_spawns_binary_without_certificate_bypass(
     claude_desktop.launch_binary(["--extra"])
 
     assert calls == [["/usr/bin/claude", "--extra"]]
-    assert all("--ignore-certificate-errors" not in cmd for cmd in calls)
 
 
 def test_launch_binary_raises_when_binary_missing(
@@ -636,13 +672,20 @@ def test_ensure_configured_and_launch_merges_then_spawns(
 ) -> None:
     config_path = tmp_path / "claude_desktop_config.json"
     order: list[str] = []
+    gateway_urls: list[str | None] = []
     original_configure = claude_desktop.configure_claude_desktop_config
+    verified_url = "https://localhost:8443/claude-desktop"
 
     def fake_configure(
-        path: Path | None = None, settings: Settings | None = None
+        path: Path | None = None,
+        settings: Settings | None = None,
+        gateway_base_url: str | None = None,
     ) -> bool:
         order.append("configure")
-        return original_configure(path or config_path, settings=settings)
+        gateway_urls.append(gateway_base_url)
+        return original_configure(
+            path or config_path, settings=settings, gateway_base_url=gateway_base_url
+        )
 
     class FakeProcess:
         def __init__(self, cmd: list[str]) -> None:
@@ -651,6 +694,11 @@ def test_ensure_configured_and_launch_merges_then_spawns(
     monkeypatch.setattr(
         claude_desktop, "configure_claude_desktop_config", fake_configure
     )
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: verified_url
+    )
+    # The post-merge read-back must observe the same file the merge wrote.
+    monkeypatch.setattr(claude_desktop, "_config_path", lambda: config_path)
     monkeypatch.setattr(claude_desktop, "find_binary", lambda: "/usr/bin/claude")
     monkeypatch.setattr(claude_desktop.subprocess, "Popen", FakeProcess)
 
@@ -658,221 +706,71 @@ def test_ensure_configured_and_launch_merges_then_spawns(
 
     assert order[0] == "configure"
     assert order[1].startswith("spawn:")
+    # The routing block must point at the verified HTTPS front, never the
+    # plain-HTTP fallback.
+    assert gateway_urls == [verified_url]
 
 
-def test_unconfigure_preserves_user_replaced_object_over_scalar_root(
-    fake_config: Path,
+def test_ensure_configured_and_launch_refuses_when_merge_skips_malformed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     fake_settings: Settings,
 ) -> None:
-    """A user object replacing FCC's generated mapping survives unconfigure."""
+    # Regression guard for the Greptile "launch after malformed config"
+    # finding: ``configure`` returns ``False`` when it skips a malformed
+    # config, so the launch must be refused rather than spawning Claude
+    # Desktop without FCC routing. The read-back distinguishes the skip
+    # from an idempotent no-op merge.
+    config_path = tmp_path / "claude_desktop_config.json"
+    config_path.write_text("{not json", encoding="utf-8")
 
-    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
+    def fail_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("a skipped merge must never reach the binary")
+
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: "https://x"
     )
+    monkeypatch.setattr(claude_desktop, "_config_path", lambda: config_path)
+    monkeypatch.setattr(claude_desktop, "find_binary", lambda: "/usr/bin/claude")
+    monkeypatch.setattr(claude_desktop.subprocess, "Popen", fail_popen)
 
-    replacement = {"provider": "user-choice", "model": "user-model"}
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"] = dict(replacement)
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="routing block could not be written"):
+        claude_desktop.ensure_configured_and_launch(settings=fake_settings)
 
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert result["inference"] == replacement
-    assert "modelDiscoveryEnabled" not in result
+    # The malformed file is left untouched.
+    assert config_path.read_text(encoding="utf-8") == "{not json"
 
 
-def test_unconfigure_preserves_user_deleted_entry_over_scalar_root(
-    fake_config: Path,
+def test_ensure_configured_and_launch_refuses_without_https_front(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     fake_settings: Settings,
 ) -> None:
-    """Deleting ``inference`` wholesale after a scalar clobber is respected."""
+    # Regression guard for the Greptile tray-bypass finding: without a
+    # verified HTTPS front the gateway URL would fall back to plain HTTP,
+    # so the credential-bearing config write and the spawn must both be
+    # refused instead of exposing the token over cleartext local transport.
+    config_path = tmp_path / "claude_desktop_config.json"
 
-    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
+    def fail_configure(*_args: object, **_kwargs: object) -> bool:
+        raise AssertionError("no HTTPS front must never write the config")
+
+    def fail_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("no HTTPS front must never reach the binary")
+
+    monkeypatch.setattr(
+        claude_desktop, "configure_claude_desktop_config", fail_configure
     )
-
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    del data["inference"]
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert "inference" not in result
-
-
-def test_unconfigure_respects_user_edited_discovery_key(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """A post-merge user edit to ``modelDiscoveryEnabled`` wins on unconfigure."""
-
-    fake_config.write_text(
-        json.dumps({"modelDiscoveryEnabled": False}), encoding="utf-8"
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: None
     )
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
+    monkeypatch.setattr(claude_desktop, "find_binary", lambda: "/usr/bin/claude")
+    monkeypatch.setattr(claude_desktop.subprocess, "Popen", fail_popen)
 
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert data["modelDiscoveryEnabled"] is True
-    data["modelDiscoveryEnabled"] = False
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="no verified FCC HTTPS front"):
+        claude_desktop.ensure_configured_and_launch(settings=fake_settings)
 
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    # The pre-merge value was False and the user re-applied False: restored.
-    assert result["modelDiscoveryEnabled"] is False
-
-
-def test_unconfigure_leaves_user_disabled_discovery_from_absent_root(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """FCC-inserted discovery flipped off by the user is not deleted twice."""
-
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["modelDiscoveryEnabled"] = False
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    result = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert result["modelDiscoveryEnabled"] is False
-
-
-def test_unconfigure_preserves_user_edited_managed_key(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """A post-merge user edit to a managed key wins over the snapshot."""
-
-    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["inferenceAnthropicApiKey"] = "user-rotated-key"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    out = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert out["inference"]["inferenceAnthropicApiKey"] == "user-rotated-key"
-    # Untouched FCC-inserted keys are still removed.
-    assert "provider" not in out["inference"]
-
-
-def test_unconfigure_preserves_user_edited_fcc_created_key(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """Same rule when FCC created ``inference`` itself."""
-
-    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["inferenceGatewayBaseUrl"] = "http://user-chosen:9"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    out = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert out["inference"]["inferenceGatewayBaseUrl"] == "http://user-chosen:9"
-    assert "provider" not in out["inference"]
-
-
-def test_repeated_merges_absorb_post_merge_user_edits(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """A merge after a user edit must not resurrect the first snapshot."""
-
-    original = {"modelDiscoveryEnabled": False, "custom": "keep"}
-    fake_config.write_text(json.dumps({"inference": dict(original)}), encoding="utf-8")
-
-    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
-    data = json.loads(fake_config.read_text(encoding="utf-8"))
-    data["inference"]["inferenceAnthropicApiKey"] = "user-key-v2"
-    fake_config.write_text(json.dumps(data), encoding="utf-8")
-
-    # Re-merge with rotated credentials; then reverse everything.
-    rotated = fake_settings.model_copy(update={"proxy_auth_token": "tok-456"})
-    assert (
-        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
-        is True
-    )
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-
-    out = json.loads(fake_config.read_text(encoding="utf-8"))
-    assert out["inference"]["inferenceAnthropicApiKey"] == "user-key-v2"
-    assert out["inference"]["custom"] == "keep"
-
-
-def test_repeated_merges_keep_container_provenance(
-    fake_config: Path,
-    fake_settings: Settings,
-) -> None:
-    """The origin container shape survives repeated merges.
-
-    Regression guard for the Greptile "repeated merge loses container
-    provenance" finding: a second merge sees the ``inference`` object the
-    FIRST merge wrote, so re-snapshotting it would record
-    ``existed=True, was_object=True`` and leave unconfigure restoring into
-    an FCC-shaped container the user never had — an empty ``inference``
-    where the entry was absent, or ``{}`` where the user held a scalar. The
-    original provenance must be retained from the ownership record.
-    """
-
-    # Absent origin: after configure + rotated re-configure + unconfigure,
-    # the inference entry must be gone entirely.
-    fake_config.write_text(json.dumps({}), encoding="utf-8")
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-    rotated = fake_settings.model_copy(update={"proxy_auth_token": "tok-456"})
-    assert (
-        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
-        is True
-    )
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == {}
-
-    # Scalar origin: the user's non-object value must come back verbatim.
-    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
-    assert (
-        claude_desktop.configure_claude_desktop_config(
-            fake_config, settings=fake_settings
-        )
-        is True
-    )
-    assert (
-        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
-        is True
-    )
-    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
-    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
-        "inference": "legacy-scalar"
-    }
+    assert not config_path.exists()
 
 
 def test_unconfigure_restores_wholesale_inference_replacement(
@@ -886,8 +784,8 @@ def test_unconfigure_restores_wholesale_inference_replacement(
     the whole ``inference`` entry for a scalar or ``null``. A later
     re-merge still writes the managed mapping (configure's contract is
     to ensure the block exists), but the replacement is now the origin
-    unconfigure must restore — re-snapshotting the pre-FCC state would
-    silently discard the user's change.
+    the snapshot must restore — keeping the first-merge value would
+    silently discard the user's later change.
     """
 
     for replacement in ("user-scalar", None):

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -1,0 +1,750 @@
+"""Tests for the Claude Desktop config merge and binary launch helpers."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from free_claude_code.cli import claude_desktop, tls_proxy
+from free_claude_code.config.settings import Settings
+
+
+@pytest.fixture
+def fake_config(tmp_path: Path) -> Path:
+    return tmp_path / "claude_desktop_config.json"
+
+
+@pytest.fixture
+def fake_settings() -> Settings:
+    return Settings(host="127.0.0.1", port=8082, proxy_auth_token="tok-123")
+
+
+@pytest.fixture(autouse=True)
+def deterministic_gateway_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin gateway URL resolution so tests never probe the network.
+
+    The TLS-front probe is disabled at its source (a developer machine may
+    have a live front on 8443); ``desktop_gateway_base_url`` still runs for
+    real, so these tests also pin the desktop path prefix wiring.
+    """
+
+    monkeypatch.setattr(tls_proxy, "probe_fcc_front", lambda *a, **kw: False)
+
+
+def test_managed_block_derives_url_and_key_from_settings(
+    fake_settings: Settings,
+) -> None:
+    block = claude_desktop.fcc_managed_block(
+        fake_settings, gateway_base_url="https://localhost:8443"
+    )
+
+    assert block["inferenceGatewayBaseUrl"] == "https://localhost:8443"
+    assert block["inferenceAnthropicApiKey"] == "tok-123"
+    assert block["provider"] == "gateway"
+
+
+def test_managed_block_resolves_url_when_not_overridden(
+    fake_settings: Settings,
+) -> None:
+    block = claude_desktop.fcc_managed_block(fake_settings)
+
+    assert block["inferenceGatewayBaseUrl"] == ("http://127.0.0.1:8082/claude-desktop")
+
+
+def test_configure_applies_block_when_file_is_missing(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    assert not fake_config.exists()
+
+    changed = claude_desktop.configure_claude_desktop_config(
+        fake_config, settings=fake_settings
+    )
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+    assert (
+        data["inference"]["inferenceGatewayBaseUrl"]
+        == "http://127.0.0.1:8082/claude-desktop"
+    )
+    assert data["inference"]["inferenceAnthropicApiKey"] == "tok-123"
+
+
+def test_configure_is_idempotent(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    second = claude_desktop.configure_claude_desktop_config(
+        fake_config, settings=fake_settings
+    )
+    assert second is False
+
+
+def test_configure_preserves_unrelated_keys(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    fake_config.parent.mkdir(parents=True, exist_ok=True)
+    fake_config.write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "mcpServers": {"fs": {"command": "node"}},
+                "coworkUserFilesPath": "/home/user/cowork",
+                "env": {"ANTHROPIC_BASE_URL": "https://localhost:8443"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["preferences"] == {"theme": "dark"}
+    assert data["mcpServers"] == {"fs": {"command": "node"}}
+    assert data["coworkUserFilesPath"] == "/home/user/cowork"
+    assert data["env"] == {"ANTHROPIC_BASE_URL": "https://localhost:8443"}
+    assert data["modelDiscoveryEnabled"] is True
+
+
+def test_configure_overwrites_partial_inference_block(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "anthropic", "keep_me": True}}),
+        encoding="utf-8",
+    )
+
+    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    inference = data["inference"]
+    assert inference["provider"] == "gateway"
+    assert inference["keep_me"] is True
+    assert (
+        inference["inferenceGatewayBaseUrl"] == "http://127.0.0.1:8082/claude-desktop"
+    )
+
+
+def test_configure_aborts_on_malformed_json(
+    fake_config: Path,
+    fake_settings: Settings,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_config.parent.mkdir(parents=True, exist_ok=True)
+    fake_config.write_text("{not json", encoding="utf-8")
+
+    changed = claude_desktop.configure_claude_desktop_config(
+        fake_config, settings=fake_settings
+    )
+
+    assert changed is False
+    assert fake_config.read_text(encoding="utf-8") == "{not json"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_configure_aborts_on_non_object_root(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    fake_config.parent.mkdir(parents=True, exist_ok=True)
+    fake_config.write_text("[1, 2]", encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is False
+    )
+
+
+def test_load_existing_config_raises_malformed_error(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("nope", encoding="utf-8")
+
+    with pytest.raises(claude_desktop.MalformedConfigError):
+        claude_desktop.load_existing_config(path)
+
+
+def test_unconfigure_restores_pre_merge_values(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    original = {
+        "preferences": {"theme": "dark"},
+        "modelDiscoveryEnabled": False,
+        "inference": {"provider": "anthropic", "extra_user_key": "stay"},
+    }
+    fake_config.write_text(json.dumps(original), encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == original
+
+
+def test_unconfigure_without_record_leaves_config_untouched(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """Settings FCC never wrote must survive ``--unconfigure``."""
+
+    managed = claude_desktop.fcc_managed_block(fake_settings)
+    preexisting = {
+        "modelDiscoveryEnabled": True,
+        "inference": managed | {"extra_user_key": "stay"},
+    }
+    fake_config.write_text(json.dumps(preexisting), encoding="utf-8")
+
+    # Configure finds nothing to change, so FCC owns nothing.
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is False
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
+
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == preexisting
+
+
+def test_unconfigure_drops_only_fcc_keys(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    fake_config.write_text(
+        json.dumps({"preferences": {"theme": "dark"}, "inference": {}}),
+        encoding="utf-8",
+    )
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    changed = claude_desktop.unconfigure_claude_desktop_config(fake_config)
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in data
+    assert data["inference"] == {}
+    assert data["preferences"] == {"theme": "dark"}
+    assert not claude_desktop._record_path(fake_config).exists()
+
+
+def test_unconfigure_ignores_malformed_ownership_record(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    original = '{"modelDiscoveryEnabled": true}'
+    fake_config.write_text(original, encoding="utf-8")
+    claude_desktop._record_path(fake_config).write_text("{corrupt", encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
+
+    assert fake_config.read_text(encoding="utf-8") == original
+
+
+def test_configure_keeps_earliest_snapshot_across_repeated_merges(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    fake_config.write_text(
+        json.dumps({"inference": {"user": "value"}}), encoding="utf-8"
+    )
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    # A second merge with different settings must not clobber the snapshot.
+    rotated = fake_settings.model_copy(update={"proxy_auth_token": "tok-456"})
+    assert (
+        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
+        is True
+    )
+
+    record = json.loads(
+        claude_desktop._record_path(fake_config).read_text(encoding="utf-8")
+    )
+    # The earliest snapshot had no managed keys; a clobbering second
+    # snapshot would have recorded the values from the first merge.
+    assert record["inferenceKeys"]["provider"] == {"present": False, "value": None}
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "inference": {"user": "value"}
+    }
+
+
+def test_unconfigure_keeps_inference_keys_added_after_configure(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """Unconfiguration must not remove inference entries FCC never touched."""
+
+    fake_config.write_text(json.dumps({"inference": {}}), encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["userAddedAfterConfigure"] = "keep"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["inference"] == {"userAddedAfterConfigure": "keep"}
+
+
+def test_unconfigure_preserves_user_replaced_inference_value(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A non-object ``inference`` after configure is user-owned, not ours."""
+
+    fake_config.write_text(
+        json.dumps({"inference": {"provider": "anthropic"}}), encoding="utf-8"
+    )
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"] = "user-replaced-scalar"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    # Unconfigure still removes the FCC-owned discovery key.
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in result
+    assert result["inference"] == "user-replaced-scalar"
+
+
+def test_unconfigure_preserves_user_deleted_inference_entry(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """Removing ``inference`` wholesale after configure must be respected."""
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    del data["inference"]
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    # Unconfigure still removes the FCC-owned discovery key.
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in result
+    assert "inference" not in result
+
+
+def test_unconfigure_keeps_additions_when_fcc_created_inference(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """An inference entry FCC created must not swallow later additions."""
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["userAddedAfterConfigure"] = "must-survive"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in result
+    assert result["inference"] == {"userAddedAfterConfigure": "must-survive"}
+
+
+def test_unconfigure_restores_non_object_inference_entry(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """Configure clobbers a non-object ``inference``; unconfigure restores it."""
+
+    original = json.dumps({"inference": "legacy-scalar"})
+    fake_config.write_text(original, encoding="utf-8")
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    assert json.loads(fake_config.read_text(encoding="utf-8"))["inference"] == (
+        "legacy-scalar"
+    )
+
+
+def test_save_config_writes_owner_only_permissions(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """The token-bearing block must stay 0o600 even under a permissive umask."""
+
+    old_umask = os.umask(0o000)
+    try:
+        assert (
+            claude_desktop.configure_claude_desktop_config(
+                fake_config, settings=fake_settings
+            )
+            is True
+        )
+    finally:
+        os.umask(old_umask)
+
+    assert (fake_config.stat().st_mode & 0o777) == 0o600
+    record = claude_desktop._record_path(fake_config)
+    assert (record.stat().st_mode & 0o777) == 0o600
+
+
+def test_unconfigure_roundtrip_is_clean_noop(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data == {}
+
+    # Second passes are no-ops.
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
+
+
+def test_configure_write_failure_leaves_existing_config_intact(
+    fake_config: Path,
+    fake_settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed save (e.g. read-only directory) must not corrupt the config."""
+
+    original = json.dumps({"preferences": {"theme": "dark"}})
+    fake_config.parent.mkdir(parents=True, exist_ok=True)
+    fake_config.write_text(original, encoding="utf-8")
+
+    def refuse_write(path: Path, data: dict[str, object]) -> None:
+        raise PermissionError(path)
+
+    monkeypatch.setattr(claude_desktop, "_save_config", refuse_write)
+
+    with pytest.raises(PermissionError):
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+
+    assert fake_config.read_text(encoding="utf-8") == original
+
+
+def test_unconfigure_silent_on_missing_file(tmp_path: Path) -> None:
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(tmp_path / "absent.json")
+        is False
+    )
+
+
+def test_config_path_resolver_returns_default_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("APPDATA", raising=False)
+    for platform in ("linux", "darwin", "win32"):
+        monkeypatch.setattr(claude_desktop.sys, "platform", platform)
+        path = claude_desktop._config_path()
+        assert path.name == claude_desktop.CONFIG_FILENAME
+        assert path.is_absolute()
+
+
+def test_main_configure_writes_block_without_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_settings: Settings,
+) -> None:
+    fake = tmp_path / "claude_desktop_config.json"
+
+    def fail_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("configure must not spawn a subprocess")
+
+    monkeypatch.setattr(claude_desktop.subprocess, "Popen", fail_popen)
+    monkeypatch.setattr(
+        claude_desktop, "get_settings", lambda: fake_settings, raising=False
+    )
+
+    claude_desktop.main(["--configure", "--config-path", str(fake)])
+
+    data = json.loads(fake.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+
+
+def test_launch_binary_spawns_binary_without_certificate_bypass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TLS trust comes from the NSS-installed CA, not a Chromium bypass flag."""
+
+    calls: list[list[str]] = []
+
+    class FakeProcess:
+        def __init__(self, cmd: list[str]) -> None:
+            calls.append(cmd)
+
+    monkeypatch.setattr(claude_desktop, "find_binary", lambda: "/usr/bin/claude")
+    monkeypatch.setattr(claude_desktop.subprocess, "Popen", FakeProcess)
+
+    claude_desktop.launch_binary(["--extra"])
+
+    assert calls == [["/usr/bin/claude", "--extra"]]
+    assert all("--ignore-certificate-errors" not in cmd for cmd in calls)
+
+
+def test_launch_binary_raises_when_binary_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(claude_desktop, "find_binary", lambda: None)
+
+    with pytest.raises(FileNotFoundError):
+        claude_desktop.launch_binary()
+
+
+def test_ensure_configured_and_launch_merges_then_spawns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_settings: Settings,
+) -> None:
+    config_path = tmp_path / "claude_desktop_config.json"
+    order: list[str] = []
+    original_configure = claude_desktop.configure_claude_desktop_config
+
+    def fake_configure(
+        path: Path | None = None, settings: Settings | None = None
+    ) -> bool:
+        order.append("configure")
+        return original_configure(path or config_path, settings=settings)
+
+    class FakeProcess:
+        def __init__(self, cmd: list[str]) -> None:
+            order.append(f"spawn:{cmd[0]}")
+
+    monkeypatch.setattr(
+        claude_desktop, "configure_claude_desktop_config", fake_configure
+    )
+    monkeypatch.setattr(claude_desktop, "find_binary", lambda: "/usr/bin/claude")
+    monkeypatch.setattr(claude_desktop.subprocess, "Popen", FakeProcess)
+
+    claude_desktop.ensure_configured_and_launch(settings=fake_settings)
+
+    assert order[0] == "configure"
+    assert order[1].startswith("spawn:")
+
+
+def test_unconfigure_preserves_user_replaced_object_over_scalar_root(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A user object replacing FCC's generated mapping survives unconfigure."""
+
+    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    replacement = {"provider": "user-choice", "model": "user-model"}
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"] = dict(replacement)
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["inference"] == replacement
+    assert "modelDiscoveryEnabled" not in result
+
+
+def test_unconfigure_preserves_user_deleted_entry_over_scalar_root(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """Deleting ``inference`` wholesale after a scalar clobber is respected."""
+
+    fake_config.write_text(json.dumps({"inference": "legacy-scalar"}), encoding="utf-8")
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    del data["inference"]
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "inference" not in result
+
+
+def test_unconfigure_respects_user_edited_discovery_key(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A post-merge user edit to ``modelDiscoveryEnabled`` wins on unconfigure."""
+
+    fake_config.write_text(
+        json.dumps({"modelDiscoveryEnabled": False}), encoding="utf-8"
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+    data["modelDiscoveryEnabled"] = False
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    # The pre-merge value was False and the user re-applied False: restored.
+    assert result["modelDiscoveryEnabled"] is False
+
+
+def test_unconfigure_leaves_user_disabled_discovery_from_absent_root(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """FCC-inserted discovery flipped off by the user is not deleted twice."""
+
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["modelDiscoveryEnabled"] = False
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    result = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert result["modelDiscoveryEnabled"] is False
+
+
+def test_unconfigure_preserves_user_edited_managed_key(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A post-merge user edit to a managed key wins over the snapshot."""
+
+    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["inferenceAnthropicApiKey"] = "user-rotated-key"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    out = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert out["inference"]["inferenceAnthropicApiKey"] == "user-rotated-key"
+    # Untouched FCC-inserted keys are still removed.
+    assert "provider" not in out["inference"]
+
+
+def test_unconfigure_preserves_user_edited_fcc_created_key(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """Same rule when FCC created ``inference`` itself."""
+
+    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["inferenceGatewayBaseUrl"] = "http://user-chosen:9"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    out = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert out["inference"]["inferenceGatewayBaseUrl"] == "http://user-chosen:9"
+    assert "provider" not in out["inference"]
+
+
+def test_repeated_merges_absorb_post_merge_user_edits(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """A merge after a user edit must not resurrect the first snapshot."""
+
+    original = {"modelDiscoveryEnabled": False, "custom": "keep"}
+    fake_config.write_text(json.dumps({"inference": dict(original)}), encoding="utf-8")
+
+    claude_desktop.configure_claude_desktop_config(fake_config, settings=fake_settings)
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    data["inference"]["inferenceAnthropicApiKey"] = "user-key-v2"
+    fake_config.write_text(json.dumps(data), encoding="utf-8")
+
+    # Re-merge with rotated credentials; then reverse everything.
+    rotated = fake_settings.model_copy(update={"proxy_auth_token": "tok-456"})
+    assert (
+        claude_desktop.configure_claude_desktop_config(fake_config, settings=rotated)
+        is True
+    )
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    out = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert out["inference"]["inferenceAnthropicApiKey"] == "user-key-v2"
+    assert out["inference"]["custom"] == "keep"

--- a/tests/cli/test_claude_desktop_config.py
+++ b/tests/cli/test_claude_desktop_config.py
@@ -1156,16 +1156,17 @@ def test_remerge_keeps_frozen_snapshot_without_user_edits(
     assert json.loads(fake_config.read_text(encoding="utf-8")) == original
 
 
-def test_remerge_absorbs_user_disabled_discovery(
+def test_remerge_keeps_user_disabled_discovery(
     fake_config: Path,
     fake_settings: Settings,
 ) -> None:
-    """A post-merge discovery flip to ``False`` becomes the restore target.
+    """A post-merge discovery flip to ``False`` survives unconfigure.
 
-    Configure always writes ``True``, so a current ``False`` can only be
-    the user's choice — including when the key was absent before the
-    first merge, whose original state was "absent" but whose chosen state
-    is now explicitly ``False``.
+    The discovery target is frozen, not absorbed: the key was absent
+    before the first merge, and the user's explicit post-merge ``False``
+    must still win on removal. Since a current ``False`` is never
+    FCC-owned (configure always writes ``True``), unconfigure simply
+    keeps it.
     """
 
     fake_config.write_text(
@@ -1189,6 +1190,51 @@ def test_remerge_absorbs_user_disabled_discovery(
     assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
     assert json.loads(fake_config.read_text(encoding="utf-8")) == {
         "modelDiscoveryEnabled": False,
+        "inference": {"provider": "p"},
+    }
+
+
+def test_unconfigure_keeps_user_final_discovery_reenable(
+    fake_config: Path,
+    fake_settings: Settings,
+) -> None:
+    """The user's final discovery re-enable survives unconfigure.
+
+    Regression guard for the Greptile "discovery ownership loses the final
+    user preference" finding: the user disables discovery, a re-merge runs,
+    and then the user re-enables it before uninstalling. Absorbing the
+    intermediate ``False`` as the restore target would make unconfigure
+    discard the user's final ``True`` and restore the stale intermediate.
+    The discovery target is frozen instead, so the final ``True`` —
+    indistinguishable from configure's own always-``True`` write — keeps
+    the recorded original, which here is the user's own ``True``.
+    """
+
+    fake_config.write_text(
+        json.dumps({"modelDiscoveryEnabled": True, "inference": {"provider": "p"}}),
+        encoding="utf-8",
+    )
+    assert (
+        claude_desktop.configure_claude_desktop_config(
+            fake_config, settings=fake_settings
+        )
+        is True
+    )
+    for value in (False, "merge", True):
+        if value == "merge":
+            assert (
+                claude_desktop.configure_claude_desktop_config(
+                    fake_config, settings=fake_settings
+                )
+                is True
+            )
+            continue
+        current = json.loads(fake_config.read_text(encoding="utf-8"))
+        current["modelDiscoveryEnabled"] = value
+        fake_config.write_text(json.dumps(current), encoding="utf-8")
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+    assert json.loads(fake_config.read_text(encoding="utf-8")) == {
+        "modelDiscoveryEnabled": True,
         "inference": {"provider": "p"},
     }
 

--- a/tests/cli/test_claude_desktop_launcher.py
+++ b/tests/cli/test_claude_desktop_launcher.py
@@ -1,0 +1,565 @@
+"""Tests for the ``fcc-claude-desktop`` console-script shim.
+
+The shim delegates to :mod:`free_claude_code.cli.claude_desktop`; these
+tests pin its CLI surface and verify it forwards to the shared routing
+implementation (patched there for determinism).
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from free_claude_code.cli import claude_desktop as routing
+from free_claude_code.cli import tls_proxy
+from free_claude_code.cli.launchers import claude_desktop
+from free_claude_code.config.settings import Settings
+
+_DETERMINISTIC_URL = "https://localhost:8443/claude-desktop"
+
+
+@pytest.fixture(autouse=True)
+def deterministic_gateway_url(monkeypatch: pytest.MonkeyPatch):
+    """Keep gateway URL resolution off the network in every test."""
+
+    monkeypatch.setattr(
+        routing,
+        "desktop_gateway_base_url",
+        lambda settings: _DETERMINISTIC_URL,
+    )
+
+
+class FakeFront:
+    """Stand-in for the managed TLS proxy the launcher brings up."""
+
+    def __init__(self) -> None:
+        self.stop_count = 0
+
+    def stop(self) -> None:
+        self.stop_count += 1
+
+
+@pytest.fixture
+def verified_front(monkeypatch: pytest.MonkeyPatch) -> FakeFront:
+    """Default-branch tests run against an already-verified HTTPS front."""
+
+    front = FakeFront()
+    monkeypatch.setattr(claude_desktop, "ensure_https_front", lambda settings: front)
+    monkeypatch.setattr(
+        claude_desktop,
+        "verified_https_gateway_url",
+        lambda settings: _DETERMINISTIC_URL,
+    )
+    return front
+
+
+@pytest.fixture
+def fake_config(tmp_path: Path) -> Path:
+    return tmp_path / "claude_desktop_config.json"
+
+
+def _managed_block() -> dict[str, object]:
+    return routing.fcc_managed_block(
+        Settings(host="127.0.0.1", port=8082),
+        gateway_base_url=_DETERMINISTIC_URL,
+    )
+
+
+def test_configure_applies_block_when_file_is_missing(fake_config: Path) -> None:
+    assert not fake_config.exists()
+
+    changed = claude_desktop.configure_claude_desktop_config(fake_config)
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+    assert data["inference"]["provider"] == "gateway"
+    assert data["inference"]["inferenceGatewayBaseUrl"] == _DETERMINISTIC_URL
+
+
+def test_configure_is_idempotent(fake_config: Path) -> None:
+    assert claude_desktop.configure_claude_desktop_config(fake_config) is True
+
+    # second call observes no diff.
+    second = claude_desktop.configure_claude_desktop_config(fake_config)
+    assert second is False
+
+
+def test_configure_preserves_unrelated_keys(fake_config: Path) -> None:
+    fake_config.parent.mkdir(parents=True, exist_ok=True)
+    fake_config.write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "mcpServers": {"fs": {"command": "node"}},
+                "coworkUserFilesPath": "/home/user/cowork",
+                "env": {"ANTHROPIC_BASE_URL": "https://localhost:8443"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    claude_desktop.configure_claude_desktop_config(fake_config)
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["preferences"] == {"theme": "dark"}
+    assert data["mcpServers"] == {"fs": {"command": "node"}}
+    assert data["coworkUserFilesPath"] == "/home/user/cowork"
+    assert data["env"] == {"ANTHROPIC_BASE_URL": "https://localhost:8443"}
+    assert data["modelDiscoveryEnabled"] is True
+
+
+def test_configure_overwrites_partial_inference_block(fake_config: Path) -> None:
+    fake_config.write_text(
+        json.dumps(
+            {"inference": {"provider": "anthropic", "credentialKind": "static"}}
+        ),
+        encoding="utf-8",
+    )
+
+    claude_desktop.configure_claude_desktop_config(fake_config)
+
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["inference"]["provider"] == "gateway"
+    assert data["inference"]["credentialKind"] == "static"
+    assert data["inference"]["inferenceGatewayBaseUrl"] == _DETERMINISTIC_URL
+
+
+def test_unconfigure_drops_only_fcc_keys(fake_config: Path) -> None:
+    fake_config.write_text(
+        json.dumps(
+            {
+                "preferences": {"theme": "dark"},
+                "modelDiscoveryEnabled": True,
+                "inference": _managed_block() | {"extra_user_key": "stay"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = claude_desktop.unconfigure_claude_desktop_config(fake_config)
+
+    assert changed is True
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert "modelDiscoveryEnabled" not in data
+    assert data["inference"] == {"extra_user_key": "stay"}
+    assert data["preferences"] == {"theme": "dark"}
+
+
+def test_unconfigure_removes_entire_inference_block_when_only_fcc_keys(
+    fake_config,
+) -> None:
+    claude_desktop.configure_claude_desktop_config(fake_config)
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is True
+
+    # Second pass is a no-op.
+    assert claude_desktop.unconfigure_claude_desktop_config(fake_config) is False
+
+
+def test_unconfigure_silent_on_missing_file(tmp_path: Path) -> None:
+    assert (
+        claude_desktop.unconfigure_claude_desktop_config(tmp_path / "absent.json")
+        is False
+    )
+
+
+def test_config_path_resolver_returns_default_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("APPDATA", raising=False)
+    for plat, expected_substring in (
+        ("linux", "claude_desktop_config.json"),
+        ("darwin", "claude_desktop_config.json"),
+        ("win32", "claude_desktop_config.json"),
+    ):
+        monkeypatch.setattr(routing.sys, "platform", plat, raising=False)
+        path = claude_desktop._config_path()
+        assert path.name == expected_substring
+        assert path.is_absolute()
+
+
+def test_launch_spawns_binary_without_certificate_bypass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    verified_front: FakeFront,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[list[str]] = []
+
+    class FakeProcess:
+        def __init__(self, cmd):
+            calls.append(cmd)
+
+        def wait(self) -> int:
+            return 0
+
+        def terminate(self) -> None:  # pragma: no cover - unused in suite
+            return None
+
+    monkeypatch.setattr(routing.shutil, "which", lambda _: "/usr/bin/claude-desktop")
+    monkeypatch.setattr(routing.subprocess, "Popen", FakeProcess)
+    fake_config = tmp_path / "claude_desktop_config.json"
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(
+            ["--config-path", str(fake_config), "/tmp/some extra path/"]
+        )
+    assert exc.value.code == 0
+    assert calls == [["/usr/bin/claude-desktop", "/tmp/some extra path/"]]
+    data = json.loads(fake_config.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+    # The routing block must point at the verified HTTPS front, and the
+    # front the launcher brought up is stopped on the way out.
+    assert data["inference"]["inferenceGatewayBaseUrl"] == _DETERMINISTIC_URL
+    assert verified_front.stop_count == 1
+
+
+def test_launch_merges_config_before_spawning_binary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    verified_front: FakeFront,
+) -> None:
+    events: list[str] = []
+
+    class FakeProcess:
+        def __init__(self, _cmd):
+            events.append("spawn")
+
+        def wait(self) -> int:
+            return 0
+
+    monkeypatch.setattr(routing.shutil, "which", lambda _: "/usr/bin/claude-desktop")
+    monkeypatch.setattr(routing.subprocess, "Popen", FakeProcess)
+    fake_config = tmp_path / "claude_desktop_config.json"
+    real_save = routing._save_config
+
+    def tracking_save(path: Path, data: dict[str, object]) -> None:
+        events.append("merge")
+        real_save(path, data)
+
+    monkeypatch.setattr(routing, "_save_config", tracking_save)
+
+    with pytest.raises(SystemExit):
+        claude_desktop.launch(["--config-path", str(fake_config)])
+
+    assert events == ["merge", "spawn"]
+
+
+def test_launch_aborts_when_merge_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    verified_front: FakeFront,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    spawned: list[list[str]] = []
+
+    class FakeProcess:
+        def __init__(self, cmd):
+            spawned.append(cmd)
+
+        def wait(self) -> int:
+            return 0
+
+    monkeypatch.setattr(routing.shutil, "which", lambda _: "/usr/bin/claude-desktop")
+    monkeypatch.setattr(routing.subprocess, "Popen", FakeProcess)
+
+    def failing_configure(_path: Path, gateway_base_url: str | None = None) -> bool:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        claude_desktop, "configure_claude_desktop_config", failing_configure
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--config-path", str(tmp_path / "absent.json")])
+
+    # Launching without routing leaves Claude Desktop pointing at Anthropic's
+    # own gateway, so a failed merge must abort instead of degrading silently.
+    assert exc.value.code == 1
+    assert spawned == []
+    assert verified_front.stop_count == 1  # front cleaned up on the abort path
+    captured = capsys.readouterr()
+    assert "could not merge the FCC routing block" in captured.err
+
+
+def test_launch_exits_127_when_binary_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    verified_front: FakeFront,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(routing.shutil, "which", lambda _: None)
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--config-path", str(tmp_path / "absent.json")])
+    assert exc.value.code == 127
+    assert verified_front.stop_count == 1
+    captured = capsys.readouterr()
+    assert "claude-desktop" in captured.err
+
+
+def test_launch_configure_does_not_invoke_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    verified_front: FakeFront,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake = tmp_path / "claude_desktop_config.json"
+    invoked: list[bool] = []
+
+    def fail_call(cmd):
+        invoked.append(True)
+        return 0
+
+    monkeypatch.setattr(routing.subprocess, "Popen", fail_call)
+
+    claude_desktop.launch(["--configure", "--config-path", str(fake)])
+
+    assert invoked == []
+    captured = capsys.readouterr()
+    assert "Updated" in captured.out
+
+    data = json.loads(fake.read_text(encoding="utf-8"))
+    assert data["modelDiscoveryEnabled"] is True
+    # The persisted block must point at the verified HTTPS front.
+    assert data["inference"]["inferenceGatewayBaseUrl"] == _DETERMINISTIC_URL
+    # --configure adopts the already-running front and never manages one,
+    # so the config it writes cannot outlive a front the command spawned.
+    assert verified_front.stop_count == 0
+
+
+def test_launch_configure_never_spawns_its_own_front(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Regression guard for the Greptile "configure kills its own gateway"
+    # finding: the command exits right after writing, so a front it
+    # spawned would die with it and leave the config pointing at a dead
+    # gateway. Adoption is probe-only: verification runs for real here
+    # (probe pinned), and any attempt to bring up a managed proxy trips
+    # the construction guard.
+    fake = tmp_path / "claude_desktop_config.json"
+
+    def fail_spawn(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("configure must never bring up its own front")
+
+    monkeypatch.setattr(tls_proxy, "CaddyTlsProxy", fail_spawn)
+    monkeypatch.setattr(tls_proxy, "probe_fcc_front", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        tls_proxy, "load_or_create_front_identity", lambda *a, **kw: "pinned"
+    )
+
+    claude_desktop.launch(["--configure", "--config-path", str(fake)])
+
+    data = json.loads(fake.read_text(encoding="utf-8"))
+    assert data["inference"]["inferenceGatewayBaseUrl"].startswith("https://")
+
+
+def test_launch_configure_refuses_malformed_config(
+    tmp_path: Path,
+    verified_front: FakeFront,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Regression guard for the Greptile "malformed configure reports
+    # success" finding: a malformed config makes configure skip without
+    # writing, which must exit nonzero — never "Already merged".
+    fake = tmp_path / "claude_desktop_config.json"
+    fake.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--configure", "--config-path", str(fake)])
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "malformed config" in captured.err
+    assert "Already merged" not in captured.out
+    assert fake.read_text(encoding="utf-8") == "{not json"
+
+
+def test_launch_configure_refuses_without_https_front(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Regression guard for the Greptile "--configure bypasses the gate"
+    # finding: the routing block embeds the reusable proxy token, so
+    # persisting it against the plain-HTTP fallback would hand the
+    # credential to whatever occupies that endpoint. Refuse, untouched.
+    fake = tmp_path / "claude_desktop_config.json"
+
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: None
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--configure", "--config-path", str(fake)])
+
+    assert exc.value.code == 1
+    assert not fake.exists()
+    captured = capsys.readouterr()
+    assert "no verified FCC HTTPS front" in captured.err
+
+
+def test_launch_refuses_malformed_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    verified_front: FakeFront,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake = tmp_path / "claude_desktop_config.json"
+    fake.write_text("{not json", encoding="utf-8")
+
+    def fail_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("malformed config must not reach the binary")
+
+    monkeypatch.setattr(routing.shutil, "which", lambda _: "/usr/bin/claude-desktop")
+    monkeypatch.setattr(routing.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--config-path", str(fake)])
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "Refusing to launch Claude Desktop" in captured.err
+
+
+def test_launch_refuses_without_https_front(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Regression guard for the Greptile "standalone launch lacks HTTPS"
+    # finding: without a verified front the gateway URL would fall back to
+    # plain HTTP, which Claude Desktop cannot use — so the launcher must
+    # refuse instead of writing an unusable routing block and spawning.
+    fake = tmp_path / "claude_desktop_config.json"
+
+    def fail_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("no HTTPS front must never reach the binary")
+
+    monkeypatch.setattr(claude_desktop, "ensure_https_front", lambda settings: None)
+    monkeypatch.setattr(routing.shutil, "which", lambda _: "/usr/bin/claude-desktop")
+    monkeypatch.setattr(routing.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--config-path", str(fake)])
+
+    assert exc.value.code == 1
+    assert not fake.exists()  # no routing block written without HTTPS
+    captured = capsys.readouterr()
+    assert "no verified FCC HTTPS front" in captured.err
+
+
+def test_launch_refuses_when_front_stops_verifying(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The front can stop verifying between bring-up and the config write;
+    # the launcher must re-check and refuse rather than fall back to HTTP.
+    fake = tmp_path / "claude_desktop_config.json"
+    front = FakeFront()
+
+    def fail_popen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("an unverified front must never reach the binary")
+
+    monkeypatch.setattr(claude_desktop, "ensure_https_front", lambda settings: front)
+    monkeypatch.setattr(
+        claude_desktop, "verified_https_gateway_url", lambda settings: None
+    )
+    monkeypatch.setattr(routing.shutil, "which", lambda _: "/usr/bin/claude-desktop")
+    monkeypatch.setattr(routing.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--config-path", str(fake)])
+
+    assert exc.value.code == 1
+    assert not fake.exists()
+    assert front.stop_count == 1
+    captured = capsys.readouterr()
+    assert "stopped verifying" in captured.err
+
+
+def test_launch_stops_front_after_binary_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    verified_front: FakeFront,
+) -> None:
+    # The launcher owns the front it brought up for the whole Desktop
+    # session and must stop it when the binary exits.
+    class FakeProcess:
+        def __init__(self, _cmd: list[str]) -> None: ...
+
+        def wait(self) -> int:
+            return 0
+
+    monkeypatch.setattr(routing.shutil, "which", lambda _: "/usr/bin/claude-desktop")
+    monkeypatch.setattr(routing.subprocess, "Popen", FakeProcess)
+
+    with pytest.raises(SystemExit) as exc:
+        claude_desktop.launch(["--config-path", str(tmp_path / "cfg.json")])
+
+    assert exc.value.code == 0
+    assert verified_front.stop_count == 1
+
+
+def test_save_config_permissions_survive_permissive_umask(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "Claude" / "claude_desktop_config.json"
+    previous_umask = os.umask(0o000)
+    try:
+        routing._save_config(target, {"modelDiscoveryEnabled": True})
+    finally:
+        os.umask(previous_umask)
+
+    # The merged block embeds the gateway auth token, so neither the config
+    # nor the directory holding it may be group/world readable.
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert stat.S_IMODE(target.parent.stat().st_mode) == 0o700
+
+
+def test_save_config_ignores_preexisting_permissive_tmp(
+    tmp_path: Path,
+) -> None:
+    # Regression guard for the Greptile "temporary path exposure" finding:
+    # a pre-existing permissive file at the old predictable ``.tmp`` name
+    # must not receive the token. The writer allocates a fresh exclusive
+    # temp file, so the attacker-placed file is left untouched and the
+    # final config is owner-only.
+    target = tmp_path / "claude_desktop_config.json"
+    planted = tmp_path / "claude_desktop_config.json.tmp"
+    planted.write_text("attacker", encoding="utf-8")
+    os.chmod(planted, 0o644)
+
+    routing._save_config(target, {"inference": {"inferenceAnthropicApiKey": "tok"}})
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    # The planted file is neither reused nor overwritten.
+    assert planted.read_text(encoding="utf-8") == "attacker"
+    assert "tok" not in planted.read_text(encoding="utf-8")
+
+
+def test_save_config_does_not_follow_tmp_symlink(
+    tmp_path: Path,
+) -> None:
+    # Regression guard for the Greptile "temporary path exposure" finding:
+    # a symlink at the old predictable ``.tmp`` name must not redirect the
+    # token write to an external file. The writer allocates a fresh
+    # exclusive temp file, so the symlink target is never written.
+    target = tmp_path / "claude_desktop_config.json"
+    external = tmp_path / "external-readable.txt"
+    external.write_text("external", encoding="utf-8")
+    os.chmod(external, 0o644)
+    planted = tmp_path / "claude_desktop_config.json.tmp"
+    planted.symlink_to(external)
+
+    routing._save_config(target, {"inference": {"inferenceAnthropicApiKey": "tok"}})
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    # The symlink target never receives the credential.
+    assert external.read_text(encoding="utf-8") == "external"
+    assert "tok" not in external.read_text(encoding="utf-8")

--- a/tests/cli/test_desktop.py
+++ b/tests/cli/test_desktop.py
@@ -470,7 +470,7 @@ def test_verified_https_readiness_repersists_desktop_config() -> None:
         )
 
     remerge.assert_called_once_with(
-        settings=settings, gateway_base_url="https://localhost:8444"
+        settings=settings, gateway_base_url="https://localhost:8444/claude-desktop"
     )
 
 

--- a/tests/cli/test_desktop.py
+++ b/tests/cli/test_desktop.py
@@ -1,7 +1,9 @@
 """Desktop shell lifecycle and singleton contracts."""
 
 import threading
+import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from free_claude_code.cli.commands import ServerStatus, ServerSupervisor
@@ -87,6 +89,9 @@ def test_desktop_controller_owns_server_thread_and_graceful_quit() -> None:
             self.status = ServerStatus.STOPPING
             self.stopped.set()
 
+        def desktop_gateway_url(self) -> str | None:
+            return None
+
     class FakeTray:
         def __init__(self, controller: DesktopController) -> None:
             self.controller = controller
@@ -159,6 +164,9 @@ def test_restart_during_server_startup_is_accepted_without_waiting() -> None:
 
         def request_stop(self) -> None:
             self.release_worker.set()
+
+        def desktop_gateway_url(self) -> str | None:
+            return None
 
     class WaitingTray:
         def __init__(self, _controller: DesktopController) -> None:
@@ -270,3 +278,165 @@ def test_fresh_desktop_launch_uses_console_free_supervisor() -> None:
     assert shell.call_args.args[:2] == (supervisor, tray_factory)
     controller.run.assert_called_once_with()
     instance_lock.release.assert_called_once_with()
+
+
+def test_desktop_controller_exposes_live_gateway_url_from_server() -> None:
+    """The desktop integration reads the gateway URL the server published.
+
+    Regression guard for the Greptile "published desktop gateway URL is
+    never handed to the Claude Desktop integration" finding: the
+    controller surfaces ``ServerOwner.desktop_gateway_url()`` so the
+    config merge consumes the live TLS-prefixed endpoint rather than
+    re-deriving it.
+    """
+
+    class PublishingSupervisor:
+        status = ServerStatus.RUNNING
+        gateway: str | None = None
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            return None
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            return None
+
+        def desktop_gateway_url(self) -> str | None:
+            return self.gateway
+
+    supervisor = PublishingSupervisor()
+    controller = DesktopController(supervisor, MagicMock(), MagicMock())
+
+    assert controller.desktop_gateway_url() is None
+    supervisor.gateway = "https://localhost:18443/claude-desktop"
+    assert controller.desktop_gateway_url() == "https://localhost:18443/claude-desktop"
+
+
+def test_tray_status_consumes_published_gateway_url() -> None:
+    """The desktop tray surface reads the supervisor-published gateway URL.
+
+    Regression guard for the Greptile "desktop gateway URL is unconsumed"
+    finding: the tray's status notification is a production consumer of
+    ``DesktopController.desktop_gateway_url()``, reporting the TLS-prefixed
+    HTTPS endpoint when a front verifies and the plain-HTTP fallback
+    otherwise — and only the process state before any URL is published.
+    """
+    from free_claude_code.cli.desktop_tray import status_notification
+
+    class PublishingSupervisor:
+        status = ServerStatus.RUNNING
+        gateway: str | None = None
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            return None
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            return None
+
+        def desktop_gateway_url(self) -> str | None:
+            return self.gateway
+
+    supervisor = PublishingSupervisor()
+    controller = DesktopController(supervisor, MagicMock(), MagicMock())
+
+    # Before the server publishes a URL, only the process state is shown.
+    assert status_notification(controller) == "Server is Running."
+
+    # HTTPS front verified: the TLS-prefixed endpoint is surfaced.
+    supervisor.gateway = "https://localhost:18443/claude-desktop"
+    assert (
+        status_notification(controller)
+        == "Server is Running. Gateway: https://localhost:18443/claude-desktop"
+    )
+
+    # Plain-HTTP fallback: the fallback endpoint is surfaced.
+    supervisor.gateway = "http://127.0.0.1:8082/claude-desktop"
+    assert (
+        status_notification(controller)
+        == "Server is Running. Gateway: http://127.0.0.1:8082/claude-desktop"
+    )
+
+
+def test_desktop_quit_stops_the_managed_tls_front() -> None:
+    """The desktop quit path tears down the HTTPS front with the server.
+
+    Regression guard for the Greptile "managed TLS proxy never enters the
+    desktop lifecycle" finding: the desktop shell drives the same
+    ``ServerSupervisor`` generation lifecycle, so quitting the tray must
+    stop the generation's ``CaddyTlsProxy`` after the server exits.
+    """
+    from free_claude_code.cli import commands, desktop
+
+    settings = _settings()
+    events: list[str] = []
+    server_running = threading.Event()
+
+    class FakeTlsProxy:
+        def __init__(self, proxy_settings: Settings) -> None:
+            assert proxy_settings is settings
+            events.append("construct")
+
+        def start(self) -> bool:
+            events.append("start")
+            return True
+
+        def stop(self) -> None:
+            events.append("stop")
+
+    class FakeServer:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit = False
+
+        def run(self):
+            events.append("server-run")
+            server_running.set()
+            while not self.should_exit:
+                time.sleep(0.05)
+
+    def fake_config(app, **kwargs):
+        return SimpleNamespace(app=app, kwargs=kwargs)
+
+    class QuittingTray:
+        def __init__(self, controller: DesktopController) -> None:
+            self._controller = controller
+
+        def run(self) -> None:
+            assert server_running.wait(2)
+            self._controller.quit()
+
+        def stop(self) -> None:
+            return None
+
+    supervisor = ServerSupervisor(console_logging=False)
+    with (
+        patch.object(desktop, "load_server_settings", return_value=settings),
+        patch.object(desktop, "get_settings", return_value=settings),
+        patch.object(commands, "get_settings", return_value=settings),
+        patch.object(commands.uvicorn, "Config", side_effect=fake_config),
+        patch.object(commands.uvicorn, "Server", side_effect=FakeServer),
+        patch.object(
+            commands,
+            "build_asgi_app",
+            return_value=SimpleNamespace(runtime=SimpleNamespace(is_closed=False)),
+        ),
+        patch.object(commands, "CaddyTlsProxy", side_effect=FakeTlsProxy),
+        patch.object(commands, "GATEWAY_HEALTH_UPGRADE_SECONDS", 0.5),
+        patch.object(commands, "probe_fcc_front", return_value=True),
+        patch.object(commands, "schedule_open_admin_browser"),
+        patch.object(commands, "kill_all_best_effort"),
+    ):
+        DesktopController(supervisor, QuittingTray, lambda: None).run()
+
+    assert events == ["construct", "start", "server-run", "stop"]

--- a/tests/cli/test_desktop.py
+++ b/tests/cli/test_desktop.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from free_claude_code.cli import commands
 from free_claude_code.cli.commands import ServerStatus, ServerSupervisor
 from free_claude_code.cli.desktop import DesktopController
 from free_claude_code.config.settings import Settings
@@ -440,3 +441,60 @@ def test_desktop_quit_stops_the_managed_tls_front() -> None:
         DesktopController(supervisor, QuittingTray, lambda: None).run()
 
     assert events == ["construct", "start", "server-run", "stop"]
+
+
+def test_verified_https_readiness_repersists_desktop_config() -> None:
+    """Readiness upgrade rewrites the persisted Claude Desktop config.
+
+    Regression guard for the Greptile "TLS endpoint stays unconfigured"
+    finding: the pre-lifecycle merge records the plain-HTTP fallback while
+    the front is still starting. Once the readiness task verifies the
+    front, the config file must be re-merged with the verified root —
+    Claude Desktop reads the config file, not this process's memory.
+    """
+
+    supervisor = ServerSupervisor(console_logging=False)
+    settings = Settings.model_construct(
+        host="0.0.0.0", port=8082, tls_proxy_enabled=True, tls_proxy_port=8444
+    )
+
+    with (
+        patch.object(
+            commands,
+            "configure_claude_desktop_config",
+            return_value=True,
+        ) as remerge,
+    ):
+        supervisor._publish_verified_https_gateway_url(
+            settings, "https://localhost:8444"
+        )
+
+    remerge.assert_called_once_with(
+        settings=settings, gateway_base_url="https://localhost:8444"
+    )
+
+
+def test_verified_https_repersist_failure_does_not_raise() -> None:
+    """A config re-merge failure downgrades to a warning, not a crash.
+
+    The re-merge runs inside the live serving window on the readiness
+    thread; a filesystem failure there must not take the generation down.
+    """
+
+    supervisor = ServerSupervisor(console_logging=False)
+    settings = Settings.model_construct(
+        host="0.0.0.0", port=8082, tls_proxy_enabled=True, tls_proxy_port=8444
+    )
+
+    with (
+        patch.object(
+            commands,
+            "configure_claude_desktop_config",
+            side_effect=OSError("disk full"),
+        ),
+    ):
+        supervisor._publish_verified_https_gateway_url(
+            settings, "https://localhost:8444"
+        )
+
+    assert supervisor.desktop_gateway_url() == "https://localhost:8444/claude-desktop"

--- a/tests/cli/test_desktop.py
+++ b/tests/cli/test_desktop.py
@@ -465,20 +465,28 @@ def test_verified_https_readiness_repersists_desktop_config() -> None:
             return_value=True,
         ) as remerge,
     ):
-        supervisor._publish_verified_https_gateway_url(
+        published = supervisor._publish_verified_https_gateway_url(
             settings, "https://localhost:8444"
         )
 
     remerge.assert_called_once_with(
         settings=settings, gateway_base_url="https://localhost:8444/claude-desktop"
     )
+    assert published is True
+    assert supervisor.desktop_gateway_url() == "https://localhost:8444/claude-desktop"
 
 
-def test_verified_https_repersist_failure_does_not_raise() -> None:
+def test_verified_https_repersist_failure_keeps_both_surfaces_on_http() -> None:
     """A config re-merge failure downgrades to a warning, not a crash.
 
     The re-merge runs inside the live serving window on the readiness
     thread; a filesystem failure there must not take the generation down.
+    It must not split the two surfaces either: Claude Desktop reads the
+    persisted config file, so publishing the HTTPS URL in memory while
+    the file still carries the plain-HTTP fallback would advertise an
+    endpoint Claude Desktop cannot use. The publication is deferred
+    until the write lands, and the return value tells the readiness loop
+    to retry the whole upgrade on its next probe.
     """
 
     supervisor = ServerSupervisor(console_logging=False)
@@ -491,10 +499,55 @@ def test_verified_https_repersist_failure_does_not_raise() -> None:
             commands,
             "configure_claude_desktop_config",
             side_effect=OSError("disk full"),
-        ),
+        ) as remerge,
     ):
-        supervisor._publish_verified_https_gateway_url(
+        published = supervisor._publish_verified_https_gateway_url(
             settings, "https://localhost:8444"
         )
 
+    assert published is False
+    assert remerge.call_count == 1
+    # Nothing was published: the in-memory URL stays None (the supervisor
+    # never got past the deferred publication), so memory and the
+    # persisted file agree on the plain-HTTP fallback.
+    assert supervisor.desktop_gateway_url() is None
+
+
+def test_verified_https_readiness_retries_until_repersist_lands() -> None:
+    """The readiness loop retries a failed config rewrite on later probes.
+
+    Regression guard for the Greptile "HTTPS config refresh is discarded"
+    finding: a transient ``OSError`` (disk full, EBUSY rename) on the
+    first verified probe used to strand the persisted config on the
+    plain-HTTP fallback forever while the serving window continued. The
+    upgrade is now retryable for the whole readiness window: each probe
+    that verifies the front reattempts the persisted rewrite, and the
+    moment one lands the in-memory publication follows atomically.
+    """
+
+    supervisor = ServerSupervisor(console_logging=False)
+    settings = Settings.model_construct(
+        host="0.0.0.0", port=8082, tls_proxy_enabled=True, tls_proxy_port=8444
+    )
+    remerge_results = iter([OSError("disk full"), OSError("disk full"), True])
+
+    def flaky_remerge(**_kwargs: object) -> bool:
+        result = next(remerge_results)
+        if isinstance(result, OSError):
+            raise result
+        return result
+
+    with (
+        patch.object(commands, "probe_fcc_front", return_value=True),
+        patch.object(commands, "GATEWAY_HEALTH_UPGRADE_SECONDS", 5.0),
+        patch.object(commands.time, "sleep"),
+        patch.object(
+            commands,
+            "configure_claude_desktop_config",
+            side_effect=flaky_remerge,
+        ) as remerge,
+    ):
+        supervisor._await_gateway_https_readiness(settings)
+
+    assert remerge.call_count == 3
     assert supervisor.desktop_gateway_url() == "https://localhost:8444/claude-desktop"

--- a/tests/cli/test_desktop.py
+++ b/tests/cli/test_desktop.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from free_claude_code.cli import commands
 from free_claude_code.cli.commands import ServerStatus, ServerSupervisor
 from free_claude_code.cli.desktop import DesktopController
@@ -246,6 +248,7 @@ def test_desktop_attaches_to_terminal_server_instead_of_binding_twice() -> None:
         patch.object(desktop, "load_server_settings", return_value=settings),
         patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
         patch.object(desktop, "preflight_proxy", return_value=None),
+        patch.object(desktop, "verified_https_gateway_url", return_value=None),
         patch.object(desktop, "open_admin_when_ready", return_value=True) as open_admin,
         patch.object(desktop, "ServerSupervisor") as supervisor,
     ):
@@ -256,7 +259,103 @@ def test_desktop_attaches_to_terminal_server_instead_of_binding_twice() -> None:
     instance_lock.release.assert_called_once_with()
 
 
-def test_fresh_desktop_launch_uses_console_free_supervisor() -> None:
+def test_existing_server_with_https_front_gets_routing_merge() -> None:
+    from free_claude_code.cli import desktop
+
+    settings = _settings()
+    instance_lock = MagicMock()
+    instance_lock.acquire.return_value = True
+    verified_url = "https://localhost:8443/claude-desktop"
+
+    with (
+        patch.object(desktop, "load_server_settings", return_value=settings),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
+        patch.object(desktop, "preflight_proxy", return_value=None),
+        patch.object(
+            desktop, "verified_https_gateway_url", return_value=verified_url
+        ) as verify,
+        patch.object(desktop, "configure_claude_desktop_config") as configure,
+        patch.object(desktop, "open_admin_when_ready", return_value=True),
+        patch.object(desktop, "ServerSupervisor"),
+        patch.object(desktop, "CaddyTlsProxy") as tls_proxy,
+    ):
+        desktop.launch_desktop(MagicMock())
+
+    configure.assert_called_once_with(settings=settings, gateway_base_url=verified_url)
+    # The merge writes the gateway credential, so the gateway must be
+    # re-verified at write time — never merged on faith.
+    verify.assert_called_once_with(settings)
+    tls_proxy.return_value.start.assert_not_called()
+    instance_lock.release.assert_called_once_with()
+
+
+def test_existing_server_without_https_front_is_left_unmerged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from free_claude_code.cli import desktop
+
+    settings = _settings()
+    instance_lock = MagicMock()
+    instance_lock.acquire.return_value = True
+
+    with (
+        patch.object(desktop, "load_server_settings", return_value=settings),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
+        patch.object(desktop, "preflight_proxy", return_value=None),
+        patch.object(desktop, "verified_https_gateway_url", return_value=None),
+        patch.object(desktop, "configure_claude_desktop_config") as configure,
+        patch.object(desktop, "open_admin_when_ready", return_value=True),
+        patch.object(desktop, "ServerSupervisor"),
+        patch.object(desktop, "CaddyTlsProxy") as tls_proxy,
+    ):
+        desktop.launch_desktop(MagicMock())
+
+    configure.assert_not_called()
+    # This short-lived launch must never spawn a managed front it cannot
+    # stay alive to own: adoption is probe-only, so no child is created
+    # that would outlive the process unmanaged.
+    tls_proxy.return_value.start.assert_not_called()
+    instance_lock.release.assert_called_once_with()
+    # The warning must name the step that actually changes the condition:
+    # relaunching against the same HTTP-only server repeats this branch,
+    # so "then relaunch" would be a dead end.
+    assert any(
+        "stop the running HTTP-only FCC server" in record.message
+        for record in caplog.records
+    )
+
+
+def test_existing_server_with_impersonated_front_is_left_unmerged() -> None:
+    """Regression guard for the Greptile impersonation finding.
+
+    A listener that merely occupies the TLS port (transport alive) but
+    cannot serve this install's identity secret must not receive the
+    gateway credential through the existing-server merge path.
+    """
+
+    from free_claude_code.cli import desktop
+
+    settings = _settings()
+    instance_lock = MagicMock()
+    instance_lock.acquire.return_value = True
+
+    with (
+        patch.object(desktop, "load_server_settings", return_value=settings),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
+        patch.object(desktop, "preflight_proxy", return_value=None),
+        # Transport may be alive, but identity fails: exactly the impersonator.
+        patch.object(desktop, "verified_https_gateway_url", return_value=None),
+        patch.object(desktop, "configure_claude_desktop_config") as configure,
+        patch.object(desktop, "open_admin_when_ready", return_value=True),
+        patch.object(desktop, "ServerSupervisor"),
+        patch.object(desktop, "CaddyTlsProxy"),
+    ):
+        desktop.launch_desktop(MagicMock())
+
+    configure.assert_not_called()
+
+
+def test_fresh_launch_skips_merge_when_no_https_front_comes_up() -> None:
     from free_claude_code.cli import desktop
 
     settings = _settings()
@@ -269,14 +368,84 @@ def test_fresh_desktop_launch_uses_console_free_supervisor() -> None:
         patch.object(desktop, "load_server_settings", return_value=settings),
         patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
         patch.object(desktop, "preflight_proxy", return_value="connection refused"),
+        patch.object(desktop, "CaddyTlsProxy") as tls_proxy,
+        patch.object(desktop, "verified_https_gateway_url", return_value=None),
+        patch.object(desktop, "configure_claude_desktop_config") as configure,
+        patch.object(desktop, "ServerSupervisor", return_value=supervisor),
+        patch.object(desktop, "DesktopController", return_value=controller),
+    ):
+        tls_proxy.return_value.start.return_value = False
+        desktop.launch_desktop(MagicMock())
+
+    configure.assert_not_called()
+    controller.run.assert_called_once_with()
+    instance_lock.release.assert_called_once_with()
+
+
+def test_fresh_launch_skips_merge_when_front_stops_verifying_after_start() -> None:
+    """Regression guard for the Greptile TOCTOU finding.
+
+    ``start()`` succeeding is not a license to merge: the front can stop
+    verifying between bring-up and the config write, and merging then would
+    fall back to a plain-HTTP gateway URL while still embedding the proxy
+    auth token. The merge must re-verify at write time and skip instead.
+    """
+
+    from free_claude_code.cli import desktop
+
+    settings = _settings()
+    instance_lock = MagicMock()
+    instance_lock.acquire.return_value = True
+    supervisor = MagicMock()
+    controller = MagicMock()
+
+    with (
+        patch.object(desktop, "load_server_settings", return_value=settings),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
+        patch.object(desktop, "preflight_proxy", return_value="connection refused"),
+        patch.object(desktop, "CaddyTlsProxy") as tls_proxy,
+        patch.object(desktop, "verified_https_gateway_url", return_value=None),
+        patch.object(desktop, "configure_claude_desktop_config") as configure,
+        patch.object(desktop, "ServerSupervisor", return_value=supervisor),
+        patch.object(desktop, "DesktopController", return_value=controller),
+    ):
+        tls_proxy.return_value.start.return_value = True
+        desktop.launch_desktop(MagicMock())
+
+    configure.assert_not_called()
+    controller.run.assert_called_once_with()
+    instance_lock.release.assert_called_once_with()
+
+
+def test_fresh_desktop_launch_uses_console_free_supervisor() -> None:
+    from free_claude_code.cli import desktop
+
+    settings = _settings()
+    instance_lock = MagicMock()
+    instance_lock.acquire.return_value = True
+    supervisor = MagicMock()
+    controller = MagicMock()
+    verified_url = "https://localhost:8443/claude-desktop"
+
+    with (
+        patch.object(desktop, "load_server_settings", return_value=settings),
+        patch.object(desktop, "InterprocessFileLock", return_value=instance_lock),
+        patch.object(desktop, "preflight_proxy", return_value="connection refused"),
+        patch.object(desktop, "CaddyTlsProxy") as tls_proxy,
+        patch.object(desktop, "verified_https_gateway_url", return_value=verified_url),
+        patch.object(desktop, "configure_claude_desktop_config") as configure,
         patch.object(desktop, "ServerSupervisor", return_value=supervisor) as owner,
         patch.object(desktop, "DesktopController", return_value=controller) as shell,
     ):
+        tls_proxy.return_value.start.return_value = True
         tray_factory = MagicMock()
         desktop.launch_desktop(tray_factory)
 
     owner.assert_called_once_with(console_logging=False)
     assert shell.call_args.args[:2] == (supervisor, tray_factory)
+    # The routing block must point at the verified HTTPS front, never the
+    # plain-HTTP fallback.
+    configure.assert_called_once_with(settings=settings, gateway_base_url=verified_url)
     controller.run.assert_called_once_with()
     instance_lock.release.assert_called_once_with()
 

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -80,7 +80,7 @@ def test_console_tray_run_blocks_until_stop():
 
 def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
     with (
-        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):
         probe.return_value = (False, "backend missing")
@@ -93,9 +93,32 @@ def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
     assert "backend missing" in output
 
 
+class _RaisingModule:
+    """Stands in for ``desktop_tray`` when its pystray import would raise."""
+
+    def __getattr__(self, name: str):
+        raise RuntimeError("no display")
+
+
+def test_launch_falls_back_to_console_when_native_adapter_import_raises(capsys):
+    with (
+        patch.dict(
+            sys.modules, {"free_claude_code.cli.desktop_tray": _RaisingModule()}
+        ),
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        launch()
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "failed to load" in output
+    assert "no display" in output
+
+
 def test_console_launch_uses_native_tray_when_probe_succeeds():
     with (
-        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):
         probe.return_value = (True, "")
@@ -120,7 +143,7 @@ def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
 def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
     with (
         patch.object(sys, "platform", "linux"),
-        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):
         probe.return_value = (False, "backend missing")

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -3,6 +3,7 @@
 import contextlib
 import sys
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -175,6 +176,108 @@ def test_entrypoint_still_rejects_unsupported_platforms(capsys):
     assert "Linux" in capsys.readouterr().err
 
 
+def test_console_tray_consumes_published_gateway_url() -> None:
+    """The tray-less console surface reports the live published gateway URL.
+
+    Regression guard for the Greptile "Claude Desktop gateway is never
+    configured / console overclaims routing" finding: the console tray is a
+    production consumer of ``DesktopController.desktop_gateway_url()``,
+    printing the endpoint the active generation actually published — the
+    TLS-prefixed HTTPS URL when a front verifies, the plain-HTTP fallback
+    otherwise — and re-printing only when the value changes.
+    """
+    from free_claude_code.cli.desktop_console import console_gateway_line
+
+    class PublishingSupervisor:
+        status = ServerStatus.RUNNING
+        gateway: str | None = None
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            return None
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            return None
+
+        def desktop_gateway_url(self) -> str | None:
+            return self.gateway
+
+    supervisor = PublishingSupervisor()
+    controller = DesktopController(supervisor, MagicMock(), MagicMock())
+
+    # Before the server publishes a URL, the console prints nothing.
+    assert console_gateway_line(controller) is None
+
+    # Plain-HTTP fallback published: the fallback endpoint is surfaced.
+    supervisor.gateway = "http://127.0.0.1:8082/claude-desktop"
+    assert (
+        console_gateway_line(controller)
+        == "Claude Desktop gateway: http://127.0.0.1:8082/claude-desktop"
+    )
+
+    # HTTPS front verified: the TLS-prefixed endpoint is surfaced.
+    supervisor.gateway = "https://localhost:18443/claude-desktop"
+    assert (
+        console_gateway_line(controller)
+        == "Claude Desktop gateway: https://localhost:18443/claude-desktop"
+    )
+
+
+def test_console_tray_prints_gateway_url_changes_while_running(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The console tray prints each new gateway URL exactly once while live."""
+
+    class PublishingSupervisor:
+        status = ServerStatus.RUNNING
+        gateway: str | None = None
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            return None
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            return None
+
+        def desktop_gateway_url(self) -> str | None:
+            return self.gateway
+
+    supervisor = PublishingSupervisor()
+    controller = DesktopController(supervisor, MagicMock(), MagicMock())
+    tray = ConsoleDesktopTray(controller)
+
+    def wait_for_printed(expected: str) -> None:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if expected in capsys.readouterr().out:
+                return
+            time.sleep(0.05)
+        raise AssertionError(f"{expected} was never printed")
+
+    worker = threading.Thread(target=tray.run, daemon=True)
+    worker.start()
+    try:
+        supervisor.gateway = "http://127.0.0.1:8082/claude-desktop"
+        wait_for_printed("http://127.0.0.1:8082/claude-desktop")
+        supervisor.gateway = "https://localhost:18443/claude-desktop"
+        wait_for_printed("https://localhost:18443/claude-desktop")
+    finally:
+        tray.stop()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+
+
 def test_console_tray_lifecycle_drives_controller_to_clean_stop():
     events: list[str] = []
     server_started = threading.Event()
@@ -194,6 +297,9 @@ def test_console_tray_lifecycle_drives_controller_to_clean_stop():
 
         def request_stop(self) -> None:
             events.append("server-stop")
+
+        def desktop_gateway_url(self) -> str | None:
+            return None
 
     controller = DesktopController(
         FakeSupervisor(),

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -1,0 +1,179 @@
+"""Linux desktop shell: tray probe, console fallback, and entrypoint routing."""
+
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from free_claude_code.cli.commands import ServerStatus
+from free_claude_code.cli.desktop import DesktopController
+from free_claude_code.cli.desktop_console import ConsoleDesktopTray, launch
+from free_claude_code.cli.desktop_entrypoint import launch as entrypoint_launch
+from free_claude_code.cli.desktop_tray import tray_is_available
+
+
+def test_tray_is_available_true_when_icon_constructs():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock()),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is True
+    assert reason == ""
+
+
+def test_tray_is_available_reports_backend_import_error():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch(
+            "free_claude_code.cli.desktop_tray.Icon",
+            MagicMock(side_effect=ImportError("gir bindings missing")),
+        ),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "appindicator" in reason
+
+
+def test_tray_is_available_reports_other_construction_errors_verbatim():
+    error = RuntimeError("no display")
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock(side_effect=error)),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert reason == "no display"
+
+
+def test_tray_is_available_reports_artwork_load_failure():
+    with patch(
+        "free_claude_code.cli.desktop_tray._create_icon",
+        MagicMock(side_effect=OSError("missing asset")),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "artwork" in reason
+
+
+def test_console_tray_run_blocks_until_stop():
+    tray = ConsoleDesktopTray(MagicMock(spec=DesktopController))
+    finished = threading.Event()
+
+    def run_tray():
+        tray.run()
+        finished.set()
+
+    worker = threading.Thread(target=run_tray)
+    worker.start()
+    assert not finished.wait(timeout=0.2)
+    tray.stop()
+    assert finished.wait(timeout=5)
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+
+
+def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
+    with (
+        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        launch()
+
+    factory = start.call_args.args[0]
+    assert factory is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "backend missing" in output
+
+
+def test_console_launch_uses_native_tray_when_probe_succeeds():
+    with (
+        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (True, "")
+        launch()
+
+    from free_claude_code.cli.desktop_tray import PystrayDesktopTray
+
+    assert start.call_args.args[0] is PystrayDesktopTray
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
+    with (
+        patch.object(sys, "platform", platform),
+        patch("free_claude_code.cli.desktop_tray.launch") as tray_launch,
+    ):
+        entrypoint_launch([])
+
+    tray_launch.assert_called_once()
+
+
+def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("free_claude_code.cli.desktop_console.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        entrypoint_launch([])
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+
+
+def test_entrypoint_still_rejects_unsupported_platforms(capsys):
+    with (
+        patch.object(sys, "platform", "freebsd"),
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        entrypoint_launch([])
+
+    assert exit_info.value.code == 1
+    assert "Linux" in capsys.readouterr().err
+
+
+def test_console_tray_lifecycle_drives_controller_to_clean_stop():
+    events: list[str] = []
+    server_started = threading.Event()
+
+    class FakeSupervisor:
+        status = ServerStatus.STOPPED
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            events.append("server-run")
+            server_started.set()
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            events.append("server-stop")
+
+    controller = DesktopController(
+        FakeSupervisor(),
+        lambda controller: ConsoleDesktopTray(controller),
+        lambda: None,
+    )
+
+    worker = threading.Thread(target=controller.run, daemon=True)
+    worker.start()
+    assert server_started.wait(timeout=5)
+    controller.quit()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    # quit() stops the server, then controller.run()'s finally chain repeats
+    # the idempotent stop; the null tray must survive both.
+    assert events[0] == "server-run"
+    assert events.count("server-stop") >= 1

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -1,0 +1,266 @@
+"""Linux desktop shell: tray probe, console fallback, and entrypoint routing."""
+
+import contextlib
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    import pystray  # noqa: F401
+except Exception:
+    # Headless session: pystray's Linux backend connects to the display at
+    # import time, which would break collection of this whole module before
+    # any console-fallback behavior can be exercised. Stub the package so
+    # the tray adapter imports; every test below replaces the tray symbols
+    # it actually uses.
+    sys.modules["pystray"] = MagicMock()
+
+from free_claude_code.cli.commands import ServerStatus
+from free_claude_code.cli.desktop import DesktopController
+from free_claude_code.cli.desktop_assets import app_icon_bytes
+from free_claude_code.cli.desktop_console import ConsoleDesktopTray, launch
+from free_claude_code.cli.desktop_entrypoint import launch as entrypoint_launch
+from free_claude_code.cli.desktop_tray import tray_is_available
+
+
+def test_tray_is_available_true_when_icon_constructs():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock()),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is True
+    assert reason == ""
+
+
+def test_tray_is_available_reports_backend_import_error():
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch(
+            "free_claude_code.cli.desktop_tray.Icon",
+            MagicMock(side_effect=ImportError("gir bindings missing")),
+        ),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "appindicator" in reason
+
+
+def test_tray_is_available_reports_other_construction_errors_verbatim():
+    error = RuntimeError("no display")
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock(side_effect=error)),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert reason == "no display"
+
+
+def test_tray_is_available_reports_artwork_load_failure():
+    with patch(
+        "free_claude_code.cli.desktop_tray._create_icon",
+        MagicMock(side_effect=OSError("missing asset")),
+    ):
+        available, reason = tray_is_available()
+
+    assert available is False
+    assert "artwork" in reason
+
+
+def test_console_tray_run_blocks_until_stop():
+    tray = ConsoleDesktopTray(MagicMock(spec=DesktopController))
+    finished = threading.Event()
+
+    def run_tray():
+        tray.run()
+        finished.set()
+
+    worker = threading.Thread(target=run_tray)
+    worker.start()
+    assert not finished.wait(timeout=0.2)
+    tray.stop()
+    assert finished.wait(timeout=5)
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+
+
+def test_console_fallback_uses_null_tray_with_reason_notice(capsys):
+    with (
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        launch()
+
+    factory = start.call_args.args[0]
+    assert factory is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "backend missing" in output
+
+
+class _RaisingModule:
+    """Stands in for ``desktop_tray`` when its pystray import would raise."""
+
+    def __getattr__(self, name: str):
+        raise RuntimeError("no display")
+
+
+def test_launch_falls_back_to_console_when_native_adapter_import_raises(capsys):
+    with (
+        patch.dict(
+            sys.modules, {"free_claude_code.cli.desktop_tray": _RaisingModule()}
+        ),
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        launch()
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+    output = capsys.readouterr().out
+    assert "console mode" in output
+    assert "failed to load" in output
+    assert "no display" in output
+
+
+def test_console_launch_uses_native_tray_when_probe_succeeds():
+    with (
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (True, "")
+        launch()
+
+    from free_claude_code.cli.desktop_tray import PystrayDesktopTray
+
+    assert start.call_args.args[0] is PystrayDesktopTray
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
+    with (
+        patch.object(sys, "platform", platform),
+        patch("free_claude_code.cli.desktop_tray.launch") as tray_launch,
+    ):
+        entrypoint_launch([])
+
+    tray_launch.assert_called_once()
+
+
+def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        probe.return_value = (False, "backend missing")
+        entrypoint_launch([])
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+
+
+def test_entrypoint_still_rejects_unsupported_platforms(capsys):
+    with (
+        patch.object(sys, "platform", "freebsd"),
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        entrypoint_launch([])
+
+    assert exit_info.value.code == 1
+    assert "Linux" in capsys.readouterr().err
+
+
+def test_console_tray_lifecycle_drives_controller_to_clean_stop():
+    events: list[str] = []
+    server_started = threading.Event()
+
+    class FakeSupervisor:
+        status = ServerStatus.STOPPED
+
+        def schedule_run(self) -> bool:
+            return True
+
+        def run(self, *, open_admin_browser: bool | None = None) -> None:
+            events.append("server-run")
+            server_started.set()
+
+        def request_restart(self) -> bool:
+            return True
+
+        def request_stop(self) -> None:
+            events.append("server-stop")
+
+    controller = DesktopController(
+        FakeSupervisor(),
+        lambda controller: ConsoleDesktopTray(controller),
+        lambda: None,
+    )
+
+    worker = threading.Thread(target=controller.run, daemon=True)
+    worker.start()
+    assert server_started.wait(timeout=5)
+    controller.quit()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    # quit() stops the server, then controller.run()'s finally chain repeats
+    # the idempotent stop; the null tray must survive both.
+    assert events[0] == "server-run"
+    assert events.count("server-stop") >= 1
+
+
+@contextlib.contextmanager
+def _headless_entrypoint():
+    """Import ``desktop_entrypoint`` as if the tray backend were broken.
+
+    Drops the cached entrypoint and tray modules, then makes the tray
+    module raise on import the way pystray does on a headless Linux
+    session without an X11/appindicator backend.
+    """
+    saved_entrypoint = sys.modules.pop("free_claude_code.cli.desktop_entrypoint", None)
+    saved_tray = sys.modules.pop("free_claude_code.cli.desktop_tray", None)
+    try:
+        with patch.dict(
+            sys.modules,
+            {"free_claude_code.cli.desktop_tray": _RaisingModule()},
+        ):
+            import free_claude_code.cli.desktop_entrypoint as fresh_entrypoint
+
+            yield fresh_entrypoint
+    finally:
+        sys.modules.pop("free_claude_code.cli.desktop_entrypoint", None)
+        if saved_entrypoint is not None:
+            sys.modules["free_claude_code.cli.desktop_entrypoint"] = saved_entrypoint
+        if saved_tray is not None:
+            sys.modules["free_claude_code.cli.desktop_tray"] = saved_tray
+
+
+def test_headless_entrypoint_import_survives_broken_tray_backend():
+    with _headless_entrypoint() as fresh_entrypoint:
+        assert callable(fresh_entrypoint.launch)
+
+
+def test_headless_entrypoint_still_exports_icon(tmp_path):
+    destination = tmp_path / "icons" / "app-icon.png"
+
+    with _headless_entrypoint() as fresh_entrypoint:
+        fresh_entrypoint.launch(["--export-icon", str(destination)])
+
+    assert destination.read_bytes() == app_icon_bytes(".png")
+
+
+def test_headless_entrypoint_routes_linux_to_console_mode(capsys):
+    with (
+        _headless_entrypoint() as fresh_entrypoint,
+        patch.object(sys, "platform", "linux"),
+        patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
+    ):
+        fresh_entrypoint.launch([])
+
+    assert start.call_args.args[0] is ConsoleDesktopTray
+    assert "failed to load" in capsys.readouterr().out

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -29,7 +29,7 @@ from free_claude_code.cli.desktop_tray import tray_is_available
 def test_tray_is_available_true_when_icon_constructs():
     with (
         patch("free_claude_code.cli.desktop_tray._create_icon"),
-        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock()),
+        patch("pystray.Icon", MagicMock()),
     ):
         available, reason = tray_is_available()
 
@@ -41,7 +41,7 @@ def test_tray_is_available_reports_backend_import_error():
     with (
         patch("free_claude_code.cli.desktop_tray._create_icon"),
         patch(
-            "free_claude_code.cli.desktop_tray.Icon",
+            "pystray.Icon",
             MagicMock(side_effect=ImportError("gir bindings missing")),
         ),
     ):
@@ -55,7 +55,7 @@ def test_tray_is_available_reports_other_construction_errors_verbatim():
     error = RuntimeError("no display")
     with (
         patch("free_claude_code.cli.desktop_tray._create_icon"),
-        patch("free_claude_code.cli.desktop_tray.Icon", MagicMock(side_effect=error)),
+        patch("pystray.Icon", MagicMock(side_effect=error)),
     ):
         available, reason = tray_is_available()
 
@@ -146,16 +146,46 @@ def test_console_launch_uses_native_tray_when_probe_succeeds():
 def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
     with (
         patch.object(sys, "platform", platform),
+        patch(
+            "free_claude_code.cli.desktop_entrypoint.configure_claude_desktop_config"
+        ) as configure,
         patch("free_claude_code.cli.desktop_tray.launch") as tray_launch,
     ):
         entrypoint_launch([])
 
     tray_launch.assert_called_once()
+    configure.assert_called_once_with()
+
+
+def test_entrypoint_configures_desktop_routing_before_the_platform_lifecycle():
+    events: list[str] = []
+
+    def record_configure() -> bool:
+        events.append("configure")
+        return True
+
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch(
+            "free_claude_code.cli.desktop_entrypoint.configure_claude_desktop_config",
+            record_configure,
+        ),
+        patch(
+            "free_claude_code.cli.desktop_console.launch_desktop",
+            side_effect=lambda *_: events.append("lifecycle"),
+        ),
+    ):
+        entrypoint_launch([])
+
+    assert events == ["configure", "lifecycle"]
 
 
 def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
     with (
         patch.object(sys, "platform", "linux"),
+        patch(
+            "free_claude_code.cli.desktop_entrypoint.configure_claude_desktop_config"
+        ),
         patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):
@@ -370,3 +400,18 @@ def test_headless_entrypoint_routes_linux_to_console_mode(capsys):
 
     assert start.call_args.args[0] is ConsoleDesktopTray
     assert "failed to load" in capsys.readouterr().out
+
+
+def test_tray_module_imports_without_display():
+    """pystray resolves an X11 display at import; the module must not."""
+
+    import importlib
+
+    module = sys.modules["free_claude_code.cli.desktop_tray"]
+    # A ``None`` entry makes ``import pystray`` fail as if it were absent.
+    try:
+        with patch.dict(sys.modules, {"pystray": None}):
+            reloaded = importlib.reload(module)
+    finally:
+        importlib.reload(module)
+    assert reloaded.tray_is_available.__module__ == module.__name__

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -37,6 +37,42 @@ def test_tray_is_available_true_when_icon_constructs():
     assert reason == ""
 
 
+def test_tray_probe_releases_backend_display_connection():
+    """A probe icon's X11 display is closed eagerly, not by ``__del__``.
+
+    Regression guard for the unraisable-exception flake: the X11 backend
+    opens a display connection in ``Icon.__init__`` and closes it only in a
+    garbage-collected destructor, which can run during an unrelated test
+    and fail on the already-closed socket (turning into a suite-wide
+    ``PytestUnraisableExceptionWarning`` failure under ``filterwarnings =
+    error``). The probe must close the connection itself and leave the
+    destructor a no-op stand-in.
+    """
+
+    class XorgLikeIcon:
+        """Backend icon holding an X11-style display connection."""
+
+        def __init__(self) -> None:
+            self._display = MagicMock()
+
+        def __del__(self) -> None:
+            self._display.close()
+
+    icon = XorgLikeIcon()
+    display = icon._display
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("pystray.Icon", MagicMock(return_value=icon)),
+    ):
+        available, _ = tray_is_available()
+
+    assert available is True
+    display.close.assert_called_once()
+    # The stand-in left behind keeps the destructor harmless.
+    assert icon._display is not display
+    icon.__del__()  # The destructor runs against the no-op stand-in.
+
+
 def test_tray_is_available_reports_backend_import_error():
     with (
         patch("free_claude_code.cli.desktop_tray._create_icon"),

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -146,30 +146,27 @@ def test_console_launch_uses_native_tray_when_probe_succeeds():
 def test_entrypoint_routes_supported_native_platforms_to_tray(platform):
     with (
         patch.object(sys, "platform", platform),
-        patch(
-            "free_claude_code.cli.desktop_entrypoint.configure_claude_desktop_config"
-        ) as configure,
         patch("free_claude_code.cli.desktop_tray.launch") as tray_launch,
     ):
         entrypoint_launch([])
 
     tray_launch.assert_called_once()
-    configure.assert_called_once_with()
 
 
-def test_entrypoint_configures_desktop_routing_before_the_platform_lifecycle():
+def test_entrypoint_defers_desktop_routing_merge_to_the_lifecycle():
+    """No config merge happens at the entrypoint.
+
+    Regression guard for the Greptile "desktop startup writes a cleartext
+    credential endpoint" finding: the entrypoint runs before any lifecycle
+    has started or verified a TLS front, so a merge here would write the
+    reusable gateway credential pointing at the plain-HTTP fallback. The
+    lifecycle layers merge only behind a verified HTTPS front.
+    """
+
     events: list[str] = []
-
-    def record_configure() -> bool:
-        events.append("configure")
-        return True
 
     with (
         patch.object(sys, "platform", "linux"),
-        patch(
-            "free_claude_code.cli.desktop_entrypoint.configure_claude_desktop_config",
-            record_configure,
-        ),
         patch(
             "free_claude_code.cli.desktop_console.launch_desktop",
             side_effect=lambda *_: events.append("lifecycle"),
@@ -177,15 +174,12 @@ def test_entrypoint_configures_desktop_routing_before_the_platform_lifecycle():
     ):
         entrypoint_launch([])
 
-    assert events == ["configure", "lifecycle"]
+    assert events == ["lifecycle"]
 
 
 def test_entrypoint_routes_linux_through_probe_and_console_mode(capsys):
     with (
         patch.object(sys, "platform", "linux"),
-        patch(
-            "free_claude_code.cli.desktop_entrypoint.configure_claude_desktop_config"
-        ),
         patch("free_claude_code.cli.desktop_tray.tray_is_available") as probe,
         patch("free_claude_code.cli.desktop_console.launch_desktop") as start,
     ):

--- a/tests/cli/test_desktop_linux.py
+++ b/tests/cli/test_desktop_linux.py
@@ -415,3 +415,150 @@ def test_tray_module_imports_without_display():
     finally:
         importlib.reload(module)
     assert reloaded.tray_is_available.__module__ == module.__name__
+
+
+def test_merge_verified_gateway_passes_verified_url_explicitly():
+    from free_claude_code.cli.desktop import _merge_verified_gateway
+
+    settings = MagicMock(name="settings")
+    verified_url = "https://localhost:8443/claude-desktop"
+    with (
+        patch(
+            "free_claude_code.cli.desktop.verified_https_gateway_url",
+            return_value=verified_url,
+        ),
+        patch(
+            "free_claude_code.cli.desktop.configure_claude_desktop_config"
+        ) as configure,
+    ):
+        _merge_verified_gateway(settings)
+
+    configure.assert_called_once_with(settings=settings, gateway_base_url=verified_url)
+
+
+def test_merge_verified_gateway_skips_when_front_unverified():
+    from free_claude_code.cli.desktop import _merge_verified_gateway
+
+    with (
+        patch(
+            "free_claude_code.cli.desktop.verified_https_gateway_url",
+            return_value=None,
+        ),
+        patch(
+            "free_claude_code.cli.desktop.configure_claude_desktop_config"
+        ) as configure,
+    ):
+        _merge_verified_gateway(MagicMock(name="settings"))
+
+    configure.assert_not_called()
+
+
+def test_merge_verified_gateway_swallows_failures():
+    from free_claude_code.cli.desktop import _merge_verified_gateway
+
+    with (
+        patch(
+            "free_claude_code.cli.desktop.verified_https_gateway_url",
+            return_value="https://localhost:8443/claude-desktop",
+        ),
+        patch(
+            "free_claude_code.cli.desktop.configure_claude_desktop_config",
+            side_effect=OSError("disk full"),
+        ),
+    ):
+        _merge_verified_gateway(MagicMock(name="settings"))  # must not raise
+
+
+def test_launch_desktop_merges_claude_desktop_config():
+    from free_claude_code.cli import desktop as desktop_module
+
+    merged: list[object] = []
+
+    def fake_configure(path=None, settings=None, gateway_base_url=None):
+        merged.append(gateway_base_url)
+        return True
+
+    supervisor = MagicMock()
+    supervisor.schedule_run.return_value = True
+    supervisor.status = ServerStatus.STOPPED
+    verified_url = "https://localhost:8443/claude-desktop"
+
+    with (
+        patch.object(desktop_module, "load_server_settings") as load_settings,
+        patch.object(desktop_module.InterprocessFileLock, "acquire", return_value=True),
+        patch.object(desktop_module, "preflight_proxy", return_value=object()),
+        patch.object(desktop_module, "CaddyTlsProxy") as tls_proxy_cls,
+        patch.object(
+            desktop_module, "verified_https_gateway_url", return_value=verified_url
+        ),
+        patch.object(desktop_module, "configure_claude_desktop_config", fake_configure),
+        patch.object(desktop_module, "DesktopController", MagicMock()) as controller,
+    ):
+        load_settings.return_value = MagicMock(name="settings")
+        tls_proxy_cls.return_value.start.return_value = True
+        controller.return_value.run.side_effect = RuntimeError("stop loop")
+
+        with contextlib.suppress(RuntimeError):
+            desktop_module.launch_desktop(MagicMock())
+
+    assert merged == [verified_url]
+    tls_proxy_cls.return_value.start.assert_called_once()
+    tls_proxy_cls.return_value.stop.assert_called_once()
+
+
+def test_tray_launch_item_spawns_claude_desktop_without_notification():
+    from free_claude_code.cli.desktop_tray import PystrayDesktopTray
+
+    controller = MagicMock(spec=DesktopController)
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("pystray.Icon", MagicMock()),
+        patch(
+            "free_claude_code.cli.desktop_tray.ensure_configured_and_launch"
+        ) as spawn,
+    ):
+        tray = PystrayDesktopTray(controller)
+        tray._launch_claude_desktop(tray._icon, MagicMock(name="item"))
+
+    spawn.assert_called_once()
+
+
+def test_tray_launch_item_notifies_when_binary_missing():
+    from free_claude_code.cli.desktop_tray import PystrayDesktopTray
+
+    controller = MagicMock(spec=DesktopController)
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("pystray.Icon", MagicMock()),
+        patch(
+            "free_claude_code.cli.desktop_tray.ensure_configured_and_launch",
+            side_effect=FileNotFoundError("claude-desktop"),
+        ),
+    ):
+        tray = PystrayDesktopTray(controller)
+        tray._launch_claude_desktop(tray._icon, MagicMock(name="item"))
+
+    tray._icon.notify.assert_called_once()
+
+
+def test_tray_launch_item_notifies_when_no_https_front():
+    # Regression guard for the Greptile tray-bypass finding: when the
+    # TLS-gated launch refuses (no verified HTTPS front), the tray must
+    # surface the refusal as a notification rather than crash the callback.
+    from free_claude_code.cli.desktop_tray import PystrayDesktopTray
+
+    controller = MagicMock(spec=DesktopController)
+    with (
+        patch("free_claude_code.cli.desktop_tray._create_icon"),
+        patch("pystray.Icon", MagicMock()),
+        patch(
+            "free_claude_code.cli.desktop_tray.ensure_configured_and_launch",
+            side_effect=RuntimeError("no verified FCC HTTPS front"),
+        ),
+    ):
+        tray = PystrayDesktopTray(controller)
+        tray._launch_claude_desktop(tray._icon, MagicMock(name="item"))
+
+    tray._icon.notify.assert_called_once()
+    notified = tray._icon.notify.call_args.args[0]
+    assert "no verified FCC HTTPS front" in notified

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -3,6 +3,8 @@
 import json
 import subprocess
 import sys
+import threading
+import time
 import tomllib
 from collections.abc import Callable
 from pathlib import Path
@@ -357,6 +359,8 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
         patch.object(commands.uvicorn, "Config", side_effect=fake_config),
         patch.object(commands.uvicorn, "Server", side_effect=FakeServer),
         patch.object(commands, "build_asgi_app", side_effect=build_asgi_app),
+        patch.object(commands, "CaddyTlsProxy") as tls_proxy,
+        patch.object(commands, "GATEWAY_HEALTH_UPGRADE_SECONDS", 0.0),
         patch.object(commands, "schedule_open_admin_browser") as schedule_open_admin,
         patch.object(commands, "clear_settings_cache") as clear_settings_cache,
         patch.object(commands, "kill_all_best_effort") as kill_all,
@@ -364,6 +368,11 @@ def test_serve_supervisor_restarts_when_app_requests_restart() -> None:
         commands.serve()
 
     assert len(servers) == 2
+    # One managed HTTPS front per server generation, each started and
+    # stopped once (the shared mock aggregates both instances' calls).
+    assert tls_proxy.call_count == 2
+    assert tls_proxy.return_value.start.call_count == 2
+    assert tls_proxy.return_value.stop.call_count == 2
     schedule_open_admin.assert_called_once_with(settings)
     clear_settings_cache.assert_called_once()
     kill_all.assert_called_once()
@@ -399,6 +408,8 @@ def test_serve_supervisor_refuses_restart_after_incomplete_shutdown() -> None:
         patch.object(commands.uvicorn, "Config", side_effect=fake_config),
         patch.object(commands.uvicorn, "Server", side_effect=FakeServer),
         patch.object(commands, "build_asgi_app", side_effect=build_asgi_app),
+        patch.object(commands, "CaddyTlsProxy") as tls_proxy,
+        patch.object(commands, "GATEWAY_HEALTH_UPGRADE_SECONDS", 0.0),
         patch.object(commands, "schedule_open_admin_browser"),
         patch.object(commands, "clear_settings_cache") as clear_settings_cache,
         patch.object(commands, "kill_all_best_effort") as kill_all,
@@ -406,8 +417,246 @@ def test_serve_supervisor_refuses_restart_after_incomplete_shutdown() -> None:
         commands.serve()
 
     assert len(servers) == 1
+    # The single generation's HTTPS front is started and stopped exactly once.
+    assert tls_proxy.call_count == 1
+    tls_proxy.return_value.start.assert_called_once_with()
+    tls_proxy.return_value.stop.assert_called_once_with()
     clear_settings_cache.assert_not_called()
     kill_all.assert_called_once()
+
+
+def test_serve_supervisor_orders_tls_front_around_each_generation() -> None:
+    """The managed HTTPS front wraps every server generation.
+
+    Regression guard for the Greptile "managed TLS proxy never enters the
+    lifecycle" finding: each generation constructs its own
+    ``CaddyTlsProxy``, starts it before the server accepts traffic, and
+    stops it when the generation exits — across a normal stop and a
+    restart.
+    """
+    from free_claude_code.cli import commands
+
+    settings = _launcher_settings()
+    get_settings = MagicMock(side_effect=[settings, settings])
+    events: list[str] = []
+    restart_callbacks: list[Callable[[], None]] = []
+
+    def build_asgi_app(_settings: Settings, restart_callback: Callable[[], None]):
+        restart_callbacks.append(restart_callback)
+        return SimpleNamespace(runtime=SimpleNamespace(is_closed=False))
+
+    class FakeTlsProxy:
+        def __init__(self, proxy_settings: Settings) -> None:
+            assert proxy_settings is settings
+            events.append("construct")
+
+        def start(self) -> bool:
+            events.append("start")
+            return True
+
+        def stop(self) -> None:
+            events.append("stop")
+
+    class FakeServer:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit = False
+
+        def run(self):
+            events.append("server-run")
+            if len(restart_callbacks) == 1:
+                # First generation: request a restart, then close cleanly.
+                restart_callbacks[-1]()
+                assert self.should_exit is True
+                self.config.app.runtime.is_closed = True
+            # The readiness task probes concurrently with this call; wait
+            # for this generation's upgrade so the ordering stays
+            # deterministic and the upgrade lands inside the serving window.
+            deadline = time.monotonic() + 2.0
+            while (
+                events.count("upgrade") < len(restart_callbacks)
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+
+    def fake_config(app, **kwargs):
+        return SimpleNamespace(app=app, kwargs=kwargs)
+
+    def record_upgrade(*_args: object) -> bool:
+        events.append("upgrade")
+        return True
+
+    with (
+        patch.object(commands, "get_settings", get_settings),
+        patch.object(commands.uvicorn, "Config", side_effect=fake_config),
+        patch.object(commands.uvicorn, "Server", side_effect=FakeServer),
+        patch.object(commands, "build_asgi_app", side_effect=build_asgi_app),
+        patch.object(commands, "CaddyTlsProxy", side_effect=FakeTlsProxy),
+        patch.object(commands, "GATEWAY_HEALTH_UPGRADE_SECONDS", 0.5),
+        patch.object(commands, "probe_fcc_front", side_effect=record_upgrade),
+        patch.object(commands, "schedule_open_admin_browser"),
+        patch.object(commands, "clear_settings_cache"),
+        patch.object(commands, "kill_all_best_effort"),
+    ):
+        commands.serve()
+
+    # The readiness task probes concurrently with ``server.run()``, so the
+    # upgrade event can land anywhere inside a generation's serving window.
+    # Assert the structural ordering that must hold instead of a fixed
+    # sequence: each generation constructs then starts its front before the
+    # server runs and stops the front after, and the upgrade lands between
+    # the front's start and stop.
+    constructs = [i for i, event in enumerate(events) if event == "construct"]
+    starts = [i for i, event in enumerate(events) if event == "start"]
+    runs = [i for i, event in enumerate(events) if event == "server-run"]
+    upgrades = [i for i, event in enumerate(events) if event == "upgrade"]
+    stops = [i for i, event in enumerate(events) if event == "stop"]
+    assert len(constructs) == 2
+    assert len(starts) == 2
+    assert len(runs) == 2
+    assert len(upgrades) == 2
+    assert len(stops) == 2
+    for construct, start, run, stop in zip(
+        constructs, starts, runs, stops, strict=True
+    ):
+        assert construct < start < run < stop
+    for start, upgrade, stop in zip(starts, upgrades, stops, strict=True):
+        assert start < upgrade < stop
+
+
+@pytest.mark.parametrize(
+    ("tls_proxy_enabled", "front_started", "probe_verifies", "expected_final"),
+    [
+        # Managed front up and verifying once Uvicorn serves: the generation
+        # starts on the plain-HTTP fallback and upgrades to the TLS-prefixed
+        # URL while the server is still serving.
+        (True, True, True, "https://localhost:18443/claude-desktop"),
+        # Front started but its health probe never verifies: the plain-HTTP
+        # fallback stays for the whole generation.
+        (True, True, False, "http://127.0.0.1:8082/claude-desktop"),
+        # An external reverse proxy already owns the TLS port: managed
+        # startup reports False (its pre-Uvicorn probe fails and the managed
+        # caddy exits on the occupied port), but the readiness task still
+        # runs and upgrades to HTTPS once the external front serves FCC.
+        (True, False, True, "https://localhost:18443/claude-desktop"),
+        # TLS disabled entirely: plain HTTP, and no readiness probing.
+        (False, False, None, "http://127.0.0.1:8082/claude-desktop"),
+    ],
+)
+def test_serve_publishes_desktop_gateway_url_matching_tls_readiness(
+    tls_proxy_enabled: bool,
+    front_started: bool,
+    probe_verifies: bool | None,
+    expected_final: str,
+) -> None:
+    """The supervisor publishes the live desktop-scoped gateway URL.
+
+    End-to-end guard for the Greptile "HTTPS gateway is published after
+    shutdown" and "external front readiness is ignored" findings: the front
+    can only pass FCC's ``/health`` marker probe while Uvicorn serves, so a
+    concurrent readiness task probes during ``server.run()`` whenever a
+    front may own the TLS port — including an external front that made
+    managed startup fail — and the TLS-prefixed URL becomes readable DURING
+    the live serving window, not after it ends. The fallback is preserved
+    when TLS is disabled or the front never verifies. The URL is cleared
+    once the supervisor shuts down so a stopped server never advertises a
+    dead endpoint.
+    """
+    from free_claude_code.cli import commands
+
+    settings = _launcher_settings(port=8082).model_copy(
+        update={
+            "tls_proxy_enabled": tls_proxy_enabled,
+            "tls_proxy_port": 18443,
+            "desktop_gateway_prefix": "claude-desktop",
+        }
+    )
+    published_at_start: list[str | None] = []
+    published_during_run: list[str | None] = []
+    published_at_stop: list[str | None] = []
+    probe_calls: list[str] = []
+    # The front can only pass FCC's /health marker while Uvicorn serves, so
+    # the fake probe only verifies once the fake server is inside ``run()``.
+    serving = threading.Event()
+
+    def build_asgi_app(_settings: Settings, restart_callback: Callable[[], None]):
+        return SimpleNamespace(runtime=SimpleNamespace(is_closed=False))
+
+    def fake_config(app, **kwargs):
+        return SimpleNamespace(app=app, kwargs=kwargs)
+
+    class FakeTlsProxy:
+        def __init__(self, proxy_settings: Settings) -> None:
+            assert proxy_settings is settings
+
+        def start(self) -> bool:
+            return front_started
+
+        def stop(self) -> None:
+            # ``stop()`` runs in the generation's ``finally`` after the
+            # readiness task is joined and before the supervisor clears the
+            # URL, so it observes the final published value.
+            published_at_stop.append(supervisor.desktop_gateway_url())
+
+    supervisor = commands.ServerSupervisor(console_logging=False)
+
+    class FakeServer:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit = False
+
+        def run(self):
+            # The readiness task probes concurrently with this call. Record
+            # the URL before the front can verify (still the HTTP fallback),
+            # then open the serving window and require the final URL to
+            # become readable before ``run()`` returns.
+            published_at_start.append(supervisor.desktop_gateway_url())
+            serving.set()
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                published_during_run.append(supervisor.desktop_gateway_url())
+                if published_during_run[-1] == expected_final:
+                    break
+                time.sleep(0.01)
+            self.config.app.runtime.is_closed = True
+
+    def fake_probe(*_args: object) -> bool:
+        probe_calls.append("probe")
+        assert probe_verifies is not None
+        return probe_verifies and serving.is_set()
+
+    with (
+        patch.object(commands, "load_server_settings", return_value=settings),
+        patch.object(commands.uvicorn, "Config", side_effect=fake_config),
+        patch.object(commands.uvicorn, "Server", side_effect=FakeServer),
+        patch.object(commands, "build_asgi_app", side_effect=build_asgi_app),
+        patch.object(commands, "CaddyTlsProxy", side_effect=FakeTlsProxy),
+        patch.object(commands, "GATEWAY_HEALTH_UPGRADE_SECONDS", 0.5),
+        patch.object(commands, "probe_fcc_front", side_effect=fake_probe),
+        patch.object(commands, "schedule_open_admin_browser"),
+        patch.object(commands, "kill_all_best_effort"),
+    ):
+        assert supervisor.desktop_gateway_url() is None
+        supervisor.run(open_admin_browser=False)
+
+    # Before Uvicorn serves, the front cannot verify FCC's health marker,
+    # so the initial publication is always the plain-HTTP fallback.
+    assert published_at_start == ["http://127.0.0.1:8082/claude-desktop"]
+    # The final URL is readable DURING the live serving window, before
+    # ``server.run()`` returns.
+    assert published_during_run[-1] == expected_final
+    # ...and it stays published until the generation actually stops.
+    assert published_at_stop == [expected_final]
+    if tls_proxy_enabled:
+        # The readiness task probes at least once whenever a front may own
+        # the TLS port — including an external front that made managed
+        # startup fail; a never-healthy front retries until the deadline,
+        # so only assert presence.
+        assert probe_calls
+    else:
+        assert probe_calls == []
+    # Cleared on shutdown so a stopped server advertises nothing.
+    assert supervisor.desktop_gateway_url() is None
 
 
 def test_serve_handles_keyboard_interrupt_without_traceback() -> None:

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -73,6 +73,7 @@ def test_cli_scripts_are_registered() -> None:
         "fcc-grok": "free_claude_code.cli.launchers.grok:launch",
         "fcc-muse": "free_claude_code.cli.launchers.muse:launch",
         "fcc-aider": "free_claude_code.cli.launchers.aider:launch",
+        "fcc-claude-desktop": "free_claude_code.cli.launchers.claude_desktop:launch",
     }
     assert pyproject["project"]["gui-scripts"] == {
         "fcc-desktop": "free_claude_code.cli.desktop_entrypoint:launch",

--- a/tests/cli/test_tls_proxy.py
+++ b/tests/cli/test_tls_proxy.py
@@ -261,6 +261,33 @@ def test_start_falls_back_to_http_without_caddy_binary(
     popen.assert_not_called()
 
 
+def test_start_swallows_state_preparation_errors(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    """Filesystem failures while preparing the caddy home fall back to HTTP.
+
+    ``start()`` promises never to raise: ``ServerSupervisor._run_once``
+    calls it outside any try/except of its own, so an escaping ``OSError``
+    from the home-directory or Caddyfile write would kill the generation
+    before the plain-HTTP fallback could serve.
+    """
+
+    unwritable = tmp_path / "occupied"
+    unwritable.write_text("not a directory", encoding="utf-8")
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
+        patch.object(tls_proxy.subprocess, "Popen") as popen,
+    ):
+        proxy = CaddyTlsProxy(settings, home_dir=unwritable / "caddy")
+        started = proxy.start()
+
+    assert started is False
+    popen.assert_not_called()
+
+
 def test_start_reports_child_that_exits_immediately(
     settings: Settings,
     tmp_path: Path,

--- a/tests/cli/test_tls_proxy.py
+++ b/tests/cli/test_tls_proxy.py
@@ -1,0 +1,365 @@
+"""Tests for the HTTPS front proxy: probing, Caddyfile rendering, lifecycle."""
+
+import email.message
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from free_claude_code.cli import tls_proxy
+from free_claude_code.cli.tls_proxy import CaddyTlsProxy, resolve_gateway_base_url
+from free_claude_code.config.settings import Settings
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(host="127.0.0.1", port=8082, tls_proxy_port=18443)
+
+
+@pytest.fixture
+def http_server() -> Iterator[HTTPServer]:
+    """Local plain-HTTP server used to exercise the HTTPS probe negatively."""
+
+    server = HTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+def test_probe_https_false_against_plain_http_listener(
+    http_server: HTTPServer,
+) -> None:
+    # An HTTPS handshake against a plain-HTTP listener must fail the probe.
+    assert (
+        tls_proxy.probe_https(f"https://127.0.0.1:{http_server.server_port}") is False
+    )
+
+
+def test_probe_https_false_when_nothing_listens(settings: Settings) -> None:
+    assert tls_proxy.probe_https(tls_proxy.tls_root_url(settings)) is False
+
+
+def test_render_caddyfile_fronts_local_server(settings: Settings) -> None:
+    proxy = CaddyTlsProxy(settings, home_dir=Path("/tmp/fcc-test-caddy"))
+
+    text = proxy.render_caddyfile()
+
+    assert "localhost:18443 {" in text
+    assert "tls internal" in text
+    assert "reverse_proxy 127.0.0.1:8082 {" in text
+    assert "flush_interval -1" in text
+
+
+def _health_response(payload: bytes | str) -> MagicMock:
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.read.return_value = (
+        payload.encode() if isinstance(payload, str) else payload
+    )
+    return response
+
+
+def test_probe_fcc_front_true_for_fcc_health_marker() -> None:
+    with patch.object(
+        tls_proxy.urllib.request,
+        "urlopen",
+        MagicMock(return_value=_health_response('{"status": "healthy"}')),
+    ) as urlopen:
+        assert tls_proxy.probe_fcc_front("https://localhost:18443") is True
+
+    request = urlopen.call_args.args[0]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == "https://localhost:18443/health"
+
+
+def test_probe_fcc_front_false_for_foreign_or_broken_listener() -> None:
+    # An unrelated local listener that answers anything other than FCC's
+    # unauthenticated /health marker must never be adopted as the gateway.
+    error = urllib.error.HTTPError(
+        "https://localhost:18443/health",
+        404,
+        "Not Found",
+        email.message.Message(),
+        None,
+    )
+    responses = [
+        _health_response(b'{"status": "ok"}'),  # different payload
+        _health_response(b"not json"),  # non-JSON body
+        _health_response(b'["healthy"]'),  # JSON but not an object
+    ]
+    errors = [
+        error,  # non-200 status through the TLS layer
+        urllib.error.URLError("connection refused"),  # nothing listening
+    ]
+    for response in responses:
+        with patch.object(
+            tls_proxy.urllib.request,
+            "urlopen",
+            MagicMock(return_value=response),
+        ):
+            assert tls_proxy.probe_fcc_front("https://localhost:18443/") is False
+    for error_side_effect in errors:
+        with patch.object(
+            tls_proxy.urllib.request,
+            "urlopen",
+            MagicMock(side_effect=error_side_effect),
+        ):
+            assert tls_proxy.probe_fcc_front("https://localhost:18443/") is False
+
+
+def test_resolve_gateway_base_url_https_when_probe_succeeds(
+    settings: Settings,
+) -> None:
+    with patch.object(tls_proxy, "probe_fcc_front", return_value=True):
+        url = resolve_gateway_base_url(settings)
+
+    assert url == "https://localhost:18443"
+
+
+def test_resolve_gateway_base_url_https_requires_fcc_identity(
+    settings: Settings,
+) -> None:
+    # A TLS listener that is alive but does not serve FCC's health marker
+    # must not be adopted; routing falls back to plain HTTP.
+    with (
+        patch.object(tls_proxy, "probe_https", return_value=True),
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+    ):
+        url = resolve_gateway_base_url(settings)
+
+    assert url == "http://127.0.0.1:8082"
+
+
+def test_resolve_gateway_base_url_http_when_disabled_or_unreachable(
+    settings: Settings,
+) -> None:
+    disabled = Settings(host="127.0.0.1", port=8082, tls_proxy_enabled=False)
+
+    assert resolve_gateway_base_url(disabled) == "http://127.0.0.1:8082"
+    assert resolve_gateway_base_url(settings) == "http://127.0.0.1:8082"
+
+
+def test_start_reuses_external_front_without_spawning(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    proxy = CaddyTlsProxy(settings, home_dir=tmp_path / "caddy")
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", side_effect=[True]),
+        patch.object(tls_proxy.shutil, "which") as which,
+        patch.object(tls_proxy.subprocess, "Popen") as popen,
+    ):
+        started = proxy.start()
+
+    assert started is True
+    which.assert_not_called()
+    popen.assert_not_called()
+
+
+def test_start_does_not_adopt_foreign_tls_listener(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    # A TLS endpoint that is alive on the port but does not front this FCC
+    # server must not be adopted; the managed Caddy path runs instead.
+
+    class FakeProcess:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.returncode = 0
+
+        def poll(self) -> int | None:
+            return None
+
+        def terminate(self) -> None: ...
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    probe_calls = 0
+
+    def counting_probe(url: str, timeout_seconds: float = 1.0) -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return False  # identity fails; readiness probes also fail
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        patch.object(tls_proxy, "probe_https", counting_probe),
+        patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
+        patch.object(tls_proxy.subprocess, "Popen", FakeProcess),
+    ):
+        proxy = CaddyTlsProxy(settings, home_dir=tmp_path / "caddy")
+        started = proxy.start()
+
+    assert started is False
+    assert probe_calls > 0  # readiness probes ran against our own child
+
+
+def test_start_spawns_managed_caddy_and_waits_for_readiness(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    caddyfile_dir = tmp_path / "caddy"
+
+    class FakeProcess:
+        def __init__(self, cmd: list[str], **_kwargs: object) -> None:
+            self.cmd = cmd
+            self.returncode = 0
+
+        def poll(self) -> int | None:
+            return None  # stays alive while readiness probes run
+
+        def terminate(self) -> None: ...
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    probe_calls = 0
+
+    def counting_probe(url: str, timeout_seconds: float = 1.0) -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        # First call (external-front check) fails; readiness checks succeed.
+        return probe_calls > 1
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        patch.object(tls_proxy, "probe_https", counting_probe),
+        patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
+        patch.object(tls_proxy.subprocess, "Popen", FakeProcess),
+    ):
+        proxy = CaddyTlsProxy(settings, home_dir=caddyfile_dir)
+        started = proxy.start()
+
+    assert started is True
+    caddyfile = (caddyfile_dir / "Caddyfile").read_text(encoding="utf-8")
+    assert "tls internal" in caddyfile
+
+
+def test_start_falls_back_to_http_without_caddy_binary(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    proxy = CaddyTlsProxy(settings, home_dir=tmp_path / "caddy")
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        patch.object(tls_proxy.shutil, "which", return_value=None),
+        patch.object(tls_proxy.subprocess, "Popen") as popen,
+    ):
+        started = proxy.start()
+
+    assert started is False
+    popen.assert_not_called()
+
+
+def test_start_reports_child_that_exits_immediately(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    class DyingProcess:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.returncode = 1
+
+        def poll(self) -> int:
+            return self.returncode
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
+        patch.object(tls_proxy.subprocess, "Popen", DyingProcess),
+    ):
+        proxy = CaddyTlsProxy(settings, home_dir=tmp_path / "caddy")
+        started = proxy.start()
+
+    assert started is False
+
+
+def test_stop_terminates_owned_running_process(settings: Settings) -> None:
+    proxy = CaddyTlsProxy(settings, home_dir=Path("/tmp/fcc-unused"))
+
+    process = MagicMock()
+    process.poll.return_value = None
+    proxy._process = process
+
+    proxy.stop()
+
+    process.terminate.assert_called_once()
+    process.wait.assert_called_once()
+
+
+def test_stop_is_noop_after_child_already_exited(settings: Settings) -> None:
+    proxy = CaddyTlsProxy(settings, home_dir=Path("/tmp/fcc-unused"))
+
+    process = MagicMock()
+    process.poll.return_value = 0
+    proxy._process = process
+
+    proxy.stop()
+
+    process.terminate.assert_not_called()
+
+
+def test_managed_caddyfile_disables_admin_api(settings: Settings) -> None:
+    proxy = CaddyTlsProxy(settings, home_dir=Path("/tmp/fcc-test-caddy"))
+
+    # A system caddy may already own the default admin endpoint (port 2019);
+    # the managed instance must never claim it.
+    assert "admin off" in proxy.render_caddyfile()
+
+
+@pytest.mark.parametrize("flag", ["--config", "--adapter"])
+def test_spawn_command_includes_config_adapter(flag: str, settings: Settings) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeProcess:
+        def __init__(self, cmd: list[str], **kwargs: object) -> None:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            self.returncode = 0
+
+        def poll(self) -> int | None:
+            return None
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        # First readiness probe fails; the next one succeeds.
+        patch.object(tls_proxy, "probe_https", side_effect=[False, True]),
+        patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
+        patch.object(tls_proxy.subprocess, "Popen", FakeProcess),
+    ):
+        proxy = CaddyTlsProxy(settings, home_dir=Path("/tmp/fcc-cmd-check"))
+        proxy.start()
+
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    assert "/usr/bin/caddy" in cmd
+    assert flag in cmd
+
+
+def test_probe_https_true_when_endpoint_returns_error_status() -> None:
+    # Any HTTP status (404 root path, 401 auth gate, 502 dead upstream)
+    # proves the TLS front is alive and answering.
+    error = urllib.error.HTTPError(
+        "https://localhost:18443/",
+        404,
+        "Not Found",
+        email.message.Message(),
+        None,
+    )
+
+    with patch.object(
+        tls_proxy.urllib.request, "urlopen", MagicMock(side_effect=error)
+    ):
+        assert tls_proxy.probe_https("https://localhost:18443/") is True

--- a/tests/cli/test_tls_proxy.py
+++ b/tests/cli/test_tls_proxy.py
@@ -618,6 +618,34 @@ def test_start_swallows_state_preparation_errors(
     popen.assert_not_called()
 
 
+def test_start_swallows_front_identity_errors(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    """Filesystem failures while creating the identity secret stay swallowed.
+
+    ``load_or_create_front_identity`` runs before the caddy state write
+    and needs the same never-raise guarantee: without a secret there is
+    nothing to prove front ownership with, so the front is not adoptable
+    and the plain-HTTP fallback must apply instead of an escaping
+    ``OSError`` killing the serving generation.
+    """
+
+    unwritable = tmp_path / "occupied"
+    unwritable.write_text("not a directory", encoding="utf-8")
+
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
+        patch.object(tls_proxy.subprocess, "Popen") as popen,
+    ):
+        proxy = CaddyTlsProxy(settings, home_dir=unwritable / "caddy")
+        started = proxy.start()
+
+    assert started is False
+    popen.assert_not_called()
+
+
 def test_start_reports_child_that_exits_immediately(
     settings: Settings,
     tmp_path: Path,

--- a/tests/cli/test_tls_proxy.py
+++ b/tests/cli/test_tls_proxy.py
@@ -1,7 +1,13 @@
 """Tests for the HTTPS front proxy: probing, Caddyfile rendering, lifecycle."""
 
 import email.message
+import os
+import shutil
+import socket
+import ssl
+import subprocess
 import threading
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Iterator
@@ -14,6 +20,8 @@ import pytest
 from free_claude_code.cli import tls_proxy
 from free_claude_code.cli.tls_proxy import CaddyTlsProxy, resolve_gateway_base_url
 from free_claude_code.config.settings import Settings
+
+TEST_IDENTITY_SECRET = "fcc-test-identity-secret"
 
 
 @pytest.fixture
@@ -33,28 +41,58 @@ def http_server() -> Iterator[HTTPServer]:
     server.server_close()
 
 
-def test_probe_https_false_against_plain_http_listener(
+def test_probe_fcc_front_false_against_plain_http_listener(
     http_server: HTTPServer,
+    tmp_path: Path,
 ) -> None:
     # An HTTPS handshake against a plain-HTTP listener must fail the probe.
-    assert (
-        tls_proxy.probe_https(f"https://127.0.0.1:{http_server.server_port}") is False
-    )
+    home = tmp_path / "caddy"
+    with patch.object(tls_proxy, "managed_ca_path", return_value=Path("ca.crt")):
+        assert (
+            tls_proxy.probe_fcc_front(
+                f"https://127.0.0.1:{http_server.server_port}",
+                TEST_IDENTITY_SECRET,
+                home,
+            )
+            is False
+        )
 
 
-def test_probe_https_false_when_nothing_listens(settings: Settings) -> None:
-    assert tls_proxy.probe_https(tls_proxy.tls_root_url(settings)) is False
+def test_probe_fcc_front_false_when_nothing_listens(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "caddy"
+    with patch.object(tls_proxy, "managed_ca_path", return_value=Path("ca.crt")):
+        assert (
+            tls_proxy.probe_fcc_front(
+                tls_proxy.tls_root_url(settings), TEST_IDENTITY_SECRET, home
+            )
+            is False
+        )
 
 
 def test_render_caddyfile_fronts_local_server(settings: Settings) -> None:
     proxy = CaddyTlsProxy(settings, home_dir=Path("/tmp/fcc-test-caddy"))
 
-    text = proxy.render_caddyfile()
+    text = proxy.render_caddyfile(TEST_IDENTITY_SECRET)
 
     assert "localhost:18443 {" in text
     assert "tls internal" in text
     assert "reverse_proxy 127.0.0.1:8082 {" in text
     assert "flush_interval -1" in text
+
+
+def test_render_caddyfile_serves_identity_secret_at_private_path(
+    settings: Settings,
+) -> None:
+    # The managed front must answer the identity probe itself so later
+    # launches can prove ownership before adopting it.
+    proxy = CaddyTlsProxy(settings, home_dir=Path("/tmp/fcc-test-caddy"))
+
+    text = proxy.render_caddyfile(TEST_IDENTITY_SECRET)
+
+    assert f'respond /.fcc-front-identity "{TEST_IDENTITY_SECRET}" 200' in text
 
 
 def _health_response(payload: bytes | str) -> MagicMock:
@@ -66,70 +104,290 @@ def _health_response(payload: bytes | str) -> MagicMock:
     return response
 
 
-def test_probe_fcc_front_true_for_fcc_health_marker() -> None:
-    with patch.object(
-        tls_proxy.urllib.request,
-        "urlopen",
-        MagicMock(return_value=_health_response('{"status": "healthy"}')),
-    ) as urlopen:
-        assert tls_proxy.probe_fcc_front("https://localhost:18443") is True
+def test_probe_fcc_front_true_when_listener_serves_identity_secret(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "caddy"
+    ca_file = tmp_path / "ca.crt"
+    ca_file.write_text("placeholder")
+    with (
+        patch.object(tls_proxy, "managed_ca_path", return_value=ca_file),
+        patch.object(tls_proxy, "_front_ssl_context") as context,
+        patch.object(
+            tls_proxy.urllib.request,
+            "urlopen",
+            MagicMock(return_value=_health_response(TEST_IDENTITY_SECRET)),
+        ) as urlopen,
+    ):
+        assert (
+            tls_proxy.probe_fcc_front(
+                "https://localhost:18443", TEST_IDENTITY_SECRET, home
+            )
+            is True
+        )
 
     request = urlopen.call_args.args[0]
     assert isinstance(request, urllib.request.Request)
-    assert request.full_url == "https://localhost:18443/health"
+    assert request.full_url == "https://localhost:18443/.fcc-front-identity"
+    # The request must run through the CA-pinned context, never an
+    # unverified one.
+    assert urlopen.call_args.kwargs["context"] is context.return_value
+    context.assert_called_once_with(ca_file)
 
 
-def test_probe_fcc_front_false_for_foreign_or_broken_listener() -> None:
-    # An unrelated local listener that answers anything other than FCC's
-    # unauthenticated /health marker must never be adopted as the gateway.
+def test_probe_fcc_front_rejects_forged_health_marker(tmp_path: Path) -> None:
+    # Regression guard for the Greptile "unauthenticated health marker
+    # permits local TLS-front impersonation" finding: the publicly forgeable
+    # /health payload must never count as front identity, even though it is
+    # exactly what FCC's own /health endpoint serves.
+    home = tmp_path / "caddy"
+    ca_file = tmp_path / "ca.crt"
+    ca_file.write_text("placeholder")
+    with (
+        patch.object(tls_proxy, "managed_ca_path", return_value=ca_file),
+        patch.object(tls_proxy, "_front_ssl_context"),
+        patch.object(
+            tls_proxy.urllib.request,
+            "urlopen",
+            MagicMock(return_value=_health_response('{"status": "healthy"}')),
+        ),
+    ):
+        assert (
+            tls_proxy.probe_fcc_front(
+                "https://localhost:18443", TEST_IDENTITY_SECRET, home
+            )
+            is False
+        )
+
+
+def test_probe_fcc_front_false_for_foreign_or_broken_listener(
+    tmp_path: Path,
+) -> None:
+    # An unrelated local listener that answers anything other than this
+    # install's identity secret must never be adopted as the gateway.
+    home = tmp_path / "caddy"
+    ca_file = tmp_path / "ca.crt"
+    ca_file.write_text("placeholder")
     error = urllib.error.HTTPError(
-        "https://localhost:18443/health",
+        "https://localhost:18443/.fcc-front-identity",
         404,
         "Not Found",
         email.message.Message(),
         None,
     )
     responses = [
-        _health_response(b'{"status": "ok"}'),  # different payload
-        _health_response(b"not json"),  # non-JSON body
-        _health_response(b'["healthy"]'),  # JSON but not an object
+        _health_response(b"a-different-secret"),  # wrong secret
+        _health_response(b'{"status": "healthy"}'),  # forged health marker
+        _health_response(b""),  # empty body
+        _health_response(b"\xff\xfe"),  # non-UTF-8 body
     ]
     errors = [
         error,  # non-200 status through the TLS layer
         urllib.error.URLError("connection refused"),  # nothing listening
+        ssl.SSLCertVerificationError("certificate verify failed"),  # foreign cert
     ]
-    for response in responses:
-        with patch.object(
-            tls_proxy.urllib.request,
-            "urlopen",
-            MagicMock(return_value=response),
+    with (
+        patch.object(tls_proxy, "managed_ca_path", return_value=ca_file),
+        patch.object(tls_proxy, "_front_ssl_context"),
+    ):
+        for response in responses:
+            with patch.object(
+                tls_proxy.urllib.request,
+                "urlopen",
+                MagicMock(return_value=response),
+            ):
+                assert (
+                    tls_proxy.probe_fcc_front(
+                        "https://localhost:18443/", TEST_IDENTITY_SECRET, home
+                    )
+                    is False
+                )
+        for error_side_effect in errors:
+            with patch.object(
+                tls_proxy.urllib.request,
+                "urlopen",
+                MagicMock(side_effect=error_side_effect),
+            ):
+                assert (
+                    tls_proxy.probe_fcc_front(
+                        "https://localhost:18443/", TEST_IDENTITY_SECRET, home
+                    )
+                    is False
+                )
+
+
+def test_probe_fcc_front_false_without_identity_secret(tmp_path: Path) -> None:
+    # No secret means nothing to compare against; never adopt.
+    assert tls_proxy.probe_fcc_front("https://localhost:18443", "", tmp_path) is False
+
+
+def test_probe_fcc_front_false_without_managed_ca_file(tmp_path: Path) -> None:
+    # Regression guard for the Greptile "reusable front identity plus
+    # disabled TLS verification" finding: without this install's managed CA
+    # root there is nothing to verify the listener's certificate against, so
+    # even a listener serving the exact secret must not be adopted.
+    home = tmp_path / "caddy"
+    tls_proxy.front_identity_path(home).parent.mkdir(parents=True)
+    assert tls_proxy.managed_ca_path(home).is_file() is False
+
+    with patch.object(
+        tls_proxy.urllib.request,
+        "urlopen",
+        MagicMock(return_value=_health_response(TEST_IDENTITY_SECRET)),
+    ) as urlopen:
+        assert (
+            tls_proxy.probe_fcc_front(
+                "https://localhost:18443", TEST_IDENTITY_SECRET, home
+            )
+            is False
+        )
+
+    urlopen.assert_not_called()  # no request ever leaves over unverified TLS
+
+
+def _self_signed_cert(directory: Path, common_name: str) -> tuple[Path, Path]:
+    key = directory / f"{common_name}.key"
+    cert = directory / f"{common_name}.crt"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+            "-days",
+            "1",
+            "-subj",
+            f"/CN={common_name}",
+            "-addext",
+            "subjectAltName=DNS:localhost",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return key, cert
+
+
+def test_front_ssl_context_rejects_foreign_certificate(tmp_path: Path) -> None:
+    # The pinned context must refuse a certificate that does not chain to
+    # the managed CA root — the exact shape of a same-user process replaying
+    # the identity secret behind its own self-signed listener.
+    if shutil.which("openssl") is None:
+        pytest.skip("openssl binary not installed")
+
+    _, ca_file = _self_signed_cert(tmp_path, "managed-ca")
+    foreign_key, foreign_cert = _self_signed_cert(tmp_path, "foreign")
+
+    context = tls_proxy._front_ssl_context(ca_file)
+    assert context.verify_mode is ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+
+    server_socket = socket.socket()
+    server_socket.bind(("127.0.0.1", 0))
+    server_socket.listen(1)
+    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_context.load_cert_chain(foreign_cert, foreign_key)
+
+    def accept_once() -> None:
+        connection, _ = server_socket.accept()
+        try:
+            server_context.wrap_socket(connection, server_side=True)
+        except ssl.SSLError:
+            pass  # expected: the client rejects our certificate mid-handshake
+        finally:
+            connection.close()
+
+    worker = threading.Thread(target=accept_once, daemon=True)
+    worker.start()
+    try:
+        port = server_socket.getsockname()[1]
+        with (
+            socket.create_connection(("127.0.0.1", port), timeout=5) as raw,
+            pytest.raises(ssl.SSLCertVerificationError),
         ):
-            assert tls_proxy.probe_fcc_front("https://localhost:18443/") is False
-    for error_side_effect in errors:
-        with patch.object(
-            tls_proxy.urllib.request,
-            "urlopen",
-            MagicMock(side_effect=error_side_effect),
-        ):
-            assert tls_proxy.probe_fcc_front("https://localhost:18443/") is False
+            context.wrap_socket(raw, server_hostname="localhost")
+    finally:
+        server_socket.close()
+
+
+def test_managed_ca_path_tracks_sandboxed_caddy_data(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "caddy"
+
+    assert tls_proxy.managed_ca_path(home) == (
+        home / "data" / "caddy" / "pki" / "authorities" / "local" / "root.crt"
+    )
+    # The default home must match what CaddyTlsProxy sandboxes via
+    # XDG_DATA_HOME, otherwise the probe could never verify the child's
+    # certificate.
+    proxy = CaddyTlsProxy(settings)
+    assert tls_proxy.managed_ca_path(None) == (
+        proxy._home_dir
+        / "data"
+        / "caddy"
+        / "pki"
+        / "authorities"
+        / "local"
+        / "root.crt"
+    )
+
+
+def test_load_or_create_front_identity_is_owner_only_and_stable(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "caddy"
+
+    first = tls_proxy.load_or_create_front_identity(home)
+    second = tls_proxy.load_or_create_front_identity(home)
+
+    assert first == second
+    assert len(first) == tls_proxy.FRONT_IDENTITY_BYTES * 2  # hex-encoded
+    secret_file = tls_proxy.front_identity_path(home)
+    assert secret_file.stat().st_mode & 0o777 == 0o600
+    assert secret_file.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_load_or_create_front_identity_survives_permissive_umask(
+    tmp_path: Path,
+) -> None:
+    # Under umask 000 the secret must still end up owner-only.
+    previous = os.umask(0)
+    try:
+        tls_proxy.load_or_create_front_identity(tmp_path / "caddy")
+    finally:
+        os.umask(previous)
+
+    secret_file = tls_proxy.front_identity_path(tmp_path / "caddy")
+    assert secret_file.stat().st_mode & 0o777 == 0o600
 
 
 def test_resolve_gateway_base_url_https_when_probe_succeeds(
     settings: Settings,
 ) -> None:
-    with patch.object(tls_proxy, "probe_fcc_front", return_value=True):
+    with (
+        patch.object(tls_proxy, "load_or_create_front_identity", return_value="secret"),
+        patch.object(tls_proxy, "probe_fcc_front", return_value=True) as probe,
+    ):
         url = resolve_gateway_base_url(settings)
 
     assert url == "https://localhost:18443"
+    probe.assert_called_once_with("https://localhost:18443", "secret")
 
 
 def test_resolve_gateway_base_url_https_requires_fcc_identity(
     settings: Settings,
 ) -> None:
-    # A TLS listener that is alive but does not serve FCC's health marker
-    # must not be adopted; routing falls back to plain HTTP.
+    # A TLS listener that is alive but cannot prove it belongs to this FCC
+    # install must not be adopted; routing falls back to plain HTTP.
     with (
-        patch.object(tls_proxy, "probe_https", return_value=True),
+        patch.object(tls_proxy, "load_or_create_front_identity", return_value="s"),
         patch.object(tls_proxy, "probe_fcc_front", return_value=False),
     ):
         url = resolve_gateway_base_url(settings)
@@ -143,7 +401,69 @@ def test_resolve_gateway_base_url_http_when_disabled_or_unreachable(
     disabled = Settings(host="127.0.0.1", port=8082, tls_proxy_enabled=False)
 
     assert resolve_gateway_base_url(disabled) == "http://127.0.0.1:8082"
-    assert resolve_gateway_base_url(settings) == "http://127.0.0.1:8082"
+    # The enabled-but-unverified case must not touch the real home dir or
+    # network: pin identity and force the probe to fail.
+    with (
+        patch.object(tls_proxy, "load_or_create_front_identity", return_value="s"),
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+    ):
+        assert resolve_gateway_base_url(settings) == "http://127.0.0.1:8082"
+
+
+def test_ensure_https_front_returns_proxy_when_start_succeeds(
+    settings: Settings,
+) -> None:
+    proxy = MagicMock(spec=CaddyTlsProxy)
+    proxy.start.return_value = True
+
+    with patch.object(tls_proxy, "CaddyTlsProxy", return_value=proxy):
+        front = tls_proxy.ensure_https_front(settings)
+
+    assert front is proxy
+    proxy.stop.assert_not_called()
+
+
+def test_ensure_https_front_returns_none_and_stops_when_start_fails(
+    settings: Settings,
+) -> None:
+    # A failed bring-up must leave no managed child behind: the gate stops
+    # the proxy it constructed and hands the caller ``None``.
+    proxy = MagicMock(spec=CaddyTlsProxy)
+    proxy.start.return_value = False
+
+    with patch.object(tls_proxy, "CaddyTlsProxy", return_value=proxy):
+        front = tls_proxy.ensure_https_front(settings)
+
+    assert front is None
+    proxy.stop.assert_called_once()
+
+
+def test_verified_https_gateway_url_returns_url_when_probe_passes(
+    settings: Settings,
+) -> None:
+    with (
+        patch.object(tls_proxy, "load_or_create_front_identity", return_value="secret"),
+        patch.object(tls_proxy, "probe_fcc_front", return_value=True) as probe,
+    ):
+        url = tls_proxy.verified_https_gateway_url(settings)
+
+    assert url == f"https://localhost:18443/{settings.desktop_gateway_prefix}"
+    probe.assert_called_once_with("https://localhost:18443", "secret")
+
+
+def test_verified_https_gateway_url_never_falls_back_to_http(
+    settings: Settings,
+) -> None:
+    # Unlike resolve_gateway_base_url, the desktop gate must return None —
+    # never a plain-HTTP URL — when the front does not verify.
+    disabled = Settings(host="127.0.0.1", port=8082, tls_proxy_enabled=False)
+    assert tls_proxy.verified_https_gateway_url(disabled) is None
+
+    with (
+        patch.object(tls_proxy, "load_or_create_front_identity", return_value="s"),
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+    ):
+        assert tls_proxy.verified_https_gateway_url(settings) is None
 
 
 def test_start_reuses_external_front_without_spawning(
@@ -153,13 +473,15 @@ def test_start_reuses_external_front_without_spawning(
     proxy = CaddyTlsProxy(settings, home_dir=tmp_path / "caddy")
 
     with (
-        patch.object(tls_proxy, "probe_fcc_front", side_effect=[True]),
+        patch.object(tls_proxy, "probe_fcc_front", side_effect=[True]) as probe,
         patch.object(tls_proxy.shutil, "which") as which,
         patch.object(tls_proxy.subprocess, "Popen") as popen,
     ):
         started = proxy.start()
 
     assert started is True
+    # Adoption must be checked against this install's managed CA.
+    assert probe.call_args.args[2] == tmp_path / "caddy"
     which.assert_not_called()
     popen.assert_not_called()
 
@@ -185,14 +507,18 @@ def test_start_does_not_adopt_foreign_tls_listener(
 
     probe_calls = 0
 
-    def counting_probe(url: str, timeout_seconds: float = 1.0) -> bool:
+    def counting_probe(
+        url: str,
+        secret: str,
+        home_dir: Path | None = None,
+        timeout_seconds: float = 1.0,
+    ) -> bool:
         nonlocal probe_calls
         probe_calls += 1
         return False  # identity fails; readiness probes also fail
 
     with (
-        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
-        patch.object(tls_proxy, "probe_https", counting_probe),
+        patch.object(tls_proxy, "probe_fcc_front", counting_probe),
         patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
         patch.object(tls_proxy.subprocess, "Popen", FakeProcess),
     ):
@@ -224,15 +550,19 @@ def test_start_spawns_managed_caddy_and_waits_for_readiness(
 
     probe_calls = 0
 
-    def counting_probe(url: str, timeout_seconds: float = 1.0) -> bool:
+    def counting_probe(
+        url: str,
+        secret: str,
+        home_dir: Path | None = None,
+        timeout_seconds: float = 1.0,
+    ) -> bool:
         nonlocal probe_calls
         probe_calls += 1
         # First call (external-front check) fails; readiness checks succeed.
         return probe_calls > 1
 
     with (
-        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
-        patch.object(tls_proxy, "probe_https", counting_probe),
+        patch.object(tls_proxy, "probe_fcc_front", counting_probe),
         patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
         patch.object(tls_proxy.subprocess, "Popen", FakeProcess),
     ):
@@ -340,7 +670,147 @@ def test_managed_caddyfile_disables_admin_api(settings: Settings) -> None:
 
     # A system caddy may already own the default admin endpoint (port 2019);
     # the managed instance must never claim it.
-    assert "admin off" in proxy.render_caddyfile()
+    assert "admin off" in proxy.render_caddyfile(TEST_IDENTITY_SECRET)
+
+
+def test_start_writes_caddyfile_owner_only(
+    settings: Settings,
+    tmp_path: Path,
+) -> None:
+    # The Caddyfile embeds the identity secret; it must not be world-readable.
+    class FakeProcess:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.returncode = 0
+
+        def poll(self) -> int | None:
+            return None
+
+        def terminate(self) -> None: ...
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    probe_calls = 0
+
+    def ready_on_second_probe(
+        url: str,
+        secret: str,
+        home_dir: Path | None = None,
+        timeout_seconds: float = 1.0,
+    ) -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return probe_calls > 1
+
+    home = tmp_path / "caddy"
+    with (
+        patch.object(tls_proxy, "probe_fcc_front", ready_on_second_probe),
+        patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
+        patch.object(tls_proxy.subprocess, "Popen", FakeProcess),
+    ):
+        proxy = CaddyTlsProxy(settings, home_dir=home)
+        assert proxy.start() is True
+
+    assert proxy.caddyfile_path.stat().st_mode & 0o777 == 0o600
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_port_free(port: int) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        with socket.socket() as probe_sock:
+            try:
+                probe_sock.connect(("127.0.0.1", port))
+            except OSError:
+                return
+        time.sleep(0.1)
+
+
+def test_managed_front_serves_identity_and_rejects_impersonation(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: the managed front proves ownership; impostors cannot.
+
+    Spawns the real managed caddy (skipped when absent) and verifies the
+    adoption probe accepts the front only with this install's secret —
+    the exact path Greptile's T-Rex exploited with a forged health marker.
+    """
+
+    if shutil.which(tls_proxy.CADDY_BINARY) is None:
+        pytest.skip("caddy binary not installed")
+
+    port = _free_port()
+    front_settings = Settings(host="127.0.0.1", port=1, tls_proxy_port=port)
+    home = tmp_path / "caddy"
+    proxy = CaddyTlsProxy(front_settings, home_dir=home)
+    base_url = f"https://localhost:{port}"
+    try:
+        assert proxy.start() is True
+        secret = tls_proxy.load_or_create_front_identity(home)
+
+        assert tls_proxy.probe_fcc_front(base_url, secret, home) is True
+        # A process that merely occupies the port cannot guess the secret.
+        assert tls_proxy.probe_fcc_front(base_url, "attacker-guess", home) is False
+    finally:
+        proxy.stop()
+        _wait_for_port_free(port)
+
+
+def test_managed_front_rejects_attacker_certificate_replaying_secret(
+    tmp_path: Path,
+) -> None:
+    """End-to-end guard for the Greptile reusable-bearer finding.
+
+    A same-user process can read the identity secret from disk and serve it
+    from its own listener. Adoption must still fail because that listener's
+    self-signed certificate does not chain to this install's managed CA.
+    """
+
+    if shutil.which(tls_proxy.CADDY_BINARY) is None or shutil.which("openssl") is None:
+        pytest.skip("caddy or openssl binary not installed")
+
+    port = _free_port()
+    front_settings = Settings(host="127.0.0.1", port=1, tls_proxy_port=port)
+    home = tmp_path / "caddy"
+    proxy = CaddyTlsProxy(front_settings, home_dir=home)
+    base_url = f"https://localhost:{port}"
+    try:
+        assert proxy.start() is True
+        secret = tls_proxy.load_or_create_front_identity(home)
+    finally:
+        proxy.stop()
+        _wait_for_port_free(port)
+
+    # Attacker: same user, so it can read the secret; it binds the port with
+    # its own self-signed certificate and replays the secret verbatim.
+    attacker_key, attacker_cert = _self_signed_cert(tmp_path, "attacker")
+
+    class IdentityHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            body = secret.encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("127.0.0.1", port), IdentityHandler)
+    attacker_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    attacker_context.load_cert_chain(attacker_cert, attacker_key)
+    server.socket = attacker_context.wrap_socket(server.socket, server_side=True)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    try:
+        # The secret matches byte-for-byte; only the certificate differs.
+        assert tls_proxy.probe_fcc_front(base_url, secret, home) is False
+    finally:
+        server.shutdown()
+        server.server_close()
+        _wait_for_port_free(port)
 
 
 @pytest.mark.parametrize("flag", ["--config", "--adapter"])
@@ -359,10 +829,20 @@ def test_spawn_command_includes_config_adapter(flag: str, settings: Settings) ->
         def wait(self, timeout: float | None = None) -> int:
             return 0
 
+    probe_calls = 0
+
+    def ready_on_second_probe(
+        url: str,
+        secret: str,
+        home_dir: Path | None = None,
+        timeout_seconds: float = 1.0,
+    ) -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return probe_calls > 1
+
     with (
-        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
-        # First readiness probe fails; the next one succeeds.
-        patch.object(tls_proxy, "probe_https", side_effect=[False, True]),
+        patch.object(tls_proxy, "probe_fcc_front", ready_on_second_probe),
         patch.object(tls_proxy.shutil, "which", return_value="/usr/bin/caddy"),
         patch.object(tls_proxy.subprocess, "Popen", FakeProcess),
     ):
@@ -373,20 +853,3 @@ def test_spawn_command_includes_config_adapter(flag: str, settings: Settings) ->
     assert isinstance(cmd, list)
     assert "/usr/bin/caddy" in cmd
     assert flag in cmd
-
-
-def test_probe_https_true_when_endpoint_returns_error_status() -> None:
-    # Any HTTP status (404 root path, 401 auth gate, 502 dead upstream)
-    # proves the TLS front is alive and answering.
-    error = urllib.error.HTTPError(
-        "https://localhost:18443/",
-        404,
-        "Not Found",
-        email.message.Message(),
-        None,
-    )
-
-    with patch.object(
-        tls_proxy.urllib.request, "urlopen", MagicMock(side_effect=error)
-    ):
-        assert tls_proxy.probe_https("https://localhost:18443/") is True

--- a/tests/cli/test_tls_proxy.py
+++ b/tests/cli/test_tls_proxy.py
@@ -368,6 +368,65 @@ def test_load_or_create_front_identity_survives_permissive_umask(
     assert secret_file.stat().st_mode & 0o777 == 0o600
 
 
+def test_load_or_create_front_identity_tightens_existing_permissive_home(
+    tmp_path: Path,
+) -> None:
+    """A pre-existing permissive Caddy home is tightened before use.
+
+    Regression guard for the Greptile "shared Caddy state directory remains
+    writable" finding: ``mkdir(mode=0o700)`` only governs directories the
+    call itself creates, so a home that already exists with 0777 (inherited
+    under a permissive umask or created by an older install) would keep
+    letting other local users traverse and write into the directory that
+    holds the credential-bearing front's identity secret. Creation must
+    restrict the existing directory itself.
+    """
+
+    home = tmp_path / "caddy"
+    # chmod (not mkdir's mode arg) defeats the test process's own umask,
+    # which would otherwise leave the directory at 0775 instead of 0777 —
+    # the permissive state the finding describes.
+    home.mkdir()
+    home.chmod(0o777)
+    assert home.stat().st_mode & 0o777 == 0o777
+
+    tls_proxy.load_or_create_front_identity(home)
+
+    assert home.stat().st_mode & 0o777 == 0o700
+    secret_file = tls_proxy.front_identity_path(home)
+    assert secret_file.stat().st_mode & 0o777 == 0o600
+
+
+def test_caddy_start_tightens_existing_permissive_home(tmp_path: Path) -> None:
+    """The managed front's state directory is forced owner-only on start.
+
+    Companion to the identity test: ``CaddyTlsProxy.start`` writes the
+    Caddyfile (which embeds the identity secret) and gives the managed
+    caddy its whole sandbox here, so the same pre-existing-permissive-home
+    hole applies on the proxy-start path.
+    """
+
+    settings = Settings.model_construct(
+        host="127.0.0.1", port=8082, tls_proxy_enabled=True, tls_proxy_port=18443
+    )
+    home = tmp_path / "caddy"
+    home.mkdir()
+    home.chmod(0o777)
+    proxy = tls_proxy.CaddyTlsProxy(settings, home_dir=home)
+
+    with (
+        patch.object(tls_proxy, "load_or_create_front_identity", return_value="s"),
+        patch.object(tls_proxy, "probe_fcc_front", return_value=False),
+        patch.object(tls_proxy, "shutil") as fake_shutil,
+        patch.object(tls_proxy, "subprocess") as fake_subprocess,
+    ):
+        fake_shutil.which.return_value = "/usr/bin/caddy"
+        fake_subprocess.Popen.return_value = MagicMock()
+        proxy.start()
+
+    assert home.stat().st_mode & 0o777 == 0o700
+
+
 def test_resolve_gateway_base_url_https_when_probe_succeeds(
     settings: Settings,
 ) -> None:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -500,3 +500,25 @@ def test_settings_defaults_do_not_contain_empty_enum_strings() -> None:
     for _name, value in Settings():
         if isinstance(value, Enum):
             assert value.value
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("claude-desktop", "claude-desktop"),
+        ("/claude-desktop", "claude-desktop"),
+        ("claude-desktop/", "claude-desktop"),
+        ("/claude-desktop/", "claude-desktop"),
+        ("//gateway//", "gateway"),
+    ],
+)
+def test_desktop_gateway_prefix_strips_boundary_slashes(
+    value: str, expected: str
+) -> None:
+    assert Settings(desktop_gateway_prefix=value).desktop_gateway_prefix == expected
+
+
+@pytest.mark.parametrize("value", ["/", "//", "///"])
+def test_desktop_gateway_prefix_requires_a_path_segment(value: str) -> None:
+    with pytest.raises(ValidationError):
+        Settings(desktop_gateway_prefix=value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,3 +241,13 @@ def _propagate_loguru_to_caplog():
         loguru_logger.remove(
             handler_id
         )  # Handler already removed (e.g. by test_logging_config)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_picker_alias_state():
+    """Keep the process-global picker alias maps inert between tests."""
+    from free_claude_code.core import gateway_model_ids as gmi
+
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()

--- a/tests/core/test_gateway_model_ids_aliases.py
+++ b/tests/core/test_gateway_model_ids_aliases.py
@@ -1,0 +1,251 @@
+"""Tests for picker aliasing in ``free_claude_code.core.gateway_model_ids``."""
+
+import pytest
+
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    """Reset module-scope alias maps before/after each test."""
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_picker_alias_prefix_is_anthropic_safe():
+    assert gmi.PICKER_ALIAS_PREFIX == "claude-sonnet-nim"
+
+
+def test_has_picker_aliases_false_before_seed():
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_populates_maps_and_marks_seeded():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    assert gmi.has_picker_aliases() is True
+
+
+def test_alias_counter_is_deterministic_from_sorted_input():
+    first = ["nvidia_nim/z-provider/z-model", "nvidia_nim/a-provider/a-model"]
+    second = list(reversed(first))
+
+    gmi.seed_picker_aliases(first)
+    a_first = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    gmi.seed_picker_aliases(second)
+    a_second = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert a_first == a_second == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/z-provider/z-model")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_reseed_keeps_existing_refs_on_their_alias():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    # A refresh that adds a ref must not renumber the advertised ones.
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+            "openai/gpt-x",
+        ]
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == (
+        "claude-sonnet-nim-0001"
+    )
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+    assert gmi.picker_alias_for("openai/gpt-x") == "claude-sonnet-nim-0003"
+
+
+def test_alias_lookup_thinking_and_no_thinking_variants():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+
+
+def test_alias_lookup_unknown_ref_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/missing/model") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/missing/model", force_reasoning_off=True)
+        is None
+    )
+
+
+def test_resolve_picker_alias_round_trip():
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        False,
+    )
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001-no-thinking") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        True,
+    )
+
+
+def test_resolve_picker_alias_unknown_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999-no-thinking") is None
+    assert gmi.resolve_picker_alias("claude-haiku-nim-0001") is None
+
+
+def test_resolve_picker_alias_for_prefix_only_when_seeded_empty():
+    # Maps are empty by default (cold-start window).
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_clear_resets_state():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.has_picker_aliases() is True
+
+    gmi.clear_picker_aliases()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_empty_iterable_keeps_state_empty():
+    gmi.seed_picker_aliases([])
+
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_replaces_previous_aliases_without_slot_reuse():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    # The removed ref's alias is retired, never recycled onto the new ref.
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_returning_ref_regains_its_previous_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    original = gmi.picker_alias_for("nvidia_nim/01-ai/yi-large")
+    assert original is not None
+
+    gmi.seed_picker_aliases(["openai/gpt-x"])
+    assert gmi.resolve_picker_alias(original) is None
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large", "openai/gpt-x"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == original
+
+
+def test_empty_refresh_keeps_retired_numbers_consumed():
+    """Disconnect-everything must not recycle aliases on the next refresh."""
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+    assert advertised is not None
+
+    # Inventory drains to empty (final provider disconnected)...
+    gmi.seed_picker_aliases([])
+    assert gmi.has_picker_aliases() is False
+    assert gmi.resolve_picker_alias(advertised) is None
+
+    # ...and a different model arrives later.
+    gmi.seed_picker_aliases(["openai/new/model"])
+
+    new_alias = gmi.picker_alias_for("openai/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(advertised) is None
+
+
+def test_aliases_are_four_digit_zero_padded():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(15)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [
+        alias for ref in refs if (alias := gmi.picker_alias_for(ref)) is not None
+    ]
+
+    assert len(aliases) == 15
+    for alias in aliases:
+        # All aliases share the same prefix and 4-digit counter width.
+        assert alias.startswith("claude-sonnet-nim-")
+        counter = alias.removeprefix("claude-sonnet-nim-").split("-")[0]
+        assert len(counter) == 4
+        assert counter.isdigit()
+
+
+def test_seed_assigns_unique_aliases_per_ref():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(10)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [gmi.picker_alias_for(ref) for ref in refs]
+
+    assert len(set(aliases)) == len(refs)
+    assert all(alias is not None for alias in aliases)
+
+
+def test_reseed_publishes_one_consistent_snapshot():
+    """Catalog output and routing must agree after an inventory swap.
+
+    Regression guard for torn publication: a reader binding the snapshot
+    before a reseed sees one self-consistent inventory, and a reader binding
+    it afterwards sees the other — never a mix of old and new maps. Sticky
+    assignments additionally guarantee the pre-reseed alias keeps resolving
+    to the same ref it advertised (or retires entirely).
+    """
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+
+    gmi.seed_picker_aliases(["nvidia_nim/new/model"])
+
+    assert advertised is not None
+    # The previously advertised alias either still routes to its original ref
+    # or is retired outright; it can never re-point to another model.
+    assert gmi.resolve_picker_alias(advertised) in {
+        ("nvidia_nim/old/model", False),
+        None,
+    }
+    # Both directions of the new snapshot are aligned with each other.
+    new_alias = gmi.picker_alias_for("nvidia_nim/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(new_alias) == ("nvidia_nim/new/model", False)
+    no_thinking_alias = gmi.picker_alias_for(
+        "nvidia_nim/new/model", force_reasoning_off=True
+    )
+    assert no_thinking_alias is not None
+    assert gmi.resolve_picker_alias(no_thinking_alias) == (
+        "nvidia_nim/new/model",
+        True,
+    )

--- a/tests/runtime/test_application_runtime_picker_aliases.py
+++ b/tests/runtime/test_application_runtime_picker_aliases.py
@@ -1,0 +1,97 @@
+"""Runtime seeding for picker aliases via ``ApplicationRuntime``."""
+
+from typing import cast
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.application import ApplicationRuntime
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+class _SeedingProviderManager:
+    """Stand-in honoring the manager's alias-refresh contract."""
+
+    def __init__(self, model_ids: list[str]) -> None:
+        self._model_ids = model_ids
+        self.refresh_calls = 0
+
+    def refresh_picker_aliases(self) -> None:
+        self.refresh_calls += 1
+        infos = tuple(
+            ProviderModelInfo(model_id=model_id, supports_thinking=None)
+            for model_id in self._model_ids
+        )
+        gmi.seed_picker_aliases(info.model_id for info in infos)
+
+
+def _make_runtime_with_models(
+    model_ids: list[str],
+) -> tuple[ApplicationRuntime, _SeedingProviderManager]:
+    provider_manager = _SeedingProviderManager(model_ids)
+    return (
+        ApplicationRuntime(
+            cast(ProviderRuntimeManager, provider_manager), transcriber=None
+        ),
+        provider_manager,
+    )
+
+
+def test_seed_picker_aliases_from_cache_populates_maps():
+    runtime, _manager = _make_runtime_with_models(
+        ["nvidia_nim/01-ai/yi-large", "nvidia_nim/meta/llama-3.3-70b-instruct"]
+    )
+
+    runtime._seed_picker_aliases_from_cache()
+
+    assert gmi.has_picker_aliases() is True
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_seed_picker_aliases_with_empty_cache_leaves_state_inert():
+    runtime, _manager = _make_runtime_with_models([])
+
+    runtime._seed_picker_aliases_from_cache()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_picker_aliases_uses_sorted_input_for_counter_stability():
+    first_runtime, first_manager = _make_runtime_with_models(
+        [
+            "nvidia_nim/z-provider/z-model",
+            "nvidia_nim/a-provider/a-model",
+        ]
+    )
+    first_runtime._seed_picker_aliases_from_cache()
+    assert first_manager.refresh_calls == 1
+    first_alias_for_a = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    second_runtime, _manager = _make_runtime_with_models(
+        [
+            "nvidia_nim/a-provider/a-model",
+            "nvidia_nim/z-provider/z-model",
+        ]
+    )
+    second_runtime._seed_picker_aliases_from_cache()
+    second_alias_for_a = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert first_alias_for_a == second_alias_for_a == "claude-sonnet-nim-0001"

--- a/tests/runtime/test_provider_manager.py
+++ b/tests/runtime/test_provider_manager.py
@@ -8,6 +8,7 @@ from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.application.ports import RequestRuntimePort
 from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from free_claude_code.providers.runtime import ProviderRuntime
@@ -240,6 +241,47 @@ async def test_catalog_publication_tracks_replacement_and_its_refresh() -> None:
         ("nvidia_nim/two", ()),
     ]
     await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_publish_reconciles_picker_aliases_with_cache_mutations() -> None:
+    gmi.clear_picker_aliases()
+    try:
+        factory = RuntimeFactory()
+        connected: set[str] = set()
+        manager = ProviderRuntimeManager(
+            _settings("nvidia_nim/one"),
+            runtime_factory=factory,
+            connected_provider_ids=lambda: tuple(connected),
+            model_catalog_publisher=RecordingModelCatalogPublisher(),
+        )
+        factory.runtimes[0].provider.list_model_infos = AsyncMock(
+            return_value=frozenset(
+                {ProviderModelInfo(model_id="old-model", supports_thinking=True)}
+            )
+        )
+
+        connected.add("openai")
+        await manager.connected_provider_changed("openai", connected=True)
+        old_alias = gmi.picker_alias_for("openai/old-model")
+        assert old_alias is not None
+
+        # A later cache mutation replaces the inventory: the new ref must gain
+        # an alias immediately, and the removed ref's alias retires instead of
+        # silently re-pointing at the replacement model.
+        manager.cache_model_infos(
+            "openai",
+            [ProviderModelInfo(model_id="new-model", supports_thinking=None)],
+        )
+
+        new_alias = gmi.picker_alias_for("openai/new-model")
+        assert new_alias is not None
+        assert gmi.picker_alias_for("openai/old-model") is None
+        assert new_alias != old_alias
+        assert gmi.resolve_picker_alias(old_alias) is None
+        await manager.close()
+    finally:
+        gmi.clear_picker_aliases()
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_manager_picker_aliases.py
+++ b/tests/runtime/test_provider_manager_picker_aliases.py
@@ -1,0 +1,87 @@
+"""Picker-alias reseeding on model-catalog republication."""
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _manager(model: str) -> ProviderRuntimeManager:
+    settings = Settings().model_copy(
+        update={"model": model, "nvidia_nim_api_key": "test-key"}
+    )
+    return ProviderRuntimeManager(settings)
+
+
+def _info(model_id: str) -> ProviderModelInfo:
+    return ProviderModelInfo(model_id=model_id, supports_thinking=None)
+
+
+def test_refresh_picker_aliases_seeds_current_cache_snapshot() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0001"
+    )
+    gmi.clear_picker_aliases()
+
+
+def test_cache_publication_reseeds_aliases_atomically() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    first_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+
+    # A refreshed inventory keeps the sticky assignment and adds new refs.
+    manager.cache_model_infos(
+        "nvidia_nim",
+        [
+            _info("meta/llama-3.3-70b-instruct"),
+            _info("01-ai/yi-large"),
+        ],
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct") == first_alias
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is not None
+
+
+def test_configured_ref_gets_alias_without_discovery_cache() -> None:
+    manager = _manager("nvidia_nim/one")
+
+    # No discovery cache yet: the configured model still gains a picker alias
+    # so a cold /v1/models request never advertises a raw gateway identifier.
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert gmi.picker_alias_for("nvidia_nim/one") is not None
+
+
+def test_empty_cache_retires_discovery_only_aliases_but_keeps_configured() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    configured_alias = gmi.picker_alias_for("nvidia_nim/one")
+    discovery_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+    assert configured_alias is not None
+    assert discovery_alias is not None
+
+    manager.cache_model_infos("nvidia_nim", [])
+
+    # The discovery-only ref retires; the configured ref keeps its alias.
+    assert gmi.has_picker_aliases() is True
+    assert gmi.resolve_picker_alias(discovery_alias) is None
+    assert gmi.picker_alias_for("nvidia_nim/one") == configured_alias

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 import os
+import pathlib
 import shutil
 import subprocess
 import sys
@@ -632,11 +633,12 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
         for call in calls
     )
     assert not any(call.startswith("git:") for call in calls)
-    assert calls[-3:] == [
+    assert calls[-4:-1] == [
         "uv:tool update-shell",
         "uv:tool dir --bin",
         "fcc-server:--version",
     ]
+    assert calls[-1].startswith("fcc-desktop:--export-icon ")
     assert not any("hermes:setup" in call for call in calls)
     home = Path(posix_harness.env["HOME"])
     assert (home / ".grok" / "bin" / "grok").is_file()
@@ -922,6 +924,12 @@ def test_install_sh_rejects_incompatible_node_for_selected_dsh(
 def test_install_sh_noninteractive_skips_dsh_without_node(
     posix_harness: PosixHarness,
 ) -> None:
+    if shutil.which("node", path="/usr/bin:/bin") or shutil.which(
+        "npm", path="/usr/bin:/bin"
+    ):
+        pytest.skip(
+            "system node/npm in the harness PATH fallback defeats the no-node setup"
+        )
     (posix_harness.bin_dir / "node").unlink()
     (posix_harness.bin_dir / "npm").unlink()
 
@@ -1490,6 +1498,50 @@ def test_install_sh_dry_run_never_executes_commands(
     assert posix_harness.calls() == []
     assert "Dry run complete. No changes were made." in result.stdout
     assert "Free Claude Code is installed and verified." not in result.stdout
+
+
+def test_install_sh_trusts_managed_caddy_cert_in_nss(
+    posix_harness: PosixHarness,
+) -> None:
+    """Managed-front root cert is trusted in Chromium/Electron's NSS database."""
+
+    def fake_logging_tool(name: str) -> None:
+        _write_executable(
+            posix_harness.bin_dir / name,
+            f"""#!/bin/sh
+echo "{name}:$*" >> "$CALL_LOG"
+exit 0
+""",
+        )
+
+    # certutil exercises the NSS trust path; sudo/update-ca-certificates are
+    # faked so the system-store step never mutates the real host.
+    for tool in ("certutil", "sudo", "update-ca-certificates"):
+        fake_logging_tool(tool)
+    managed_root = (
+        pathlib.Path(posix_harness.env["HOME"])
+        / ".fcc"
+        / "caddy"
+        / "data"
+        / "caddy"
+        / "pki"
+        / "authorities"
+        / "local"
+    )
+    managed_root.mkdir(parents=True)
+    (managed_root / "root.crt").write_text("-----BEGIN CERTIFICATE-----\n")
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    home = posix_harness.env["HOME"]
+    certutil_calls = [
+        call for call in posix_harness.calls() if call.startswith("certutil:")
+    ]
+    assert any(
+        call.startswith("certutil:-A ") and f"sql:{home}/.pki/nssdb" in call
+        for call in certutil_calls
+    ), certutil_calls
+    assert any("-n FCC-Caddy" in call for call in certutil_calls)
 
 
 def test_install_sh_rejects_broken_existing_client_without_replacing_it(
@@ -3479,3 +3531,71 @@ if ($resolved -ne {str(fallback)!r}) {{
     )
 
     assert result.returncode == 0, result.stderr
+
+
+LINUX_DESKTOP_MARKER = "# Owned by Free Claude Code. Remove this line to unclaim."
+
+
+def _linux_desktop_entry_path(posix_harness: PosixHarness) -> Path:
+    return (
+        Path(posix_harness.env["XDG_DATA_HOME"])
+        / "applications"
+        / "free-claude-code.desktop"
+    )
+
+
+def test_install_sh_writes_linux_desktop_entry_and_icon(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.env["XDG_DATA_HOME"] = str(posix_harness.root / "xdgdata")
+    tool_bin = posix_harness.root / "tool's bin"
+    posix_harness.env["FAKE_TOOL_BIN"] = str(tool_bin)
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    entry = _linux_desktop_entry_path(posix_harness)
+    icon = posix_harness.root / "xdgdata" / "icons" / "free-claude-code.png"
+    text = entry.read_text(encoding="utf-8")
+    assert text.splitlines()[0] == LINUX_DESKTOP_MARKER
+    assert "[Desktop Entry]" in text
+    assert "Name=Free Claude Code" in text
+    expected_command = str(tool_bin / "fcc-desktop").replace("'", "'\\''")
+    assert f"Exec={expected_command}" in text or f"Exec='{expected_command}'" in text
+    assert f"Icon={icon}" in text
+    assert icon.read_bytes() == b"fake icon\n"
+    assert any(
+        call.startswith("fcc-desktop:--export-icon ") and call.endswith(str(icon))
+        for call in posix_harness.calls()
+    )
+    assert "Open Free Claude Code from your application launcher" in result.stdout
+
+
+def test_install_sh_preserves_unowned_linux_desktop_entry(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.env["XDG_DATA_HOME"] = str(posix_harness.root / "xdgdata")
+    entry = _linux_desktop_entry_path(posix_harness)
+    entry.parent.mkdir(parents=True)
+    entry.write_text("[Desktop Entry]\nName=User Custom\n", encoding="utf-8")
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert entry.read_text(encoding="utf-8") == "[Desktop Entry]\nName=User Custom\n"
+    assert "leaving it unchanged" in result.stdout
+    assert not (
+        posix_harness.root / "xdgdata" / "icons" / "free-claude-code.png"
+    ).exists()
+
+
+def test_install_sh_stops_when_linux_icon_export_fails(
+    posix_harness: PosixHarness,
+) -> None:
+    posix_harness.env["XDG_DATA_HOME"] = str(posix_harness.root / "xdgdata")
+    posix_harness.env["FAIL_STEP"] = "desktop-icon-export"
+
+    result = posix_harness.run(fail_step="desktop-icon-export")
+
+    assert result.returncode != 0
+    assert not _linux_desktop_entry_path(posix_harness).exists()

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -15,6 +15,7 @@ FCC_COMMANDS = (
     "fcc-desktop",
     "fcc-server",
     "fcc-claude",
+    "fcc-claude-desktop",
     "fcc-codex",
     "fcc-pi",
     "fcc-opencode",
@@ -160,6 +161,7 @@ if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "install" ]; then
     cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-server"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-desktop"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-claude"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-claude-desktop"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-pi"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-opencode"
     cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-cline"
@@ -1826,6 +1828,7 @@ if not exist "%UV_BIN_DIR%" mkdir "%UV_BIN_DIR%"
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-server.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-desktop.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-claude.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-claude-desktop.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-pi.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-opencode.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-cline.cmd" >nul

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -1500,7 +1500,54 @@ def test_install_sh_dry_run_never_executes_commands(
     assert "Free Claude Code is installed and verified." not in result.stdout
 
 
-def test_install_sh_trusts_managed_caddy_cert_in_nss(
+def test_install_sh_skips_cert_trust_by_default(
+    posix_harness: PosixHarness,
+) -> None:
+    """CA trust is opt-in: the default install never mutates any trust store.
+
+    Regression guard for the Greptile "CA trust escapes Claude Desktop"
+    security finding: the NSS user database is shared by every
+    Chromium-based app, so trusting the FCC-managed CA there must be an
+    explicit decision. Without the opt-in the installer touches nothing —
+    no certutil, no Firefox profile stores, no system CA directory.
+    """
+
+    def fake_logging_tool(name: str) -> None:
+        _write_executable(
+            posix_harness.bin_dir / name,
+            f"""#!/bin/sh
+echo "{name}:$*" >> "$CALL_LOG"
+exit 0
+""",
+        )
+
+    # cp is intentionally NOT faked: the curl stub uses the real cp to stage
+    # the uv installer, and shadowing it would break unrelated install steps.
+    for tool in ("certutil", "sudo", "update-ca-certificates"):
+        fake_logging_tool(tool)
+    managed_root = (
+        pathlib.Path(posix_harness.env["HOME"])
+        / ".fcc"
+        / "caddy"
+        / "data"
+        / "caddy"
+        / "pki"
+        / "authorities"
+        / "local"
+    )
+    managed_root.mkdir(parents=True)
+    (managed_root / "root.crt").write_text("-----BEGIN CERTIFICATE-----\n")
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "FCC_TRUST_DESKTOP_CERT=1" in result.stderr
+    calls = posix_harness.calls()
+    assert not any(call.startswith("certutil:") for call in calls), calls
+    assert not any("update-ca-certificates" in call for call in calls), calls
+    assert not any("ca-certificates" in call for call in calls), calls
+
+
+def test_install_sh_trusts_managed_caddy_cert_in_nss_on_opt_in(
     posix_harness: PosixHarness,
 ) -> None:
     """Managed-front root cert is trusted in Chromium/Electron's NSS database."""
@@ -1530,18 +1577,23 @@ exit 0
     )
     managed_root.mkdir(parents=True)
     (managed_root / "root.crt").write_text("-----BEGIN CERTIFICATE-----\n")
+    posix_harness.env["FCC_TRUST_DESKTOP_CERT"] = "1"
     result = posix_harness.run()
 
     assert result.returncode == 0, result.stderr
     home = posix_harness.env["HOME"]
-    certutil_calls = [
-        call for call in posix_harness.calls() if call.startswith("certutil:")
-    ]
+    all_calls = posix_harness.calls()
+    certutil_calls = [call for call in all_calls if call.startswith("certutil:")]
     assert any(
         call.startswith("certutil:-A ") and f"sql:{home}/.pki/nssdb" in call
         for call in certutil_calls
     ), certutil_calls
     assert any("-n FCC-Caddy" in call for call in certutil_calls)
+    # Trust stays scoped to the NSS user database: no Firefox profile
+    # enumeration, no writes to the system CA store.
+    assert not any(".mozilla/firefox" in call for call in all_calls), all_calls
+    assert not any("ca-certificates" in call for call in all_calls), all_calls
+    assert not any(call.startswith("sudo:") for call in all_calls), all_calls
 
 
 def test_install_sh_rejects_broken_existing_client_without_replacing_it(

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -192,7 +192,7 @@ if [ "${1:-}" = "tool" ] && [ "${2:-}" = "uninstall" ]; then
         echo 'Tool `free-claude-code` is not installed' >&2
         exit 2
     fi
-    for name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code; do
+    for name in fcc-desktop fcc-server fcc-claude fcc-claude-desktop fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider fcc-init free-claude-code; do
         /bin/rm -f "$FAKE_TOOL_BIN/$name"
     done
     echo "Uninstalled free-claude-code"

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -846,3 +846,42 @@ def test_uninstallers_guard_running_commands_and_preserve_shared_owners() -> Non
         assert "is not installed" in text
         assert "no tool" not in text
         assert "nothing to uninstall" not in text
+
+
+LINUX_DESKTOP_MARKER = "# Owned by Free Claude Code. Remove this line to unclaim."
+
+
+def test_uninstall_sh_removes_owned_linux_desktop_entry_and_icon(
+    posix_uninstall_harness,
+) -> None:
+    data_home = posix_uninstall_harness.home / ".local" / "share"
+    posix_uninstall_harness.env["XDG_DATA_HOME"] = str(data_home)
+    posix_uninstall_harness.env["FAKE_UNAME"] = "Linux"
+    entry = data_home / "applications" / "free-claude-code.desktop"
+    icon = data_home / "icons" / "free-claude-code.png"
+    entry.parent.mkdir(parents=True)
+    icon.parent.mkdir(parents=True)
+    entry.write_text(f"{LINUX_DESKTOP_MARKER}\n[Desktop Entry]\n", encoding="utf-8")
+    icon.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = posix_uninstall_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert not entry.exists()
+    assert not icon.exists()
+
+
+def test_uninstall_sh_preserves_unowned_linux_desktop_entry(
+    posix_uninstall_harness,
+) -> None:
+    data_home = posix_uninstall_harness.home / ".local" / "share"
+    posix_uninstall_harness.env["XDG_DATA_HOME"] = str(data_home)
+    posix_uninstall_harness.env["FAKE_UNAME"] = "Linux"
+    entry = data_home / "applications" / "free-claude-code.desktop"
+    entry.parent.mkdir(parents=True)
+    entry.write_text("[Desktop Entry]\nName=User Custom\n", encoding="utf-8")
+
+    result = posix_uninstall_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert entry.read_text(encoding="utf-8") == "[Desktop Entry]\nName=User Custom\n"

--- a/tests/scripts/test_uninstallers.py
+++ b/tests/scripts/test_uninstallers.py
@@ -10,6 +10,7 @@ FCC_COMMANDS = (
     "fcc-desktop",
     "fcc-server",
     "fcc-claude",
+    "fcc-claude-desktop",
     "fcc-codex",
     "fcc-pi",
     "fcc-opencode",

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.19.0"
+version = "5.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.23.0"
+version = "5.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.21.0"
+version = "5.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.22.0"
+version = "5.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -620,9 +620,9 @@ dependencies = [
     { name = "loguru" },
     { name = "markdown-it-py" },
     { name = "openai" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pillow" },
     { name = "pydantic" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pystray" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "requests", extra = ["socks"] },
@@ -671,9 +671,9 @@ requires-dist = [
     { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "nvidia-riva-client", marker = "extra == 'voice'", specifier = ">=2.26.0" },
     { name = "openai", specifier = ">=3.2.0" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=12.0.0" },
+    { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=0.19.5" },
+    { name = "pystray", specifier = ">=0.19.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-telegram-bot", specifier = ">=22.8" },
     { name = "requests", extras = ["socks"], specifier = ">=2.34.2" },
@@ -1553,11 +1553,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
     { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
     { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
     { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
     { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
     { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
     { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
     { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
     { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
     { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
     { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
@@ -1566,11 +1574,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
     { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
     { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
     { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
     { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
     { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
     { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
     { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
@@ -1900,7 +1916,8 @@ version = "0.19.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
     { name = "six" },
 ]
 wheels = [
@@ -2031,6 +2048,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
+]
+
+[[package]]
+name = "python-xlib"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -449,6 +449,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -598,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.11"
+version = "5.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -612,9 +621,9 @@ dependencies = [
     { name = "loguru" },
     { name = "markdown-it-py" },
     { name = "openai" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pillow" },
     { name = "pydantic" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pystray" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "requests", extra = ["socks"] },
@@ -664,9 +673,9 @@ requires-dist = [
     { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "nvidia-riva-client", marker = "extra == 'voice'", specifier = ">=2.26.0" },
     { name = "openai", specifier = ">=3.2.0" },
-    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=12.0.0" },
+    { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
-    { name = "pystray", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=0.19.5" },
+    { name = "pystray", specifier = ">=0.19.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-telegram-bot", specifier = ">=22.8" },
     { name = "requests", extras = ["socks"], specifier = ">=2.34.2" },
@@ -1030,38 +1039,35 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.16.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
-    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
-    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
-    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
-    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
-    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
-    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
-    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
-    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
-    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
-    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
 ]
 
 [[package]]
@@ -1513,19 +1519,20 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "3.3.1"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "distro" },
     { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/9c/ba0c292b4032ede74c249ca314ad64eb1bb5a03a843f6e01facb02f80cd8/openai-3.3.1.tar.gz", hash = "sha256:6f22807de1a976c932cecda620e8172a8c3fdbaeed29c7f21564e0c2410edf56", size = 1282113, upload-time = "2026-08-19T16:31:35.006Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/6c/670271205379061112bf5ed900b78a68e21bf11733de829772c5322f92aa/openai-3.3.0.tar.gz", hash = "sha256:28f904a9fbff15288e9dd67bc0f7020d4f576d37786383a480db02fe5d8139d3", size = 1166178, upload-time = "2026-08-18T21:17:53.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/db/2b7a1b3de659bb82aef979116c74e809982b13e42c057759767552b5155f/openai-3.3.1-py3-none-any.whl", hash = "sha256:9652df7fdf8ee6f5bd58e0a12f2b1d414a18e0f06bb7a9a57c8643a5f5469bd3", size = 1690337, upload-time = "2026-08-19T16:31:32.812Z" },
+    { url = "https://files.pythonhosted.org/packages/82/83/d44980712bf51dddaca090cd772b3102e75377ddac877eaa4b2cb58d886a/openai-3.3.0-py3-none-any.whl", hash = "sha256:ded6b2112e6d299c7a2573ff6f165dc92fb64ceaa4d7daa42345f091157bd373", size = 1690265, upload-time = "2026-08-18T21:17:51.351Z" },
 ]
 
 [[package]]
@@ -1548,11 +1555,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
     { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
     { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
     { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
     { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
     { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
     { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
     { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
     { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
     { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
     { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
@@ -1561,11 +1576,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
     { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
     { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
     { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
     { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
     { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
     { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
     { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
@@ -1895,7 +1918,8 @@ version = "0.19.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
     { name = "six" },
 ]
 wheels = [
@@ -2026,6 +2050,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
+]
+
+[[package]]
+name = "python-xlib"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
 ]
 
 [[package]]
@@ -2260,27 +2296,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.4"
+version = "0.16.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
-    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
-    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
-    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
-    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]
@@ -2617,7 +2653,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.15.1"
+version = "5.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -2630,9 +2666,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/92/c50c61da7046bbb59a4d011291aeadcfb4d7980ab36fdb31e93823a3fb93/transformers-5.15.1.tar.gz", hash = "sha256:27c996bd9075ddc82d40f8590dfdc81ea45f611bfca477e0db5d7fd257a482f7", size = 9378434, upload-time = "2026-08-19T11:28:20.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/3f/d89353267d511e18f137dfd7769d07837350c11b88408ce1dfe2e93e56c7/transformers-5.15.0.tar.gz", hash = "sha256:bbf98f57b2ddd7c4ecbccfa2c0069017aa6fd01cc204bd50cbc0eeadcf2a13b8", size = 9377983, upload-time = "2026-08-10T10:27:23.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/c4/a12e1d9b387fb0c40a57116db82b457e8c771cb419163cda29204d74a595/transformers-5.15.1-py3-none-any.whl", hash = "sha256:b7cdf238ff583e3a58dbc7fa34da1aaf091ce063141f65a30538160bd5afe93f", size = 11749582, upload-time = "2026-08-19T11:28:16.726Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/43/81355710a4c84e9420e11a86d41a5364deb561f2ef36dfdf254a07371bbb/transformers-5.15.0-py3-none-any.whl", hash = "sha256:d7f007736f67749ae9490c4f8cb5d30b452ae2d68c8675e50ba8d63ea7feb107", size = 11749280, upload-time = "2026-08-10T10:27:20.416Z" },
 ]
 
 [[package]]
@@ -2657,27 +2693,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.74"
+version = "0.0.72"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/0f/c767853e88567a2ec7e996dd95e3105b1bc62c95d103689311ef0f4a603c/ty-0.0.74.tar.gz", hash = "sha256:da14344fc8625fc9ff359bafb856ad575636ea86d9bb6a629b146bff27b380e6", size = 6786318, upload-time = "2026-08-22T15:05:54.054Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/df/656e684bafb13c1d146e7d5b5f3e7978ca177232acc84998ff36427e9462/ty-0.0.72.tar.gz", hash = "sha256:ec2b8066b618df18cab4cb8e992f8da45d360332acb23fa34df7fa29cd1b9d3a", size = 6654939, upload-time = "2026-08-14T21:35:42.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/95/6ded58bc97885c6d88fa1f9cd815031489200738f961cbf0466663213f80/ty-0.0.74-py3-none-linux_armv6l.whl", hash = "sha256:8969ef4e508debf00cf58f9ea85a539f799b1732c59cdfcecd037630b9755b30", size = 12790043, upload-time = "2026-08-22T15:05:05.015Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/8a/5e323603b6ab8731144421877ee8a0f8ac5a5511e67857127caa09f6730e/ty-0.0.74-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51fb6cf5b98e1e1140825b2430943f78d744876a735231656eafbb4c3f7eca3c", size = 12371748, upload-time = "2026-08-22T15:05:08.609Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/44/ee72e08cb705281e8d8c42917dd577aa598a8a098008495fda5176ee3f6e/ty-0.0.74-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ebe60b1f0a948c793d6c77fc9e9ddda599e4f023c04ab16e8e03bcb428c3fa0", size = 12282403, upload-time = "2026-08-22T15:05:11.448Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b3/fd935b694ff68bc278af50f7ad04770b36ce6306399baef7e1847b553a9d/ty-0.0.74-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa97f407a695c890a53615966a663c7d2167e2cabe88db7ca1a24d62635cdfc8", size = 12345164, upload-time = "2026-08-22T15:05:14.19Z" },
-    { url = "https://files.pythonhosted.org/packages/54/5c/5b5825268e029ebb164c909780103dbbae367f069801410068bf1cef29b3/ty-0.0.74-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:673ddb733d4a0db31385ba1ed9ff1f6bd9dc5565413ce57b1ca5ac4c7803da5d", size = 12556646, upload-time = "2026-08-22T15:05:16.994Z" },
-    { url = "https://files.pythonhosted.org/packages/56/e7/515914e571d62ce0101744fed3f881936eeb1b30dc37beb72b4f7ca1e289/ty-0.0.74-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1028e7c6b4f6145e9704552f43a5fffdcd51b42263ffdcd9c9677762bc395a4a", size = 13311653, upload-time = "2026-08-22T15:05:20.254Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/07/d1452babb6f9266c2122cabc095180b70ed306fb770b2996753814d2237d/ty-0.0.74-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79841a8890493021fb308772474983316eb91f7b56cb227a6a05a06b262a36f0", size = 13768284, upload-time = "2026-08-22T15:05:23.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/60/8d4a2fc7842a47210a1cb0a16a187d9de39ad5d509a00fb74c1c073afcde/ty-0.0.74-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94859d321f3c6a6c8f7bfc3f40e8319cda7e6e012e613440f3dfd145d5010e2e", size = 13422306, upload-time = "2026-08-22T15:05:26.248Z" },
-    { url = "https://files.pythonhosted.org/packages/de/76/ebbc269a8c4efcc4d44624993bd188145f20d60ebda9680b15aaec42cc50/ty-0.0.74-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:970a8b2c09ff3be04c8a1c6767332d861be4fce85efe7bb205e4ade7c8655274", size = 12970637, upload-time = "2026-08-22T15:05:29.15Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/dd/b99f7236acbf856780ca1779a48143d2d9f2c24d7f531a0ce15a022b8a87/ty-0.0.74-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:795f763b3ded85574c2c2846a6fb8acf2aa76e9e83d761143e92b1f0c7ffa2cd", size = 13344891, upload-time = "2026-08-22T15:05:32.033Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/d7/9ff7449a4c7e6428f2c6f298e74cf24b70668f29d45c249507a723ff3782/ty-0.0.74-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dc086db5367d912c31c0cc872deb7387290e779a4b9b54fcb944673a7cd52c7b", size = 12395272, upload-time = "2026-08-22T15:05:34.702Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/dd/b23a5b6b35d37df89dc8dc5daa09efd9245a668b50c4c81c25de21567dc1/ty-0.0.74-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0314d7b391cf684e47c2fa093d2ce4c597cfc9b01d9a315fe204aed6359b271b", size = 12573079, upload-time = "2026-08-22T15:05:37.683Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c5/ccba16239d6129533c8b3603458d0f4dd2ba69478e47059073968e74261d/ty-0.0.74-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4a45dd2e991e8bdae82ba78c8cd051b253f60bc71a6536598fa3ef580b4fc9b", size = 12832506, upload-time = "2026-08-22T15:05:40.505Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/1c/2390912634dff4f341f97b397f2aee341ff062be0a66cda37d59375454f2/ty-0.0.74-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:210e2eac6b018fb934e2b8dac3956a0ba076a3fb1fa6f135058c825e5b759b81", size = 13154752, upload-time = "2026-08-22T15:05:43.355Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/33/a8c12188227e6f74f91853a7374e01ed81d6ad21c16c8b70e92dbebfe46a/ty-0.0.74-py3-none-win32.whl", hash = "sha256:db0bb6a8f098ef9bd1be861f73b4f7c0320d40d4c05c7ae0a8677d4e7aa4f6e5", size = 12130002, upload-time = "2026-08-22T15:05:46.058Z" },
-    { url = "https://files.pythonhosted.org/packages/21/5c/064f28ccb9c234cfce5a2f7aa69a256663d5ae5bb0290b3a9706cc4d1e4c/ty-0.0.74-py3-none-win_amd64.whl", hash = "sha256:bebff181515255b3c78bd2e7693ae66fab6064ad4feea2065c68bc01022aa678", size = 12771435, upload-time = "2026-08-22T15:05:48.811Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/06/d6becdaca0315346c26b6df97cb0eafa81de4f870945d6989e88704374ed/ty-0.0.74-py3-none-win_arm64.whl", hash = "sha256:1a3469eaaf8c85b1c0a15bede25d36daea4b09fce1d913e965b24e24b3f1d6c6", size = 12558299, upload-time = "2026-08-22T15:05:51.543Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3b/f51461239a4e66565d4b362f97a3b55fe7fdba2e944068341f87c62f6743/ty-0.0.72-py3-none-linux_armv6l.whl", hash = "sha256:fda86db153ffd85ee52000cf175d6a3f1c0223772cf7c5b6f726200bf92c7b44", size = 12621989, upload-time = "2026-08-14T21:35:01.676Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/79ddf683affc679ca856f3510b5640ec3a88a842ba5f654f5d4bc78f1786/ty-0.0.72-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ceb944c612529b9023acfdc9cf4c0dcbb722549f9d17d46baecd1141baf01d7f", size = 12233910, upload-time = "2026-08-14T21:35:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/45/10562a0d84802158db8fa4ec46de54aa9fdcecdeeaabbfe3639ae7042b66/ty-0.0.72-py3-none-macosx_11_0_arm64.whl", hash = "sha256:108d76218333d6c092e5f1cebf8e9b06f25738613a0236a28e2dd47c936ee52c", size = 12084108, upload-time = "2026-08-14T21:35:06.686Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/dc/1fe1aef8d697e3509face271a5331700c7aa1d1e44a4b622707bdfa41d4b/ty-0.0.72-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f3943f186f741a2499a31053872169250c9264a9a49684920e48d8fcf4ef4f5", size = 12132640, upload-time = "2026-08-14T21:35:09.305Z" },
+    { url = "https://files.pythonhosted.org/packages/14/46/41ceb265e96969487311a2014bd0e53abb4fbc1395efb2ebe411fcb4db62/ty-0.0.72-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf283c07dc3cc52ca48a3ad8ab100fb5aec3aebbd03ef6a12d5f910b8e596fc5", size = 12402489, upload-time = "2026-08-14T21:35:11.555Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/45/30bf43cb4fd505c5c2dd30fda27dde5f05208686cd21217adec77c954204/ty-0.0.72-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:95f3b6462c38f9f115d10cee21f47fedf715fcf2040daf36eef210359300bc7c", size = 13130835, upload-time = "2026-08-14T21:35:13.746Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2f/03bba754d2613f640df168335c41f83f41db150bb515839c60d80e3a7880/ty-0.0.72-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30caf658feb8ffb250d9e9e47107657a78f5f3425c227df1664d8df2ebe38880", size = 13590392, upload-time = "2026-08-14T21:35:16.839Z" },
+    { url = "https://files.pythonhosted.org/packages/04/c7/03c67f00e63005ec41585653dc3096064570b1e6273742baae2798cd242f/ty-0.0.72-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:27bdc012ddfbeec8948e4a6036c0dc39ac7cf2c8ec7c7d48dc7d2fd56d57b399", size = 13309629, upload-time = "2026-08-14T21:35:19.169Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/df/102d3b264eb7f2a58dd11952f229bb5150bb5668d176a6154976a6675981/ty-0.0.72-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:802c5970a77d7739e6f499921fbb6984fb7ad8a31d95e1ff42fd46f3642e4f3b", size = 12734028, upload-time = "2026-08-14T21:35:22.099Z" },
+    { url = "https://files.pythonhosted.org/packages/61/85/d0737c8c54d0ba67366ddfb9f31d88edf0b02299e65923e6945ae60ebcb5/ty-0.0.72-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:47dce65114fdc615c68ca0edb393b433df0956447e4267df0e264137a789598d", size = 13174832, upload-time = "2026-08-14T21:35:24.71Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/31/497f5a96c36d9b586ab6afe0574986835c6fd5b835a89773d2bec4711b49/ty-0.0.72-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:325144fa07e2675d0faa337fcc864213c272a499eb0cfe5bde2fdc62282d27bc", size = 12215005, upload-time = "2026-08-14T21:35:26.892Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7d/46e65b17b4966c7cd0140f134380d33d8e84fe6efccd761533ce793dc502/ty-0.0.72-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a5c9f15d0f58e43707d8848274be1821a0ef408eccb8aa7dda28a4a9eddf7640", size = 12421298, upload-time = "2026-08-14T21:35:29.301Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2a/12ada4ec17700b3cb1d4fd3bc3e5b1852df9e6885288429318cade87b3c1/ty-0.0.72-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ee508d64b381871529cc22c412b41071bf5e908b7aa5d66a38f3f6b2573a806", size = 12669242, upload-time = "2026-08-14T21:35:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/4692536880790fb550ed6d44a6096778dc71bb112f2c6d615cebb01a57e5/ty-0.0.72-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3699e2ec7921d44da79d6b089f7bf239b2cc53c4e45a5a38430adc34ee9e9a55", size = 12988199, upload-time = "2026-08-14T21:35:33.749Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0d/f5e5a50322e9c45865e7b7a428ba6cd6527387cf0f2472492ac3cf746243/ty-0.0.72-py3-none-win32.whl", hash = "sha256:f25f72a67bd36cd247707c4784e52fad0b6b4f42a1b7dd14804110fa95c486ed", size = 11939708, upload-time = "2026-08-14T21:35:36.006Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4e/8af3534b2e4214e6184a5a59c34101e94a68d578f081f97b995866bab1bf/ty-0.0.72-py3-none-win_amd64.whl", hash = "sha256:cdeee869341717e1736cea2e2d7856738c6957c320f584ed2f68c8f90100d2f5", size = 12643876, upload-time = "2026-08-14T21:35:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ea/a2606e654c7276bd08586391a2525b0af3f3bf60228a8c57b2d248f273f9/ty-0.0.72-py3-none-win_arm64.whl", hash = "sha256:1bd3ac3ed4424a6d6990a85dc388556aea012bd752de21349a84b685951de0d8", size = 12394857, upload-time = "2026-08-14T21:35:40.277Z" },
 ]
 
 [[package]]
@@ -2727,15 +2763,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.4"
+version = "0.52.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.20.0"
+version = "5.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Part 7 of 7 — splits the closed #1545 into reviewable pieces (≤750 lines each).
Each part is a separate PR against `main` and should be merged in order (after Part 6); until earlier parts merge, this diff against `main` also shows them.

## What this PR does

Wires the installer/uninstaller to the Claude Desktop routing layer and documents it.

- Registers `fcc-claude-desktop` and merges the FCC gateway block into `claude_desktop_config.json` at install time; reverses it on uninstall.
- On Linux, installs a `.desktop` launcher entry and trusts the active Caddy certificate in the per-user NSS database (Chromium/Electron) plus the system store — best-effort, never fatal.
- Documents the Linux Claude Desktop flow in the README.
- Removes a duplicate `Unconfigure-ClaudeDesktopApp` definition in `uninstall.ps1` (the second copy referenced an undefined helper and would break dry-run uninstall).

## Verification

- `ruff format --check`, `ruff check`, `ty check` clean
- Full pytest suite passes












































<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Claude Desktop routing through FCC, desktop-scoped model aliases, launcher and installer integration, reversible configuration handling, and opt-in local certificate trust.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted P0 or P1 finding remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I located the exact README excerpt used in the review (lines 356–365) and noted that the automatic-trust claim is described in lines 356–358.
- I examined the installer execution and confirmed there were no certutil, sudo, or update-ca-certificates invocations; the run ended with exit 0 and a message about skipping Claude Desktop certificate trust.
- I verified the opt-in control path by finding certutil -N and certutil -A invocations in the installer, showing NSS mutation is conditional rather than automatic.
- I found direct evidence in install\_claude\_desktop\_cert between lines 1251 and 1266 demonstrating the opt-in flow and that the implementation does not touch system trust unless opted in.
- I collected the uploaded artifacts (Python artifact and several installer logs) and used them to support the observations above.

<a href="https://app.greptile.com/trex/runs/21761342/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (22): Last reviewed commit: ["fix: release the probe icon&#39;s X11 displa..."](https://github.com/alishahryar1/free-claude-code/commit/2411966ec515d732385fb09f3b9cd4197a982d8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56608170)</sub>

<!-- /greptile_comment -->