### PR TITLE
feat: propagate model token limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.16.0"
+version = "5.17.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -53,6 +53,12 @@ class ModelResponse(BaseModel):
     input_modalities: tuple[ModelInputModality, ...] | None = Field(
         default=None, serialization_alias="inputModalities"
     )
+    context_window_tokens: int | None = Field(
+        default=None, serialization_alias="contextWindow"
+    )
+    max_output_tokens: int | None = Field(
+        default=None, serialization_alias="maxCompletionTokens"
+    )
     reasoning_efforts: tuple[str, ...] | None = Field(
         default=None, serialization_alias="reasoningEfforts"
     )
@@ -118,6 +124,8 @@ class _InventoryModel:
     provider_model_ref: str
     supports_thinking: bool | None
     input_modalities: frozenset[ModelInputModality] | None
+    context_window_tokens: int | None
+    max_output_tokens: int | None
 
 
 def build_models_list_response(
@@ -208,6 +216,8 @@ def _build_direct_models_response(
                 input_modalities=_serialize_input_modalities(
                     inventory_model.input_modalities
                 ),
+                context_window_tokens=inventory_model.context_window_tokens,
+                max_output_tokens=inventory_model.max_output_tokens,
                 supports_reasoning_effort=(
                     allows_reasoning if view is ModelCatalogView.RESPONSES else None
                 ),
@@ -248,6 +258,12 @@ def _collect_inventory(
                 input_modalities=(
                     model_info.input_modalities if model_info is not None else None
                 ),
+                context_window_tokens=(
+                    model_info.context_window_tokens if model_info is not None else None
+                ),
+                max_output_tokens=(
+                    model_info.max_output_tokens if model_info is not None else None
+                ),
             )
         )
 
@@ -260,6 +276,8 @@ def _collect_inventory(
                 provider_model_ref=model_info.model_id,
                 supports_thinking=model_info.supports_thinking,
                 input_modalities=model_info.input_modalities,
+                context_window_tokens=model_info.context_window_tokens,
+                max_output_tokens=model_info.max_output_tokens,
             )
         )
 

--- a/src/free_claude_code/application/model_metadata.py
+++ b/src/free_claude_code/application/model_metadata.py
@@ -12,6 +12,8 @@ class ProviderModelInfo:
     model_id: str
     supports_thinking: bool | None = None
     input_modalities: frozenset[ModelInputModality] | None = None
+    context_window_tokens: int | None = None
+    max_output_tokens: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/free_claude_code/cli/launchers/aider_config.py
+++ b/src/free_claude_code/cli/launchers/aider_config.py
@@ -65,4 +65,8 @@ def _model_metadata(model: ClientModel) -> JsonObject:
     }
     if model.input_modalities is not None:
         metadata["supports_vision"] = ModelInputModality.IMAGE in model.input_modalities
+    if model.context_window_tokens is not None:
+        metadata["max_input_tokens"] = model.context_window_tokens
+    if model.max_output_tokens is not None:
+        metadata["max_output_tokens"] = model.max_output_tokens
     return metadata

--- a/src/free_claude_code/cli/launchers/cline_config.py
+++ b/src/free_claude_code/cli/launchers/cline_config.py
@@ -113,4 +113,8 @@ def _model_entry(model: ClientModel) -> JsonObject:
                 "outputModalities": ["text"],
             }
         )
+    if model.context_window_tokens is not None:
+        entry["contextWindow"] = model.context_window_tokens
+    if model.max_output_tokens is not None:
+        entry["maxTokens"] = model.max_output_tokens
     return entry

--- a/src/free_claude_code/cli/launchers/codex_model_catalog.py
+++ b/src/free_claude_code/cli/launchers/codex_model_catalog.py
@@ -70,6 +70,11 @@ def _codex_catalog_entry(candidate: ClientModel, *, priority: int) -> JsonObject
     input_modalities = candidate.input_modalities or frozenset(
         {ModelInputModality.TEXT}
     )
+    context_window = (
+        candidate.context_window_tokens
+        if candidate.context_window_tokens is not None
+        else 200000
+    )
     entry: JsonObject = {
         "slug": candidate.wire_slug,
         "display_name": candidate.display_name,
@@ -92,8 +97,8 @@ def _codex_catalog_entry(candidate: ClientModel, *, priority: int) -> JsonObject
         "truncation_policy": {"mode": "tokens", "limit": 10000},
         "supports_parallel_tool_calls": True,
         "supports_image_detail_original": True,
-        "context_window": 200000,
-        "max_context_window": 200000,
+        "context_window": context_window,
+        "max_context_window": context_window,
         "effective_context_window_percent": 95,
         "experimental_supported_tools": [],
         "input_modalities": [

--- a/src/free_claude_code/cli/launchers/dsh_config.py
+++ b/src/free_claude_code/cli/launchers/dsh_config.py
@@ -121,6 +121,10 @@ def _model_profile(model: ClientModel) -> JsonObject:
             for modality in ModelInputModality
             if modality in model.input_modalities
         ]
+    if model.context_window_tokens is not None:
+        profile["contextWindow"] = model.context_window_tokens
+    if model.max_output_tokens is not None:
+        profile["maxTokens"] = model.max_output_tokens
     return profile
 
 

--- a/src/free_claude_code/cli/launchers/hermes_config.py
+++ b/src/free_claude_code/cli/launchers/hermes_config.py
@@ -128,4 +128,8 @@ def _model_override(model: ClientModel) -> JsonObject:
         override["supports_reasoning"] = model.supports_reasoning
     if model.input_modalities is not None:
         override["supports_vision"] = ModelInputModality.IMAGE in model.input_modalities
+    if model.context_window_tokens is not None:
+        override["context_window"] = model.context_window_tokens
+    if model.max_output_tokens is not None:
+        override["max_output_tokens"] = model.max_output_tokens
     return override

--- a/src/free_claude_code/cli/launchers/model_catalog.py
+++ b/src/free_claude_code/cli/launchers/model_catalog.py
@@ -22,6 +22,8 @@ class ClientModel:
     display_name: str
     supports_reasoning: bool | None
     input_modalities: frozenset[ModelInputModality] | None = None
+    context_window_tokens: int | None = None
+    max_output_tokens: int | None = None
 
 
 def client_models_from_response(
@@ -108,6 +110,10 @@ def _catalog_candidates(
                 display_name=_nonempty_string(item.get("display_name")) or model_id,
                 supports_reasoning=_optional_boolean(item.get("supportsReasoning")),
                 input_modalities=_input_modalities(item.get("inputModalities")),
+                context_window_tokens=_optional_positive_int(item.get("contextWindow")),
+                max_output_tokens=_optional_positive_int(
+                    item.get("maxCompletionTokens")
+                ),
             )
         )
     return candidates
@@ -122,6 +128,10 @@ def _nonempty_string(value: object) -> str | None:
 
 def _optional_boolean(value: object) -> bool | None:
     return value if isinstance(value, bool) else None
+
+
+def _optional_positive_int(value: object) -> int | None:
+    return value if type(value) is int and value > 0 else None
 
 
 def _input_modalities(value: object) -> frozenset[ModelInputModality] | None:

--- a/src/free_claude_code/cli/launchers/opencode_config.py
+++ b/src/free_claude_code/cli/launchers/opencode_config.py
@@ -74,8 +74,15 @@ def _model_config(model: ClientModel) -> JsonObject:
             ]
         }
     if model.context_window_tokens is not None or model.max_output_tokens is not None:
+        # OpenCode requires both fields and uses zero when either limit is unknown.
         config["limit"] = {
-            "context": model.context_window_tokens or 0,
-            "output": model.max_output_tokens or 0,
+            "context": (
+                model.context_window_tokens
+                if model.context_window_tokens is not None
+                else 0
+            ),
+            "output": (
+                model.max_output_tokens if model.max_output_tokens is not None else 0
+            ),
         }
     return config

--- a/src/free_claude_code/cli/launchers/opencode_config.py
+++ b/src/free_claude_code/cli/launchers/opencode_config.py
@@ -73,4 +73,11 @@ def _model_config(model: ClientModel) -> JsonObject:
                 if modality in model.input_modalities
             ]
         }
+    limit: JsonObject = {}
+    if model.context_window_tokens is not None:
+        limit["context"] = model.context_window_tokens
+    if model.max_output_tokens is not None:
+        limit["output"] = model.max_output_tokens
+    if limit:
+        config["limit"] = limit
     return config

--- a/src/free_claude_code/cli/launchers/opencode_config.py
+++ b/src/free_claude_code/cli/launchers/opencode_config.py
@@ -73,11 +73,9 @@ def _model_config(model: ClientModel) -> JsonObject:
                 if modality in model.input_modalities
             ]
         }
-    limit: JsonObject = {}
-    if model.context_window_tokens is not None:
-        limit["context"] = model.context_window_tokens
-    if model.max_output_tokens is not None:
-        limit["output"] = model.max_output_tokens
-    if limit:
-        config["limit"] = limit
+    if model.context_window_tokens is not None or model.max_output_tokens is not None:
+        config["limit"] = {
+            "context": model.context_window_tokens or 0,
+            "output": model.max_output_tokens or 0,
+        }
     return config

--- a/src/free_claude_code/cli/launchers/pi_extension.ts
+++ b/src/free_claude_code/cli/launchers/pi_extension.ts
@@ -37,6 +37,10 @@ function optionalBoolean(value: unknown): boolean | undefined {
 	return typeof value === "boolean" ? value : undefined;
 }
 
+function optionalPositiveInteger(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
 function inputModalities(value: unknown): ("text" | "image")[] | undefined {
 	if (!Array.isArray(value) || value.length === 0) return undefined;
 	if (value.some((item) => item !== "text" && item !== "image")) return undefined;
@@ -49,6 +53,8 @@ function modelDefinition(
 	providerModel: string,
 	supportsReasoning: boolean | undefined,
 	input: ("text" | "image")[] | undefined,
+	contextWindow: number | undefined,
+	maxTokens: number | undefined,
 ): ProviderModelConfig {
 	return {
 		id,
@@ -56,8 +62,8 @@ function modelDefinition(
 		reasoning: supportsReasoning ?? true,
 		input: input ?? ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: DEFAULT_CONTEXT_WINDOW,
-		maxTokens: DEFAULT_MAX_TOKENS,
+		contextWindow: contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+		maxTokens: maxTokens ?? DEFAULT_MAX_TOKENS,
 	};
 }
 
@@ -79,6 +85,8 @@ export function projectFccModels(payload: unknown): ProviderModelConfig[] {
 				providerModel,
 				optionalBoolean(entry.supportsReasoning),
 				inputModalities(entry.inputModalities),
+				optionalPositiveInteger(entry.contextWindow),
+				optionalPositiveInteger(entry.maxCompletionTokens),
 			),
 		);
 	}

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -21,6 +21,7 @@ from free_claude_code.providers.openai_chat import (
     OpenAIChatProfile,
     OpenAIChatProvider,
     OpenAIChatRequestPolicy,
+    OpenAIModelListing,
     validate_extra_body_does_not_override_reasoning_fields,
 )
 
@@ -48,6 +49,10 @@ _PROFILE = OpenAIChatProfile(
         _GROQ_EFFORTS,
         disabled_value="none",
         enabled_value="medium",
+    ),
+    model_listing=OpenAIModelListing(
+        context_window_tokens_path=("context_window",),
+        max_output_tokens_path=("max_completion_tokens",),
     ),
 )
 

--- a/src/free_claude_code/providers/mistral/client.py
+++ b/src/free_claude_code/providers/mistral/client.py
@@ -40,6 +40,7 @@ _PROFILE = OpenAIChatProfile(
             ),
             (ModelInputModality.IMAGE, ("capabilities", "vision")),
         ),
+        context_window_tokens_path=("max_context_length",),
     ),
 )
 

--- a/src/free_claude_code/providers/model_listing.py
+++ b/src/free_claude_code/providers/model_listing.py
@@ -1,6 +1,6 @@
 """Provider model-list response parsing helpers."""
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import replace
 from typing import Any, TypeIs
 
@@ -14,6 +14,7 @@ type RequiredPathValues = tuple[
     tuple[tuple[str, ...], tuple[ModelListScalar, ...]], ...
 ]
 type InputModalityBooleanPaths = tuple[tuple[ModelInputModality, tuple[str, ...]], ...]
+type ModelTokenLimitResolver = Callable[[object], int | None]
 
 
 class ModelListResponseError(ValueError):
@@ -54,6 +55,9 @@ def extract_openai_model_infos(
     thinking_sequence_path: tuple[str, ...] | None = None,
     fixed_input_modalities: frozenset[ModelInputModality] | None = None,
     input_modality_boolean_paths: InputModalityBooleanPaths = (),
+    context_window_tokens_path: tuple[str, ...] | None = None,
+    max_output_tokens_path: tuple[str, ...] | None = None,
+    context_window_tokens_resolver: ModelTokenLimitResolver | None = None,
 ) -> frozenset[_ProviderModelInfo]:
     """Extract routable IDs from an OpenAI-compatible model-list response."""
     model_infos: dict[str, _ProviderModelInfo] = {}
@@ -146,6 +150,12 @@ def extract_openai_model_infos(
             fixed=fixed_input_modalities,
             boolean_paths=input_modality_boolean_paths,
         )
+        context_window_tokens = (
+            context_window_tokens_resolver(item)
+            if context_window_tokens_resolver is not None
+            else _optional_positive_int_at_path(item, context_window_tokens_path)
+        )
+        max_output_tokens = _optional_positive_int_at_path(item, max_output_tokens_path)
 
         if not included:
             continue
@@ -154,6 +164,8 @@ def extract_openai_model_infos(
             model_id=model_id,
             supports_thinking=supports_thinking,
             input_modalities=input_modalities,
+            context_window_tokens=context_window_tokens,
+            max_output_tokens=max_output_tokens,
         )
         model_infos.setdefault(model_id, model_info)
         if aliases_field is not None:
@@ -211,6 +223,12 @@ def extract_tool_capable_model_infos(
                 ),
                 input_modalities=optional_input_modalities(
                     _path(item, ("architecture", "input_modalities"))
+                ),
+                context_window_tokens=optional_positive_int(
+                    _path(item, ("context_length",))
+                ),
+                max_output_tokens=optional_positive_int(
+                    _path(item, ("top_provider", "max_completion_tokens"))
                 ),
             )
         )
