### PR TITLE
Show failed chat regenerations inline

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -108,7 +108,13 @@ class _ModelListingProvider(BaseProvider):
         )
         fragmented = "[fragmented]" in user_content
         self._slow_used = self._slow_used or slow
-        text = "Earlier details retained." if summary else "E2E answer"
+        failed_regeneration = "[fail-regenerate]" in user_content and attempt > 1
+        if summary:
+            text = "Earlier details retained."
+        elif failed_regeneration:
+            text = "Partial replacement"
+        else:
+            text = "E2E answer"
         frames = [
             format_sse_event(
                 "message_start",
@@ -179,7 +185,7 @@ class _ModelListingProvider(BaseProvider):
                 },
             )
             return
-        if not summary and "[fail-turn]" in user_content:
+        if not summary and ("[fail-turn]" in user_content or failed_regeneration):
             yield format_sse_event(
                 "error",
                 {

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -587,6 +587,27 @@ def test_regeneration_is_visible_and_recovers_in_another_tab(
         other.close()
 
 
+def test_failed_regeneration_replaces_the_reply_without_a_page_notice(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _new_chat(page, admin_base_url)
+    page.get_by_role("textbox", name="Message", exact=True).fill("[fail-regenerate]")
+    page.get_by_role("button", name="Send").click()
+    expect(page.get_by_text("E2E answer", exact=True)).to_be_visible()
+
+    page.get_by_role("button", name="Regenerate").click()
+
+    expect(page.get_by_role("button", name="Retry")).to_be_visible()
+    expect(page.get_by_text("E2E answer", exact=True)).to_have_count(0)
+    expect(page.get_by_text("Partial replacement", exact=True)).to_be_visible()
+    expect(
+        page.locator(".assistant-message .chat-generation-status.failed")
+    ).to_have_text("E2E provider failed")
+    expect(page.locator("#chatNotice")).to_be_hidden()
+    expect(page.get_by_text("E2E provider failed", exact=True)).to_have_count(1)
+
+
 def test_manual_compaction_is_visible_and_recovers_in_another_tab(
     page: Page,
     admin_base_url: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.8"
+version = "5.18.9"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/application/chat/ports.py
+++ b/src/free_claude_code/application/chat/ports.py
@@ -134,7 +134,13 @@ class ChatStorePort(Protocol):
     async def discard_generation(self, generation_id: str) -> None: ...
 
     async def finish_regeneration(
-        self, generation_id: str, *, stop_reason: str | None
+        self,
+        generation_id: str,
+        *,
+        status: GenerationStatus,
+        stop_reason: str | None,
+        error_code: str | None,
+        error_message: str | None,
     ) -> ChatSession: ...
 
     async def upsert_compaction(

--- a/src/free_claude_code/application/chat/service.py
+++ b/src/free_claude_code/application/chat/service.py
@@ -862,7 +862,11 @@ class ChatService:
             await self._flush_terminal_segments(active)
             if active.regeneration:
                 return await self._finish_regeneration(
-                    generation_id, stop_reason=stop_reason
+                    generation_id,
+                    status=GenerationStatus.COMPLETED,
+                    stop_reason=stop_reason,
+                    error_code=None,
+                    error_message=None,
                 )
             return await self._finish_generation(
                 generation_id,
@@ -1313,10 +1317,16 @@ class ChatService:
             )
         if active.generation_id is not None:
             try:
+                await self._flush_terminal_segments(active)
                 if active.regeneration:
-                    await self._discard_regeneration(active.generation_id)
+                    await self._finish_regeneration(
+                        active.generation_id,
+                        status=GenerationStatus.FAILED,
+                        stop_reason=None,
+                        error_code=code,
+                        error_message=message,
+                    )
                 else:
-                    await self._flush_terminal_segments(active)
                     await self._finish_generation(
                         active.generation_id,
                         status=GenerationStatus.FAILED,
@@ -1371,14 +1381,20 @@ class ChatService:
         self,
         generation_id: str,
         *,
+        status: GenerationStatus,
         stop_reason: str | None,
+        error_code: str | None,
+        error_message: str | None,
     ) -> ChatSession:
         return await self._retry_terminal_persistence(
             lambda: self._store.finish_regeneration(
                 generation_id,
+                status=status,
                 stop_reason=stop_reason,
+                error_code=error_code,
+                error_message=error_message,
             ),
-            label=f"regeneration_id={generation_id} status=completed",
+            label=f"regeneration_id={generation_id} status={status.value}",
         )
 
     async def _discard_regeneration(self, generation_id: str) -> None:

--- a/src/free_claude_code/runtime/chat_sqlite.py
+++ b/src/free_claude_code/runtime/chat_sqlite.py
@@ -655,8 +655,17 @@ class SQLiteChatStore:
         await self._run(operation)
 
     async def finish_regeneration(
-        self, generation_id: str, *, stop_reason: str | None
+        self,
+        generation_id: str,
+        *,
+        status: GenerationStatus,
+        stop_reason: str | None,
+        error_code: str | None,
+        error_message: str | None,
     ) -> ChatSession:
+        if status not in {GenerationStatus.COMPLETED, GenerationStatus.FAILED}:
+            raise ValueError("A regeneration must finish as Completed or Failed.")
+
         def operation(connection: sqlite3.Connection) -> ChatSession:
             connection.execute("BEGIN IMMEDIATE")
             row = connection.execute(
@@ -673,7 +682,7 @@ class SQLiteChatStore:
                 raise ChatConflictError("Staged regeneration is unavailable.")
             session_id = _row_str(row, "session_id")
             if bool(_row_int(row, "visible")):
-                if _row_str(row, "status") == GenerationStatus.COMPLETED.value:
+                if _row_str(row, "status") == status.value:
                     connection.rollback()
                     return self._get_session(connection, session_id)
                 connection.rollback()
@@ -690,13 +699,15 @@ class SQLiteChatStore:
             connection.execute(
                 """
                 UPDATE chat_generations
-                SET visible = 1, status = ?, stop_reason = ?, error_code = NULL,
-                    error_message = NULL, finished_at = ?
+                SET visible = 1, status = ?, stop_reason = ?, error_code = ?,
+                    error_message = ?, finished_at = ?
                 WHERE id = ? AND visible = 0 AND status = ?
                 """,
                 (
-                    GenerationStatus.COMPLETED.value,
+                    status.value,
                     stop_reason,
+                    error_code,
+                    error_message,
                     now,
                     generation_id,
                     GenerationStatus.RUNNING.value,

--- a/tests/application/test_chat_service.py
+++ b/tests/application/test_chat_service.py
@@ -405,6 +405,76 @@ async def test_regeneration_retries_an_ambiguous_terminal_commit(
 
 
 @pytest.mark.asyncio
+async def test_failed_regeneration_replaces_original_with_failed_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider = FakeChatProvider()
+    service, _runtime, store = await _service(tmp_path, provider)
+    try:
+        session = await service.create_session()
+        initial = await service.send(
+            session.id,
+            expected_revision=session.revision,
+            operation_id="01355e92-06c4-4820-b80a-fc8e0dff2553",
+            text="replace this answer",
+        )
+        assert (await _drain(initial))[-1] == "turn.completed"
+        before = await store.get_transcript(session.id)
+        original_id = before.turns[0].generation.id
+
+        async def failing_stream(*args, **kwargs):
+            del args, kwargs
+            yield "".join(
+                (
+                    format_sse_event(
+                        "message_start",
+                        {"type": "message_start", "message": {"content": []}},
+                    ),
+                    format_sse_event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": 0,
+                            "content_block": {"type": "text", "text": ""},
+                        },
+                    ),
+                    format_sse_event(
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {"type": "text_delta", "text": "partial"},
+                        },
+                    ),
+                    format_sse_event(
+                        "error",
+                        {
+                            "type": "error",
+                            "error": {"message": "provider failed"},
+                        },
+                    ),
+                )
+            )
+
+        monkeypatch.setattr(provider, "stream_messages", failing_stream)
+        replacement = await service.regenerate(
+            session.id,
+            expected_revision=before.session.revision,
+            operation_id="810b8d15-adab-4df6-9084-3189ca534d09",
+        )
+
+        assert (await _drain(replacement))[-1] == "turn.failed"
+        generation = (await store.get_transcript(session.id)).turns[0].generation
+        assert generation.id != original_id
+        assert generation.status is GenerationStatus.FAILED
+        assert generation.error_message == "provider failed"
+        assert generation.segments[-1].text == "partial"
+    finally:
+        await service.close()
+
+
+@pytest.mark.asyncio
 async def test_stopped_regeneration_retries_an_ambiguous_discard(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/runtime/test_chat_sqlite.py
+++ b/tests/runtime/test_chat_sqlite.py
@@ -367,12 +367,90 @@ async def test_regeneration_keeps_visible_answer_until_atomic_swap(tmp_path: Pat
                 error_code=None,
                 error_message=None,
             )
-        await store.finish_regeneration(replacement_id, stop_reason="end_turn")
+        await store.finish_regeneration(
+            replacement_id,
+            status=GenerationStatus.COMPLETED,
+            stop_reason="end_turn",
+            error_code=None,
+            error_message=None,
+        )
         visible = (await store.get_transcript(session.id)).turns[0].generation
         assert visible.id == replacement_id
         assert visible.status is GenerationStatus.COMPLETED
         assert visible.stop_reason == "end_turn"
         assert visible.segments[0].text == "replacement"
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_regeneration_atomically_replaces_visible_answer(tmp_path: Path):
+    store = _store(tmp_path)
+    await store.start()
+    try:
+        session = await store.create_session(
+            session_id=_id(), model="groq/model", reasoning=ChatReasoning.OFF
+        )
+        original_id = _id()
+        await store.begin_send(
+            session.id,
+            expected_revision=session.revision,
+            turn_id=_id(),
+            generation_id=original_id,
+            operation_id=_id(),
+            user_text="hello",
+            requested_model=session.model,
+            reasoning=session.reasoning,
+            effective_output_limit=1024,
+        )
+        session = await store.finish_generation(
+            original_id,
+            status=GenerationStatus.COMPLETED,
+            stop_reason="end_turn",
+            error_code=None,
+            error_message=None,
+        )
+        replacement_id = _id()
+        await store.begin_regenerate(
+            session.id,
+            expected_revision=session.revision,
+            generation_id=replacement_id,
+            requested_model=session.model,
+            reasoning=session.reasoning,
+            effective_output_limit=1024,
+        )
+        await store.replace_generation_segments(
+            replacement_id, (ChatSegment(0, SegmentKind.TEXT, "partial"),)
+        )
+
+        finished = await store.finish_regeneration(
+            replacement_id,
+            status=GenerationStatus.FAILED,
+            stop_reason=None,
+            error_code="provider_error",
+            error_message="provider failed",
+        )
+        repeated = await store.finish_regeneration(
+            replacement_id,
+            status=GenerationStatus.FAILED,
+            stop_reason=None,
+            error_code="provider_error",
+            error_message="provider failed",
+        )
+
+        visible = (await store.get_transcript(session.id)).turns[0].generation
+        assert repeated.revision == finished.revision
+        assert visible.id == replacement_id
+        assert visible.status is GenerationStatus.FAILED
+        assert visible.error_code == "provider_error"
+        assert visible.error_message == "provider failed"
+        assert visible.segments[0].text == "partial"
+        with closing(sqlite3.connect(tmp_path / "chat.db")) as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM chat_generations WHERE turn_id = "
+                "(SELECT turn_id FROM chat_generations WHERE id = ?)",
+                (replacement_id,),
+            ).fetchone() == (1,)
     finally:
         await store.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.8"
+version = "5.18.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

A failed regeneration discarded its replacement and restored the previous answer, so the provider error appeared as a page-level notice instead of replacing the reply inline.

## Changes

| Before | After |
| --- | --- |
| Successful regenerations atomically replaced the reply, while failed regenerations discarded the staged replacement. | Completed and failed regenerations atomically replace the reply with their terminal state and streamed segments. |
| Stopping a regeneration and provider failure shared the same discard path. | Stopping still restores the previous answer, while provider failure persists an inline failed answer with Retry. |
| The browser could show a regeneration failure only as a page-level notice. | The browser shows the persisted failure once in the assistant reply and keeps the page-level notice hidden. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update makes failed chat regenerations replace the prior assistant reply with the streamed partial replacement and its provider error, while keeping the error attached to the reply instead of showing a duplicate page notice.

The focused browser flow was exercised against both the previous commit and this change. The previous behavior retained the old answer and surfaced the provider error at page level; the updated behavior removed the old answer, displayed the partial replacement with its failed state and Retry action, and showed no page-level notice. No defects were found.
</details>


<h3>Confidence Score: 5/5</h3>

The focused end-to-end regeneration failure flow behaves correctly and is safe to merge.

Browser validation exercised the provider-error path after partial streamed output and confirmed that the visible transcript and error presentation match the intended behavior.

**Files Needing Attention:** No files need follow-up attention. The exercised path covers the regeneration persistence changes in `src/free_claude_code/application/chat/service.py`, `src/free_claude_code/runtime/chat_sqlite.py`, and the Chat Sessions browser flow.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused browser test against the parent commit; it exited with code 1 and displayed the old E2E answer and E2E provider failed as page-level text.
- Ran the focused browser test against HEAD; it passed in 1.05 seconds, the old answer was removed, the partial replacement appeared as a failed reply with Retry, the provider error appeared once on that reply, and the page-level notice remained hidden.
- Compared UI states before and after HEAD and confirmed the HEAD flow without a page-level notice, and noted that no repository code changes were made—only command-output artifacts were created.
- Uploaded logs documenting both the failing parent commit run and the passing HEAD run to support review.

<a href="https://app.greptile.com/trex/runs/21523948/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Persist failed chat regenerations"](https://github.com/alishahryar1/free-claude-code/commit/b06e4f6c00a6981992d01a0198c53a2a5049d25c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58471782)</sub>

<!-- /greptile_comment -->