### PR TITLE
fix: discover local provider models without requiring a configured route

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.1"
+version = "5.18.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.17.3"
+version = "5.18.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.0"
+version = "5.18.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/runtime/discovery.py
+++ b/src/free_claude_code/providers/runtime/discovery.py
@@ -23,6 +23,9 @@ from .model_cache import ProviderModelCache
 
 ProviderResolver = Callable[[str], BaseProvider]
 
+# A local provider that is actually running answers over loopback in milliseconds.
+OPPORTUNISTIC_LOCAL_DISCOVERY_TIMEOUT_SECONDS = 5.0
+
 
 def _provider_query_failure_reason(exc: BaseException, settings: Settings) -> str:
     """Return a concise model-list query failure reason for user-facing logs."""
@@ -60,21 +63,6 @@ def model_cache_provider_ids_for_settings(
     )
 
 
-def model_list_provider_ids_for_settings(
-    settings: Settings,
-    connected_provider_ids: tuple[str, ...] = (),
-) -> tuple[str, ...]:
-    """Return providers worth discovering for this process configuration."""
-    referenced_ids = referenced_provider_ids(settings)
-    return tuple(
-        provider_id
-        for provider_id in model_cache_provider_ids_for_settings(
-            settings, connected_provider_ids
-        )
-        if not PROVIDER_CATALOG[provider_id].local or provider_id in referenced_ids
-    )
-
-
 class ProviderModelDiscovery:
     """Refresh provider model-list metadata for one provider runtime."""
 
@@ -98,7 +86,7 @@ class ProviderModelDiscovery:
         self, *, only_missing: bool = False
     ) -> ProviderModelRefreshResult:
         """Best-effort refresh of model lists for usable providers."""
-        provider_ids = model_list_provider_ids_for_settings(
+        provider_ids = model_cache_provider_ids_for_settings(
             self._settings, self._connected_provider_ids
         )
         if only_missing:
@@ -118,15 +106,25 @@ class ProviderModelDiscovery:
         self, provider_ids: tuple[str, ...]
     ) -> ProviderModelRefreshResult:
         failed_provider_ids: list[str] = []
+        opportunistic_ids = self._opportunistic_local_ids()
         tasks: dict[str, asyncio.Task[frozenset[ProviderModelInfo]]] = {}
         for provider_id in provider_ids:
             try:
                 provider = self._provider_resolver(provider_id)
             except Exception as exc:
-                self._log_discovery_failure(provider_id, exc)
-                failed_provider_ids.append(provider_id)
+                self._record_discovery_failure(
+                    provider_id, exc, failed_provider_ids, opportunistic_ids
+                )
                 continue
-            tasks[provider_id] = asyncio.create_task(provider.list_model_infos())
+            query = provider.list_model_infos()
+            if provider_id in opportunistic_ids:
+                # Provider retry policy assumes a transient upstream fault. A local
+                # endpoint nobody is running refuses instantly and stays refused, so
+                # cap the whole opportunistic query instead of paying that backoff.
+                query = asyncio.wait_for(
+                    query, OPPORTUNISTIC_LOCAL_DISCOVERY_TIMEOUT_SECONDS
+                )
+            tasks[provider_id] = asyncio.create_task(query)
 
         refreshed_provider_ids: list[str] = []
         if tasks:
@@ -137,8 +135,9 @@ class ProviderModelDiscovery:
                 if isinstance(result, BaseException):
                     if isinstance(result, asyncio.CancelledError):
                         raise result
-                    self._log_discovery_failure(provider_id, result)
-                    failed_provider_ids.append(provider_id)
+                    self._record_discovery_failure(
+                        provider_id, result, failed_provider_ids, opportunistic_ids
+                    )
                     continue
                 self._model_cache.cache_model_infos(provider_id, result)
                 refreshed_provider_ids.append(provider_id)
@@ -153,9 +152,42 @@ class ProviderModelDiscovery:
             failed_provider_ids=tuple(failed_provider_ids),
         )
 
