### PR TITLE
Preserve cache-write accounting across translated outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.15.4"
+version = "5.15.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/anthropic/usage.py
+++ b/src/free_claude_code/core/anthropic/usage.py
@@ -1,0 +1,38 @@
+"""Anthropic terminal usage accounting helpers."""
+
+
+def anthropic_input_usage_fields(
+    total_tokens: int | None,
+    *,
+    cache_read_tokens: int | None,
+    cache_creation_tokens: int | None,
+) -> dict[str, int]:
+    """Partition an inclusive input total into trustworthy Anthropic fields."""
+    if (
+        not isinstance(total_tokens, int)
+        or isinstance(total_tokens, bool)
+        or total_tokens < 0
+    ):
+        return {}
+
+    fields: dict[str, int] = {}
+    remaining_tokens = total_tokens
+    if (
+        isinstance(cache_read_tokens, int)
+        and not isinstance(cache_read_tokens, bool)
+        and 0 <= cache_read_tokens <= remaining_tokens
+    ):
+        fields["cache_read_input_tokens"] = cache_read_tokens
+        remaining_tokens -= cache_read_tokens
+
+    if (
+        isinstance(cache_creation_tokens, int)
+        and not isinstance(cache_creation_tokens, bool)
+        and 0 <= cache_creation_tokens <= remaining_tokens
+    ):
+        fields["cache_creation_input_tokens"] = cache_creation_tokens
+        remaining_tokens -= cache_creation_tokens
+
+    if not fields:
+        return {}
+    return {"input_tokens": remaining_tokens, **fields}

--- a/src/free_claude_code/core/openai_responses/provider_stream.py
+++ b/src/free_claude_code/core/openai_responses/provider_stream.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from free_claude_code.core.anthropic.streaming import AnthropicStreamLedger
+from free_claude_code.core.anthropic.usage import anthropic_input_usage_fields
 from free_claude_code.core.openai_tool_names import OpenAIToolNameCodec
 
 
@@ -217,15 +218,12 @@ class ResponsesProviderStream:
         details = usage.get("input_tokens_details")
         details = details if isinstance(details, dict) else {}
         cached_tokens = _integer(details.get("cached_tokens"))
