### PR TITLE
fix: recover Groq requests above TPM allowance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.9"
+version = "5.18.10"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -10,6 +10,7 @@ import openai
 from loguru import logger
 
 from free_claude_code.core.anthropic import ReasoningReplayMode
+from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.reasoning import (
     ReasoningEffort,
     ReasoningPolicy,
@@ -140,9 +141,9 @@ class GroqProvider(OpenAIChatProvider):
     def _next_create_retry_body(
         self,
         error: Exception,
-        body: dict[str, Any],
+        body: JsonObject,
         used_retry_kinds: set[str],
-    ) -> dict[str, Any] | None:
+    ) -> JsonObject | None:
         retry_body = super()._next_create_retry_body(error, body, used_retry_kinds)
         if retry_body is not None or "groq_tpm" in used_retry_kinds:
             return retry_body

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -25,6 +25,8 @@ from free_claude_code.providers.openai_chat import (
     validate_extra_body_does_not_override_reasoning_fields,
 )
 
+from .tpm import correct_tpm_completion_budget
+
 _GROQ_EFFORTS = (
     (ReasoningEffort.MINIMAL, "low"),
     (ReasoningEffort.LOW, "low"),
@@ -134,6 +136,30 @@ class GroqProvider(OpenAIChatProvider):
         )
         logger.warning("GROQ_STREAM: {} after upstream rejection", action)
         return retry_body
+
+    def _next_create_retry_body(
+        self,
+        error: Exception,
+        body: dict[str, Any],
+        used_retry_kinds: set[str],
+    ) -> dict[str, Any] | None:
+        retry_body = super()._next_create_retry_body(error, body, used_retry_kinds)
+        if retry_body is not None or "groq_tpm" in used_retry_kinds:
+            return retry_body
+
+        correction = correct_tpm_completion_budget(error, body)
+        if correction is None:
+            return None
+        used_retry_kinds.add("groq_tpm")
+        logger.warning(
+            "GROQ_STREAM: TPM limit={} requested={}; retrying "
+            "max_completion_tokens {} -> {}",
+            correction.limit,
+            correction.requested,
+            correction.previous_max_completion_tokens,
+            correction.corrected_max_completion_tokens,
+        )
+        return correction.body
 
 
 def _parse_reasoning_vocabulary(error: Exception) -> frozenset[str] | None:

--- a/src/free_claude_code/providers/groq/tpm.py
+++ b/src/free_claude_code/providers/groq/tpm.py
@@ -12,7 +12,8 @@ _TPM_MARKER = re.compile(_TPM_PREFIX, re.IGNORECASE)
 _TPM_CLAUSE = re.compile(
     _TPM_PREFIX
     + rf"limit\s+([0-9]{{1,{_MAX_DECIMAL_DIGITS}}})(?![0-9])\s*,\s*"
-    + rf"requested\s+([0-9]{{1,{_MAX_DECIMAL_DIGITS}}})(?=\s*(?:,|$))",
+    + rf"requested\s+([0-9]{{1,{_MAX_DECIMAL_DIGITS}}})"
+    + r"(?=\s*(?:,(?!\s*[0-9])|$))",
     re.IGNORECASE,
 )
 _OUTPUT_FIELDS = frozenset({"max_completion_tokens", "max_tokens"})
