### PR TITLE
feat(admin): redesign UI with developer monospace typography and silv…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.15.0"
+version = "5.16.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -1,62 +1,92 @@
 :root {
   color-scheme: dark;
   
-  /* Color Palette */
-  --bg: #090a0f;
-  --panel: #11131c;
-  --panel-strong: #171b26;
-  --card: #151822;
-  --card-hover: #1e2230;
-  --input: #0a0b10;
-  --input-focus: #0f1118;
-  --text: #f3f4f6;
+  /* Dark Graphite & Metallic Base */
+  --bg: #090b0e;
+  --bg-subtle: #0e1116;
+  --panel: #13171f;
+  --panel-solid: #13171f;
+  --panel-strong: #191e28;
+  --card: #161b24;
+  --card-solid: #161b24;
+  --card-hover: #1e2430;
+  --input: #0b0e13;
+  --input-focus: #10141c;
+  
+  /* Text Hierarchy */
   --text-strong: #ffffff;
-  --muted: #9ca3af;
-  --line: rgba(255, 255, 255, 0.06);
-  --line-strong: rgba(255, 255, 255, 0.12);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --subtle: #64748b;
   
-  /* Brand and Accent Colors */
-  --accent: #10b981;
-  --accent-dark: #059669;
-  --accent-muted: rgba(16, 185, 129, 0.08);
-  --accent-border: rgba(16, 185, 129, 0.3);
+  /* Silver & Metallic Tokens */
+  --silver-100: #ffffff;
+  --silver-200: #f1f5f9;
+  --silver-300: #e2e8f0;
+  --silver-400: #cbd5e1;
+  --silver-500: #94a3b8;
+  --silver-600: #64748b;
   
-  /* Status Colors */
-  --ok: #10b981;
-  --ok-bg: rgba(16, 185, 129, 0.08);
-  --ok-border: rgba(16, 185, 129, 0.25);
+  /* Gradients */
+  --silver-gradient: linear-gradient(180deg, #ffffff 0%, #cbd5e1 100%);
+  --silver-badge-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.04) 100%);
+  --silver-button-gradient: linear-gradient(180deg, #ffffff 0%, #d5dde6 100%);
+  --silver-button-hover: linear-gradient(180deg, #ffffff 0%, #e2e8f0 100%);
+  --dark-button-gradient: linear-gradient(180deg, #1f2532 0%, #151922 100%);
+  --dark-button-hover: linear-gradient(180deg, #272f3e 0%, #1a202b 100%);
+  --card-gradient: linear-gradient(180deg, rgba(24, 29, 39, 0.9) 0%, rgba(18, 22, 30, 0.95) 100%);
+  --panel-gradient: linear-gradient(180deg, rgba(20, 24, 33, 0.92) 0%, rgba(15, 18, 25, 0.98) 100%);
   
-  --warn: #f59e0b;
-  --warn-bg: rgba(245, 158, 11, 0.08);
-  --warn-border: rgba(245, 158, 11, 0.25);
+  /* Borders & Insets */
+  --line: rgba(255, 255, 255, 0.08);
+  --line-strong: rgba(255, 255, 255, 0.16);
+  --line-silver: rgba(255, 255, 255, 0.28);
+  --line-focus: #cbd5e1;
   
-  --error: #ef4444;
-  --error-bg: rgba(239, 68, 68, 0.08);
-  --error-border: rgba(239, 68, 68, 0.25);
+  /* Semantic Status Colors (Clean, no neon glow) */
+  --ok: #34d399;
+  --ok-bg: rgba(52, 211, 153, 0.08);
+  --ok-border: rgba(52, 211, 153, 0.22);
   
-  --neutral: #6b7280;
-  --neutral-bg: rgba(107, 114, 128, 0.08);
-  --neutral-border: rgba(107, 114, 128, 0.25);
+  --warn: #fbbf24;
+  --warn-bg: rgba(251, 191, 36, 0.08);
+  --warn-border: rgba(251, 191, 36, 0.22);
   
-  --info: #3b82f6;
+  --error: #f87171;
+  --error-bg: rgba(248, 113, 113, 0.08);
+  --error-border: rgba(248, 113, 113, 0.22);
   
-  /* Box Shadow & Glows */
-  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.2);
-  --shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
-  --glow-accent: 0 0 12px rgba(16, 185, 129, 0.15);
+  --info: #38bdf8;
+  --info-bg: rgba(56, 189, 248, 0.08);
+  --info-border: rgba(56, 189, 248, 0.22);
   
-  /* Borders and Radius */
+  --neutral: #94a3b8;
+  --neutral-bg: rgba(148, 163, 184, 0.08);
+  --neutral-border: rgba(148, 163, 184, 0.18);
+  
+  /* Clean Solid Shadows (Zero glow) */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 14px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 30px rgba(0, 0, 0, 0.65);
+  --inset-top: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  
+  /* Radii */
+  --radius-xs: 4px;
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 14px;
+  --radius-xl: 18px;
   --radius-full: 9999px;
-  --dropdown-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
   
-  /* Typography */
-  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  /* Dropdown icon */
+  --dropdown-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23cbd5e1' stroke-width='2.2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19.5 8.25l-7.5 7.5-7.5-7.5'/%3E%3C/svg%3E");
+  
+  /* Typography - Developer Monospace Font Stack */
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", "Cascadia Code", "Cascadia Mono", "Segoe UI Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --font-sans: var(--font-mono);
   
   /* Transitions */
-  --transition-fast: 0.15s ease;
+  --transition-fast: 0.14s cubic-bezier(0.4, 0, 0.2, 1);
   --transition-normal: 0.22s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -64,47 +94,72 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   min-width: 320px;
-  background: var(--bg);
+  background-color: var(--bg);
   color: var(--text);
-  font-family: var(--font-sans);
-  letter-spacing: -0.01em;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  letter-spacing: -0.015em;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Subtle Neutral Backdrop Vignette (Zero color glow) */
+.ambient-glow {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 350px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, transparent 100%);
+  pointer-events: none;
+  z-index: 0;
+}
+
 /* Custom Scrollbars */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
 }
 ::-webkit-scrollbar-track {
   background: var(--bg);
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--panel-strong);
+  background: #232936;
   border-radius: var(--radius-full);
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--muted);
+  background: var(--silver-600);
 }
 
 button,
 input,
 select,
 textarea {
-  font: inherit;
+  font-family: inherit;
+  font-size: inherit;
   color: inherit;
 }
 
 /* App Shell Layout */
 .app-shell {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
   min-height: 100vh;
-  padding-bottom: 96px; /* Space for action bar */
+  padding-bottom: 96px;
 }
 
 /* Sidebar Navigation */
