### PR TITLE
Recover Groq requests that exceed TPM reservation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.9"
+version = "5.18.10"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/admission.py
+++ b/src/free_claude_code/providers/admission.py
@@ -88,6 +88,7 @@ class ProviderExecution:
         self._attempts_started = 0
         self._active_claim: _AttemptClaim | None = None
         self._last_failure: Exception | None = None
+        self._corrections_used: set[str] = set()
         self._state = ProviderExecutionState.ACTIVE
 
     @property
@@ -126,6 +127,14 @@ class ProviderExecution:
     @property
     def last_failure(self) -> Exception | None:
         return self._last_failure
+
+    def correction_was_used(self, kind: str) -> bool:
+        """Return whether this logical execution already used ``kind``."""
+        return kind in self._corrections_used
+
+    def record_correction(self, kind: str) -> None:
+        """Remember one deterministic correction for this logical execution."""
+        self._corrections_used.add(kind)
 
     async def open_attempt(
         self,

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -14,7 +14,10 @@ from free_claude_code.core.reasoning import (
     ReasoningEffort,
     ReasoningPolicy,
 )
-from free_claude_code.providers.admission import ProviderAdmissionController
+from free_claude_code.providers.admission import (
+    ProviderAdmissionController,
+    ProviderExecution,
+)
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_chat import (
     NamedEffortReasoning,
@@ -141,16 +144,16 @@ class GroqProvider(OpenAIChatProvider):
         self,
         error: Exception,
         body: dict[str, Any],
-        used_retry_kinds: set[str],
+        execution: ProviderExecution,
     ) -> dict[str, Any] | None:
-        retry_body = super()._next_create_retry_body(error, body, used_retry_kinds)
-        if retry_body is not None or "groq_tpm" in used_retry_kinds:
+        retry_body = super()._next_create_retry_body(error, body, execution)
+        if retry_body is not None or execution.correction_was_used("groq_tpm"):
             return retry_body
 
         correction = correct_tpm_completion_budget(error, body)
         if correction is None:
             return None
-        used_retry_kinds.add("groq_tpm")
+        execution.record_correction("groq_tpm")
         logger.warning(
             "GROQ_STREAM: reducing max_completion_tokens after TPM rejection "
             "limit={} requested={} previous={} corrected={}",

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -25,6 +25,8 @@ from free_claude_code.providers.openai_chat import (
     validate_extra_body_does_not_override_reasoning_fields,
 )
 
+from .tpm import correct_tpm_completion_budget
+
 _GROQ_EFFORTS = (
     (ReasoningEffort.MINIMAL, "low"),
     (ReasoningEffort.LOW, "low"),
@@ -134,6 +136,30 @@ class GroqProvider(OpenAIChatProvider):
         )
         logger.warning("GROQ_STREAM: {} after upstream rejection", action)
         return retry_body
+
+    def _next_create_retry_body(
+        self,
+        error: Exception,
+        body: dict[str, Any],
+        used_retry_kinds: set[str],
+    ) -> dict[str, Any] | None:
+        retry_body = super()._next_create_retry_body(error, body, used_retry_kinds)
+        if retry_body is not None or "groq_tpm" in used_retry_kinds:
+            return retry_body
+
+        correction = correct_tpm_completion_budget(error, body)
+        if correction is None:
+            return None
+        used_retry_kinds.add("groq_tpm")
+        logger.warning(
+            "GROQ_STREAM: reducing max_completion_tokens after TPM rejection "
+            "limit={} requested={} previous={} corrected={}",
+            correction.limit,
+            correction.requested,
+            correction.previous_max_completion_tokens,
+            correction.corrected_max_completion_tokens,
+        )
+        return correction.body
 
 
 def _parse_reasoning_vocabulary(error: Exception) -> frozenset[str] | None:

--- a/src/free_claude_code/providers/groq/tpm.py
+++ b/src/free_claude_code/providers/groq/tpm.py
@@ -1,0 +1,147 @@
+"""Strict recovery for Groq requests above an account TPM ceiling."""
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+_TPM_LIMIT_HEADER = "x-ratelimit-limit-tokens"
+_TPM_CLAUSE = re.compile(
+    r"tokens\s+per\s+minute\s*\(\s*tpm\s*\)\s*:\s*"
+    r"limit\s+([0-9]+)\s*,\s*requested\s+([0-9]+)",
+    re.IGNORECASE,
+)
+_OUTPUT_FIELDS = frozenset({"max_completion_tokens", "max_tokens"})
+
+
+@dataclass(frozen=True, slots=True)
+class GroqTpmCorrection:
+    """Validated request-local reduction derived from one Groq rejection."""
+
+    body: dict[str, object]
+    limit: int
+    requested: int
+    previous_max_completion_tokens: int
+    corrected_max_completion_tokens: int
+
+
+def correct_tpm_completion_budget(
+    error: Exception,
+    body: Mapping[str, object],
+) -> GroqTpmCorrection | None:
+    """Clone ``body`` with Groq's reported TPM overage removed from its cap."""
+    if _status_code(error) != 413:
+        return None
+
+    detail = _error_detail(getattr(error, "body", None))
+    if detail is None:
+        return None
+    if _normalized_marker(detail.get("type")) != "tokens":
+        return None
+    if _normalized_marker(detail.get("code")) != "rate_limit_exceeded":
+        return None
+
+    message = detail.get("message")
+    if not isinstance(message, str):
+        return None
+    matches = tuple(_TPM_CLAUSE.finditer(message))
+    if len(matches) != 1:
+        return None
+    limit = int(matches[0].group(1))
+    requested = int(matches[0].group(2))
+    if limit <= 0 or requested <= limit:
+        return None
+    if not _header_agrees(error, limit):
+        return None
+
+    previous = body.get("max_completion_tokens")
+    if not isinstance(previous, int) or isinstance(previous, bool) or previous <= 0:
+        return None
+    extra_body = body.get("extra_body")
+    if isinstance(extra_body, Mapping) and any(
+        field in extra_body for field in _OUTPUT_FIELDS
+    ):
+        return None
+
+    corrected = previous - (requested - limit)
+    if corrected <= 0 or corrected >= previous:
+        return None
+
+    corrected_body = dict(body)
+    corrected_body["max_completion_tokens"] = corrected
+    return GroqTpmCorrection(
+        body=corrected_body,
+        limit=limit,
+        requested=requested,
+        previous_max_completion_tokens=previous,
+        corrected_max_completion_tokens=corrected,
+    )
+
+
+def _status_code(error: Exception) -> int | None:
+    status = getattr(error, "status_code", None)
+    if isinstance(status, int) and not isinstance(status, bool):
+        return status
+    response = getattr(error, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) and not isinstance(status, bool) else None
+
+
+def _error_detail(value: object) -> Mapping[object, object] | None:
+    if not isinstance(value, Mapping):
+        return None
+    if _has_detail_shape(value):
+        return value
+    if len(value) != 1:
+        return None
+    nested = value.get("error")
+    if not isinstance(nested, Mapping) or not _has_detail_shape(nested):
+        return None
+    return nested
+
+
+def _has_detail_shape(value: Mapping[object, object]) -> bool:
+    return all(field in value for field in ("message", "type", "code"))
+
+
+def _normalized_marker(value: object) -> str | None:
+    return value.strip().lower() if isinstance(value, str) else None
+
+
+def _header_agrees(error: Exception, limit: int) -> bool:
+    values = _header_values(error, _TPM_LIMIT_HEADER)
+    if values is None:
+        return False
+    if not values:
+        return True
+    if len(values) != 1:
+        return False
+    value = values[0].strip()
+    return value.isascii() and value.isdecimal() and int(value) == limit
+
+
+def _header_values(error: Exception, name: str) -> tuple[str, ...] | None:
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return ()
+
+    get_list = getattr(headers, "get_list", None)
+    if callable(get_list):
+        try:
+            values = get_list(name)
+        except Exception:
+            return None
+        if isinstance(values, list) and all(isinstance(value, str) for value in values):
+            return tuple(values)
+        return None
+
+    if not isinstance(headers, Mapping):
+        return None
+    values = [
+        value
+        for key, value in headers.items()
+        if isinstance(key, str) and key.lower() == name
+    ]
+    if not all(isinstance(value, str) for value in values):
+        return None
+    return tuple(values)

--- a/src/free_claude_code/providers/groq/tpm.py
+++ b/src/free_claude_code/providers/groq/tpm.py
@@ -6,9 +6,12 @@ from dataclasses import dataclass
 
 _TPM_LIMIT_HEADER = "x-ratelimit-limit-tokens"
 _MAX_DECIMAL_DIGITS = 19
+_TPM_PREFIX = r"tokens\s+per\s+minute\s*\(\s*tpm\s*\)\s*:\s*"
+_TPM_MARKER = re.compile(_TPM_PREFIX, re.IGNORECASE)
 _TPM_CLAUSE = re.compile(
-    r"tokens\s+per\s+minute\s*\(\s*tpm\s*\)\s*:\s*"
-    r"limit\s+([0-9]+)\s*,\s*requested\s+([0-9]+)(?=\s*(?:[,;]|$))",
+    _TPM_PREFIX
+    + r"limit\s+([0-9]+)\s*,\s*requested\s+([0-9]+)"
+    + r"(?=\s*(?:,\s+(?![0-9])|$))",
     re.IGNORECASE,
 )
 _OUTPUT_FIELDS = frozenset({"max_completion_tokens", "max_tokens"})
@@ -43,6 +46,8 @@ def correct_tpm_completion_budget(
 
     message = detail.get("message")
     if not isinstance(message, str):
+        return None
+    if sum(1 for _ in _TPM_MARKER.finditer(message)) != 1:
         return None
     matches = tuple(_TPM_CLAUSE.finditer(message))
     if len(matches) != 1:

--- a/src/free_claude_code/providers/groq/tpm.py
+++ b/src/free_claude_code/providers/groq/tpm.py
@@ -46,8 +46,10 @@ def correct_tpm_completion_budget(
     matches = tuple(_TPM_CLAUSE.finditer(message))
     if len(matches) != 1:
         return None
-    limit = int(matches[0].group(1))
-    requested = int(matches[0].group(2))
+    limit = _ascii_decimal(matches[0].group(1))
+    requested = _ascii_decimal(matches[0].group(2))
+    if limit is None or requested is None:
+        return None
     if limit <= 0 or requested <= limit:
         return None
     if not _header_agrees(error, limit):
@@ -115,8 +117,16 @@ def _header_agrees(error: Exception, limit: int) -> bool:
         return True
     if len(values) != 1:
         return False
-    value = values[0].strip()
-    return value.isascii() and value.isdecimal() and int(value) == limit
+    return _ascii_decimal(values[0].strip()) == limit
+
+
+def _ascii_decimal(value: str) -> int | None:
+    if not value.isascii() or not value.isdecimal():
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def _header_values(error: Exception, name: str) -> tuple[str, ...] | None:

--- a/src/free_claude_code/providers/groq/tpm.py
+++ b/src/free_claude_code/providers/groq/tpm.py
@@ -5,9 +5,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 _TPM_LIMIT_HEADER = "x-ratelimit-limit-tokens"
+_MAX_DECIMAL_DIGITS = 19
 _TPM_CLAUSE = re.compile(
     r"tokens\s+per\s+minute\s*\(\s*tpm\s*\)\s*:\s*"
-    r"limit\s+([0-9]+)\s*,\s*requested\s+([0-9]+)",
+    r"limit\s+([0-9]+)\s*,\s*requested\s+([0-9]+)(?=\s*(?:[,;]|$))",
     re.IGNORECASE,
 )
 _OUTPUT_FIELDS = frozenset({"max_completion_tokens", "max_tokens"})
@@ -121,7 +122,7 @@ def _header_agrees(error: Exception, limit: int) -> bool:
 
 
 def _ascii_decimal(value: str) -> int | None:
-    if not value.isascii() or not value.isdecimal():
+    if not value.isascii() or not value.isdecimal() or len(value) > _MAX_DECIMAL_DIGITS:
         return None
     try:
         return int(value)

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -119,6 +119,32 @@ class _CollectedRecoveryOutput:
     accepted_body: dict[str, Any]
 
 
+def _carry_request_corrections(
+    base_body: dict[str, Any],
+    attempted_body: dict[str, Any],
+    accepted_body: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply only accepted retry changes to a fresh recovery request base."""
+    if attempted_body == accepted_body:
+        return base_body
+
+    updated = dict(base_body)
+    for key in attempted_body.keys() | accepted_body.keys():
+        attempted_has_key = key in attempted_body
+        accepted_has_key = key in accepted_body
+        if (
+            attempted_has_key
+            and accepted_has_key
+            and attempted_body[key] == accepted_body[key]
+        ):
+            continue
+        if accepted_has_key:
+            updated[key] = accepted_body[key]
+        else:
+            updated.pop(key, None)
+    return updated
+
+
 def _iter_visible_text_events(
     output: ChatStreamOutput,
     text: str,
@@ -1500,6 +1526,7 @@ class _OpenAIChatStreamRunner:
     ) -> list[str] | None:
         schemas = self._tool_schemas
         events: list[str] = []
+        repair_base_body = body
         for tool_index, state in output.started_tool_states():
             block = output.tool_block_for_tool_index(tool_index)
             emitted_prefix = block.content if block is not None else ""
@@ -1518,7 +1545,7 @@ class _OpenAIChatStreamRunner:
 
             schema = schemas.get(state.name)
             recovery_body = make_tool_repair_body(
-                body,
+                repair_base_body,
                 tool_name=state.name,
                 prefix=repair_prefix,
                 input_schema=schema.input_schema if schema is not None else None,
@@ -1527,11 +1554,17 @@ class _OpenAIChatStreamRunner:
             repair_attempt = 0
             while execution.can_attempt:
                 repair_attempt += 1
+                attempted_body = recovery_body
                 recovered = await self._collect_recovery_output(
-                    recovery_body,
+                    attempted_body,
                     include_reasoning=False,
                     execution=execution,
                     operation_kind=ProviderOperationKind.TOOL_REPAIR,
+                )
+                repair_base_body = _carry_request_corrections(
+                    repair_base_body,
+                    attempted_body,
+                    recovered.accepted_body,
                 )
                 recovery_body = recovered.accepted_body
                 repair = accept_tool_json_repair(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -116,6 +116,7 @@ class _CollectedRecoveryOutput:
     text: str
     thinking: str
     tool_calls: tuple[CompletedOpenAIToolCall, ...]
+    accepted_body: dict[str, Any]
 
 
 def _iter_visible_text_events(
@@ -1353,6 +1354,7 @@ class _OpenAIChatStreamRunner:
                     text="".join(text_parts),
                     thinking="".join(thinking_parts),
                     tool_calls=completed_tool_calls or (),
+                    accepted_body=body,
                 )
             except Exception as error:
                 last_error = error
@@ -1382,7 +1384,12 @@ class _OpenAIChatStreamRunner:
                     await scope.aclose(active_error=sys.exception())
         if last_error is not None:
             raise last_error
-        return _CollectedRecoveryOutput(text="", thinking="", tool_calls=())
+        return _CollectedRecoveryOutput(
+            text="",
+            thinking="",
+            tool_calls=(),
+            accepted_body=body,
+        )
 
     async def _recovery_events(
         self,
@@ -1526,6 +1533,7 @@ class _OpenAIChatStreamRunner:
                     execution=execution,
                     operation_kind=ProviderOperationKind.TOOL_REPAIR,
                 )
+                recovery_body = recovered.accepted_body
                 repair = accept_tool_json_repair(
                     repair_prefix,
                     recovered.text,

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -773,7 +773,6 @@ class OpenAIChatProvider(BaseProvider):
     ) -> tuple[Any, dict, ProviderAttempt]:
         """Create a streaming chat completion with bounded request fallbacks."""
         body = self._apply_learned_output_cap(body)
-        used_retry_kinds: set[str] = set()
 
         while execution.can_attempt:
             attempt = await execution.open_attempt(operation_kind)
@@ -791,7 +790,7 @@ class OpenAIChatProvider(BaseProvider):
             except asyncio.CancelledError:
                 raise
             except Exception as error:
-                retry_body = self._next_create_retry_body(error, body, used_retry_kinds)
+                retry_body = self._next_create_retry_body(error, body, execution)
                 if retry_body is not None:
                     correction = await attempt.correct(error)
                     if correction is ProviderCorrectionAction.RETRY:
@@ -827,16 +826,18 @@ class OpenAIChatProvider(BaseProvider):
         self,
         error: Exception,
         body: dict,
-        used_retry_kinds: set[str],
+        execution: ProviderExecution,
     ) -> dict | None:
         retry_body = self._retry_body_for_output_cap(error, body)
         if retry_body is not None:
             return retry_body
 
-        if "stream_usage" not in used_retry_kinds and is_stream_usage_rejection(error):
+        if not execution.correction_was_used(
+            "stream_usage"
+        ) and is_stream_usage_rejection(error):
             retry_body = clone_without_stream_usage(body)
             if retry_body is not None:
-                used_retry_kinds.add("stream_usage")
+                execution.record_correction("stream_usage")
                 logger.warning(
                     "{}_STREAM: retrying without stream_options.include_usage "
                     "after upstream rejection",
@@ -844,10 +845,10 @@ class OpenAIChatProvider(BaseProvider):
                 )
                 return retry_body
 
-        if "provider_specific" not in used_retry_kinds:
+        if not execution.correction_was_used("provider_specific"):
             retry_body = self._get_retry_request_body(error, body)
             if retry_body is not None:
-                used_retry_kinds.add("provider_specific")
+                execution.record_correction("provider_specific")
                 return retry_body
 
         return None

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -1300,6 +1300,7 @@ class _OpenAIChatStreamRunner:
                     execution,
                     operation_kind,
                 )
+                body = accepted_body
                 scope = ProviderAttemptScope(
                     attempt,
                     provider_name=self._provider._provider_name,

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -126,16 +126,19 @@ async def _failing_stream():
     raise httpx.ReadError("early cutoff")
 
 
-async def _incomplete_tool_stream():
-    function = MagicMock()
-    function.name = "echo_smoke"
-    function.arguments = '{"message":'
-    tool_call = MagicMock()
-    tool_call.index = 0
-    tool_call.id = "call_repair"
-    tool_call.function = function
+async def _incomplete_tool_stream(*, tool_count: int = 1):
+    tool_calls: list[object] = []
+    for index in range(tool_count):
+        function = MagicMock()
+        function.name = "echo_smoke"
+        function.arguments = '{"message":'
+        tool_call = MagicMock()
+        tool_call.index = index
+        tool_call.id = f"call_repair_{index}"
+        tool_call.function = function
+        tool_calls.append(tool_call)
     yield _chunk(content="Working on it. " + "x" * 70_000)
-    yield _chunk(tool_calls=[tool_call])
+    yield _chunk(tool_calls=tool_calls)
 
 
 def test_exact_observed_failure_reduces_only_completion_budget() -> None:
@@ -436,6 +439,45 @@ async def test_tool_repair_reuses_tpm_corrected_budget() -> None:
     events = parse_sse_text(raw)
     assert budgets == [_PREVIOUS, _PREVIOUS, _CORRECTED, _CORRECTED]
     assert '"partial_json": "\\"ok\\"}"' in raw
+    assert [event.event for event in events].count("message_start") == 1
+    assert [event.event for event in events].count("message_stop") == 1
+
+
+@pytest.mark.asyncio
+async def test_parallel_tool_repairs_share_tpm_corrected_budget() -> None:
+    provider = _provider()
+    request = make_messages_request(
+        _MODEL,
+        max_tokens=_PREVIOUS,
+        tools=[
+            {
+                "name": "echo_smoke",
+                "description": "Echo",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                    "additionalProperties": False,
+                },
+            }
+        ],
+    )
+    create = AsyncMock(
+        side_effect=[
+            _incomplete_tool_stream(tool_count=2),
+            _error(),
+            _successful_stream('"first"}'),
+            _successful_stream('"second"}'),
+        ]
+    )
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        raw = "".join([event async for event in provider.stream_messages(request)])
+
+    budgets = [call.kwargs["max_completion_tokens"] for call in create.await_args_list]
+    events = parse_sse_text(raw)
+    assert budgets == [_PREVIOUS, _PREVIOUS, _CORRECTED, _CORRECTED]
+    assert raw.count('"partial_json": "\\"') == 2
     assert [event.event for event in events].count("message_start") == 1
     assert [event.event for event in events].count("message_stop") == 1
 

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -3,12 +3,14 @@
 from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import httpx2
 import openai
 import pytest
 
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.admission import ProviderOperationKind
 from free_claude_code.providers.groq import GroqProvider
@@ -111,6 +113,12 @@ def _chunk(*, content: str | None = None, finish_reason: str | None = None):
 async def _successful_stream(text: str = "visible"):
     yield _chunk(content=text)
     yield _chunk(finish_reason="stop")
+
+
+async def _failing_stream():
+    if False:
+        yield _chunk()
+    raise httpx.ReadError("early cutoff")
 
 
 def test_exact_observed_failure_reduces_only_completion_budget() -> None:
@@ -243,6 +251,22 @@ def test_rejects_present_header_that_cannot_be_validated() -> None:
     assert correct_tpm_completion_budget(error, _body()) is None
 
 
+@pytest.mark.parametrize("source", ["message", "header"])
+def test_rejects_oversized_decimal_without_masking_the_413(source: str) -> None:
+    oversized = "9" * 5_000
+    error = (
+        _error(
+            message=(
+                f"tokens per minute (TPM): Limit {oversized}, Requested {oversized}0"
+            )
+        )
+        if source == "message"
+        else _error(headers=[(_TPM_HEADER, oversized)])
+    )
+
+    assert correct_tpm_completion_budget(error, _body()) is None
+
+
 def test_requires_machine_status_not_body_status() -> None:
     error = _StatusError(
         "Groq rejected request",
@@ -314,6 +338,28 @@ async def test_second_tpm_rejection_is_terminal_without_a_third_create() -> None
         )
 
     assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_precommit_stream_retry_cannot_reset_the_tpm_correction_guard() -> None:
+    provider = _provider()
+    request = make_messages_request(_MODEL, max_tokens=_PREVIOUS)
+    tpm_error = _error(message="tokens per minute (TPM): Limit 8000, Requested 9000")
+    create = AsyncMock(
+        side_effect=[tpm_error, _failing_stream(), tpm_error, _successful_stream()]
+    )
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(ExecutionFailure),
+    ):
+        _ = [event async for event in provider.stream_messages(request)]
+
+    corrected = _PREVIOUS - 1_000
+    assert create.await_count == 3
+    assert create.await_args_list[0].kwargs["max_completion_tokens"] == _PREVIOUS
+    assert create.await_args_list[1].kwargs["max_completion_tokens"] == corrected
+    assert create.await_args_list[2].kwargs["max_completion_tokens"] == corrected
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -94,14 +94,19 @@ def _provider(*, max_attempts: int = 5) -> GroqProvider:
     )
 
 
-def _chunk(*, content: str | None = None, finish_reason: str | None = None):
+def _chunk(
+    *,
+    content: str | None = None,
+    finish_reason: str | None = None,
+    tool_calls: list[object] | None = None,
+):
     return MagicMock(
         choices=[
             MagicMock(
                 delta=MagicMock(
                     content=content,
                     reasoning_content=None,
-                    tool_calls=None,
+                    tool_calls=tool_calls,
                 ),
                 finish_reason=finish_reason,
             )
@@ -119,6 +124,18 @@ async def _failing_stream():
     if False:
         yield _chunk()
     raise httpx.ReadError("early cutoff")
+
+
+async def _incomplete_tool_stream():
+    function = MagicMock()
+    function.name = "echo_smoke"
+    function.arguments = '{"message":'
+    tool_call = MagicMock()
+    tool_call.index = 0
+    tool_call.id = "call_repair"
+    tool_call.function = function
+    yield _chunk(content="Working on it. " + "x" * 70_000)
+    yield _chunk(tool_calls=[tool_call])
 
 
 def test_exact_observed_failure_reduces_only_completion_budget() -> None:
@@ -155,8 +172,8 @@ def test_accepts_bounded_case_and_whitespace_variation() -> None:
 
 @pytest.mark.parametrize(
     "requested",
-    ["26206.5", "26206e3", "26206tokens"],
-    ids=["decimal", "exponent", "suffix"],
+    ["26206.5", "26206e3", "26206tokens", "26206,000", "26206, 000"],
+    ids=["decimal", "exponent", "suffix", "grouped", "spaced_grouped"],
 )
 def test_rejects_requested_values_with_trailing_numeric_syntax(
     requested: str,
@@ -183,6 +200,12 @@ def test_rejects_requested_values_with_trailing_numeric_syntax(
                 "tokens per minute (TPM): Limit 8000, Requested 26206"
             )
         ),
+        _error(
+            message=(
+                "tokens per minute (TPM): Limit 8000, Requested 26206; "
+                "tokens per minute (TPM): Limit nope, Requested 99999"
+            )
+        ),
     ],
     ids=[
         "wrong_status",
@@ -192,6 +215,7 @@ def test_rejects_requested_values_with_trailing_numeric_syntax(
         "not_over_limit",
         "zero_limit",
         "ambiguous_clauses",
+        "valid_and_malformed_clauses",
     ],
 )
 def test_rejects_unrecognized_or_ambiguous_errors(
@@ -375,6 +399,45 @@ async def test_precommit_stream_retry_cannot_reset_the_tpm_correction_guard() ->
     assert create.await_args_list[0].kwargs["max_completion_tokens"] == _PREVIOUS
     assert create.await_args_list[1].kwargs["max_completion_tokens"] == corrected
     assert create.await_args_list[2].kwargs["max_completion_tokens"] == corrected
+
+
+@pytest.mark.asyncio
+async def test_tool_repair_reuses_tpm_corrected_budget() -> None:
+    provider = _provider()
+    request = make_messages_request(
+        _MODEL,
+        max_tokens=_PREVIOUS,
+        tools=[
+            {
+                "name": "echo_smoke",
+                "description": "Echo",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                    "additionalProperties": False,
+                },
+            }
+        ],
+    )
+    create = AsyncMock(
+        side_effect=[
+            _incomplete_tool_stream(),
+            _error(),
+            _successful_stream("1}"),
+            _successful_stream('"ok"}'),
+        ]
+    )
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        raw = "".join([event async for event in provider.stream_messages(request)])
+
+    budgets = [call.kwargs["max_completion_tokens"] for call in create.await_args_list]
+    events = parse_sse_text(raw)
+    assert budgets == [_PREVIOUS, _PREVIOUS, _CORRECTED, _CORRECTED]
+    assert '"partial_json": "\\"ok\\"}"' in raw
+    assert [event.event for event in events].count("message_start") == 1
+    assert [event.event for event in events].count("message_stop") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -1,0 +1,402 @@
+"""Groq request-local TPM ceiling correction contracts."""
+
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx2
+import openai
+import pytest
+
+from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.admission import ProviderOperationKind
+from free_claude_code.providers.groq import GroqProvider
+from free_claude_code.providers.groq.tpm import correct_tpm_completion_budget
+from tests.providers.request_factory import make_messages_request
+from tests.providers.support import immediate_admission, make_provider_config
+
+_MODEL = "openai/gpt-oss-120b"
+_LIMIT = 8_000
+_REQUESTED = 26_206
+_PREVIOUS = 24_576
+_CORRECTED = 6_370
+_TPM_HEADER = "x-ratelimit-limit-tokens"
+_MESSAGE = (
+    "Request too large for model `openai/gpt-oss-120b` in organization "
+    "`org_private` service tier `on_demand` on tokens per minute (TPM): "
+    "Limit 8000, Requested 26206, please reduce your message size and try again."
+)
+
+
+class _StatusError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None,
+        body: object,
+        response: object | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+        self.response = response
+
+
+class _Response:
+    def __init__(self, headers: object) -> None:
+        self.headers = headers
+
+
+def _error(
+    *,
+    status: int = 413,
+    message: str = _MESSAGE,
+    error_type: str = "tokens",
+    code: str = "rate_limit_exceeded",
+    wrapped: bool = False,
+    headers: list[tuple[str, str]] | None = None,
+) -> openai.APIStatusError:
+    request = httpx2.Request("POST", f"{GROQ_DEFAULT_BASE}/chat/completions")
+    response = httpx2.Response(status, request=request, headers=headers)
+    detail = {"message": message, "type": error_type, "code": code}
+    body = {"error": detail} if wrapped else detail
+    return openai.APIStatusError("Groq rejected request", response=response, body=body)
+
+
+def _body(**updates: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_completion_tokens": _PREVIOUS,
+        "reasoning_effort": "high",
+        "stream": True,
+    }
+    body.update(updates)
+    return body
+
+
+def _provider(*, max_attempts: int = 5) -> GroqProvider:
+    return GroqProvider(
+        make_provider_config(
+            api_key="test_groq_key",
+            base_url=GROQ_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(
+            provider_name="GROQ",
+            max_attempts=max_attempts,
+        ),
+    )
+
+
+def _chunk(*, content: str | None = None, finish_reason: str | None = None):
+    return MagicMock(
+        choices=[
+            MagicMock(
+                delta=MagicMock(
+                    content=content,
+                    reasoning_content=None,
+                    tool_calls=None,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+    )
+
+
+async def _successful_stream(text: str = "visible"):
+    yield _chunk(content=text)
+    yield _chunk(finish_reason="stop")
+
+
+def test_exact_observed_failure_reduces_only_completion_budget() -> None:
+    body = _body()
+    original = deepcopy(body)
+
+    correction = correct_tpm_completion_budget(_error(), body)
+
+    assert correction is not None
+    assert correction.limit == _LIMIT
+    assert correction.requested == _REQUESTED
+    assert correction.previous_max_completion_tokens == _PREVIOUS
+    assert correction.corrected_max_completion_tokens == _CORRECTED
+    assert correction.body == {**body, "max_completion_tokens": _CORRECTED}
+    assert correction.body is not body
+    assert body == original
+
+
+@pytest.mark.parametrize("wrapped", [False, True], ids=["sdk_inner", "raw_wrapper"])
+def test_accepts_sdk_inner_or_one_raw_error_wrapper(wrapped: bool) -> None:
+    correction = correct_tpm_completion_budget(_error(wrapped=wrapped), _body())
+
+    assert correction is not None
+    assert correction.corrected_max_completion_tokens == _CORRECTED
+
+
+def test_accepts_bounded_case_and_whitespace_variation() -> None:
+    error = _error(
+        message="Request on TOKENS  per minute ( TPM ) : LIMIT 8000 , REQUESTED 26206"
+    )
+
+    assert correct_tpm_completion_budget(error, _body()) is not None
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _error(status=429),
+        _error(error_type="requests"),
+        _error(code="context_length_exceeded"),
+        _error(message="Request requires 26206 tokens but limit is 8000"),
+        _error(message="tokens per minute (TPM): Limit 8000, Requested 8000"),
+        _error(message="tokens per minute (TPM): Limit 0, Requested 26206"),
+        _error(
+            message=(
+                "tokens per minute (TPM): Limit 8000, Requested 26206; "
+                "tokens per minute (TPM): Limit 8000, Requested 26206"
+            )
+        ),
+    ],
+    ids=[
+        "wrong_status",
+        "wrong_type",
+        "wrong_code",
+        "unbound_numbers",
+        "not_over_limit",
+        "zero_limit",
+        "ambiguous_clauses",
+    ],
+)
+def test_rejects_unrecognized_or_ambiguous_errors(
+    error: openai.APIStatusError,
+) -> None:
+    assert correct_tpm_completion_budget(error, _body()) is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        _body(max_completion_tokens=None),
+        _body(max_completion_tokens=True),
+        _body(max_completion_tokens="24576"),
+        _body(max_completion_tokens=1),
+        _body(extra_body={"max_completion_tokens": _PREVIOUS}),
+        _body(extra_body={"max_tokens": _PREVIOUS}),
+    ],
+    ids=[
+        "missing_integer",
+        "boolean",
+        "string",
+        "nonpositive_correction",
+        "extra_completion_override",
+        "extra_tokens_override",
+    ],
+)
+def test_rejects_bodies_that_cannot_be_authoritatively_lowered(
+    body: dict[str, object],
+) -> None:
+    assert correct_tpm_completion_budget(_error(), body) is None
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        (None, True),
+        ([("x-ratelimit-limit-tokens", "8000")], True),
+        ([("X-RateLimit-Limit-Tokens", "8001")], False),
+        ([("x-ratelimit-limit-tokens", "eight-thousand")], False),
+        (
+            [
+                ("x-ratelimit-limit-tokens", "8000"),
+                ("x-ratelimit-limit-tokens", "8000"),
+            ],
+            False,
+        ),
+    ],
+    ids=["absent", "matching", "mismatch", "malformed", "repeated"],
+)
+def test_rate_limit_header_must_agree_when_present(
+    headers: list[tuple[str, str]] | None,
+    expected: bool,
+) -> None:
+    correction = correct_tpm_completion_budget(_error(headers=headers), _body())
+
+    assert (correction is not None) is expected
+
+
+def test_rejects_present_header_that_cannot_be_validated() -> None:
+    error = _StatusError(
+        "Groq rejected request",
+        status_code=413,
+        body={
+            "message": _MESSAGE,
+            "type": "tokens",
+            "code": "rate_limit_exceeded",
+        },
+        response=_Response({_TPM_HEADER: object()}),
+    )
+
+    assert correct_tpm_completion_budget(error, _body()) is None
+
+
+def test_requires_machine_status_not_body_status() -> None:
+    error = _StatusError(
+        "Groq rejected request",
+        status_code=None,
+        body={
+            "status": 413,
+            "message": _MESSAGE,
+            "type": "tokens",
+            "code": "rate_limit_exceeded",
+        },
+    )
+
+    assert correct_tpm_completion_budget(error, _body()) is None
+
+
+@pytest.mark.asyncio
+async def test_provider_corrects_once_before_one_downstream_stream() -> None:
+    provider = _provider()
+    request = make_messages_request(_MODEL, max_tokens=_PREVIOUS)
+    create = AsyncMock(side_effect=[_error(), _successful_stream()])
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        patch("free_claude_code.providers.admission.asyncio.sleep") as sleep,
+        patch("free_claude_code.providers.admission.trace_event") as trace,
+    ):
+        raw = "".join(
+            [
+                event
+                async for event in provider.stream_messages(
+                    request,
+                    reasoning=ReasoningPolicy.on(effort=ReasoningEffort.MAX),
+                )
+            ]
+        )
+
+    events = parse_sse_text(raw)
+    assert create.await_count == 2
+    assert create.await_args_list[0].kwargs["max_completion_tokens"] == _PREVIOUS
+    assert create.await_args_list[1].kwargs["max_completion_tokens"] == _CORRECTED
+    assert create.await_args_list[0].kwargs["reasoning_effort"] == "high"
+    assert create.await_args_list[1].kwargs["reasoning_effort"] == "high"
+    assert [event.event for event in events].count("message_start") == 1
+    assert [event.event for event in events].count("message_stop") == 1
+    sleep.assert_not_awaited()
+    assert all(
+        call.kwargs.get("event") != "provider.recovery.opened"
+        for call in trace.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_second_tpm_rejection_is_terminal_without_a_third_create() -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        make_messages_request(_MODEL, max_tokens=_PREVIOUS),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.MAX),
+    )
+    create = AsyncMock(side_effect=[_error(), _error()])
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(openai.APIStatusError),
+    ):
+        await provider._create_stream(
+            body,
+            provider._admission.start_execution(),
+            ProviderOperationKind.GENERATION,
+        )
+
+    assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_single_attempt_budget_does_not_create_corrected_request() -> None:
+    provider = _provider(max_attempts=1)
+    body = provider._build_request_body(
+        make_messages_request(_MODEL, max_tokens=_PREVIOUS),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.MAX),
+    )
+    create = AsyncMock(side_effect=_error())
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(openai.APIStatusError),
+    ):
+        await provider._create_stream(
+            body,
+            provider._admission.start_execution(),
+            ProviderOperationKind.GENERATION,
+        )
+
+    assert create.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tpm_first", [True, False], ids=["tpm_first", "reasoning_first"]
+)
+async def test_tpm_and_reasoning_corrections_compose(tpm_first: bool) -> None:
+    provider = _provider()
+    body = provider._build_request_body(
+        make_messages_request(_MODEL, max_tokens=_PREVIOUS),
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.MAX),
+    )
+    vocabulary_message = (
+        "`reasoning_effort` value `high` must be one of `none` or `default`"
+    )
+    vocabulary_error = _StatusError(
+        vocabulary_message,
+        status_code=400,
+        body={"message": vocabulary_message, "type": "invalid_request_error"},
+    )
+    errors = [_error(), vocabulary_error] if tpm_first else [vocabulary_error, _error()]
+    create = AsyncMock(side_effect=[*errors, _successful_stream()])
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        stream, used_body, attempt = await provider._create_stream(
+            body,
+            provider._admission.start_execution(),
+            ProviderOperationKind.GENERATION,
+        )
+        await stream.aclose()
+        await attempt.aclose()
+
+    assert create.await_count == 3
+    assert used_body["max_completion_tokens"] == _CORRECTED
+    assert used_body["reasoning_effort"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_tpm_limit_is_not_cached_across_requests() -> None:
+    provider = _provider()
+    request = make_messages_request(_MODEL, max_tokens=_PREVIOUS)
+    body = provider._build_request_body(request)
+    create = AsyncMock(
+        side_effect=[_error(), _successful_stream(), _successful_stream()]
+    )
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        first_stream, _, first_attempt = await provider._create_stream(
+            body,
+            provider._admission.start_execution(),
+            ProviderOperationKind.GENERATION,
+        )
+        await first_stream.aclose()
+        await first_attempt.aclose()
+        second_stream, _, second_attempt = await provider._create_stream(
+            provider._build_request_body(request),
+            provider._admission.start_execution(),
+            ProviderOperationKind.GENERATION,
+        )
+        await second_stream.aclose()
+        await second_attempt.aclose()
+
+    assert create.await_args_list[1].kwargs["max_completion_tokens"] == _CORRECTED
+    assert create.await_args_list[2].kwargs["max_completion_tokens"] == _PREVIOUS

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -154,6 +154,21 @@ def test_accepts_bounded_case_and_whitespace_variation() -> None:
 
 
 @pytest.mark.parametrize(
+    "requested",
+    ["26206.5", "26206e3", "26206tokens"],
+    ids=["decimal", "exponent", "suffix"],
+)
+def test_rejects_requested_values_with_trailing_numeric_syntax(
+    requested: str,
+) -> None:
+    error = _error(
+        message=f"tokens per minute (TPM): Limit 8000, Requested {requested}"
+    )
+
+    assert correct_tpm_completion_budget(error, _body()) is None
+
+
+@pytest.mark.parametrize(
     "error",
     [
         _error(status=429),
@@ -253,7 +268,7 @@ def test_rejects_present_header_that_cannot_be_validated() -> None:
 
 @pytest.mark.parametrize("source", ["message", "header"])
 def test_rejects_oversized_decimal_without_masking_the_413(source: str) -> None:
-    oversized = "9" * 5_000
+    oversized = "9" * 20
     error = (
         _error(
             message=(

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -1645,6 +1645,55 @@ class TestStreamingExceptionHandling:
         assert all(stream.closed for stream in streams)
 
     @pytest.mark.asyncio
+    async def test_recovery_retry_preserves_create_correction(self):
+        """A recovery stream retry reuses the body accepted by create."""
+        provider = _make_provider()
+        runner = _make_stream_runner(provider)
+        execution = provider._admission.start_execution()
+        response = httpx2.Response(
+            status_code=400,
+            request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        )
+        usage_rejection = openai.BadRequestError(
+            "stream_options is unsupported",
+            response=response,
+            body={"error": {"message": "stream_options is unsupported"}},
+        )
+        failed_stream = ClosableAsyncStreamMock(
+            [],
+            error=httpx.ReadError("early cutoff"),
+        )
+        completed_stream = ClosableAsyncStreamMock(
+            [_make_chunk(content="world"), _make_chunk(finish_reason="stop")]
+        )
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[usage_rejection, failed_stream, completed_stream],
+        ) as create:
+            result = await runner._collect_recovery_output(
+                {
+                    "messages": [],
+                    "stream_options": {"include_usage": True},
+                },
+                include_reasoning=True,
+                execution=execution,
+                operation_kind=ProviderOperationKind.CONTINUATION,
+            )
+
+        assert create.await_count == 3
+        assert create.await_args_list[0].kwargs["stream_options"] == {
+            "include_usage": True
+        }
+        assert "stream_options" not in create.await_args_list[1].kwargs
+        assert "stream_options" not in create.await_args_list[2].kwargs
+        assert result.text == "world"
+        assert failed_stream.closed is True
+        assert completed_stream.closed is True
+
+    @pytest.mark.asyncio
     async def test_recovery_collect_text_accepts_finish_reason(self):
         """Recovery collectors return text only after the upstream terminal marker."""
         stream = ClosableAsyncStreamMock(

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -70,8 +70,14 @@ def _recovery_output(
     text: str = "",
     thinking: str = "",
     tool_calls: tuple[dict, ...] = (),
+    accepted_body: dict | None = None,
 ) -> SimpleNamespace:
-    return SimpleNamespace(text=text, thinking=thinking, tool_calls=tool_calls)
+    return SimpleNamespace(
+        text=text,
+        thinking=thinking,
+        tool_calls=tool_calls,
+        accepted_body=accepted_body or {},
+    )
 
 
 class ClosableAsyncStreamMock(AsyncStreamMock):
@@ -2096,6 +2102,63 @@ class TestStreamingExceptionHandling:
             for event in parsed
         )
         assert not any(event.event == "error" for event in parsed)
+
+    @pytest.mark.asyncio
+    async def test_tool_repair_retry_preserves_accepted_request_body(self):
+        """A schema retry reuses corrections accepted by the prior collection."""
+        provider = _make_provider()
+        request = _make_request(
+            tools=[
+                {
+                    "name": "echo_smoke",
+                    "description": "Echo",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                        "required": ["message"],
+                        "additionalProperties": False,
+                    },
+                }
+            ]
+        )
+        stream_mock = AsyncStreamMock(
+            [
+                _make_tool_calls_chunk(
+                    name="echo_smoke",
+                    arguments='{"message":',
+                    tool_id="call_repair",
+                )
+            ]
+        )
+        collection_count = 0
+
+        async def collect(body, **_kwargs):
+            nonlocal collection_count
+            collection_count += 1
+            if collection_count == 1:
+                corrected_body = {**body, "max_completion_tokens": 6_370}
+                return _recovery_output(text="1}", accepted_body=corrected_body)
+            return _recovery_output(text='"ok"}', accepted_body=body)
+
+        with (
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                return_value=stream_mock,
+            ),
+            patch.object(
+                _OpenAIChatStreamRunner,
+                "_collect_recovery_output",
+                new_callable=AsyncMock,
+                side_effect=collect,
+            ) as mock_collect,
+        ):
+            events = await _collect_stream(provider, request)
+
+        assert mock_collect.await_count == 2
+        assert mock_collect.await_args_list[1].args[0]["max_completion_tokens"] == 6_370
+        assert '"partial_json": "\\"ok\\"}"' in "".join(events)
 
     @pytest.mark.asyncio
     async def test_stream_rate_limit_uses_the_execution_retry_session(self):

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.9"
+version = "5.18.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Groq can return HTTP 413 when a request's declared completion allowance makes its total reserved tokens exceed the account's tokens-per-minute limit. FCC treated every 413 as terminal, even when lowering only that allowance would make the same request valid.

## Changes

| Before | After |
| --- | --- |
| An exact Groq TPM reservation rejection ended the request immediately. | FCC subtracts Groq's reported overage from `max_completion_tokens` and makes one bounded, request-local retry. |
| The correction could have been guessed from loose error text. | Recovery requires HTTP 413, Groq's structured `tokens` / `rate_limit_exceeded` markers, one unambiguous TPM clause, and an agreeing token-limit header when present. |
| Any later failure risked entering unrelated recovery behavior. | Repeated or unrecognized 413 responses remain terminal; reasoning, messages, tools, and all other request fields stay unchanged. |









<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Groq requests that exceed a verified TPM reservation now retry once with a reduced completion-token budget. The corrected budget is retained for continuation and tool-repair recovery requests while repeated TPM rejections remain bounded.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains in the changed provider recovery behavior.

Focused mocked-provider flows confirmed the one-time TPM correction, terminal behavior for repeated rejections, and propagation of accepted corrections through continuations and tool repairs.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Groq TPM tests and confirmed the full pytest run reported 41 passed, the targeted five-flow run exited cleanly, and the standalone Groq TPM validation script also completed successfully.
- Compared pre- and post-TPM-correction continuation behavior and observed that after correction the flow produced requests at \[24576, 24576, 6370\] and completed.
- Reviewed the code changes in groq/client.py and groq/tpm.py, noting the single TPM correction per ProviderExecution and the strict validation and cloning of the output cap.
- Verified recovery propagation via integration tests that exercise the corrected path to ensure changes propagate through the system as intended.
- Reviewed and organized the artifact set, including logs and the mocked TPM validation source, to support review of the before/after behavior and test results.

<a href="https://app.greptile.com/trex/runs/21530649/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["Carry corrections across parallel tool r..."](https://github.com/alishahryar1/free-claude-code/commit/9c4cb38aa42789c0e7e5edfddd8f9dd923440fd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58476573)</sub>

<!-- /greptile_comment -->