### PR TITLE
Align chat messages to transcript edges

### DIFF
--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -709,17 +709,27 @@ def test_chat_uses_desktop_width_with_one_responsive_gutter(
 ) -> None:
     page.set_viewport_size({"width": 1_600, "height": 900})
     _new_chat(page, admin_base_url)
+    page.get_by_role("textbox", name="Message", exact=True).fill("hello")
+    page.get_by_role("button", name="Send").click()
+    expect(page.get_by_text("E2E answer")).to_be_visible()
+    page.reload()
+    expect(page.get_by_text("E2E answer")).to_be_visible()
 
     layout = page.locator(".chat-session-shell").evaluate(
         """shell => {
             const main = document.querySelector(".main").getBoundingClientRect();
             const shellBox = shell.getBoundingClientRect();
             const composer = shell.querySelector(".chat-composer").getBoundingClientRect();
+            const transcript = shell.querySelector(".chat-transcript").getBoundingClientRect();
+            const user = shell.querySelector(".user-message").getBoundingClientRect();
+            const assistant = shell.querySelector(".assistant-message").getBoundingClientRect();
             return {
                 shellShare: shellBox.width / main.width,
                 composerShare: composer.width / main.width,
                 leftGutter: composer.left - shellBox.left,
                 rightGutter: shellBox.right - composer.right,
+                userRightGap: transcript.right - user.right,
+                assistantLeftGap: assistant.left - transcript.left,
             };
         }"""
     )
@@ -729,6 +739,8 @@ def test_chat_uses_desktop_width_with_one_responsive_gutter(
     assert layout["leftGutter"] < 0.5
     assert layout["rightGutter"] < 0.5
     assert abs(layout["leftGutter"] - layout["rightGutter"]) < 0.5
+    assert abs(layout["userRightGap"]) < 0.5
+    assert abs(layout["assistantLeftGap"]) < 0.5
 
 
 def test_chat_rename_prompt_and_delete(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.6"
+version = "5.18.7"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/chat_sessions.css
+++ b/src/free_claude_code/api/admin_static/chat_sessions.css
@@ -258,7 +258,7 @@
 
 .chat-message {
   max-width: 1120px;
-  margin: 0 auto 22px;
+  margin: 0 0 22px;
   border-radius: var(--radius-lg);
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.6"
+version = "5.18.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Chat messages inherited automatic horizontal margins. User bubbles and assistant responses were centered instead of aligning to opposite transcript edges.

## Changes

| Before | After |
| --- | --- |
| User bubbles retained automatic margins on both sides. | User bubbles align to the transcript's right edge. |
| Assistant responses were centered inside their readable-width column. | Assistant responses align to the transcript's left edge. |
| Wide-layout coverage checked only the shell and composer. | Wide-layout coverage also checks both message-edge alignments. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change places assistant messages at the transcript’s left edge while preserving right-aligned user messages, and updates the project version metadata.

Chromium browser coverage created a chat, sent a message, reloaded the persisted conversation, and confirmed the assistant response remains flush left while the user message remains flush right at a 1600px desktop viewport. No defects were found.
</details>


<h3>Confidence Score: 5/5</h3>

The reviewed chat-layout behavior is safe to merge based on the exercised desktop create, send, persistence, and reload flow.

No review findings remain. Browser validation directly verified the intended message-edge alignment after a persisted conversation reload.

**Files Needing Attention:** No files need further attention; the layout stylesheet and its matching browser test were exercised.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the parent Chromium revision and the PR 1630 change at a 1600px desktop viewport.
- Created a chat, sent a message, reloaded the page, and confirmed the persisted assistant response rendered in both flows.
- Validated the updated browser assertion passed, with the assistant message flush to the transcript's left edge and the user message flush to the right edge.
- Compared the pre-change baseline with the post-change behavior using the captured videos and images, and verified the logs show the commands and exit code 0 were preserved.

<a href="https://app.greptile.com/trex/runs/21521722/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Align chat messages to transcript edges"](https://github.com/alishahryar1/free-claude-code/commit/66e241d5816f5d4fff621a6db030a75cc7debd58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58467619)</sub>

<!-- /greptile_comment -->