-        usage_fields = None
-        if (
-            input_tokens is not None
-            and input_tokens >= 0
-            and cached_tokens is not None
-            and 0 <= cached_tokens <= input_tokens
-        ):
-            input_tokens -= cached_tokens
-            usage_fields = {"cache_read_input_tokens": cached_tokens}
+        cache_write_tokens = _integer(details.get("cache_write_tokens"))
+        usage_fields = anthropic_input_usage_fields(
+            input_tokens,
+            cache_read_tokens=cached_tokens,
+            cache_creation_tokens=cache_write_tokens,
+        )
         stop_reason = "max_tokens" if incomplete else "end_turn"
         events.append(
             self.ledger.message_delta(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -32,6 +32,7 @@ from free_claude_code.core.anthropic.streaming import (
     parse_complete_tool_input,
     tool_schemas_by_name,
 )
+from free_claude_code.core.anthropic.usage import anthropic_input_usage_fields
 from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.openai_responses import (
     OpenAIResponsesRequest,
@@ -726,23 +727,21 @@ class OpenAIChatProvider(BaseProvider):
             "cached_tokens",
         )
 
-    def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:
-        """Split standard cached prompt tokens for final Anthropic usage."""
-        prompt_tokens = usage_int(usage_info, "prompt_tokens")
-        cached_tokens = self._cached_input_tokens(usage_info)
-        if (
-            prompt_tokens is None
-            or prompt_tokens < 0
-            or cached_tokens is None
-            or cached_tokens < 0
-            or cached_tokens > prompt_tokens
-        ):
-            return {}
+    def _cache_write_input_tokens(self, usage_info: object) -> int | None:
+        """Return the provider's cache-write count from final Chat usage."""
+        return nested_usage_int(
+            usage_info,
+            "prompt_tokens_details",
+            "cache_write_tokens",
+        )
 
-        return {
-            "input_tokens": prompt_tokens - cached_tokens,
-            "cache_read_input_tokens": cached_tokens,
-        }
+    def _anthropic_usage_fields(self, usage_info: Any) -> dict[str, int]:
+        """Split standard prompt cache counts for final Anthropic usage."""
+        return anthropic_input_usage_fields(
+            usage_int(usage_info, "prompt_tokens"),
+            cache_read_tokens=self._cached_input_tokens(usage_info),
+            cache_creation_tokens=self._cache_write_input_tokens(usage_info),
+        )
 
     async def _create_stream(
         self,
@@ -1104,6 +1103,9 @@ class _OpenAIChatStreamRunner:
             output_tokens=completion.output_tokens,
             cached_tokens=self._provider._cached_input_tokens(assembler.usage_info)
             or 0,
+            cache_write_tokens=self._provider._cache_write_input_tokens(
+                assembler.usage_info
+            ),
             reasoning_tokens=(
                 nested_usage_int(
                     assembler.usage_info,

--- a/src/free_claude_code/providers/openai_chat/stream_output.py
+++ b/src/free_claude_code/providers/openai_chat/stream_output.py
@@ -685,7 +685,13 @@ class ResponsesChatStreamOutput(ChatStreamOutput):
 
 
 def _responses_usage(usage: ChatStreamUsage) -> dict[str, object]:
-    cached_tokens = max(0, min(usage.cached_tokens, usage.input_tokens))
+    cached_tokens = usage.cached_tokens
+    if (
+        not isinstance(cached_tokens, int)
+        or isinstance(cached_tokens, bool)
+        or not 0 <= cached_tokens <= usage.input_tokens
+    ):
+        cached_tokens = 0
     reasoning_tokens = max(0, min(usage.reasoning_tokens, usage.output_tokens))
     input_token_details = {"cached_tokens": cached_tokens}
     cache_write_tokens = usage.cache_write_tokens

--- a/src/free_claude_code/providers/openai_chat/stream_output.py
+++ b/src/free_claude_code/providers/openai_chat/stream_output.py
@@ -47,6 +47,7 @@ class ChatStreamUsage:
     input_tokens: int
     output_tokens: int
     cached_tokens: int = 0
+    cache_write_tokens: int | None = None
     reasoning_tokens: int = 0
     anthropic_fields: Mapping[str, int] = field(default_factory=dict)
 
@@ -686,9 +687,17 @@ class ResponsesChatStreamOutput(ChatStreamOutput):
 def _responses_usage(usage: ChatStreamUsage) -> dict[str, object]:
     cached_tokens = max(0, min(usage.cached_tokens, usage.input_tokens))
     reasoning_tokens = max(0, min(usage.reasoning_tokens, usage.output_tokens))
+    input_token_details = {"cached_tokens": cached_tokens}
+    cache_write_tokens = usage.cache_write_tokens
+    if (
+        isinstance(cache_write_tokens, int)
+        and not isinstance(cache_write_tokens, bool)
+        and 0 <= cache_write_tokens <= usage.input_tokens - cached_tokens
+    ):
+        input_token_details["cache_write_tokens"] = cache_write_tokens
     return {
         "input_tokens": usage.input_tokens,
-        "input_tokens_details": {"cached_tokens": cached_tokens},
+        "input_tokens_details": input_token_details,
         "output_tokens": usage.output_tokens,
         "output_tokens_details": {"reasoning_tokens": reasoning_tokens},
         "total_tokens": usage.input_tokens + usage.output_tokens,

--- a/tests/core/anthropic/test_usage.py
+++ b/tests/core/anthropic/test_usage.py
@@ -1,0 +1,105 @@
+from typing import cast
+
+import pytest
+
+from free_claude_code.core.anthropic.usage import anthropic_input_usage_fields
+
+
+@pytest.mark.parametrize(
+    ("total_tokens", "cache_read_tokens", "cache_creation_tokens", "expected"),
+    [
+        (
+            30,
+            10,
+            5,
+            {
+                "input_tokens": 15,
+                "cache_read_input_tokens": 10,
+                "cache_creation_input_tokens": 5,
+            },
+        ),
+        (30, 10, None, {"input_tokens": 20, "cache_read_input_tokens": 10}),
+        (
+            30,
+            None,
+            5,
+            {"input_tokens": 25, "cache_creation_input_tokens": 5},
+        ),
+        (
+            30,
+            0,
+            0,
+            {
+                "input_tokens": 30,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            },
+        ),
+        (30, None, None, {}),
+        (None, 10, 5, {}),
+        (-1, 0, 0, {}),
+        (True, 0, 0, {}),
+        (30.0, 10, 5, {}),
+        (
+            30,
+            -1,
+            5,
+            {"input_tokens": 25, "cache_creation_input_tokens": 5},
+        ),
+        (
+            30,
+            True,
+            5,
+            {"input_tokens": 25, "cache_creation_input_tokens": 5},
+        ),
+        (
+            30,
+            "10",
+            5,
+            {"input_tokens": 25, "cache_creation_input_tokens": 5},
+        ),
+        (
+            30,
+            31,
+            5,
+            {"input_tokens": 25, "cache_creation_input_tokens": 5},
+        ),
+        (30, 10, -1, {"input_tokens": 20, "cache_read_input_tokens": 10}),
+        (30, 10, True, {"input_tokens": 20, "cache_read_input_tokens": 10}),
+        (30, 10, "5", {"input_tokens": 20, "cache_read_input_tokens": 10}),
+        (30, 10, 21, {"input_tokens": 20, "cache_read_input_tokens": 10}),
+    ],
+    ids=[
+        "read-and-creation",
+        "read-only",
+        "creation-only",
+        "explicit-zeroes",
+        "no-cache-details",
+        "missing-total",
+        "negative-total",
+        "boolean-total",
+        "float-total",
+        "negative-read",
+        "boolean-read",
+        "string-read",
+        "read-over-total",
+        "negative-creation",
+        "boolean-creation",
+        "string-creation",
+        "creation-over-remaining-total",
+    ],
+)
+def test_anthropic_input_usage_fields_preserve_only_trustworthy_partitions(
+    total_tokens: object,
+    cache_read_tokens: object,
+    cache_creation_tokens: object,
+    expected: dict[str, int],
+) -> None:
+    assert (
+        anthropic_input_usage_fields(
+            cast(int | None, total_tokens),
+            cache_read_tokens=cast(int | None, cache_read_tokens),
+            cache_creation_tokens=cast(int | None, cache_creation_tokens),
+        )
+        == expected
+    )

--- a/tests/core/openai_responses/test_native.py
+++ b/tests/core/openai_responses/test_native.py
@@ -140,7 +140,15 @@ def test_native_relay_preserves_payload_and_rewrites_only_response_model() -> No
             "model": "upstream-model",
             "status": "completed",
             "output": [item["item"]],
-            "usage": {"input_tokens": 11, "output_tokens": 4, "total_tokens": 15},
+            "usage": {
+                "input_tokens": 11,
+                "input_tokens_details": {
+                    "cached_tokens": 6,
+                    "cache_write_tokens": 2,
+                },
+                "output_tokens": 4,
+                "total_tokens": 15,
+            },
         },
     }
 

--- a/tests/core/openai_responses/test_provider_stream.py
+++ b/tests/core/openai_responses/test_provider_stream.py
@@ -12,6 +12,26 @@ from free_claude_code.core.openai_responses.provider_stream import (
 from free_claude_code.core.openai_tool_names import OpenAIToolNameCodec
 
 
+def _terminal_usage(usage: dict[str, object]) -> dict[str, object]:
+    stream = ResponsesProviderStream(
+        message_id="msg_test",
+        model="openai/gpt-test",
+        input_tokens=12,
+    )
+    output = stream.start()
+    output.extend(
+        stream.feed(
+            "response.completed",
+            {"response": {"usage": usage}},
+        )
+    )
+    return next(
+        event.data["usage"]
+        for event in parse_sse_text("".join(output))
+        if event.event == "message_delta"
+    )
+
+
 def test_responses_provider_stream_preserves_reasoning_tools_usage_and_ids() -> None:
     stream = ResponsesProviderStream(
         message_id="msg_test",
@@ -95,7 +115,10 @@ def test_responses_provider_stream_preserves_reasoning_tools_usage_and_ids() -> 
                     "usage": {
                         "input_tokens": 20,
                         "output_tokens": 8,
-                        "input_tokens_details": {"cached_tokens": 15},
+                        "input_tokens_details": {
+                            "cached_tokens": 15,
+                            "cache_write_tokens": 3,
+                        },
                     }
                 }
             },
@@ -125,10 +148,101 @@ def test_responses_provider_stream_preserves_reasoning_tools_usage_and_ids() -> 
     assert argument_deltas == ['{"q":', '"x"}']
     message_delta = next(event for event in events if event.event == "message_delta")
     assert message_delta.data["usage"] == {
-        "input_tokens": 5,
+        "input_tokens": 2,
         "output_tokens": 8,
         "cache_read_input_tokens": 15,
+        "cache_creation_input_tokens": 3,
     }
+
+
+@pytest.mark.parametrize(
+    ("details", "expected"),
+    [
+        (
+            {"cached_tokens": 10, "cache_write_tokens": 5},
+            {
+                "input_tokens": 15,
+                "output_tokens": 8,
+                "cache_read_input_tokens": 10,
+                "cache_creation_input_tokens": 5,
+            },
+        ),
+        (
+            {"cached_tokens": 10},
+            {
+                "input_tokens": 20,
+                "output_tokens": 8,
+                "cache_read_input_tokens": 10,
+            },
+        ),
+        (
+            {"cache_write_tokens": 5},
+            {
+                "input_tokens": 25,
+                "output_tokens": 8,
+                "cache_creation_input_tokens": 5,
+            },
+        ),
+        (
+            {"cached_tokens": 0, "cache_write_tokens": 0},
+            {
+                "input_tokens": 30,
+                "output_tokens": 8,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            },
+        ),
+        (
+            {"cached_tokens": 10, "cache_write_tokens": -1},
+            {
+                "input_tokens": 20,
+                "output_tokens": 8,
+                "cache_read_input_tokens": 10,
+            },
+        ),
+        (
+            {"cached_tokens": 10, "cache_write_tokens": 21},
+            {
+                "input_tokens": 20,
+                "output_tokens": 8,
+                "cache_read_input_tokens": 10,
+            },
+        ),
+        (
+            {"cached_tokens": -1, "cache_write_tokens": 5},
+            {
+                "input_tokens": 25,
+                "output_tokens": 8,
+                "cache_creation_input_tokens": 5,
+            },
+        ),
+        ({}, {"input_tokens": 30, "output_tokens": 8}),
+    ],
+    ids=[
+        "read-and-creation",
+        "read-only",
+        "creation-only",
+        "explicit-zeroes",
+        "invalid-creation",
+        "creation-over-remaining-total",
+        "invalid-read-preserves-creation",
+        "no-cache-details",
+    ],
+)
+def test_responses_provider_stream_preserves_trustworthy_cache_partitions(
+    details: dict[str, object],
+    expected: dict[str, object],
+) -> None:
+    assert (
+        _terminal_usage(
+            {
+                "input_tokens": 30,
+                "output_tokens": 8,
+                "input_tokens_details": details,
+            }
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/test_openai_chat_stream_output.py
+++ b/tests/providers/test_openai_chat_stream_output.py
@@ -1,4 +1,7 @@
 import json
+from typing import cast
+
+import pytest
 
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.openai_responses.models import OpenAIResponsesRequest
@@ -17,6 +20,18 @@ def _parse_frame(frame: str) -> tuple[str, dict[str, object]]:
 def _object_dict(value: object) -> dict[str, object]:
     assert isinstance(value, dict)
     return value
+
+
+def _finished_responses_usage(usage: ChatStreamUsage) -> dict[str, object]:
+    output = ResponsesChatStreamOutput(
+        OpenAIResponsesRequest.model_validate(
+            {"model": "public-model", "input": "Hello"}
+        ),
+        input_tokens=1,
+    )
+    frames = output.finish_success(stop_reason="stop", usage=usage)
+    final = _object_dict(_parse_frame(frames[-1])[1]["response"])
+    return _object_dict(final["usage"])
 
 
 def test_anthropic_chat_output_preserves_existing_wire_lifecycle() -> None:
@@ -112,6 +127,7 @@ def test_responses_chat_output_emits_one_native_lifecycle_with_exact_usage() -> 
                 input_tokens=20,
                 output_tokens=8,
                 cached_tokens=5,
+                cache_write_tokens=4,
                 reasoning_tokens=3,
             ),
         )
@@ -134,7 +150,7 @@ def test_responses_chat_output_emits_one_native_lifecycle_with_exact_usage() -> 
     assert final["status"] == "completed"
     assert final["usage"] == {
         "input_tokens": 20,
-        "input_tokens_details": {"cached_tokens": 5},
+        "input_tokens_details": {"cached_tokens": 5, "cache_write_tokens": 4},
         "output_tokens": 8,
         "output_tokens_details": {"reasoning_tokens": 3},
         "total_tokens": 28,
@@ -155,6 +171,48 @@ def test_responses_chat_output_emits_one_native_lifecycle_with_exact_usage() -> 
         "name": "lookup",
         "namespace": "mcp",
         "arguments": '{"q":"fcc"}',
+    }
+
+
+def test_responses_chat_output_preserves_explicit_zero_cache_write() -> None:
+    usage = _finished_responses_usage(
+        ChatStreamUsage(
+            input_tokens=20,
+            output_tokens=8,
+            cached_tokens=5,
+            cache_write_tokens=0,
+        )
+    )
+
+    assert usage["input_tokens_details"] == {
+        "cached_tokens": 5,
+        "cache_write_tokens": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "cache_write_tokens",
+    [None, -1, 16, True, "4"],
+    ids=["absent", "negative", "over-remaining-total", "boolean", "string"],
+)
+def test_responses_chat_output_omits_untrustworthy_cache_write_without_losing_read(
+    cache_write_tokens: object,
+) -> None:
+    usage = _finished_responses_usage(
+        ChatStreamUsage(
+            input_tokens=20,
+            output_tokens=8,
+            cached_tokens=5,
+            cache_write_tokens=cast(int | None, cache_write_tokens),
+        )
+    )
+
+    assert usage == {
+        "input_tokens": 20,
+        "input_tokens_details": {"cached_tokens": 5},
+        "output_tokens": 8,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": 28,
     }
 
 

--- a/tests/providers/test_openai_chat_stream_output.py
+++ b/tests/providers/test_openai_chat_stream_output.py
@@ -216,6 +216,28 @@ def test_responses_chat_output_omits_untrustworthy_cache_write_without_losing_re
     }
 
 
+def test_responses_chat_output_ignores_overflowing_read_without_losing_write() -> None:
+    usage = _finished_responses_usage(
+        ChatStreamUsage(
+            input_tokens=20,
+            output_tokens=8,
+            cached_tokens=21,
+            cache_write_tokens=5,
+        )
+    )
+
+    assert usage == {
+        "input_tokens": 20,
+        "input_tokens_details": {
+            "cached_tokens": 0,
+            "cache_write_tokens": 5,
+        },
+        "output_tokens": 8,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": 28,
+    }
+
+
 def test_responses_chat_output_finishes_committed_failure_once() -> None:
     output = ResponsesChatStreamOutput(
         OpenAIResponsesRequest.model_validate(

--- a/tests/providers/test_openai_chat_usage.py
+++ b/tests/providers/test_openai_chat_usage.py
@@ -15,6 +15,7 @@ from free_claude_code.core.anthropic.sse_aggregation import (
     aggregate_anthropic_sse_to_message,
 )
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
 from free_claude_code.providers.admission import ProviderOperationKind
 from free_claude_code.providers.openai_chat import (
@@ -156,30 +157,89 @@ def test_usage_int_reads_dict_object_and_model_extra():
     ("usage", "expected"),
     [
         (
-            {
-                "prompt_tokens": 22,
-                "prompt_tokens_details": {"cached_tokens": 15},
-            },
-            {"input_tokens": 7, "cache_read_input_tokens": 15},
+            {"prompt_tokens_details": {"cache_write_tokens": 5}},
+            5,
         ),
         (
             CompletionUsage(
                 completion_tokens=4,
                 prompt_tokens=22,
                 total_tokens=26,
-                prompt_tokens_details=PromptTokensDetails(cached_tokens=15),
+                prompt_tokens_details=PromptTokensDetails(cache_write_tokens=5),
             ),
-            {"input_tokens": 7, "cache_read_input_tokens": 15},
+            5,
+        ),
+        (
+            SimpleNamespace(
+                prompt_tokens_details=None,
+                model_extra={
+                    "prompt_tokens_details": {"cache_write_tokens": 5},
+                },
+            ),
+            5,
+        ),
+        ({"prompt_tokens_details": {"cache_write_tokens": 0}}, 0),
+        ({"prompt_tokens_details": {"cache_write_tokens": True}}, None),
+        ({"prompt_tokens_details": {"cache_write_tokens": 5.0}}, None),
+        ({"prompt_tokens_details": {"cache_write_tokens": "5"}}, None),
+        ({"prompt_tokens_details": None}, None),
+    ],
+)
+def test_extracts_standard_chat_cache_write_tokens(usage, expected) -> None:
+    provider = _UsageTestProvider()
+
+    assert provider._cache_write_input_tokens(usage) == expected
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        (
+            {
+                "prompt_tokens": 22,
+                "prompt_tokens_details": {
+                    "cached_tokens": 15,
+                    "cache_write_tokens": 3,
+                },
+            },
+            {
+                "input_tokens": 4,
+                "cache_read_input_tokens": 15,
+                "cache_creation_input_tokens": 3,
+            },
+        ),
+        (
+            CompletionUsage(
+                completion_tokens=4,
+                prompt_tokens=22,
+                total_tokens=26,
+                prompt_tokens_details=PromptTokensDetails(
+                    cached_tokens=15,
+                    cache_write_tokens=3,
+                ),
+            ),
+            {
+                "input_tokens": 4,
+                "cache_read_input_tokens": 15,
+                "cache_creation_input_tokens": 3,
+            },
         ),
         (
             SimpleNamespace(
                 prompt_tokens=22,
                 prompt_tokens_details=None,
                 model_extra={
-                    "prompt_tokens_details": {"cached_tokens": 15},
+                    "prompt_tokens_details": {
+                        "cached_tokens": 15,
+                        "cache_write_tokens": 3,
+                    },
                 },
             ),
-            {"input_tokens": 7, "cache_read_input_tokens": 15},
+            {
+                "input_tokens": 4,
+                "cache_read_input_tokens": 15,
+                "cache_creation_input_tokens": 3,
+            },
         ),
         (
             {
@@ -194,6 +254,23 @@ def test_usage_int_reads_dict_object_and_model_extra():
                 "prompt_tokens_details": {"cached_tokens": 0},
             },
             {"input_tokens": 0, "cache_read_input_tokens": 0},
+        ),
+        (
+            {
+                "prompt_tokens": 22,
+                "prompt_tokens_details": {"cache_write_tokens": 3},
+            },
+            {"input_tokens": 19, "cache_creation_input_tokens": 3},
+        ),
+        (
+            {
+                "prompt_tokens": 22,
+                "prompt_tokens_details": {
+                    "cached_tokens": 15,
+                    "cache_write_tokens": 8,
+                },
+            },
+            {"input_tokens": 7, "cache_read_input_tokens": 15},
         ),
     ],
 )
@@ -282,7 +359,10 @@ async def test_openai_chat_stream_requests_usage_and_uses_provider_prompt_tokens
         completion_tokens=4,
         prompt_tokens=22,
         total_tokens=26,
-        prompt_tokens_details=PromptTokensDetails(cached_tokens=15),
+        prompt_tokens_details=PromptTokensDetails(
+            cached_tokens=15,
+            cache_write_tokens=3,
+        ),
     )
     create = AsyncMock(
         return_value=_stream(
@@ -314,9 +394,10 @@ async def test_openai_chat_stream_requests_usage_and_uses_provider_prompt_tokens
     )
     assert start_usage["input_tokens"] == 7
     assert final_usage == {
-        "input_tokens": 7,
+        "input_tokens": 4,
         "output_tokens": 4,
         "cache_read_input_tokens": 15,
+        "cache_creation_input_tokens": 3,
     }
     assert sum(event.event == "message_delta" for event in parsed) == 1
     assert sum(event.event == "message_stop" for event in parsed) == 1
@@ -330,7 +411,10 @@ async def test_openai_chat_nonstream_message_uses_final_cache_partition():
         completion_tokens=4,
         prompt_tokens=22,
         total_tokens=26,
-        prompt_tokens_details=PromptTokensDetails(cached_tokens=15),
+        prompt_tokens_details=PromptTokensDetails(
+            cached_tokens=15,
+            cache_write_tokens=3,
+        ),
     )
     create = AsyncMock(
         return_value=_stream(
@@ -349,9 +433,55 @@ async def test_openai_chat_nonstream_message_uses_final_cache_partition():
 
     assert error is None
     assert message["usage"] == {
-        "input_tokens": 7,
+        "input_tokens": 4,
         "output_tokens": 4,
         "cache_read_input_tokens": 15,
+        "cache_creation_input_tokens": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_responses_stream_preserves_cache_write_usage():
+    provider = _UsageTestProvider()
+    request = OpenAIResponsesRequest.model_validate({"model": "m", "input": "hello"})
+    usage = CompletionUsage(
+        completion_tokens=4,
+        prompt_tokens=22,
+        total_tokens=26,
+        prompt_tokens_details=PromptTokensDetails(
+            cached_tokens=15,
+            cache_write_tokens=3,
+        ),
+    )
+    create = AsyncMock(
+        return_value=_stream(
+            [
+                _chunk(content="hello"),
+                _chunk(finish_reason="stop"),
+                _chunk(usage=usage),
+            ]
+        )
+    )
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        events = [
+            event async for event in provider.stream_responses(request, input_tokens=7)
+        ]
+
+    completed = next(
+        event.data["response"]
+        for event in parse_sse_text("".join(events))
+        if event.event == "response.completed"
+    )
+    assert completed["usage"] == {
+        "input_tokens": 22,
+        "input_tokens_details": {
+            "cached_tokens": 15,
+            "cache_write_tokens": 3,
+        },
+        "output_tokens": 4,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": 26,
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.15.4"
+version = "5.15.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

OpenAI-compatible providers can report cache-write tokens, but FCC drops that accounting when Chat Completions or Responses usage is translated into another client protocol.

## Changes

| Before | After |
| --- | --- |
| Chat-to-Responses output preserved cache reads but dropped reported cache writes. | Chat-to-Responses output preserves valid, explicitly reported cache reads and writes. |
| Chat and Responses output counted cache writes as ordinary Anthropic input. | Chat and Responses output map valid writes to Anthropic cache-creation usage. |
| Invalid write metadata could not be represented independently of valid reads. | Invalid writes are ignored without erasing valid read accounting or changing inclusive totals. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change preserves cache-write token accounting while translating usage between OpenAI Chat Completions, OpenAI Responses, and Anthropic streaming formats.

The cache-usage flows were exercised with valid cache reads and writes as well as missing, malformed, boolean, and overflowing metadata. OpenAI Chat-to-Anthropic, OpenAI Chat-to-Responses, and Responses-to-Anthropic terminal usage all produced the expected accounting, and the focused regression suite passed.
</details>


<h3>Confidence Score: 5/5</h3>

The change is safe to merge based on the exercised usage translation paths and passing regression coverage.

No defects were found. The runtime checks exercised the shared usage partitioner and each changed protocol boundary with valid and invalid cache metadata.

**Files Needing Attention:** No files require follow-up attention; the primary exercised areas were the Anthropic usage helper, Responses stream adapter, and OpenAI Chat output adapter.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Independent validation ran and produced 10 passing cache-translation assertions and exited with code 0.
- The Anthropic SSE flows were additionally checked with the production Anthropic stream-contract validator.
- No product code changes were made during this work and validation evidence was authored for review.
- Artifacts documenting the validation were uploaded, including the validation source and two validation logs.

<a href="https://app.greptile.com/trex/runs/21179910/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Preserve writes when cache reads are inv..."](https://github.com/alishahryar1/free-claude-code/commit/43cf6cdc95ab27e7364c40f6f81b9a219c8bbaac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57789264)</sub>

<!-- /greptile_comment -->