### PR TITLE
Preserve DeepSeek cache hits in Responses usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.15.3"
+version = "5.15.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/deepseek/client.py
+++ b/src/free_claude_code/providers/deepseek/client.py
@@ -25,6 +25,27 @@ _PROFILE = OpenAIChatProfile(
 )
 
 
+def _deepseek_cache_partition(
+    usage_info: object,
+) -> tuple[int, int, int | None] | None:
+    cache_hit_tokens = usage_int(usage_info, "prompt_cache_hit_tokens")
+    cache_miss_tokens = usage_int(usage_info, "prompt_cache_miss_tokens")
+    if (
+        cache_hit_tokens is None
+        or cache_hit_tokens < 0
+        or cache_miss_tokens is None
+        or cache_miss_tokens < 0
+    ):
+        return None
+
+    prompt_tokens = usage_int(usage_info, "prompt_tokens")
+    if prompt_tokens is None or prompt_tokens < 0:
+        return cache_hit_tokens, cache_miss_tokens, None
+    if prompt_tokens != cache_hit_tokens + cache_miss_tokens:
+        return None
+    return cache_hit_tokens, cache_miss_tokens, prompt_tokens
+
+
 class DeepSeekProvider(OpenAIChatProvider):
     """DeepSeek using ``https://api.deepseek.com`` Chat Completions."""
 
@@ -58,25 +79,18 @@ class DeepSeekProvider(OpenAIChatProvider):
         finalize_deepseek_chat_body(body, reasoning)
         return body
 
+    def _cached_input_tokens(self, usage_info: object) -> int | None:
+        cache_partition = _deepseek_cache_partition(usage_info)
+        if cache_partition is None:
+            return None
+        cache_hit_tokens, _, prompt_tokens = cache_partition
+        return cache_hit_tokens if prompt_tokens is not None else None
+
     def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:
-        cache_hit_tokens = usage_int(usage_info, "prompt_cache_hit_tokens")
-        cache_miss_tokens = usage_int(usage_info, "prompt_cache_miss_tokens")
-        if (
-            cache_hit_tokens is None
-            or cache_hit_tokens < 0
-            or cache_miss_tokens is None
-            or cache_miss_tokens < 0
-        ):
+        cache_partition = _deepseek_cache_partition(usage_info)
+        if cache_partition is None:
             return {}