@@ -113,11 +168,13 @@ textarea {
   top: 0;
   height: 100vh;
   border-right: 1px solid var(--line);
-  background: var(--bg);
-  padding: 24px 20px;
+  background: var(--panel-gradient);
+  padding: 24px 18px 20px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 20px;
+  z-index: 50;
+  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.3);
 }
 
 .brand {
@@ -128,63 +185,126 @@ textarea {
 
 .brand-mark {
   display: grid;
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
   place-items: center;
   border-radius: var(--radius-md);
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: #ffffff;
-  font-weight: 800;
-  font-size: 15px;
-  box-shadow: var(--glow-accent);
+  background: var(--silver-gradient);
+  color: #0b0e13;
+  box-shadow: var(--shadow-sm);
+  flex-shrink: 0;
 }
 
-.brand h1 {
-  font-size: 16px;
+.brand-icon {
+  width: 22px;
+  height: 22px;
+}
+
+.brand-text h1 {
+  font-size: 14.5px;
   font-weight: 700;
   line-height: 1.2;
   color: var(--text-strong);
   margin: 0;
+  letter-spacing: -0.02em;
 }
 
-.brand p {
+.brand-text p {
   color: var(--muted);
-  font-size: 12px;
-  margin: 0;
+  font-size: 11.5px;
+  margin: 2px 0 0;
+  font-weight: 500;
+}
+
+/* Server Status Indicator in Sidebar */
+.server-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--silver-300);
+  align-self: flex-start;
+}
+
+.status-indicator-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ok);
 }
 
 .section-nav {
   display: grid;
-  gap: 6px;
+  gap: 4px;
+  margin-top: 4px;
 }
 
 .nav-link {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   width: 100%;
-  min-height: 40px;
+  min-height: 38px;
   border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  padding: 10px 14px;
+  padding: 8px 12px;
   text-align: left;
   cursor: pointer;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
   transition: all var(--transition-fast);
 }
 
 .nav-link:hover {
-  background: var(--panel-strong);
+  background: rgba(255, 255, 255, 0.04);
   color: var(--text-strong);
+  border-color: var(--line);
 }
 
 .nav-link.active {
-  background: var(--accent-muted);
-  border-color: var(--accent-border);
-  color: var(--accent);
-  box-shadow: var(--shadow-sm);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.09) 0%, rgba(255, 255, 255, 0.02) 100%);
+  border-color: var(--line-strong);
+  border-left: 3px solid var(--silver-300);
+  color: var(--text-strong);
+}
+
+/* Sidebar Footer */
+.sidebar-footer {
+  margin-top: auto;
+}
+
+.sidebar-footer-card {
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--line);
+}
+
+.footer-badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--silver-300);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  margin-bottom: 4px;
+  border: 1px solid var(--line);
+}
+
+.footer-subtext {
+  margin: 0;
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.35;
 }
 
 /* Accessible focus outlines */
@@ -193,41 +313,180 @@ input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
 .nav-link:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--silver-400);
   outline-offset: 2px;
 }
 
 /* Main Content Area */
 .main {
   min-width: 0;
-  padding: 40px 48px;
+  padding: 32px 40px;
+  max-width: 1320px;
+  margin: 0 auto;
+  width: 100%;
 }
 
+/* Topbar Header */
 .topbar {
-  margin-bottom: 32px;
+  margin-bottom: 28px;
+}
+
+.topbar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 22px;
+  flex-wrap: wrap;
 }
 
 .topbar h2 {
-  font-size: 30px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
   color: var(--text-strong);
   margin: 0;
 }
 
-/* Provider Strip & Panels */
+.page-subtitle {
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Live Search Box */
+.search-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 270px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 12px;
+  width: 15px;
+  height: 15px;
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.search-input {
+  width: 100%;
+  min-height: 38px;
+  background: var(--input);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  padding: 8px 48px 8px 36px;
+  color: var(--text-strong);
+  font-size: 13px;
+  transition: all var(--transition-fast);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.search-input:focus {
+  border-color: var(--line-focus);
+  background: var(--input-focus);
+  outline: none;
+}
+
+.search-shortcut {
+  position: absolute;
+  right: 8px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 2px 5px;
+  border-radius: var(--radius-xs);
+  background: #191f2b;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  pointer-events: none;
+}
+
+/* KPI Quick Stats Overview */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--card-gradient);
+  box-shadow: var(--inset-top), var(--shadow-sm);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: all var(--transition-fast);
+}
+
+.stat-card:hover {
+  border-color: var(--line-strong);
+  background: var(--panel-strong);
+}
+
+.stat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.stat-label {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-icon-badge {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-xs);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--line);
+  color: var(--silver-300);
+}
+
+.stat-icon-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+.stat-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-strong);
+  letter-spacing: -0.02em;
+  margin-top: 2px;
+}
+
+.stat-subtext {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+
+/* Provider Panels & Settings Sections */
 .provider-strip,
 .settings-section {
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: var(--panel);
-  box-shadow: var(--shadow);
-  margin-bottom: 24px;
+  background: var(--panel-gradient);
+  box-shadow: var(--inset-top), var(--shadow-md);
+  margin-bottom: 22px;
+  padding: 22px;
   transition: border-color var(--transition-normal);
-}
-
-.provider-strip {
-  padding: 24px;
 }
 
 .strip-header,
@@ -239,45 +498,103 @@ textarea:focus-visible,
   margin-bottom: 20px;
 }
 
