### PR TITLE
Refactor provider candidate execution lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.14.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -3,7 +3,7 @@
 import asyncio
 import math
 import sys
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Literal
 
 from loguru import logger
@@ -23,17 +23,21 @@ from free_claude_code.core.trace import (
 )
 
 from .ports import ProviderResolver
-from .routing import ProviderModelTarget, RoutedMessagesRequest
+from .routing import ProviderModelTarget, ResolvedModelRoute, RoutedMessagesRequest
 
 TokenCounter = Callable[
     [list[Message], str | list[SystemContent] | None, list[Tool] | None],
     int,
 ]
 WireApi = Literal["messages", "responses"]
+type CandidateStreamResult = AsyncIterator[str] | ExecutionFailure
+type CandidateStreamFactory = Callable[
+    [ProviderModelTarget], Awaitable[CandidateStreamResult]
+]
 
 
 class ProviderExecutor:
-    """Resolve a provider and execute one routed Anthropic Messages stream."""
+    """Execute routed provider candidates with shared application lifecycle."""
 
     def __init__(
         self,
@@ -157,7 +161,6 @@ class ProviderExecutor:
             primary_request,
             reasoning=routed.reasoning,
         )
-        candidates = (primary, *routed.resolved.fallbacks)
 
         gateway_model = routed.resolved.original_model
         route_trace: dict[str, object] = {
@@ -208,43 +211,102 @@ class ProviderExecutor:
             routed.request.tools,
         )
 
-        async def provider_body() -> AsyncIterator[str]:
+        async def open_candidate(target: ProviderModelTarget) -> CandidateStreamResult:
+            provider = (
+                primary_provider
+                if target is primary
+                else self._provider_resolver(target.provider_id)
+            )
+            candidate_request = (
+                primary_request
+                if target is primary
+                else routed.request.model_copy(
+                    update={"model": target.provider_model},
+                    deep=True,
+                )
+            )
+            if target is not primary:
+                provider.preflight_stream(
+                    candidate_request,
+                    reasoning=routed.reasoning,
+                )
+            try:
+                return provider.stream_response(
+                    candidate_request,
+                    input_tokens=input_tokens,
+                    request_id=request_id,
+                    response_model=gateway_model,
+                    reasoning=routed.reasoning,
+                )
+            except ExecutionFailure as failure:
+                return failure
+
+        return self.stream_candidates(
+            routed.resolved,
+            wire_api=wire_api,
+            request_id=request_id,
+            open_candidate=open_candidate,
+        )
+
+    def stream_candidates(
+        self,
+        resolved: ResolvedModelRoute,
+        *,
+        wire_api: WireApi,
+        request_id: str,
+        open_candidate: CandidateStreamFactory,
+    ) -> AsyncIterator[str]:
+        """Execute ordered candidates without owning their wire protocol.
+
+        The callback owns resources until it returns an iterator. The executor
+        owns and closes every returned iterator. Returning an ExecutionFailure
+        makes that failure fallback-eligible; raising remains terminal.
+        """
+        candidates = (resolved.primary, *resolved.fallbacks)
+
+        async def candidate_body() -> AsyncIterator[str]:
             loop = asyncio.get_running_loop()
             progress_deadline = loop.time() + self._progress_timeout_seconds
             for index, target in enumerate(candidates):
-                provider = (
-                    primary_provider
-                    if index == 0
-                    else self._provider_resolver(target.provider_id)
-                )
-                candidate_request = (
-                    primary_request
-                    if index == 0
-                    else routed.request.model_copy(
-                        update={"model": target.provider_model},
-                        deep=True,
-                    )
-                )
-                if index > 0:
-                    provider.preflight_stream(
-                        candidate_request,
-                        reasoning=routed.reasoning,
-                    )
-
                 provider_stream: AsyncIterator[str] | None = None
                 candidate_committed = False
                 candidate_failure: ExecutionFailure | None = None
                 try:
