### PR TITLE
Show persisted chat failures only once

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -179,6 +179,18 @@ class _ModelListingProvider(BaseProvider):
                 },
             )
             return
+        if not summary and "[fail-turn]" in user_content:
+            yield format_sse_event(
+                "error",
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "api_error",
+                        "message": "E2E provider failed",
+                    },
+                },
+            )
+            return
         if slow:
             await asyncio.Event().wait()
         yield format_sse_event(

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -406,6 +406,22 @@ def test_rejected_send_preserves_draft_after_stale_revision(
     expect(page.locator("#chatNotice")).to_contain_text("changed in another tab")
 
 
+def test_provider_failure_appears_only_in_assistant_reply(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _new_chat(page, admin_base_url)
+    page.get_by_role("textbox", name="Message", exact=True).fill("[fail-turn]")
+    page.get_by_role("button", name="Send").click()
+
+    expect(page.get_by_role("button", name="Retry")).to_be_visible()
+    expect(
+        page.locator(".assistant-message .chat-generation-status.failed")
+    ).to_have_text("E2E provider failed")
+    expect(page.locator("#chatNotice")).to_be_hidden()
+    expect(page.get_by_text("E2E provider failed", exact=True)).to_have_count(1)
+
+
 def test_committed_send_does_not_restore_draft_when_stream_ack_is_lost(
     page: Page,
     admin_base_url: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.7"
+version = "5.18.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -1026,7 +1026,12 @@
       cancelOperationRender(operation);
       if (state.operation === operation) state.operation = null;
       if (state.session?.id === operation.sessionId) await reloadSession();
-      if (failure) setNotice(failure.message, "error");
+      const persistedFailure = state.turns[state.turns.length - 1]?.generation;
+      const failureIsInline =
+        operation.failureMessage &&
+        persistedFailure?.status === "failed" &&
+        persistedFailure.error_message === operation.failureMessage;
+      if (failure && !failureIsInline) setNotice(failure.message, "error");
     }
   }
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.7"
+version = "5.18.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Persisted provider failures appeared twice in Chat Sessions: once in the assistant reply and again in the page-level notice.

## Changes

| Before | After |
| --- | --- |
| A persisted failed generation also populated the global error notice. | A persisted failed generation appears only in its assistant reply. |
| Rejected requests and non-turn failures used the global notice. | Rejected requests and non-turn failures continue using the global notice. |
| Browser coverage did not detect duplicate provider errors. | Browser coverage requires exactly one visible persisted provider error. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change prevents a persisted provider failure from being shown both in the assistant reply and in the page-level notice. Browser validation confirmed that a matching persisted failure is shown once inline with a Retry action and no global notice, while a distinct compaction failure remains visible in the page-level notice. The related Chat Sessions browser suite completed successfully.
</details>


<h3>Confidence Score: 5/5</h3>

The Chat Sessions failure presentation behaves as intended in the exercised browser flows and is safe to merge.

No defects remain in the final review. Validation exercised both the duplicate-error suppression path and the separate failure path that must retain a global notice, including a before-and-after browser comparison.

**Files Needing Attention:** No files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused Playwright validation was run comparing the parent commit with the updated implementation in an isolated local environment, and it showed the parent had a persisted provider failure both inline and in the page-level notice while the updated run had one inline failure with Retry and the page-level notice hidden; the validation also confirmed that an unconfirmed compaction failure remains visible as a page-level notice and it completed in 3.58 seconds.
- Before recording shows the pre-change duplicate presentation: the same persisted provider failure appears inline and in the page-level notice.
- After recording shows the changed behavior: the persisted provider failure has one inline error and Retry with the page-level notice hidden, and the targeted validation also asserted the separate global compaction-failure notice.
- The focused validation after-change completed in 3.58 seconds.

<a href="https://app.greptile.com/trex/runs/21523025/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Show persisted chat failures only once"](https://github.com/alishahryar1/free-claude-code/commit/8d429482e2cd6499fe3d4f7bb6486c9e6591d369) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58470074)</sub>

<!-- /greptile_comment -->