### PR TITLE
Speed up Chat Sessions loading

### DIFF
--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -66,6 +66,44 @@ def test_chat_navigation_create_and_browser_history(
     expect(page.get_by_role("button", name="New chat", exact=True)).to_be_visible()
 
 
+def test_chat_routes_render_while_provider_health_is_still_loading(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    session = page.request.post(
+        f"{admin_base_url}/admin/api/chat/sessions",
+        data={},
+    ).json()
+    routes = (
+        ("/admin/chat", page.get_by_role("button", name="New chat", exact=True)),
+        (
+            f"/admin/chat/{session['id']}",
+            page.get_by_role("textbox", name="Message", exact=True),
+        ),
+    )
+    page.add_init_script(
+        """
+        const originalFetch = window.fetch.bind(window);
+        window.__localProviderStatusRequested = false;
+        window.fetch = (...args) => {
+          const input = args[0];
+          const value = typeof input === "string" ? input : input.url;
+          const url = new URL(value, window.location.href);
+          if (url.pathname === "/admin/api/providers/local-status") {
+            window.__localProviderStatusRequested = true;
+            return new Promise(() => {});
+          }
+          return originalFetch(...args);
+        };
+        """
+    )
+
+    for path, ready in routes:
+        page.goto(f"{admin_base_url}{path}")
+        expect(ready).to_be_visible()
+        assert page.evaluate("window.__localProviderStatusRequested === true")
+
+
 def test_model_refresh_updates_chat_bootstrap(
     page: Page,
     admin_base_url: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.5"
+version = "5.18.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -1,5 +1,6 @@
 """Local admin UI routes and APIs."""
 
+import asyncio
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -128,10 +129,16 @@ async def admin_status(
 async def local_provider_status(request: Request):
     require_loopback_admin(request)
     values = {key: entry.value or "" for key, entry in load_value_state().items()}
-    checks = []
-    for provider_id, path in LOCAL_PROVIDER_PATHS.items():
-        base_url = _local_provider_url(provider_id, values)
-        checks.append(await _check_local_provider(provider_id, base_url, path))
+    checks = await asyncio.gather(
+        *(
+            _check_local_provider(
+                provider_id,
+                _local_provider_url(provider_id, values),
+                path,
+            )
+            for provider_id, path in LOCAL_PROVIDER_PATHS.items()
+        )
+    )
     return {"providers": checks}
 
 

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -100,12 +100,12 @@ async function load() {
   renderProviders(config.provider_status);
   renderSections(config.sections, config.fields);
   byId("configPath").textContent = config.paths.managed;
-  await refreshConnectedAccounts();
-  await hydrateModelOptions();
-  await refreshLocalStatus();
-  if (window.ChatSessions) {
-    await window.ChatSessions.initialize(api);
-  }
+  await Promise.all([
+    refreshConnectedAccounts(),
+    hydrateModelOptions(),
+    refreshLocalStatus(),
+    window.ChatSessions ? window.ChatSessions.initialize(api) : Promise.resolve(),
+  ]);
   updateDirtyState();
   showMessage("");
 }
@@ -993,7 +993,7 @@ async function loadModelOptions(refresh = false) {
     method: refresh ? "POST" : "GET",
   });
   setModelOptions(result.models);
-  if (window.ChatSessions) await window.ChatSessions.refresh();
+  if (refresh && window.ChatSessions) await window.ChatSessions.refresh();
   return result;
 }
 

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -63,8 +63,6 @@
     state.initialized = true;
     if (chatIsVisible()) {
       await activate(window.location.pathname);
-    } else {
-      await refresh();
     }
   }
 

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -1839,6 +1840,43 @@ def test_admin_local_provider_status_reports_reachable(monkeypatch, tmp_path):
     assert response.status_code == 200
     providers = response.json()["providers"]
     assert {provider["status"] for provider in providers} == {"reachable"}
+
+
+def test_admin_local_provider_status_checks_all_providers_concurrently(
+    monkeypatch, tmp_path
+):
+    _set_home(monkeypatch, tmp_path)
+    _clear_process_config(monkeypatch)
+    app = create_test_app()
+    calls = 0
+    active = 0
+    max_active = 0
+
+    class SlowAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url: str):
+            nonlocal active, calls, max_active
+            calls += 1
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return httpx.Response(200, json={"data": []})
+
+    with patch("free_claude_code.api.admin_routes.httpx.AsyncClient", SlowAsyncClient):
+        response = _local_client(app).get("/admin/api/providers/local-status")
+
+    assert response.status_code == 200
+    assert calls == 3
+    assert max_active == 3
 
 
 def test_admin_config_exposes_structured_provider_configuration_targets(

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.5"
+version = "5.18.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Chat Sessions and direct chat links waited for unrelated local-provider health probes before rendering. Offline local providers could delay usable chat pages by roughly 4.6 seconds.

## Changes

| Before | After |
| --- | --- |
| Admin hydration ran connected-account, model, and local-provider requests sequentially before Chat Sessions initialized. | Independent Admin hydration and Chat Sessions initialization run concurrently. |
| Three local-provider health probes could consume three consecutive 1.5-second timeouts. | Local-provider health probes run concurrently and preserve their existing result order. |
| Hidden Chat Sessions eagerly loaded its bootstrap data on every Admin visit. | Chat Sessions loads its bootstrap data only when its view is active. |
| Initial model hydration could trigger an extra Chat Sessions refresh. | Only an explicit model-catalog refresh reloads Chat Sessions metadata. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change improves Admin responsiveness by starting independent account, model, local-provider, and Chat Sessions initialization work concurrently. Chat Sessions bootstrap data is now loaded only when the chat view is active, while an explicit model-catalog refresh continues to update the active chat model list. Browser validation exercised chat list and session routes with local-provider status deliberately left unresolved, verified that non-chat Admin startup does not fetch Chat Sessions bootstrap data, and verified that model refresh reloads the active chat bootstrap. No defects were found.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge based on focused browser validation of the affected Admin and Chat Sessions startup flows.

An isolated ASGI application and Chromium browser run completed all targeted flows successfully: chat remains usable during a stalled provider-status request, non-chat startup defers chat bootstrap, and model refresh updates active chat data.

**Files Needing Attention:** None identified; the relevant behavior in admin.js, chat_sessions.js, and admin_routes.py was exercised.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the end-to-end startup validation for Admin and Chat flows against the isolated uvicorn/ASGI stack; the run produced 3 passed in 2.18 seconds.
- Verified that no production files were modified during the validation run.
- Uploaded the focused startup validation script that deterministically exercises all three Admin/Chat startup flows.
- Uploaded logs capturing baseline startup behavior before changes and the final validation results to support review.

<a href="https://app.greptile.com/trex/runs/21519684/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Speed up Chat Sessions loading"](https://github.com/alishahryar1/free-claude-code/commit/26376289d20bddf3f4ed2cf57cfdc17a8edb3ee9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58461369)</sub>

<!-- /greptile_comment -->