### PR TITLE
Keep Admin sidebar pinned at page bottom

### DIFF
--- a/e2e/test_admin_providers.py
+++ b/e2e/test_admin_providers.py
@@ -57,6 +57,21 @@ def test_missing_provider_configuration_scrolls_to_exact_field(
         )
 
 
+def test_desktop_sidebar_stays_pinned_at_document_bottom(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _open_admin(page, admin_base_url, {"width": 1280, "height": 720})
+    sidebar = page.locator(".sidebar")
+
+    page.evaluate("window.scrollTo(0, document.documentElement.scrollHeight)")
+
+    sidebar_top = float(
+        sidebar.evaluate("element => element.getBoundingClientRect().top")
+    )
+    assert sidebar_top == pytest.approx(0, abs=0.5)
+
+
 def test_configured_provider_check_keeps_readiness_and_adds_models(
     page: Page,
     admin_base_url: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.17.3"
+version = "5.17.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -199,7 +199,8 @@ textarea:focus-visible,
 /* Main Content Area */
 .main {
   min-width: 0;
-  padding: 40px 48px 136px; /* Includes space for the fixed action bar */
+  padding: 40px 48px;
+  padding-bottom: calc(40px + 96px); /* Fixed action bar clearance */
 }
 
 .topbar {
@@ -817,7 +818,8 @@ textarea:focus-visible,
   }
 
   .main {
-    padding: 24px 20px 204px; /* Includes space for the stacked action bar */
+    padding: 24px 20px;
+    padding-bottom: calc(24px + 180px); /* Stacked action bar clearance */
   }
 
   .action-bar {

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -104,7 +104,6 @@ textarea {
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
   min-height: 100vh;
-  padding-bottom: 96px; /* Space for action bar */
 }
 
 /* Sidebar Navigation */
@@ -200,7 +199,7 @@ textarea:focus-visible,
 /* Main Content Area */
 .main {
   min-width: 0;
-  padding: 40px 48px;
+  padding: 40px 48px 136px; /* Includes space for the fixed action bar */
 }
 
 .topbar {
@@ -802,7 +801,6 @@ textarea:focus-visible,
   .app-shell {
     display: flex;
     flex-direction: column;
-    padding-bottom: 180px; /* More room for stacked action bar */
   }
 
   .sidebar {
@@ -819,7 +817,7 @@ textarea:focus-visible,
   }
 
   .main {
-    padding: 24px 20px;
+    padding: 24px 20px 204px; /* Includes space for the stacked action bar */
   }
 
   .action-bar {

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.17.3"
+version = "5.17.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The desktop Admin sidebar moved upward during the final 96 pixels of document scrolling because fixed-action-bar clearance was applied to its sticky containing block.

## Changes

| Before | After |
| --- | --- |
| Fixed-action-bar clearance padded the entire app shell and shortened the sidebar's sticky boundary. | Fixed-action-bar clearance belongs to the main content column, so the sidebar remains pinned. |
| The rendered UI test checked the sticky sidebar only during an intermediate field scroll. | A rendered UI regression scrolls to the document bottom and verifies the sidebar remains at the viewport top. |
| The package version was 5.17.3. | The patch version is 5.17.4. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change moves fixed action-bar clearance into the Admin content area, allowing the desktop sidebar to remain pinned through the bottom of the document while preserving mobile and desktop spacing.

The suggested scroll-condition concern in `e2e/test_admin_providers.py` was disproved with the rendered Admin page at its configured 1280×720 viewport: the document height was 7,900px and the tested scroll reached `scrollY=7,180` before the sidebar position was measured. The same interaction also passed with an explicit nonzero-scroll assertion.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge based on the rendered Admin regression behavior that was exercised.

No publishable defects remain. The only reported concern was directly contradicted by a Chromium run that reached the actual document bottom before checking the sticky sidebar.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the desktop Admin providers end-to-end test with pytest in the isolated Admin application, and the test passed.
- Validated the UI by rendering at 1280×720 in Chromium, performing window.scrollTo(0, document.documentElement.scrollHeight), and observed scrollY=7,180 and scrollHeight=7,900 with the sidebar top near zero.
- Re-ran the interaction with an explicit nonzero-scroll requirement; the validation passed, confirming the assertion runs after a real bottom scroll.
- Uploaded and reviewed the validation artifacts, including the exact pytest result, the Playwright validation source, the rendered-browser outputs, and two validation videos with poster frames.

<a href="https://app.greptile.com/trex/runs/21455964/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify Admin action bar clearance"](https://github.com/alishahryar1/free-claude-code/commit/20c5d1e8ec25ff1b6856be9bf6d63da8dbb0765b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58335854)</sub>

<!-- /greptile_comment -->