@@ -363,6 +381,37 @@ def optional_input_modalities(
     if ModelInputModality.TEXT not in modalities:
         return None
     return modalities
+
+
+def optional_positive_int(value: object) -> int | None:
+    """Return an exact positive integer, otherwise unknown."""
+    return value if type(value) is int and value > 0 else None
+
+
+def live_provider_context_window_consensus(item: object) -> int | None:
+    """Return the common context limit across every advertised live route."""
+    routes = _path(item, ("providers",))
+    if not _is_sequence(routes):
+        return None
+    live_limits: list[int] = []
+    for route in routes:
+        if _path(route, ("status",)) != "live":
+            continue
+        limit = optional_positive_int(_path(route, ("context_length",)))
+        if limit is None:
+            return None
+        live_limits.append(limit)
+    if not live_limits or len(set(live_limits)) != 1:
+        return None
+    return live_limits[0]
+
+
+def _optional_positive_int_at_path(
+    item: object, path: tuple[str, ...] | None
+) -> int | None:
+    if path is None:
+        return None
+    return optional_positive_int(_path(item, path))
 
 
 def _input_modalities(

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -13,7 +13,9 @@ from free_claude_code.core.model_capabilities import ModelInputModality
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.model_listing import (
     InputModalityBooleanPaths,
+    ModelTokenLimitResolver,
     RequiredPathValues,
+    live_provider_context_window_consensus,
 )
 
 from .base_url import openai_v1_base_url
@@ -103,6 +105,9 @@ class OpenAIModelListing:
     thinking_sequence_path: tuple[str, ...] | None = None
     fixed_input_modalities: frozenset[ModelInputModality] | None = None
     input_modality_boolean_paths: InputModalityBooleanPaths = ()
+    context_window_tokens_path: tuple[str, ...] | None = None
+    max_output_tokens_path: tuple[str, ...] | None = None
+    context_window_tokens_resolver: ModelTokenLimitResolver | None = None
     pagination: OpenAIModelPagination | None = None
 
 
@@ -280,6 +285,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             path="/models",
             collection_field=None,
             required_path_values=((("type",), ("chat",)),),
+            context_window_tokens_path=("context_length",),
         ),
         reasoning_delta_field="reasoning",
     ),
@@ -305,6 +311,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             required_null_field="deprecated",
             tags_field="tags",
             non_thinking_tag="non-reasoning",
+            context_window_tokens_path=("max_tokens",),
         ),
     ),
     "siliconflow": OpenAIChatProfile(
@@ -337,6 +344,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             query_params=(("verbose", "true"),),
             required_path_values=((("architecture", "modality"), ("text->text",)),),
             fixed_input_modalities=_TEXT_INPUT_MODALITIES,
+            context_window_tokens_path=("context_length",),
         ),
     ),
     "chutes": OpenAIChatProfile(
@@ -356,6 +364,8 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             exclude_missing_sequence_fields=True,
             tags_field="supported_features",
             input_modalities_path=("input_modalities",),
+            context_window_tokens_path=("context_length",),
+            max_output_tokens_path=("max_output_length",),
         ),
     ),
     "featherless": OpenAIChatProfile(
@@ -384,6 +394,8 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             input_modality_boolean_paths=(
                 (ModelInputModality.IMAGE, ("features", "image_input")),
             ),
+            context_window_tokens_path=("context_length",),
+            max_output_tokens_path=("max_completion_tokens",),
             pagination=OpenAIModelPagination(),
         ),
     ),
@@ -415,6 +427,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             ),
             thinking_boolean_path=("capabilities", "reasoning"),
             input_modalities_path=("input_modalities",),
+            context_window_tokens_path=("context_length",),
         ),
         reasoning_delta_field="reasoning",
         reasoning_delta_fallback_field="reasoning_content",
@@ -456,6 +469,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
                 ),
                 (ModelInputModality.IMAGE, ("capabilities", "vision")),
             ),
+            context_window_tokens_path=("max_context_length",),
         ),
     ),
     "vercel": OpenAIChatProfile(
@@ -469,6 +483,8 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         model_listing=OpenAIModelListing(
             input_modalities_path=("modalities", "input"),
             thinking_sequence_path=("supported_parameters",),
+            context_window_tokens_path=("context_window",),
+            max_output_tokens_path=("max_tokens",),
         ),
     ),
     "bedrock": OpenAIChatProfile(
@@ -486,6 +502,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         NO_REASONING,
         model_listing=OpenAIModelListing(
             input_modalities_path=("architecture", "input_modalities"),
+            context_window_tokens_resolver=live_provider_context_window_consensus,
         ),
     ),
     "cohere": OpenAIChatProfile(
@@ -675,6 +692,7 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             ),
             thinking_boolean_path=("reasoning",),
             input_modalities_path=("modalities", "input"),
+            context_window_tokens_path=("context_window", "tokens"),
         ),
     ),
     "ollama_cloud": OpenAIChatProfile(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -4,7 +4,7 @@ import asyncio
 import sys
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any
 
@@ -561,7 +561,15 @@ class OpenAIChatProvider(BaseProvider):
             model_info.model_id: model_info for model_info in live_model_infos
         }
         for model_info in model_infos_from_ids(listing.additional_model_ids):
-            model_infos_by_id.setdefault(model_info.model_id, model_info)
+            existing = model_infos_by_id.get(model_info.model_id)
+            if existing is None:
+                model_infos_by_id[model_info.model_id] = model_info
+                continue
+            model_infos_by_id[model_info.model_id] = replace(
+                existing,
+                context_window_tokens=None,
+                max_output_tokens=None,
+            )
         return frozenset(model_infos_by_id.values())
 
     async def _list_models_payload(self) -> Any:

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -553,6 +553,9 @@ class OpenAIChatProvider(BaseProvider):
             thinking_sequence_path=listing.thinking_sequence_path,
             fixed_input_modalities=listing.fixed_input_modalities,
             input_modality_boolean_paths=listing.input_modality_boolean_paths,
+            context_window_tokens_path=listing.context_window_tokens_path,
+            max_output_tokens_path=listing.max_output_tokens_path,
+            context_window_tokens_resolver=listing.context_window_tokens_resolver,
         )
         model_infos_by_id = {
             model_info.model_id: model_info for model_info in live_model_infos

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -48,7 +48,10 @@ from free_claude_code.providers.failure_policy import (
     is_retryable_stream_error,
 )
 from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
-from free_claude_code.providers.model_listing import optional_input_modalities
+from free_claude_code.providers.model_listing import (
+    optional_input_modalities,
+    optional_positive_int,
+)
 from free_claude_code.providers.openai_responses.presentation import (
     MessagesResponsesPresenter,
     NativeResponsesPresenter,
@@ -608,6 +611,9 @@ def _model_infos(payload: Any) -> frozenset[ProviderModelInfo]:
                 supports_thinking=_supports_reasoning(efforts),
                 input_modalities=optional_input_modalities(
                     model.get("input_modalities")
+                ),
+                context_window_tokens=optional_positive_int(
+                    model.get("context_window")
                 ),
             )
         )

--- a/src/free_claude_code/providers/opencode/catalog.py
+++ b/src/free_claude_code/providers/opencode/catalog.py
@@ -19,6 +19,7 @@ from free_claude_code.providers.failure_policy import classify_provider_failure
 from free_claude_code.providers.model_listing import (
     ModelListResponseError,
     optional_input_modalities,
+    optional_positive_int,
 )
 
 OPENCODE_CATALOG_URL = "https://models.opencode.ai/api.json"
@@ -44,6 +45,8 @@ class OpenCodeModelRoute:
     transport: OpenCodeUpstreamTransport
     supports_thinking: bool | None
     input_modalities: frozenset[ModelInputModality] | None
