### PR TITLE
docs: add macOS troubleshooting guide for common installer and provider edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Code style: Ruff](https://img.shields.io/badge/code%20formatting-ruff-f5a623.svg?style=for-the-badge)](https://github.com/astral-sh/ruff)
 [![Logging: Loguru](https://img.shields.io/badge/logging-loguru-4ecdc4.svg?style=for-the-badge)](https://github.com/Delgan/loguru)
 
-[Quick Start](#quick-start) · [Providers](#choose-a-provider) · [Clients](#connect-your-client) · [Integrations](#optional-integrations) · [Manage](#manage-your-installation)
+[Quick Start](#quick-start) · [Providers](#choose-a-provider) · [Clients](#connect-your-client) · [Integrations](#optional-integrations) · [Manage](#manage-your-installation) · [Troubleshooting](#troubleshooting)
 
 </div>
 
@@ -577,6 +577,49 @@ Restart `fcc-server`. In **Admin UI → Messaging → Voice**, enable voice note
 ## Manage Your Installation
 
 Run `fcc-server --version` to check the installed version without starting FCC.
+
+<a id="troubleshooting"></a>
+
+### Troubleshooting
+
+<details>
+<summary><strong>macOS: Homebrew symlink errors during Node.js install (Pi / DeepSeek Harness)</strong></summary>
+
+If the installer encounters Homebrew linking conflicts when upgrading Node.js (`Could not symlink ... Target is a symlink belonging to <formula>`):
+
+```bash
+brew link --overwrite brotli ca-certificates openssl@3 xz zstd
+brew install node
+```
+
+Verify Node.js version (&ge; 22.19.0 required):
+```bash
+node -v
+```
+
+</details>
+
+<details>
+<summary><strong>macOS / Linux: <code>~/.zshrc: Permission denied</code> during installation</strong></summary>
+
+If your shell configuration was previously created or edited with `sudo` permissions, reset file ownership to your user:
+
+```bash
+cp ~/.zshrc ~/.zshrc.tmp && rm -f ~/.zshrc && mv ~/.zshrc.tmp ~/.zshrc
+```
+
+</details>
+
+<details>
+<summary><strong><code>503 NVIDIA_NIM_API_KEY is not set</code> when using another provider</strong></summary>
+
+If you configured an alternative provider key (such as `OPENROUTER_API_KEY`) but requests fail with `NVIDIA_NIM_API_KEY is not set`:
+
+1. Open the Admin UI or edit `~/.fcc/.env`.
+2. Update the `MODEL_*` mappings to your active provider (for example, `open_router/openrouter/free`).
+3. Restart FCC (`fcc-server` or the desktop app).
+
+</details>
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -602,10 +602,10 @@ node -v
 <details>
 <summary><strong>macOS / Linux: <code>~/.zshrc: Permission denied</code> during installation</strong></summary>
 
-If your shell configuration was previously created or edited with `sudo` permissions, reset file ownership to your user:
+If your shell configuration was previously created or modified by root/sudo, reset ownership to your current user:
 
 ```bash
-cp ~/.zshrc ~/.zshrc.tmp && rm -f ~/.zshrc && mv ~/.zshrc.tmp ~/.zshrc
+sudo chown "$USER" ~/.zshrc
 ```
 
 </details>
@@ -617,7 +617,9 @@ If you configured an alternative provider key (such as `OPENROUTER_API_KEY`) but
 
 1. Open the Admin UI or edit `~/.fcc/.env`.
 2. Update the `MODEL_*` mappings to your active provider (for example, `open_router/openrouter/free`).
-3. Restart FCC (`fcc-server` or the desktop app).
+3. Restart FCC:
+   - **Desktop app (macOS/Windows)**: Click the menu-bar/tray icon and select **Restart**, or re-open the app.
+   - **Terminal (`fcc-server`)**: Stop the active server with `Ctrl+C` (or `pkill -f fcc-server`), then start `fcc-server` again.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -617,8 +617,8 @@ If you configured an alternative provider key (such as `OPENROUTER_API_KEY`) but
 
 1. Open the Admin UI or edit `~/.fcc/.env`.
 2. Update the `MODEL_*` mappings to your active provider (for example, `open_router/openrouter/free`).
-3. Restart FCC:
-   - **Desktop app (macOS/Windows)**: Click the menu-bar/tray icon and select **Restart**, or re-open the app.
+3. Restart FCC to reload the configuration:
+   - **Desktop app (macOS/Windows)**: Click the menu-bar/tray icon and select **Restart** (or select **Quit** and launch Free Claude Code again).
    - **Terminal (`fcc-server`)**: Stop the active server with `Ctrl+C` (or `pkill -f fcc-server`), then start `fcc-server` again.
 
 </details>


### PR DESCRIPTION
Resolves #1613

### What this PR does
Adds a dedicated `### Troubleshooting` section to `README.md` covering 3 common edge cases encountered during installation and initial setup on macOS (Apple Silicon / Intel):

1. **Homebrew linking conflicts during Node.js upgrades** (resolves Pi / DeepSeek Harness prerequisites with `brew link --overwrite`).
2. **`~/.zshrc: Permission denied`** (recovering from root/sudo ownership on shell configs).
3. **`503 NVIDIA_NIM_API_KEY is not set`** when configuring non-NIM providers (such as OpenRouter free tier).

### Changes
- Added `· [Troubleshooting](#troubleshooting)` link to the header navigation.
- Added expandable `<details>` blocks for each scenario with exact terminal commands.

### Quality Checklist
- [x] Followed `CONTRIBUTING.md` guidelines (opened issue #1613 prior to PR).
- [x] No changes to runtime Python/package dependencies (no version bump needed).






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The troubleshooting documentation adds guidance for Homebrew conflicts, shell ownership repair, and provider configuration reloads. The terminal restart instructions can still terminate unrelated processes, so this change should not merge until the broad kill command is removed or narrowed.

<h3>Confidence Score: 4/5</h3>

One confirmed non-security P1 issue remains: the terminal restart command can interrupt unrelated running processes.

The score is 4 because there is exactly one P1 finding and it is not a security finding.

**Files Needing Attention:** README.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment detailing the finding.
- A shell script was prepared as part of the proof to reproduce and verify the P1 finding steps.
- Three log artifacts with accessible URLs were captured to document the proof run and results.
- The review comment documents the validation steps and confirms the P1 finding based on the produced proof.

<a href="https://app.greptile.com/trex/runs/21449680/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: clarify desktop restart via menu/t..."](https://github.com/alishahryar1/free-claude-code/commit/78342e854f6e0b0445e7ab88a83bac7435554fd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58322922)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->