@@ -63,7 +64,7 @@ def correct_tpm_completion_budget(
     previous = body.get("max_completion_tokens")
     if not isinstance(previous, int) or isinstance(previous, bool) or previous <= 0:
         return None
-    if requested < previous:
+    if requested <= previous:
         return None
     extra_body = body.get("extra_body")
     if isinstance(extra_body, Mapping) and any(

--- a/src/free_claude_code/providers/groq/tpm.py
+++ b/src/free_claude_code/providers/groq/tpm.py
@@ -1,0 +1,105 @@
+"""Strict request-local correction for Groq TPM-size rejections."""
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from free_claude_code.core.json_types import JsonObject, JsonValue
+
+_MAX_DECIMAL_DIGITS = 19
+_TPM_PREFIX = r"(?<![a-z])tokens\s+per\s+minute\s*\(\s*tpm\s*\)\s*:\s*"
+_TPM_MARKER = re.compile(_TPM_PREFIX, re.IGNORECASE)
+_TPM_CLAUSE = re.compile(
+    _TPM_PREFIX
+    + rf"limit\s+([0-9]{{1,{_MAX_DECIMAL_DIGITS}}})(?![0-9])\s*,\s*"
+    + rf"requested\s+([0-9]{{1,{_MAX_DECIMAL_DIGITS}}})(?=\s*(?:,|$))",
+    re.IGNORECASE,
+)
+_OUTPUT_FIELDS = frozenset({"max_completion_tokens", "max_tokens"})
+_DETAIL_FIELDS = frozenset({"message", "type", "code"})
+
+
+@dataclass(frozen=True, slots=True)
+class GroqTpmCorrection:
+    """One validated completion-budget correction and its safe diagnostics."""
+
+    body: JsonObject
+    limit: int
+    requested: int
+    previous_max_completion_tokens: int
+    corrected_max_completion_tokens: int
+
+
+def correct_tpm_completion_budget(
+    error: Exception,
+    body: Mapping[str, JsonValue],
+) -> GroqTpmCorrection | None:
+    """Subtract Groq's reported TPM overage from this request's output cap."""
+    if _status_code(error) != 413:
+        return None
+
+    detail = _error_detail(getattr(error, "body", None))
+    if detail is None:
+        return None
+    if detail.get("type") != "tokens":
+        return None
+    if detail.get("code") != "rate_limit_exceeded":
+        return None
+
+    message = detail.get("message")
+    if not isinstance(message, str):
+        return None
+    if sum(1 for _ in _TPM_MARKER.finditer(message)) != 1:
+        return None
+    matches = tuple(_TPM_CLAUSE.finditer(message))
+    if len(matches) != 1:
+        return None
+
+    limit = int(matches[0].group(1))
+    requested = int(matches[0].group(2))
+    if limit <= 0 or requested <= limit:
+        return None
+
+    previous = body.get("max_completion_tokens")
+    if not isinstance(previous, int) or isinstance(previous, bool) or previous <= 0:
+        return None
+    extra_body = body.get("extra_body")
+    if isinstance(extra_body, Mapping) and any(
+        field in extra_body for field in _OUTPUT_FIELDS
+    ):
+        return None
+
+    corrected = previous - (requested - limit)
+    if corrected <= 0 or corrected >= previous:
+        return None
+
+    corrected_body = dict(body)
+    corrected_body["max_completion_tokens"] = corrected
+    return GroqTpmCorrection(
+        body=corrected_body,
+        limit=limit,
+        requested=requested,
+        previous_max_completion_tokens=previous,
+        corrected_max_completion_tokens=corrected,
+    )
+
+
+def _status_code(error: Exception) -> int | None:
+    status = getattr(error, "status_code", None)
+    if isinstance(status, int) and not isinstance(status, bool):
+        return status
+    response = getattr(error, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) and not isinstance(status, bool) else None
+
+
+def _error_detail(value: object) -> Mapping[object, object] | None:
+    if not isinstance(value, Mapping):
+        return None
+    candidates: list[Mapping[object, object]] = []
+    if _DETAIL_FIELDS.issubset(value):
+        candidates.append(value)
+    nested = value.get("error")
+    if isinstance(nested, Mapping) and _DETAIL_FIELDS.issubset(nested):
+        candidates.append(nested)
+    return candidates[0] if len(candidates) == 1 else None

--- a/src/free_claude_code/providers/groq/tpm.py
+++ b/src/free_claude_code/providers/groq/tpm.py
@@ -63,6 +63,8 @@ def correct_tpm_completion_budget(
     previous = body.get("max_completion_tokens")
     if not isinstance(previous, int) or isinstance(previous, bool) or previous <= 0:
         return None
+    if requested < previous:
+        return None
     extra_body = body.get("extra_body")
     if isinstance(extra_body, Mapping) and any(
         field in extra_body for field in _OUTPUT_FIELDS

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -35,6 +35,7 @@ from free_claude_code.core.anthropic.streaming import (
 )
 from free_claude_code.core.anthropic.usage import anthropic_input_usage_fields
 from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import (
     OpenAIResponsesRequest,
     ResponsesChatRequest,
@@ -116,6 +117,7 @@ class _CollectedRecoveryOutput:
     text: str
     thinking: str
     tool_calls: tuple[CompletedOpenAIToolCall, ...]
+    request_body: JsonObject
 
 
 def _iter_visible_text_events(
@@ -1349,6 +1351,7 @@ class _OpenAIChatStreamRunner:
                     text="".join(text_parts),
                     thinking="".join(thinking_parts),
                     tool_calls=completed_tool_calls or (),
+                    request_body=body,
                 )
             except Exception as error:
                 last_error = error
@@ -1378,7 +1381,12 @@ class _OpenAIChatStreamRunner:
                     await scope.aclose(active_error=sys.exception())
         if last_error is not None:
             raise last_error
-        return _CollectedRecoveryOutput(text="", thinking="", tool_calls=())
+        return _CollectedRecoveryOutput(
+            text="",
+            thinking="",
+            tool_calls=(),
+            request_body=body,
+        )
 
     async def _recovery_events(
         self,
@@ -1539,6 +1547,7 @@ class _OpenAIChatStreamRunner:
                         attempt=repair_attempt,
                     )
                     break
+                recovery_body = recovered.request_body
             if accepted_suffix is None:
                 return None
             to_emit = (

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -1294,7 +1294,7 @@ class _OpenAIChatStreamRunner:
         while execution.can_attempt:
             scope: ProviderAttemptScope | None = None
             try:
-                stream, accepted_body, attempt = await self._provider._create_stream(
+                stream, body, attempt = await self._provider._create_stream(
                     body,
                     execution,
                     operation_kind,
@@ -1335,9 +1335,7 @@ class _OpenAIChatStreamRunner:
                 completed_tool_calls = tool_calls.completed_calls(
                     self._tool_schemas,
                     tool_names=self._tool_names,
-                    tool_argument_aliases=self._provider._tool_argument_aliases(
-                        accepted_body
-                    ),
+                    tool_argument_aliases=self._provider._tool_argument_aliases(body),
                 )
                 if tool_calls.has_calls and completed_tool_calls is None:
                     raise TruncatedProviderStreamError(

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -772,10 +772,13 @@ class OpenAIChatProvider(BaseProvider):
         body: dict,
         execution: ProviderExecution,
         operation_kind: ProviderOperationKind,
+        *,
+        used_retry_kinds: set[str] | None = None,
     ) -> tuple[Any, dict, ProviderAttempt]:
         """Create a streaming chat completion with bounded request fallbacks."""
         body = self._apply_learned_output_cap(body)
-        used_retry_kinds: set[str] = set()
+        if used_retry_kinds is None:
+            used_retry_kinds = set()
 
         while execution.can_attempt:
             attempt = await execution.open_attempt(operation_kind)
@@ -1021,6 +1024,7 @@ class _OpenAIChatStreamRunner:
         body = self._body
         request_stream_usage(body)
         output_reasoning = self._reasoning.output_enabled
+        used_retry_kinds: set[str] = set()
         trace_event(
             stage="provider",
             event="provider.request.sent",
@@ -1043,6 +1047,7 @@ class _OpenAIChatStreamRunner:
                     body,
                     execution,
                     ProviderOperationKind.GENERATION,
+                    used_retry_kinds=used_retry_kinds,
                 )
                 scope = ProviderAttemptScope(
                     attempt,
@@ -1290,8 +1295,11 @@ class _OpenAIChatStreamRunner:
         include_reasoning: bool,
         execution: ProviderExecution,
         operation_kind: ProviderOperationKind,
+        used_retry_kinds: set[str] | None = None,
     ) -> _CollectedRecoveryOutput:
         """Collect one complete buffered continuation response."""
+        if used_retry_kinds is None:
+            used_retry_kinds = set()
         last_error: Exception | None = None
         while execution.can_attempt:
             scope: ProviderAttemptScope | None = None
@@ -1300,6 +1308,7 @@ class _OpenAIChatStreamRunner:
                     body,
                     execution,
                     operation_kind,
+                    used_retry_kinds=used_retry_kinds,
                 )
                 scope = ProviderAttemptScope(
                     attempt,
@@ -1522,6 +1531,7 @@ class _OpenAIChatStreamRunner:
             )
             accepted_suffix: str | None = None
             repair_attempt = 0
+            used_retry_kinds: set[str] = set()
             while execution.can_attempt:
                 repair_attempt += 1
                 recovered = await self._collect_recovery_output(
@@ -1529,6 +1539,7 @@ class _OpenAIChatStreamRunner:
                     include_reasoning=False,
                     execution=execution,
                     operation_kind=ProviderOperationKind.TOOL_REPAIR,
+                    used_retry_kinds=used_retry_kinds,
                 )
                 repair = accept_tool_json_repair(
                     repair_prefix,

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -144,6 +144,12 @@ def test_exact_tpm_rejection_corrects_only_completion_budget(wrapped: bool) -> N
         ),
         (
             _status_error(
+                detail=_detail("tokens per minute (TPM): Limit 8000, Requested 9000")
+            ),
+            _body(),
+        ),
+        (
+            _status_error(
                 detail=_detail(
                     "tokens per minute (TPM): Limit 80000000000000000000, "
                     "Requested 90000000000000000000"
@@ -171,6 +177,7 @@ def test_exact_tpm_rejection_corrects_only_completion_budget(wrapped: bool) -> N
         "malformed-requested-boundary",
         "ambiguous-clause",
         "no-overage",
+        "requested-under-output-cap",
         "oversized-number",
         "non-integer-max",
         "boolean-max",
@@ -294,7 +301,7 @@ async def test_distinct_bodies_get_independent_tpm_corrections() -> None:
     provider = _provider()
     execution = provider._admission.start_execution()
     second_error = _status_error(
-        detail=_detail("tokens per minute (TPM): Limit 8000, Requested 18000")
+        detail=_detail("tokens per minute (TPM): Limit 8000, Requested 22000")
     )
     create = AsyncMock(side_effect=[_status_error(), object(), second_error, object()])
 
@@ -315,4 +322,4 @@ async def test_distinct_bodies_get_independent_tpm_corrections() -> None:
 
     assert execution.attempts_started == 4
     assert first_body["max_completion_tokens"] == _CORRECTED_MAX
-    assert second_body["max_completion_tokens"] == 10_000
+    assert second_body["max_completion_tokens"] == 6_000

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -1,0 +1,318 @@
+"""Groq request-local recovery from exact TPM-size rejections."""
+
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx2
+import openai
+import pytest
+
+from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.providers.admission import ProviderOperationKind
+from free_claude_code.providers.groq import GroqProvider
+from free_claude_code.providers.groq.tpm import correct_tpm_completion_budget
+from tests.providers.request_factory import make_messages_request
+from tests.providers.support import immediate_admission, make_provider_config
+
+_MODEL = "openai/gpt-oss-120b"
+_LIMIT = 8_000
+_REQUESTED = 26_206
+_ORIGINAL_MAX = 24_576
+_CORRECTED_MAX = 6_370
+
+
+def _detail(
+    message: str = (
+        "Request too large for model `openai/gpt-oss-120b` on tokens per minute "
+        "(TPM): Limit 8000, Requested 26206, please reduce your message size"
+    ),
+    *,
+    error_type: str = "tokens",
+    code: str = "rate_limit_exceeded",
+) -> dict[str, str]:
+    return {"message": message, "type": error_type, "code": code}
+
+
+def _status_error(
+    *,
+    status: int = 413,
+    detail: object | None = None,
+    wrapped: bool = False,
+) -> openai.APIStatusError:
+    request = httpx2.Request("POST", f"{GROQ_DEFAULT_BASE}/chat/completions")
+    response = httpx2.Response(status, request=request)
+    body = _detail() if detail is None else detail
+    if wrapped:
+        body = {"error": body}
+    return openai.APIStatusError(
+        "Groq request rejected",
+        response=response,
+        body=body,
+    )
+
+
+def _body(max_completion_tokens: object = _ORIGINAL_MAX) -> dict:
+    return {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_completion_tokens": max_completion_tokens,
+    }
+
+
+def _provider(*, max_attempts: int = 5) -> GroqProvider:
+    return GroqProvider(
+        make_provider_config("test-groq-key", GROQ_DEFAULT_BASE),
+        admission=immediate_admission(
+            provider_name="GROQ",
+            max_attempts=max_attempts,
+        ),
+    )
+
+
+def _chunk(*, content: str | None = None, finish_reason: str | None = None):
+    return MagicMock(
+        choices=[
+            MagicMock(
+                delta=MagicMock(
+                    content=content,
+                    reasoning_content=None,
+                    tool_calls=None,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+    )
+
+
+async def _successful_stream():
+    yield _chunk(content="working")
+    yield _chunk(finish_reason="stop")
+
+
+@pytest.mark.parametrize("wrapped", [False, True], ids=["sdk-detail", "wire-wrapper"])
+def test_exact_tpm_rejection_corrects_only_completion_budget(wrapped: bool) -> None:
+    body = _body()
+    original = deepcopy(body)
+
+    correction = correct_tpm_completion_budget(
+        _status_error(wrapped=wrapped),
+        body,
+    )
+
+    assert correction is not None
+    assert correction.limit == _LIMIT
+    assert correction.requested == _REQUESTED
+    assert correction.previous_max_completion_tokens == _ORIGINAL_MAX
+    assert correction.corrected_max_completion_tokens == _CORRECTED_MAX
+    assert correction.body == {**body, "max_completion_tokens": _CORRECTED_MAX}
+    assert correction.body is not body
+    assert body == original
+
+
+@pytest.mark.parametrize(
+    ("error", "body"),
+    [
+        (_status_error(status=429), _body()),
+        (_status_error(detail=_detail(error_type="rate_limit")), _body()),
+        (_status_error(detail=_detail(code="context_length_exceeded")), _body()),
+        (_status_error(detail=_detail("Request too large")), _body()),
+        (
+            _status_error(
+                detail=_detail(
+                    "tokens per minute (TPM): Limit 8000, Requested 26206garbage"
+                )
+            ),
+            _body(),
+        ),
+        (
+            _status_error(
+                detail=_detail(
+                    "tokens per minute (TPM): Limit 8000, Requested 26206; "
+                    "tokens per minute (TPM): Limit 8000, Requested 26206"
+                )
+            ),
+            _body(),
+        ),
+        (
+            _status_error(
+                detail=_detail("tokens per minute (TPM): Limit 8000, Requested 8000")
+            ),
+            _body(),
+        ),
+        (
+            _status_error(
+                detail=_detail(
+                    "tokens per minute (TPM): Limit 80000000000000000000, "
+                    "Requested 90000000000000000000"
+                )
+            ),
+            _body(),
+        ),
+        (_status_error(), _body(None)),
+        (_status_error(), _body(True)),
+        (_status_error(), _body(10_000)),
+        (
+            _status_error(),
+            {**_body(), "extra_body": {"max_completion_tokens": _ORIGINAL_MAX}},
+        ),
+        (
+            _status_error(),
+            {**_body(), "extra_body": {"max_tokens": _ORIGINAL_MAX}},
+        ),
+    ],
+    ids=[
+        "wrong-status",
+        "wrong-type",
+        "wrong-code",
+        "missing-clause",
+        "malformed-requested-boundary",
+        "ambiguous-clause",
+        "no-overage",
+        "oversized-number",
+        "non-integer-max",
+        "boolean-max",
+        "prompt-alone-too-large",
+        "extra-max-completion-tokens",
+        "extra-max-tokens",
+    ],
+)
+def test_non_authoritative_tpm_rejection_is_not_corrected(
+    error: Exception,
+    body: dict,
+) -> None:
+    assert correct_tpm_completion_budget(error, body) is None
+
+
+@pytest.mark.asyncio
+async def test_tpm_correction_emits_one_downstream_lifecycle() -> None:
+    provider = _provider()
+    request = make_messages_request(_MODEL, max_tokens=_ORIGINAL_MAX)
+    create = AsyncMock(side_effect=[_status_error(), _successful_stream()])
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        raw = "".join(
+            [
+                event
+                async for event in provider.stream_messages(
+                    request,
+                    reasoning=ReasoningPolicy.off(),
+                )
+            ]
+        )
+
+    events = parse_sse_text(raw)
+    assert create.await_count == 2
+    assert create.await_args_list[0].kwargs["max_completion_tokens"] == _ORIGINAL_MAX
+    assert create.await_args_list[1].kwargs["max_completion_tokens"] == _CORRECTED_MAX
+    assert "working" in raw
+    assert "event: error" not in raw
+    assert sum(event.event == "message_start" for event in events) == 1
+    assert sum(event.event == "message_stop" for event in events) == 1
+
+
+@pytest.mark.asyncio
+async def test_tpm_correction_is_one_shot_per_stream_creation() -> None:
+    provider = _provider()
+    create = AsyncMock(side_effect=[_status_error(), _status_error()])
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(openai.APIStatusError),
+    ):
+        await provider._create_stream(
+            _body(),
+            provider._admission.start_execution(),
+            ProviderOperationKind.GENERATION,
+        )
+
+    assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tpm_correction_respects_physical_attempt_ceiling() -> None:
+    provider = _provider(max_attempts=1)
+    create = AsyncMock(side_effect=_status_error())
+
+    with (
+        patch.object(provider._client.chat.completions, "create", create),
+        pytest.raises(openai.APIStatusError),
+    ):
+        await provider._create_stream(
+            _body(),
+            provider._admission.start_execution(),
+            ProviderOperationKind.GENERATION,
+        )
+
+    assert create.await_count == 1
+
+
+def _reasoning_error() -> openai.APIStatusError:
+    message = "`reasoning_effort` value `high` must be one of `none` or `default`"
+    return _status_error(
+        status=400,
+        detail={"message": message, "type": "invalid_request_error"},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("errors", [("tpm", "reasoning"), ("reasoning", "tpm")])
+async def test_tpm_and_reasoning_corrections_compose(
+    errors: tuple[str, str],
+) -> None:
+    provider = _provider()
+    request = make_messages_request(_MODEL, max_tokens=_ORIGINAL_MAX)
+    body = provider._build_request_body(
+        request,
+        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+    )
+    failures = {
+        "tpm": _status_error(),
+        "reasoning": _reasoning_error(),
+    }
+    create = AsyncMock(side_effect=[*(failures[name] for name in errors), object()])
+    execution = provider._admission.start_execution()
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        _stream, accepted_body, attempt = await provider._create_stream(
+            body,
+            execution,
+            ProviderOperationKind.GENERATION,
+        )
+        await attempt.aclose()
+
+    assert create.await_count == 3
+    assert execution.attempts_started == 3
+    assert accepted_body["max_completion_tokens"] == _CORRECTED_MAX
+    assert accepted_body["reasoning_effort"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_distinct_bodies_get_independent_tpm_corrections() -> None:
+    provider = _provider()
+    execution = provider._admission.start_execution()
+    second_error = _status_error(
+        detail=_detail("tokens per minute (TPM): Limit 8000, Requested 18000")
+    )
+    create = AsyncMock(side_effect=[_status_error(), object(), second_error, object()])
+
+    with patch.object(provider._client.chat.completions, "create", create):
+        _stream, first_body, first_attempt = await provider._create_stream(
+            _body(),
+            execution,
+            ProviderOperationKind.CONTINUATION,
+        )
+        await first_attempt.accept()
+        await first_attempt.aclose()
+        _stream, second_body, second_attempt = await provider._create_stream(
+            _body(20_000),
+            execution,
+            ProviderOperationKind.TOOL_REPAIR,
+        )
+        await second_attempt.aclose()
+
+    assert execution.attempts_started == 4
+    assert first_body["max_completion_tokens"] == _CORRECTED_MAX
+    assert second_body["max_completion_tokens"] == 10_000

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -130,6 +130,22 @@ def test_exact_tpm_rejection_corrects_only_completion_budget(wrapped: bool) -> N
         (
             _status_error(
                 detail=_detail(
+                    "tokens per minute (TPM): Limit 8000, Requested 26206,000"
+                )
+            ),
+            _body(),
+        ),
+        (
+            _status_error(
+                detail=_detail(
+                    "tokens per minute (TPM): Limit 8000, Requested 26206, 000"
+                )
+            ),
+            _body(),
+        ),
+        (
+            _status_error(
+                detail=_detail(
                     "tokens per minute (TPM): Limit 8000, Requested 26206; "
                     "tokens per minute (TPM): Limit 8000, Requested 26206"
                 )
@@ -145,6 +161,12 @@ def test_exact_tpm_rejection_corrects_only_completion_budget(wrapped: bool) -> N
         (
             _status_error(
                 detail=_detail("tokens per minute (TPM): Limit 8000, Requested 9000")
+            ),
+            _body(),
+        ),
+        (
+            _status_error(
+                detail=_detail("tokens per minute (TPM): Limit 8000, Requested 24576")
             ),
             _body(),
         ),
@@ -175,9 +197,12 @@ def test_exact_tpm_rejection_corrects_only_completion_budget(wrapped: bool) -> N
         "wrong-code",
         "missing-clause",
         "malformed-requested-boundary",
+        "grouped-requested-no-space",
+        "grouped-requested-with-space",
         "ambiguous-clause",
         "no-overage",
         "requested-under-output-cap",
+        "requested-equals-output-cap",
         "oversized-number",
         "non-integer-max",
         "boolean-max",

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -1645,6 +1645,56 @@ class TestStreamingExceptionHandling:
         assert all(stream.closed for stream in streams)
 
     @pytest.mark.asyncio
+    async def test_recovery_stream_reopen_retains_accepted_corrected_body(self):
+        """Reopening one derived request reuses its accepted correction."""
+        provider = _make_provider()
+        runner = _make_stream_runner(provider)
+        execution = provider._admission.start_execution()
+        response = httpx2.Response(
+            status_code=400,
+            request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        )
+        usage_rejection = openai.BadRequestError(
+            "stream_options is unsupported",
+            response=response,
+            body={"error": {"message": "stream_options is unsupported"}},
+        )
+        failed_stream = ClosableAsyncStreamMock(
+            [_make_chunk(content="discarded")],
+            error=httpx.ReadError("recovery cutoff"),
+        )
+        successful_stream = ClosableAsyncStreamMock(
+            [_make_chunk(content="visible"), _make_chunk(finish_reason="stop")]
+        )
+        body = {
+            "messages": [],
+            "stream_options": {"include_usage": True},
+        }
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[usage_rejection, failed_stream, successful_stream],
+        ) as create:
+            recovered = await runner._collect_recovery_output(
+                body,
+                include_reasoning=True,
+                execution=execution,
+                operation_kind=ProviderOperationKind.CONTINUATION,
+            )
+
+        assert create.await_count == 3
+        assert create.await_args_list[0].kwargs["stream_options"] == {
+            "include_usage": True
+        }
+        assert "stream_options" not in create.await_args_list[1].kwargs
+        assert "stream_options" not in create.await_args_list[2].kwargs
+        assert recovered.text == "visible"
+        assert failed_stream.closed
+        assert successful_stream.closed
+
+    @pytest.mark.asyncio
     async def test_recovery_collect_text_accepts_finish_reason(self):
         """Recovery collectors return text only after the upstream terminal marker."""
         stream = ClosableAsyncStreamMock(

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -1671,12 +1671,20 @@ class TestStreamingExceptionHandling:
             "stream_options": {"include_usage": True},
         }
 
-        with patch.object(
-            provider._client.chat.completions,
-            "create",
-            new_callable=AsyncMock,
-            side_effect=[usage_rejection, failed_stream, successful_stream],
-        ) as create:
+        with (
+            patch.object(
+                provider,
+                "_create_stream",
+                new_callable=AsyncMock,
+                wraps=provider._create_stream,
+            ) as create_stream,
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[usage_rejection, failed_stream, successful_stream],
+            ) as create,
+        ):
             recovered = await runner._collect_recovery_output(
                 body,
                 include_reasoning=True,
@@ -1690,6 +1698,11 @@ class TestStreamingExceptionHandling:
         }
         assert "stream_options" not in create.await_args_list[1].kwargs
         assert "stream_options" not in create.await_args_list[2].kwargs
+        assert create_stream.await_count == 2
+        assert (
+            create_stream.await_args_list[0].kwargs["used_retry_kinds"]
+            is create_stream.await_args_list[1].kwargs["used_retry_kinds"]
+        )
         assert recovered.text == "visible"
         assert failed_stream.closed
         assert successful_stream.closed
@@ -1743,12 +1756,20 @@ class TestStreamingExceptionHandling:
         )
         execution = provider._admission.start_execution()
 
-        with patch.object(
-            provider._client.chat.completions,
-            "create",
-            new_callable=AsyncMock,
-            side_effect=[usage_rejection, invalid_repair, valid_repair],
-        ) as create:
+        with (
+            patch.object(
+                provider,
+                "_create_stream",
+                new_callable=AsyncMock,
+                wraps=provider._create_stream,
+            ) as create_stream,
+            patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=[usage_rejection, invalid_repair, valid_repair],
+            ) as create,
+        ):
             events = await runner._repair_tool_args(
                 body=body,
                 output=assembler.output,
@@ -1763,6 +1784,11 @@ class TestStreamingExceptionHandling:
         }
         assert "stream_options" not in create.await_args_list[1].kwargs
         assert "stream_options" not in create.await_args_list[2].kwargs
+        assert create_stream.await_count == 2
+        assert (
+            create_stream.await_args_list[0].kwargs["used_retry_kinds"]
+            is create_stream.await_args_list[1].kwargs["used_retry_kinds"]
+        )
         assert invalid_repair.closed
         assert valid_repair.closed
 

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -1695,6 +1695,78 @@ class TestStreamingExceptionHandling:
         assert successful_stream.closed
 
     @pytest.mark.asyncio
+    async def test_tool_repair_iterations_reuse_accepted_corrected_body(self):
+        """Schema-repair retries reuse corrections accepted for that repair body."""
+        provider = _make_provider()
+        request = _make_request(
+            tools=[
+                {
+                    "name": "echo_smoke",
+                    "description": "Echo one message",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                        "required": ["message"],
+                        "additionalProperties": False,
+                    },
+                }
+            ]
+        )
+        runner = _make_stream_runner(provider, request=request)
+        assembler = runner._new_stream_assembler(output_reasoning=False)
+        tuple(assembler.start_events())
+        tuple(
+            assembler.feed(
+                _make_tool_calls_chunk(
+                    name="echo_smoke",
+                    arguments='{"message":',
+                    tool_id="call_repair",
+                )
+            )
+        )
+        body = provider._build_request_body(request)
+        body["stream_options"] = {"include_usage": True}
+        response = httpx2.Response(
+            status_code=400,
+            request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        )
+        usage_rejection = openai.BadRequestError(
+            "stream_options is unsupported",
+            response=response,
+            body={"error": {"message": "stream_options is unsupported"}},
+        )
+        invalid_repair = ClosableAsyncStreamMock(
+            [_make_chunk(content="123}"), _make_chunk(finish_reason="stop")]
+        )
+        valid_repair = ClosableAsyncStreamMock(
+            [_make_chunk(content='"ok"}'), _make_chunk(finish_reason="stop")]
+        )
+        execution = provider._admission.start_execution()
+
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=[usage_rejection, invalid_repair, valid_repair],
+        ) as create:
+            events = await runner._repair_tool_args(
+                body=body,
+                output=assembler.output,
+                tool_argument_alias_buffers=assembler.tool_argument_alias_buffers,
+                execution=execution,
+            )
+
+        assert events is not None
+        assert create.await_count == 3
+        assert create.await_args_list[0].kwargs["stream_options"] == {
+            "include_usage": True
+        }
+        assert "stream_options" not in create.await_args_list[1].kwargs
+        assert "stream_options" not in create.await_args_list[2].kwargs
+        assert invalid_repair.closed
+        assert valid_repair.closed
+
+    @pytest.mark.asyncio
     async def test_recovery_collect_text_accepts_finish_reason(self):
         """Recovery collectors return text only after the upstream terminal marker."""
         stream = ClosableAsyncStreamMock(

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.9"
+version = "5.18.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Groq rejects otherwise valid requests when the requested input plus maximum output exceeds an account's TPM allowance. Retrying the unchanged HTTP 413 body cannot succeed.

## Changes

| Before | After |
| --- | --- |
| Exact Groq TPM-size 413 responses failed immediately. | Groq reduces only that request's completion allowance by the reported excess and retries once. |
| Groq correction kinds could collide with reasoning negotiation. | TPM correction has its own request-local key and composes with existing corrections. |
| Buffered recovery reopened an original body after accepting a correction. | Buffered recovery reuses the accepted body for the same derived request. |
| TPM handling was validated only through generic terminal 413 behavior. | Focused contracts and live Groq/FCC Codex smokes cover correction and single-lifecycle behavior. |





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update adds bounded recovery for Groq requests rejected for exceeding the TPM allowance, and preserves accepted request corrections across continuation and tool-repair recovery. Focused provider checks and the affected regression suite completed successfully.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The exercised Groq TPM retry, continuation recovery, and tool-repair flows retained corrected request state and respected the configured attempt budget.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The pre-PR TPM validation showed that free\_claude\_code.providers.groq.tpm did not exist, establishing the absence of a TPM implementation before the PR.
- After the capture, four focused contracts with real async mocked OpenAI/Groq client calls passed, and the broader affected test suite reported 102 passed.
- The exact Groq TPM test source, the streaming recovery test source, and the JsonObject typing assertion source were executed and attached for inspection.
- The Groq retry body JsonObject typing assertion output was captured as a log artifact for review.

<a href="https://app.greptile.com/trex/runs/21539134/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: preserve one-shot request correctio..."](https://github.com/alishahryar1/free-claude-code/commit/8913337ea2cd5b930c7010b20adc7eecec1ba921) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58496163)</sub>

<!-- /greptile_comment -->