+    context_window_tokens: int | None
+    max_output_tokens: int | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,6 +130,17 @@ def parse_open_code_catalog(
             if isinstance(raw_modalities, Mapping)
             else None
         )
+        limit = model.get("limit")
+        context_window_tokens = (
+            optional_positive_int(limit.get("context"))
+            if isinstance(limit, Mapping)
+            else None
+        )
+        max_output_tokens = (
+            optional_positive_int(limit.get("output"))
+            if isinstance(limit, Mapping)
+            else None
+        )
         effective_package = model_package or provider_package or _DEFAULT_PACKAGE
         route = OpenCodeModelRoute(
             selector_id=selector_id,
@@ -138,6 +152,8 @@ def parse_open_code_catalog(
             ),
             supports_thinking=supports_thinking,
             input_modalities=input_modalities,
+            context_window_tokens=context_window_tokens,
+            max_output_tokens=max_output_tokens,
         )
         routes[selector_id] = route
 
@@ -148,6 +164,8 @@ def parse_open_code_catalog(
             model_id=route.selector_id,
             supports_thinking=route.supports_thinking,
             input_modalities=route.input_modalities,
+            context_window_tokens=route.context_window_tokens,
+            max_output_tokens=route.max_output_tokens,
         )
         for route in routes.values()
     )

--- a/tests/api/test_model_listing.py
+++ b/tests/api/test_model_listing.py
@@ -237,11 +237,14 @@ def test_direct_model_views_serialize_known_capabilities_and_omit_unknowns():
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=131072,
+                max_output_tokens=8192,
             ),
             ProviderModelInfo(
                 "text-only",
                 supports_thinking=False,
                 input_modalities=frozenset({ModelInputModality.TEXT}),
+                context_window_tokens=65536,
             ),
             ProviderModelInfo("unknown"),
         },
@@ -262,12 +265,20 @@ def test_direct_model_views_serialize_known_capabilities_and_omit_unknowns():
         "text",
         "image",
     ]
+    assert messages["open_router/vision-reasoning"]["contextWindow"] == 131072
+    assert messages["open_router/vision-reasoning"]["maxCompletionTokens"] == 8192
     assert messages["open_router/text-only"]["supportsReasoning"] is False
     assert messages["open_router/text-only"]["inputModalities"] == ["text"]
+    assert messages["open_router/text-only"]["contextWindow"] == 65536
+    assert "maxCompletionTokens" not in messages["open_router/text-only"]
     assert "supportsReasoning" not in messages["open_router/unknown"]
     assert "inputModalities" not in messages["open_router/unknown"]
+    assert "contextWindow" not in messages["open_router/unknown"]
+    assert "maxCompletionTokens" not in messages["open_router/unknown"]
     assert responses["open_router/text-only"]["supportsReasoningEffort"] is False
     assert "reasoningEfforts" not in responses["open_router/text-only"]
+    assert responses["open_router/vision-reasoning"]["contextWindow"] == 131072
+    assert responses["open_router/vision-reasoning"]["maxCompletionTokens"] == 8192
 
 
 def test_claude_model_view_does_not_expose_capability_fields():
@@ -281,6 +292,8 @@ def test_claude_model_view_does_not_expose_capability_fields():
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=131072,
+                max_output_tokens=8192,
             )
         },
     )
@@ -288,7 +301,11 @@ def test_claude_model_view_does_not_expose_capability_fields():
     rows = TestClient(app).get("/v1/models").json()["data"]
 
     assert all(
-        "supportsReasoning" not in row and "inputModalities" not in row for row in rows
+        "supportsReasoning" not in row
+        and "inputModalities" not in row
+        and "contextWindow" not in row
+        and "maxCompletionTokens" not in row
+        for row in rows
     )
 
 

--- a/tests/application/test_model_metadata.py
+++ b/tests/application/test_model_metadata.py
@@ -9,10 +9,14 @@ def test_provider_model_info_preserves_capabilities_when_identity_is_replaced() 
         model_id="vendor/model",
         supports_thinking=True,
         input_modalities=frozenset({ModelInputModality.TEXT, ModelInputModality.IMAGE}),
+        context_window_tokens=131072,
+        max_output_tokens=8192,
     )
 
     assert replace(info, model_id="provider/vendor/model") == ProviderModelInfo(
         model_id="provider/vendor/model",
         supports_thinking=True,
         input_modalities=frozenset({ModelInputModality.TEXT, ModelInputModality.IMAGE}),
+        context_window_tokens=131072,
+        max_output_tokens=8192,
     )

--- a/tests/cli/test_aider_config.py
+++ b/tests/cli/test_aider_config.py
@@ -19,6 +19,8 @@ def _models() -> tuple[ClientModel, ...]:
             input_modalities=frozenset(
                 {ModelInputModality.TEXT, ModelInputModality.IMAGE}
             ),
+            context_window_tokens=131072,
+            max_output_tokens=8192,
         ),
         ClientModel(
             wire_slug="ollama_cloud/qwen3-coder:480b",
@@ -26,6 +28,7 @@ def _models() -> tuple[ClientModel, ...]:
             display_name="Colon model",
             supports_reasoning=False,
             input_modalities=frozenset({ModelInputModality.TEXT}),
+            max_output_tokens=4096,
         ),
         ClientModel(
             wire_slug="future_provider/unknown-model",
@@ -70,11 +73,14 @@ def test_aider_config_projects_messages_route_and_canonical_catalog() -> None:
             "litellm_provider": "anthropic",
             "mode": "chat",
             "supports_vision": True,
+            "max_input_tokens": 131072,
+            "max_output_tokens": 8192,
         },
         "anthropic/ollama_cloud/qwen3-coder:480b": {
             "litellm_provider": "anthropic",
             "mode": "chat",
             "supports_vision": False,
+            "max_output_tokens": 4096,
         },
         "anthropic/future_provider/unknown-model": {
             "litellm_provider": "anthropic",

--- a/tests/cli/test_cline_launcher.py
+++ b/tests/cli/test_cline_launcher.py
@@ -59,6 +59,8 @@ def test_cline_config_uses_responses_and_only_known_metadata() -> None:
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=131072,
+                max_output_tokens=8192,
             ),
             ClientModel(
                 wire_slug="claude-3-freecc-no-thinking/open_router/plain-model",
@@ -66,6 +68,7 @@ def test_cline_config_uses_responses_and_only_known_metadata() -> None:
                 display_name="No-thinking model",
                 supports_reasoning=False,
                 input_modalities=frozenset({ModelInputModality.TEXT}),
+                context_window_tokens=65536,
             ),
             ClientModel(
                 wire_slug="future_provider/unknown-model",
@@ -123,6 +126,8 @@ def test_cline_config_uses_responses_and_only_known_metadata() -> None:
                         "supportsVision": True,
                         "inputModalities": ["text", "image"],
                         "outputModalities": ["text"],
+                        "contextWindow": 131072,
+                        "maxTokens": 8192,
                         "apiFormat": "openai-responses",
                     },
                     "claude-3-freecc-no-thinking/open_router/plain-model": {
@@ -132,6 +137,7 @@ def test_cline_config_uses_responses_and_only_known_metadata() -> None:
                         "supportsVision": False,
                         "inputModalities": ["text"],
                         "outputModalities": ["text"],
+                        "contextWindow": 65536,
                         "apiFormat": "openai-responses",
                     },
                     "future_provider/unknown-model": {
@@ -145,8 +151,6 @@ def test_cline_config_uses_responses_and_only_known_metadata() -> None:
         },
     }
     serialized = json.dumps(config.providers | config.models)
