### PR TITLE
Install Aider with FCC's managed uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.15.8"
+version = "5.15.9"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -27,7 +27,6 @@ $DshVersion = "0.1.0-rc.8"
 $DshPackage = "@deepseek-ai/dsh@$DshVersion"
 $GrokInstallUrl = "https://x.ai/cli/install.ps1"
 $MuseInstallUrl = "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/scripts/install-muse.ps1"
-$AiderInstallUrl = "https://aider.chat/install.ps1"
 $RtkVersion = "0.44.2"
 $RtkReleaseBaseUrl = "https://github.com/rtk-ai/rtk/releases/download/v$RtkVersion"
 $RtkWindowsAssetName = "rtk-x86_64-pc-windows-msvc.zip"
@@ -834,8 +833,28 @@ function Ensure-Grok {
 }
 
 function Install-Aider {
-    Invoke-DownloadedPowerShellInstaller -Url $AiderInstallUrl -Name "Aider"
-    Add-KnownBinDirectories
+    $uvPath = "uv"
+    if (-not $DryRun) {
+        $uvCommand = Get-ApplicationCommand "uv"
+        if (-not $uvCommand) {
+            throw "Aider installation requires the verified uv command, but it is not available on PATH."
+        }
+        $uvPath = $uvCommand.Source
+    }
+
+    Invoke-NativeCommand -FilePath $uvPath -Arguments @(
+        "tool",
+        "install",
+        "--force",
+        "--python",
+        "python3.12",
+        "--with",
+        "pip",
+        "aider-chat@latest"
+    )
+    if (-not $DryRun) {
+        Add-KnownBinDirectories
+    }
 }
 
 function Ensure-Aider {
@@ -1339,11 +1358,11 @@ if (Test-InteractiveInstaller) {
     Select-CodingAgents
 }
 
-Ensure-SelectedCodingAgents
-Configure-RtkForSelectedAgents
-
 Write-Step "Ensuring uv $MinUvVersion or newer is installed"
 Ensure-Uv
+
+Ensure-SelectedCodingAgents
+Configure-RtkForSelectedAgents
 
 Write-Step "Installing or updating Free Claude Code"
 Install-FreeClaudeCode

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -863,9 +863,6 @@ function Install-Aider {
         "pip",
         "aider-chat@latest"
     )
-    if (-not $DryRun) {
-        $null = Add-UvToolBinDirectory -UvPath $uvPath
-    }
 }
 
 function Add-UvToolBinDirectory {
@@ -882,6 +879,15 @@ function Add-UvToolBinDirectory {
 
 function Ensure-Aider {
     $command = Get-ApplicationCommand "aider"
+    if ((-not $command) -and (-not $DryRun)) {
+        $uvCommand = Get-ApplicationCommand "uv"
+        if (-not $uvCommand) {
+            throw "Aider installation requires the verified uv command, but it is not available on PATH."
+        }
+        $null = Add-UvToolBinDirectory -UvPath $uvCommand.Source
+        $command = Get-ApplicationCommand "aider"
+    }
+
     if ($command) {
         Write-Host "Aider already found on PATH; verifying it."
     }
@@ -1113,6 +1119,9 @@ function Confirm-Uv {
 }
 
 function Get-UvInstallBinDirectory {
+    if (-not [string]::IsNullOrWhiteSpace($env:UV_UNMANAGED_INSTALL)) {
+        return $env:UV_UNMANAGED_INSTALL
+    }
     if (-not [string]::IsNullOrWhiteSpace($env:UV_INSTALL_DIR)) {
         $cargoHome = if (-not [string]::IsNullOrWhiteSpace($env:CARGO_HOME)) {
             $env:CARGO_HOME

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1114,6 +1114,18 @@ function Confirm-Uv {
 
 function Get-UvInstallBinDirectory {
     if (-not [string]::IsNullOrWhiteSpace($env:UV_INSTALL_DIR)) {
+        $cargoHome = if (-not [string]::IsNullOrWhiteSpace($env:CARGO_HOME)) {
+            $env:CARGO_HOME
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace($HOME)) {
+            Join-Path $HOME ".cargo"
+        }
+        else {
+            $null
+        }
+        if ($cargoHome -and $env:UV_INSTALL_DIR.Replace("\\", "\") -eq $cargoHome) {
+            return Join-Path $env:UV_INSTALL_DIR "bin"
+        }
         return $env:UV_INSTALL_DIR
     }
     if (-not [string]::IsNullOrWhiteSpace($env:XDG_BIN_HOME)) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -268,6 +268,17 @@ function Add-PathEntry {
     }
 }
 
+function Prioritize-PathEntry {
+    param([string] $PathEntry)
+
+    if ([string]::IsNullOrWhiteSpace($PathEntry)) {
+        return
+    }
+
+    $separator = [IO.Path]::PathSeparator
+    $env:Path = "$PathEntry$separator$env:Path"
+}
+
 function Add-KnownBinDirectories {
     if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
         Add-PathEntry (Join-Path $env:USERPROFILE ".local\bin")
@@ -853,8 +864,20 @@ function Install-Aider {
         "aider-chat@latest"
     )
     if (-not $DryRun) {
-        Add-KnownBinDirectories
+        $null = Add-UvToolBinDirectory -UvPath $uvPath
     }
+}
+
+function Add-UvToolBinDirectory {
+    param([string] $UvPath)
+
+    $toolBin = Invoke-Utf8NativeCapture -FilePath $UvPath -Arguments @("tool", "dir", "--bin")
+    if ([string]::IsNullOrWhiteSpace($toolBin)) {
+        throw "uv returned an empty tool bin directory."
+    }
+
+    Add-PathEntry $toolBin
+    return $toolBin
 }
 
 function Ensure-Aider {
@@ -1089,6 +1112,23 @@ function Confirm-Uv {
     Write-Host "Verified uv $version."
 }
 
+function Get-UvInstallBinDirectory {
+    if (-not [string]::IsNullOrWhiteSpace($env:UV_INSTALL_DIR)) {
+        return $env:UV_INSTALL_DIR
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:XDG_BIN_HOME)) {
+        return $env:XDG_BIN_HOME
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:XDG_DATA_HOME)) {
+        return Join-Path $env:XDG_DATA_HOME "..\bin"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+        return Join-Path $env:USERPROFILE ".local\bin"
+    }
+
+    throw "Could not determine where the standalone uv installer places uv."
+}
+
 function Ensure-Uv {
     if ($DryRun) {
         if (Get-ApplicationCommand "uv") {
@@ -1117,7 +1157,7 @@ function Ensure-Uv {
     }
 
     Invoke-DownloadedPowerShellInstaller -Url $UvInstallUrl -Name "uv"
-    Add-KnownBinDirectories
+    Prioritize-PathEntry (Get-UvInstallBinDirectory)
     Confirm-Uv
 }
 
@@ -1225,12 +1265,7 @@ function Configure-AndConfirmFreeClaudeCode {
         throw "uv is not available for PATH configuration."
     }
     Invoke-NativeCommand -FilePath $uvCommand.Source -Arguments @("tool", "update-shell")
-    $toolBin = Invoke-Utf8NativeCapture -FilePath $uvCommand.Source -Arguments @("tool", "dir", "--bin")
-    if ([string]::IsNullOrWhiteSpace($toolBin)) {
-        throw "uv returned an empty tool bin directory."
-    }
-
-    Add-PathEntry $toolBin
+    $toolBin = Add-UvToolBinDirectory -UvPath $uvCommand.Source
     $toolBinPath = ([IO.Path]::GetFullPath($toolBin)).TrimEnd(
         [IO.Path]::DirectorySeparatorChar,
         [IO.Path]::AltDirectorySeparatorChar

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1119,10 +1119,17 @@ function Confirm-Uv {
 }
 
 function Get-UvInstallBinDirectory {
-    if (-not [string]::IsNullOrWhiteSpace($env:UV_UNMANAGED_INSTALL)) {
-        return $env:UV_UNMANAGED_INSTALL
+    $forceInstallDirectory = if (-not [string]::IsNullOrWhiteSpace($env:UV_INSTALL_DIR)) {
+        $env:UV_INSTALL_DIR
     }
-    if (-not [string]::IsNullOrWhiteSpace($env:UV_INSTALL_DIR)) {
+    elseif (-not [string]::IsNullOrWhiteSpace($env:UV_UNMANAGED_INSTALL)) {
+        $env:UV_UNMANAGED_INSTALL
+    }
+    else {
+        $null
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($forceInstallDirectory)) {
         $cargoHome = if (-not [string]::IsNullOrWhiteSpace($env:CARGO_HOME)) {
             $env:CARGO_HOME
         }
@@ -1132,10 +1139,10 @@ function Get-UvInstallBinDirectory {
         else {
             $null
         }
-        if ($cargoHome -and $env:UV_INSTALL_DIR.Replace("\\", "\") -eq $cargoHome) {
-            return Join-Path $env:UV_INSTALL_DIR "bin"
+        if ($cargoHome -and $forceInstallDirectory.Replace("\\", "\") -eq $cargoHome) {
+            return Join-Path $forceInstallDirectory "bin"
         }
-        return $env:UV_INSTALL_DIR
+        return $forceInstallDirectory
     }
     if (-not [string]::IsNullOrWhiteSpace($env:XDG_BIN_HOME)) {
         return $env:XDG_BIN_HOME

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1048,24 +1048,45 @@ verify_uv() {
     printf 'Verified uv %s.\n' "$version"
 }
 
+uv_installer_home_directory() {
+    if [ -n "${HOME:-}" ]; then
+        printf '%s\n' "$HOME"
+        return 0
+    fi
+
+    if [ -n "${USER:-}" ]; then
+        user_name=$USER
+    else
+        user_name=$(id -un) || fail "Could not determine the current user for uv installation."
+    fi
+    home_directory=$(getent passwd "$user_name" | cut -d: -f6)
+    [ -n "$home_directory" ] || fail "Could not determine the home directory for uv installation."
+    printf '%s\n' "$home_directory"
+}
+
 uv_install_bin_directory() {
-    if [ -n "${UV_UNMANAGED_INSTALL:-}" ]; then
-        printf '%s\n' "$UV_UNMANAGED_INSTALL"
-    elif [ -n "${UV_INSTALL_DIR:-}" ]; then
-        cargo_home=${CARGO_HOME:-${HOME:-}/.cargo}
-        if [ "$UV_INSTALL_DIR" = "$cargo_home" ]; then
-            printf '%s/bin\n' "$UV_INSTALL_DIR"
+    force_install_directory=""
+    if [ -n "${UV_INSTALL_DIR:-}" ]; then
+        force_install_directory=$UV_INSTALL_DIR
+    elif [ -n "${UV_UNMANAGED_INSTALL:-}" ]; then
+        force_install_directory=$UV_UNMANAGED_INSTALL
+    fi
+
+    if [ -n "$force_install_directory" ]; then
+        inferred_home=$(uv_installer_home_directory)
+        cargo_home=${CARGO_HOME:-$inferred_home/.cargo}
+        if [ "$force_install_directory" = "$cargo_home" ]; then
+            printf '%s/bin\n' "$force_install_directory"
         else
-            printf '%s\n' "$UV_INSTALL_DIR"
+            printf '%s\n' "$force_install_directory"
         fi
     elif [ -n "${XDG_BIN_HOME:-}" ]; then
         printf '%s\n' "$XDG_BIN_HOME"
     elif [ -n "${XDG_DATA_HOME:-}" ]; then
         printf '%s/../bin\n' "$XDG_DATA_HOME"
-    elif [ -n "${HOME:-}" ]; then
-        printf '%s/.local/bin\n' "$HOME"
     else
-        fail "Could not determine where the standalone uv installer places uv."
+        inferred_home=$(uv_installer_home_directory)
+        printf '%s/.local/bin\n' "$inferred_home"
     fi
 }
 
@@ -1094,7 +1115,8 @@ ensure_uv() {
     fi
 
     download_and_run "$UV_INSTALL_URL" sh "uv"
-    prioritize_path_entry "$(uv_install_bin_directory)"
+    uv_bin=$(uv_install_bin_directory) || return $?
+    prioritize_path_entry "$uv_bin"
     verify_uv
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,6 @@ DSH_VERSION="0.1.0-rc.8"
 DSH_PACKAGE="@deepseek-ai/dsh@$DSH_VERSION"
 GROK_INSTALL_URL="https://x.ai/cli/install.sh"
 MUSE_INSTALL_URL="https://dev.meta.ai/install.sh"
-AIDER_INSTALL_URL="https://aider.chat/install.sh"
 RTK_VERSION="0.44.2"
 RTK_RELEASE_BASE_URL="https://github.com/rtk-ai/rtk/releases/download/v$RTK_VERSION"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
@@ -889,8 +888,10 @@ ensure_muse() {
 }
 
 install_aider_cli() {
-    download_and_run "$AIDER_INSTALL_URL" bash "Aider"
-    add_known_bin_directories
+    run uv tool install --force --python python3.12 --with pip aider-chat@latest
+    if [ "$dry_run" -eq 0 ]; then
+        add_known_bin_directories
+    fi
 }
 
 ensure_aider() {
@@ -1282,7 +1283,7 @@ fi
 
 step "Checking installation prerequisites"
 require_command curl
-if [ "$install_claude" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_hermes" -eq 1 ] || [ "$install_grok" -eq 1 ] || [ "$install_muse" -eq 1 ] || [ "$install_aider" -eq 1 ]; then
+if [ "$install_claude" -eq 1 ] || [ "$install_opencode" -eq 1 ] || [ "$install_hermes" -eq 1 ] || [ "$install_grok" -eq 1 ] || [ "$install_muse" -eq 1 ]; then
     require_command bash
 fi
 require_command sh
@@ -1296,11 +1297,11 @@ if [ "$enable_rtk" -eq 1 ] && ! command -v rtk >/dev/null 2>&1; then
     fi
 fi
 
-ensure_selected_coding_agents
-configure_rtk_for_selected_agents
-
 step "Ensuring uv $MIN_UV_VERSION or newer is installed"
 ensure_uv
+
+ensure_selected_coding_agents
+configure_rtk_for_selected_agents
 
 step "Installing or updating Free Claude Code"
 install_free_claude_code

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -267,6 +267,13 @@ add_path_entry() {
     esac
 }
 
+prioritize_path_entry() {
+    [ -n "$1" ] || return 0
+    PATH="$1:$PATH"
+    export PATH
+    hash -r 2>/dev/null || true
+}
+
 add_known_bin_directories() {
     if [ -n "${XDG_BIN_HOME:-}" ]; then
         add_path_entry "$XDG_BIN_HOME"
@@ -285,6 +292,21 @@ add_known_bin_directories() {
         add_path_entry "$HOME/.grok/bin"
     fi
 
+    export PATH
+    hash -r 2>/dev/null || true
+}
+
+add_uv_tool_bin_directory() {
+    print_command uv tool dir --bin
+    if tool_bin=$(uv tool dir --bin); then
+        :
+    else
+        status=$?
+        fail "Could not determine the uv tool bin directory (exit code $status)."
+    fi
+    [ -n "$tool_bin" ] || fail "uv returned an empty tool bin directory."
+
+    add_path_entry "$tool_bin"
     export PATH
     hash -r 2>/dev/null || true
 }
@@ -890,7 +912,7 @@ ensure_muse() {
 install_aider_cli() {
     run uv tool install --force --python python3.12 --with pip aider-chat@latest
     if [ "$dry_run" -eq 0 ]; then
-        add_known_bin_directories
+        add_uv_tool_bin_directory
     fi
 }
 
@@ -1025,6 +1047,20 @@ verify_uv() {
     printf 'Verified uv %s.\n' "$version"
 }
 
+uv_install_bin_directory() {
+    if [ -n "${UV_INSTALL_DIR:-}" ]; then
+        printf '%s\n' "$UV_INSTALL_DIR"
+    elif [ -n "${XDG_BIN_HOME:-}" ]; then
+        printf '%s\n' "$XDG_BIN_HOME"
+    elif [ -n "${XDG_DATA_HOME:-}" ]; then
+        printf '%s/../bin\n' "$XDG_DATA_HOME"
+    elif [ -n "${HOME:-}" ]; then
+        printf '%s/.local/bin\n' "$HOME"
+    else
+        fail "Could not determine where the standalone uv installer places uv."
+    fi
+}
+
 ensure_uv() {
     if [ "$dry_run" -eq 1 ]; then
         if command -v uv >/dev/null 2>&1; then
@@ -1050,7 +1086,7 @@ ensure_uv() {
     fi
 
     download_and_run "$UV_INSTALL_URL" sh "uv"
-    add_known_bin_directories
+    prioritize_path_entry "$(uv_install_bin_directory)"
     verify_uv
 }
 
@@ -1147,18 +1183,7 @@ configure_and_verify_free_claude_code() {
         return 0
     fi
 
-    print_command uv tool dir --bin
-    if tool_bin=$(uv tool dir --bin); then
-        :
-    else
-        status=$?
-        fail "Could not determine the uv tool bin directory (exit code $status)."
-    fi
-    [ -n "$tool_bin" ] || fail "uv returned an empty tool bin directory."
-
-    add_path_entry "$tool_bin"
-    export PATH
-    hash -r 2>/dev/null || true
+    add_uv_tool_bin_directory
 
     for command_name in fcc-desktop fcc-server fcc-claude fcc-codex fcc-pi fcc-opencode fcc-cline fcc-hermes fcc-dsh fcc-grok fcc-muse fcc-aider; do
         [ -x "$tool_bin/$command_name" ] || fail "Free Claude Code installation did not create $tool_bin/$command_name."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -911,12 +911,13 @@ ensure_muse() {
 
 install_aider_cli() {
     run uv tool install --force --python python3.12 --with pip aider-chat@latest
-    if [ "$dry_run" -eq 0 ]; then
-        add_uv_tool_bin_directory
-    fi
 }
 
 ensure_aider() {
+    if ! command -v aider >/dev/null 2>&1 && [ "$dry_run" -eq 0 ]; then
+        add_uv_tool_bin_directory
+    fi
+
     if command -v aider >/dev/null 2>&1; then
         printf 'Aider already found on PATH; verifying it.\n'
     else
@@ -1048,7 +1049,9 @@ verify_uv() {
 }
 
 uv_install_bin_directory() {
-    if [ -n "${UV_INSTALL_DIR:-}" ]; then
+    if [ -n "${UV_UNMANAGED_INSTALL:-}" ]; then
+        printf '%s\n' "$UV_UNMANAGED_INSTALL"
+    elif [ -n "${UV_INSTALL_DIR:-}" ]; then
         cargo_home=${CARGO_HOME:-${HOME:-}/.cargo}
         if [ "$UV_INSTALL_DIR" = "$cargo_home" ]; then
             printf '%s/bin\n' "$UV_INSTALL_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1049,7 +1049,12 @@ verify_uv() {
 
 uv_install_bin_directory() {
     if [ -n "${UV_INSTALL_DIR:-}" ]; then
-        printf '%s\n' "$UV_INSTALL_DIR"
+        cargo_home=${CARGO_HOME:-${HOME:-}/.cargo}
+        if [ "$UV_INSTALL_DIR" = "$cargo_home" ]; then
+            printf '%s/bin\n' "$UV_INSTALL_DIR"
+        else
+            printf '%s\n' "$UV_INSTALL_DIR"
+        fi
     elif [ -n "${XDG_BIN_HOME:-}" ]; then
         printf '%s\n' "$XDG_BIN_HOME"
     elif [ -n "${XDG_DATA_HOME:-}" ]; then

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -339,6 +339,13 @@ esac
 """,
     )
     _write_executable(
+        bin_dir / "getent",
+        """#!/bin/sh
+[ "${1:-}" = "passwd" ] || exit 61
+printf 'fcc-test:x:1000:1000::%s:/bin/sh\n' "$FAKE_INFERRED_HOME"
+""",
+    )
+    _write_executable(
         bin_dir / "curl",
         """#!/bin/sh
 url=""
@@ -464,19 +471,31 @@ chmod +x "$HOME/.local/bin/muse"
         """#!/bin/sh
 echo "uv-install" >> "$CALL_LOG"
 [ "$FAIL_STEP" = "uv-install" ] && exit 23
-if [ -n "${UV_UNMANAGED_INSTALL:-}" ]; then
-    uv_bin=$UV_UNMANAGED_INSTALL
-elif [ -n "${UV_INSTALL_DIR:-}" ]; then
-    uv_bin=$UV_INSTALL_DIR
-    if [ "$UV_INSTALL_DIR" = "${CARGO_HOME:-$HOME/.cargo}" ]; then
-        uv_bin=$UV_INSTALL_DIR/bin
+inferred_home=${HOME:-}
+if [ -z "$inferred_home" ]; then
+    if [ -n "${USER:-}" ]; then
+        inferred_home=$(getent passwd "$USER" | cut -d: -f6)
+    else
+        inferred_home=$(getent passwd "$(id -un)" | cut -d: -f6)
+    fi
+fi
+force_install_dir=""
+if [ -n "${UV_INSTALL_DIR:-}" ]; then
+    force_install_dir=$UV_INSTALL_DIR
+elif [ -n "${UV_UNMANAGED_INSTALL:-}" ]; then
+    force_install_dir=$UV_UNMANAGED_INSTALL
+fi
+if [ -n "$force_install_dir" ]; then
+    uv_bin=$force_install_dir
+    if [ "$force_install_dir" = "${CARGO_HOME:-$inferred_home/.cargo}" ]; then
+        uv_bin=$force_install_dir/bin
     fi
 elif [ -n "${XDG_BIN_HOME:-}" ]; then
     uv_bin=$XDG_BIN_HOME
 elif [ -n "${XDG_DATA_HOME:-}" ]; then
     uv_bin=$XDG_DATA_HOME/../bin
 else
-    uv_bin=$HOME/.local/bin
+    uv_bin=$inferred_home/.local/bin
 fi
 mkdir -p "$uv_bin"
 cp "$FAKE_FIXTURES/uv-command.sh" "$uv_bin/uv"
@@ -555,16 +574,23 @@ printf '%s  %s\n' "$checksum" "$1"
             "CALL_LOG": str(log),
             "FAKE_FIXTURES": str(fixtures),
             "FAKE_TOOL_BIN": str(tool_bin),
+            "FAKE_INFERRED_HOME": str(home),
             "FCC_PROCESS_MARKER": str(tmp_path / "fcc-process-ready"),
             "FCC_RUNNING_COMMAND": "",
             "FCC_RUNNING_PHASE": "early",
             "FAKE_UNAME": "Linux",
             "FAKE_NPM_PREFIX": str(npm_prefix),
+            "USER": "fcc-test",
             "CLAUDE_CONFIG_DIR": "",
             "FAIL_STEP": "",
         }
     )
     env.pop("XDG_BIN_HOME", None)
+    env.pop("XDG_DATA_HOME", None)
+    env.pop("UV_INSTALL_DIR", None)
+    env.pop("UV_UNMANAGED_INSTALL", None)
+    env.pop("UV_TOOL_BIN_DIR", None)
+    env.pop("CARGO_HOME", None)
     env.pop("GROK_BIN_DIR", None)
     return PosixHarness(tmp_path, bin_dir, fixtures, tool_bin, log, env)
 
@@ -1302,14 +1328,16 @@ def test_install_sh_prioritizes_replacement_uv_over_obsolete_cargo_uv(
     assert "uv-install" in posix_harness.calls()
 
 
-def test_install_sh_prioritizes_cargo_home_uv_install_layout(
+@pytest.mark.parametrize("install_variable", ("UV_INSTALL_DIR", "UV_UNMANAGED_INSTALL"))
+def test_install_sh_prioritizes_forced_cargo_home_uv_install_layout(
     posix_harness: PosixHarness,
+    install_variable: str,
 ) -> None:
     home = Path(posix_harness.env["HOME"])
     cargo_home = home / ".cargo"
     cargo_bin = cargo_home / "bin"
     posix_harness.env["CARGO_HOME"] = str(cargo_home)
-    posix_harness.env["UV_INSTALL_DIR"] = str(cargo_home)
+    posix_harness.env[install_variable] = str(cargo_home)
     posix_harness.env["PATH"] = f"{posix_harness.env['PATH']}:{cargo_bin}"
     posix_harness.add_uv("0.5.9")
 
@@ -1318,6 +1346,22 @@ def test_install_sh_prioritizes_cargo_home_uv_install_layout(
     assert result.returncode == 0, result.stderr
     assert "Verified uv 0.11.28." in result.stdout
     assert "uv-install" in posix_harness.calls()
+
+
+def test_install_sh_uv_install_dir_takes_precedence_over_unmanaged_install(
+    posix_harness: PosixHarness,
+) -> None:
+    install_bin = posix_harness.root / "uv-install-bin"
+    unmanaged_bin = posix_harness.root / "unmanaged-uv-bin"
+    posix_harness.env["UV_INSTALL_DIR"] = str(install_bin)
+    posix_harness.env["UV_UNMANAGED_INSTALL"] = str(unmanaged_bin)
+    posix_harness.add_uv("0.5.9")
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert (install_bin / "uv").is_file()
+    assert not (unmanaged_bin / "uv").exists()
 
 
 def test_install_sh_prioritizes_replacement_uv_from_unmanaged_install_directory(
@@ -1332,6 +1376,24 @@ def test_install_sh_prioritizes_replacement_uv_from_unmanaged_install_directory(
     assert result.returncode == 0, result.stderr
     assert "Verified uv 0.11.28." in result.stdout
     assert "uv-install" in posix_harness.calls()
+
+
+@pytest.mark.parametrize("cargo_layout", (False, True), ids=("default", "cargo-home"))
+def test_install_sh_infers_home_for_replacement_uv(
+    posix_harness: PosixHarness,
+    cargo_layout: bool,
+) -> None:
+    inferred_home = Path(posix_harness.env["FAKE_INFERRED_HOME"])
+    posix_harness.env.pop("HOME")
+    if cargo_layout:
+        posix_harness.env["UV_INSTALL_DIR"] = str(inferred_home / ".cargo")
+
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\nn\nn\nn\ny\nn\n")
+
+    assert result.returncode == 0, result.stderr
+    relative_uv = Path(".cargo/bin/uv") if cargo_layout else Path(".local/bin/uv")
+    assert (inferred_home / relative_uv).is_file()
+    assert "Verified uv 0.11.28." in result.stdout
 
 
 @pytest.mark.parametrize("version", ("0.11.16-alpha.1", "0.12.0-rc.1"))
@@ -1999,15 +2061,21 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "muse-install"
     )
     (fixtures / "uv-installer.ps1").write_text(
         r"""if ($env:FAIL_STEP -eq "uv-install") { exit 63 }
-$bin = if ($env:UV_UNMANAGED_INSTALL) {
+$forceInstallDir = if ($env:UV_INSTALL_DIR) {
+    $env:UV_INSTALL_DIR
+}
+elseif ($env:UV_UNMANAGED_INSTALL) {
     $env:UV_UNMANAGED_INSTALL
 }
-elseif ($env:UV_INSTALL_DIR) {
-    if ($env:UV_INSTALL_DIR -eq $(if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE ".cargo" })) {
-        Join-Path $env:UV_INSTALL_DIR "bin"
+else {
+    $null
+}
+$bin = if ($forceInstallDir) {
+    if ($forceInstallDir -eq $(if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE ".cargo" })) {
+        Join-Path $forceInstallDir "bin"
     }
     else {
-        $env:UV_INSTALL_DIR
+        $forceInstallDir
     }
 }
 elseif ($env:XDG_BIN_HOME) {
@@ -2164,6 +2232,12 @@ $installer = [scriptblock]::Create($installerSource)
             "FAIL_STEP": "",
         }
     )
+    env.pop("XDG_BIN_HOME", None)
+    env.pop("XDG_DATA_HOME", None)
+    env.pop("UV_INSTALL_DIR", None)
+    env.pop("UV_UNMANAGED_INSTALL", None)
+    env.pop("UV_TOOL_BIN_DIR", None)
+    env.pop("CARGO_HOME", None)
     env.pop("GROK_BIN_DIR", None)
     return PowerShellHarness(
         tmp_path, bin_dir, fixtures, tool_bin, log, env, powershell, wrapper
@@ -2839,13 +2913,15 @@ def test_install_ps1_prioritizes_replacement_uv_from_custom_install_directory(
     assert "uv-install" in powershell_harness.calls()
 
 
-def test_install_ps1_prioritizes_cargo_home_uv_install_layout(
+@pytest.mark.parametrize("install_variable", ("UV_INSTALL_DIR", "UV_UNMANAGED_INSTALL"))
+def test_install_ps1_prioritizes_forced_cargo_home_uv_install_layout(
     powershell_harness: PowerShellHarness,
+    install_variable: str,
 ) -> None:
     cargo_home = Path(powershell_harness.env["USERPROFILE"]) / ".cargo"
     cargo_bin = cargo_home / "bin"
     powershell_harness.env["CARGO_HOME"] = str(cargo_home)
-    powershell_harness.env["UV_INSTALL_DIR"] = str(cargo_home)
+    powershell_harness.env[install_variable] = str(cargo_home)
     powershell_harness.env["PATH"] = (
         f"{powershell_harness.env['PATH']}{os.pathsep}{cargo_bin}"
     )
@@ -2856,6 +2932,22 @@ def test_install_ps1_prioritizes_cargo_home_uv_install_layout(
     assert result.returncode == 0, result.stderr
     assert "Verified uv 0.11.28." in result.stdout
     assert "uv-install" in powershell_harness.calls()
+
+
+def test_install_ps1_uv_install_dir_takes_precedence_over_unmanaged_install(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    install_bin = powershell_harness.root / "uv-install-bin"
+    unmanaged_bin = powershell_harness.root / "unmanaged-uv-bin"
+    powershell_harness.env["UV_INSTALL_DIR"] = str(install_bin)
+    powershell_harness.env["UV_UNMANAGED_INSTALL"] = str(unmanaged_bin)
+    powershell_harness.add_uv("0.5.9")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert (install_bin / "uv.cmd").is_file()
+    assert not (unmanaged_bin / "uv.cmd").exists()
 
 
 def test_install_ps1_prioritizes_replacement_uv_from_unmanaged_install_directory(

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -464,7 +464,9 @@ chmod +x "$HOME/.local/bin/muse"
         """#!/bin/sh
 echo "uv-install" >> "$CALL_LOG"
 [ "$FAIL_STEP" = "uv-install" ] && exit 23
-if [ -n "${UV_INSTALL_DIR:-}" ]; then
+if [ -n "${UV_UNMANAGED_INSTALL:-}" ]; then
+    uv_bin=$UV_UNMANAGED_INSTALL
+elif [ -n "${UV_INSTALL_DIR:-}" ]; then
     uv_bin=$UV_INSTALL_DIR
     if [ "$UV_INSTALL_DIR" = "${CARGO_HOME:-$HOME/.cargo}" ]; then
         uv_bin=$UV_INSTALL_DIR/bin
@@ -782,6 +784,34 @@ def test_install_sh_discovers_aider_in_custom_uv_tool_bin(
     calls = posix_harness.calls()
     assert "uv:tool dir --bin" in calls
     assert "aider:--version" in calls
+
+
+@pytest.mark.parametrize("fail_step", ("", "aider-verify"), ids=("valid", "broken"))
+def test_install_sh_checks_existing_aider_in_custom_uv_tool_bin_before_installing(
+    posix_harness: PosixHarness,
+    fail_step: str,
+) -> None:
+    custom_tool_bin = posix_harness.root / "custom-tool-bin"
+    existing_aider = custom_tool_bin / "aider"
+    posix_harness.env["UV_TOOL_BIN_DIR"] = str(custom_tool_bin)
+    _write_executable(
+        existing_aider,
+        _posix_command("aider", version_output="existing aider 1.0.0"),
+    )
+    original = existing_aider.read_bytes()
+
+    result = posix_harness.run_interactive(
+        "n\nn\nn\nn\nn\nn\nn\nn\nn\ny\nn\n", fail_step=fail_step
+    )
+
+    if fail_step:
+        assert result.returncode != 0
+    else:
+        assert result.returncode == 0, result.stderr
+    calls = posix_harness.calls()
+    assert calls.index("uv:tool dir --bin") < calls.index("aider:--version")
+    assert not any("aider-chat@latest" in call for call in calls)
+    assert existing_aider.read_bytes() == original
 
 
 def test_install_sh_rejects_broken_existing_aider_without_replacing_it(
@@ -1281,6 +1311,20 @@ def test_install_sh_prioritizes_cargo_home_uv_install_layout(
     posix_harness.env["CARGO_HOME"] = str(cargo_home)
     posix_harness.env["UV_INSTALL_DIR"] = str(cargo_home)
     posix_harness.env["PATH"] = f"{posix_harness.env['PATH']}:{cargo_bin}"
+    posix_harness.add_uv("0.5.9")
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Verified uv 0.11.28." in result.stdout
+    assert "uv-install" in posix_harness.calls()
+
+
+def test_install_sh_prioritizes_replacement_uv_from_unmanaged_install_directory(
+    posix_harness: PosixHarness,
+) -> None:
+    unmanaged_bin = posix_harness.root / "unmanaged-uv-bin"
+    posix_harness.env["UV_UNMANAGED_INSTALL"] = str(unmanaged_bin)
     posix_harness.add_uv("0.5.9")
 
     result = posix_harness.run()
@@ -1955,7 +1999,10 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "muse-install"
     )
     (fixtures / "uv-installer.ps1").write_text(
         r"""if ($env:FAIL_STEP -eq "uv-install") { exit 63 }
-$bin = if ($env:UV_INSTALL_DIR) {
+$bin = if ($env:UV_UNMANAGED_INSTALL) {
+    $env:UV_UNMANAGED_INSTALL
+}
+elseif ($env:UV_INSTALL_DIR) {
     if ($env:UV_INSTALL_DIR -eq $(if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE ".cargo" })) {
         Join-Path $env:UV_INSTALL_DIR "bin"
     }
@@ -2311,6 +2358,33 @@ def test_install_ps1_discovers_aider_in_custom_uv_tool_bin(
     calls = powershell_harness.calls()
     assert "uv:tool dir --bin" in calls
     assert "aider:--version" in calls
+
+
+@pytest.mark.parametrize("fail_step", ("", "aider-verify"), ids=("valid", "broken"))
+def test_install_ps1_checks_existing_aider_in_custom_uv_tool_bin_before_installing(
+    powershell_harness: PowerShellHarness,
+    fail_step: str,
+) -> None:
+    custom_tool_bin = powershell_harness.root / "custom-tool-bin"
+    existing_aider = custom_tool_bin / "aider.cmd"
+    custom_tool_bin.mkdir()
+    powershell_harness.env["UV_TOOL_BIN_DIR"] = str(custom_tool_bin)
+    existing_aider.write_text(
+        _batch_client("aider", version_output="existing aider 1.0.0"),
+        encoding="utf-8",
+    )
+    original = existing_aider.read_bytes()
+
+    result = powershell_harness.run(fail_step=fail_step)
+
+    if fail_step:
+        assert result.returncode != 0
+    else:
+        assert result.returncode == 0, result.stderr
+    calls = powershell_harness.calls()
+    assert calls.index("uv:tool dir --bin") < calls.index("aider:--version")
+    assert not any("aider-chat@latest" in call for call in calls)
+    assert existing_aider.read_bytes() == original
 
 
 def test_install_ps1_rejects_broken_existing_aider_without_replacing_it(
@@ -2775,6 +2849,20 @@ def test_install_ps1_prioritizes_cargo_home_uv_install_layout(
     powershell_harness.env["PATH"] = (
         f"{powershell_harness.env['PATH']}{os.pathsep}{cargo_bin}"
     )
+    powershell_harness.add_uv("0.5.9")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Verified uv 0.11.28." in result.stdout
+    assert "uv-install" in powershell_harness.calls()
+
+
+def test_install_ps1_prioritizes_replacement_uv_from_unmanaged_install_directory(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    unmanaged_bin = powershell_harness.root / "unmanaged-uv-bin"
+    powershell_harness.env["UV_UNMANAGED_INSTALL"] = str(unmanaged_bin)
     powershell_harness.add_uv("0.5.9")
 
     result = powershell_harness.run()

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -33,6 +33,11 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _assert_uv_ready_without_fcc_install(calls: list[str]) -> None:
+    assert "uv:--version" in calls
+    assert not any("--refresh-package free-claude-code" in call for call in calls)
+
+
 def _write_executable(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
@@ -136,6 +141,17 @@ if [ "${{1:-}}" = "--version" ]; then
     exit 0
 fi
 if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "install" ]; then
+    case " $* " in
+        *" aider-chat@latest "*)
+            if [ "$FAIL_STEP" = "aider-install" ]; then
+                exit 29
+            fi
+            mkdir -p "$HOME/.local/bin"
+            cp "$FAKE_FIXTURES/aider-command.sh" "$HOME/.local/bin/aider"
+            chmod +x "$HOME/.local/bin/aider"
+            exit 0
+            ;;
+    esac
     if [ "$FAIL_STEP" = "fcc-install" ]; then
         exit 33
     fi
@@ -340,7 +356,7 @@ while [ "$#" -gt 0 ]; do
 done
 echo "download:$url" >> "$CALL_LOG"
 case "$url:$FAIL_STEP" in
-    *claude.ai*:claude-download|*chatgpt.com*:codex-download|*pi.dev*:pi-download|*opencode.ai*:opencode-download|*hermes-agent.nousresearch.com*:hermes-download|*x.ai*:grok-download|*dev.meta.ai*:muse-download|*aider.chat*:aider-download|*rtk-ai*:rtk-download|*astral.sh*:uv-download)
+    *claude.ai*:claude-download|*chatgpt.com*:codex-download|*pi.dev*:pi-download|*opencode.ai*:opencode-download|*hermes-agent.nousresearch.com*:hermes-download|*x.ai*:grok-download|*dev.meta.ai*:muse-download|*rtk-ai*:rtk-download|*astral.sh*:uv-download)
         exit 41
         ;;
 esac
@@ -352,7 +368,6 @@ case "$url" in
     *hermes-agent.nousresearch.com*) source="$FAKE_FIXTURES/hermes-installer.sh" ;;
     *x.ai*) source="$FAKE_FIXTURES/grok-installer.sh" ;;
     *dev.meta.ai*) source="$FAKE_FIXTURES/muse-installer.sh" ;;
-    *aider.chat*) source="$FAKE_FIXTURES/aider-installer.sh" ;;
     *rtk-ai*)
         if [ "$FAIL_STEP" = "rtk-install" ]; then
             printf 'invalid archive\n' > "$output"
@@ -441,16 +456,6 @@ echo "muse-install" >> "$CALL_LOG"
 mkdir -p "$HOME/.local/bin"
 cp "$FAKE_FIXTURES/muse-command.sh" "$HOME/.local/bin/muse"
 chmod +x "$HOME/.local/bin/muse"
-""",
-    )
-    _write_executable(
-        fixtures / "aider-installer.sh",
-        """#!/bin/sh
-echo "aider-install" >> "$CALL_LOG"
-[ "$FAIL_STEP" = "aider-install" ] && exit 29
-mkdir -p "$HOME/.local/bin"
-cp "$FAKE_FIXTURES/aider-command.sh" "$HOME/.local/bin/aider"
-chmod +x "$HOME/.local/bin/aider"
 """,
     )
     _write_executable(
@@ -569,8 +574,12 @@ def test_install_sh_fresh_install_is_verified(posix_harness: PosixHarness) -> No
     )
     assert calls.index("grok-install") < calls.index("grok:--version")
     assert calls.index("muse-install") < calls.index("muse:--version")
-    assert calls.index("aider-install") < calls.index("aider:--version")
     assert calls.index("uv-install") < calls.index("uv:--version")
+    aider_install = (
+        "uv:tool install --force --python python3.12 --with pip aider-chat@latest"
+    )
+    assert calls.index("uv:--version") < calls.index("claude-install")
+    assert calls.index(aider_install) < calls.index("aider:--version")
     assert any(
         call.startswith(
             "uv:tool install --force --refresh-package free-claude-code "
@@ -634,7 +643,7 @@ def test_install_sh_stops_when_selected_hermes_install_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any("astral.sh" in call for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 def test_install_sh_rejects_unsupported_hermes_platform_before_download(
@@ -660,7 +669,10 @@ def test_install_sh_rejects_unsupported_hermes_platform_before_download(
         ("hermes", "hermes-install:--non-interactive --skip-setup"),
         ("grok", "grok-install"),
         ("muse", "muse-install"),
-        ("aider", "aider-install"),
+        (
+            "aider",
+            "uv:tool install --force --python python3.12 --with pip aider-chat@latest",
+        ),
     ],
 )
 def test_install_sh_preserves_upstream_managed_harness_without_parsing_version(
@@ -692,7 +704,7 @@ def test_install_sh_stops_when_grok_install_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 @pytest.mark.parametrize("failure", ["muse-download", "muse-install"])
@@ -706,21 +718,25 @@ def test_install_sh_stops_when_muse_install_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
-@pytest.mark.parametrize("failure", ["aider-download", "aider-install"])
 def test_install_sh_stops_when_aider_install_fails(
     posix_harness: PosixHarness,
-    failure: str,
 ) -> None:
     result = posix_harness.run_interactive(
-        "n\nn\nn\nn\nn\nn\nn\nn\nn\ny\nn\n", fail_step=failure
+        "n\nn\nn\nn\nn\nn\nn\nn\nn\ny\nn\n", fail_step="aider-install"
     )
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+    calls = posix_harness.calls()
+    aider_install = (
+        "uv:tool install --force --python python3.12 --with pip aider-chat@latest"
+    )
+    assert calls.index("uv:--version") < calls.index(aider_install)
+    assert not any("aider.chat/install" in call for call in calls)
+    assert not any("--refresh-package free-claude-code" in call for call in calls)
 
 
 def test_install_sh_accepts_aider_as_the_only_selected_agent(
@@ -730,8 +746,12 @@ def test_install_sh_accepts_aider_as_the_only_selected_agent(
 
     assert result.returncode == 0, result.stdout
     calls = posix_harness.calls()
-    assert "download:https://aider.chat/install.sh" in calls
-    assert calls.index("aider-install") < calls.index("aider:--version")
+    aider_install = (
+        "uv:tool install --force --python python3.12 --with pip aider-chat@latest"
+    )
+    assert calls.index("uv:--version") < calls.index(aider_install)
+    assert calls.index(aider_install) < calls.index("aider:--version")
+    assert not any("aider.chat/install" in call for call in calls)
     assert "Run Aider with: fcc-aider" in result.stdout
     assert "Select at least one coding agent." not in result.stdout
 
@@ -746,7 +766,7 @@ def test_install_sh_rejects_broken_existing_aider_without_replacing_it(
     assert result.returncode != 0
     calls = posix_harness.calls()
     assert "aider:--version" in calls
-    assert "aider-install" not in calls
+    assert not any("aider-chat@latest" in call for call in calls)
     assert not any("aider.chat" in call for call in calls)
 
 
@@ -793,7 +813,7 @@ def test_install_sh_rejects_exact_dsh_on_unsupported_node(
 
     assert result.returncode != 0
     assert "requires Node.js ^22.19.0 or >=24.0.0" in result.stderr
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 @pytest.mark.parametrize("node_version", ["22.18.0", "23.9.0", "not-a-version"])
@@ -810,7 +830,7 @@ def test_install_sh_rejects_incompatible_node_for_selected_dsh(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 def test_install_sh_noninteractive_skips_dsh_without_node(
@@ -837,7 +857,7 @@ def test_install_sh_stops_when_selected_dsh_install_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 def test_install_sh_installs_and_configures_rtk_for_selected_agents(
@@ -864,8 +884,8 @@ def test_install_sh_installs_and_configures_rtk_for_selected_agents(
         "rtk:init --global --agent pi:telemetry=1",
         "rtk:init --global --opencode:telemetry=1",
     ]
-    assert calls.index("rtk:init --global --opencode:telemetry=1") < calls.index(
-        "uv-install"
+    assert calls.index("uv:--version") < calls.index(
+        "rtk:init --global --opencode:telemetry=1"
     )
     assert (Path(posix_harness.env["HOME"]) / ".claude").is_dir()
 
@@ -947,7 +967,7 @@ def test_install_sh_rejects_conflicting_rtk_command(
     assert result.returncode != 0
     assert "not a compatible Rust Token Killer installation" in result.stderr
     assert not any("rtk-ai/rtk" in call for call in posix_harness.calls())
-    assert not any("astral.sh" in call for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 @pytest.mark.parametrize(
@@ -968,7 +988,7 @@ def test_install_sh_stops_when_rtk_setup_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any("astral.sh" in call for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 def test_install_sh_reprompts_then_installs_only_selected_agent(
@@ -999,7 +1019,7 @@ def test_install_sh_rejects_uninstalled_only_selection(
 
     assert result.returncode != 0
     assert "No selected coding agent was installed." in result.stdout
-    assert not any("astral.sh" in call for call in posix_harness.calls())
+    _assert_uv_ready_without_fcc_install(posix_harness.calls())
 
 
 def test_install_sh_creates_native_macos_app_and_desktop_link(
@@ -1269,12 +1289,12 @@ def test_install_sh_stops_without_success_on_each_failure(
         "codex-verify": "pi.dev",
         "pi-download": "pi-install",
         "pi-install": "pi:--version",
-        "pi-verify": "astral.sh",
+        "pi-verify": "opencode:--version",
         "opencode-download": "opencode-install",
         "opencode-install": "opencode:--version",
-        "opencode-verify": "astral.sh",
+        "opencode-verify": "npm:install -g cline",
         "cline-install": "cline:--version",
-        "cline-verify": "astral.sh",
+        "cline-verify": "hermes-agent.nousresearch.com",
         "uv-download": "uv-install",
         "uv-install": "uv:--version",
         "uv-verify": "uv:tool install",
@@ -1305,7 +1325,9 @@ def test_install_sh_rejects_broken_existing_client_without_replacing_it(
     result = posix_harness.run(fail_step="claude-verify")
 
     assert result.returncode != 0
-    assert not any(call.startswith("download:") for call in posix_harness.calls())
+    calls = posix_harness.calls()
+    _assert_uv_ready_without_fcc_install(calls)
+    assert not any("claude.ai" in call for call in calls)
 
 
 def test_install_sh_rejects_unparseable_existing_uv(
@@ -1373,7 +1395,9 @@ def test_install_sh_rechecks_for_fcc_process_before_tool_replacement(
 
     assert result.returncode != 0
     assert "fcc-server (PID 4242)" in result.stderr
-    assert not any(call.startswith("uv:tool install") for call in posix_harness.calls())
+    assert not any(
+        "--refresh-package free-claude-code" in call for call in posix_harness.calls()
+    )
 
 
 def test_install_sh_ignores_similarly_named_process(
@@ -1621,6 +1645,7 @@ if "%FAIL_STEP%"=="uv-verify" exit /b 52
 echo uv {version}
 exit /b 0
 :install
+if "%5"=="python3.12" goto install_aider
 if "%FAIL_STEP%"=="fcc-install" exit /b 53
 if not exist "%FAKE_TOOL_BIN%" mkdir "%FAKE_TOOL_BIN%"
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-server.cmd" >nul
@@ -1635,6 +1660,11 @@ copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-grok.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-muse.cmd" >nul
 copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-aider.cmd" >nul
 if not "%FAIL_STEP%"=="fcc-missing" copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-codex.cmd" >nul
+exit /b 0
+:install_aider
+if "%FAIL_STEP%"=="aider-install" exit /b 57
+if not exist "%USERPROFILE%\.local\bin" mkdir "%USERPROFILE%\.local\bin"
+copy /y "%FAKE_FIXTURES%\aider-command.cmd" "%USERPROFILE%\.local\bin\aider.cmd" >nul
 exit /b 0
 :update_shell
 if "%FAIL_STEP%"=="path-update" exit /b 54
@@ -1854,15 +1884,6 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "muse-install"
 """,
         encoding="utf-8",
     )
-    (fixtures / "aider-installer.ps1").write_text(
-        r"""if ($env:FAIL_STEP -eq "aider-install") { exit 67 }
-$bin = Join-Path $env:USERPROFILE ".local\bin"
-New-Item -ItemType Directory -Force -Path $bin | Out-Null
-Copy-Item (Join-Path $env:FAKE_FIXTURES "aider-command.cmd") (Join-Path $bin "aider.cmd") -Force
-Add-Content -LiteralPath $env:CALL_LOG -Value "aider-install"
-""",
-        encoding="utf-8",
-    )
     (fixtures / "uv-installer.ps1").write_text(
         r"""if ($env:FAIL_STEP -eq "uv-install") { exit 63 }
 $bin = Join-Path $env:USERPROFILE ".local\bin"
@@ -1909,7 +1930,6 @@ function Invoke-RestMethod {
         ($env:FAIL_STEP -eq "hermes-download" -and $Uri.Contains("hermes-agent.nousresearch.com")) -or
         ($env:FAIL_STEP -eq "grok-download" -and $Uri.Contains("x.ai/cli")) -or
         ($env:FAIL_STEP -eq "muse-download" -and $Uri.Contains("scripts/install-muse.ps1")) -or
-        ($env:FAIL_STEP -eq "aider-download" -and $Uri.Contains("aider.chat")) -or
         ($env:FAIL_STEP -eq "rtk-download" -and $Uri.Contains("rtk-ai/rtk")) -or
         ($env:FAIL_STEP -eq "uv-download" -and $Uri.Contains("astral.sh"))
     ) {
@@ -1932,9 +1952,6 @@ function Invoke-RestMethod {
     }
     elseif ($Uri.Contains("scripts/install-muse.ps1")) {
         $source = Join-Path $env:FAKE_FIXTURES "muse-installer.ps1"
-    }
-    elseif ($Uri.Contains("aider.chat")) {
-        $source = Join-Path $env:FAKE_FIXTURES "aider-installer.ps1"
     }
     elseif ($Uri.Contains("opencode-windows-")) {
         if ($env:FAIL_STEP -eq "opencode-archive") {
@@ -2042,9 +2059,13 @@ def test_install_ps1_fresh_install_is_verified(
     )
     assert calls.index("grok-install") < calls.index("grok:--version")
     assert calls.index("muse-install") < calls.index("muse:--version")
-    assert calls.index("aider-install") < calls.index("aider:--version")
     assert not any("hermes:setup" in call for call in calls)
     assert calls.index("uv-install") < calls.index("uv:--version")
+    aider_install = (
+        "uv:tool install --force --python python3.12 --with pip aider-chat@latest"
+    )
+    assert calls.index("uv:--version") < calls.index("claude-install")
+    assert calls.index(aider_install) < calls.index("aider:--version")
     assert any(
         call.startswith(
             "uv:tool install --force --refresh-package free-claude-code "
@@ -2111,7 +2132,10 @@ def test_install_ps1_discovers_grok_in_custom_bin_directory(
         ("cline", "npm:install -g cline"),
         ("hermes", "hermes-install:True:True"),
         ("grok", "grok-install"),
-        ("aider", "aider-install"),
+        (
+            "aider",
+            "uv:tool install --force --python python3.12 --with pip aider-chat@latest",
+        ),
     ],
 )
 def test_install_ps1_preserves_upstream_managed_harness_without_parsing_version(
@@ -2158,7 +2182,7 @@ def test_install_ps1_stops_when_muse_install_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+    _assert_uv_ready_without_fcc_install(powershell_harness.calls())
 
 
 @pytest.mark.parametrize("failure", ["grok-download", "grok-install"])
@@ -2170,19 +2194,23 @@ def test_install_ps1_stops_when_grok_install_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+    _assert_uv_ready_without_fcc_install(powershell_harness.calls())
 
 
-@pytest.mark.parametrize("failure", ["aider-download", "aider-install"])
 def test_install_ps1_stops_when_aider_install_fails(
     powershell_harness: PowerShellHarness,
-    failure: str,
 ) -> None:
-    result = powershell_harness.run(fail_step=failure)
+    result = powershell_harness.run(fail_step="aider-install")
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+    calls = powershell_harness.calls()
+    aider_install = (
+        "uv:tool install --force --python python3.12 --with pip aider-chat@latest"
+    )
+    assert calls.index("uv:--version") < calls.index(aider_install)
+    assert not any("aider.chat/install" in call for call in calls)
+    assert not any("--refresh-package free-claude-code" in call for call in calls)
 
 
 def test_install_ps1_rejects_broken_existing_aider_without_replacing_it(
@@ -2195,7 +2223,7 @@ def test_install_ps1_rejects_broken_existing_aider_without_replacing_it(
     assert result.returncode != 0
     calls = powershell_harness.calls()
     assert "aider:--version" in calls
-    assert "aider-install" not in calls
+    assert not any("aider-chat@latest" in call for call in calls)
     assert not any("aider.chat" in call for call in calls)
 
 
@@ -2243,7 +2271,7 @@ def test_install_ps1_rejects_exact_dsh_on_unsupported_node(
     assert "requires Node.js ^22.19.0 or >=24.0.0" in (
         f"{result.stdout}\n{result.stderr}"
     )
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+    _assert_uv_ready_without_fcc_install(powershell_harness.calls())
 
 
 @pytest.mark.parametrize("node_version", ["22.18.0", "23.9.0", "not-a-version"])
@@ -2264,7 +2292,7 @@ def test_install_ps1_rejects_incompatible_node_for_selected_dsh(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+    _assert_uv_ready_without_fcc_install(powershell_harness.calls())
 
 
 def test_install_ps1_noninteractive_skips_dsh_without_node(
@@ -2289,7 +2317,7 @@ def test_install_ps1_stops_when_selected_dsh_install_fails(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
-    assert not any(call.startswith("uv:") for call in powershell_harness.calls())
+    _assert_uv_ready_without_fcc_install(powershell_harness.calls())
 
 
 def test_install_ps1_rejects_unsupported_hermes_architecture_before_download(
@@ -2381,7 +2409,7 @@ def test_install_ps1_rejects_conflicting_rtk_command(
     assert result.returncode != 0
     assert "not a compatible Rust Token Killer installation" in result.stderr
     assert not any("rtk-ai/rtk" in call for call in powershell_harness.calls())
-    assert not any("astral.sh" in call for call in powershell_harness.calls())
+    _assert_uv_ready_without_fcc_install(powershell_harness.calls())
 
 
 def test_install_ps1_rtk_dry_run_prints_install_and_agent_setup(
@@ -2685,12 +2713,12 @@ def test_install_ps1_stops_without_success_on_each_failure(
         "codex-verify": "pi.dev",
         "pi-download": "pi-install",
         "pi-install": "pi:--version",
-        "pi-verify": "astral.sh",
-        "opencode-download": "uv-install",
-        "opencode-archive": "uv-install",
-        "opencode-verify": "astral.sh",
+        "pi-verify": "opencode:--version",
+        "opencode-download": "opencode:--version",
+        "opencode-archive": "opencode:--version",
+        "opencode-verify": "npm:install -g cline",
         "cline-install": "cline:--version",
-        "cline-verify": "astral.sh",
+        "cline-verify": "hermes-agent.nousresearch.com",
         "uv-download": "uv-install",
         "uv-install": "uv:--version",
         "uv-verify": "uv:tool install",
@@ -2721,7 +2749,9 @@ def test_install_ps1_rejects_broken_existing_client_without_replacing_it(
     result = powershell_harness.run(fail_step="claude-verify")
 
     assert result.returncode != 0
-    assert not any(call.startswith("download:") for call in powershell_harness.calls())
+    calls = powershell_harness.calls()
+    _assert_uv_ready_without_fcc_install(calls)
+    assert not any("claude.ai" in call for call in calls)
 
 
 def test_install_ps1_rejects_unparseable_existing_uv(
@@ -2781,7 +2811,8 @@ def test_install_ps1_rechecks_for_fcc_process_before_tool_replacement(
     assert result.returncode != 0
     assert "fcc-server (PID 4242)" in result.stderr
     assert not any(
-        call.startswith("uv:tool install") for call in powershell_harness.calls()
+        "--refresh-package free-claude-code" in call
+        for call in powershell_harness.calls()
     )
 
 
@@ -2821,8 +2852,6 @@ def test_installers_use_native_clients_and_single_python_selection() -> None:
     assert "https://x.ai/cli/install.sh" in shell
     assert "https://x.ai/cli/install.ps1" in powershell
     assert "https://dev.meta.ai/install.sh" in shell
-    assert "https://aider.chat/install.sh" in shell
-    assert "https://aider.chat/install.ps1" in powershell
     assert (
         "https://raw.githubusercontent.com/Alishahryar1/free-claude-code/"
         "main/scripts/install-muse.ps1"

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -130,6 +130,7 @@ exit 71
 def _posix_uv_command(version: str) -> str:
     return f"""#!/bin/sh
 echo "uv:$*" >> "$CALL_LOG"
+tool_bin=${{UV_TOOL_BIN_DIR:-$FAKE_TOOL_BIN}}
 if [ "${{1:-}}" = "--version" ]; then
     if [ "${{FCC_RUNNING_PHASE:-}}" = "late" ]; then
         : > "$FCC_PROCESS_MARKER"
@@ -146,31 +147,31 @@ if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "install" ]; then
             if [ "$FAIL_STEP" = "aider-install" ]; then
                 exit 29
             fi
-            mkdir -p "$HOME/.local/bin"
-            cp "$FAKE_FIXTURES/aider-command.sh" "$HOME/.local/bin/aider"
-            chmod +x "$HOME/.local/bin/aider"
+            mkdir -p "$tool_bin"
+            cp "$FAKE_FIXTURES/aider-command.sh" "$tool_bin/aider"
+            chmod +x "$tool_bin/aider"
             exit 0
             ;;
     esac
     if [ "$FAIL_STEP" = "fcc-install" ]; then
         exit 33
     fi
-    mkdir -p "$FAKE_TOOL_BIN"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-server"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-desktop"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-claude"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-pi"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-opencode"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-cline"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-hermes"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-dsh"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-grok"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-muse"
-    cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-aider"
+    mkdir -p "$tool_bin"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-server"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-desktop"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-claude"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-pi"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-opencode"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-cline"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-hermes"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-dsh"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-grok"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-muse"
+    cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-aider"
     if [ "$FAIL_STEP" != "fcc-missing" ]; then
-        cp "$FAKE_FIXTURES/fcc-command.sh" "$FAKE_TOOL_BIN/fcc-codex"
+        cp "$FAKE_FIXTURES/fcc-command.sh" "$tool_bin/fcc-codex"
     fi
-    chmod +x "$FAKE_TOOL_BIN"/fcc-*
+    chmod +x "$tool_bin"/fcc-*
     exit 0
 fi
 if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "update-shell" ]; then
@@ -180,7 +181,7 @@ if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "update-shell" ]; then
     exit 0
 fi
 if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "dir" ] && [ "${{3:-}}" = "--bin" ]; then
-    printf '%s\n' "$FAKE_TOOL_BIN"
+    printf '%s\n' "$tool_bin"
     exit 0
 fi
 exit 35
@@ -463,9 +464,18 @@ chmod +x "$HOME/.local/bin/muse"
         """#!/bin/sh
 echo "uv-install" >> "$CALL_LOG"
 [ "$FAIL_STEP" = "uv-install" ] && exit 23
-mkdir -p "$HOME/.local/bin"
-cp "$FAKE_FIXTURES/uv-command.sh" "$HOME/.local/bin/uv"
-chmod +x "$HOME/.local/bin/uv"
+if [ -n "${UV_INSTALL_DIR:-}" ]; then
+    uv_bin=$UV_INSTALL_DIR
+elif [ -n "${XDG_BIN_HOME:-}" ]; then
+    uv_bin=$XDG_BIN_HOME
+elif [ -n "${XDG_DATA_HOME:-}" ]; then
+    uv_bin=$XDG_DATA_HOME/../bin
+else
+    uv_bin=$HOME/.local/bin
+fi
+mkdir -p "$uv_bin"
+cp "$FAKE_FIXTURES/uv-command.sh" "$uv_bin/uv"
+chmod +x "$uv_bin/uv"
 """,
     )
     _write_executable(fixtures / "claude-command.sh", _posix_command("claude"))
@@ -754,6 +764,21 @@ def test_install_sh_accepts_aider_as_the_only_selected_agent(
     assert not any("aider.chat/install" in call for call in calls)
     assert "Run Aider with: fcc-aider" in result.stdout
     assert "Select at least one coding agent." not in result.stdout
+
+
+def test_install_sh_discovers_aider_in_custom_uv_tool_bin(
+    posix_harness: PosixHarness,
+) -> None:
+    custom_tool_bin = posix_harness.root / "custom-tool-bin"
+    posix_harness.env["UV_TOOL_BIN_DIR"] = str(custom_tool_bin)
+
+    result = posix_harness.run_interactive("n\nn\nn\nn\nn\nn\nn\nn\nn\ny\nn\n")
+
+    assert result.returncode == 0, result.stderr
+    assert (custom_tool_bin / "aider").is_file()
+    calls = posix_harness.calls()
+    assert "uv:tool dir --bin" in calls
+    assert "aider:--version" in calls
 
 
 def test_install_sh_rejects_broken_existing_aider_without_replacing_it(
@@ -1227,6 +1252,23 @@ def test_install_sh_replaces_obsolete_uv(posix_harness: PosixHarness) -> None:
     assert "uv-install" in posix_harness.calls()
 
 
+def test_install_sh_prioritizes_replacement_uv_over_obsolete_cargo_uv(
+    posix_harness: PosixHarness,
+) -> None:
+    home = Path(posix_harness.env["HOME"])
+    cargo_bin = home / ".cargo" / "bin"
+    local_bin = home / ".local" / "bin"
+    _write_executable(cargo_bin / "uv", _posix_uv_command("0.5.9"))
+    local_bin.mkdir(parents=True)
+    posix_harness.env["PATH"] = f"{cargo_bin}:{local_bin}:{posix_harness.env['PATH']}"
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Verified uv 0.11.28." in result.stdout
+    assert "uv-install" in posix_harness.calls()
+
+
 @pytest.mark.parametrize("version", ("0.11.16-alpha.1", "0.12.0-rc.1"))
 def test_install_sh_replaces_prerelease_uv(
     posix_harness: PosixHarness,
@@ -1280,6 +1322,11 @@ def test_install_sh_stops_without_success_on_each_failure(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
+    calls = posix_harness.calls()
+    if failure == "path-update":
+        failure_index = calls.index("uv:tool update-shell")
+        assert "uv:tool dir --bin" not in calls[failure_index + 1 :]
+
     forbidden = {
         "claude-download": "claude-install",
         "claude-install": "claude:--version",
@@ -1299,11 +1346,10 @@ def test_install_sh_stops_without_success_on_each_failure(
         "uv-install": "uv:--version",
         "uv-verify": "uv:tool install",
         "fcc-install": "uv:tool update-shell",
-        "path-update": "uv:tool dir --bin",
         "fcc-missing": "fcc-server:--version",
     }.get(failure)
     if forbidden is not None:
-        assert not any(forbidden in call for call in posix_harness.calls())
+        assert not any(forbidden in call for call in calls)
 
 
 def test_install_sh_dry_run_never_executes_commands(
@@ -1633,6 +1679,8 @@ exit /b 0
 
 def _batch_uv(version: str) -> str:
     return rf"""@echo off
+set "UV_BIN_DIR=%FAKE_TOOL_BIN%"
+if defined UV_TOOL_BIN_DIR set "UV_BIN_DIR=%UV_TOOL_BIN_DIR%"
 echo uv:%*>>"%CALL_LOG%"
 if "%1"=="--version" goto version
 if "%1"=="tool" if "%2"=="install" goto install
@@ -1647,30 +1695,30 @@ exit /b 0
 :install
 if "%5"=="python3.12" goto install_aider
 if "%FAIL_STEP%"=="fcc-install" exit /b 53
-if not exist "%FAKE_TOOL_BIN%" mkdir "%FAKE_TOOL_BIN%"
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-server.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-desktop.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-claude.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-pi.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-opencode.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-cline.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-hermes.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-dsh.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-grok.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-muse.cmd" >nul
-copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-aider.cmd" >nul
-if not "%FAIL_STEP%"=="fcc-missing" copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%FAKE_TOOL_BIN%\fcc-codex.cmd" >nul
+if not exist "%UV_BIN_DIR%" mkdir "%UV_BIN_DIR%"
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-server.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-desktop.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-claude.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-pi.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-opencode.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-cline.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-hermes.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-dsh.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-grok.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-muse.cmd" >nul
+copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-aider.cmd" >nul
+if not "%FAIL_STEP%"=="fcc-missing" copy /y "%FAKE_FIXTURES%\fcc-command.cmd" "%UV_BIN_DIR%\fcc-codex.cmd" >nul
 exit /b 0
 :install_aider
 if "%FAIL_STEP%"=="aider-install" exit /b 57
-if not exist "%USERPROFILE%\.local\bin" mkdir "%USERPROFILE%\.local\bin"
-copy /y "%FAKE_FIXTURES%\aider-command.cmd" "%USERPROFILE%\.local\bin\aider.cmd" >nul
+if not exist "%UV_BIN_DIR%" mkdir "%UV_BIN_DIR%"
+copy /y "%FAKE_FIXTURES%\aider-command.cmd" "%UV_BIN_DIR%\aider.cmd" >nul
 exit /b 0
 :update_shell
 if "%FAIL_STEP%"=="path-update" exit /b 54
 exit /b 0
 :tool_bin
-echo %FAKE_TOOL_BIN%
+echo %UV_BIN_DIR%
 exit /b 0
 """
 
@@ -1886,7 +1934,18 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "muse-install"
     )
     (fixtures / "uv-installer.ps1").write_text(
         r"""if ($env:FAIL_STEP -eq "uv-install") { exit 63 }
-$bin = Join-Path $env:USERPROFILE ".local\bin"
+$bin = if ($env:UV_INSTALL_DIR) {
+    $env:UV_INSTALL_DIR
+}
+elseif ($env:XDG_BIN_HOME) {
+    $env:XDG_BIN_HOME
+}
+elseif ($env:XDG_DATA_HOME) {
+    Join-Path $env:XDG_DATA_HOME "..\bin"
+}
+else {
+    Join-Path $env:USERPROFILE ".local\bin"
+}
 New-Item -ItemType Directory -Force -Path $bin | Out-Null
 Copy-Item (Join-Path $env:FAKE_FIXTURES "uv-command.cmd") (Join-Path $bin "uv.cmd") -Force
 Add-Content -LiteralPath $env:CALL_LOG -Value "uv-install"
@@ -2211,6 +2270,21 @@ def test_install_ps1_stops_when_aider_install_fails(
     assert calls.index("uv:--version") < calls.index(aider_install)
     assert not any("aider.chat/install" in call for call in calls)
     assert not any("--refresh-package free-claude-code" in call for call in calls)
+
+
+def test_install_ps1_discovers_aider_in_custom_uv_tool_bin(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    custom_tool_bin = powershell_harness.root / "custom-tool-bin"
+    powershell_harness.env["UV_TOOL_BIN_DIR"] = str(custom_tool_bin)
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert (custom_tool_bin / "aider.cmd").is_file()
+    calls = powershell_harness.calls()
+    assert "uv:tool dir --bin" in calls
+    assert "aider:--version" in calls
 
 
 def test_install_ps1_rejects_broken_existing_aider_without_replacing_it(
@@ -2651,6 +2725,20 @@ def test_install_ps1_replaces_obsolete_uv(
     assert "uv-install" in powershell_harness.calls()
 
 
+def test_install_ps1_prioritizes_replacement_uv_from_custom_install_directory(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    custom_install_dir = powershell_harness.root / "custom-uv-bin"
+    powershell_harness.env["UV_INSTALL_DIR"] = str(custom_install_dir)
+    powershell_harness.add_uv("0.5.9")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Verified uv 0.11.28." in result.stdout
+    assert "uv-install" in powershell_harness.calls()
+
+
 @pytest.mark.parametrize("version", ("0.11.16-alpha.1", "0.12.0-rc.1"))
 def test_install_ps1_replaces_prerelease_uv(
     powershell_harness: PowerShellHarness,
@@ -2704,6 +2792,11 @@ def test_install_ps1_stops_without_success_on_each_failure(
 
     assert result.returncode != 0
     assert "Free Claude Code is installed and verified." not in result.stdout
+    calls = powershell_harness.calls()
+    if failure == "path-update":
+        failure_index = calls.index("uv:tool update-shell")
+        assert "uv:tool dir --bin" not in calls[failure_index + 1 :]
+
     forbidden = {
         "claude-download": "claude-install",
         "claude-install": "claude:--version",
@@ -2723,11 +2816,10 @@ def test_install_ps1_stops_without_success_on_each_failure(
         "uv-install": "uv:--version",
         "uv-verify": "uv:tool install",
         "fcc-install": "uv:tool update-shell",
-        "path-update": "uv:tool dir --bin",
         "fcc-missing": "fcc-server:--version",
     }.get(failure)
     if forbidden is not None:
-        assert not any(forbidden in call for call in powershell_harness.calls())
+        assert not any(forbidden in call for call in calls)
 
 
 def test_install_ps1_dry_run_never_executes_commands(

--- a/tests/scripts/test_installers.py
+++ b/tests/scripts/test_installers.py
@@ -466,6 +466,9 @@ echo "uv-install" >> "$CALL_LOG"
 [ "$FAIL_STEP" = "uv-install" ] && exit 23
 if [ -n "${UV_INSTALL_DIR:-}" ]; then
     uv_bin=$UV_INSTALL_DIR
+    if [ "$UV_INSTALL_DIR" = "${CARGO_HOME:-$HOME/.cargo}" ]; then
+        uv_bin=$UV_INSTALL_DIR/bin
+    fi
 elif [ -n "${XDG_BIN_HOME:-}" ]; then
     uv_bin=$XDG_BIN_HOME
 elif [ -n "${XDG_DATA_HOME:-}" ]; then
@@ -1269,6 +1272,24 @@ def test_install_sh_prioritizes_replacement_uv_over_obsolete_cargo_uv(
     assert "uv-install" in posix_harness.calls()
 
 
+def test_install_sh_prioritizes_cargo_home_uv_install_layout(
+    posix_harness: PosixHarness,
+) -> None:
+    home = Path(posix_harness.env["HOME"])
+    cargo_home = home / ".cargo"
+    cargo_bin = cargo_home / "bin"
+    posix_harness.env["CARGO_HOME"] = str(cargo_home)
+    posix_harness.env["UV_INSTALL_DIR"] = str(cargo_home)
+    posix_harness.env["PATH"] = f"{posix_harness.env['PATH']}:{cargo_bin}"
+    posix_harness.add_uv("0.5.9")
+
+    result = posix_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Verified uv 0.11.28." in result.stdout
+    assert "uv-install" in posix_harness.calls()
+
+
 @pytest.mark.parametrize("version", ("0.11.16-alpha.1", "0.12.0-rc.1"))
 def test_install_sh_replaces_prerelease_uv(
     posix_harness: PosixHarness,
@@ -1935,7 +1956,12 @@ Add-Content -LiteralPath $env:CALL_LOG -Value "muse-install"
     (fixtures / "uv-installer.ps1").write_text(
         r"""if ($env:FAIL_STEP -eq "uv-install") { exit 63 }
 $bin = if ($env:UV_INSTALL_DIR) {
-    $env:UV_INSTALL_DIR
+    if ($env:UV_INSTALL_DIR -eq $(if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE ".cargo" })) {
+        Join-Path $env:UV_INSTALL_DIR "bin"
+    }
+    else {
+        $env:UV_INSTALL_DIR
+    }
 }
 elseif ($env:XDG_BIN_HOME) {
     $env:XDG_BIN_HOME
@@ -2730,6 +2756,25 @@ def test_install_ps1_prioritizes_replacement_uv_from_custom_install_directory(
 ) -> None:
     custom_install_dir = powershell_harness.root / "custom-uv-bin"
     powershell_harness.env["UV_INSTALL_DIR"] = str(custom_install_dir)
+    powershell_harness.add_uv("0.5.9")
+
+    result = powershell_harness.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Verified uv 0.11.28." in result.stdout
+    assert "uv-install" in powershell_harness.calls()
+
+
+def test_install_ps1_prioritizes_cargo_home_uv_install_layout(
+    powershell_harness: PowerShellHarness,
+) -> None:
+    cargo_home = Path(powershell_harness.env["USERPROFILE"]) / ".cargo"
+    cargo_bin = cargo_home / "bin"
+    powershell_harness.env["CARGO_HOME"] = str(cargo_home)
+    powershell_harness.env["UV_INSTALL_DIR"] = str(cargo_home)
+    powershell_harness.env["PATH"] = (
+        f"{powershell_harness.env['PATH']}{os.pathsep}{cargo_bin}"
+    )
     powershell_harness.add_uv("0.5.9")
 
     result = powershell_harness.run()

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.15.8"
+version = "5.15.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Aider's upstream bootstrap pins and overwrites uv 0.5.9, causing FCC installation to fail when a newer uv is active and risking a silent downgrade.

## Changes

| Before | After |
| --- | --- |
| FCC delegated Aider installation to bootstrap scripts that replaced shared uv. | FCC verifies its modern uv prerequisite first and installs `aider-chat` directly through it. |
| Aider setup ran before FCC established uv. | Both installers establish uv before any selected harness installation. |
| Installer tests modeled an independent Aider bootstrap. | Installer tests model Aider as a uv-managed tool and verify ordering and failures on both platforms. |










<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update moves Aider installation to FCC’s uv toolchain, prioritizes configured uv installation locations, and adds native Windows Muse Code installation and lifecycle support. The exercised installer workflows completed successfully with no blocking product failures found.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised installer workflows.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the focused installer harness captures from before the PR head and from the PR head, and confirmed they are in the same scope with identical commands, revisions, working directories, and exit codes.
- Attempted the Windows installer harness without PowerShell and ran under a repository fake-command harness rather than a real installer.
- Attempted the Native Windows Muse lifecycle harness without PowerShell and used a fake-command harness instead of a real installer.
- Performed a PowerShell availability check to determine whether PowerShell could be used for Windows harnesses.
- Validated installer shell syntax and diff whitespace to ensure consistent wrapper behavior and diff interpretation.

<a href="https://app.greptile.com/trex/runs/21216965/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["match uv standalone install resolution"](https://github.com/alishahryar1/free-claude-code/commit/84f91bcf87717bba38094bf6ee164fe50a1b4f69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57853472)</sub>

<!-- /greptile_comment -->