### PR TITLE
docs: add macOS troubleshooting section (Homebrew symlinks, zshrc perms, model routing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,74 @@ Restart `fcc-server`. In **Admin UI → Messaging → Voice**, enable voice note
 
 </details>
 
+## Troubleshooting
+
+<details>
+<summary>macOS: Homebrew symlink conflicts during Node.js upgrade (Pi / DeepSeek Harness dependency)</summary>
+
+**Symptom:** When the installer verifies or upgrades Node.js for Pi/DeepSeek Harness (>= 22.19.0), Homebrew fails if prior symlinks exist:
+
+```text
+Error: The `brew link` step did not complete successfully
+Error: node: Could not symlink include/brotli/decode.h
+Target /opt/homebrew/include/brotli/decode.h is a symlink belonging to brotli.
+error: Pi requires Node.js 22.19.0 or newer.
+```
+
+**Fix:** Force overwrite the conflicting dependency links before installing Node:
+
+```bash
+brew link --overwrite brotli ca-certificates openssl@3 xz zstd
+brew install node
+```
+
+</details>
+
+<details>
+<summary>macOS: `~/.zshrc: Permission denied` during Grok Build / PATH configuration</summary>
+
+**Symptom:** If `~/.zshrc` was previously created or edited by root/sudo, the installer script cannot append exports:
+
+```text
+line 493: /Users/<user>/.zshrc: Permission denied
+error: Grok Build installation failed with exit code 1.
+```
+
+**Fix:** Reset the file's ownership to the current user:
+
+```bash
+cp ~/.zshrc ~/.zshrc.tmp && rm -f ~/.zshrc && mv ~/.zshrc.tmp ~/.zshrc
+```
+
+</details>
+
+<details>
+<summary>`503 NVIDIA_NIM_API_KEY is not set` when using OpenRouter or another provider</summary>
+
+**Symptom:** When launching `fcc-claude`, requests fail if `MODEL_*` still defaults to NVIDIA NIM even though `OPENROUTER_API_KEY` is configured in `~/.fcc/.env`:
+
+```text
+* 503 NVIDIA_NIM_API_KEY is not set. Add it in the Admin UI ...
+```
+
+**Fix:** Map the model variables in `~/.fcc/.env` to the provider you configured (e.g. OpenRouter):
+
+```env
+FCC_CONFIG_SCHEMA=1
+MODEL=open_router/openrouter/free
+MODEL_FABLE=open_router/openrouter/free
+MODEL_HAIKU=open_router/openrouter/free
+MODEL_OPUS=open_router/openrouter/free
+MODEL_SONNET=open_router/openrouter/free
+OPENROUTER_API_KEY=your_openrouter_key
+```
+
+Then restart the FCC daemon / desktop app.
+
+</details>
+
+*Thanks to [@Suryanshsaraf](https://github.com/Suryanshsaraf) for reporting and verifying these fixes in [#1613](https://github.com/Alishahryar1/free-claude-code/issues/1613).*
+
 ## Manage Your Installation
 
 Run `fcc-server --version` to check the installed version without starting FCC.


### PR DESCRIPTION
Closes #1613.

Adds a **Troubleshooting** section to the README (right before *Manage Your Installation*) covering three verified macOS issues reported and root-caused in #1613 by @Suryanshsaraf:

1. Homebrew symlink conflicts when the installer upgrades Node.js for Pi/DeepSeek Harness
2. `~/.zshrc: Permission denied` during install when the file is owned by root/sudo
3. `503 NVIDIA_NIM_API_KEY is not set` when a non-NIM provider (e.g. OpenRouter) is configured but `MODEL_*` still defaults to NIM

Each is collapsed in a `<details>` block so it doesn't add length to the README for users who don't need it. Content/fixes are unchanged from what was verified in the issue - this PR just gets it somewhere new users will actually find it instead of buried in the issue tracker.

No code changes, README only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds troubleshooting guidance for Homebrew Node linking, `.zshrc` permissions, and provider-model routing. The documented `.zshrc` recovery command was tested in isolated home directories and does not repair the unreadable root-owned-file scenario it describes; it can also overwrite an existing temporary file and replace a symlink. Update that recovery guidance before merging.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the `.zshrc` ownership recovery guidance is corrected.

There is one verified P1 non-security finding. The exact command was exercised in disposable home-directory fixtures covering unreadable ownership, an existing temporary file, and a symlink.

**Files Needing Attention:** README.md, line 613

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding.
- The finding details were reviewed in the corresponding review comment to confirm the scope and conclusions.
- The validation workflow was exercised by using the validation script source for isolated zshrc repair fixtures.
- The zshrc repair command was observed operating in isolated homes to verify the expected repair behavior.

<a href="https://app.greptile.com/trex/runs/21481188/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add macOS troubleshooting section ..."](https://github.com/alishahryar1/free-claude-code/commit/813947bed07b6fb3afd3749ed75c5d9aaabc485c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58385675)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->