-    assert "contextWindow" not in serialized
-    assert "maxTokens" not in serialized
     assert "reasoningEffort" not in serialized
     assert "proxy-token" not in repr(config)
 

--- a/tests/cli/test_codex_model_catalog.py
+++ b/tests/cli/test_codex_model_catalog.py
@@ -159,12 +159,15 @@ def test_codex_catalog_projects_known_capabilities_and_preserves_unknown_default
                     "provider_model_ref": "provider/vision-reasoning",
                     "supportsReasoning": True,
                     "inputModalities": ["text", "image"],
+                    "contextWindow": 131072,
+                    "maxCompletionTokens": 8192,
                 },
                 {
                     "id": "claude-3-freecc-no-thinking/provider/text-only",
                     "provider_model_ref": "provider/text-only",
                     "supportsReasoning": False,
                     "inputModalities": ["text"],
+                    "maxCompletionTokens": 4096,
                 },
                 {
                     "id": "provider/unknown",
@@ -180,18 +183,24 @@ def test_codex_catalog_projects_known_capabilities_and_preserves_unknown_default
     assert vision["supported_reasoning_levels"]
     assert vision["supports_reasoning_summaries"] is True
     assert vision["default_reasoning_summary"] == "none"
+    assert vision["context_window"] == 131072
+    assert vision["max_context_window"] == 131072
 
     assert text_only["input_modalities"] == ["text"]
     assert "default_reasoning_level" not in text_only
     assert text_only["supported_reasoning_levels"] == []
     assert text_only["supports_reasoning_summaries"] is False
     assert "default_reasoning_summary" not in text_only
+    assert text_only["context_window"] == 200000
+    assert text_only["max_context_window"] == 200000
 
     assert unknown["input_modalities"] == ["text"]
     assert unknown["default_reasoning_level"] == "medium"
     assert unknown["supported_reasoning_levels"]
     assert unknown["supports_reasoning_summaries"] is True
     assert unknown["default_reasoning_summary"] == "none"
+    assert unknown["context_window"] == 200000
+    assert unknown["max_context_window"] == 200000
 
 
 def test_launcher_config_composes_with_persistent_codex_config(

--- a/tests/cli/test_dsh_config.py
+++ b/tests/cli/test_dsh_config.py
@@ -21,6 +21,8 @@ def _models() -> tuple[ClientModel, ...]:
             input_modalities=frozenset(
                 {ModelInputModality.TEXT, ModelInputModality.IMAGE}
             ),
+            context_window_tokens=131072,
+            max_output_tokens=8192,
         ),
         ClientModel(
             wire_slug="claude-3-freecc-no-thinking/open_router/plain-model",
@@ -28,6 +30,7 @@ def _models() -> tuple[ClientModel, ...]:
             display_name="No-thinking model",
             supports_reasoning=False,
             input_modalities=frozenset({ModelInputModality.TEXT}),
+            max_output_tokens=4096,
         ),
         ClientModel(
             wire_slug="future_provider/unknown-model",
@@ -92,12 +95,15 @@ def test_dsh_config_pins_responses_models_retries_and_private_state(
                     "max": "max",
                 },
                 "input": ["text", "image"],
+                "contextWindow": 131072,
+                "maxTokens": 8192,
             },
             {
                 "id": "claude-3-freecc-no-thinking/open_router/plain-model",
                 "name": "No-thinking model",
                 "reasoningEfforts": False,
                 "input": ["text"],
+                "maxTokens": 4096,
             },
             {
                 "id": "future_provider/unknown-model",
@@ -139,13 +145,7 @@ def test_dsh_config_pins_responses_models_retries_and_private_state(
 
     serialized = json.dumps(launch.patch)
     assert "proxy-token" not in serialized
-    for unsupported in (
-        "contextWindow",
-        "maxTokens",
-        "compat",
-        "headers",
-        "telemetry",
-    ):
+    for unsupported in ("compat", "headers", "telemetry"):
         assert unsupported not in serialized
 
 

--- a/tests/cli/test_hermes_config.py
+++ b/tests/cli/test_hermes_config.py
@@ -21,6 +21,8 @@ def _models() -> tuple[ClientModel, ...]:
             input_modalities=frozenset(
                 {ModelInputModality.TEXT, ModelInputModality.IMAGE}
             ),
+            context_window_tokens=131072,
+            max_output_tokens=8192,
         ),
         ClientModel(
             wire_slug="claude-3-freecc-no-thinking/open_router/plain-model",
@@ -28,6 +30,7 @@ def _models() -> tuple[ClientModel, ...]:
             display_name="No-thinking model",
             supports_reasoning=False,
             input_modalities=frozenset({ModelInputModality.TEXT}),
+            max_output_tokens=4096,
         ),
         ClientModel(
             wire_slug="future_provider/unknown-model",
@@ -81,10 +84,13 @@ def test_hermes_config_pins_responses_catalog_and_fallbacks() -> None:
             "nvidia_nim/vendor/model": {
                 "supports_reasoning": True,
                 "supports_vision": True,
+                "context_window": 131072,
+                "max_output_tokens": 8192,
             },
             "claude-3-freecc-no-thinking/open_router/plain-model": {
                 "supports_reasoning": False,
                 "supports_vision": False,
+                "max_output_tokens": 4096,
             },
         }
     }

--- a/tests/cli/test_model_catalog.py
+++ b/tests/cli/test_model_catalog.py
@@ -101,12 +101,16 @@ def test_client_models_parse_capabilities_without_deriving_reasoning_from_slug()
                     "provider_model_ref": "provider/reasoning",
                     "supportsReasoning": False,
                     "inputModalities": ["text"],
+                    "contextWindow": 131072,
+                    "maxCompletionTokens": 8192,
                 },
                 {
                     "id": "claude-3-freecc-no-thinking/provider/unknown",
                     "provider_model_ref": "provider/unknown",
                     "supportsReasoning": "not-a-bool",
                     "inputModalities": ["text", "image"],
+                    "contextWindow": 0,
+                    "maxCompletionTokens": "8192",
                 },
                 {
                     "id": "provider/malformed-media",
@@ -118,13 +122,23 @@ def test_client_models_parse_capabilities_without_deriving_reasoning_from_slug()
         }
     )
 
