### PR TITLE
docs(env): document HOST/PORT and MAX_MESSAGE_LOG_ENTRIES_PER_CHAT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -234,7 +234,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # FCC_SMOKE_MODEL_GITHUB_MODELS=<provider/model-id>
 # FCC_SMOKE_MODEL_ZAI=<provider/model-id>
 # FCC_SMOKE_MODEL_ZAI_API=<provider/model-id>
-# FCC_SMOKE_MODEL_TOKENROUTER=<your-token>
+# FCC_SMOKE_MODEL_TOKENROUTER=<provider/model-id>
 # FCC_SMOKE_MODEL_NARAROUTE=<provider/model-id>
 # FCC_SMOKE_MODEL_POOLSIDE=<provider/model-id>
 # FCC_SMOKE_MODEL_LLM7=<provider/model-id>
@@ -346,6 +346,11 @@ PROXY_AUTH_ENABLED=false
 ANTHROPIC_AUTH_TOKEN="freecc"
 
 
+# Server listen address and port (defaults: 0.0.0.0:8082)
+# HOST=0.0.0.0
+# PORT=8082
+
+
 # Open /admin in the default browser when fcc-server becomes healthy (set 0/false/no to disable)
 FCC_OPEN_BROWSER=true
 
@@ -408,6 +413,8 @@ WEB_FETCH_ALLOW_PRIVATE_NETWORKS=false
 # Defaults to INFO. Use DEBUG temporarily for detailed request traces, or WARNING for quieter logs.
 # The file rotates at 50 MB and retains five rotated files (roughly 300 MB including the active file).
 LOG_LEVEL=INFO
+# Maximum number of log entries retained per chat in memory (default: no limit)
+# MAX_MESSAGE_LOG_ENTRIES_PER_CHAT=200
 #
 # Verbose diagnostics (avoid logging raw prompts / SSE bodies in production)
 DEBUG_PLATFORM_EDITS=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.14.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.14.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Documented three existing settings in `.env.example` that were missing from the sample:

- `HOST` / `PORT` (server listen address, defaults `0.0.0.0:8082`)
- `MAX_MESSAGE_LOG_ENTRIES_PER_CHAT` (log retention cap per chat)

Also fixed the `FCC_SMOKE_MODEL_TOKENROUTER` placeholder from `<your-token>` to `<provider/model-id>` to match all sibling `FCC_SMOKE_MODEL_*` entries.

## Verification
- `uv lock` — lockfile updated for the version bump only (no dependency changes)
- Version `5.14.7` → `5.14.8` (PATCH, production-file change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change documents server bind settings and the per-chat managed-message setting, updates the TokenRouter smoke-model placeholder, and synchronizes the 5.14.8 package version. The new description for `MAX_MESSAGE_LOG_ENTRIES_PER_CHAT` is misleading: it controls the managed-message ownership ledger, not general server-log or message-content retention.

<h3>Confidence Score: 4/5</h3>

The environment-variable description should be corrected before merge so operators understand which retained data the setting limits.

Focused execution showed that a cap of two retains only the newest managed message IDs while conversation records and ordinary server-log output remain unaffected.

**Files Needing Attention:** .env.example needs its `MAX_MESSAGE_LOG_ENTRIES_PER_CHAT` description corrected at lines 416-417.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P2 finding and linked it to the review comment.
- T-Rex produced a second proof for a different posted P2 finding.
- T-Rex summarized the general-contract-validation-proof, including how MAX\_MESSAGE\_LOG\_ENTRIES\_PER\_CHAT routes to the SessionStore with managed\_message\_cap, the cap-two probe results, and that the final status is inconclusive because the corrected runtime probe was not captured within the mandatory step limit.

<a href="https://app.greptile.com/trex/runs/20658704/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **MAX_MESSAGE_LOG_ENTRIES_PER_CHAT documentation describes the wrong retained data**

   - **Bug**
     - `.env.example:416-417` describes the setting as limiting in-memory log entries per chat. Focused implementation tracing shows it is passed solely as `managed_message_cap` and trims the per-chat managed platform-message ledger (message IDs plus metadata). It does not configure server logging, and conversation snapshots are persisted separately without this cap.
   - **Cause**
     - The sample-env comment retained an older/misleading “log entries” description while the setting is wired to `SessionStore`'s `ManagedMessageLog` ownership/ID tracking.
   - **Fix**
     - Replace the comment at `.env.example:416` with wording such as: `# Maximum managed platform message IDs retained per chat for ownership/cleanup tracking (default: no limit)`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs(env): document HOST/PORT and MAX\_ME..."](https://github.com/alishahryar1/free-claude-code/commit/909ab251de0ba04ebe81708d6701fb3891c39d31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56794868)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->