### PR TITLE
Simplify Chat Sessions context meter

### DIFF
--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -123,7 +123,7 @@ def test_chat_model_picker_searches_and_selects_in_one_control(
     assert len(model_patches) == 1
 
 
-def test_chat_context_meter_shows_used_over_usable_input_capacity(
+def test_chat_context_meter_shows_used_over_advertised_context_window(
     page: Page,
     admin_base_url: str,
 ) -> None:
@@ -139,7 +139,7 @@ def test_chat_context_meter_shows_used_over_usable_input_capacity(
     page.get_by_role("textbox", name="Message", exact=True).fill("hello")
 
     meter = page.locator("#chatContextMeter")
-    expect(meter).to_have_text(re.compile(r"^Context: \d+% · \d+ / 81\.6K$"))
+    expect(meter).to_have_text(re.compile(r"^Context: \d+% · \d+ / 100K$"))
 
 
 def test_delayed_older_page_cannot_cross_into_another_chat(

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -123,6 +123,25 @@ def test_chat_model_picker_searches_and_selects_in_one_control(
     assert len(model_patches) == 1
 
 
+def test_chat_context_meter_shows_used_over_usable_input_capacity(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _new_chat(page, admin_base_url)
+    _select_model(page, "open_router/vendor/model-b")
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH"
+            and "/admin/api/chat/sessions/" in response.url
+        )
+    ):
+        page.get_by_label("Thinking").select_option("high")
+    page.get_by_role("textbox", name="Message", exact=True).fill("hello")
+
+    meter = page.locator("#chatContextMeter")
+    expect(meter).to_have_text(re.compile(r"^Context: \d+% · \d+ / 81\.6K$"))
+
+
 def test_delayed_older_page_cannot_cross_into_another_chat(
     page: Page,
     admin_base_url: str,

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -13,6 +13,28 @@ def _new_chat(page: Page, admin_base_url: str) -> None:
     expect(page.get_by_role("textbox", name="Message", exact=True)).to_be_visible()
 
 
+def _hold_next_chat_operation(page: Page, action: str) -> None:
+    page.evaluate(
+        """
+        action => {
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (...args) => {
+            if (!String(args[0]).endsWith(`/${action}`)) {
+              return originalFetch(...args);
+            }
+            window.fetch = originalFetch;
+            return new Promise((resolve, reject) => {
+              window.__releaseHeldChatRequest = () => {
+                originalFetch(...args).then(resolve, reject);
+              };
+            });
+          };
+        }
+        """,
+        action,
+    )
+
+
 def _select_model(page: Page, model_ref: str) -> None:
     model = page.get_by_role("combobox", name="Selected model")
     model.click()
@@ -260,6 +282,38 @@ def test_chat_streams_thinking_and_persists_answer(
     page.reload()
     expect(page.get_by_text("E2E answer")).to_be_visible()
     expect(page.get_by_text("hello", exact=True)).to_be_visible()
+
+
+def test_generation_status_occupies_the_answer_slot(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _new_chat(page, admin_base_url)
+    message = page.get_by_role("textbox", name="Message", exact=True)
+
+    _hold_next_chat_operation(page, "send")
+    message.fill("answer in place")
+    page.get_by_role("button", name="Send").click()
+
+    assistant = page.locator(".assistant-message")
+    expect(assistant).to_have_count(1)
+    expect(assistant.get_by_text("Thinking…", exact=True)).to_be_visible()
+    expect(page.locator("#chatComposerStatus")).to_be_empty()
+
+    page.evaluate("() => { window.__releaseHeldChatRequest(); }")
+    expect(page.get_by_role("button", name="Regenerate")).to_be_visible()
+
+    _hold_next_chat_operation(page, "regenerate")
+    page.get_by_role("button", name="Regenerate").click()
+
+    expect(assistant).to_have_count(1)
+    expect(assistant.get_by_text("Thinking…", exact=True)).to_be_visible()
+    expect(assistant).not_to_contain_text("E2E answer")
+    expect(page.locator("#chatComposerStatus")).to_be_empty()
+
+    page.evaluate("() => { window.__releaseHeldChatRequest(); }")
+    expect(page.get_by_role("button", name="Regenerate")).to_be_visible()
+    expect(assistant).to_contain_text("E2E answer")
 
 
 def test_fragmented_stream_does_not_rebuild_transcript_per_delta(

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -665,6 +665,34 @@ def test_chat_composer_is_one_compact_surface_and_grows_to_six_lines(
     assert reset_height == two_line_height
 
 
+def test_chat_uses_desktop_width_with_one_responsive_gutter(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    page.set_viewport_size({"width": 1_600, "height": 900})
+    _new_chat(page, admin_base_url)
+
+    layout = page.locator(".chat-session-shell").evaluate(
+        """shell => {
+            const main = document.querySelector(".main").getBoundingClientRect();
+            const shellBox = shell.getBoundingClientRect();
+            const composer = shell.querySelector(".chat-composer").getBoundingClientRect();
+            return {
+                shellShare: shellBox.width / main.width,
+                composerShare: composer.width / main.width,
+                leftGutter: composer.left - shellBox.left,
+                rightGutter: shellBox.right - composer.right,
+            };
+        }"""
+    )
+
+    assert layout["shellShare"] > 0.9
+    assert layout["composerShare"] > 0.84
+    assert layout["leftGutter"] <= 40.5
+    assert layout["rightGutter"] <= 40.5
+    assert abs(layout["leftGutter"] - layout["rightGutter"]) < 0.5
+
+
 def test_chat_rename_prompt_and_delete(
     page: Page,
     admin_base_url: str,

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -687,9 +687,9 @@ def test_chat_uses_desktop_width_with_one_responsive_gutter(
     )
 
     assert layout["shellShare"] > 0.9
-    assert layout["composerShare"] > 0.84
-    assert layout["leftGutter"] <= 40.5
-    assert layout["rightGutter"] <= 40.5
+    assert layout["composerShare"] > 0.9
+    assert layout["leftGutter"] < 0.5
+    assert layout["rightGutter"] < 0.5
     assert abs(layout["leftGutter"] - layout["rightGutter"]) < 0.5
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.4"
+version = "5.18.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/chat_sessions.css
+++ b/src/free_claude_code/api/admin_static/chat_sessions.css
@@ -13,7 +13,7 @@
 }
 
 .chat-root {
-  padding: 36px 42px 16px;
+  padding: 36px clamp(16px, 3vw, 42px) 16px;
 }
 
 .chat-library-header,
@@ -252,7 +252,7 @@
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 24px clamp(12px, 3vw, 40px) 30px;
+  padding: 24px 0 30px;
   scroll-behavior: auto;
 }
 
@@ -374,7 +374,7 @@
 
 .chat-composer {
   grid-area: composer;
-  margin: 8px clamp(12px, 3vw, 40px) 0;
+  margin: 8px 0 0;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-lg);
   background: var(--input);
@@ -554,13 +554,13 @@
   }
 
   .chat-transcript {
-    padding-left: 4px;
-    padding-right: 4px;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .chat-composer {
-    margin-left: 4px;
-    margin-right: 4px;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 

--- a/src/free_claude_code/api/admin_static/chat_sessions.css
+++ b/src/free_claude_code/api/admin_static/chat_sessions.css
@@ -125,8 +125,6 @@
     "composer";
   grid-template-rows: auto auto minmax(0, 1fr) auto;
   position: relative;
-  max-width: 1120px;
-  margin: 0 auto;
 }
 
 .chat-session-header {
@@ -254,12 +252,12 @@
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 24px max(12px, 7vw) 30px;
+  padding: 24px clamp(12px, 3vw, 40px) 30px;
   scroll-behavior: auto;
 }
 
 .chat-message {
-  max-width: 780px;
+  max-width: 1120px;
   margin: 0 auto 22px;
   border-radius: var(--radius-lg);
 }
@@ -345,7 +343,7 @@
 }
 
 .chat-compaction {
-  max-width: 780px;
+  max-width: 1120px;
   margin: 0 auto 24px;
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
@@ -376,7 +374,7 @@
 
 .chat-composer {
   grid-area: composer;
-  margin: 8px max(12px, 7vw) 0;
+  margin: 8px clamp(12px, 3vw, 40px) 0;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-lg);
   background: var(--input);

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -529,7 +529,8 @@
     state.turns.forEach((turn, index) => {
       scroller.appendChild(renderUserMessage(turn));
       const replacingLatest =
-        index === state.turns.length - 1 && state.operation?.action === "retry";
+        index === state.turns.length - 1 &&
+        ["retry", "regenerate"].includes(state.operation?.action);
       if (!replacingLatest) scroller.appendChild(renderAssistantMessage(turn));
       if (
         state.compaction &&
@@ -550,7 +551,7 @@
     if (state.compaction && !dividerRendered) {
       scroller.insertBefore(renderCompaction(), scroller.firstChild);
     }
-    if (state.operation?.segments?.length) {
+    if (state.operation && state.operation.action !== "compact") {
       scroller.appendChild(renderLiveAssistant(state.operation));
     }
   }
@@ -619,6 +620,15 @@
   function renderLiveAssistant(operation) {
     const message = node("article", "chat-message assistant-message live-message");
     message.appendChild(node("div", "chat-message-label", "Assistant"));
+    if (!operation.segments.length || operation.status !== "Thinking…") {
+      const status = node(
+        "p",
+        "chat-muted chat-operation-status",
+        operation.status,
+      );
+      status.setAttribute("aria-live", "polite");
+      message.appendChild(status);
+    }
     operation.segments.forEach((segment, ordinal) => {
       const content = node("div", "chat-message-plain");
       content.dataset.liveSegment = String(ordinal);
@@ -927,7 +937,12 @@
     send.hidden = Boolean(state.operation);
     stop.hidden = !state.operation;
     textarea.disabled = Boolean(state.operation);
-    status.textContent = state.operation ? state.operation.status : blocked;
+    status.textContent =
+      state.operation?.action === "compact"
+        ? state.operation.status
+        : state.operation
+          ? ""
+          : blocked;
     document
       .querySelectorAll(
         ".chat-controls button, .chat-controls input, .chat-controls select",
@@ -1168,7 +1183,7 @@
     const operation = state.operation;
     if (!operation) return;
     operation.status = "Stopping…";
-    refreshComposerState();
+    renderOperationStructure(operation);
     try {
       await state.api(`/admin/api/chat/sessions/${operation.sessionId}/stop`, {
         method: "POST",

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -465,7 +465,7 @@
       return;
     }
     const percent = Math.round((context.usage_ratio || 0) * 100);
-    element.textContent = `Context: ${percent}% · ${formatCount(context.estimated_input_tokens)} input + ${formatCount(context.completion_tokens)} output`;
+    element.textContent = `Context: ${percent}% · ${formatCount(context.estimated_input_tokens)} / ${formatCount(context.usable_input_tokens)}`;
     element.className = `chat-context-meter${percent >= 85 ? " warn" : ""}`;
   }
 
@@ -1262,7 +1262,10 @@
   }
 
   function formatCount(value) {
-    return new Intl.NumberFormat(undefined, { notation: "compact" }).format(value);
+    return new Intl.NumberFormat(undefined, {
+      notation: "compact",
+      maximumFractionDigits: 1,
+    }).format(value);
   }
 
   function capitalize(value) {

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -465,7 +465,7 @@
       return;
     }
     const percent = Math.round((context.usage_ratio || 0) * 100);
-    element.textContent = `Context: ${percent}% · ${formatCount(context.estimated_input_tokens)} / ${formatCount(context.usable_input_tokens)}`;
+    element.textContent = `Context: ${percent}% · ${formatCount(context.estimated_input_tokens)} / ${formatCount(context.context_window_tokens)}`;
     element.className = `chat-context-meter${percent >= 85 ? " warn" : ""}`;
   }
 
@@ -898,8 +898,9 @@
     }
     if (state.contextError) return state.contextError;
     if (
-      state.context?.usage_ratio !== null &&
-      state.context?.usage_ratio > 1 &&
+      state.context?.usable_input_tokens !== null &&
+      state.context?.estimated_input_tokens >
+        state.context?.usable_input_tokens &&
       !state.context?.can_compact
     ) {
       return "This message exceeds the model context";

--- a/src/free_claude_code/application/chat/context.py
+++ b/src/free_claude_code/application/chat/context.py
@@ -364,14 +364,16 @@ class ChatContextBuilder:
             raise ChatValidationError(
                 "The selected model's output reserve leaves no input context."
             )
-        ratio = input_tokens / usable
+        ratio = input_tokens / context_window
         return ChatContextEstimate(
             estimated_input_tokens=input_tokens,
             completion_tokens=output_limit,
             context_window_tokens=context_window,
             usable_input_tokens=usable,
             usage_ratio=ratio,
-            should_auto_compact=ratio > _AUTO_COMPACT_RATIO and can_compact,
+            should_auto_compact=(
+                can_compact and (ratio > _AUTO_COMPACT_RATIO or input_tokens > usable)
+            ),
             can_compact=can_compact,
         )
 

--- a/tests/application/test_chat_context.py
+++ b/tests/application/test_chat_context.py
@@ -262,6 +262,67 @@ def test_known_context_reserves_input_when_output_cap_is_unknown():
 
     assert prepared.routed.request.max_tokens == 15_360
     assert prepared.estimate.usable_input_tokens == 1_024
+    assert prepared.estimate.usage_ratio == (
+        prepared.estimate.estimated_input_tokens / 16_384
+    )
+
+
+def test_auto_compaction_uses_visible_context_ratio_with_fit_safety():
+    transcript = _transcript(reasoning=ChatReasoning.OFF)
+    transcript = ChatTranscript(
+        session=transcript.session,
+        turns=transcript.turns * 2,
+        compaction=None,
+    )
+    builder = ChatContextBuilder(
+        FakeRuntime(
+            configured=ProviderModelInfo(
+                "model",
+                context_window_tokens=100_000,
+                max_output_tokens=4_096,
+            )
+        )
+    )
+
+    below = builder.prepare(
+        transcript,
+        system_prompt="",
+        draft="token " * 83_000,
+    ).estimate
+    above = builder.prepare(
+        transcript,
+        system_prompt="",
+        draft="token " * 86_000,
+    ).estimate
+
+    assert below.usable_input_tokens is not None
+    assert below.usage_ratio is not None and below.usage_ratio < 0.85
+    assert below.estimated_input_tokens / below.usable_input_tokens > 0.85
+    assert below.should_auto_compact is False
+    assert above.usage_ratio is not None and above.usage_ratio > 0.85
+    assert above.should_auto_compact is True
+
+    tight = (
+        ChatContextBuilder(
+            FakeRuntime(
+                configured=ProviderModelInfo(
+                    "model",
+                    context_window_tokens=40_000,
+                    max_output_tokens=20_000,
+                )
+            )
+        )
+        .prepare(
+            transcript,
+            system_prompt="",
+            draft="token " * 24_000,
+        )
+        .estimate
+    )
+    assert tight.usable_input_tokens is not None
+    assert tight.usage_ratio is not None and tight.usage_ratio < 0.85
+    assert tight.estimated_input_tokens > tight.usable_input_tokens
+    assert tight.should_auto_compact is True
 
 
 def test_existing_compaction_replaces_only_covered_context():

--- a/tests/application/test_chat_service.py
+++ b/tests/application/test_chat_service.py
@@ -1408,6 +1408,7 @@ async def test_send_auto_compacts_without_removing_original_turns(tmp_path: Path
             "4e542b5b-8386-46d2-8643-67a523c216f0",
             "86293f1e-2899-47b9-8590-27450fc00989",
             "dd945983-b49c-4749-83b3-3051d3998bc2",
+            "3a4f8108-2cf4-45c1-b412-56a8551e7f8b",
         )
         for operation_id in operation_ids:
             stream = await service.send(
@@ -1430,7 +1431,7 @@ async def test_send_auto_compacts_without_removing_original_turns(tmp_path: Path
         transcript = await store.get_transcript(session.id)
         assert "compaction.started" in events
         assert "compaction.completed" in events
-        assert len(transcript.turns) == 4
+        assert len(transcript.turns) == 5
         assert transcript.compaction is not None
         assert transcript.compaction.covered_through_sequence >= 1
     finally:
@@ -1454,6 +1455,7 @@ async def test_stop_during_auto_compaction_commit_keeps_checkpoint_without_new_t
             "d3bb405e-245f-4dbf-bbdd-b72508926367",
             "d4fec5fe-a75a-4752-8c33-f51fd105774f",
             "79cd9bd9-df33-4ed4-8a5c-5e34770a30f7",
+            "71ac3c34-7be1-4c26-b69e-f6f7193fa353",
         ):
             stream = await service.send(
                 session.id,
@@ -1499,7 +1501,7 @@ async def test_stop_during_auto_compaction_commit_keeps_checkpoint_without_new_t
         transcript = await store.get_transcript(session.id)
         assert events[-2:] == ["compaction.completed", "turn.stopped"]
         assert transcript.compaction is not None
-        assert len(transcript.turns) == 3
+        assert len(transcript.turns) == 4
     finally:
         if blocker is not None:
             blocker.rollback()

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.4"
+version = "5.18.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Chat Sessions context meter treated a fixed response reservation as visible usage, while active generation status lived in the composer instead of the answer position. Before the first stream segment there was no assistant response slot, and Regenerate kept the old answer visible while constructing its replacement.

## Changes

| Before | After |
| --- | --- |
| The meter displayed derived usable capacity and measured its percentage against that value. | The meter displays current context usage against the model's advertised context window, with normal auto-compaction aligned to the visible 85% threshold. |
| Send showed `Thinking…` in the composer until content arrived. | Send immediately creates one assistant response slot and shows `Thinking…` there until streamed content replaces it. |
| Regenerate retained the old answer and could append a second live assistant block. | Retry and Regenerate replace the latest answer in place throughout generation. |
| Browser coverage did not exercise the pre-first-token state. | A deterministic Playwright test pauses Send and Regenerate before their requests begin and verifies one stable answer slot. |





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Chat Sessions now displays context usage against the selected model’s advertised context window while preserving safe generation limits. The interface keeps streaming, retry, and regeneration activity in a single assistant-answer position and expands the desktop chat layout.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains in the validated Chat Sessions behavior.

No accepted blocking findings remain. Context-meter display, send, cancellation, retry, regeneration, delayed acknowledgement, and cross-tab recovery behaved as intended.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran focused ChatContextBuilder contracts covering safe usable-input fallback and advertised-window compaction accounting; both tests passed.
- Ran the Playwright model-selection flow and observed the context meter render a 100K denominator for the advertised model window.
- Executed browser flows for in-place send and regeneration, delayed send acknowledgement, cancellation to retry, and cross-tab regeneration recovery; all flows completed without duplicate assistant-answer slots.
- Verified backend context safety and UI meter rendering via chat-context-01-before and chat-context-02-after, confirming the 100K denominator in the UI.
- Validated chat lifecycle paths: chat-lifecycle-01-before exercises one in-place assistant slot during send/regenerate with delayed acknowledgement; chat-lifecycle-02-after covers cancellation to Retry, successful Retry, and cross-tab regeneration recovery.

<a href="https://app.greptile.com/trex/runs/21516966/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["Use one Chat Sessions page gutter"](https://github.com/alishahryar1/free-claude-code/commit/d8c3d84c9e2387df83016a85ba6328f2f40f99cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58451725)</sub>

<!-- /greptile_comment -->