### PR TITLE
Treat upstream HTTP 413 as terminal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.17.1"
+version = "5.17.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -38,6 +38,7 @@ _BILLING_MESSAGE = (
 )
 _RATE_LIMIT_MESSAGE = "Provider rate limit reached. Please retry shortly."
 _INVALID_REQUEST_MESSAGE = "Invalid request sent to provider."
+_REQUEST_TOO_LARGE_MESSAGE = "Provider rejected the request as too large."
 _CONTEXT_WINDOW_EXCEEDED_MESSAGE = "Provider input exceeds the model context window."
 _OVERLOADED_MESSAGE = "Provider is currently overloaded. Please retry."
 
@@ -114,6 +115,8 @@ def retryable_transient_status(exc: BaseException) -> int | None:
     if isinstance(exc, ExecutionFailure):
         status = exc.status_code
         return status if exc.retryable and _is_retryable_status(status) else None
+    if _reported_status(exc) == 413:
+        return None
     if isinstance(exc, openai.RateLimitError):
         return 429
     if isinstance(exc, httpx.HTTPStatusError):
@@ -264,6 +267,14 @@ def _classify_provider_failure(
     if isinstance(exc, ExecutionFailure):
         return exc
 
+    if _reported_status(exc) == 413:
+        return _failure(
+            FailureKind.INVALID_REQUEST,
+            413,
+            _REQUEST_TOO_LARGE_MESSAGE,
+            False,
+        )
+
     if isinstance(exc, openai.AuthenticationError):
         return _failure(FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False)
     if isinstance(exc, openai.PermissionDeniedError):
@@ -375,6 +386,17 @@ def _stable_upstream(status_code: int) -> str:
 def _status_from_exception(exc: BaseException) -> int | None:
     status = getattr(exc, "status_code", None)
     return status if isinstance(status, int) else None
+
+
+def _reported_status(exc: BaseException) -> int | None:
+    status = _status_from_exception(exc)
+    if status is not None:
+        return status
+    response = getattr(exc, "response", None)
+    response_status = getattr(response, "status_code", None)
+    if isinstance(response_status, int):
+        return response_status
+    return _status_from_body(getattr(exc, "body", None))
 
 
 def _status_from_body(body: Any) -> int | None:

--- a/tests/api/test_execution_failure_contract.py
+++ b/tests/api/test_execution_failure_contract.py
@@ -516,6 +516,43 @@ def test_pre_start_permission_failure_preserves_403_without_client_retry(
     assert trace["provider_retryable"] is False
 
 
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/v1/messages", _messages_payload(stream=True)),
+        ("/v1/responses", _responses_payload()),
+    ],
+)
+def test_pre_start_request_too_large_failure_preserves_413(
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    provider = CanonicalFailureProvider(
+        [],
+        kind=FailureKind.INVALID_REQUEST,
+        status_code=413,
+        message="Provider rejected the request as too large.",
+        retryable=False,
+    )
+    resolver_patch, client = _client_for(provider)
+
+    with resolver_patch, client:
+        response = client.post(path, json=payload)
+
+    request_id = response.headers["request-id"]
+    body = response.json()
+    assert response.status_code == 413
+    assert response.headers["x-should-retry"] == "false"
+    assert body["error"]["type"] == "request_too_large"
+    assert body["error"]["message"] == (
+        f"Provider rejected the request as too large.\n\nRequest ID: {request_id}"
+    )
+    if path == "/v1/messages":
+        assert body["request_id"] == request_id
+    else:
+        assert response.headers["x-request-id"] == request_id
+
+
 def test_messages_context_window_failure_triggers_client_compaction() -> None:
     provider = CanonicalFailureProvider(
         [],

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -29,9 +29,10 @@ def _openai_status_error(
     status_code: int,
     message: str,
     body: object | None = None,
+    headers: dict[str, str] | None = None,
 ) -> openai.APIStatusError:
     request = httpx2.Request("POST", "https://provider.test/v1/chat/completions")
-    response = httpx2.Response(status_code, request=request)
+    response = httpx2.Response(status_code, request=request, headers=headers)
     return error_type(
         message,
         response=response,
@@ -112,6 +113,94 @@ def test_stream_retry_classification_rejects_openai_bad_request() -> None:
             message="bad request",
         )
     )
+
+
+def test_http_413_status_wins_over_rate_limit_markers() -> None:
+    error = _openai_status_error(
+        openai.APIStatusError,
+        status_code=413,
+        message="Request too large for token rate limit",
+        body={
+            "error": {
+                "message": "Request requires 55940 tokens but limit is 8000",
+                "type": "tokens",
+                "code": "rate_limit_exceeded",
+            }
+        },
+        headers={"retry-after": "67", "x-should-retry": "false"},
+    )
+
+    assert not is_retryable_provider_error(error)
+    assert not is_retryable_stream_error(error)
+    assert retryable_upstream_status(error) is None
+
+    failure = classify_provider_failure(
+        error,
+        provider_name="GROQ",
+        read_timeout_s=60.0,
+        request_id="req_too_large",
+    )
+
+    assert failure.kind is FailureKind.INVALID_REQUEST
+    assert failure.status_code == 413
+    assert failure.retryable is False
+    assert "Provider rejected the request as too large." in failure.message
+    assert "Request requires 55940 tokens but limit is 8000" in failure.message
+    assert "Request ID: req_too_large" in failure.message
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _http_status_error(413, "request too large"),
+        _statusless_openai_error(
+            "rate limit exceeded",
+            {
+                "error": {
+                    "status": 413,
+                    "code": "rate_limit_exceeded",
+                    "message": "request too large",
+                }
+            },
+        ),
+    ],
+    ids=["httpx_status", "structured_body_status"],
+)
+def test_http_413_sources_are_terminal_invalid_requests(error: Exception) -> None:
+    assert not is_retryable_provider_error(error)
+    assert not is_retryable_stream_error(error)
+    assert retryable_upstream_status(error) is None
+
+    failure = classify_provider_failure(
+        error,
+        provider_name="TEST_PROVIDER",
+        read_timeout_s=60.0,
+        request_id="req_413",
+    )
+
+    assert failure.kind is FailureKind.INVALID_REQUEST
+    assert failure.status_code == 413
+    assert failure.retryable is False
+    assert "Provider rejected the request as too large." in failure.message
+
+
+def test_nonstandard_capacity_status_remains_retryable() -> None:
+    error = _openai_status_error(
+        openai.APIStatusError,
+        status_code=498,
+        message="capacity exceeded",
+        body={"error": {"code": "capacity_exceeded"}},
+    )
+
+    assert retryable_upstream_status(error) == 503
+    failure = classify_provider_failure(
+        error,
+        provider_name="GROQ",
+        read_timeout_s=60.0,
+        request_id="req_capacity",
+    )
+    assert failure.kind is FailureKind.OVERLOADED
+    assert failure.retryable is True
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/providers/test_provider_admission.py
+++ b/tests/providers/test_provider_admission.py
@@ -8,6 +8,8 @@ from email.utils import format_datetime
 from unittest.mock import patch
 
 import httpx
