### PR TITLE
Keep Chat Sessions composer in viewport

### DIFF
--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -506,7 +506,7 @@ def test_manual_compaction_failure_remains_visible(
     expect(notice).to_have_text("summary provider failed")
 
 
-def test_terminal_refresh_preserves_reader_scroll_position(
+def test_long_transcript_keeps_composer_visible_and_preserves_reader_scroll_position(
     page: Page,
     admin_base_url: str,
 ) -> None:
@@ -514,16 +514,22 @@ def test_terminal_refresh_preserves_reader_scroll_position(
     long_message = "[slow]\n" + "\n".join(
         f"line {index}: keep reading here" for index in range(100)
     )
-    page.get_by_role("textbox", name="Message", exact=True).fill(long_message)
+    message = page.get_by_role("textbox", name="Message", exact=True)
+    message.fill(long_message)
     page.get_by_role("button", name="Send").click()
     expect(page.get_by_role("button", name="Stop")).to_be_visible()
     scroller = page.locator("#chatTranscript")
     assert scroller.evaluate("node => node.scrollHeight > node.clientHeight")
+    composer_is_fully_visible = message.evaluate(
+        "node => { const box = node.getBoundingClientRect(); "
+        "return box.top >= 0 && box.bottom <= window.innerHeight; }"
+    )
     scroller.evaluate("node => { node.scrollTop = 0; }")
 
     page.get_by_role("button", name="Stop").click()
 
     expect(page.get_by_role("button", name="Retry")).to_be_visible()
+    assert composer_is_fully_visible
     assert scroller.evaluate("node => node.scrollTop") < 10
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.2"
+version = "5.18.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/chat_sessions.css
+++ b/src/free_claude_code/api/admin_static/chat_sessions.css
@@ -118,6 +118,11 @@
 
 .chat-session-shell {
   display: grid;
+  grid-template-areas:
+    "header"
+    "notice"
+    "transcript"
+    "composer";
   grid-template-rows: auto auto minmax(0, 1fr) auto;
   position: relative;
   max-width: 1120px;
@@ -125,6 +130,7 @@
 }
 
 .chat-session-header {
+  grid-area: header;
   padding-bottom: 16px;
   border-bottom: 1px solid var(--line);
 }
@@ -227,6 +233,7 @@
 }
 
 .chat-notice {
+  grid-area: notice;
   margin-top: 12px;
   margin-bottom: 10px;
   border: 1px solid var(--line);
@@ -243,6 +250,7 @@
 }
 
 .chat-transcript {
+  grid-area: transcript;
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -367,6 +375,7 @@
 }
 
 .chat-composer {
+  grid-area: composer;
   border-top: 1px solid var(--line);
   background: var(--bg);
   padding: 16px max(12px, 7vw) 20px;

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.2"
+version = "5.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Hiding an empty Chat Sessions notice removed it from CSS Grid auto-placement. Long transcripts then occupied the wrong row and pushed most of the message composer below the viewport.

## Changes

| Before | After |
| --- | --- |
| Conditional notice visibility could shift transcript and composer rows. | Named grid areas keep every Chat Sessions region in its intended row. |
| Browser coverage only required the composer to intersect the viewport. | A long-transcript regression test requires the complete composer to remain visible. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update fixes the Chat Sessions layout so the header, notice, transcript, and composer retain fixed positions even when the notice is hidden. Chromium validation exercised a 160-line overflowing transcript while a response was running and after Stop exposed Retry: the composer and Message input remained within the viewport, and the transcript continued to scroll independently. The focused long-transcript browser test passed.
</details>


<h3>Confidence Score: 5/5</h3>

The layout change is safe to merge based on the exercised long-transcript browser flow.

The relevant browser behavior was tested at the viewport boundary that previously allowed the composer to be clipped, including both the active response and Stop-to-Retry states. No defects remain in the final findings.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- During the run, initial measurements showed the composer bottom at 721 and textarea bottom at 801 against a 720px viewport, indicating the composer was partly outside the viewport.
- After applying the variant, the measurements showed the composer bottom at 684 and textarea bottom at 617 while running, and after Stop/Retry they were 684 and 619, with the transcript overflow continuing and the notice staying hidden in all measured states.
- The run reached the maximum steps for this agent and evidence was saved locally, with no separate greptile artifact-upload tool available to perform the upload.
- Collected visual artifacts, including before and after layout images and videos, to support inspection of how the layout interacts with the viewport clipping.

<a href="https://app.greptile.com/trex/runs/21506909/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump version to 5.18.3"](https://github.com/alishahryar1/free-claude-code/commit/1c6460b96ab7204fa89ecdd9f90b881c553f8d2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58433350)</sub>

<!-- /greptile_comment -->