### PR TITLE
Reuse searchable model picker in Chat Sessions

### DIFF
--- a/e2e/test_admin_assets.py
+++ b/e2e/test_admin_assets.py
@@ -32,10 +32,12 @@ def test_admin_loads_current_release_assets_before_rendering_dynamic_content(
     versioned_root = f"/admin/assets/{package_version()}"
     assert f"{versioned_root}/admin.css" in requested_paths
     assert f"{versioned_root}/chat_sessions.css" in requested_paths
+    assert f"{versioned_root}/model_combobox.js" in requested_paths
     assert f"{versioned_root}/chat_sessions.js" in requested_paths
     assert f"{versioned_root}/admin.js" in requested_paths
     assert "/admin/assets/admin.css" not in requested_paths
     assert "/admin/assets/chat_sessions.css" not in requested_paths
+    assert "/admin/assets/model_combobox.js" not in requested_paths
     assert "/admin/assets/chat_sessions.js" not in requested_paths
     assert "/admin/assets/admin.js" not in requested_paths
     assert page_errors == []

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -13,6 +13,21 @@ def _new_chat(page: Page, admin_base_url: str) -> None:
     expect(page.get_by_role("textbox", name="Message", exact=True)).to_be_visible()
 
 
+def _select_model(page: Page, model_ref: str) -> None:
+    model = page.get_by_role("combobox", name="Selected model")
+    model.click()
+    model.fill(model_ref)
+    expect(page.get_by_role("option", name=model_ref, exact=True)).to_be_visible()
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH"
+            and "/admin/api/chat/sessions/" in response.url
+        )
+    ):
+        model.press("Enter")
+    expect(page.get_by_role("combobox", name="Selected model")).to_have_value(model_ref)
+
+
 def test_chat_navigation_create_and_browser_history(
     page: Page,
     admin_base_url: str,
@@ -71,12 +86,41 @@ def test_model_refresh_updates_chat_bootstrap(
     page.get_by_role("button", name="Chat Sessions").click()
     page.locator(".chat-session-card").click()
 
-    expect(page.get_by_label("Selected model")).to_have_value(target)
-    expect(page.get_by_label("Selected model").locator("option:checked")).to_have_text(
-        "vendor/model-b"
-    )
+    expect(page.get_by_role("combobox", name="Selected model")).to_have_value(target)
     page.get_by_role("textbox", name="Message", exact=True).fill("still available")
     expect(page.get_by_role("button", name="Send")).to_be_enabled()
+
+
+def test_chat_model_picker_searches_and_selects_in_one_control(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _new_chat(page, admin_base_url)
+    model_patches: list[str] = []
+    page.on(
+        "request",
+        lambda request: (
+            model_patches.append(request.url)
+            if request.method == "PATCH" and "/admin/api/chat/sessions/" in request.url
+            else None
+        ),
+    )
+
+    model = page.get_by_role("combobox", name="Selected model")
+    expect(model).to_have_value("open_router/e2e-default")
+    expect(page.get_by_role("searchbox", name="Filter models")).to_have_count(0)
+    expect(page.locator("select#chatModel")).to_have_count(0)
+    expect(page.locator("#chatNotice")).to_be_hidden()
+
+    model.fill("not-a-catalog-model")
+    expect(page.get_by_text("No matching models.", exact=True)).to_be_visible()
+    page.get_by_label("Thinking").click()
+    expect(model).to_have_value("open_router/e2e-default")
+
+    _select_model(page, "open_router/vendor/small-context")
+    expect(page.get_by_role("listbox")).to_be_hidden()
+    page.wait_for_timeout(100)
+    assert len(model_patches) == 1
 
 
 def test_delayed_older_page_cannot_cross_into_another_chat(
@@ -537,9 +581,7 @@ def test_reset_system_prompt_refreshes_context_and_unblocks_send(
     admin_base_url: str,
 ) -> None:
     _new_chat(page, admin_base_url)
-    page.get_by_label("Selected model").select_option(
-        "open_router/vendor/small-context"
-    )
+    _select_model(page, "open_router/vendor/small-context")
     message = page.get_by_role("textbox", name="Message", exact=True)
     message.fill("send after reset")
 
@@ -590,6 +632,6 @@ def test_chat_remains_usable_at_narrow_viewport(
     page.set_viewport_size({"width": 390, "height": 844})
     _new_chat(page, admin_base_url)
 
-    expect(page.get_by_label("Selected model")).to_be_visible()
+    expect(page.get_by_role("combobox", name="Selected model")).to_be_visible()
     expect(page.get_by_label("Thinking")).to_be_visible()
     expect(page.get_by_role("textbox", name="Message", exact=True)).to_be_in_viewport()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.1"
+version = "5.18.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -32,7 +32,13 @@ router = APIRouter()
 STATIC_DIR = Path(__file__).resolve().parent / "admin_static"
 _ADMIN_ASSET_VERSION_PLACEHOLDER = "__FCC_VERSION__"
 _ADMIN_ASSET_FILENAMES = frozenset(
-    {"admin.css", "admin.js", "chat_sessions.css", "chat_sessions.js"}
+    {
+        "admin.css",
+        "admin.js",
+        "chat_sessions.css",
+        "chat_sessions.js",
+        "model_combobox.js",
+    }
 )
 LOCAL_PROVIDER_PATHS = {
     "lmstudio": "/models",

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -616,7 +616,7 @@ function renderField(field) {
 
   let control = input;
   if (field.type === "model" || field.type === "optional_model") {
-    control = new ModelCombobox(input, field).element;
+    control = createModelCombobox(input, field).element;
   } else if (field.type === "model_list") {
     const editor = new ModelListEditor(input, field);
     label.htmlFor = editor.inputId;
@@ -700,184 +700,20 @@ function inputForField(field) {
   return input;
 }
 
-class ModelCombobox {
-  constructor(input, field) {
-    this.input = input;
-    this.fieldType = field.type;
-    this.activeIndex = -1;
-    this.query = "";
-
-    this.element = document.createElement("div");
-    this.element.className = "model-combobox";
-    this.listbox = document.createElement("div");
-    this.listbox.className = "model-combobox-list";
-    this.listbox.id = `model-options-${field.key}`;
-    this.listbox.setAttribute("role", "listbox");
-    this.listbox.hidden = true;
-    this.toggle = document.createElement("button");
-    this.toggle.type = "button";
-    this.toggle.className = "model-combobox-toggle";
-    this.toggle.disabled = input.disabled;
-    this.toggle.setAttribute("aria-label", `Show ${field.label} options`);
-
-    input.setAttribute("role", "combobox");
-    input.setAttribute("aria-autocomplete", "list");
-    input.setAttribute("aria-haspopup", "listbox");
-    for (const control of [input, this.toggle]) {
-      control.setAttribute("aria-controls", this.listbox.id);
-      control.setAttribute("aria-expanded", "false");
-    }
-
-    input.addEventListener("click", () => this.open());
-    input.addEventListener("input", () => this.open(input.value));
-    input.addEventListener("keydown", (event) => this.handleKeydown(event));
-    this.toggle.addEventListener("mousedown", (event) => event.preventDefault());
-    this.toggle.addEventListener("click", () => {
-      if (this.isOpen) this.close();
-      else this.open();
-      input.focus();
-    });
-    this.listbox.addEventListener("mousedown", (event) => event.preventDefault());
-    this.listbox.addEventListener("mousemove", (event) => {
-      const optionEl = event.target.closest('[role="option"]');
-      if (optionEl) this.setActive(this.visibleOptions.indexOf(optionEl));
-    });
-    this.listbox.addEventListener("click", (event) => {
-      const optionEl = event.target.closest('[role="option"]');
-      if (optionEl) this.select(optionEl.dataset.value);
-    });
-
-    this.element.append(input, this.toggle, this.listbox);
-    state.modelComboboxes.add(this);
-  }
-
-  get isOpen() {
-    return this.element.classList.contains("open");
-  }
-
-  get values() {
-    return this.fieldType === "optional_model"
-      ? ["None", ...state.modelOptions]
-      : state.modelOptions;
-  }
-
-  get visibleOptions() {
-    return Array.from(this.listbox.querySelectorAll('[role="option"]'));
-  }
-
-  open(query = "") {
-    if (this.input.disabled) return;
-    state.modelComboboxes.forEach((combobox) => {
-      if (combobox !== this) combobox.close();
-    });
-    this.render(query);
-    this.element.classList.add("open");
-    this.listbox.hidden = false;
-    this.setExpanded(true);
-  }
-
-  close() {
-    this.element.classList.remove("open");
-    this.listbox.hidden = true;
-    this.activeIndex = -1;
-    this.input.removeAttribute("aria-activedescendant");
-    this.setExpanded(false);
-  }
-
-  setExpanded(expanded) {
-    for (const control of [this.input, this.toggle]) {
-      control.setAttribute("aria-expanded", String(expanded));
-    }
-  }
-
-  render(query) {
-    this.query = query;
-    const normalizedQuery = query.trim().toLocaleLowerCase();
-    const values = normalizedQuery
-      ? this.values.filter((value) =>
-          value.toLocaleLowerCase().includes(normalizedQuery),
-        )
-      : this.values;
-    this.listbox.innerHTML = "";
-
-    if (values.length === 0) {
-      const empty = document.createElement("div");
-      empty.className = "model-combobox-empty";
-      empty.textContent = state.modelOptions.length
+function createModelCombobox(input, field) {
+  return new window.FccModelCombobox(input, {
+    listboxId: `model-options-${field.key}`,
+    label: field.label,
+    values: () =>
+      field.type === "optional_model"
+        ? ["None", ...state.modelOptions]
+        : state.modelOptions,
+    emptyMessage: () =>
+      state.modelOptions.length
         ? "No matching models. You can still enter a custom slug."
-        : "No discovered models. Refresh models or enter a custom slug.";
-      this.listbox.appendChild(empty);
-      this.activeIndex = -1;
-      this.input.removeAttribute("aria-activedescendant");
-      return;
-    }
-
-    values.forEach((value, index) => {
-      const optionEl = document.createElement("div");
-      optionEl.className = "model-combobox-option";
-      optionEl.id = `${this.listbox.id}-option-${index}`;
-      optionEl.dataset.value = value;
-      optionEl.setAttribute("role", "option");
-      optionEl.textContent = value;
-      this.listbox.appendChild(optionEl);
-    });
-    const selectedIndex = values.indexOf(this.input.value);
-    this.setActive(selectedIndex >= 0 ? selectedIndex : 0, false);
-  }
-
-  setActive(index, scroll = true) {
-    const options = this.visibleOptions;
-    if (options.length === 0) return;
-    this.activeIndex = Math.max(0, Math.min(index, options.length - 1));
-    options.forEach((optionEl, optionIndex) => {
-      const active = optionIndex === this.activeIndex;
-      optionEl.classList.toggle("active", active);
-      optionEl.setAttribute("aria-selected", String(active));
-    });
-    const activeOption = options[this.activeIndex];
-    this.input.setAttribute("aria-activedescendant", activeOption.id);
-    if (scroll) activeOption.scrollIntoView({ block: "nearest" });
-  }
-
-  move(offset) {
-    const count = this.visibleOptions.length;
-    if (count) this.setActive((this.activeIndex + offset + count) % count);
-  }
-
-  select(value) {
-    this.input.value = value;
-    this.input.dispatchEvent(new Event("change", { bubbles: true }));
-    this.close();
-    this.input.focus();
-  }
-
-  handleKeydown(event) {
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      if (this.isOpen) {
-        this.move(event.key === "ArrowDown" ? 1 : -1);
-      } else {
-        this.open();
-        if (event.key === "ArrowUp") {
-          this.setActive(this.visibleOptions.length - 1);
-        }
-      }
-    } else if (this.isOpen && (event.key === "Home" || event.key === "End")) {
-      event.preventDefault();
-      this.setActive(event.key === "Home" ? 0 : this.visibleOptions.length - 1);
-    } else if (this.isOpen && event.key === "Enter") {
-      const active = this.visibleOptions[this.activeIndex];
-      if (active) {
-        event.preventDefault();
-        this.select(active.dataset.value);
-      }
-    } else if (this.isOpen && event.key === "Escape") {
-      event.preventDefault();
-      this.close();
-    } else if (this.isOpen && event.key === "Tab") {
-      this.close();
-    }
-  }
+        : "No discovered models. Refresh models or enter a custom slug.",
+    registry: state.modelComboboxes,
+  });
 }
 
 class ModelListEditor {
@@ -900,7 +736,7 @@ class ModelListEditor {
     this.addInput.autocomplete = "off";
     this.addInput.placeholder = "provider/model";
     this.addInput.disabled = field.locked;
-    const addCombobox = new ModelCombobox(this.addInput, {
+    const addCombobox = createModelCombobox(this.addInput, {
       ...field,
       key: `${field.key}-add`,
       label: "fallback model",

--- a/src/free_claude_code/api/admin_static/chat_sessions.css
+++ b/src/free_claude_code/api/admin_static/chat_sessions.css
@@ -57,11 +57,15 @@
 .chat-session-list,
 .chat-load-more,
 .chat-notice {
-  display: block;
   width: 100%;
   max-width: 920px;
   margin-left: auto;
   margin-right: auto;
+}
+
+.chat-search,
+.chat-load-more {
+  display: block;
 }
 
 .chat-search {
@@ -175,7 +179,7 @@
 }
 
 .chat-control select,
-.chat-model-filter {
+.chat-model-input {
   min-height: 38px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);
@@ -186,11 +190,21 @@
 }
 
 .chat-model-control {
-  grid-template-columns: minmax(110px, 160px) minmax(190px, 260px);
+  flex: 1 1 360px;
+  max-width: 520px;
 }
 
-.chat-model-control > span {
-  grid-column: 1 / -1;
+.chat-model-control .model-combobox input[type="text"] {
+  width: 100%;
+  padding-right: 44px;
+}
+
+.chat-model-control .model-combobox {
+  text-transform: none;
+}
+
+.chat-model-control .model-combobox-toggle {
+  height: 38px;
 }
 
 .chat-context-meter {
@@ -475,6 +489,10 @@
   .chat-context-meter {
     grid-column: 1 / -1;
   }
+
+  .chat-model-control {
+    max-width: none;
+  }
 }
 
 @media (max-width: 700px) {
@@ -507,12 +525,10 @@
     flex-basis: 100%;
   }
 
-  .chat-controls,
-  .chat-model-control {
+  .chat-controls {
     grid-template-columns: 1fr;
   }
 
-  .chat-model-control > span,
   .chat-model-control,
   .chat-context-meter {
     grid-column: auto;

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -26,6 +26,7 @@
     foreignPollTimer: null,
     serverOperationActive: false,
     eventChannel: null,
+    modelComboboxes: new Set(),
   };
 
   const root = () => document.getElementById("chatRoot");
@@ -120,11 +121,13 @@
   }
 
   function renderLoading() {
+    state.modelComboboxes.clear();
     const container = root();
     container.replaceChildren(node("div", "chat-empty", "Loading Chat Sessions…"));
   }
 
   function renderUnavailable() {
+    state.modelComboboxes.clear();
     const container = node("section", "chat-empty");
     container.append(
       node("h3", "", "Chat Sessions unavailable"),
@@ -150,6 +153,7 @@
   }
 
   function renderLibraryShell() {
+    state.modelComboboxes.clear();
     const header = node("header", "chat-library-header");
     const copy = node("div");
     copy.append(
@@ -329,6 +333,7 @@
   function renderSession({ followLatest = true, scrollTop = 0 } = {}) {
     const session = state.session;
     if (!session) return;
+    state.modelComboboxes.clear();
     const shell = node("div", "chat-session-shell");
     const header = renderSessionHeader(session);
     const notice = node("div", "chat-notice");
@@ -388,51 +393,35 @@
   }
 
   function renderModelControl(session) {
-    const group = node("label", "chat-control chat-model-control");
-    group.appendChild(node("span", "", "Model"));
-    const filter = node("input", "chat-model-filter");
-    filter.type = "search";
-    filter.placeholder = "Filter models";
-    filter.setAttribute("aria-label", "Filter models");
-    const select = node("select");
-    select.id = "chatModel";
-    select.setAttribute("aria-label", "Selected model");
-    fillModelOptions(select, "", session.model);
-    filter.addEventListener("input", () =>
-      fillModelOptions(select, filter.value, state.session.model),
-    );
-    select.addEventListener("change", () => updateSession({ model: select.value }));
-    group.append(filter, select);
+    const group = node("div", "chat-control chat-model-control");
+    const label = node("label", "", "Model");
+    label.htmlFor = "chatModel";
+    const input = node("input", "chat-model-input");
+    input.id = "chatModel";
+    input.type = "text";
+    input.autocomplete = "off";
+    input.value = session.model;
+    input.setAttribute("aria-label", "Selected model");
+    let committedModel = session.model;
+    const availableModels = () =>
+      (state.bootstrap?.models || []).map((option) => option.model_ref);
+    const combobox = new window.FccModelCombobox(input, {
+      listboxId: "chat-model-options",
+      label: "model",
+      values: availableModels,
+      emptyMessage: () =>
+        availableModels().length ? "No matching models." : "No models available.",
+      registry: state.modelComboboxes,
+      onSelect: (model) => {
+        committedModel = model;
+        void updateSession({ model });
+      },
+      onClose: () => {
+        input.value = committedModel;
+      },
+    });
+    group.append(label, combobox.element);
     return group;
-  }
-
-  function fillModelOptions(select, query, selected) {
-    const folded = query.trim().toLowerCase();
-    const matches = (state.bootstrap.models || []).filter(
-      (option) => !folded || option.model_ref.toLowerCase().includes(folded),
-    );
-    const groups = new Map();
-    matches.forEach((option) => {
-      if (!groups.has(option.provider_id)) groups.set(option.provider_id, []);
-      groups.get(option.provider_id).push(option);
-    });
-    select.replaceChildren();
-    if (!(state.bootstrap.models || []).some((item) => item.model_ref === selected)) {
-      const unavailable = node("option", "", `${selected} (Unavailable)`);
-      unavailable.value = selected;
-      select.appendChild(unavailable);
-    }
-    [...groups.keys()].sort().forEach((provider) => {
-      const group = document.createElement("optgroup");
-      group.label = provider;
-      groups.get(provider).forEach((option) => {
-        const item = node("option", "", option.model_id);
-        item.value = option.model_ref;
-        group.appendChild(item);
-      });
-      select.appendChild(group);
-    });
-    select.value = selected;
   }
 
   function renderReasoningControl(session) {
@@ -930,11 +919,13 @@
     stop.hidden = !state.operation;
     textarea.disabled = Boolean(state.operation);
     status.textContent = state.operation ? state.operation.status : blocked;
-    document.querySelectorAll(".chat-controls button, .chat-controls select").forEach(
-      (control) => {
+    document
+      .querySelectorAll(
+        ".chat-controls button, .chat-controls input, .chat-controls select",
+      )
+      .forEach((control) => {
         control.disabled = busy;
-      },
-    );
+      });
     if (compact) {
       compact.disabled = busy || !state.context?.can_compact;
     }
@@ -1271,4 +1262,12 @@
   }
 
   window.ChatSessions = { initialize, activate, refresh };
+
+  document.addEventListener("pointerdown", (event) => {
+    state.modelComboboxes.forEach((combobox) => {
+      if (combobox.isOpen && !combobox.element.contains(event.target)) {
+        combobox.close();
+      }
+    });
+  });
 })();

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -90,6 +90,7 @@
         </div>
       </footer>
     </div>
+    <script src="/admin/assets/__FCC_VERSION__/model_combobox.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/chat_sessions.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/admin.js"></script>
   </body>

--- a/src/free_claude_code/api/admin_static/model_combobox.js
+++ b/src/free_claude_code/api/admin_static/model_combobox.js
@@ -1,0 +1,194 @@
+(() => {
+  class FccModelCombobox {
+    constructor(
+      input,
+      {
+        listboxId,
+        label,
+        values,
+        emptyMessage,
+        registry,
+        onSelect = null,
+        onClose = null,
+      },
+    ) {
+      this.input = input;
+      this.getValues = values;
+      this.getEmptyMessage = emptyMessage;
+      this.registry = registry;
+      this.onSelect = onSelect;
+      this.onClose = onClose;
+      this.activeIndex = -1;
+      this.query = "";
+
+      this.element = document.createElement("div");
+      this.element.className = "model-combobox";
+      this.listbox = document.createElement("div");
+      this.listbox.className = "model-combobox-list";
+      this.listbox.id = listboxId;
+      this.listbox.setAttribute("role", "listbox");
+      this.listbox.hidden = true;
+      this.toggle = document.createElement("button");
+      this.toggle.type = "button";
+      this.toggle.className = "model-combobox-toggle";
+      this.toggle.disabled = input.disabled;
+      this.toggle.setAttribute("aria-label", `Show ${label} options`);
+
+      input.setAttribute("role", "combobox");
+      input.setAttribute("aria-autocomplete", "list");
+      input.setAttribute("aria-haspopup", "listbox");
+      for (const control of [input, this.toggle]) {
+        control.setAttribute("aria-controls", this.listbox.id);
+        control.setAttribute("aria-expanded", "false");
+      }
+
+      input.addEventListener("click", () => this.open());
+      input.addEventListener("input", () => this.open(input.value));
+      input.addEventListener("keydown", (event) => this.handleKeydown(event));
+      this.toggle.addEventListener("mousedown", (event) => event.preventDefault());
+      this.toggle.addEventListener("click", () => {
+        if (this.isOpen) this.close();
+        else this.open();
+        input.focus();
+      });
+      this.listbox.addEventListener("mousedown", (event) => event.preventDefault());
+      this.listbox.addEventListener("mousemove", (event) => {
+        const optionEl = event.target.closest('[role="option"]');
+        if (optionEl) this.setActive(this.visibleOptions.indexOf(optionEl));
+      });
+      this.listbox.addEventListener("click", (event) => {
+        const optionEl = event.target.closest('[role="option"]');
+        if (optionEl) this.select(optionEl.dataset.value);
+      });
+
+      this.element.append(input, this.toggle, this.listbox);
+      registry.add(this);
+    }
+
+    get isOpen() {
+      return this.element.classList.contains("open");
+    }
+
+    get visibleOptions() {
+      return Array.from(this.listbox.querySelectorAll('[role="option"]'));
+    }
+
+    open(query = "") {
+      if (this.input.disabled) return;
+      this.registry.forEach((combobox) => {
+        if (combobox !== this && combobox.isOpen) combobox.close();
+      });
+      this.render(query);
+      this.element.classList.add("open");
+      this.listbox.hidden = false;
+      this.setExpanded(true);
+    }
+
+    close() {
+      if (!this.isOpen) return;
+      this.element.classList.remove("open");
+      this.listbox.hidden = true;
+      this.activeIndex = -1;
+      this.input.removeAttribute("aria-activedescendant");
+      this.setExpanded(false);
+      if (this.onClose) this.onClose();
+    }
+
+    setExpanded(expanded) {
+      for (const control of [this.input, this.toggle]) {
+        control.setAttribute("aria-expanded", String(expanded));
+      }
+    }
+
+    render(query) {
+      this.query = query;
+      const normalizedQuery = query.trim().toLocaleLowerCase();
+      const allValues = this.getValues();
+      const values = normalizedQuery
+        ? allValues.filter((value) =>
+            value.toLocaleLowerCase().includes(normalizedQuery),
+          )
+        : allValues;
+      this.listbox.replaceChildren();
+
+      if (values.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "model-combobox-empty";
+        empty.textContent = this.getEmptyMessage();
+        this.listbox.appendChild(empty);
+        this.activeIndex = -1;
+        this.input.removeAttribute("aria-activedescendant");
+        return;
+      }
+
+      values.forEach((value, index) => {
+        const optionEl = document.createElement("div");
+        optionEl.className = "model-combobox-option";
+        optionEl.id = `${this.listbox.id}-option-${index}`;
+        optionEl.dataset.value = value;
+        optionEl.setAttribute("role", "option");
+        optionEl.textContent = value;
+        this.listbox.appendChild(optionEl);
+      });
+      const selectedIndex = values.indexOf(this.input.value);
+      this.setActive(selectedIndex >= 0 ? selectedIndex : 0, false);
+    }
+
+    setActive(index, scroll = true) {
+      const options = this.visibleOptions;
+      if (options.length === 0) return;
+      this.activeIndex = Math.max(0, Math.min(index, options.length - 1));
+      options.forEach((optionEl, optionIndex) => {
+        const active = optionIndex === this.activeIndex;
+        optionEl.classList.toggle("active", active);
+        optionEl.setAttribute("aria-selected", String(active));
+      });
+      const activeOption = options[this.activeIndex];
+      this.input.setAttribute("aria-activedescendant", activeOption.id);
+      if (scroll) activeOption.scrollIntoView({ block: "nearest" });
+    }
+
+    move(offset) {
+      const count = this.visibleOptions.length;
+      if (count) this.setActive((this.activeIndex + offset + count) % count);
+    }
+
+    select(value) {
+      this.input.value = value;
+      if (this.onSelect) this.onSelect(value);
+      this.input.dispatchEvent(new Event("change", { bubbles: true }));
+      this.close();
+      this.input.focus();
+    }
+
+    handleKeydown(event) {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        if (this.isOpen) {
+          this.move(event.key === "ArrowDown" ? 1 : -1);
+        } else {
+          this.open();
+          if (event.key === "ArrowUp") {
+            this.setActive(this.visibleOptions.length - 1);
+          }
+        }
+      } else if (this.isOpen && (event.key === "Home" || event.key === "End")) {
+        event.preventDefault();
+        this.setActive(event.key === "Home" ? 0 : this.visibleOptions.length - 1);
+      } else if (this.isOpen && event.key === "Enter") {
+        const active = this.visibleOptions[this.activeIndex];
+        if (active) {
+          event.preventDefault();
+          this.select(active.dataset.value);
+        }
+      } else if (this.isOpen && event.key === "Escape") {
+        event.preventDefault();
+        this.close();
+      } else if (this.isOpen && event.key === "Tab") {
+        this.close();
+      }
+    }
+  }
+
+  window.FccModelCombobox = FccModelCombobox;
+})();

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -107,6 +107,7 @@ def test_admin_page_uses_installed_version(monkeypatch, tmp_path):
     assert "<p>Server Control · v9.8.7</p>" in response.text
     assert 'href="/admin/assets/9.8.7/admin.css"' in response.text
     assert 'href="/admin/assets/9.8.7/chat_sessions.css"' in response.text
+    assert 'src="/admin/assets/9.8.7/model_combobox.js"' in response.text
     assert 'src="/admin/assets/9.8.7/chat_sessions.js"' in response.text
     assert 'src="/admin/assets/9.8.7/admin.js"' in response.text
     assert 'href="/admin/assets/admin.css"' not in response.text
@@ -122,6 +123,7 @@ def test_admin_page_uses_installed_version(monkeypatch, tmp_path):
         ("admin.js", "text/javascript"),
         ("chat_sessions.css", "text/css"),
         ("chat_sessions.js", "text/javascript"),
+        ("model_combobox.js", "text/javascript"),
     ),
 )
 def test_admin_versioned_assets_serve_packaged_files(
@@ -156,6 +158,7 @@ def test_admin_versioned_assets_serve_packaged_files(
         f"/admin/assets/{package_version()}/admin.js",
         f"/admin/assets/{package_version()}/chat_sessions.css",
         f"/admin/assets/{package_version()}/chat_sessions.js",
+        f"/admin/assets/{package_version()}/model_combobox.js",
         "/admin/api/config",
     ),
 )
@@ -424,23 +427,27 @@ def test_admin_static_model_combobox_owns_dropdown_and_search_behavior():
     script = Path("src/free_claude_code/api/admin_static/admin.js").read_text(
         encoding="utf-8"
     )
+    combobox_script = Path(
+        "src/free_claude_code/api/admin_static/model_combobox.js"
+    ).read_text(encoding="utf-8")
     styles = Path("src/free_claude_code/api/admin_static/admin.css").read_text(
         encoding="utf-8"
     )
 
     assert 'api("/admin/api/models" + (refresh ? "/refresh" : "")' in script
     assert 'field.type === "model" || field.type === "optional_model"' in script
-    assert 'input.setAttribute("role", "combobox")' in script
-    assert 'listbox.setAttribute("role", "listbox")' in script
-    assert 'toggle.className = "model-combobox-toggle"' in script
-    assert "class ModelCombobox" in script
-    assert 'input.addEventListener("click", () => this.open())' in script
-    assert "value.toLocaleLowerCase().includes(normalizedQuery)" in script
-    assert 'event.key === "ArrowDown" || event.key === "ArrowUp"' in script
-    assert "this.setActive(this.visibleOptions.length - 1)" in script
-    assert 'event.key === "Enter"' in script
-    assert 'event.key === "Escape"' in script
-    assert 'document.createElement("datalist")' not in script
+    assert "new window.FccModelCombobox" in script
+    assert 'input.setAttribute("role", "combobox")' in combobox_script
+    assert 'this.listbox.setAttribute("role", "listbox")' in combobox_script
+    assert 'this.toggle.className = "model-combobox-toggle"' in combobox_script
+    assert "class FccModelCombobox" in combobox_script
+    assert 'input.addEventListener("click", () => this.open())' in combobox_script
+    assert "value.toLocaleLowerCase().includes(normalizedQuery)" in combobox_script
+    assert 'event.key === "ArrowDown" || event.key === "ArrowUp"' in combobox_script
+    assert "this.setActive(this.visibleOptions.length - 1)" in combobox_script
+    assert 'event.key === "Enter"' in combobox_script
+    assert 'event.key === "Escape"' in combobox_script
+    assert 'document.createElement("datalist")' not in combobox_script
     assert ".model-combobox-list" in styles
     assert ".model-combobox-option.active" in styles
     assert styles.count("background-image: var(--dropdown-chevron)") == 2

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.1"
+version = "5.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Chat Sessions used a separate model filter and native selector instead of the searchable model picker already used elsewhere in the Admin UI. This made model selection inconsistent and took unnecessary space.

## Changes

| Before | After |
| --- | --- |
| Chat Sessions rendered separate filter and select controls. | Chat Sessions uses one searchable, keyboard-accessible model picker. |
| Model-picker behavior lived inside the configuration page script. | Shared model-picker behavior lives in one reusable Admin UI component. |
| Hidden chat notices could retain visible layout styling. | Hidden chat notices occupy no layout space. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change consolidates model selection into a shared searchable combobox for the Admin configuration and Chat Sessions interfaces, adds versioned delivery of the shared script, and updates related styling and coverage.

The rendered Chat Sessions flow was exercised with filtered mouse selection, Escape and blur cancellation, and keyboard selection. Each selected model update produced the expected single request, cancelled unmatched input restored the previously committed model without a request, and no browser runtime errors occurred. No defects were found.

Merge safety: safe to merge.
</details>


<h3>Confidence Score: 5/5</h3>

The updated Chat Sessions model picker behaved correctly across the rendered selection, cancellation, and keyboard interaction paths changed by this pull request.

Focused Chromium coverage verified model-update request counts, committed-value restoration after cancellation, keyboard selection, asset loading, and the absence of browser runtime errors. No findings remain.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the focused regression test e2e/test\_pr1624\_model\_combobox\_review.py with uv run pytest, and it passed (1 test).
- The test verified that filtered mouse selection sends exactly one PATCH, Escape/blur does not send a PATCH, and ArrowDown/Enter sends one additional PATCH, while there were no browser runtime errors.
- Before and after browser recordings and poster frames were captured to illustrate the UI change from the old two-control picker to the new shared searchable combobox.

<a href="https://app.greptile.com/trex/runs/21500634/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reuse searchable model picker in ch..."](https://github.com/alishahryar1/free-claude-code/commit/1607c738f766d5353c275cd78b7bfd91f00b6451) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58421978)</sub>

<!-- /greptile_comment -->