### PR TITLE
Dockerfile created

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Only Local access to admin dashboard
+# LOCAL_ONLY_ADMIN=false
+
 # NVIDIA NIM Config
 # NVIDIA_NIM_API_KEY=<your-token>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# vim: ft=Dockerfile
+
+FROM python:3.13-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . /app/
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:$PATH"
+
+WORKDIR /app
+
+RUN uv sync --frozen
+
+ENTRYPOINT ["uv", "run", "fcc-server"]
+
+# build:
+# docker build -t fcc-image .
+
+# run:
+# docker run -d --rm -p 8082:8082 --env-file .env fcc-image:latest
+# docker run -d --rm -p 8082:8082 --env LOCAL_ONLY_ADMIN=false fcc-image:latest

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -28,7 +28,11 @@ from free_claude_code.core.json_types import JsonObject, JsonValue
 from .dependencies import get_services
 from .ports import ApiServices
 
+import os
+
 router = APIRouter()
+
+LOCAL_ONLY_ADMIN=os.getenv("LOCAL_ONLY_ADMIN")
 
 STATIC_DIR = Path(__file__).resolve().parent / "admin_static"
 LOCAL_PROVIDER_PATHS = {
@@ -74,6 +78,9 @@ def _origin_is_local(origin: str | None) -> bool:
 
 def require_loopback_admin(request: Request) -> None:
     """Allow admin access only from the local machine."""
+
+    if LOCAL_ONLY_ADMIN == "false":
+        return
 
     client_host = request.client.host if request.client else None
     if not _is_loopback_host(client_host):


### PR DESCRIPTION
Option to set if allow only local to admin access added just set LOCAL_ONLY_ADMIN=false on .env file
Dockerfile created

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a Docker image for running the server and introduces `LOCAL_ONLY_ADMIN=false` to allow administration beyond loopback clients. Runtime checks confirmed that this setting allows unauthenticated remote callers to invoke sensitive admin operations, and the required release metadata update is absent. Docker checks also confirmed that local `.env` and `.venv` content is copied into the image and that the server process runs as root.

The Python base-image concern was disproved by a no-cache Docker build: `uv sync --frozen` downloaded and used CPython 3.14.0, completed successfully, and the resulting image ran with Python 3.14.0.

<h3>Confidence Score: 0/5</h3>

The change is not safe to merge until remote administrative access is protected and the container packaging issues are addressed.

Direct API and Docker executions reproduced unauthenticated remote administration, inclusion of ignored local files in the image, root execution, and the missing required release metadata update.

**Files Needing Attention:** `src/free_claude_code/api/admin_routes.py` needs authenticated remote-admin handling and release metadata updates; `Dockerfile` needs build-context exclusions and an unprivileged runtime user.

<details open><summary><h3>Security Review</h3></summary>

Setting `LOCAL_ONLY_ADMIN=false` exposes sensitive admin actions to unauthenticated non-loopback callers while the server defaults to an all-interface bind. The Docker image can also embed ignored environment files in image layers and runs the network-facing server as root.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and referenced the review comment for details.
- T-Rex validated the P1 admin cancellation change by showing pre-change cancellation, the 403 Forbidden state, and the post-change behavior with 200 OK and disconnect state including cancel\_login invocation.
- T-Rex demonstrated Docker entrypoint root checks related to P2 by running the root check script and capturing the before and after outputs.
- T-Rex tested Docker build context handling with a temporary .dockerignore to exclude env and .venv, and also built without a dockerignore to show inclusion of env and .venv and a large context.
- T-Rex validated the runtime code change rule by comparing a blocked and an allowed commit, and listing the changed files that trigger the semantic versioning requirement.

<a href="https://app.greptile.com/trex/runs/21051352/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (3)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **LOCAL_ONLY_ADMIN=false disables all remote admin access controls**

   - **Bug**
     - A non-loopback client (`203.0.113.10:50123`) made an unauthenticated `POST /admin/api/providers/openai/auth/cancel` request with `LOCAL_ONLY_ADMIN=false`. The endpoint returned `200 OK` and executed `cancel_login`, changing the connected-account state to disconnected. The server default bind host is `0.0.0.0`, so this surface is network-reachable by default.
   - **Cause**
     - `require_loopback_admin()` returns before checking client host or Origin when the module-level `LOCAL_ONLY_ADMIN` equals the string `false`. Admin routes do not apply proxy-token authentication.
   - **Fix**
     - Do not make remote admin access unauthenticated. Keep loopback enforcement, or require a dedicated strong admin authentication mechanism before allowing non-loopback clients; bind to loopback by default if remote exposure is not intended.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Runtime admin-access change lacks the required same-commit version bump**

   - **Bug**
     - `LOCAL_ONLY_ADMIN=false` changes the production API/admin authorization contract by allowing a non-loopback client that was previously rejected. The repository versioning rule requires runtime-code changes to include a semantic `pyproject.toml` bump and matching `uv.lock` update in the same commit, but neither file is part of commit `37d1452`.
   - **Cause**
     - The commit modified `require_loopback_admin` in `src/free_claude_code/api/admin_routes.py` without updating release metadata or lockfile.
   - **Fix**
     - In the same commit, increment `[project].version` in `pyproject.toml` according to semver and regenerate/commit the matching `uv.lock` update.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Docker build includes ignored environment file and virtual environment**

   - **Bug**
     - The actual Docker build context and resulting layer include the probe `.env` file and the existing `.venv` directory under `/app` because no `.dockerignore` is present.
   - **Cause**
     - Docker ignores `.gitignore`; `COPY . /app/` copies all build-context files not excluded by `.dockerignore`.
   - **Fix**
     - Add a `.dockerignore` that excludes at least `.env` and `.venv` (and other local caches/artifacts as appropriate).

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Dockerfile created"](https://github.com/alishahryar1/free-claude-code/commit/37d1452e8ed9ca52a75584858daca8d295cba9e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57553750)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->