-    assert [(model.supports_reasoning, model.input_modalities) for model in models] == [
-        (False, frozenset({ModelInputModality.TEXT})),
+    assert [
+        (
+            model.supports_reasoning,
+            model.input_modalities,
+            model.context_window_tokens,
+            model.max_output_tokens,
+        )
+        for model in models
+    ] == [
+        (False, frozenset({ModelInputModality.TEXT}), 131072, 8192),
         (
             None,
             frozenset({ModelInputModality.TEXT, ModelInputModality.IMAGE}),
+            None,
+            None,
         ),
-        (True, None),
+        (True, None, None, None),
     ]
 
 

--- a/tests/cli/test_opencode_launcher.py
+++ b/tests/cli/test_opencode_launcher.py
@@ -54,6 +54,8 @@ def test_opencode_config_uses_responses_sdk_and_only_known_metadata() -> None:
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=131072,
+                max_output_tokens=8192,
             ),
             ClientModel(
                 wire_slug="claude-3-freecc-no-thinking/open_router/plain-model",
@@ -61,6 +63,7 @@ def test_opencode_config_uses_responses_sdk_and_only_known_metadata() -> None:
                 display_name="No-thinking model",
                 supports_reasoning=False,
                 input_modalities=frozenset({ModelInputModality.TEXT}),
+                context_window_tokens=65536,
             ),
             ClientModel(
                 wire_slug="future_provider/unknown-model",
@@ -86,11 +89,13 @@ def test_opencode_config_uses_responses_sdk_and_only_known_metadata() -> None:
             "name": "Nested model",
             "reasoning": True,
             "modalities": {"input": ["text", "image"]},
+            "limit": {"context": 131072, "output": 8192},
         },
         "claude-3-freecc-no-thinking/open_router/plain-model": {
             "name": "No-thinking model",
             "reasoning": False,
             "modalities": {"input": ["text"]},
+            "limit": {"context": 65536},
         },
         "future_provider/unknown-model": {
             "name": "Unknown model",
@@ -115,7 +120,6 @@ def test_opencode_config_uses_responses_sdk_and_only_known_metadata() -> None:
     }
     serialized = json.dumps(config.file | config.overlay)
     assert "proxy-token" not in serialized
-    assert "context" not in serialized
     assert "attachment" not in serialized
 
 

--- a/tests/cli/test_opencode_launcher.py
+++ b/tests/cli/test_opencode_launcher.py
@@ -71,6 +71,13 @@ def test_opencode_config_uses_responses_sdk_and_only_known_metadata() -> None:
                 display_name="Unknown model",
                 supports_reasoning=None,
             ),
+            ClientModel(
+                wire_slug="future_provider/output-only",
+                provider_model_ref="future_provider/output-only",
+                display_name="Output-only model",
+                supports_reasoning=None,
+                max_output_tokens=4096,
+            ),
         ),
         proxy_root_url="http://127.0.0.1:9191",
     )
@@ -95,11 +102,16 @@ def test_opencode_config_uses_responses_sdk_and_only_known_metadata() -> None:
             "name": "No-thinking model",
             "reasoning": False,
             "modalities": {"input": ["text"]},
-            "limit": {"context": 65536},
+            "limit": {"context": 65536, "output": 0},
         },
         "future_provider/unknown-model": {
             "name": "Unknown model",
             "reasoning": True,
+        },
+        "future_provider/output-only": {
+            "name": "Output-only model",
+            "reasoning": True,
+            "limit": {"context": 0, "output": 4096},
         },
     }
     assert config.overlay == {

--- a/tests/cli/test_pi_extension.py
+++ b/tests/cli/test_pi_extension.py
@@ -24,12 +24,15 @@ def test_pi_extension_projects_known_capabilities_and_preserves_unknown_defaults
                 "provider_model_ref": "provider/vision-reasoning",
                 "supportsReasoning": True,
                 "inputModalities": ["text", "image"],
+                "contextWindow": 131072,
+                "maxCompletionTokens": 8192,
             },
             {
                 "id": "claude-3-freecc-no-thinking/provider/text-only",
                 "provider_model_ref": "provider/text-only",
                 "supportsReasoning": False,
                 "inputModalities": ["text"],
+                "contextWindow": 65536,
             },
             {
                 "id": "provider/unknown",
@@ -67,4 +70,9 @@ console.log(JSON.stringify(projectFccModels(payload)));
         (True, ["text", "image"]),
         (False, ["text"]),
         (True, ["text"]),
+    ]
+    assert [(model["contextWindow"], model["maxTokens"]) for model in projected] == [
+        (131072, 8192),
+        (65536, 16384),
+        (128000, 16384),
     ]

--- a/tests/providers/test_groq.py
+++ b/tests/providers/test_groq.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
 from free_claude_code.providers.groq import GroqProvider
 from tests.providers.request_factory import make_messages_request
@@ -45,6 +46,36 @@ def test_init(groq_config):
 
 def test_default_base_url_constant():
     assert GROQ_DEFAULT_BASE == "https://api.groq.com/openai/v1"
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_extracts_documented_token_limits(groq_provider) -> None:
+    with patch.object(
+        groq_provider,
+        "_list_models_payload",
+        new=AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "id": "model",
+                        "context_window": 131072,
+                        "max_completion_tokens": 8192,
+                    }
+                ]
+            }
+        ),
+    ):
+        infos = await groq_provider.list_model_infos()
+
+    assert infos == frozenset(
+        {
+            ProviderModelInfo(
+                "model",
+                context_window_tokens=131072,
+                max_output_tokens=8192,
+            )
+        }
+    )
 
 
 def test_build_request_body_basic(groq_provider):

--- a/tests/providers/test_huggingface.py
+++ b/tests/providers/test_huggingface.py
@@ -78,6 +78,11 @@ async def test_model_catalog_extracts_exact_input_modalities(
                 {
                     "id": "vision-model",
                     "architecture": {"input_modalities": ["text", "image", "audio"]},
+                    "providers": [
+                        {"status": "live", "context_length": 131072},
+                        {"status": "live", "context_length": 131072},
+                        {"status": "staging", "context_length": 999999},
+                    ],
                 },
                 {
                     "id": "unknown-model",
@@ -94,9 +99,37 @@ async def test_model_catalog_extracts_exact_input_modalities(
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=131072,
             ),
             ProviderModelInfo("unknown-model"),
         }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "providers",
+    [
+        [],
+        [{"status": "staging", "context_length": 131072}],
+        [{"status": "live"}],
+        [{"status": "live", "context_length": "131072"}],
+        [
+            {"status": "live", "context_length": 131072},
+            {"status": "live", "context_length": 65536},
+        ],
+    ],
+)
+async def test_model_catalog_requires_consensus_across_live_huggingface_routes(
+    huggingface_provider,
+    providers: list[dict[str, object]],
+) -> None:
+    huggingface_provider._client.models.list = AsyncMock(
+        return_value=SimpleNamespace(data=[{"id": "model", "providers": providers}])
+    )
+
+    assert await huggingface_provider.list_model_infos() == frozenset(
+        {ProviderModelInfo("model")}
     )
 
 

--- a/tests/providers/test_kilo.py
+++ b/tests/providers/test_kilo.py
@@ -380,6 +380,8 @@ async def test_model_list_filters_to_chat_tool_models_with_capabilities(kilo_pro
                         "output_modalities": ["text"],
                     },
                     "opencode": {"ai_sdk_provider": "anthropic"},
