### PR TITLE
Keep Chat tool-call IDs conversation-unique

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.14.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/anthropic/streaming/ledger.py
+++ b/src/free_claude_code/core/anthropic/streaming/ledger.py
@@ -80,11 +80,6 @@ class StreamBlockLedger:
             )
         return self.tool_states[index]
 
-    def set_stream_tool_id(self, index: int, tool_id: str | None) -> None:
-        if not tool_id:
-            return
-        self.ensure_tool_state(index).tool_id = str(tool_id)
-
     def set_tool_extra_content(
         self, index: int, extra_content: dict[str, Any] | None
     ) -> None:

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -71,6 +71,7 @@ from .profiles import OpenAIChatProfile
 from .reasoning_details import StructuredReasoningStream
 from .request_policy import build_openai_chat_request_body
 from .tool_calls import (
+    CompletedOpenAIToolCall,
     OpenAIToolCallAssembler,
     OpenAIToolCallCollector,
     all_emitted_tools_complete,
@@ -94,7 +95,7 @@ _ExtraReasoningEvents = Callable[[Any, AnthropicStreamLedger], Iterator[str]]
 class _CollectedRecoveryOutput:
     text: str
     thinking: str
-    tool_calls: tuple[dict[str, Any], ...]
+    tool_calls: tuple[CompletedOpenAIToolCall, ...]
 
 
 def _iter_visible_text_events(
@@ -231,7 +232,9 @@ class _OpenAIChatStreamAssembler:
     def tool_argument_alias_buffers(self) -> Mapping[int, str]:
         return self._tool_argument_alias_buffers
 
-    def recovered_tool_call_events(self, tool_call: dict[str, Any]) -> Iterator[str]:
+    def recovered_tool_call_events(
+        self, tool_call: CompletedOpenAIToolCall
+    ) -> Iterator[str]:
         """Emit one buffered recovery call through this attempt's ID scope."""
         yield from self._tool_calls.process_tool_call(tool_call, self._ledger)
 

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -231,6 +231,10 @@ class _OpenAIChatStreamAssembler:
     def tool_argument_alias_buffers(self) -> Mapping[int, str]:
         return self._tool_argument_alias_buffers
 
+    def recovered_tool_call_events(self, tool_call: dict[str, Any]) -> Iterator[str]:
+        """Emit one buffered recovery call through this attempt's ID scope."""
+        yield from self._tool_calls.process_tool_call(tool_call, self._ledger)
+
     def start_events(self) -> Iterator[str]:
         if self._started:
             return
@@ -806,9 +810,6 @@ class _OpenAIChatStreamRunner:
         self._reasoning = reasoning
         self._tool_names = OpenAIToolNameCodec.from_request(request)
         self._message_id = f"msg_{uuid.uuid4()}"
-        self._tool_calls = OpenAIToolCallAssembler(
-            record_extra_content=provider._record_tool_call_extra_content
-        )
 
     async def run(self) -> AsyncIterator[str]:
         """Convert the upstream OpenAI-chat stream into Anthropic SSE."""
@@ -1009,7 +1010,7 @@ class _OpenAIChatStreamRunner:
             try:
                 recovery_events = await self._recovery_events(
                     body=body,
-                    ledger=assembler.ledger,
+                    assembler=assembler,
                     error=error,
                     tool_argument_alias_buffers=(assembler.tool_argument_alias_buffers),
                     output_reasoning=self._reasoning.output_enabled,
@@ -1188,13 +1189,14 @@ class _OpenAIChatStreamRunner:
         self,
         *,
         body: dict[str, Any],
-        ledger: AnthropicStreamLedger,
+        assembler: _OpenAIChatStreamAssembler,
         error: Exception,
         tool_argument_alias_buffers: Mapping[int, str],
         output_reasoning: bool,
         execution: ProviderExecution,
     ) -> list[str] | None:
         """Build terminal recovery events when the interrupted stream permits it."""
+        ledger = assembler.ledger
         if ledger.has_emitted_tool_block():
             if not all_emitted_tools_complete(ledger, self._request):
                 repair_events = await self._repair_tool_args(
@@ -1260,7 +1262,7 @@ class _OpenAIChatStreamRunner:
         if recovered.tool_calls:
             events.extend(ledger.close_content_blocks())
             for tool_call in recovered.tool_calls:
-                events.extend(self._tool_calls.process_tool_call(tool_call, ledger))
+                events.extend(assembler.recovered_tool_call_events(tool_call))
         if not events:
             return None
         events.extend(ledger.close_all_blocks())
@@ -1374,6 +1376,9 @@ class _OpenAIChatStreamRunner:
             provider_name=self._provider._provider_name,
             output_reasoning=output_reasoning,
             tool_names=self._tool_names,
-            tool_calls=self._tool_calls,
+            tool_calls=OpenAIToolCallAssembler(
+                request=self._request,
+                record_extra_content=self._provider._record_tool_call_extra_content,
+            ),
             extra_reasoning_events=extra_reasoning_events,
         )

--- a/src/free_claude_code/providers/openai_chat/tool_calls.py
+++ b/src/free_claude_code/providers/openai_chat/tool_calls.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from free_claude_code.core.anthropic import OpenAIToolNameCodec
-from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.models import (
+    ContentBlockToolUse,
+    MessagesRequest,
+)
 from free_claude_code.core.anthropic.streaming import (
     AnthropicStreamLedger,
     parse_complete_tool_input,
@@ -189,9 +192,21 @@ class OpenAIToolCallAssembler:
     """Assemble OpenAI tool-call deltas into Anthropic SSE tool blocks."""
 
     def __init__(
-        self, *, record_extra_content: RecordToolExtraContent | None = None
+        self,
+        *,
+        request: MessagesRequest,
+        record_extra_content: RecordToolExtraContent | None = None,
     ) -> None:
         self._record_extra_content = record_extra_content
+        self._reserved_tool_ids = {
+            block.id
+            for message in request.messages
+            if isinstance(message.content, list)
+            for block in message.content
+            if isinstance(block, ContentBlockToolUse) and block.id.strip()
+        }
+        self._candidate_tool_ids: dict[int, str] = {}
+        self._public_tool_ids: dict[int, str] = {}
 
     def process_tool_call(
         self,
@@ -213,8 +228,15 @@ class OpenAIToolCallAssembler:
         incoming_name = fn_delta.get("name")
         arguments = fn_delta.get("arguments", "") or ""
 
-        if tc.get("id") is not None:
-            ledger.blocks.set_stream_tool_id(tc_index, tc.get("id"))
+        candidate_id = tc.get("id")
+        if candidate_id is not None:
+            ledger.blocks.ensure_tool_state(tc_index)
+        if (
+            tc_index not in self._public_tool_ids
+            and isinstance(candidate_id, str)
+            and candidate_id.strip()
+        ):
+            self._candidate_tool_ids[tc_index] = candidate_id
 
         raw_extra_content = tc.get("extra_content")
         extra_content = (
@@ -236,15 +258,12 @@ class OpenAIToolCallAssembler:
                 ledger.blocks.register_tool_name(tc_index, resolved_name)
 
         state = ledger.blocks.tool_states.get(tc_index)
-        resolved_id = (state.tool_id if state and state.tool_id else None) or tc.get(
-            "id"
-        )
         resolved_name = (state.name if state else "") or ""
 
         if not state or not state.started:
             name_ok = bool((resolved_name or "").strip())
             if name_ok:
-                tool_id = str(resolved_id) if resolved_id else f"tool_{uuid.uuid4()}"
+                tool_id = self._assign_public_tool_id(tc_index)
                 display_name = (resolved_name or "").strip() or "tool_call"
                 start_extra_content = state.extra_content if state else extra_content
                 if start_extra_content:
@@ -285,6 +304,23 @@ class OpenAIToolCallAssembler:
             tool_argument_aliases=tool_argument_aliases,
             tool_argument_alias_buffers=tool_argument_alias_buffers,
         )
+
+    def _assign_public_tool_id(self, tool_index: int) -> str:
+        assigned = self._public_tool_ids.get(tool_index)
+        if assigned is not None:
+            return assigned
+
+        candidate = self._candidate_tool_ids.get(tool_index)
+        if candidate is not None and candidate not in self._reserved_tool_ids:
+            public_id = candidate
+        else:
+            public_id = f"tool_{uuid.uuid4()}"
+            while public_id in self._reserved_tool_ids:
+                public_id = f"tool_{uuid.uuid4()}"
+
+        self._reserved_tool_ids.add(public_id)
+        self._public_tool_ids[tool_index] = public_id
+        return public_id
 
     def flush_task_arg_buffers(self, ledger: AnthropicStreamLedger) -> Iterator[str]:
         """Emit buffered Task args as a single JSON delta."""

--- a/src/free_claude_code/providers/openai_chat/tool_calls.py
+++ b/src/free_claude_code/providers/openai_chat/tool_calls.py
@@ -2,9 +2,9 @@
 
 import json
 import uuid
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 from free_claude_code.core.anthropic import OpenAIToolNameCodec
 from free_claude_code.core.anthropic.models import (
@@ -16,6 +16,7 @@ from free_claude_code.core.anthropic.streaming import (
     parse_complete_tool_input,
     tool_schemas_by_name,
 )
+from free_claude_code.core.json_types import JsonObject
 
 RecordToolExtraContent = Callable[[str, dict[str, Any]], None]
 
@@ -27,6 +28,20 @@ class _CollectedToolCall:
     name: str = ""
     argument_parts: list[str] = field(default_factory=list)
     extra_content: dict[str, Any] | None = None
+
+
+class _CompletedOpenAIToolFunction(TypedDict):
+    name: str
+    arguments: str
+
+
+class CompletedOpenAIToolCall(TypedDict):
+    """Schema-valid OpenAI tool-call payload collected for recovery emission."""
+
+    index: int
+    id: str | None
+    function: _CompletedOpenAIToolFunction
+    extra_content: NotRequired[JsonObject]
 
 
 class OpenAIToolCallCollector:
@@ -68,10 +83,10 @@ class OpenAIToolCallCollector:
         *,
         tool_names: OpenAIToolNameCodec | None = None,
         tool_argument_aliases: dict[str, dict[str, str]] | None = None,
-    ) -> tuple[dict[str, Any], ...] | None:
+    ) -> tuple[CompletedOpenAIToolCall, ...] | None:
         """Return complete schema-valid calls, or None when output is incomplete."""
         schemas = tool_schemas_by_name(request)
-        completed: list[dict[str, Any]] = []
+        completed: list[CompletedOpenAIToolCall] = []
         for index in sorted(self._calls):
             state = self._calls[index]
             wire_name = state.name.strip()
@@ -92,7 +107,7 @@ class OpenAIToolCallCollector:
             if parse_complete_tool_input(arguments, name, schemas) is None:
                 return None
 
-            call: dict[str, Any] = {
+            call: CompletedOpenAIToolCall = {
                 "index": index,
                 "id": state.tool_id,
                 "function": {
@@ -210,7 +225,7 @@ class OpenAIToolCallAssembler:
 
     def process_tool_call(
         self,
-        tc: dict[str, Any],
+        tc: Mapping[str, Any],
         ledger: AnthropicStreamLedger,
         *,
         tool_names: OpenAIToolNameCodec | None = None,

--- a/tests/providers/test_gemini.py
+++ b/tests/providers/test_gemini.py
@@ -6,6 +6,7 @@ import pytest
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.config.provider_catalog import GEMINI_DEFAULT_BASE
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.gemini import GeminiProvider
 from free_claude_code.providers.google_openai import (
@@ -520,6 +521,121 @@ async def test_stream_response_preserves_tool_call_extra_content(gemini_provider
         '"extra_content"' in event and "sig-stream" in event for event in tool_starts
     )
     assert gemini_provider._tool_call_extra_content_by_id["function-call-1"] == {
+        "google": {"thought_signature": "sig-stream"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_colliding_stream_tool_id_rekeys_cached_thought_signature(
+    gemini_provider,
+):
+    """Gemini metadata follows the public ID returned to the client."""
+    history = [
+        {"role": "user", "content": "Find files once."},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "function-call-1",
+                    "name": "Glob",
+                    "input": {"pattern": "*.py"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "function-call-1",
+                    "content": "[]",
+                }
+            ],
+        },
+    ]
+    request = make_request(
+        system=None,
+        messages=[*history, {"role": "user", "content": "Find files again."}],
+    )
+    tool_call = MagicMock()
+    tool_call.index = 0
+    tool_call.id = "function-call-1"
+    tool_call.extra_content = {"google": {"thought_signature": "sig-stream"}}
+    tool_call.function = MagicMock()
+    tool_call.function.name = "Glob"
+    tool_call.function.arguments = '{"pattern":"*.py"}'
+    chunk = MagicMock()
+    chunk.choices = [
+        MagicMock(
+            delta=MagicMock(
+                content=None,
+                reasoning_content=None,
+                tool_calls=[tool_call],
+            ),
+            finish_reason="tool_calls",
+        )
+    ]
+    chunk.usage = MagicMock(completion_tokens=5, prompt_tokens=10)
+
+    async def mock_stream():
+        yield chunk
+
+    with patch.object(
+        gemini_provider._client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=mock_stream(),
+    ):
+        events = [event async for event in gemini_provider.stream_response(request)]
+
+    starts = [
+        event.data["content_block"]
+        for event in parse_sse_text("".join(events))
+        if event.event == "content_block_start"
+        and event.data.get("content_block", {}).get("type") == "tool_use"
+    ]
+    [start] = starts
+    public_id = start["id"]
+    assert public_id != "function-call-1"
+    assert gemini_provider._tool_call_extra_content_by_id[public_id] == {
+        "google": {"thought_signature": "sig-stream"}
+    }
+
+    replay = make_request(
+        system=None,
+        messages=[
+            *request.messages,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": public_id,
+                        "name": "Glob",
+                        "input": {"pattern": "*.py"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": public_id,
+                        "content": "[]",
+                    }
+                ],
+            },
+        ],
+    )
+    body = gemini_provider._build_request_body(
+        replay,
+        reasoning=reasoning_for(replay),
+    )
+    replayed_call = body["messages"][-2]["tool_calls"][0]
+    assert replayed_call["id"] == public_id
+    assert replayed_call["extra_content"] == {
         "google": {"thought_signature": "sig-stream"}
     }
 

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -123,9 +123,12 @@ def _make_provider():
     )
 
 
-def _make_tool_assembler(provider: NvidiaNimProvider) -> OpenAIToolCallAssembler:
+def _make_tool_assembler(
+    provider: NvidiaNimProvider, *, request=None
+) -> OpenAIToolCallAssembler:
     return OpenAIToolCallAssembler(
-        record_extra_content=provider._record_tool_call_extra_content
+        request=request or _make_request(),
+        record_extra_content=provider._record_tool_call_extra_content,
     )
 
 
@@ -191,7 +194,9 @@ def _make_usage_chunk(*, prompt_tokens: int, completion_tokens: int):
     return chunk
 
 
-def _make_tool_calls_chunk(*, name: str, arguments: str, tool_id: str, index: int = 0):
+def _make_tool_calls_chunk(
+    *, name: str | None, arguments: str, tool_id: str | None, index: int = 0
+):
     """Single OpenAI-style tool_calls delta (starts a native streamed tool block)."""
     tc = MagicMock()
     tc.index = index
@@ -227,6 +232,15 @@ async def _collect_stream_and_error(
         async for event in provider.stream_response(request, **kwargs):
             events.extend((event,))
     return events, exc_info.value
+
+
+def _tool_use_starts(events: list[str]) -> list[dict]:
+    return [
+        event.data["content_block"]
+        for event in parse_sse_text("".join(events))
+        if event.event == "content_block_start"
+        and event.data.get("content_block", {}).get("type") == "tool_use"
+    ]
 
 
 def _assert_no_content_deltas_after_error_text(
@@ -1007,6 +1021,147 @@ class TestStreamingExceptionHandling:
         assert [block["name"] for block in tool_starts] == ["Bash"]
 
     @pytest.mark.asyncio
+    async def test_precommit_retry_discards_abandoned_tool_id_candidate(self):
+        """An ID observed only by an invisible attempt cannot leak into its replay."""
+        provider = _make_provider()
+        request = _make_request()
+        first_stream = AsyncStreamMock(
+            [
+                _make_tool_calls_chunk(
+                    name=None,
+                    arguments="",
+                    tool_id="call_abandoned",
+                )
+            ],
+            error=httpx.ReadError("early cutoff"),
+        )
+        second_stream = AsyncStreamMock(
+            [
+                _make_tool_calls_chunk(
+                    name="Bash",
+                    arguments="{}",
+                    tool_id=None,
+                ),
+                _make_chunk(finish_reason="tool_calls"),
+            ]
+        )
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[first_stream, second_stream],
+        ) as mock_create:
+            events = await _collect_stream(provider, request)
+
+        parsed = parse_sse_text("".join(events))
+        [start] = _tool_use_starts(events)
+        assert mock_create.await_count == 2
+        assert start["id"].startswith("tool_")
+        assert start["id"] != "call_abandoned"
+        assert sum(event.event == "message_start" for event in parsed) == 1
+        assert sum(event.event == "content_block_start" for event in parsed) == 1
+        assert sum(event.event == "message_delta" for event in parsed) == 1
+        assert sum(event.event == "message_stop" for event in parsed) == 1
+
+    @pytest.mark.asyncio
+    async def test_colliding_tool_id_round_trips_as_distinct_matched_pair(self):
+        """A repaired public ID stays paired when Claude replays the next turn."""
+        provider = _make_provider()
+        first_pair = [
+            {"role": "user", "content": "Run it once."},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "Bash:0",
+                        "name": "Bash",
+                        "input": {"command": "printf first"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "Bash:0",
+                        "content": "first",
+                    }
+                ],
+            },
+        ]
+        request = _make_request(
+            messages=[*first_pair, {"role": "user", "content": "Run it again."}]
+        )
+        stream = AsyncStreamMock(
+            [
+                _make_tool_calls_chunk(
+                    name="Bash",
+                    arguments='{"command":"printf second"}',
+                    tool_id="Bash:0",
+                ),
+                _make_chunk(finish_reason="tool_calls"),
+            ]
+        )
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            return_value=stream,
+        ):
+            events = await _collect_stream(provider, request)
+
+        [start] = _tool_use_starts(events)
+        public_id = start["id"]
+        assert public_id != "Bash:0"
+
+        replay = _make_request(
+            messages=[
+                *request.messages,
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": public_id,
+                            "name": "Bash",
+                            "input": {"command": "printf second"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": public_id,
+                            "content": "second",
+                        }
+                    ],
+                },
+            ]
+        )
+        body = provider._build_request_body(
+            replay,
+            reasoning=DEFAULT_REASONING_POLICY,
+        )
+        assistant_ids = [
+            message["tool_calls"][0]["id"]
+            for message in body["messages"]
+            if message.get("role") == "assistant" and message.get("tool_calls")
+        ]
+        result_ids = [
+            message["tool_call_id"]
+            for message in body["messages"]
+            if message.get("role") == "tool"
+        ]
+        assert assistant_ids == ["Bash:0", public_id]
+        assert result_ids == ["Bash:0", public_id]
+
+    @pytest.mark.asyncio
     async def test_precommit_retry_emits_one_unduplicated_downstream_lifecycle(self):
         """An abandoned attempt contributes no frame to the successful replay."""
         provider = _make_provider()
@@ -1660,7 +1815,8 @@ class TestStreamingExceptionHandling:
         runner = _make_stream_runner(
             _make_provider(), request=_make_request(), request_id="req_recovery"
         )
-        ledger = AnthropicStreamLedger("msg_recovery", "model")
+        assembler = runner._new_stream_assembler(output_reasoning=True)
+        ledger = assembler.ledger
         ledger.start_thinking_block()
         ledger.emit_thinking_delta("hidden reasoning")
         list(ledger.ensure_text_block())
@@ -1678,7 +1834,7 @@ class TestStreamingExceptionHandling:
             execution = runner._provider._admission.start_execution()
             events = await runner._recovery_events(
                 body={"messages": [{"role": "user", "content": "hello"}]},
-                ledger=ledger,
+                assembler=assembler,
                 error=TimeoutError("cutoff"),
                 tool_argument_alias_buffers={},
                 output_reasoning=True,
@@ -1875,10 +2031,115 @@ class TestProcessToolCall:
             "function": {"name": "search", "arguments": '{"q": "test"}'},
         }
         events = list(_make_tool_assembler(provider).process_tool_call(tc, sse))
-        event_text = "".join(events)
-        assert "tool_use" in event_text
-        assert "search" in event_text
-        assert "call_123" in event_text
+        assert _tool_use_starts(events) == [
+            {
+                "type": "tool_use",
+                "id": "call_123",
+                "name": "search",
+                "input": {},
+            }
+        ]
+
+    @pytest.mark.parametrize("missing_id", [None, "", "   "])
+    def test_missing_or_blank_tool_call_id_generates_public_id(self, missing_id):
+        """An absent identity never escapes as an empty Anthropic tool-use ID."""
+        provider = _make_provider()
+        sse = AnthropicStreamLedger("msg_test", "test-model")
+
+        events = list(
+            _make_tool_assembler(provider).process_tool_call(
+                {
+                    "index": 0,
+                    "id": missing_id,
+                    "function": {"name": "Bash", "arguments": "{}"},
+                },
+                sse,
+            )
+        )
+
+        [start] = _tool_use_starts(events)
+        assert start["id"].startswith("tool_")
+
+    def test_historical_tool_call_id_collision_is_remapped(self):
+        """A later turn cannot reuse a tool identity already visible in history."""
+        provider = _make_provider()
+        request = _make_request(
+            messages=[
+                {"role": "user", "content": "Run it once."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "Bash:0",
+                            "name": "Bash",
+                            "input": {"command": "printf first"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "Bash:0",
+                            "content": "first",
+                        }
+                    ],
+                },
+            ]
+        )
+        sse = AnthropicStreamLedger("msg_test", "test-model")
+
+        events = list(
+            _make_tool_assembler(provider, request=request).process_tool_call(
+                {
+                    "index": 0,
+                    "id": "Bash:0",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": '{"command":"printf second"}',
+                    },
+                },
+                sse,
+            )
+        )
+
+        [start] = _tool_use_starts(events)
+        assert start["id"].startswith("tool_")
+        assert start["id"] != "Bash:0"
+
+    def test_current_response_tool_call_id_collision_is_remapped(self):
+        """Two simultaneous calls cannot expose the same public identity."""
+        provider = _make_provider()
+        sse = AnthropicStreamLedger("msg_test", "test-model")
+        assembler = _make_tool_assembler(provider)
+
+        first = list(
+            assembler.process_tool_call(
+                {
+                    "index": 0,
+                    "id": "Bash:0",
+                    "function": {"name": "Bash", "arguments": "{}"},
+                },
+                sse,
+            )
+        )
+        second = list(
+            assembler.process_tool_call(
+                {
+                    "index": 1,
+                    "id": "Bash:0",
+                    "function": {"name": "Bash", "arguments": "{}"},
+                },
+                sse,
+            )
+        )
+
+        starts = _tool_use_starts(first + second)
+        assert starts[0]["id"] == "Bash:0"
+        assert starts[1]["id"].startswith("tool_")
+        assert starts[1]["id"] != starts[0]["id"]
 
     def test_structured_tool_call_restores_portable_wire_alias(self):
         """A wire alias never escapes in the Anthropic tool block."""
