### PR TITLE
test(scripts): scope installer harness PATH to host utilities

### DIFF
--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -27,6 +27,30 @@ FCC_COMMANDS = (
     "free-claude-code",
 )
 
+# Host utilities install.sh calls. Everything else on the host stays off the
+# harness PATH so real agent CLIs cannot satisfy the installer's checks.
+POSIX_SYSTEM_UTILITIES = (
+    "awk",
+    "bash",
+    "cat",
+    "chmod",
+    "cp",
+    "dirname",
+    "env",
+    "gzip",
+    "ln",
+    "mkdir",
+    "mktemp",
+    "mv",
+    "readlink",
+    "rm",
+    "sed",
+    "sh",
+    "sort",
+    "tar",
+    "tr",
+)
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
@@ -293,6 +317,20 @@ printf '%s\n' "$FCC_PS_OUTPUT"
         return self.log.read_text(encoding="utf-8").splitlines()
 
 
+def _link_system_utilities(bin_dir: Path) -> None:
+    """Expose only the host utilities install.sh needs.
+
+    Putting /usr/bin on the harness PATH would let a real agent CLI installed on
+    the host (dsh, cline, grok, ...) satisfy the installer's discovery checks and
+    shadow the fixtures, so the scenarios would assert against host state.
+    """
+    for name in POSIX_SYSTEM_UTILITIES:
+        resolved = shutil.which(name)
+        if resolved is None:
+            continue
+        (bin_dir / name).symlink_to(resolved)
+
+
 @pytest.fixture
 def posix_harness(tmp_path: Path) -> PosixHarness:
     if os.name == "nt":
@@ -513,10 +551,12 @@ printf '%s  %s\n' "$checksum" "$1"
 """,
     )
 
+    _link_system_utilities(bin_dir)
+
     env = os.environ.copy()
     env.update(
         {
-            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "PATH": str(bin_dir),
             "HOME": str(home),
             "CALL_LOG": str(log),
             "FAKE_FIXTURES": str(fixtures),


### PR DESCRIPTION
## [Files Changed]
- `tests/scripts/test_installers.py`

## [Logic Altered]
Харнесс POSIX-установки раньше клал `/usr/bin` на PATH, поэтому реальный агентский CLI, установленный на хосте (dsh, cline, grok, ...), мог удовлетворить проверки `install.sh` и затенять фейковые фикстуры — сценарии ассертили бы состояние хоста, а не фикстур. Теперь на PATH только host-утилиты, которые реально вызывает install.sh: добавлен `POSIX_SYSTEM_UTILITIES`, `_link_system_utilities()` создаёт симлинки в bin_dir, PATH указывает строго на bin_dir.

## [Verification Method]
`./scripts/ci.sh` локально: 99 passed / 86 skipped. Проверял сценарии install для posix-платформ.

## [Residual Risks]
none

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change isolates the POSIX installer test harness from software installed on the host by exposing only explicitly allowed system utilities and test fixtures through PATH. The complete installer suite passed with the isolated environment (`99 passed, 86 skipped`), including download, checksum, archive extraction, platform selection, filesystem setup, and process-discovery scenarios. A comparison with the earlier harness confirmed that its broader PATH could invoke a host-installed npm command; the updated harness prevents that host-state leakage. No reportable defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the affected installer scenarios run successfully with the new isolated PATH configuration.

The complete affected test suite passed, and comparison with the previous harness demonstrated that the change removes host-command discovery without breaking installer utility, download, checksum, archive, or platform paths.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the isolated PATH installer tests against the updated harness; the run completed with 99 passed, 86 skipped in 10.39s.
- Compared the results to the parent revision and observed a failure due to a host-installed npm command, demonstrating that the host-state dependency was removed by this change.
- Inspected the PATH allowlist and installer command sources to confirm fixtures provide the download, platform, checksum, and process-discovery commands excluded from the host utilities.
- Validated the exact before/after outcomes for the test\_installers.py suite; after-run exited 0 with 99 passed, 86 skipped, while the before-run path invoked host npm and failed with EACCES under /usr/lib/node\_modules/cline.

<a href="https://app.greptile.com/trex/runs/20628905/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(scripts): scope installer harness P..."](https://github.com/alishahryar1/free-claude-code/commit/45de42e30bfecb010d999c1b88e0b6f919718c5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56740608)</sub>

<!-- /greptile_comment -->