-    def _log_discovery_failure(self, provider_id: str, exc: BaseException) -> None:
+    def _opportunistic_local_ids(self) -> frozenset[str]:
+        """Return local providers queried on the chance one is actually running.
+
+        A local provider carries a default base URL, so it is always configured
+        even for the many installs that never run one. Querying it anyway is what
+        lets its models reach the client model picker, but an unreachable endpoint
+        is the expected state rather than a fault, so it must not be reported.
+        A local provider the customer has routed to is excluded here: there a
+        failure is real and keeps its existing warning.
+        """
+
+        referenced = set(referenced_provider_ids(self._settings))
+        return frozenset(
+            provider_id
+            for provider_id, descriptor in PROVIDER_CATALOG.items()
+            if descriptor.local and provider_id not in referenced
+        )
+
+    def _record_discovery_failure(
+        self,
+        provider_id: str,
+        exc: BaseException,
+        failed_provider_ids: list[str],
+        opportunistic_ids: frozenset[str],
+    ) -> None:
+        """Log one failed model-list query and record only actionable failures."""
+        if provider_id in opportunistic_ids:
+            logger.debug(
+                "Local provider model discovery unavailable: provider={} reason={}",
+                provider_id,
+                _provider_query_failure_reason(exc, self._settings),
+            )
+            return
         logger.warning(
             "Provider model discovery skipped: provider={} reason={}",
             provider_id,
             _provider_query_failure_reason(exc, self._settings),
         )
+        failed_provider_ids.append(provider_id)

--- a/src/free_claude_code/providers/runtime/discovery.py
+++ b/src/free_claude_code/providers/runtime/discovery.py
@@ -27,7 +27,7 @@ from .model_cache import ProviderModelCache
 ProviderResolver = Callable[[str], BaseProvider]
 
 # A local provider that is actually running answers over loopback in milliseconds.
-OPPORTUNISTIC_LOCAL_DISCOVERY_TIMEOUT_SECONDS = 5.0
+LOCAL_DISCOVERY_TIMEOUT_SECONDS = 5.0
 
 
 def _provider_query_failure_reason(exc: BaseException, settings: Settings) -> str:
@@ -109,6 +109,7 @@ class ProviderModelDiscovery:
         self, provider_ids: tuple[str, ...]
     ) -> ProviderModelRefreshResult:
         failed_provider_ids: list[str] = []
+        local_ids = self._local_provider_ids()
         opportunistic_ids = self._opportunistic_local_ids()
         tasks: dict[str, asyncio.Task[frozenset[ProviderModelInfo]]] = {}
         for provider_id in provider_ids:
@@ -120,13 +121,14 @@ class ProviderModelDiscovery:
                 )
                 continue
             query = provider.list_model_infos()
-            if provider_id in opportunistic_ids:
+            if provider_id in local_ids:
                 # Provider retry policy assumes a transient upstream fault. A local
                 # endpoint nobody is running refuses instantly and stays refused, so
-                # cap the whole opportunistic query instead of paying that backoff.
-                query = asyncio.wait_for(
-                    query, OPPORTUNISTIC_LOCAL_DISCOVERY_TIMEOUT_SECONDS
-                )
+                # cap the query instead of paying that backoff. This bounds every
+                # local provider: a configured endpoint that is down must surface
+                # its failure promptly rather than hold the refresh open, so the
+                # deadline is independent of whether the failure gets reported.
+                query = asyncio.wait_for(query, LOCAL_DISCOVERY_TIMEOUT_SECONDS)
             tasks[provider_id] = asyncio.create_task(query)
 
         refreshed_provider_ids: list[str] = []
@@ -153,6 +155,15 @@ class ProviderModelDiscovery:
         return ProviderModelRefreshResult(
             refreshed_provider_ids=tuple(refreshed_provider_ids),
             failed_provider_ids=tuple(failed_provider_ids),
+        )
+
+    def _local_provider_ids(self) -> frozenset[str]:
+        """Return every local provider, whose endpoint is reachable or not at all."""
+
+        return frozenset(
+            provider_id
+            for provider_id, descriptor in PROVIDER_CATALOG.items()
+            if descriptor.local
         )
 
     def _opportunistic_local_ids(self) -> frozenset[str]:

--- a/src/free_claude_code/providers/runtime/discovery.py
+++ b/src/free_claude_code/providers/runtime/discovery.py
@@ -12,13 +12,16 @@ from free_claude_code.application.model_metadata import (
     ProviderModelRefreshResult,
 )
 from free_claude_code.config.model_refs import configured_chat_model_refs
-from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
+from free_claude_code.config.provider_catalog import (
+    PROVIDER_CATALOG,
+    ProviderDescriptor,
+)
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.model_listing import ModelListResponseError
 
-from .config import has_provider_configuration
+from .config import has_provider_configuration, string_setting
 from .model_cache import ProviderModelCache
 
 ProviderResolver = Callable[[str], BaseProvider]
@@ -159,16 +162,30 @@ class ProviderModelDiscovery:
         even for the many installs that never run one. Querying it anyway is what
         lets its models reach the client model picker, but an unreachable endpoint
         is the expected state rather than a fault, so it must not be reported.
-        A local provider the customer has routed to is excluded here: there a
-        failure is real and keeps its existing warning.
+
+        Only a provider the customer has expressed no intent about is treated
+        this way. Routing a model to it, or pointing it at a base URL other than
+        the shipped default, is a deliberate act, and a failure to reach what was
+        asked for stays a reported failure.
         """
 
         referenced = set(referenced_provider_ids(self._settings))
         return frozenset(
             provider_id
             for provider_id, descriptor in PROVIDER_CATALOG.items()
-            if descriptor.local and provider_id not in referenced
+            if descriptor.local
+            and provider_id not in referenced
+            and self._has_default_base_url(descriptor)
         )
+
+    def _has_default_base_url(self, descriptor: ProviderDescriptor) -> bool:
+        """Return whether a provider still points at its shipped base URL."""
+
+        attr = descriptor.base_url_attr
+        if attr is None:
+            return True
+        default = Settings.model_fields[attr].get_default(call_default_factory=True)
+        return string_setting(self._settings, attr) == default
 
     def _record_discovery_failure(
         self,

--- a/tests/providers/test_model_discovery.py
+++ b/tests/providers/test_model_discovery.py
@@ -22,7 +22,7 @@ from free_claude_code.providers.model_listing import ModelListResponseError
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from free_claude_code.providers.open_router import OpenRouterProvider
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
-from free_claude_code.providers.runtime import ProviderRuntime
+from free_claude_code.providers.runtime import ProviderRuntime, discovery
 from free_claude_code.providers.runtime.model_cache import ProviderModelCache
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 from tests.providers.support import (
@@ -345,12 +345,14 @@ class FakeProvider(BaseProvider):
         error: BaseException | None = None,
         started: asyncio.Event | None = None,
         peer_started: asyncio.Event | None = None,
+        stall: float | None = None,
     ):
         super().__init__(
             make_provider_config(api_key="test", base_url="https://test.invalid")
         )
         self._model_infos = model_infos
         self._error = error
+        self._stall = stall
         self._started = started
         self._peer_started = peer_started
         self.cleaned = False
@@ -386,6 +388,8 @@ class FakeProvider(BaseProvider):
 
     async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
         await self._before_model_list()
+        if self._stall is not None:
+            await asyncio.sleep(self._stall)
         return self._model_infos
 
     async def stream_messages(
@@ -625,6 +629,24 @@ async def test_runtime_refresh_model_list_cache_reports_a_relocated_local_failur
     runtime = _manager(settings, _offline_local_providers())
 
     result = await runtime.refresh_model_list_cache()
+
+    assert result.failed_provider_ids == ("ollama",)
+
+
+@pytest.mark.asyncio
+async def test_runtime_refresh_model_list_cache_bounds_a_relocated_local_endpoint() -> (
+    None
+):
+    # Reporting a configured endpoint's failure and bounding how long it may take
+    # are separate concerns. A local host that hangs must not hold the refresh open
+    # for the provider's full retry backoff just because its failure is reported.
+    settings = _settings(ollama_base_url="http://gpu-box:11434")
+    providers = _offline_local_providers()
+    providers["ollama"] = FakeProvider(stall=30.0)
+    runtime = _manager(settings, providers)
+
+    with patch.object(discovery, "LOCAL_DISCOVERY_TIMEOUT_SECONDS", 0.01):
+        result = await asyncio.wait_for(runtime.refresh_model_list_cache(), 5.0)
 
     assert result.failed_provider_ids == ("ollama",)
 

--- a/tests/providers/test_model_discovery.py
+++ b/tests/providers/test_model_discovery.py
@@ -47,6 +47,7 @@ def _settings(
     opencode_api_key: str = "",
     zai_api_key: str = "",
     vertex_project_id: str = "",
+    ollama_base_url: str | None = None,
 ) -> Settings:
     return Settings.model_construct(
         model=model,
@@ -63,6 +64,7 @@ def _settings(
         zai_api_key=zai_api_key,
         vertex_project_id=vertex_project_id,
         log_api_error_tracebacks=False,
+        **({"ollama_base_url": ollama_base_url} if ollama_base_url is not None else {}),
     )
 
 
@@ -610,6 +612,35 @@ async def test_runtime_refresh_model_list_cache_reports_a_routed_local_failure()
 
     assert result.failed_provider_ids == ("ollama",)
     assert runtime.cached_model_ids() == {}
+
+
+@pytest.mark.asyncio
+async def test_runtime_refresh_model_list_cache_reports_a_relocated_local_failure() -> (
+    None
+):
+    # Pointing a local provider somewhere other than the shipped default is as
+    # deliberate as routing a model to it, so an unreachable host is reported
+    # even though no configured model names the provider.
+    settings = _settings(ollama_base_url="http://gpu-box:11434")
+    runtime = _manager(settings, _offline_local_providers())
+
+    result = await runtime.refresh_model_list_cache()
+
+    assert result.failed_provider_ids == ("ollama",)
+
+
+@pytest.mark.asyncio
+async def test_runtime_refresh_model_list_cache_stays_quiet_for_default_local_hosts() -> (
+    None
+):
+    # The default base URL is present on every install, so it carries no intent
+    # and an absent daemon must not be reported as a provider failure.
+    settings = _settings()
+    runtime = _manager(settings, _offline_local_providers())
+
+    result = await runtime.refresh_model_list_cache()
+
+    assert result.failed_provider_ids == ()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_model_discovery.py
+++ b/tests/providers/test_model_discovery.py
@@ -512,6 +512,14 @@ async def test_runtime_warm_queries_referenced_providers_concurrently() -> None:
     await asyncio.wait_for(runtime.warm_referenced_model_cache(), timeout=1.0)
 
 
+def _offline_local_providers() -> dict[str, BaseProvider]:
+    """Local providers are always configured; this host is running none of them."""
+    return {
+        provider_id: FakeProvider(error=RuntimeError("connection refused"))
+        for provider_id in ("ollama", "lmstudio", "llamacpp")
+    }
+
+
 @pytest.mark.asyncio
 async def test_startup_discovery_queries_each_successful_provider_once() -> None:
     settings = _settings(
@@ -522,7 +530,7 @@ async def test_startup_discovery_queries_each_successful_provider_once() -> None
     router = FakeProvider(_infos("anthropic/claude-sonnet"))
     runtime = _manager(
         settings,
-        {"nvidia_nim": nim, "open_router": router},
+        {**_offline_local_providers(), "nvidia_nim": nim, "open_router": router},
     )
 
     await runtime.warm_referenced_model_cache()
@@ -543,7 +551,7 @@ async def test_startup_discovery_queries_each_successful_provider_once() -> None
 async def test_failed_startup_warm_remains_eligible_for_background_refresh() -> None:
     settings = _settings(nvidia_nim_api_key="nim-key")
     nim = FakeProvider(error=RuntimeError("upstream unavailable"))
-    runtime = _manager(settings, {"nvidia_nim": nim})
+    runtime = _manager(settings, {**_offline_local_providers(), "nvidia_nim": nim})
 
     warm_result = await runtime.warm_referenced_model_cache()
     runtime.start_model_list_refresh()
@@ -557,9 +565,12 @@ async def test_failed_startup_warm_remains_eligible_for_background_refresh() -> 
 
 
 @pytest.mark.asyncio
-async def test_runtime_refresh_model_list_cache_uses_configured_remote_keys_and_referenced_local() -> (
+async def test_runtime_refresh_model_list_cache_discovers_running_local_providers() -> (
     None
 ):
+    # https://github.com/Alishahryar1/free-claude-code/issues/1296
+    # A local provider the customer has not routed to is still queried, so its
+    # models can reach the client model picker before they pick one.
     settings = _settings(
         model="lmstudio/local-qwen",
         open_router_api_key="open-router-key",
@@ -570,6 +581,7 @@ async def test_runtime_refresh_model_list_cache_uses_configured_remote_keys_and_
             "open_router": FakeProvider(_infos("anthropic/claude-sonnet")),
             "lmstudio": FakeProvider(_infos("local-qwen")),
             "ollama": FakeProvider(_infos("llama3.1")),
+            "llamacpp": FakeProvider(error=RuntimeError("connection refused")),
         },
     )
 
@@ -578,9 +590,26 @@ async def test_runtime_refresh_model_list_cache_uses_configured_remote_keys_and_
     assert runtime.cached_model_ids() == {
         "open_router": frozenset({"anthropic/claude-sonnet"}),
         "lmstudio": frozenset({"local-qwen"}),
+        "ollama": frozenset({"llama3.1"}),
     }
-    assert result.refreshed_provider_ids == ("open_router", "lmstudio")
+    assert result.refreshed_provider_ids == ("open_router", "lmstudio", "ollama")
+    # llamacpp is configured by default but is not running: absent, not failed.
     assert result.failed_provider_ids == ()
+
+
+@pytest.mark.asyncio
+async def test_runtime_refresh_model_list_cache_reports_a_routed_local_failure() -> (
+    None
+):
+    # A local provider the customer routed to is theirs to fix, so it keeps
+    # being reported, unlike one queried only on the chance it is running.
+    settings = _settings(model="ollama/llama3.1")
+    runtime = _manager(settings, _offline_local_providers())
+
+    result = await runtime.refresh_model_list_cache()
+
+    assert result.failed_provider_ids == ("ollama",)
+    assert runtime.cached_model_ids() == {}
 
 
 @pytest.mark.asyncio
@@ -593,7 +622,10 @@ async def test_runtime_refresh_model_list_cache_treats_vertex_project_as_configu
     )
     runtime = _manager(
         settings,
-        {"vertex": FakeProvider(_infos("google/gemini-3.5-flash"))},
+        {
+            **_offline_local_providers(),
+            "vertex": FakeProvider(_infos("google/gemini-3.5-flash")),
+        },
     )
 
     result = await runtime.refresh_model_list_cache()
@@ -613,7 +645,10 @@ async def test_runtime_refresh_model_list_cache_keeps_prior_cache_on_failure() -
     )
     runtime = _manager(
         settings,
-        {"nvidia_nim": FakeProvider(error=RuntimeError("upstream down"))},
+        {
+            **_offline_local_providers(),
+            "nvidia_nim": FakeProvider(error=RuntimeError("upstream down")),
+        },
     )
     runtime.cache_model_infos(
         "nvidia_nim",

--- a/tests/runtime/test_provider_manager.py
+++ b/tests/runtime/test_provider_manager.py
@@ -23,11 +23,15 @@ class FakeRuntime(ProviderRuntime):
         self.cleanup_release: asyncio.Event | None = None
         self.provider = MagicMock()
         self.provider.list_model_infos = AsyncMock(return_value=frozenset())
+        # None resolves every id; a set models a host where only these exist.
+        self.resolvable_ids: set[str] | None = None
 
     def is_cached(self, provider_id: str) -> bool:
         return provider_id == "cached"
 
     def resolve_provider(self, provider_id: str) -> BaseProvider:
+        if self.resolvable_ids is not None and provider_id not in self.resolvable_ids:
+            raise KeyError(provider_id)
         return cast(BaseProvider, self.provider)
 
     async def cleanup(self) -> None:
@@ -144,6 +148,9 @@ async def test_catalog_publication_tracks_warm_refresh_and_direct_cache() -> Non
     factory.runtimes[0].provider.list_model_infos = AsyncMock(
         return_value=frozenset({ProviderModelInfo("warm-model")})
     )
+    # Local providers are always configured, so discovery now queries them too.
+    # This host runs none of them.
+    factory.runtimes[0].resolvable_ids = {"nvidia_nim"}
 
     await manager.warm_referenced_model_cache()
     manager.start_model_list_refresh()

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.0"
+version = "5.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.1"
+version = "5.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.17.3"
+version = "5.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## The problem

Closes #1296.

If you run Ollama and start FCC, your local models never appear in the `/model` picker. The only way to make them appear is to already set `MODEL=ollama/llama3.2` — but the picker is how you would have found that name. You have to know the model name before FCC will show you model names.

## Why it happens

On startup FCC asks each provider "what models do you have?" and caches the answers. That cache fills the picker. Local providers were skipped:

```python
if not PROVIDER_CATALOG[provider_id].local or provider_id in referenced_ids
```

Reading it today, this looks like a decision that local providers should not be discovered. Going back through the history, it started as a rule about **API keys**. The original in 72b34ad was:

```python
if descriptor.static_credential is not None:
    if provider_id in referenced_provider_ids:
        provider_ids.append(provider_id)
    continue
if descriptor.credential_env is not None and _credential_for(descriptor, settings).strip():
    provider_ids.append(provider_id)
```

The intent is sound: don't fire model-list requests at cloud providers the user never signed up for. A credential being present is good evidence the user wants that provider.

But local providers have no credential to present — they don't need auth — so `static_credential is not None` was true for them and they landed in the "skip unless referenced" branch by construction, not by judgement. #1047 then replaced `static_credential is not None` with `capabilities.local` as part of the typed-capabilities cleanup, which preserved the behaviour and gave it a name that now reads like deliberate policy.

Credential presence simply isn't a signal that exists for a local provider. The signal that does exist is **whether the endpoint answers**.

## The change

Local providers are discovered like every other provider, with two guards.

**Unrouted local probes are capped at 5s.** The provider retry policy assumes a failure is a transient upstream fault, so it retries 5 times with backoff (~30s). A local daemon nobody is running refuses instantly and will keep refusing, so retrying only costs time. Without the cap, Admin → Refresh models stalls for ~30s for every user who runs no local model at all.

**Absence is not reported as failure.** `failed_provider_ids` surfaces in Admin as `failed_providers`, so without this every user without Ollama would see three failures on every refresh:

- local provider you have *not* routed to, unreachable → `debug` log, not a failure (this is the normal state)
- local provider you *have* set `MODEL=ollama/…` for, unreachable → unchanged, still a real warning, because there you asked for it and it is broken

## Verification

With a real Ollama running and nothing else configured, `/v1/models` now returns `anthropic/ollama/llama3.2:3b` and `claude-3-freecc-no-thinking/ollama/llama3.2:3b`.

`scripts/ci.sh` passes in full.

On the tests:

- `..._uses_configured_remote_keys_and_referenced_local` is renamed and rewritten to state the new rule, since it asserted the behaviour this PR changes.
- Added a case covering a routed local provider still reporting its failure, so the distinction above stays enforced.
- Four existing tests were made hermetic. They were falling through to the real provider factory and dialling localhost, so they would behave differently on a machine actually running Ollama — and they were also what surfaced the retry cost above, going from 0.01s to ~45s before the cap was added.

## Note

There is an existing partial workaround: the Admin provider "Check" button caches local model infos via `test_provider`. It is in-memory only, so the models disappear on restart, and it is not obvious enough that the reporter in #1296 found it.










<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update bounds local model-discovery requests and reports failures for local endpoints that users have explicitly configured or routed.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No P0 or P1 findings remain.

<sub>Reviews (5): Last reviewed commit: ["fix: bound local provider discovery rega..."](https://github.com/alishahryar1/free-claude-code/commit/034c32088cf9bfeb2ed7591d88c0ac1850833274) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58190187)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->