@@ -2128,9 +2389,10 @@ class TestProcessToolCall:
             "id": "call_split",
             "function": {"name": None, "arguments": "{}"},
         }
-        b1 = "".join(_make_tool_assembler(provider).process_tool_call(t1, sse))
-        b2 = "".join(_make_tool_assembler(provider).process_tool_call(t2, sse))
-        b3 = "".join(_make_tool_assembler(provider).process_tool_call(t3, sse))
+        assembler = _make_tool_assembler(provider)
+        b1 = "".join(assembler.process_tool_call(t1, sse))
+        b2 = "".join(assembler.process_tool_call(t2, sse))
+        b3 = "".join(assembler.process_tool_call(t3, sse))
         combined = b1 + b2 + b3
         assert "call_split" in combined
         assert "Grep" in combined
@@ -2152,28 +2414,47 @@ class TestProcessToolCall:
             "id": "call_buf",
             "function": {"name": "Read", "arguments": "1}"},
         }
-        b1 = "".join(_make_tool_assembler(provider).process_tool_call(t1, sse))
-        b2 = "".join(_make_tool_assembler(provider).process_tool_call(t2, sse))
+        assembler = _make_tool_assembler(provider)
+        b1 = "".join(assembler.process_tool_call(t1, sse))
+        b2 = "".join(assembler.process_tool_call(t2, sse))
         assert b1 == ""
         combined = b2
         assert "Read" in combined
         assert "call_buf" in combined
         assert '{"x":' in combined or "partial_json" in combined
 
