### PR TITLE
Reject invalid provider proxy settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.15.0"
+version = "5.15.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/admin/persistence.py
+++ b/src/free_claude_code/config/admin/persistence.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+import httpx
+
 from free_claude_code.config.env_files import (
     FCC_CONFIG_SCHEMA_ENV,
     dotenv_values_from_file,
@@ -15,6 +17,7 @@ from free_claude_code.config.env_migrations import (
     render_managed_config,
 )
 from free_claude_code.config.paths import managed_env_path
+from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.json_types import JsonObject
 
@@ -22,6 +25,21 @@ from .manifest import FIELD_BY_KEY
 from .state import ConfigInputValue
 from .validation import settings_from_values
 from .values import MASKED_SECRET, is_locked_source, load_value_state, normalize_for_env
+
+_PROVIDER_PROXY_ATTRS = frozenset(
+    descriptor.proxy_attr
+    for descriptor in PROVIDER_CATALOG.values()
+    if descriptor.proxy_attr is not None
+)
+_PROVIDER_PROXY_KEYS = tuple(
+    field.key
+    for field in FIELD_BY_KEY.values()
+    if field.settings_attr in _PROVIDER_PROXY_ATTRS
+)
+_PROVIDER_PROXY_ERROR = (
+    "must be a proxy URL with a supported scheme and host "
+    "(for example http://127.0.0.1:8080 or socks5://127.0.0.1:1080)"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,7 +160,11 @@ def prepare_admin_update(
     update_errors = _update_protocol_errors(updates)
     target_values = target_values_with_updates(updates)
     settings, settings_errors = settings_from_values(target_values)
-    errors = (*update_errors, *settings_errors)
+    errors = (
+        *update_errors,
+        *settings_errors,
+        *_provider_proxy_errors(target_values),
+    )
     pending_fields = (
         tuple(changed_pending_fields(updates, settings=settings))
         if settings is not None and not errors
@@ -184,6 +206,22 @@ def _update_protocol_errors(
             and not field.nullable
         ):
             errors.append(f"{key}: this setting cannot be blank")
+    return tuple(errors)
+
+
+def _provider_proxy_errors(values: Mapping[str, str]) -> tuple[str, ...]:
+    errors: list[str] = []
+    for key in _PROVIDER_PROXY_KEYS:
+        value = values.get(key)
+        if not value:
+            continue
+        try:
+            proxy = httpx.Proxy(value)
+        except httpx.InvalidURL, ValueError:
+            errors.append(f"{key}: {_PROVIDER_PROXY_ERROR}")
+            continue
+        if not proxy.url.host:
+            errors.append(f"{key}: {_PROVIDER_PROXY_ERROR}")
     return tuple(errors)
 
 

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -61,6 +61,23 @@ def _clear_process_config(monkeypatch) -> None:
         "CLAUDE_CLI_BIN",
     ):
         monkeypatch.delenv(key, raising=False)
+    for descriptor in PROVIDER_CATALOG.values():
+        if descriptor.proxy_attr is None:
+            continue
+        alias = Settings.model_fields[descriptor.proxy_attr].validation_alias
+        if alias is not None:
+            monkeypatch.delenv(str(alias), raising=False)
+
+
+def _catalog_proxy_env_keys() -> tuple[str, ...]:
+    keys: list[str] = []
+    for descriptor in PROVIDER_CATALOG.values():
+        if descriptor.proxy_attr is None:
+            continue
+        alias = Settings.model_fields[descriptor.proxy_attr].validation_alias
+        if alias is not None:
+            keys.append(str(alias))
+    return tuple(keys)
 
 
 def test_admin_page_is_loopback_only(monkeypatch, tmp_path):
@@ -816,6 +833,180 @@ def test_admin_validate_rejects_duplicate_model_fallbacks(monkeypatch, tmp_path)
     body = response.json()
     assert body["valid"] is False
     assert any("duplicate" in error.lower() for error in body["errors"])
+
+
+@pytest.mark.parametrize("proxy_key", _catalog_proxy_env_keys())
+def test_admin_validate_rejects_invalid_catalog_provider_proxy(
+    monkeypatch,
+    tmp_path,
+    proxy_key,
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    invalid_proxy = "not-a-proxy://user:leaked-secret@proxy.example:8080"
+
+    response = _local_client(create_test_app()).post(
+        "/admin/api/config/validate",
+        json={"values": {proxy_key: invalid_proxy}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is False
+    assert body["errors"] == [
+        (
+            f"{proxy_key}: must be a proxy URL with a supported scheme and host "
+            "(for example http://127.0.0.1:8080 or socks5://127.0.0.1:1080)"
+        )
+    ]
+    assert invalid_proxy not in response.text
+    assert "leaked-secret" not in response.text
+
+
+@pytest.mark.parametrize(
+    "proxy",
+    (
+        "http://user:password@127.0.0.1:8080",
+        "https://proxy.example:8443",
+        "socks5://127.0.0.1:1080",
+        "socks5h://proxy.example:1080",
+        "  http://127.0.0.1:8080  ",
+    ),
+)
+def test_admin_validate_accepts_httpx_provider_proxy(monkeypatch, tmp_path, proxy):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+
+    response = _local_client(create_test_app()).post(
+        "/admin/api/config/validate",
+        json={"values": {"OPENAI_PROXY": proxy}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["valid"] is True
+
+
+@pytest.mark.parametrize(
+    "proxy",
+    (
+        "copied Admin page text",
+        "socks://127.0.0.1:1080",
+        "http://",
+        "http:///path",
+        "http://proxy.example:notaport",
+    ),
+)
+def test_admin_validate_rejects_unusable_provider_proxy(monkeypatch, tmp_path, proxy):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+
+    response = _local_client(create_test_app()).post(
+        "/admin/api/config/validate",
+        json={"values": {"OPENAI_PROXY": proxy}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is False
+    assert len(body["errors"]) == 1
+    assert body["errors"][0].startswith("OPENAI_PROXY: must be a proxy URL")
+    assert "OPENAI_PROXY=********" in body["env_preview"]
+
+
+def test_admin_apply_rejects_invalid_provider_proxy_without_side_effects(
+    monkeypatch,
+    tmp_path,
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    env_file = tmp_path / ".fcc" / ".env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text("MODEL=open_router/test-model\n", encoding="utf-8")
+    callbacks: list[str] = []
+
+    async def restart_callback() -> None:
+        callbacks.append("restart")
+
+    app = create_test_app(restart_callback=restart_callback)
+    _local_client(app).get("/admin/api/config")
+    baseline = env_file.read_bytes()
+    invalid_proxy = "invalid://user:leaked-secret@proxy.example:8080"
+
+    response = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"OPENAI_PROXY": invalid_proxy}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is False
+    assert body["applied"] is False
+    assert body["pending_fields"] == []
+    assert env_file.read_bytes() == baseline
+    assert callbacks == []
+    assert invalid_proxy not in response.text
+    assert "leaked-secret" not in response.text
+
+
+def test_admin_apply_validates_retained_proxy_and_allows_removal(
+    monkeypatch,
+    tmp_path,
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    env_file = tmp_path / ".fcc" / ".env"
+    env_file.parent.mkdir(parents=True)
+    invalid_proxy = "invalid://proxy.example:8080"
+    original = f"GROQ_PROXY={invalid_proxy}\n"
+    env_file.write_text(original, encoding="utf-8")
+    app = create_test_app()
+    _local_client(app).get("/admin/api/config")
+    baseline = env_file.read_bytes()
+
+    rejected = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"MODEL": "open_router/test-model"}},
+    )
+
+    assert rejected.status_code == 200
+    assert rejected.json()["applied"] is False
+    assert env_file.read_bytes() == baseline
+
+    removed = _local_client(app).post(
+        "/admin/api/config/apply",
+        json={"values": {"GROQ_PROXY": None}},
+    )
+
+    assert removed.status_code == 200
+    assert removed.json()["applied"] is True
+    assert "GROQ_PROXY=" not in env_file.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("submitted", (MASKED_SECRET, "", "   "))
+def test_admin_validate_preserves_valid_stored_proxy_secret(
+    monkeypatch,
+    tmp_path,
+    submitted,
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    env_file = tmp_path / ".fcc" / ".env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text(
+        "OPENAI_PROXY=http://user:password@127.0.0.1:8080\n",
+        encoding="utf-8",
+    )
+
+    response = _local_client(create_test_app()).post(
+        "/admin/api/config/validate",
+        json={"values": {"OPENAI_PROXY": submitted}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is True
+    assert "OPENAI_PROXY=********" in body["env_preview"]
+    assert "password" not in response.text
 
 
 def test_admin_apply_writes_complete_managed_env_and_masks_preview(

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.15.0"
+version = "5.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Admin UI accepted any non-empty provider proxy string, allowing an invalid value to be persisted and later prevent HTTPX client construction. Fixes #1582.

## Changes

| Before | After |
| --- | --- |
| Admin validation accepted malformed catalog-provider proxy values. | Admin validation checks every catalog-provider proxy with HTTPX and requires a host. |
| Invalid Apply requests could persist unusable proxy configuration and trigger restart handling. | Invalid Apply requests return redacted errors without writing or restarting FCC. |
| Proxy validation had no catalog-wide regression coverage. | Tests cover all 48 catalog proxy fields, supported schemes, hostless URLs, redaction, and atomic rejection. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds provider-catalog-driven proxy validation before admin configuration is saved. The new exception handler in the persistence module uses invalid Python syntax, so Python cannot compile or import the module and application paths that load admin configuration persistence cannot start until it is corrected.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge until the persistence module's exception syntax is corrected.

A direct Python 3.11 compile check reproduced the syntax error at the changed exception handler, establishing that the module cannot load.

**Files Needing Attention:** src/free_claude_code/config/admin/persistence.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex published a proof for the posted P1 finding and attached a syntax-check command source and a Python compile failure log.
- During contract validation, T-Rex inspected the admin persistence code at src/free\_claude\_code/config/admin/persistence.py:220 and noted a Python compile failure with exit code 1 on Python 3.11.6, with related command source and output artifacts uploaded.
- T-Rex published a second proof for another posted P1 finding, with details in the corresponding review comment.

<a href="https://app.greptile.com/trex/runs/20988077/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Python 2 exception syntax prevents admin persistence module compilation**

   - **Bug**
     - Compiling `src/free_claude_code/config/admin/persistence.py` under Python 3.11 fails at line 220 with `SyntaxError: multiple exception types must be parenthesized`.
   - **Cause**
     - The handler uses comma-separated exception types without parentheses: `except httpx.InvalidURL, ValueError:`.
   - **Fix**
     - Use Python 3 syntax: `except (httpx.InvalidURL, ValueError):`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Freject-invalid-provider-proxies%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Freject-invalid-provider-proxies%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231585%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=alishahryar1%2Ffree-claude-code&pr=1585&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Freject-invalid-provider-proxies%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Freject-invalid-provider-proxies%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fconfig%2Fadmin%2Fpersistence.py%3A220%0A**Exception%20syntax%20prevents%20imports**%0A%0AThe%20comma-separated%20exception%20clause%20uses%20Python%202%20syntax%3A%20%60except%20httpx.InvalidURL%2C%20ValueError%3A%60.%20Python%203%20raises%20%60SyntaxError%3A%20multiple%20exception%20types%20must%20be%20parenthesized%60%20while%20compiling%20this%20module%2C%20so%20any%20application%20path%20that%20imports%20admin%20configuration%20persistence%20cannot%20start.%20Parenthesize%20the%20exception%20types%20as%20%60except%20%28httpx.InvalidURL%2C%20ValueError%29%3A%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1585&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Reject invalid provider proxy settings"](https://github.com/alishahryar1/free-claude-code/commit/f9acedc3c2e69ee4ebdb555494966825d47b9135) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57430839)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->