+import httpx2
+import openai
 import pytest
 
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
@@ -454,6 +456,51 @@ async def test_non_retryable_error_is_attempted_once() -> None:
         )
 
     assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_413_does_not_retry_sleep_or_open_recovery() -> None:
+    controller = _controller()
+    attempts = 0
+    request = httpx2.Request("POST", "https://provider.test/chat/completions")
+    response = httpx2.Response(
+        413,
+        request=request,
+        headers={"retry-after": "237", "x-should-retry": "false"},
+    )
+    error = openai.APIStatusError(
+        "Request too large for token rate limit",
+        response=response,
+        body={
+            "error": {
+                "type": "tokens",
+                "code": "rate_limit_exceeded",
+                "message": "Request requires 55940 tokens but limit is 8000",
+            }
+        },
+    )
+
+    async def reject() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise error
+
+    with (
+        patch("free_claude_code.providers.admission.asyncio.sleep") as sleep,
+        patch("free_claude_code.providers.admission.trace_event") as trace,
+        pytest.raises(openai.APIStatusError),
+    ):
+        await controller.start_execution(request_id="req_413").run_call(
+            reject,
+            operation_kind=ProviderOperationKind.GENERATION,
+        )
+
+    assert attempts == 1
+    sleep.assert_not_awaited()
+    assert all(
+        call.kwargs.get("event") != "provider.recovery.opened"
+        for call in trace.call_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.17.1"
+version = "5.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Fixes #1610. An upstream HTTP 413 could be reclassified from its rate-limit-shaped body as a retryable 429, causing FCC to honor `Retry-After`, open provider-wide recovery, and appear to hang even though the request could not succeed unchanged.

## Changes

| Before | After |
|---|---|
| HTTP 413 could fall through to transient body markers and enter coordinated retry recovery. | A machine-reported HTTP 413 is a terminal invalid request with preserved `request_too_large` wire semantics. |
| The reported Groq response shape and public API behavior were not covered together. | Regression tests cover SDK, raw HTTP, and structured-body 413s; one-attempt admission; no sleep or recovery episode; and Messages/Responses serialization. |
| Package version was 5.17.1. | Patch version is 5.17.2 with the lockfile synchronized. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change treats upstream HTTP 413 responses as terminal request-size failures, including provider errors whose body also contains rate-limit markers and retry headers. The exercised public Responses API flow returned HTTP 413 with `request_too_large` and `x-should-retry: false`, while making exactly one provider call without sleeping or opening recovery.

No defects were found.
</details>


<h3>Confidence Score: 5/5</h3>

The change is safe to merge based on the exercised terminal request-size failure flow.

The end-to-end check injected an OpenAI HTTP 413 error containing misleading rate-limit metadata and confirmed correct provider admission, failure classification, and public API behavior.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran uv run python trex-artifacts/openai-413-provider-admission-api.py from /home/user/repo.
- The harness observed an HTTP 413 terminal oversized-request failure with one provider call, no admission sleep, and no recovery episode.
- The run surfaced the request\_too\_large indicator and x-should-retry: false.
- I re-ran the same command to validate consistency, and the second run exited with code 0 with all terminal-413 assertions passing.
- Artifacts from both runs include the harness source and the terminal log for review.

<a href="https://app.greptile.com/trex/runs/21440081/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: treat request-too-large responses a..."](https://github.com/alishahryar1/free-claude-code/commit/7e9c282c5a15a43216a444407dd26ed81d2e31d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58307442)</sub>

<!-- /greptile_comment -->