-    def test_tool_call_without_id_generates_uuid(self):
-        """Tool call without id generates a uuid-based id."""
+    def test_late_upstream_id_cannot_overwrite_started_public_id(self):
+        """The identity emitted at block start stays authoritative."""
         provider = _make_provider()
-        from free_claude_code.core.anthropic import AnthropicStreamLedger
-
         sse = AnthropicStreamLedger("msg_test", "test-model")
-        tc = {
-            "index": 0,
-            "id": None,
-            "function": {"name": "test", "arguments": "{}"},
-        }
-        events = list(_make_tool_assembler(provider).process_tool_call(tc, sse))
-        event_text = "".join(events)
-        assert "tool_" in event_text
+        assembler = _make_tool_assembler(provider)
+
+        initial = list(
+            assembler.process_tool_call(
+                {
+                    "index": 0,
+                    "id": None,
+                    "function": {"name": "Bash", "arguments": "{}"},
+                },
+                sse,
+            )
+        )
+        [start] = _tool_use_starts(initial)
+        generated_id = start["id"]
+
+        later = list(
+            assembler.process_tool_call(
+                {
+                    "index": 0,
+                    "id": "late_upstream_id",
+                    "function": {"name": None, "arguments": ""},
+                },
+                sse,
+            )
+        )
+
+        assert later == []
+        assert sse.blocks.tool_states[0].tool_id == generated_id
 
     def test_task_tool_forces_background_false(self):
         """Task tool with run_in_background=true is forced to false."""
