### PR TITLE
Show running version in Admin sidebar

### DIFF
--- a/e2e/test_admin_assets.py
+++ b/e2e/test_admin_assets.py
@@ -25,6 +25,9 @@ def test_admin_loads_current_release_assets_before_rendering_dynamic_content(
     page.goto(f"{admin_base_url}/admin")
 
     expect(page.locator('[data-provider="nvidia_nim"]')).to_be_visible()
+    expect(page.locator(".brand p")).to_have_text(
+        f"Server Control · v{package_version()}"
+    )
 
     versioned_root = f"/admin/assets/{package_version()}"
     assert f"{versioned_root}/admin.css" in requested_paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.17.4"
+version = "5.17.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -14,7 +14,7 @@
           <div class="brand-mark">FC</div>
           <div>
             <h1>Free Claude Code</h1>
-            <p>Server Control</p>
+            <p>Server Control · v__FCC_VERSION__</p>
           </div>
         </div>
         <nav id="sectionNav" class="section-nav" aria-label="Admin views"></nav>

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -90,7 +90,7 @@ def test_admin_page_is_loopback_only(monkeypatch, tmp_path):
     assert remote_client.get("/admin").status_code == 403
 
 
-def test_admin_page_uses_installed_version_for_asset_urls(monkeypatch, tmp_path):
+def test_admin_page_uses_installed_version(monkeypatch, tmp_path):
     _set_home(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "free_claude_code.api.admin_routes.package_version",
@@ -100,6 +100,7 @@ def test_admin_page_uses_installed_version_for_asset_urls(monkeypatch, tmp_path)
     response = _local_client(create_test_app()).get("/admin")
 
     assert response.status_code == 200
+    assert "<p>Server Control · v9.8.7</p>" in response.text
     assert 'href="/admin/assets/9.8.7/admin.css"' in response.text
     assert 'src="/admin/assets/9.8.7/admin.js"' in response.text
     assert 'href="/admin/assets/admin.css"' not in response.text

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.17.4"
+version = "5.17.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Admin sidebar did not identify the FCC version currently serving the page, making update verification and support screenshots less informative.

## Changes

| Before | After |
| --- | --- |
| The sidebar subtitle displayed only `Server Control`. | The sidebar subtitle displays `Server Control · v<running version>`. |
| Only asset URLs exercised the canonical server-side version substitution. | The visible version uses the same canonical substitution and is covered by API and rendered UI contracts. |
| The package version was 5.17.4. | The patch version is 5.17.5. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds the running package version to the Admin sidebar and adds coverage for the rendered value. Requests to `/admin` at the base revision and this revision confirmed that the version display is new. The release metadata needs updating because a new Admin-visible field requires a minor version increment rather than the current patch increment.
</details>


<h3>Confidence Score: 4/5</h3>

Do not merge until the release version and lockfile metadata reflect the required minor release.

The Admin behavior was exercised before and after the change, the focused rendering test passed, and the repository release guidance directly classifies this new Admin field as requiring a minor version increment.

**Files Needing Attention:** `pyproject.toml` needs the corrected version, and `uv.lock` must be regenerated to match it.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and documented the validation approach against the corresponding review comment.
- T-Rex produced a second proof for another P1 finding to extend the review coverage.
- General-contract-validation-proof shows the admin behavior change after PR head, with /admin returning 200 and displaying v5.17.5, and confirms the validator source is present in the artifacts.

<a href="https://app.greptile.com/trex/runs/21456462/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Admin version capability receives a patch rather than required minor version bump**

   - **Bug**
     - PR #1617 adds the running version to the Admin sidebar, a new user-visible Admin field. The commit bumps `pyproject.toml` from `5.17.4` to `5.17.5`, but the repository rule delegated by UUID `d2fd24d8-0dec-4faf-8ee4-e085e215a2f8` classifies new admin fields and behavior additions as MINOR changes. The compliant version is `5.18.0`.
   - **Cause**
     - The change was classified as a PATCH despite adding a new Admin capability; PATCH is reserved for fixes/refactors without user-visible behavior change, while the authoritative guide explicitly names admin fields as MINOR.
   - **Fix**
     - Update `pyproject.toml` to `5.18.0`, regenerate `uv.lock` so its package entry matches, and amend the PR commit/release metadata accordingly.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fshow-admin-version%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fshow-admin-version%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231617%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1617&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fshow-admin-version%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fshow-admin-version%22.%0A%0A%23%23%23%20Issue%201%0Apyproject.toml%3A7%0A**Admin%20field%20receives%20a%20patch%20release**%0A%0AThe%20running%20version%20is%20a%20new%20user-visible%20Admin%20field%2C%20but%20this%20changes%20the%20package%20version%20only%20from%20%605.17.4%60%20to%20%605.17.5%60.%20The%20repository%20SemVer%20rule%20classifies%20new%20Admin%20fields%20and%20behavior%20additions%20as%20minor%20changes.%20Update%20the%20release%20to%20%605.18.0%60%20and%20regenerate%20%60uv.lock%60%20so%20its%20package%20metadata%20stays%20in%20sync.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1617&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Show running version in Admin sidebar"](https://github.com/alishahryar1/free-claude-code/commit/a64d09831677536d2c824e21995d258426a6ccc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58337029)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->