### PR TITLE
Report Chat cache hits in Anthropic usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.15.2"
+version = "5.15.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -719,8 +719,26 @@ class OpenAIChatProvider(BaseProvider):
         return {}
 
     def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:
-        """Return provider-specific Anthropic usage fields for final SSE usage."""
-        return {}
+        """Split standard cached prompt tokens for final Anthropic usage."""
+        prompt_tokens = usage_int(usage_info, "prompt_tokens")
+        cached_tokens = nested_usage_int(
+            usage_info,
+            "prompt_tokens_details",
+            "cached_tokens",
+        )
+        if (
+            prompt_tokens is None
+            or prompt_tokens < 0
+            or cached_tokens is None
+            or cached_tokens < 0
+            or cached_tokens > prompt_tokens
+        ):
+            return {}
+
+        return {
+            "input_tokens": prompt_tokens - cached_tokens,
+            "cache_read_input_tokens": cached_tokens,
+        }
 
     async def _create_stream(
         self,

--- a/tests/providers/test_openai_chat_usage.py
+++ b/tests/providers/test_openai_chat_usage.py
@@ -7,9 +7,13 @@ from unittest.mock import AsyncMock, patch
 import openai
 import pytest
 from httpx2 import Request, Response
+from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
 
 from free_claude_code.core.anthropic import ReasoningReplayMode
 from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.sse_aggregation import (
+    aggregate_anthropic_sse_to_message,
+)
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
 from free_claude_code.providers.admission import ProviderOperationKind
@@ -148,6 +152,110 @@ def test_usage_int_reads_dict_object_and_model_extra():
     assert usage_int({"prompt_tokens": True}, "prompt_tokens") is None
 
 
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        (
+            {
+                "prompt_tokens": 22,
+                "prompt_tokens_details": {"cached_tokens": 15},
+            },
+            {"input_tokens": 7, "cache_read_input_tokens": 15},
+        ),
+        (
+            CompletionUsage(
+                completion_tokens=4,
+                prompt_tokens=22,
+                total_tokens=26,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=15),
+            ),
+            {"input_tokens": 7, "cache_read_input_tokens": 15},
+        ),
+        (
+            SimpleNamespace(
+                prompt_tokens=22,
+                prompt_tokens_details=None,
+                model_extra={
+                    "prompt_tokens_details": {"cached_tokens": 15},
+                },
+            ),
+            {"input_tokens": 7, "cache_read_input_tokens": 15},
+        ),
+        (
+            {
+                "prompt_tokens": 22,
+                "prompt_tokens_details": {"cached_tokens": 0},
+            },
+            {"input_tokens": 22, "cache_read_input_tokens": 0},
+        ),
+        (
+            {
+                "prompt_tokens": 0,
+                "prompt_tokens_details": {"cached_tokens": 0},
+            },
+            {"input_tokens": 0, "cache_read_input_tokens": 0},
+        ),
+    ],
+)
+def test_maps_standard_chat_cache_usage_to_anthropic_fields(usage, expected):
+    provider = _UsageTestProvider()
+
+    assert provider._anthropic_usage_fields(usage) == expected
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        None,
+        {},
+        {"prompt_tokens_details": {"cached_tokens": 15}},
+        {"prompt_tokens": 22},
+        {"prompt_tokens": 22, "prompt_tokens_details": None},
+        {"prompt_tokens": 22, "prompt_tokens_details": "invalid"},
+        {
+            "prompt_tokens": -1,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        },
+        {
+            "prompt_tokens": 22,
+            "prompt_tokens_details": {"cached_tokens": -1},
+        },
+        {
+            "prompt_tokens": 22,
+            "prompt_tokens_details": {"cached_tokens": 23},
+        },
+        {
+            "prompt_tokens": True,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        },
+        {
+            "prompt_tokens": 22.0,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        },
+        {
+            "prompt_tokens": "22",
+            "prompt_tokens_details": {"cached_tokens": 0},
+        },
+        {
+            "prompt_tokens": 22,
+            "prompt_tokens_details": {"cached_tokens": True},
+        },
+        {
+            "prompt_tokens": 22,
+            "prompt_tokens_details": {"cached_tokens": 15.0},
+        },
+        {
+            "prompt_tokens": 22,
+            "prompt_tokens_details": {"cached_tokens": "15"},
+        },
+    ],
+)
+def test_ignores_incomplete_or_inconsistent_standard_cache_usage(usage):
+    provider = _UsageTestProvider()
+
+    assert provider._anthropic_usage_fields(usage) == {}
+
+
 def test_stream_usage_rejection_matches_usage_option_400():
     error = _bad_request(
         "Unrecognized request argument supplied: stream_options",
@@ -170,7 +278,12 @@ def test_stream_usage_rejection_does_not_match_unrelated_400():
 async def test_openai_chat_stream_requests_usage_and_uses_provider_prompt_tokens():
     provider = _UsageTestProvider()
     request = make_messages_request(model="m")
-    usage = SimpleNamespace(prompt_tokens=22, completion_tokens=4)
+    usage = CompletionUsage(
+        completion_tokens=4,
+        prompt_tokens=22,
+        total_tokens=26,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=15),
+    )
     create = AsyncMock(
         return_value=_stream(
             [
@@ -200,7 +313,46 @@ async def test_openai_chat_stream_requests_usage_and_uses_provider_prompt_tokens
         event.data["usage"] for event in parsed if event.event == "message_delta"
     )
     assert start_usage["input_tokens"] == 7
-    assert final_usage == {"input_tokens": 22, "output_tokens": 4}
+    assert final_usage == {
+        "input_tokens": 7,
+        "output_tokens": 4,
+        "cache_read_input_tokens": 15,
+    }
+    assert sum(event.event == "message_delta" for event in parsed) == 1
+    assert sum(event.event == "message_stop" for event in parsed) == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_nonstream_message_uses_final_cache_partition():
+    provider = _UsageTestProvider()
+    request = make_messages_request(model="m")
+    usage = CompletionUsage(
+        completion_tokens=4,
+        prompt_tokens=22,
+        total_tokens=26,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=15),
+    )
+    create = AsyncMock(
+        return_value=_stream(
+            [
+                _chunk(content="hello"),
+                _chunk(finish_reason="stop"),
+                _chunk(usage=usage),
+            ]
+        )
+    )
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        message, error = await aggregate_anthropic_sse_to_message(
+            provider.stream_messages(request, input_tokens=7)
+        )
+
+    assert error is None
+    assert message["usage"] == {
+        "input_tokens": 7,
+        "output_tokens": 4,
+        "cache_read_input_tokens": 15,
+    }
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.15.2"
+version = "5.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

OpenAI-compatible Chat providers count cached prompt tokens inside `prompt_tokens`, but FCC reported that inclusive total as ordinary Anthropic input and omitted the cache-read usage field.

## Changes

| Before | After |
| --- | --- |
| Anthropic usage counted standard Chat cache hits as ordinary input. | Anthropic usage separates validated standard Chat cache hits into `cache_read_input_tokens`. |
| Missing or inconsistent upstream cache metrics had no generic partition. | Missing or inconsistent metrics retain the existing unsplit usage without guessing. |
| Streaming and non-streaming Messages inherited the same incorrect final usage. | Streaming and non-streaming Messages receive the same corrected terminal usage. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change reports validated OpenAI-compatible cached prompt tokens separately from ordinary input tokens in Anthropic-compatible usage responses, and updates the package version to 5.15.3.

The potential for cached tokens to be double-counted, ordinary prompt tokens to be lost, or malformed cache metrics to corrupt final usage was exercised and disproved. Streamed and aggregated non-stream responses with 22 prompt tokens and 15 cached tokens reported 7 input tokens, 15 cache-read input tokens, and 4 output tokens. An invalid cache count of 23 against 22 prompt tokens retained ordinary input usage of 22 without a cache-read field. The focused OpenAI Chat usage tests passed.
</details>


<h3>Confidence Score: 5/5</h3>

The updated usage reporting is safe to merge based on the exercised streaming, non-stream aggregation, and invalid-metric paths.

No defects remain in the final review. The key accounting behavior was executed with valid cached usage and an inconsistent cache-token count, and the focused provider test suite passed.

**Files Needing Attention:** No files require follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an executable mocked-provider validation to exercise valid streamed usage, valid aggregated non-stream usage, and a malformed cached-token scenario.
- Validated that valid usage with prompt\_tokens=\[REDACTED\] and cached\_tokens=\[REDACTED\] produced input\_tokens=\[REDACTED\], cache\_read\_input\_tokens=\[REDACTED\], and output\_tokens=\[REDACTED\] in both delivery modes, and that an invalid cached\_tokens=\[REDACTED\] value against prompt\_tokens yielded ordinary input\_tokens=\[REDACTED\] without a cache field.
- Ran the focused OpenAI Chat usage suite, which completed with 31 tests passed.
- Collected and reviewed artifacts, including the mocked-provider validation source, the cache-usage validation output, and the focused OpenAI Chat suite output.

<a href="https://app.greptile.com/trex/runs/21161145/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: report chat cache hits in Anthropic..."](https://github.com/alishahryar1/free-claude-code/commit/b680f0511ea244a930ed5460ce2a861baedfe7a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57758076)</sub>

<!-- /greptile_comment -->