### PR TITLE
Remove misplaced Chat Sessions jump button

### DIFF
--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -481,7 +481,6 @@ def test_terminal_refresh_preserves_reader_scroll_position(
 
     expect(page.get_by_role("button", name="Retry")).to_be_visible()
     assert scroller.evaluate("node => node.scrollTop") < 10
-    expect(page.get_by_role("button", name="Jump to latest")).to_be_visible()
 
 
 def test_chat_rename_prompt_and_delete(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.0"
+version = "5.18.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/chat_sessions.css
+++ b/src/free_claude_code/api/admin_static/chat_sessions.css
@@ -379,14 +379,6 @@
   font-size: 12px;
 }
 
-.chat-jump {
-  position: absolute;
-  right: 22px;
-  bottom: 104px;
-  z-index: 2;
-  width: auto;
-}
-
 .chat-older {
   display: block;
   margin: 0 auto 24px;

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -337,16 +337,8 @@
     const scroller = node("div", "chat-transcript");
     scroller.id = "chatTranscript";
     scroller.setAttribute("aria-label", "Conversation");
-    const jump = button("Jump to latest", "secondary-button chat-jump", () =>
-      scrollLatest(true),
-    );
-    jump.id = "chatJumpLatest";
-    jump.hidden = true;
-    scroller.addEventListener("scroll", () => {
-      jump.hidden = nearBottom(scroller);
-    });
     const composer = renderComposer();
-    shell.append(header, notice, scroller, jump, composer);
+    shell.append(header, notice, scroller, composer);
     root().replaceChildren(shell);
     renderTranscript();
     refreshComposerState();
@@ -355,7 +347,6 @@
     } else {
       scroller.scrollTop = scrollTop;
     }
-    jump.hidden = nearBottom(scroller);
     syncForeignOperationPoll();
   }
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.0"
+version = "5.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Chat Sessions "Jump to latest" control floated over the message composer and looked misplaced at desktop and narrow widths.

## Changes

| Before | After |
| --- | --- |
| Chat Sessions rendered an absolutely positioned jump control over the composer. | Chat Sessions omit the jump control while preserving automatic following and reader scroll position. |
| The UI test required the misplaced control after stopping a response. | The UI test verifies scroll preservation without requiring the removed control. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change removes the misplaced “Jump to latest” control from Admin Chat Sessions and updates the package version to 5.18.1.

Rendered Chromium checks verified that the control is absent after the change, a reader’s position remains preserved when a terminal refresh occurs, and live transcript updates continue following when the reader is already at the bottom. The existing targeted terminal-refresh browser scenario also passed.

The potential regression that removing the control would break reader-position preservation or bottom-follow behavior was disproved by the executed browser checks.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed transcript UI behavior was exercised in Chromium and retained its expected scrolling behavior.

No defects remain after directly checking removal of the control, terminal-refresh position preservation, and live-update following behavior.

**Files Needing Attention:** None. The changed JavaScript, stylesheet, browser test expectation, and version metadata are consistent with the intended removal.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Rendered Chromium checks confirmed the intended transcript behavior: the changed page no longer displayed Jump to latest, the terminal refresh preserved the reader position at scrollTop 0, and a fragmented live update left 0 px below the viewport for a reader already at the bottom, and the repository's targeted terminal-refresh browser scenario passed.
- No severity-bearing proof was emitted because the executed rendered checks disproved the relevant failure paths: the changed page had no Jump to latest button, preserved the reader's terminal-refresh position at scrollTop 0, and maintained 0 px remaining below the viewport during a fragmented live update.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove misplaced chat jump button"](https://github.com/alishahryar1/free-claude-code/commit/e372f7f8078168d266a5c5ccfc3229652c6bf305) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58417013)</sub>

<!-- /greptile_comment -->