@@ -2209,11 +2490,12 @@ class TestProcessToolCall:
             "function": {"name": None, "arguments": ' "prompt": "test"}'},
         }
 
-        events1 = list(_make_tool_assembler(provider).process_tool_call(tc1, sse))
+        assembler = _make_tool_assembler(provider)
+        events1 = list(assembler.process_tool_call(tc1, sse))
         assert len(events1) > 0
         assert "false" not in "".join(events1).lower()
 
-        events2 = list(_make_tool_assembler(provider).process_tool_call(tc2, sse))
+        events2 = list(assembler.process_tool_call(tc2, sse))
         event_text = "".join(events1 + events2)
         assert "false" in event_text.lower()
 
@@ -2228,11 +2510,12 @@ class TestProcessToolCall:
             "id": "call_task2",
             "function": {"name": "Task", "arguments": "not json"},
         }
-        events = list(_make_tool_assembler(provider).process_tool_call(tc, sse))
+        assembler = _make_tool_assembler(provider)
+        events = list(assembler.process_tool_call(tc, sse))
         assert len(events) > 0
 
         with caplog.at_level("WARNING"):
-            flushed = list(_make_tool_assembler(provider).flush_task_arg_buffers(sse))
+            flushed = list(assembler.flush_task_arg_buffers(sse))
         assert len(flushed) > 0
         assert "{}" in "".join(flushed)
         assert any("Task args invalid JSON" in r.message for r in caplog.records)
