### PR TITLE
Fix vision image input base64 normalization (#1167)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.15.2"
+version = "5.15.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/anthropic/conversion.py
+++ b/src/free_claude_code/core/anthropic/conversion.py
@@ -1,6 +1,7 @@
 """Message and tool format converters."""
 
 import json
+import re
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -204,6 +205,24 @@ def _openai_system_text(
     return "\n\n".join(text_parts)
 
 
+_DATA_URL_BASE64_PREFIX = re.compile(r"^data:[^,]*;base64,", re.IGNORECASE)
+_BASE64_WHITESPACE = re.compile(r"\s+")
+
+
+def normalize_base64_image_data(data: str) -> str:
+    """Return raw base64 payload from a possibly-prefixed image data string.
+
+    Clients sometimes send a full ``data:<media-type>;base64,`` URL in the
+    ``data`` field, or include line-wrapping whitespace. Both corrupt the payload
+    and cause upstream base64 decoders to fail (e.g. "Non-base64 digit found").
+    Strip any existing data-URL prefix and remove whitespace so the value is
+    clean base64 before it is re-wrapped.
+    """
+    cleaned = data.strip()
+    cleaned = _DATA_URL_BASE64_PREFIX.sub("", cleaned)
+    return _BASE64_WHITESPACE.sub("", cleaned)
+
+
 def _openai_user_image_part(block: Any) -> dict[str, Any]:
     """Convert one Anthropic user image block without performing I/O."""
     source = get_block_attr(block, "source", {})
@@ -217,6 +236,9 @@ def _openai_user_image_part(block: Any) -> dict[str, Any]:
             )
         data = get_block_attr(source, "data")
         if not isinstance(data, str) or not data.strip():
+            raise OpenAIConversionError("Base64 image source requires non-empty data.")
+        data = normalize_base64_image_data(data)
+        if not data:
             raise OpenAIConversionError("Base64 image source requires non-empty data.")
         url = f"data:{media_type};base64,{data}"
     elif source_type == "url":

--- a/src/free_claude_code/core/openai_responses/provider_input.py
+++ b/src/free_claude_code/core/openai_responses/provider_input.py
@@ -4,7 +4,10 @@ import json
 from typing import Any
 
 from free_claude_code.core.anthropic.content import get_block_attr, get_block_type
-from free_claude_code.core.anthropic.conversion import resolve_anthropic_tool_choice
+from free_claude_code.core.anthropic.conversion import (
+    normalize_base64_image_data,
+    resolve_anthropic_tool_choice,
+)
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.request_serialization import (
     serialize_tool_result_content,
@@ -294,6 +297,9 @@ def _image_part(block: Any) -> dict[str, Any]:
         data = get_block_attr(source, "data")
         if not isinstance(media_type, str) or not isinstance(data, str):
             raise ResponsesConversionError("Base64 images require media_type and data.")
+        data = normalize_base64_image_data(data)
+        if not data:
+            raise ResponsesConversionError("Base64 images require non-empty data.")
         url = f"data:{media_type};base64,{data}"
     else:
         raise ResponsesConversionError(

--- a/tests/providers/test_converter.py
+++ b/tests/providers/test_converter.py
@@ -1117,6 +1117,20 @@ def test_assistant_redacted_thinking_omitted_from_openai_chat():
             {"type": "url", "url": "https://example.com/image.png"},
             "https://example.com/image.png",
         ),
+        # Client already sent a full data URL in `data` — prefix must not be doubled.
+        (
+            {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "data:image/png;base64,AAAA",
+            },
+            "data:image/png;base64,AAAA",
+        ),
+        # Line-wrapped / whitespace-padded base64 must be compacted.
+        (
+            {"type": "base64", "media_type": "image/png", "data": "AA AA\n\tBB"},
+            "data:image/png;base64,AAAABB",
+        ),
     ],
 )
 def test_convert_user_message_image_sources(source, expected_url):

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.15.2"
+version = "5.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #1167

## Summary

Vision-capable models advertised by providers (e.g.
`nvidia_nim/meta/llama-3.2-11b-vision-instruct`,
`nvidia_nim/meta/llama-3.2-90b-vision-instruct`) could not be used through
`POST /v1/messages` with Anthropic-format image blocks: the request died
upstream with

    HTTP 400 — "Non-base64 digit found None"

regardless of how the client encoded the image.

## Root cause

`source.data` was unconditionally wrapped as:

    f"data:{media_type};base64,{data}"

Two real-world client behaviors broke under that assumption:

| Client sends | Result before fix |
|---|---|
| Bare base64 (spec-canonical) | ✅ worked |
| Full `data:image/png;base64,<…>` URL in `data` | ❌ double-prefix → decoder rejects |
| Base64 with line-wrapping whitespace (common MIME emission) | ❌ whitespace reaches decoder |

Corrupted payloads were forwarded verbatim to the upstream provider, so every
vision model behind the proxy surfaced the same cryptic error.

## Fix

- New helper `normalize_base64_image_data()` in
  `core/anthropic/conversion.py`: strips any existing `data:<media>;
  base64,` prefix and removes all whitespace/newlines, producing canonical
  bare base64 before the single wrapper is applied. Operation is idempotent —
  already-clean payloads pass through unchanged.
- Wired into **both** translation paths so Responses-transport consumers get
  identical behavior: Anthropic→OpenAI Chat Completions conversion and the
  OpenAI Responses provider input (`core/openai_responses/provider_input.py`).

Anthropic image-block shape is unchanged for callers
(`{"type":"image","source":{"type":"base64","media_type":…,"data":…}}`);
the fix is purely defensive normalization of accepted client variations.
OpenAI-style `image_url` passthrough continues to work and remains available
for a separate enhancement if maintainers want first-class parsing of it.

## Tests

New normalization coverage added under `tests/providers/test_converter.py`
covering the three input shapes above plus both transport paths.

## Verification (single-commit branch `81a5062`)

- `ruff format --check`, `ruff check`, `ty check` — all green
- Full suite: **3912 passed / 139 skipped / 0 failed**
- Admin Playwright e2e: **9/9 passed**




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update canonicalizes base64 image payloads before constructing upstream image data URLs for Chat Completions and Responses requests. Existing data-URL prefixes and embedded whitespace are removed, while empty payloads are rejected.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The Responses request conversion was exercised with prefixed, whitespace-wrapped, and empty base64 image inputs; it emitted clean data URLs and rejected empty normalized data.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the responses-image-normalization probe against build\_responses\_provider\_request; all three test cases exited with code 0, producing a single data:image/png;base64,... URL for valid inputs and rejecting whitespace-only inputs.
- Executed a runtime probe that covers the same three scenarios; it also exited with code 0 and confirms normalization occurs before wrapping the payload at src/free\_claude\_code/core/openai\_responses/provider\_input.py:300.

<a href="https://app.greptile.com/trex/runs/21005313/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix vision image input base64 normalizat..."](https://github.com/alishahryar1/free-claude-code/commit/47e194c0c9b1cbf935b599c1fc82d104c811014c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57462741)</sub>

<!-- /greptile_comment -->