+.strip-title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.strip-badge {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 8px;
+  border-radius: var(--radius-xs);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--silver-300);
+  border: 1px solid var(--line-strong);
+}
+
 .strip-header h3,
 .section-heading h3 {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
   color: var(--text-strong);
   margin: 0;
+  letter-spacing: -0.01em;
 }
 
+.strip-header p,
+.strip-subtext,
 .section-heading p {
   color: var(--muted);
-  font-size: 13px;
-  line-height: 1.4;
-  margin: 4px 0 0 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  margin: 3px 0 0 0;
 }
 
-/* Provider Status Cards */
+/* Provider Filter Tabs */
+.provider-filter-tabs {
+  display: inline-flex;
+  align-items: center;
+  background: var(--input);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 3px;
+  gap: 3px;
+  align-self: flex-start;
+}
+
+.filter-tab {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-xs);
+  color: var(--muted);
+  padding: 4px 10px;
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.filter-tab:hover {
+  color: var(--text-strong);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.filter-tab.active {
+  background: var(--dark-button-gradient);
+  border-color: var(--line-strong);
+  color: #ffffff;
+  box-shadow: var(--shadow-sm);
+}
+
+/* Provider Status Cards Grid */
 .provider-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 16px;
 }
 
 .provider-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 16px;
-  min-height: 140px;
+  gap: 14px;
+  min-height: 145px;
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
   padding: 16px;
-  background: var(--card);
-  transition: all var(--transition-normal);
+  background: var(--card-gradient);
+  box-shadow: var(--inset-top), var(--shadow-sm);
+  transition: all var(--transition-fast);
 }
 
 .provider-card:hover {
   border-color: var(--line-strong);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-sm);
   background: var(--card-hover);
 }
 
@@ -285,30 +602,41 @@ textarea:focus-visible,
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .provider-title strong {
   font-size: 14px;
   font-weight: 700;
   color: var(--text-strong);
+  letter-spacing: -0.01em;
 }
 
-/* Modern status pills with color indicators */
+/* Status Pills (Crisp, zero glow) */
 .status-pill {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   min-height: 22px;
   border: 1px solid var(--neutral-border);
-  border-radius: var(--radius-full);
-  padding: 2px 10px;
+  border-radius: var(--radius-xs);
+  padding: 2px 8px;
   background: var(--neutral-bg);
   color: var(--muted);
-  font-size: 11px;
+  font-size: 10.5px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   white-space: nowrap;
+}
+
+.status-pill::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
 }
 
 .status-pill.ok {
@@ -331,39 +659,51 @@ textarea:focus-visible,
 
 .provider-meta {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11.5px;
   line-height: 1.4;
   word-break: break-all;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
+  background: #0d1015;
+  padding: 5px 8px;
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--line);
 }
 
 .provider-check-result {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11.5px;
   line-height: 1.4;
   overflow-wrap: anywhere;
+  padding: 5px 8px;
+  border-radius: var(--radius-xs);
+  background: #0d1015;
+  border: 1px solid var(--line);
 }
 
 .provider-check-result.ok {
   color: var(--ok);
+  border-left: 2px solid var(--ok);
 }
 
 .provider-check-result.error {
   color: var(--error);
+  border-left: 2px solid var(--error);
 }
 
 .provider-check-result.checking {
   color: var(--info);
+  border-left: 2px solid var(--info);
 }
 
 .provider-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
+  gap: 8px;
   align-items: center;
+  margin-top: 2px;
 }
 
-/* Button & Form Controls styling */
+/* Brushed Silver & Dark Metallic Buttons */
 .test-button,
 .ghost-button,
 .secondary-button,
@@ -371,103 +711,115 @@ textarea:focus-visible,
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 7px;
   min-height: 36px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
   padding: 6px 14px;
   font-weight: 600;
-  font-size: 13px;
+  font-size: 12.5px;
   cursor: pointer;
   transition: all var(--transition-fast);
   text-decoration: none;
 }
 
+.btn-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
 .test-button {
-  background: var(--panel-strong);
-  color: var(--text);
-  border-color: var(--line);
-  margin-top: auto;
-  align-self: flex-start;
+  background: var(--dark-button-gradient);
+  color: var(--silver-300);
+  border: 1px solid var(--line-strong);
+  box-shadow: var(--shadow-sm);
 }
 
 .test-button:hover:not(:disabled) {
-  background: var(--card-hover);
-  border-color: var(--accent);
-  color: var(--accent);
+  background: var(--dark-button-hover);
+  border-color: var(--silver-400);
+  color: #ffffff;
 }
 
 .test-button:disabled {
-  opacity: 0.6;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
 .secondary-button {
-  background: transparent;
-  color: var(--text);
-  border-color: var(--line-strong);
+  background: var(--dark-button-gradient);
+  color: var(--silver-300);
+  border: 1px solid var(--line-strong);
+  box-shadow: var(--shadow-sm);
 }
 
 .secondary-button:hover:not(:disabled) {
-  background: var(--panel-strong);
-  border-color: var(--text);
+  background: var(--dark-button-hover);
+  border-color: var(--silver-400);
+  color: #ffffff;
 }
 
 .primary-button {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #06100b;
+  border: 1px solid #ffffff;
+  background: var(--silver-button-gradient);
+  color: #0b0e13;
+  font-weight: 700;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), inset 0 1px 0 #ffffff;
 }
 
 .primary-button:hover:not(:disabled) {
-  background: var(--accent-dark);
+  background: var(--silver-button-hover);
+  border-color: #ffffff;
+  color: #000000;
 }
 
 .primary-button:disabled {
   cursor: not-allowed;
   border-color: var(--line);
-  background: var(--panel-strong);
-  color: var(--muted);
+  background: #1b202a;
+  color: var(--subtle);
+  box-shadow: none;
 }
 
 .ghost-button {
   background: transparent;
   color: var(--muted);
-  border-color: transparent;
+  border: 1px solid transparent;
 }
 
 .ghost-button:hover:not(:disabled) {
   color: var(--text-strong);
-  background: var(--panel-strong);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--line);
 }
 
 /* Forms layout */
 .form-sections {
   display: grid;
-  gap: 24px;
+  gap: 22px;
 }
 
 .settings-section {
-  padding: 24px;
   scroll-margin-top: 24px;
 }
 
 .section-heading {
   border-bottom: 1px solid var(--line);
   padding-bottom: 16px;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 .field-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 20px;
+  gap: 18px;
 }
 
 /* Field Grouping */
 .field {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   align-content: start;
 }
 
