### PR TITLE
Refine Chat Sessions composer

### DIFF
--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -332,8 +332,12 @@ def test_chat_stop_then_retry_uses_one_operation_owner(
     page.get_by_role("textbox", name="Message", exact=True).fill("[slow] please answer")
     page.get_by_role("button", name="Send").click()
     expect(page.get_by_text("E2E answer")).to_be_visible()
-    page.get_by_role("button", name="Stop").click()
+    stop = page.get_by_role("button", name="Stop")
+    expect(stop).to_be_visible()
+    send_is_hidden = page.locator("#chatSend").is_hidden()
+    stop.click()
     expect(page.get_by_role("button", name="Retry")).to_be_visible()
+    assert send_is_hidden
 
     page.get_by_role("button", name="Retry").click()
     expect(page.get_by_role("button", name="Regenerate")).to_be_visible()

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -533,6 +533,61 @@ def test_long_transcript_keeps_composer_visible_and_preserves_reader_scroll_posi
     assert scroller.evaluate("node => node.scrollTop") < 10
 
 
+def test_chat_composer_is_one_compact_surface_and_grows_to_six_lines(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    page.set_viewport_size({"width": 1_258, "height": 566})
+    _new_chat(page, admin_base_url)
+    composer = page.locator(".chat-composer")
+    message = page.get_by_role("textbox", name="Message", exact=True)
+
+    surface = composer.evaluate(
+        """node => {
+            const box = node.getBoundingClientRect();
+            const textarea = node.querySelector("textarea").getBoundingClientRect();
+            const send = node.querySelector("#chatSend").getBoundingClientRect();
+            const surfaceStyle = getComputedStyle(node);
+            const textareaStyle = getComputedStyle(node.querySelector("textarea"));
+            return {
+                contained:
+                    textarea.left >= box.left && textarea.right <= box.right &&
+                    textarea.top >= box.top && textarea.bottom <= box.bottom &&
+                    send.left >= box.left && send.right <= box.right &&
+                    send.top >= box.top && send.bottom <= box.bottom,
+                surfaceBorder: surfaceStyle.borderLeftWidth,
+                textareaBorder: textareaStyle.borderLeftWidth,
+                bottomGap: window.innerHeight - box.bottom,
+            };
+        }"""
+    )
+    assert surface == {
+        "contained": True,
+        "surfaceBorder": "1px",
+        "textareaBorder": "0px",
+        "bottomGap": 16,
+    }
+
+    two_line_height = message.evaluate("node => node.getBoundingClientRect().height")
+    message.fill("one\ntwo\nthree\nfour")
+    four_line_height = message.evaluate("node => node.getBoundingClientRect().height")
+    message.fill("\n".join(f"line {index}" for index in range(6)))
+    six_line_height = message.evaluate("node => node.getBoundingClientRect().height")
+    six_line_overflow = message.evaluate("node => getComputedStyle(node).overflowY")
+    message.fill("\n".join(f"line {index}" for index in range(8)))
+    capped_height = message.evaluate("node => node.getBoundingClientRect().height")
+    overflow = message.evaluate("node => getComputedStyle(node).overflowY")
+    message.fill("short again")
+    reset_height = message.evaluate("node => node.getBoundingClientRect().height")
+
+    assert four_line_height > two_line_height
+    assert six_line_height > four_line_height
+    assert six_line_overflow == "hidden"
+    assert capped_height == six_line_height
+    assert overflow == "auto"
+    assert reset_height == two_line_height
+
+
 def test_chat_rename_prompt_and_delete(
     page: Page,
     admin_base_url: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.3"
+version = "5.18.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -64,6 +64,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   min-width: 320px;
@@ -583,10 +587,6 @@ textarea:focus-visible,
   padding: 6px;
 }
 
-.model-combobox-list[hidden] {
-  display: none;
-}
-
 .model-combobox-option {
   border-radius: var(--radius-sm);
   padding: 9px 10px;
@@ -738,10 +738,6 @@ textarea:focus-visible,
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.3);
-}
-
-.action-bar[hidden] {
-  display: none;
 }
 
 .action-meta {

--- a/src/free_claude_code/api/admin_static/chat_sessions.css
+++ b/src/free_claude_code/api/admin_static/chat_sessions.css
@@ -13,7 +13,7 @@
 }
 
 .chat-root {
-  padding: 36px 42px;
+  padding: 36px 42px 16px;
 }
 
 .chat-library-header,
@@ -376,25 +376,37 @@
 
 .chat-composer {
   grid-area: composer;
-  border-top: 1px solid var(--line);
-  background: var(--bg);
-  padding: 16px max(12px, 7vw) 20px;
+  margin: 8px max(12px, 7vw) 0;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: var(--input);
+  padding: 10px 12px 9px;
+}
+
+.chat-composer:focus-within {
+  border-color: var(--accent);
+  background: var(--input-focus);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
 }
 
 .chat-composer textarea {
   display: block;
   width: 100%;
+  min-height: calc(3em + 8px);
+  max-height: calc(9em + 8px);
   resize: none;
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius-lg);
-  background: var(--input);
-  padding: 13px 15px;
+  overflow-y: hidden;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 4px 2px;
   line-height: 1.5;
+  outline: none;
 }
 
 .chat-composer-actions {
   gap: 12px;
-  margin-top: 9px;
+  margin-top: 4px;
 }
 
 .chat-composer-status {
@@ -486,7 +498,7 @@
   }
 
   .chat-root {
-    padding: 24px 20px;
+    padding: 24px 20px 12px;
   }
 
   .chat-controls {
@@ -514,7 +526,7 @@
   }
 
   .chat-root {
-    padding: 16px 12px;
+    padding: 16px 12px 8px;
   }
 
   .chat-session-shell {
@@ -543,10 +555,14 @@
     grid-column: auto;
   }
 