-                    try:
-                        provider_stream = provider.stream_response(
-                            candidate_request,
-                            input_tokens=input_tokens,
+                    if loop.time() >= progress_deadline:
+                        raise self._progress_timeout_failure(
                             request_id=request_id,
-                            response_model=gateway_model,
-                            reasoning=routed.reasoning,
+                            provider_id=target.provider_id,
                         )
-                    except ExecutionFailure as failure:
-                        candidate_failure = failure
+                    open_timeout = asyncio.timeout_at(progress_deadline)
+                    try:
+                        async with open_timeout:
+                            opened_candidate = await open_candidate(target)
+                    except TimeoutError as exc:
+                        if (
+                            not open_timeout.expired()
+                            and loop.time() < progress_deadline
+                        ):
+                            raise
+                        raise self._progress_timeout_failure(
+                            request_id=request_id,
+                            provider_id=target.provider_id,
+                        ) from exc
+                    except Exception as exc:
+                        if loop.time() < progress_deadline:
+                            raise
+                        raise self._progress_timeout_failure(
+                            request_id=request_id,
+                            provider_id=target.provider_id,
+                        ) from exc
+                    if isinstance(opened_candidate, ExecutionFailure):
+                        candidate_failure = opened_candidate
+                    else:
+                        provider_stream = opened_candidate
+                    if open_timeout.expired() or loop.time() >= progress_deadline:
+                        raise self._progress_timeout_failure(
+                            request_id=request_id,
+                            provider_id=target.provider_id,
+                        )
 
                     if provider_stream is None and candidate_failure is None:
                         raise TypeError(
@@ -336,14 +398,14 @@ class ProviderExecutor:
 
         stream_trace: dict[str, object] = {
             "request_id": request_id,
-            "initial_provider_id": primary.provider_id,
-            "gateway_model": gateway_model,
+            "initial_provider_id": resolved.primary.provider_id,
+            "gateway_model": resolved.original_model,
         }
         if self._generation_id is not None:
             stream_trace["generation_id"] = self._generation_id
 
         return traced_async_stream(
-            provider_body(),
+            candidate_body(),
             stage="egress",
             source="api",
             complete_event=(

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -3,7 +3,7 @@
 import asyncio
 import math
 import sys
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Callable
 from typing import Literal
 
 from loguru import logger
@@ -31,9 +31,7 @@ TokenCounter = Callable[
 ]
 WireApi = Literal["messages", "responses"]
 type CandidateStreamResult = AsyncIterator[str] | ExecutionFailure
-type CandidateStreamFactory = Callable[
-    [ProviderModelTarget], Awaitable[CandidateStreamResult]
-]
+type CandidateStreamFactory = Callable[[ProviderModelTarget], CandidateStreamResult]
 
 
 class ProviderExecutor:
@@ -211,7 +209,7 @@ class ProviderExecutor:
             routed.request.tools,
         )
 
-        async def open_candidate(target: ProviderModelTarget) -> CandidateStreamResult:
+        def open_candidate(target: ProviderModelTarget) -> CandidateStreamResult:
             provider = (
                 primary_provider
                 if target is primary
@@ -258,9 +256,10 @@ class ProviderExecutor:
     ) -> AsyncIterator[str]:
         """Execute ordered candidates without owning their wire protocol.
 
-        The callback owns resources until it returns an iterator. The executor
-        owns and closes every returned iterator. Returning an ExecutionFailure
-        makes that failure fallback-eligible; raising remains terminal.
+        The synchronous callback owns resources until it returns an iterator.
+        The executor owns and closes every returned iterator. Returning an
+        ExecutionFailure makes that failure fallback-eligible; raising remains
+        terminal.
         """
         candidates = (resolved.primary, *resolved.fallbacks)
 
@@ -272,41 +271,11 @@ class ProviderExecutor:
                 candidate_committed = False
                 candidate_failure: ExecutionFailure | None = None
                 try:
-                    if loop.time() >= progress_deadline:
-                        raise self._progress_timeout_failure(
-                            request_id=request_id,
-                            provider_id=target.provider_id,
-                        )
-                    open_timeout = asyncio.timeout_at(progress_deadline)
-                    try:
-                        async with open_timeout:
-                            opened_candidate = await open_candidate(target)
-                    except TimeoutError as exc:
-                        if (
-                            not open_timeout.expired()
-                            and loop.time() < progress_deadline
-                        ):
-                            raise
-                        raise self._progress_timeout_failure(
-                            request_id=request_id,
-                            provider_id=target.provider_id,
-                        ) from exc
-                    except Exception as exc:
-                        if loop.time() < progress_deadline:
-                            raise
-                        raise self._progress_timeout_failure(
-                            request_id=request_id,
-                            provider_id=target.provider_id,
-                        ) from exc
+                    opened_candidate = open_candidate(target)
                     if isinstance(opened_candidate, ExecutionFailure):
                         candidate_failure = opened_candidate
                     else:
                         provider_stream = opened_candidate
-                    if open_timeout.expired() or loop.time() >= progress_deadline:
-                        raise self._progress_timeout_failure(
-                            request_id=request_id,
-                            provider_id=target.provider_id,
-                        )
 
                     if provider_stream is None and candidate_failure is None:
                         raise TypeError(

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -1,7 +1,6 @@
 """Application-owned provider execution contracts."""
 
 import asyncio
-import time
 from collections.abc import AsyncIterator
 from unittest.mock import MagicMock, patch
 
@@ -331,7 +330,7 @@ async def test_candidate_execution_seam_needs_no_messages_or_provider_resolver()
         finally:
             closed.append(fallback.provider_model_ref)
 
-    async def open_candidate(target: ProviderModelTarget) -> AsyncIterator[str]:
+    def open_candidate(target: ProviderModelTarget) -> AsyncIterator[str]:
         opened.append(target.provider_model_ref)
         if target == primary:
             return primary_stream()
@@ -360,157 +359,6 @@ async def test_candidate_execution_seam_needs_no_messages_or_provider_resolver()
         "primary/primary-model",
         "fallback/fallback-model",
     ]
-
-
-@pytest.mark.asyncio
-async def test_candidate_opening_obeys_request_progress_deadline() -> None:
-    primary = _target("primary", "primary-model")
-    fallback = _target("fallback", "fallback-model")
-    resolved = ResolvedModelRoute(
-        original_model="gateway-model",
-        primary=primary,
-        fallbacks=(fallback,),
-        reasoning_preference=ReasoningPreference.CLIENT,
-    )
-    opened: list[str] = []
-    never_ready = asyncio.Event()
-
-    async def open_candidate(target: ProviderModelTarget) -> AsyncIterator[str]:
-        opened.append(target.provider_model_ref)
-        await never_ready.wait()
-        raise AssertionError("candidate opening unexpectedly resumed")
-
-    executor = ProviderExecutor(
-        lambda _provider_id: FakeProvider(),
-        progress_timeout_seconds=0.02,
-    )
-    stream = executor.stream_candidates(
-        resolved,
-        wire_api="responses",
-        request_id="req_candidate_open_timeout",
-        open_candidate=open_candidate,
-    )
-
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await asyncio.wait_for(anext(stream), timeout=0.2)
-
-    assert exc_info.value.kind is FailureKind.TIMEOUT
-    assert exc_info.value.status_code == 504
-    assert opened == ["primary/primary-model"]
-
-
-@pytest.mark.asyncio
-async def test_candidate_opening_overrun_maps_failure_to_current_timeout() -> None:
-    primary = _target("primary", "primary-model")
-    resolved = ResolvedModelRoute(
-        original_model="gateway-model",
-        primary=primary,
-        fallbacks=(),
-        reasoning_preference=ReasoningPreference.CLIENT,
-    )
-    provider_failure = _execution_failure("late provider failure")
-
-    async def open_candidate(_target: ProviderModelTarget) -> AsyncIterator[str]:
-        time.sleep(0.03)
-        raise provider_failure
-
-    executor = ProviderExecutor(
-        lambda _provider_id: FakeProvider(),
-        progress_timeout_seconds=0.01,
-    )
-    stream = executor.stream_candidates(
-        resolved,
-        wire_api="responses",
-        request_id="req_candidate_open_overrun",
-        open_candidate=open_candidate,
-    )
-
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await anext(stream)
-
-    assert exc_info.value.kind is FailureKind.TIMEOUT
-    assert exc_info.value.status_code == 504
-
-
-@pytest.mark.asyncio
-async def test_candidate_opening_overrun_closes_returned_stream_once() -> None:
-    primary = _target("primary", "primary-model")
-    resolved = ResolvedModelRoute(
-        original_model="gateway-model",
-        primary=primary,
-        fallbacks=(),
-        reasoning_preference=ReasoningPreference.CLIENT,
-    )
-    returned_stream = CloseControlledProvider(_execution_failure("unused"))
-
-    async def open_candidate(_target: ProviderModelTarget) -> AsyncIterator[str]:
-        time.sleep(0.03)
-        return returned_stream
-
-    executor = ProviderExecutor(
-        lambda _provider_id: FakeProvider(),
-        progress_timeout_seconds=0.01,
-    )
-    stream = executor.stream_candidates(
-        resolved,
-        wire_api="responses",
-        request_id="req_candidate_open_stream_overrun",
-        open_candidate=open_candidate,
-    )
-
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await anext(stream)
-
-    assert exc_info.value.kind is FailureKind.TIMEOUT
-    assert returned_stream.stream_close_calls == 1
-
-
-@pytest.mark.asyncio
-async def test_candidate_opening_propagates_external_cancellation() -> None:
-    primary = _target("primary", "primary-model")
-    fallback = _target("fallback", "fallback-model")
-    resolved = ResolvedModelRoute(
-        original_model="gateway-model",
-        primary=primary,
-        fallbacks=(fallback,),
-        reasoning_preference=ReasoningPreference.CLIENT,
-    )
-    opened: list[str] = []
-    opening_started = asyncio.Event()
-    opening_unwound = asyncio.Event()
-
-    async def open_candidate(target: ProviderModelTarget) -> AsyncIterator[str]:
-        opened.append(target.provider_model_ref)
-        try:
-            opening_started.set()
-            await asyncio.Event().wait()
-        finally:
-            opening_unwound.set()
-        raise AssertionError("candidate opening unexpectedly resumed")
-
-    executor = ProviderExecutor(
-        lambda _provider_id: FakeProvider(),
-        progress_timeout_seconds=60.0,
-    )
-    stream = executor.stream_candidates(
-        resolved,
-        wire_api="responses",
-        request_id="req_candidate_open_cancelled",
-        open_candidate=open_candidate,
-    )
-
-    async def read_first_chunk() -> str:
-        return await anext(stream)
-
-    read_task = asyncio.create_task(read_first_chunk())
-    await opening_started.wait()
-
-    read_task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await read_task
-
-    assert opening_unwound.is_set()
-    assert opened == ["primary/primary-model"]
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -1,6 +1,7 @@
 """Application-owned provider execution contracts."""
 
 import asyncio
+import time
 from collections.abc import AsyncIterator
 from unittest.mock import MagicMock, patch
 
@@ -145,6 +146,21 @@ class FailingPreflightProvider(FakeProvider):
         raise ValueError("invalid provider request")
 
 
+class ExecutionFailurePreflightProvider(FakeProvider):
+    def __init__(self, failure: ExecutionFailure) -> None:
+        super().__init__()
+        self._failure = failure
+
+    def preflight_stream(
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
+    ) -> None:
+        del request, reasoning
+        raise self._failure
+
+
 class ApplicationErrorPreflightProvider(FakeProvider):
     def __init__(self, error: InvalidRequestError) -> None:
         super().__init__()
@@ -284,6 +300,217 @@ def _executor_stream(
         raw_log_payload={},
         request_id=request_id,
     )
+
+
+@pytest.mark.asyncio
+async def test_candidate_execution_seam_needs_no_messages_or_provider_resolver() -> (
+    None
+):
+    primary = _target("primary", "primary-model")
+    fallback = _target("fallback", "fallback-model")
+    resolved = ResolvedModelRoute(
+        original_model="gateway-model",
+        primary=primary,
+        fallbacks=(fallback,),
+        reasoning_preference=ReasoningPreference.CLIENT,
+    )
+    opened: list[str] = []
+    closed: list[str] = []
+    primary_failure = _execution_failure("primary failed")
+
+    async def primary_stream() -> AsyncIterator[str]:
+        try:
+            raise primary_failure
+            yield
+        finally:
+            closed.append(primary.provider_model_ref)
+
+    async def fallback_stream() -> AsyncIterator[str]:
+        try:
+            yield "fallback-frame"
+        finally:
+            closed.append(fallback.provider_model_ref)
+
+    async def open_candidate(target: ProviderModelTarget) -> AsyncIterator[str]:
+        opened.append(target.provider_model_ref)
+        if target == primary:
+            return primary_stream()
+        return fallback_stream()
+
+    def unexpected_provider_resolution(_provider_id: str) -> FakeProvider:
+        raise AssertionError("protocol-neutral execution must not resolve providers")
+
+    executor = ProviderExecutor(
+        unexpected_provider_resolution,
+        progress_timeout_seconds=60.0,
+    )
+    stream = executor.stream_candidates(
+        resolved,
+        wire_api="responses",
+        request_id="req_protocol_neutral",
+        open_candidate=open_candidate,
+    )
+
+    assert [chunk async for chunk in stream] == ["fallback-frame"]
+    assert opened == [
+        "primary/primary-model",
+        "fallback/fallback-model",
+    ]
+    assert closed == [
+        "primary/primary-model",
+        "fallback/fallback-model",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_candidate_opening_obeys_request_progress_deadline() -> None:
+    primary = _target("primary", "primary-model")
+    fallback = _target("fallback", "fallback-model")
+    resolved = ResolvedModelRoute(
+        original_model="gateway-model",
+        primary=primary,
+        fallbacks=(fallback,),
+        reasoning_preference=ReasoningPreference.CLIENT,
+    )
+    opened: list[str] = []
+    never_ready = asyncio.Event()
+
+    async def open_candidate(target: ProviderModelTarget) -> AsyncIterator[str]:
+        opened.append(target.provider_model_ref)
+        await never_ready.wait()
+        raise AssertionError("candidate opening unexpectedly resumed")
+
+    executor = ProviderExecutor(
+        lambda _provider_id: FakeProvider(),
+        progress_timeout_seconds=0.02,
+    )
+    stream = executor.stream_candidates(
+        resolved,
+        wire_api="responses",
+        request_id="req_candidate_open_timeout",
+        open_candidate=open_candidate,
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await asyncio.wait_for(anext(stream), timeout=0.2)
+
+    assert exc_info.value.kind is FailureKind.TIMEOUT
+    assert exc_info.value.status_code == 504
+    assert opened == ["primary/primary-model"]
+
+
+@pytest.mark.asyncio
+async def test_candidate_opening_overrun_maps_failure_to_current_timeout() -> None:
+    primary = _target("primary", "primary-model")
+    resolved = ResolvedModelRoute(
+        original_model="gateway-model",
+        primary=primary,
+        fallbacks=(),
+        reasoning_preference=ReasoningPreference.CLIENT,
+    )
+    provider_failure = _execution_failure("late provider failure")
+
+    async def open_candidate(_target: ProviderModelTarget) -> AsyncIterator[str]:
+        time.sleep(0.03)
+        raise provider_failure
+
+    executor = ProviderExecutor(
+        lambda _provider_id: FakeProvider(),
+        progress_timeout_seconds=0.01,
+    )
+    stream = executor.stream_candidates(
+        resolved,
+        wire_api="responses",
+        request_id="req_candidate_open_overrun",
+        open_candidate=open_candidate,
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await anext(stream)
+
+    assert exc_info.value.kind is FailureKind.TIMEOUT
+    assert exc_info.value.status_code == 504
+
+
+@pytest.mark.asyncio
+async def test_candidate_opening_overrun_closes_returned_stream_once() -> None:
+    primary = _target("primary", "primary-model")
+    resolved = ResolvedModelRoute(
+        original_model="gateway-model",
+        primary=primary,
+        fallbacks=(),
+        reasoning_preference=ReasoningPreference.CLIENT,
+    )
+    returned_stream = CloseControlledProvider(_execution_failure("unused"))
+
+    async def open_candidate(_target: ProviderModelTarget) -> AsyncIterator[str]:
+        time.sleep(0.03)
+        return returned_stream
+
+    executor = ProviderExecutor(
+        lambda _provider_id: FakeProvider(),
+        progress_timeout_seconds=0.01,
+    )
+    stream = executor.stream_candidates(
+        resolved,
+        wire_api="responses",
+        request_id="req_candidate_open_stream_overrun",
+        open_candidate=open_candidate,
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await anext(stream)
+
+    assert exc_info.value.kind is FailureKind.TIMEOUT
+    assert returned_stream.stream_close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_candidate_opening_propagates_external_cancellation() -> None:
+    primary = _target("primary", "primary-model")
+    fallback = _target("fallback", "fallback-model")
+    resolved = ResolvedModelRoute(
+        original_model="gateway-model",
+        primary=primary,
+        fallbacks=(fallback,),
+        reasoning_preference=ReasoningPreference.CLIENT,
+    )
+    opened: list[str] = []
+    opening_started = asyncio.Event()
+    opening_unwound = asyncio.Event()
+
+    async def open_candidate(target: ProviderModelTarget) -> AsyncIterator[str]:
+        opened.append(target.provider_model_ref)
+        try:
+            opening_started.set()
+            await asyncio.Event().wait()
+        finally:
+            opening_unwound.set()
+        raise AssertionError("candidate opening unexpectedly resumed")
+
+    executor = ProviderExecutor(
+        lambda _provider_id: FakeProvider(),
+        progress_timeout_seconds=60.0,
+    )
+    stream = executor.stream_candidates(
+        resolved,
+        wire_api="responses",
+        request_id="req_candidate_open_cancelled",
+        open_candidate=open_candidate,
+    )
+
+    async def read_first_chunk() -> str:
+        return await anext(stream)
+
+    read_task = asyncio.create_task(read_first_chunk())
+    await opening_started.wait()
+
+    read_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await read_task
+
+    assert opening_unwound.is_set()
+    assert opened == ["primary/primary-model"]
 
 
 @pytest.mark.asyncio
@@ -431,6 +658,43 @@ async def test_retryable_preframe_failure_selects_fallback_after_closing_primary
     )
     assert selected["selected_provider_model_ref"] == "fallback/fallback-model"
     assert selected["candidate_index"] == 2
+
+
+@pytest.mark.asyncio
+async def test_fallback_preflight_failure_remains_terminal() -> None:
+    primary = ControlledProvider([_execution_failure("primary failed")])
+    preflight_failure = _execution_failure("fallback preflight failed")
+    second = ExecutionFailurePreflightProvider(preflight_failure)
+    third = ControlledProvider(["unexpected-third-frame"])
+    resolved_ids: list[str] = []
+
+    def resolve(provider_id: str) -> FakeProvider:
+        resolved_ids.append(provider_id)
+        return {
+            "provider": primary,
+            "second": second,
+            "third": third,
+        }[provider_id]
+
+    executor = ProviderExecutor(resolve, progress_timeout_seconds=60.0)
+    stream = executor.stream(
+        _routed_request(
+            _target("second", "second-model"),
+            _target("third", "third-model"),
+        ),
+        wire_api="messages",
+        raw_log_label="FULL_PAYLOAD",
+        raw_log_payload={},
+        request_id="req_fallback_preflight_failure",
+    )
+
+    with pytest.raises(ExecutionFailure) as exc_info:
+        await anext(stream)
+
+    assert exc_info.value is preflight_failure
+    assert resolved_ids == ["provider", "second"]
+    assert third.preflight_calls == []
+    assert third.stream_calls == []
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.14.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The ordered fallback, progress deadline, commitment, and stream-cleanup loop is coupled to Anthropic Messages preparation. That prevents later protocol-specific route adapters from reusing the proven application lifecycle without translating through Messages.

## Changes

| Before | After |
| --- | --- |
| Candidate iteration resolves providers and builds Messages requests inline. | Messages preparation supplies an asynchronous candidate callback to a protocol-neutral executor. |
| Opening work sat outside an explicit deadline contract. | Candidate opening shares the request-wide progress deadline and canonical timeout mapping. |
| Fallback eligibility and stream ownership were implicit in exception placement. | Returned `ExecutionFailure` values are fallback-eligible; raised preparation errors remain terminal; returned iterators are closed exactly once. |
| Version `5.14.7`. | Patch version `5.14.8` with the lockfile synchronized. |



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The refactor centralizes ordered provider stream opening, fallback handling, tracing, and iterator cleanup. A synchronous provider opener can still hold the event loop past the configured progress deadline, delaying timeout handling and request recovery.
</details>


<h3>Confidence Score: 4/5</h3>

The change is not ready to merge until provider stream opening is bounded without blocking the event loop.

The configured progress deadline does not interrupt synchronous work performed while opening a provider stream, so a stalled opener delays the request for its full blocking duration.

**Files Needing Attention:** src/free_claude_code/application/execution.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the posted P1 finding by reviewing the finding-comment-proof and the accompanying reproduction script.
- Validated the second posted P1 finding by reviewing its finding-comment-proof; this proof has no artifacts attached.
- Validated the general contract behavior by reviewing timing evidence, the blocking-candidate-open reproduction scripts, and the timing log that demonstrates the timeout is delivered after the synchronous block.

<a href="https://app.greptile.com/trex/runs/20729367/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (2)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Candidate-opening progress timeout cannot interrupt synchronous event-loop blocking**

   - **Bug**
     - `stream_candidates` wraps `await open_candidate(target)` in `asyncio.timeout_at`, but a callback that invokes synchronous work such as `time.sleep`, a blocking provider resolver, or a blocking preflight holds the event loop and prevents asyncio's cancellation timer from running. The request therefore remains blocked until that work returns; only then does the post-open expiration check convert the result to a 504 timeout.
   - **Cause**
     - At `src/free_claude_code/application/execution.py:280-305`, the timeout context requires the event loop to run in order to deliver cancellation. The callback is permitted to execute synchronous work before its first suspension point, so the deadline cannot execute during that work. The post-return test at line 305 detects an overrun but cannot bound it.
   - **Fix**
     - Do not claim this is a hard candidate-opening deadline unless opening is guaranteed non-blocking. Move synchronous resolver/preflight/opening work off the event loop (for example, explicitly model synchronous opening and use `asyncio.to_thread` where safe), or enforce provider-side synchronous connect/read deadlines and document that asyncio progress timeouts only apply at awaitable yield points. Add a wall-clock regression test using a blocking callback and an independently observed deadline, rather than only asserting the eventual 504 type.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Progress timeout does not bound synchronous candidate opening**

   - **Bug**
     - A provider candidate opener that blocks synchronously for 150 ms delays the async consumer for the full 150 ms despite a configured 25 ms progress timeout. The timeout failure is raised only after the opener returns.
   - **Cause**
     - `stream_candidates` directly calls synchronous `open_candidate(target)` at `src/free_claude_code/application/execution.py:274`; its deadline check and `asyncio.timeout_at` scope protect only `anext(provider_stream)` beginning at lines 285 and 290.
   - **Fix**
     - Ensure potentially blocking candidate opening is non-blocking or move it to a cancellable worker boundary with a separately enforced opening timeout; alternatively make the provider-opening interface async and require implementations not to block the event loop.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: preserve synchronous candidate open..."](https://github.com/alishahryar1/free-claude-code/commit/3da94ab0617e8545648aa7fb5b5d6dec94e53d4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56919444)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->