+                    "context_length": 200000,
+                    "top_provider": {"max_completion_tokens": 16000},
                 },
                 {
                     "id": "plain-tool",
@@ -426,6 +428,8 @@ async def test_model_list_filters_to_chat_tool_models_with_capabilities(kilo_pro
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=200000,
+                max_output_tokens=16000,
             ),
             ProviderModelInfo("plain-tool", supports_thinking=False),
             ProviderModelInfo(

--- a/tests/providers/test_llm7.py
+++ b/tests/providers/test_llm7.py
@@ -71,6 +71,7 @@ def _catalog_model(
     tools_calling: object = True,
     reasoning: bool | None = None,
     input_modalities: object = ("text",),
+    context_window_tokens: int | None = None,
 ) -> dict[str, object]:
     model: dict[str, object] = {
         "id": model_id,
@@ -81,6 +82,11 @@ def _catalog_model(
     }
     if reasoning is not None:
         model["reasoning"] = reasoning
+    if context_window_tokens is not None:
+        model["context_window"] = {
+            "tokens": context_window_tokens,
+            "characters": context_window_tokens * 4,
+        }
     return model
 
 
@@ -185,7 +191,11 @@ async def test_filters_catalog_and_adds_live_authoritative_selectors(
                 ),
                 _catalog_model("plain-model", reasoning=False),
                 _catalog_model("unknown-reasoning-model"),
-                _catalog_model("default", reasoning=True),
+                _catalog_model(
+                    "default",
+                    reasoning=True,
+                    context_window_tokens=114688,
+                ),
                 _catalog_model("image-generator", model_type="image"),
                 _catalog_model("video-generator", model_type="video"),
                 _catalog_model("nonstreaming-chat", stream=False),

--- a/tests/providers/test_mistral.py
+++ b/tests/providers/test_mistral.py
@@ -62,6 +62,7 @@ async def test_model_catalog_extracts_exact_input_modalities(mistral_provider):
             "data": [
                 {
                     "id": "vision-model",
+                    "max_context_length": 131072,
                     "capabilities": {
                         "completion_chat": True,
                         "vision": True,
@@ -85,6 +86,7 @@ async def test_model_catalog_extracts_exact_input_modalities(mistral_provider):
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=131072,
             ),
             ProviderModelInfo(
                 "text-model",

--- a/tests/providers/test_model_token_limit_profiles.py
+++ b/tests/providers/test_model_token_limit_profiles.py
@@ -1,0 +1,177 @@
+"""Provider-profile contracts for advertised model token limits."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from tests.providers.support import (
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_id", "payload", "context_window_tokens", "max_output_tokens"),
+    [
+        (
+            "vercel",
+            {"data": [{"id": "model", "context_window": 131072, "max_tokens": 8192}]},
+            131072,
+            8192,
+        ),
+        (
+            "chutes",
+            {
+                "data": [
+                    {
+                        "id": "model",
+                        "input_modalities": ["text"],
+                        "output_modalities": ["text"],
+                        "supported_features": ["tools"],
+                        "context_length": 32768,
+                        "max_output_length": 4096,
+                    }
+                ]
+            },
+            32768,
+            4096,
+        ),
+        (
+            "featherless",
+            {
+                "data": [
+                    {
+                        "id": "model",
+                        "features": {"tool_use": True, "image_input": False},
+                        "is_gated": False,
+                        "available_on_current_plan": True,
+                        "context_length": 65536,
+                        "max_completion_tokens": 8192,
+                    }
+                ]
+            },
+            65536,
+            8192,
+        ),
+        (
+            "zenmux",
+            {
+                "data": [
+                    {
+                        "id": "model",
+                        "input_modalities": ["text"],
+                        "output_modalities": ["text"],
+                        "context_length": 200000,
+                    }
+                ]
+            },
+            200000,
+            None,
+        ),
+        (
+            "deepinfra",
+            [
+                {
+                    "model_name": "model",
+                    "reported_type": "text-generation",
+                    "deprecated": None,
+                    "max_tokens": 131072,
+                }
+            ],
+            131072,
+            None,
+        ),
+        (
+            "nebius",
+            {
+                "data": [
+                    {
+                        "id": "model",
+                        "architecture": {"modality": "text->text"},
+                        "context_length": 128000,
+                    }
+                ]
+            },
+            128000,
+            None,
+        ),
+        (
+            "mistral_codestral",
+            {
+                "data": [
+                    {
+                        "id": "model",
+                        "capabilities": {
+                            "completion_chat": True,
+                            "vision": False,
+                        },
+                        "max_context_length": 256000,
+                    }
+                ]
+            },
+            256000,
+            None,
+        ),
+        (
+            "together",
+            [{"id": "model", "type": "chat", "context_length": 131072}],
+            131072,
+            None,
+        ),
+        (
+            "llm7",
+            {
+                "data": [
+                    {
+                        "id": "model",
+                        "model_type": "chat",
+                        "stream": True,
+                        "tools_calling": True,
+                        "context_window": {"tokens": 114688, "characters": 458752},
+                    }
+                ]
+            },
+            114688,
+            None,
+        ),
+    ],
+)
+async def test_profile_extracts_only_its_documented_token_limit_fields(
+    provider_id: str,
+    payload: object,
+    context_window_tokens: int | None,
+    max_output_tokens: int | None,
+) -> None:
+    provider = profiled_provider(
+        provider_id,
+        make_provider_config(api_key="test", base_url="https://provider.test/v1"),
+        admission=immediate_admission(provider_name=provider_id),
+    )
+    try:
+        with patch.object(
+            provider,
+            "_list_models_payload",
+            new=AsyncMock(return_value=payload),
+        ):
+            infos = await provider.list_model_infos()
+    finally:
+        await provider.cleanup()
+
+    info = next(info for info in infos if info.model_id == "model")
+    assert info == ProviderModelInfo(
+        "model",
+        supports_thinking=info.supports_thinking,
+        input_modalities=info.input_modalities,
+        context_window_tokens=context_window_tokens,
+        max_output_tokens=max_output_tokens,
+    )
+    if provider_id == "llm7":
+        selectors = {info.model_id: info for info in infos if info.model_id != "model"}
+        assert set(selectors) == {"default", "fast", "pro"}
+        assert all(
+            info.context_window_tokens is None and info.max_output_tokens is None
+            for info in selectors.values()
+        )

--- a/tests/providers/test_open_router.py
+++ b/tests/providers/test_open_router.py
@@ -344,6 +344,11 @@ async def test_model_infos_filter_tool_models_and_thinking_metadata(
                     id="tool-model",
                     supported_parameters=["tools", "reasoning"],
                     architecture=SimpleNamespace(input_modalities=["text", "image"]),
+                    context_length=262144,
+                    top_provider=SimpleNamespace(
+                        context_length=999999,
+                        max_completion_tokens=32768,
+                    ),
                 ),
                 SimpleNamespace(
                     id="tool-model-with-malformed-capabilities",
@@ -365,6 +370,8 @@ async def test_model_infos_filter_tool_models_and_thinking_metadata(
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=262144,
+                max_output_tokens=32768,
             ),
             ProviderModelInfo(
                 "tool-model-with-malformed-capabilities",

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -197,6 +197,7 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
                             "supported_in_api": False,
                             "supported_reasoning_levels": [{"effort": "high"}],
                             "input_modalities": ["text", "image"],
+                            "context_window": 272000,
                         },
                         {
                             "slug": "gpt-no-reasoning",
@@ -248,6 +249,7 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=272000,
             ),
             ProviderModelInfo("gpt-no-reasoning", supports_thinking=False),
             ProviderModelInfo("gpt-malformed-reasoning"),

--- a/tests/providers/test_openai_model_listing_filters.py
+++ b/tests/providers/test_openai_model_listing_filters.py
@@ -99,6 +99,7 @@ def test_optional_model_capabilities_are_normalized_and_copied_to_aliases() -> N
                     "aliases": ["latest"],
                     "architecture": {"input_modalities": ["text", "image", "audio"]},
                     "supported_parameters": ["tools", "reasoning"],
+                    "limits": {"context": 131072, "output": 16384},
                 },
                 {
                     "id": "text-only",
@@ -112,12 +113,16 @@ def test_optional_model_capabilities_are_normalized_and_copied_to_aliases() -> N
         aliases_field="aliases",
         input_modalities_path=("architecture", "input_modalities"),
         thinking_sequence_path=("supported_parameters",),
+        context_window_tokens_path=("limits", "context"),
+        max_output_tokens_path=("limits", "output"),
     )
 
     vision = ProviderModelInfo(
         "vision-reasoning",
         supports_thinking=True,
         input_modalities=frozenset({ModelInputModality.TEXT, ModelInputModality.IMAGE}),
+        context_window_tokens=131072,
+        max_output_tokens=16384,
     )
     assert model_infos == frozenset(
         {
@@ -126,6 +131,8 @@ def test_optional_model_capabilities_are_normalized_and_copied_to_aliases() -> N
                 "latest",
                 supports_thinking=True,
                 input_modalities=vision.input_modalities,
+                context_window_tokens=131072,
+                max_output_tokens=16384,
             ),
             ProviderModelInfo(
                 "text-only",
@@ -134,6 +141,50 @@ def test_optional_model_capabilities_are_normalized_and_copied_to_aliases() -> N
             ),
         }
     )
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [True, False, 0, -1, 1.5, "4096", None, [], {}],
+)
+def test_optional_token_limits_require_exact_positive_integers(
+    invalid_value: object,
+) -> None:
+    [info] = extract_openai_model_infos(
+        {
+            "data": [
+                {
+                    "id": "model",
+                    "limits": {"context": invalid_value, "output": invalid_value},
+                }
+            ]
+        },
+        provider_name="TEST",
+        context_window_tokens_path=("limits", "context"),
+        max_output_tokens_path=("limits", "output"),
+    )
+
+    assert info.context_window_tokens is None
+    assert info.max_output_tokens is None
+
+
+def test_optional_token_limits_degrade_independently() -> None:
+    [info] = extract_openai_model_infos(
+        {
+            "data": [
+                {
+                    "id": "model",
+                    "limits": {"context": "bad", "output": 8192},
+                }
+            ]
+        },
+        provider_name="TEST",
+        context_window_tokens_path=("limits", "context"),
+        max_output_tokens_path=("limits", "output"),
+    )
+
+    assert info.context_window_tokens is None
+    assert info.max_output_tokens == 8192
 
 
 @pytest.mark.parametrize(
@@ -202,6 +253,8 @@ def test_tool_capable_parser_retains_exact_input_modalities() -> None:
                     "id": "vision",
                     "supported_parameters": ["tools", "reasoning"],
                     "architecture": {"input_modalities": ["text", "image", "audio"]},
+                    "context_length": 262144,
+                    "top_provider": {"max_completion_tokens": 32768},
                 },
                 {
                     "id": "unknown-media",
@@ -221,6 +274,8 @@ def test_tool_capable_parser_retains_exact_input_modalities() -> None:
                 input_modalities=frozenset(
                     {ModelInputModality.TEXT, ModelInputModality.IMAGE}
                 ),
+                context_window_tokens=262144,
+                max_output_tokens=32768,
             ),
             ProviderModelInfo("unknown-media", supports_thinking=False),
         }

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -329,6 +329,7 @@ def test_catalog_resolves_package_precedence_status_alias_and_reasoning() -> Non
                     "id": "provider-default",
                     "reasoning": False,
                     "modalities": {"input": ["text"]},
+                    "limit": {"context": 131072, "output": 8192},
                 },
                 "responses-alias": {
                     "id": "actual-responses-id",
@@ -382,6 +383,8 @@ def test_catalog_resolves_package_precedence_status_alias_and_reasoning() -> Non
                 "provider-default",
                 supports_thinking=False,
                 input_modalities=frozenset({ModelInputModality.TEXT}),
+                context_window_tokens=131072,
+                max_output_tokens=8192,
             ),
             ProviderModelInfo(
                 "responses-alias",
@@ -410,6 +413,28 @@ def test_catalog_defaults_missing_package_to_chat_completions() -> None:
     route = snapshot.route("defaulted")
     assert route is not None
     assert route.transport is OpenCodeUpstreamTransport.CHAT_COMPLETIONS
+
+
+def test_catalog_token_limits_degrade_independently_without_rejecting_model() -> None:
+    snapshot = parse_open_code_catalog(
+        _catalog_payload(
+            {
+                "partial": {
+                    "id": "upstream",
+                    "limit": {"context": "bad", "output": 8192},
+                },
+                "malformed": {"id": "other", "limit": "bad"},
+            }
+        ),
+        provider_key="opencode",
+        provider_name="OPENCODE_ZEN",
+    )
+
+    infos = {info.model_id: info for info in snapshot.model_infos}
+    assert infos["partial"].context_window_tokens is None
+    assert infos["partial"].max_output_tokens == 8192
+    assert infos["malformed"].context_window_tokens is None
+    assert infos["malformed"].max_output_tokens is None
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/test_model_cache.py
+++ b/tests/runtime/test_model_cache.py
@@ -9,6 +9,8 @@ def test_model_cache_returns_and_prefixes_complete_model_metadata() -> None:
         model_id="vendor/model",
         supports_thinking=False,
         input_modalities=frozenset({ModelInputModality.TEXT, ModelInputModality.IMAGE}),
+        context_window_tokens=131072,
+        max_output_tokens=8192,
     )
 
     cache.cache_model_infos("open_router", (info,))
@@ -22,5 +24,7 @@ def test_model_cache_returns_and_prefixes_complete_model_metadata() -> None:
             input_modalities=frozenset(
                 {ModelInputModality.TEXT, ModelInputModality.IMAGE}
             ),
+            context_window_tokens=131072,
+            max_output_tokens=8192,
         ),
     )

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.16.0"
+version = "5.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Provider model catalogs exposed context and output limits that FCC discarded, so downstream harnesses used generic defaults even when exact per-model values were available.

## Changes

| Before | After |
| --- | --- |
| Provider token-limit fields were discarded during model discovery. | Documented positive token limits flow through the canonical model metadata record. |
| FCC model-list responses omitted context and output limits. | Messages and Responses catalogs expose known limits and omit unknown values. |
| Harnesses relied on universal or incomplete token defaults. | Codex, Pi, OpenCode, Cline, Hermes, DeepSeek Harness, and Aider receive matching native limit fields. |
| Malformed optional limits could not be represented independently. | Strict parsing degrades each malformed or missing limit to unknown without dropping the model or its other metadata. |







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update clarifies OpenCode’s paired token-limit representation. Models with only one known limit continue to use OpenCode’s zero sentinel for the unknown value, allowing OpenCode to apply its configured output-token fallback rather than imposing a zero-token generation limit.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains: context-only and output-only model configurations produce OpenCode’s supported paired-limit representation, and the zero output sentinel resolves to the configured fallback.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the token-sentinel regression script with the before revision to verify that the prior implementation emitted unpaired, one-sided limits.
- Ran the token-sentinel regression script with the after revision to verify that the current implementation emits zero sentinels and caps the effective output at 32000.
- Ran the pytest suite for the opencode launcher and confirmed that all 37 tests passed, showing zero is interpreted as OpenCode’s fallback sentinel rather than a zero-token generation cap.

<a href="https://app.greptile.com/trex/runs/21366151/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["docs: clarify OpenCode limit sentinel"](https://github.com/alishahryar1/free-claude-code/commit/eb381931781794d301130b9053af165376b14c4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58159693)</sub>

<!-- /greptile_comment -->