-
-        prompt_tokens = usage_int(usage_info, "prompt_tokens")
-        if (
-            prompt_tokens is not None
-            and prompt_tokens >= 0
-            and prompt_tokens != cache_hit_tokens + cache_miss_tokens
-        ):
-            return {}
-
+        cache_hit_tokens, cache_miss_tokens, _ = cache_partition
         return {
             "input_tokens": cache_miss_tokens,
             "cache_read_input_tokens": cache_hit_tokens,

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -718,14 +718,18 @@ class OpenAIChatProvider(BaseProvider):
         """Return provider-specific per-tool argument aliases for this request."""
         return {}
 
-    def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:
-        """Split standard cached prompt tokens for final Anthropic usage."""
-        prompt_tokens = usage_int(usage_info, "prompt_tokens")
-        cached_tokens = nested_usage_int(
+    def _cached_input_tokens(self, usage_info: object) -> int | None:
+        """Return the provider's cached-input count from final Chat usage."""
+        return nested_usage_int(
             usage_info,
             "prompt_tokens_details",
             "cached_tokens",
         )
+
+    def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:
+        """Split standard cached prompt tokens for final Anthropic usage."""
+        prompt_tokens = usage_int(usage_info, "prompt_tokens")
+        cached_tokens = self._cached_input_tokens(usage_info)
         if (
             prompt_tokens is None
             or prompt_tokens < 0
@@ -1098,14 +1102,8 @@ class _OpenAIChatStreamRunner:
         usage = ChatStreamUsage(
             input_tokens=completion.input_tokens,
             output_tokens=completion.output_tokens,
-            cached_tokens=(
-                nested_usage_int(
-                    assembler.usage_info,
-                    "prompt_tokens_details",
-                    "cached_tokens",
-                )
-                or 0
-            ),
+            cached_tokens=self._provider._cached_input_tokens(assembler.usage_info)
+            or 0,
             reasoning_tokens=(
                 nested_usage_int(
                     assembler.usage_info,

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -134,7 +134,7 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
 
 
 @pytest.mark.parametrize(
-    ("usage", "expected"),
+    ("usage", "anthropic_expected", "responses_cached"),
     [
         (
             {
@@ -143,6 +143,7 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": 20,
             },
             {"input_tokens": 20, "cache_read_input_tokens": 10},
+            10,
         ),
         (
             {
@@ -151,6 +152,7 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": 30,
             },
             {"input_tokens": 30, "cache_read_input_tokens": 0},
+            0,
         ),
         (
             {
@@ -159,18 +161,22 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": 0,
             },
             {"input_tokens": 0, "cache_read_input_tokens": 30},
+            30,
         ),
         (
             {"prompt_cache_hit_tokens": 10, "prompt_cache_miss_tokens": 20},
             {"input_tokens": 20, "cache_read_input_tokens": 10},
+            None,
         ),
         (
             {"prompt_tokens": 30, "prompt_cache_miss_tokens": 20},
             {},
+            None,
         ),
         (
             {"prompt_tokens": 30, "prompt_cache_hit_tokens": 10},
             {},
+            None,
         ),
         (
             {
@@ -179,6 +185,7 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": 20,
             },
             {},
+            None,
         ),
         (
             {
@@ -187,6 +194,7 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": 20.0,
             },
             {},
+            None,
         ),
         (
             {
@@ -195,6 +203,7 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": 31,
             },
             {},
+            None,
         ),
         (
             {
@@ -203,6 +212,16 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": -1,
             },
             {},
+            None,
+        ),
+        (
+            {
+                "prompt_tokens": -1,
+                "prompt_cache_hit_tokens": 10,
+                "prompt_cache_miss_tokens": 20,
+            },
+            {"input_tokens": 20, "cache_read_input_tokens": 10},
+            None,
         ),
         (
             {
@@ -211,13 +230,15 @@ def test_responses_tool_history_keeps_deepseek_replayable_reasoning(
                 "prompt_cache_miss_tokens": 19,
             },
             {},
+            None,
         ),
     ],
 )
 def test_maps_only_complete_consistent_cache_usage(
-    deepseek_provider, usage, expected
+    deepseek_provider, usage, anthropic_expected, responses_cached
 ) -> None:
-    assert deepseek_provider._anthropic_usage_fields(usage) == expected
+    assert deepseek_provider._anthropic_usage_fields(usage) == anthropic_expected
+    assert deepseek_provider._cached_input_tokens(usage) == responses_cached
 
 
 def test_build_request_body_openai_chat_shape(deepseek_provider):
@@ -1177,6 +1198,69 @@ async def test_stream_uses_chat_completions_and_maps_cache_usage(deepseek_provid
         "input_tokens": 20,
         "output_tokens": 3,
         "cache_read_input_tokens": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_maps_deepseek_cache_usage(deepseek_provider):
+    request = OpenAIResponsesRequest(model="m", input="hi")
+
+    async def fake_stream():
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        content="hello", reasoning_content=None, tool_calls=None
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        )
+        yield SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        content=None, reasoning_content=None, tool_calls=None
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=None,
+        )
+        yield SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                completion_tokens=3,
+                prompt_tokens=30,
+                model_extra={
+                    "prompt_cache_hit_tokens": 10,
+                    "prompt_cache_miss_tokens": 20,
+                },
+            ),
+        )
+
+    create = AsyncMock(return_value=fake_stream())
+    with patch.object(deepseek_provider._client.chat.completions, "create", create):
+        chunks = [
+            chunk
+            async for chunk in deepseek_provider.stream_responses(
+                request, input_tokens=7, request_id="r1"
+            )
+        ]
+
+    parsed = parse_sse_text("".join(chunks))
+    completed = next(
+        event.data["response"]
+        for event in parsed
+        if event.event == "response.completed"
+    )
+    assert completed["usage"] == {
+        "input_tokens": 30,
+        "input_tokens_details": {"cached_tokens": 10},
+        "output_tokens": 3,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": 33,
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.15.3"
+version = "5.15.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

DeepSeek reports cache reads through proprietary top-level usage fields. FCC preserved them for Anthropic output but lost them on Responses output, reporting cached tokens as zero.

## Changes

| Before | After |
| --- | --- |
| Chat-source Responses output read only standard OpenAI cache details. | Chat-source Responses output asks the active provider for its cached-input count. |
| DeepSeek cache metadata reached Anthropic output only. | DeepSeek validates its hit/miss partition once and exposes valid cache hits to both output protocols. |
| Responses coverage did not exercise DeepSeek's proprietary usage fields. | Deterministic stream coverage verifies the final Responses cache count and malformed-metadata fallbacks. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change preserves DeepSeek cache-hit accounting when Chat Completions streams are adapted into OpenAI Responses output. A mocked end-to-end stream confirmed that valid DeepSeek usage with 30 prompt tokens, 10 cache-hit tokens, and 20 cache-miss tokens now emits 30 input tokens with 10 cached tokens. Missing, malformed, negative, and inconsistent cache metadata continues to emit zero cached tokens.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed DeepSeek usage path preserves valid cache hits and rejects invalid usage partitions.

No defects remain in the final review. The provider stream was exercised through emitted Responses SSE events, including valid, missing, malformed, and inconsistent DeepSeek cache usage; focused repository coverage also passed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a mocked DeepSeek chat-to-responses stream against the parent commit and the change to compare cache-token handling.
- Verified that the parent stream emitted valid cache token signals while the change emitted input\_tokens and cached\_tokens, and confirmed missing or invalid counters produced zero cached tokens with 14 tests in the focused cache-usage suite passing.
- Observed an initial harness run exit with code 1 due to a counter-violation, followed by a rerun that exited with code 0 and produced the expected valid usage plus zero cached tokens for invalid counter cases.
- Noted that no source changes were required and the authored executable harness was retained as evidence.

<a href="https://app.greptile.com/trex/runs/21170627/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Preserve DeepSeek cache hits in Response..."](https://github.com/alishahryar1/free-claude-code/commit/19334302b876db57bf5d5ecf821a7b37e8d07cf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57779208)</sub>

<!-- /greptile_comment -->