@@ -2385,9 +2668,10 @@ class TestStreamChunkEdgeCases:
             "function": {"name": None, "arguments": " never valid }"},
         }
 
-        events1 = list(_make_tool_assembler(provider).process_tool_call(tc1, sse))
-        events2 = list(_make_tool_assembler(provider).process_tool_call(tc2, sse))
-        flushed = list(_make_tool_assembler(provider).flush_task_arg_buffers(sse))
+        assembler = _make_tool_assembler(provider)
+        events1 = list(assembler.process_tool_call(tc1, sse))
+        events2 = list(assembler.process_tool_call(tc2, sse))
+        flushed = list(assembler.flush_task_arg_buffers(sse))
 
         event_text = "".join(events1 + events2 + flushed)
         assert "tool_use" in event_text

--- a/tests/providers/test_subagent_interception.py
+++ b/tests/providers/test_subagent_interception.py
@@ -10,6 +10,7 @@ from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from free_claude_code.providers.openai_chat.tool_calls import (
     OpenAIToolCallAssembler,
 )
+from tests.providers.request_factory import make_messages_request
 from tests.providers.support import (
     immediate_admission,
     make_provider_config,
@@ -26,9 +27,7 @@ async def test_task_tool_interception():
         admission=immediate_admission(),
     )
 