-  .chat-transcript,
-  .chat-composer {
+  .chat-transcript {
     padding-left: 4px;
     padding-right: 4px;
+  }
+
+  .chat-composer {
+    margin-left: 4px;
+    margin-right: 4px;
   }
 }
 

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -473,7 +473,7 @@
     const wrapper = node("div", "chat-composer");
     const textarea = node("textarea");
     textarea.id = "chatComposer";
-    textarea.rows = 3;
+    textarea.rows = 2;
     textarea.placeholder = "Message this model";
     textarea.value = state.draft;
     textarea.setAttribute("aria-label", "Message");
@@ -501,6 +501,13 @@
     actions.append(status, send, stop);
     wrapper.append(textarea, actions);
     return wrapper;
+  }
+
+  function resizeComposer(textarea) {
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+    textarea.style.overflowY =
+      textarea.scrollHeight > textarea.clientHeight ? "auto" : "hidden";
   }
 
   function renderTranscript() {
@@ -907,6 +914,7 @@
     const compact = document.getElementById("chatCompact");
     const status = document.getElementById("chatComposerStatus");
     if (!textarea || !send || !stop || !status) return;
+    resizeComposer(textarea);
     const blocked = sendBlockReason();
     const latest = state.turns[state.turns.length - 1];
     const busy = Boolean(

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.3"
+version = "5.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Chat Sessions composer separated its text field and action row visually, left excessive space below short messages, and could not grow naturally for longer drafts. During generation, styled controls could also override the semantic `hidden` state and leave Send visible beside Stop.

## Changes

| Before | After |
| --- | --- |
| The textarea had its own border above a separate action strip. | One rounded composer surface contains the textarea and Send or Stop action. |
| The textarea stayed at three rows for every draft. | The textarea starts at two lines, grows through six lines, then scrolls internally. |
| Chat pages retained 36px of unused desktop space below the composer. | Responsive bottom spacing is reduced to 16px on desktop, 12px on tablets, and 8px on narrow screens. |
| CSS display rules could keep elements rendered despite `hidden`. | A shared Admin UI rule makes hidden controls leave layout, keeping Send and Stop mutually exclusive. |
| Rendered tests checked only that the textarea remained visible. | Playwright verifies surface containment, compact spacing, growth, overflow, shrinking, and Send/Stop exclusivity. |


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Chat Sessions composer now uses a compact unified input surface with responsive spacing and automatic textarea growth up to six lines. Browser coverage confirmed the composer grows while typing, scrolls internally after reaching its cap, shrinks after content is removed, and correctly swaps Send for Stop during an active request.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

Browser validation exercised the updated composer behavior and control visibility without reproducing a defect.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Chat Sessions composer tests were run in Chromium to exercise typing across six and eight lines, scrolling, and sending.
- The textarea height grew from 56px to 152px during multi-line input, stayed at 152px while eight lines enabled internal scrolling, and returned to 56px after content deletion.
- During the active send operation, the Send control was hidden with display: none while Stop remained visible.
- All focused composer tests and Send/Stop browser scenarios passed, confirming the updated sizing, overflow handling, shrinking, and control visibility.
- No security issue was observed in the captured scenarios; classification: not applicable.

<a href="https://app.greptile.com/trex/runs/21513061/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Honor hidden Admin controls"](https://github.com/alishahryar1/free-claude-code/commit/15f98f95bff59e11e5d3517811f9688dac34f381) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58444135)</sub>

<!-- /greptile_comment -->