### PR TITLE
Version Admin assets with FCC releases

### DIFF
--- a/e2e/test_admin_assets.py
+++ b/e2e/test_admin_assets.py
@@ -1,0 +1,34 @@
+"""Rendered contracts for Admin asset generation consistency."""
+
+from urllib.parse import urlsplit
+
+from playwright.sync_api import Error, Page, Request, expect
+
+from free_claude_code.core.version import package_version
+
+
+def test_admin_loads_current_release_assets_before_rendering_dynamic_content(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    requested_paths: list[str] = []
+    page_errors: list[str] = []
+
+    def record_request(request: Request) -> None:
+        requested_paths.append(urlsplit(request.url).path)
+
+    def record_page_error(error: Error) -> None:
+        page_errors.append(str(error))
+
+    page.on("request", record_request)
+    page.on("pageerror", record_page_error)
+    page.goto(f"{admin_base_url}/admin")
+
+    expect(page.locator('[data-provider="nvidia_nim"]')).to_be_visible()
+
+    versioned_root = f"/admin/assets/{package_version()}"
+    assert f"{versioned_root}/admin.css" in requested_paths
+    assert f"{versioned_root}/admin.js" in requested_paths
+    assert "/admin/assets/admin.css" not in requested_paths
+    assert "/admin/assets/admin.js" not in requested_paths
+    assert page_errors == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.17.2"
+version = "5.17.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -7,7 +7,7 @@ from urllib.parse import urlsplit
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from loguru import logger
 from pydantic import BaseModel, Field
 
@@ -23,6 +23,7 @@ from free_claude_code.config.provider_catalog import (
     ProviderAuthKind,
 )
 from free_claude_code.core.json_types import JsonObject, JsonValue
+from free_claude_code.core.version import package_version
 
 from .dependencies import get_services
 from .ports import ApiServices
@@ -30,6 +31,8 @@ from .ports import ApiServices
 router = APIRouter()
 
 STATIC_DIR = Path(__file__).resolve().parent / "admin_static"
+_ADMIN_ASSET_VERSION_PLACEHOLDER = "__FCC_VERSION__"
+_ADMIN_ASSET_FILENAMES = frozenset({"admin.css", "admin.js"})
 LOCAL_PROVIDER_PATHS = {
     "lmstudio": "/models",
     "llamacpp": "/models",
@@ -83,23 +86,34 @@ def require_loopback_admin(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Admin UI is local-only")
 
 
-def _asset_response(filename: str) -> FileResponse:
+def _asset_path(filename: str) -> Path:
     path = STATIC_DIR / filename
     if not path.is_file():
         raise HTTPException(status_code=404, detail="Admin asset not found")
-    return FileResponse(path)
+    return path
+
+
+def _asset_response(filename: str) -> FileResponse:
+    return FileResponse(_asset_path(filename))
+
+
+def _admin_page_response() -> HTMLResponse:
+    template = _asset_path("index.html").read_text(encoding="utf-8")
+    return HTMLResponse(
+        template.replace(_ADMIN_ASSET_VERSION_PLACEHOLDER, package_version())
+    )
 
 
 @router.get("/admin", include_in_schema=False)
-async def admin_page(request: Request):
+def admin_page(request: Request):
     require_loopback_admin(request)
-    return _asset_response("index.html")
+    return _admin_page_response()
 
 
-@router.get("/admin/assets/{filename}", include_in_schema=False)
-async def admin_asset(filename: str, request: Request):
+@router.get("/admin/assets/{version}/{filename}", include_in_schema=False)
+async def admin_asset(version: str, filename: str, request: Request):
     require_loopback_admin(request)
-    if filename not in {"admin.css", "admin.js"}:
+    if version != package_version() or filename not in _ADMIN_ASSET_FILENAMES:
         raise HTTPException(status_code=404, detail="Admin asset not found")
     return _asset_response(filename)
 

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Free Claude Code Admin</title>
     <link rel="icon" href="data:," />
-    <link rel="stylesheet" href="/admin/assets/admin.css" />
+    <link rel="stylesheet" href="/admin/assets/__FCC_VERSION__/admin.css" />
   </head>
   <body>
     <div class="app-shell">
@@ -85,6 +85,6 @@
         </div>
       </footer>
     </div>
-    <script src="/admin/assets/admin.js"></script>
+    <script src="/admin/assets/__FCC_VERSION__/admin.js"></script>
   </body>
 </html>

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -18,6 +18,7 @@ from free_claude_code.config.admin.values import MASKED_SECRET
 from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
 from free_claude_code.config.server_urls import local_admin_url
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.version import package_version
 from tests.api.support import create_test_app, provider_manager_for_app, runtime_for_app
 
 
@@ -89,12 +90,56 @@ def test_admin_page_is_loopback_only(monkeypatch, tmp_path):
     assert remote_client.get("/admin").status_code == 403
 
 
+def test_admin_page_uses_installed_version_for_asset_urls(monkeypatch, tmp_path):
+    _set_home(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "free_claude_code.api.admin_routes.package_version",
+        lambda: "9.8.7",
+    )
+
+    response = _local_client(create_test_app()).get("/admin")
+
+    assert response.status_code == 200
+    assert 'href="/admin/assets/9.8.7/admin.css"' in response.text
+    assert 'src="/admin/assets/9.8.7/admin.js"' in response.text
+    assert 'href="/admin/assets/admin.css"' not in response.text
+    assert 'src="/admin/assets/admin.js"' not in response.text
+
+
+@pytest.mark.parametrize(
+    ("filename", "media_type"),
+    (("admin.css", "text/css"), ("admin.js", "text/javascript")),
+)
+def test_admin_versioned_assets_serve_packaged_files(
+    monkeypatch,
+    tmp_path,
+    filename,
+    media_type,
+):
+    asset_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "free_claude_code"
+        / "api"
+        / "admin_static"
+        / filename
+    )
+    _set_home(monkeypatch, tmp_path)
+    response = _local_client(create_test_app()).get(
+        f"/admin/assets/{package_version()}/{filename}"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(media_type)
+    assert response.content == asset_path.read_bytes()
+
+
 @pytest.mark.parametrize(
     "path",
     (
         "/admin",
-        "/admin/assets/admin.css",
-        "/admin/assets/admin.js",
+        f"/admin/assets/{package_version()}/admin.css",
+        f"/admin/assets/{package_version()}/admin.js",
         "/admin/api/config",
     ),
 )
@@ -110,7 +155,22 @@ def test_admin_responses_are_never_cached(monkeypatch, tmp_path, path):
     ("path", "client_host", "expected_status"),
     (
         ("/admin", "203.0.113.10", 403),
-        ("/admin/assets/missing.js", "127.0.0.1", 404),
+        ("/admin/assets/admin.js", "127.0.0.1", 404),
+        (
+            f"/admin/assets/{package_version()}.stale/admin.js",
+            "127.0.0.1",
+            404,
+        ),
+        (
+            f"/admin/assets/{package_version()}/missing.js",
+            "127.0.0.1",
+            404,
+        ),
+        (
+            f"/admin/assets/{package_version()}/admin.js",
+            "203.0.113.10",
+            403,
+        ),
     ),
 )
 def test_admin_http_errors_are_never_cached(

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.17.2"
+version = "5.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

A browser can combine the current Admin HTML with JavaScript or CSS cached before FCC adopted no-store responses, leaving the Admin page blank after an upgrade. Restarting FCC cannot invalidate browser-owned historical assets. Fixes #1612.

## Changes

| Before | After |
| --- | --- |
| Admin releases reused unversioned CSS and JavaScript URLs. | Admin HTML derives virtual asset paths from the installed FCC release. |
| Stale and current Admin assets shared one browser cache identity. | Only assets matching the running FCC version are served, while no-store remains enforced. |
| Tests covered uncached responses without exercising HTML-to-asset generation. | API and Chromium contracts verify versioned routing and successful dynamic Admin rendering. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change versions the Admin CSS and JavaScript URLs with the installed Free Claude Code release so the Admin page cannot combine current HTML with stale browser assets.

The rendered Admin page was exercised against the running application. Both current versioned assets loaded successfully, while unversioned, stale-version, and unknown asset URLs returned 404. Non-loopback access remained blocked, and Admin success and error responses retained the `Cache-Control: no-store` policy. The focused API and browser suite completed with 149 passing tests.

No defects were found.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge: the Admin page and its versioned asset contract work in the running application while preserving access and cache protections.

Runtime checks covered rendered asset URLs, valid asset retrieval, rejection of stale and unversioned URLs, remote-access denial, cache headers, and the focused API and browser test suite.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the PR-specific admin assets probe to compare the updated application against the baseline, using EXPECT\_VERSIONED=1 for the PR and EXPECT\_VERSIONED=0 for the baseline.
- Verified that the updated Admin page serves versioned asset URLs (version 5.17.3) with 200 responses, non-empty bodies, and Cache-Control: no-store, while unversioned, stale-version, and unknown asset paths return 404 and remote clients see 403.
- Executed the focused API and browser test suite and confirmed all tests passed (149 tests total).
- Documented the exact probe commands and baseline commands used for validation, with no repository source changes observed.
- Produced evidence artifacts to support the validation, including the runtime probe source and post-PR behavior logs, to help reviewers inspect the results.

<a href="https://app.greptile.com/trex/runs/21451228/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Version Admin assets with FCC releases"](https://github.com/alishahryar1/free-claude-code/commit/01027cea214e48cd6d3e16b8c6e023c469d42d8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58327638)</sub>

<!-- /greptile_comment -->