### PR TITLE
Remove redundant Aider routing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,6 @@ Aider:
 fcc-aider
 ```
 
-`fcc-aider` exposes FCC models as `anthropic/<provider>/<model>`. Use ordinary
-`aider` when you want Aider's native providers instead.
-
 <a id="model-picker"></a>
 
 <div align="center">


### PR DESCRIPTION
## Problem

The Aider launch section adds routing detail after the copyable command that users do not need to start FCC.

## Changes

| Before | After |
| --- | --- |
| The Aider section explained FCC model prefixes and when to use ordinary Aider. | The Aider section contains only the copyable `fcc-aider` command. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update removes the supplementary Aider routing explanation beneath the `fcc-aider` command in the README. The potential Markdown-formatting or command-usability issue was disproved by parsing the affected section on both revisions: the Bash fence remains closed, `fcc-aider` remains present, and the following anchor and image remain normal document content. No defects were found.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge: the documentation section remains structurally valid and continues to present the installed Aider launcher command.

No review findings remain after the affected README section was checked before and after the text removal with a Markdown parser and launcher-entry-point assertion.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Aider Markdown validation across base and HEAD revisions to verify the Aider launch command and fence integrity, confirming no regression due to routing-note removal.
- Reviewed the base revision validation log to confirm a valid parsed Aider fence and the expected launch command before routing-note removal.
- Reviewed the HEAD revision validation log to confirm the same valid structure after routing-note removal and the unchanged launch command.
- Collected the validation artifacts, including the script, before/after logs, and command-output, to support reviewer inspection of the checks.

<a href="https://app.greptile.com/trex/runs/21339230/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove redundant Aider routing not..."](https://github.com/alishahryar1/free-claude-code/commit/72c6692f5da5ddd7e246bbf01bd9598582ca1806) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58104007)</sub>

<!-- /greptile_comment -->