-    # Mock request and stream ledger with real StreamBlockLedger
-    request = MagicMock()
-    request.model = "test-model"
+    request = make_messages_request("test-model")
 
     sse = MagicMock()
     sse.blocks = StreamBlockLedger()
@@ -50,7 +49,7 @@ async def test_task_tool_interception():
     }
 
     tool_calls = OpenAIToolCallAssembler(
-        record_extra_content=provider._record_tool_call_extra_content
+        request=request, record_extra_content=provider._record_tool_call_extra_content
     )
 
     # Call the assembler (consume generator to trigger side effects)

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.14.7"
+version = "5.14.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Some OpenAI-compatible providers can repeat message-local tool-call IDs across conversation turns. FCC forwarded those IDs unchanged, leaving Claude Code unable to correlate a later tool result unambiguously and causing interrupted or repeated tool execution. Fixes #1572.

## Changes

| Before | After |
| --- | --- |
| FCC trusted every nonempty Chat tool-call ID. | FCC preserves safe IDs and regenerates only missing, blank, or conversation-colliding IDs. |
| Chat tool-call assembly had no history-aware identity scope. | Each discardable stream attempt owns a request-seeded identity scope, while continuation and salvage reuse that same scope. |
| Provider metadata followed the raw upstream ID. | Extra content such as Gemini thought signatures follows the public ID returned to the client. |
| Duplicate-ID behavior lacked end-to-end coverage. | Regression tests cover history/current collisions, fragmented streams, retries, stateless replay, and Gemini metadata. |

Verification: 224 focused tests, the full 3,820-test pytest suite, 9 Playwright tests, and the live NVIDIA Kimi K3 Claude CLI matrix passed.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change keeps OpenAI-compatible tool-call identifiers unique across an interrupted conversation and its recovered continuation. The exercised recovery flow correctly replaced a historical collision with a fresh public identifier and emitted one complete response lifecycle.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The exercised recovery path preserved tool-call identity and completed the response exactly once.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The recovery tool script was executed from the repository and its run confirmed a distinct public\_recovered\_id and a single completed tool lifecycle with one tool\_use\_start and one terminal\_message\_stop.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: type recovered tool calls"](https://github.com/alishahryar1/free-claude-code/commit/ff7a91c858450f8701160b924aa29416b90b55f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56964932)</sub>

<!-- /greptile_comment -->