@@ -476,20 +828,22 @@ textarea:focus-visible,
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 700;
-  color: var(--text-strong);
+  color: var(--silver-200);
 }
 
 .field-source {
-  color: var(--accent);
-  font-size: 11px;
+  color: var(--silver-400);
+  font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  background: var(--accent-muted);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--line);
   padding: 1px 6px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
+  font-family: var(--font-mono);
 }
 
 /* Form Inputs, Select, Textareas */
@@ -501,12 +855,13 @@ textarea:focus-visible,
   width: 100%;
   min-height: 40px;
   border: 1px solid var(--line-strong);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   background: var(--input);
   color: var(--text-strong);
-  padding: 10px 14px;
-  font-size: 14px;
+  padding: 8px 12px;
+  font-size: 13px;
   transition: all var(--transition-fast);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 /* Custom Dropdown Styling for Select Elements */
@@ -516,7 +871,7 @@ textarea:focus-visible,
   -moz-appearance: none;
   background-image: var(--dropdown-chevron);
   background-repeat: no-repeat;
-  background-position: right 14px center;
+  background-position: right 12px center;
   background-size: 14px;
   padding-right: 36px;
 }
@@ -531,7 +886,7 @@ textarea:focus-visible,
 }
 
 .field .model-combobox input[type="text"] {
-  padding-right: 44px;
+  padding-right: 42px;
 }
 
 .model-combobox-toggle {
@@ -539,7 +894,7 @@ textarea:focus-visible,
   top: 0;
   right: 0;
   display: grid;
-  width: 42px;
+  width: 40px;
   height: 40px;
   place-items: center;
   border: 0;
@@ -564,12 +919,12 @@ textarea:focus-visible,
 
 .model-combobox-toggle:disabled {
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: 0.35;
 }
 
 .model-combobox-list {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + 4px);
   right: 0;
   left: 0;
   z-index: 120;
@@ -577,10 +932,10 @@ textarea:focus-visible,
   overflow-y: auto;
   overscroll-behavior: contain;
   border: 1px solid var(--line-strong);
-  border-radius: var(--radius-md);
-  background: var(--panel-strong);
-  box-shadow: var(--shadow);
-  padding: 6px;
+  border-radius: var(--radius-sm);
+  background: #141822;
+  box-shadow: var(--shadow-lg);
+  padding: 5px;
 }
 
 .model-combobox-list[hidden] {
@@ -588,20 +943,21 @@ textarea:focus-visible,
 }
 
 .model-combobox-option {
-  border-radius: var(--radius-sm);
-  padding: 9px 10px;
+  border-radius: var(--radius-xs);
+  padding: 8px 10px;
   color: var(--text);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.35;
   overflow-wrap: anywhere;
   cursor: pointer;
+  transition: background var(--transition-fast);
 }
 
 .model-combobox-option:hover,
 .model-combobox-option.active {
-  background: var(--accent-muted);
-  color: var(--accent);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
 }
 
 .model-combobox-empty {
@@ -633,52 +989,60 @@ textarea:focus-visible,
   grid-template-columns: minmax(0, 1fr) auto auto auto;
   gap: 4px;
   align-items: center;
-  min-height: 44px;
-  padding: 6px 8px 6px 12px;
+  min-height: 42px;
+  padding: 4px 8px 4px 12px;
   border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: var(--panel-strong);
+  border-radius: var(--radius-sm);
+  background: #10141b;
+  box-shadow: var(--shadow-sm);
+  transition: all var(--transition-fast);
+}
+
+.model-list-row:hover {
+  border-color: var(--line-strong);
+  background: #161b24;
 }
 
 .model-list-value {
   min-width: 0;
   overflow-wrap: anywhere;
-  color: var(--text-strong);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 13px;
+  color: var(--silver-200);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
 }
 
 .model-list-action {
-  min-height: 32px;
-  padding: 4px 8px;
+  min-height: 30px;
+  padding: 2px 8px;
+  font-size: 11.5px;
 }
 
 .model-list-editor button:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  opacity: 0.4;
 }
 
 .model-list-empty {
-  padding: 8px 2px;
+  padding: 10px 2px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 12.5px;
+  font-style: italic;
 }
 
 .field input:focus,
 .field select:focus,
 .field textarea:focus {
-  border-color: var(--accent);
+  border-color: var(--line-focus);
   background: var(--input-focus);
-  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
   outline: none;
 }
 
 /* Checkbox specific layout styling */
 .field input[type="checkbox"] {
   align-self: flex-start;
-  width: 20px;
-  height: 20px;
-  accent-color: var(--accent);
+  width: 18px;
+  height: 18px;
+  accent-color: #cbd5e1;
   cursor: pointer;
   margin: 4px 0;
 }
