### PR TITLE
fix(claude): filter inherited ANTHROPIC_* env vars case-insensitively

### DIFF
--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -7,6 +7,12 @@ from free_claude_code.cli.local_http import with_local_proxy_bypass
 CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"
 CLAUDE_BINARY_NAME = "claude"
 
+# Environment variable names FCC always sets itself; any inherited entry with
+# one of these names is dropped before the block below re-sets it, regardless
+# of casing.
+_ANTHROPIC_PREFIX = "anthropic_"
+_STRIPPED_KEYS = frozenset({"claude_code_disable_nonessential_traffic"})
+
 
 def build_claude_proxy_env(
     *,
@@ -16,13 +22,24 @@ def build_claude_proxy_env(
 ) -> dict[str, str]:
     """Return the canonical environment for Claude Code proxy sessions."""
 
+    # Windows environment variables are case-insensitive, so a leftover
+    # differently-cased entry (e.g. `Anthropic_Base_Url`, set by an installer
+    # or a Windows System Properties GUI) would survive a case-sensitive
+    # startswith() filter and sit alongside the value we set below. The two
+    # keys look distinct to this Python dict, but the child process's runtime
+    # resolves env lookups case-insensitively on Windows, so which one wins
+    # becomes ambiguous - in practice this is how Claude Code has been
+    # observed silently falling back to the real Anthropic API instead of
+    # the local proxy. Filtering by casefolded name avoids the ambiguity
+    # entirely, on every platform.
+    #
     # Claude's aggregate traffic flag also suppresses gateway model discovery.
     env = with_local_proxy_bypass(
         {
             key: value
             for key, value in base_env.items()
-            if not key.startswith("ANTHROPIC_")
-            and key != "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"
+            if not key.casefold().startswith(_ANTHROPIC_PREFIX)
+            and key.casefold() not in _STRIPPED_KEYS
         },
         proxy_root_url=proxy_root_url,
     )

--- a/tests/cli/test_claude_env.py
+++ b/tests/cli/test_claude_env.py
@@ -1,0 +1,69 @@
+"""build_claude_proxy_env must always win over inherited Anthropic env vars,
+including on Windows where environment variable names are case-insensitive.
+"""
+
+from free_claude_code.cli.claude_env import build_claude_proxy_env
+
+
+def test_proxy_env_overrides_matching_case_anthropic_vars() -> None:
+    base_env = {
+        "ANTHROPIC_BASE_URL": "https://stale.example.com",
+        "ANTHROPIC_API_KEY": "sk-stale",
+        "PATH": "/usr/bin",
+    }
+
+    env = build_claude_proxy_env(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="fcc-token",
+        base_env=base_env,
+    )
+
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8082"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "fcc-token"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_proxy_env_overrides_differently_cased_anthropic_vars() -> None:
+    """Regression test for #1043: on Windows, a leftover `Anthropic_Base_Url`
+    (e.g. set via the System Properties GUI, or by another installer) is a
+    distinct key from `ANTHROPIC_BASE_URL` in this Python dict, but the two
+    are the same variable to the Windows OS and to a case-insensitive child
+    runtime - so it must be filtered out here rather than left to coexist
+    with the value FCC is trying to set.
+    """
+    base_env = {
+        "Anthropic_Base_Url": "https://stale.example.com",
+        "anthropic_api_key": "sk-stale",
+        "Claude_Code_Disable_Nonessential_Traffic": "1",
+    }
+
+    env = build_claude_proxy_env(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="fcc-token",
+        base_env=base_env,
+    )
+
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8082"
+    assert not any(
+        key.casefold() == "anthropic_base_url" and key != "ANTHROPIC_BASE_URL"
+        for key in env
+    )
+    assert not any(key.casefold() == "anthropic_api_key" for key in env)
+    assert not any(
+        key.casefold() == "claude_code_disable_nonessential_traffic" for key in env
+    )
+
+
+def test_proxy_env_sets_expected_claude_code_flags() -> None:
+    env = build_claude_proxy_env(
+        proxy_root_url="http://127.0.0.1:8082",
+        auth_token="fcc-token",
+        base_env={},
+    )
+
+    assert env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+    assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "190000"
+    assert env["DISABLE_AUTOUPDATER"] == "1"
+    assert env["DISABLE_FEEDBACK_COMMAND"] == "1"
+    assert env["DISABLE_ERROR_REPORTING"] == "1"


### PR DESCRIPTION
Relates to #1043.

## What
`build_claude_proxy_env()` strips inherited `ANTHROPIC_*` env vars before setting `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` itself, but did the strip with a case-sensitive `key.startswith("ANTHROPIC_")` check (same gap existed for the `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` strip).

## Why this looks like the #1043 root cause
Windows environment variables are case-insensitive, so a leftover differently-cased entry - e.g. `Anthropic_Base_Url`, which can end up set by an installer or added manually via the System Properties GUI (Windows users don't get the same all-caps shell convention Unix users do) - survives a case-sensitive filter and sits in the same env dict alongside the value FCC is trying to set. The two keys are distinct to this Python dict, but the same variable to Windows itself and to a child process runtime that resolves env lookups case-insensitively, so which one Claude Code actually reads becomes ambiguous. That matches the reported symptom exactly: the proxy launches, Claude authenticates successfully, but `/v1/messages` never reaches `fcc-server` and traffic goes straight to the real Anthropic API instead.

I don't have a Windows machine to reproduce the original report directly, so I want to be upfront: this is the most concrete, evidence-based cause I could find by reading the code carefully (case-sensitive filtering + Windows' case-insensitive env vars is a well-known class of bug), not a confirmed-on-hardware fix. It's a real correctness bug either way - the filter clearly does not do what its own comment says on Windows - so I think it's worth shipping regardless, but @Alishahryar1 or the issue reporter may be able to confirm whether it was in fact the cause.

## Fix
Filter by casefolded key name instead, which removes the ambiguity on every platform (not just Windows) and is a one-line-per-check change.

## Testing
- Added `tests/cli/test_claude_env.py`: same-case behavior (existing coverage gap) + a differently-cased regression case reproducing the #1043 scenario.
- `uv run pytest tests/cli` - 15/15 pass
- `uv run ruff format --check` / `uv run ruff check` - clean
- `uv run ty check` - clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes Claude proxy environment sanitization case-insensitive so that inherited mixed-case Anthropic settings cannot coexist with FCC-managed routing on Windows.

The environment builder was exercised with mixed-case inherited Anthropic endpoint, credential, model, and traffic-disable settings. It removed every conflicting case variant, installed only the canonical FCC proxy URL and auth token, and preserved unrelated environment variables. The focused Claude environment tests also passed.

Disproved drop: a mixed-case inherited Anthropic setting surviving into the child environment and overriding FCC routing does not occur in the current implementation.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed environment-construction path removes conflicting case variants before installing FCC-managed proxy settings.

A deterministic executable check exercised the Windows-style case-insensitive failure path and observed only canonical managed values in the resulting environment; the focused test suite passed as well.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the deterministic mixed-case environment validation for phase before and phase after to compare legacy behavior against the current FCC environment builder.
- Executed pytest tests for claude\_env to verify environment handling; all 3 focused tests passed.
- Reviewed the before-capture baseline to understand why the legacy case-sensitive filter was unsafe for Windows-style lookups due to two ANTHROPIC\_BASE\_URL aliases and stale values.
- Reviewed the after-capture results showing the utility removes all case-variant inherited Anthropic entries and the mixed-case traffic flag, then adds only the managed credentials and URL.

<a href="https://app.greptile.com/trex/runs/21481831/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(claude): filter inherited ANTHROPIC\_..."](https://github.com/alishahryar1/free-claude-code/commit/7bee15ca056e848894d3bc8f8b6e6cc176bb2389) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58386781)</sub>

<!-- /greptile_comment -->