@@ -694,13 +1058,13 @@ textarea:focus-visible,
 .field textarea:disabled {
   background: rgba(255, 255, 255, 0.02);
   border-color: var(--line);
-  color: var(--muted);
+  color: var(--subtle);
   cursor: not-allowed;
 }
 
 .field-description {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11.5px;
   line-height: 1.4;
   margin-top: 2px;
 }
@@ -715,12 +1079,12 @@ textarea:focus-visible,
 }
 
 .advanced-toggle {
-  margin-top: 20px;
+  margin-top: 18px;
   font-size: 12px;
   border: 1px solid var(--line-strong);
 }
 
-/* Fixed Bottom Action Bar */
+/* Fixed Bottom Action Dock */
 .action-bar {
   position: fixed;
   right: 0;
@@ -729,28 +1093,29 @@ textarea:focus-visible,
   z-index: 100;
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(200px, 1fr) auto;
-  gap: 20px;
+  gap: 18px;
   align-items: center;
-  min-height: 80px;
+  min-height: 76px;
   border-top: 1px solid var(--line);
-  background: rgba(9, 10, 15, 0.82);
-  padding: 16px 40px;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.3);
+  background: rgba(11, 14, 20, 0.95);
+  padding: 14px 36px;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.6);
 }
 
 .action-meta {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
   min-width: 0;
 }
 
-.action-meta strong {
-  font-size: 14px;
+.dirty-badge-wrapper strong {
+  display: inline-block;
+  font-size: 13px;
   font-weight: 700;
-  color: var(--text-strong);
+  color: var(--silver-200);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -759,7 +1124,7 @@ textarea:focus-visible,
 .action-meta span {
   color: var(--muted);
   font-size: 11px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -768,29 +1133,38 @@ textarea:focus-visible,
 .message-area {
   min-width: 0;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
   line-height: 1.4;
+  padding: 4px 8px;
+  border-radius: var(--radius-xs);
+  transition: all var(--transition-fast);
 }
 
 .message-area.error {
   color: var(--error);
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
   font-weight: 600;
 }
 
 .message-area.ok {
   color: var(--ok);
+  background: var(--ok-bg);
+  border: 1px solid var(--ok-border);
   font-weight: 600;
 }
 
 .message-area.warn {
   color: var(--warn);
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
   font-weight: 600;
 }
 
 .action-buttons {
   display: flex;
-  gap: 12px;
+  gap: 10px;
 }
 
 .action-buttons button {
@@ -802,7 +1176,7 @@ textarea:focus-visible,
   .app-shell {
     display: flex;
     flex-direction: column;
-    padding-bottom: 180px; /* More room for stacked action bar */
+    padding-bottom: 170px;
   }
 
   .sidebar {
@@ -810,8 +1184,8 @@ textarea:focus-visible,
     height: auto;
     border-right: 0;
     border-bottom: 1px solid var(--line);
-    padding: 20px;
-    gap: 20px;
+    padding: 18px;
+    gap: 16px;
   }
 
   .section-nav {
@@ -819,16 +1193,15 @@ textarea:focus-visible,
   }
 
   .main {
-    padding: 24px 20px;
+    padding: 22px 18px;
   }
 
   .action-bar {
     left: 0;
     grid-template-columns: 1fr;
-    gap: 12px;
-    padding: 16px 20px;
+    gap: 10px;
+    padding: 14px 18px;
     min-height: auto;
-    background: rgba(9, 10, 15, 0.95);
   }
 
   .action-meta {
@@ -847,33 +1220,35 @@ textarea:focus-visible,
 
   .action-buttons button {
     flex: 1;
-    min-height: 44px; /* Better touch target on mobile */
+    min-height: 42px;
   }
 }
 
 /* Mobile Layout Optimization */
 @media (max-width: 600px) {
   .brand {
-    justify-content: center;
-    text-align: center;
-    flex-direction: column;
+    justify-content: flex-start;
   }
   
   .brand-mark {
-    width: 48px;
-    height: 48px;
+    width: 36px;
+    height: 36px;
   }
 
   .section-nav {
     grid-template-columns: 1fr;
   }
   
-  .topbar {
-    text-align: center;
+  .topbar h2 {
+    font-size: 20px;
   }
 
-  .topbar h2 {
-    font-size: 24px;
+  .search-wrapper {
+    min-width: 100%;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
   }
 
   .provider-grid {

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -5,6 +5,8 @@ const state = {
   modelComboboxes: new Set(),
   authPollers: new Map(),
   activeView: "providers",
+  searchQuery: "",
+  providerFilter: "all",
 };
 
 const MASKED_SECRET = "********";
@@ -14,6 +16,7 @@ const VIEW_GROUPS = [
     id: "providers",
     label: "Providers",
     title: "Providers",
+    subtitle: "Manage AI backends, credentials, and model orchestration",
     sections: ["providers", "runtime"],
     containerId: "providersSections",
   },
@@ -21,6 +24,7 @@ const VIEW_GROUPS = [
     id: "model_config",
     label: "Model Config",
     title: "Model Config",
+    subtitle: "Configure default models, reasoning effort, web tools, and fallback priorities",
     sections: ["models", "reasoning", "web_tools"],
     containerId: "modelConfigSections",
   },
@@ -28,6 +32,7 @@ const VIEW_GROUPS = [
     id: "messaging",
     label: "Messaging",
     title: "Messaging",
+    subtitle: "Manage Telegram, Discord, and Voice assistant gateways",
     sections: ["messaging", "voice"],
     containerId: "messagingSections",
   },
@@ -90,13 +95,163 @@ async function load() {
   renderNav();
   renderProviders(config.provider_status);
   renderSections(config.sections, config.fields);
-  byId("configPath").textContent = config.paths.managed;
+  const configPathEl = byId("configPath");
+  if (configPathEl) {
+    configPathEl.textContent = config.paths.managed;
+  }
   await refreshConnectedAccounts();
   await hydrateModelOptions();
   await validate(false);
   await refreshLocalStatus();
   updateDirtyState();
+  updateStats();
+  initSearch();
+  initFilterTabs();
+  initGlobalShortcuts();
   showMessage("");
+}
+
+function updateStats() {
+  if (!state.config) return;
+  const providers = state.config.provider_status || [];
+  const regularProviders = providers.filter((p) => p.kind !== "connected_account");
+  const configuredProviders = regularProviders.filter(
+    (p) => !p.missing_configuration_keys || p.missing_configuration_keys.length === 0,
+  );
+  const connectedAccounts = providers.filter((p) => p.kind === "connected_account");
+
+  const statProvCount = byId("statProvidersCount");
+  const statProvSub = byId("statProvidersSub");
+  if (statProvCount) {
+    statProvCount.textContent = `${configuredProviders.length} / ${regularProviders.length}`;
+  }
+  if (statProvSub) {
+    statProvSub.textContent = connectedAccounts.length
+      ? `${connectedAccounts.length} subscription${connectedAccounts.length > 1 ? "s" : ""} connected`
+      : "Standard API backends";
+  }
+
+  const statModelsCount = byId("statModelsCount");
+  const statModelsSub = byId("statModelsSub");
+  if (statModelsCount) {
+    statModelsCount.textContent = state.modelOptions.length
+      ? `${state.modelOptions.length}`
+      : "Ready";
+  }
+  if (statModelsSub) {
+    statModelsSub.textContent = state.modelOptions.length
+      ? "Models discovered in catalog"
+      : "Refresh to discover models";
+  }
+
+  const statConfigStatus = byId("statConfigStatus");
+  const statConfigSub = byId("statConfigSub");
+  const dirtyCount = Object.keys(changedValues()).length;
+  if (statConfigStatus) {
+    statConfigStatus.textContent = dirtyCount === 0 ? "Synced" : `${dirtyCount} Pending`;
+  }
+  if (statConfigSub) {
+    statConfigSub.textContent = dirtyCount === 0 ? "No unsaved changes" : "Changes ready to apply";
+  }
+}
+
+function initSearch() {
+  const searchInput = byId("adminSearchInput");
+  if (!searchInput || searchInput.dataset.initialized === "true") return;
+  searchInput.dataset.initialized = "true";
+
+  searchInput.addEventListener("input", () => {
+    state.searchQuery = searchInput.value.trim().toLowerCase();
+    filterViewsBySearch();
+  });
+
+  window.addEventListener("keydown", (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      event.preventDefault();
+      searchInput.focus();
+      searchInput.select();
+    } else if (event.key === "Escape" && document.activeElement === searchInput) {
+      searchInput.value = "";
+      state.searchQuery = "";
+      filterViewsBySearch();
+      searchInput.blur();
+    }
+  });
+}
+
+function initFilterTabs() {
+  const container = byId("providerFilterTabs");
+  if (!container || container.dataset.initialized === "true") return;
+  container.dataset.initialized = "true";
+
+  container.querySelectorAll(".filter-tab").forEach((tab) => {
+    tab.addEventListener("click", () => {
+      container.querySelectorAll(".filter-tab").forEach((t) => t.classList.remove("active"));
+      tab.classList.add("active");
+      state.providerFilter = tab.dataset.filter || "all";
+      filterViewsBySearch();
+    });
+  });
+}
+
+function initGlobalShortcuts() {
+  window.addEventListener("keydown", (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+      event.preventDefault();
+      const applyBtn = byId("applyButton");
+      if (applyBtn && !applyBtn.disabled) apply();
+    }
+  });
+}
+
+function filterViewsBySearch() {
+  const q = state.searchQuery;
+  const filter = state.providerFilter || "all";
+  
+  // Filter provider cards
+  document.querySelectorAll("#providerGrid .provider-card").forEach((card) => {
+    const providerId = card.dataset.provider;
+    const provider = state.config?.provider_status?.find((p) => p.provider_id === providerId);
+    
+    let filterMatch = true;
+    if (filter === "configured") {
+      filterMatch = !provider?.missing_configuration_keys || provider.missing_configuration_keys.length === 0;
+    } else if (filter === "missing") {
+      filterMatch = provider?.missing_configuration_keys && provider.missing_configuration_keys.length > 0;
+    } else if (filter === "local") {
+      filterMatch = provider?.kind === "local";
+    }
+
+    let searchMatch = true;
+    if (q) {
+      const text = (card.textContent || "").toLowerCase();
+      searchMatch = text.includes(q);
+    }
+
+    card.hidden = !(filterMatch && searchMatch);
+  });
+
+  // Filter fields
+  document.querySelectorAll(".settings-section").forEach((section) => {
+    let hasVisibleField = false;
+    section.querySelectorAll(".field").forEach((field) => {
+      if (!q) {
+        field.style.display = "";
+        hasVisibleField = true;
+        return;
+      }
+      const text = (field.textContent || "").toLowerCase();
+      const match = text.includes(q);
+      field.style.display = match ? "flex" : "none";
+      if (match) hasVisibleField = true;
+    });
+
+    if (q) {
+      section.hidden = !hasVisibleField;
+    } else {
+      section.hidden = false;
+    }
+  });
 }
 
 function renderNav() {
@@ -124,6 +279,10 @@ function setActiveView(viewId, { scroll = false } = {}) {
     VIEW_GROUPS.find((view) => view.id === viewId) || VIEW_GROUPS[0];
   state.activeView = activeView.id;
   byId("pageTitle").textContent = activeView.title;
+  const subtitleEl = byId("pageSubtitle");
+  if (subtitleEl && activeView.subtitle) {
+    subtitleEl.textContent = activeView.subtitle;
+  }
 
   document.querySelectorAll(".nav-link").forEach((link) => {
     const selected = link.dataset.view === activeView.id;
@@ -427,6 +586,7 @@ async function disconnectConnectedAccount(providerId) {
   });
   updateConnectedAccountCard(connectedAccountDescriptor(providerId), status);
   await hydrateModelOptions();
+  updateStats();
 }
 
 function pollConnectedAccount(provider) {
@@ -439,7 +599,10 @@ function pollConnectedAccount(provider) {
         state.authPollers.set(provider.provider_id, window.setTimeout(poll, 1000));
       } else {
         state.authPollers.delete(provider.provider_id);
-        if (status.connected) await hydrateModelOptions();
+        if (status.connected) {
+          await hydrateModelOptions();
+          updateStats();
+        }
       }
     } catch (error) {
       state.authPollers.delete(provider.provider_id);
@@ -464,7 +627,7 @@ function connectedAccountDescriptor(providerId) {
 async function copyDeviceCode(code) {
   try {
     await navigator.clipboard.writeText(code);
-    showMessage("Device code copied.");
+    showMessage("Device code copied to clipboard.", "ok");
   } catch {
     showMessage(`Copy this device code: ${code}`);
   }
@@ -570,8 +733,14 @@ function renderField(field) {
   input.dataset.remove = "false";
   input.dataset.fieldType = field.type;
   input.disabled = field.locked;
-  input.addEventListener("input", updateDirtyState);
-  input.addEventListener("change", updateDirtyState);
+  input.addEventListener("input", () => {
+    updateDirtyState();
+    updateStats();
+  });
+  input.addEventListener("change", () => {
+    updateDirtyState();
+    updateStats();
+  });
   input.addEventListener("input", () => {
     input.dataset.remove = "false";
   });
@@ -580,6 +749,7 @@ function renderField(field) {
       if (!input.value.trim() || input.value.trim().toLowerCase() === "none") {
         input.value = "None";
         updateDirtyState();
+        updateStats();
       }
     });
   }
@@ -604,6 +774,7 @@ function renderField(field) {
       input.readOnly = removing;
       removeButton.textContent = removing ? "Undo removal" : "Remove";
       updateDirtyState();
+      updateStats();
     });
     wrapper.appendChild(removeButton);
   }
@@ -927,6 +1098,7 @@ class ModelListEditor {
     this.input.dataset.remove = "false";
     this.input.dispatchEvent(new Event("input", { bubbles: true }));
     this.renderRows();
+    updateStats();
   }
 
   renderRows() {
@@ -1020,6 +1192,7 @@ function updateDirtyState() {
   byId("dirtyState").textContent =
     count === 0 ? "No changes" : `${count} unsaved change${count === 1 ? "" : "s"}`;
   byId("applyButton").disabled = count === 0;
+  updateStats();
 }
 
 async function validate(showResult = true) {
@@ -1092,6 +1265,7 @@ async function refreshLocalStatus() {
       `Unavailable: ${detail}`,
     );
   });
+  updateStats();
 }
 
 async function testProvider(providerId, button) {
@@ -1130,6 +1304,7 @@ async function testProvider(providerId, button) {
   } finally {
     button.disabled = false;
     button.textContent = original;
+    updateStats();
   }
 }
 
@@ -1170,6 +1345,7 @@ async function refreshModelOptions(button) {
   } finally {
     button.disabled = false;
     button.textContent = original;
+    updateStats();
   }
 }
 
@@ -1187,6 +1363,7 @@ function setModelOptions(models) {
   state.modelComboboxes.forEach((combobox) => {
     if (combobox.isOpen) combobox.render(combobox.query);
   });
+  updateStats();
 }
 
 function showMessage(message, kind = "") {

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -11,19 +11,92 @@
     <div class="app-shell">
       <aside class="sidebar">
         <div class="brand">
-          <div class="brand-mark">FC</div>
-          <div>
+          <div class="brand-mark">
+            <svg class="brand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+            </svg>
+          </div>
+          <div class="brand-text">
             <h1>Free Claude Code</h1>
-            <p>Server Control</p>
+            <p>Control Center</p>
           </div>
         </div>
+
+        <div class="server-status-pill">
+          <span class="status-indicator-dot"></span>
+          <span class="status-indicator-text">Proxy Active</span>
+        </div>
+
         <nav id="sectionNav" class="section-nav" aria-label="Admin views"></nav>
+
+        <div class="sidebar-footer">
+          <div class="sidebar-footer-card">
+            <div class="footer-badge">v5.16.0</div>
+            <p class="footer-subtext">OpenAI-compatible gateway</p>
+          </div>
+        </div>
       </aside>
 
       <main class="main">
         <header class="topbar">
-          <div>
-            <h2 id="pageTitle">Providers</h2>
+          <div class="topbar-header">
+            <div>
+              <h2 id="pageTitle">Providers</h2>
+              <p class="page-subtitle" id="pageSubtitle">Manage AI backends, credentials, and model orchestration</p>
+            </div>
+            <div class="topbar-actions">
+              <div class="search-wrapper">
+                <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="11" cy="11" r="8"></circle>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
+                <input
+                  id="adminSearchInput"
+                  type="text"
+                  class="search-input"
+                  placeholder="Quick filter (⌘K)..."
+                  aria-label="Filter providers and settings"
+                  autocomplete="off"
+                />
+                <kbd class="search-shortcut">⌘K</kbd>
+              </div>
+            </div>
+          </div>
+
+          <!-- Quick Stats KPI Overview Strip -->
+          <div id="quickStatsBar" class="stats-grid" aria-label="System Metrics">
+            <div class="stat-card">
+              <div class="stat-header">
+                <span class="stat-label">Providers</span>
+                <span class="stat-icon-badge">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect><rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect><line x1="6" y1="6" x2="6.01" y2="6"></line><line x1="6" y1="18" x2="6.01" y2="18"></line></svg>
+                </span>
+              </div>
+              <div class="stat-value" id="statProvidersCount">--</div>
+              <div class="stat-subtext" id="statProvidersSub">Checking status...</div>
+            </div>
+
+            <div class="stat-card">
+              <div class="stat-header">
+                <span class="stat-label">Models Available</span>
+                <span class="stat-icon-badge">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+                </span>
+              </div>
+              <div class="stat-value" id="statModelsCount">--</div>
+              <div class="stat-subtext" id="statModelsSub">Catalog discovery</div>
+            </div>
+
+            <div class="stat-card">
+              <div class="stat-header">
+                <span class="stat-label">Configuration</span>
+                <span class="stat-icon-badge">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                </span>
+              </div>
+              <div class="stat-value" id="statConfigStatus">Ready</div>
+              <div class="stat-subtext" id="statConfigSub">Managed environment</div>
+            </div>
           </div>
         </header>
 
@@ -37,18 +110,35 @@
             >
               <div class="strip-header">
                 <div>
-                  <h3>Connected accounts</h3>
+                  <div class="strip-title-wrapper">
+                    <span class="strip-badge">Subscriptions</span>
+                    <h3>Connected accounts</h3>
+                  </div>
                   <p>Use an existing subscription without storing credentials in .env.</p>
                 </div>
               </div>
               <div id="connectedAccountGrid" class="provider-grid"></div>
             </section>
+
             <section class="provider-strip" aria-label="Provider status">
               <div class="strip-header">
-                <h3>Providers</h3>
+                <div>
+                  <div class="strip-title-wrapper">
+                    <span class="strip-badge">Backends</span>
+                    <h3>Providers</h3>
+                  </div>
+                  <p class="strip-subtext">Active and available upstream LLM service connections</p>
+                </div>
+                <div class="provider-filter-tabs" id="providerFilterTabs">
+                  <button type="button" class="filter-tab active" data-filter="all">All</button>
+                  <button type="button" class="filter-tab" data-filter="configured">Configured</button>
+                  <button type="button" class="filter-tab" data-filter="missing">Unconfigured</button>
+                  <button type="button" class="filter-tab" data-filter="local">Local</button>
+                </div>
               </div>
               <div id="providerGrid" class="provider-grid"></div>
             </section>
+
             <div
               id="providersSections"
               class="form-sections"
@@ -76,13 +166,21 @@
 
       <footer class="action-bar">
         <div class="action-meta">
-          <strong id="dirtyState">No changes</strong>
-          <span id="configPath"></span>
+          <div class="dirty-badge-wrapper">
+            <strong id="dirtyState">No changes</strong>
+          </div>
+          <span id="configPath" title="Configuration file location"></span>
         </div>
-        <div id="messageArea" class="message-area"></div>
+        <div id="messageArea" class="message-area" aria-live="polite"></div>
         <div class="action-buttons">
-          <button id="validateButton" class="secondary-button" type="button">Validate</button>
-          <button id="applyButton" class="primary-button" type="button" disabled>Apply</button>
+          <button id="validateButton" class="secondary-button" type="button">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg>
+            <span>Validate</span>
+          </button>
+          <button id="applyButton" class="primary-button" type="button" disabled>
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path><polyline points="17 21 17 13 7 13 7 21"></polyline><polyline points="7 3 7 8 15 8"></polyline></svg>
+            <span>Apply</span>
+          </button>
         </div>
       </footer>
     </div>

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.15.0"
+version = "5.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
…er dark theme

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change redesigns the local Admin interface with dashboard statistics, provider filters, keyboard shortcuts, and quick settings search. The dashboard can report a disconnected subscription as connected because it counts provider descriptors rather than live account state. The settings search also hides a section when the query matches only its visible heading or description.

## T-Rex validation blocked

- Tool: the connected-account dashboard check ran through initial load, connection, and disconnect interactions, but the artifact-upload mechanism was unavailable. Its required uploaded evidence references could not be produced.

<h3>Confidence Score: 4/5</h3>

The Admin UI should not be merged as-is because connection status can be displayed incorrectly and visible section metadata cannot be found through quick search.

The section-search failure was reproduced in the rendered local Admin UI with uploaded source and output. The subscription-count failure was exercised across disconnected and connected states, but its evidence upload was unavailable.

**Files Needing Attention:** src/free_claude_code/api/admin_static/admin.js

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for two P2 findings and linked them to reviewer comments.
- T-Rex produced a proof for a posted P1 finding and linked it to the reviewer comment.
- T-Rex performed contract-validation work by reproducing the connected-account dashboard against the local Admin UI, validating the server descriptor contract and live-status endpoint, and running a Playwright-based UI repro; the artifact-upload tool was unavailable, so uploaded artifact references could not be produced.

<a href="https://app.greptile.com/trex/runs/20984222/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Disconnected connected-account descriptors are counted as connected**

   - **Bug**
     - The Admin stats subtitle says `1 subscription connected` both on initial load and after the rendered OpenAI/ChatGPT account card shows `NOT CONNECTED`.
   - **Cause**
     - `updateStats()` filters descriptors only by `p.kind === "connected_account"` at line 121 and uses that descriptor count for the connected label at lines 129-130; descriptor status is not consulted.
   - **Fix**
     - Track live connected-account status returned by the auth endpoint and count only statuses with `connected === true` (or state `connected`) when generating the subtitle.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(admin): redesign UI with developer ..."](https://github.com/alishahryar1/free-claude-code/commit/274d09ff4e1323c2e98ac889c9a755af023e3465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57423419)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->