### PR TITLE
Polish Admin branding and Chat interactions

### DIFF
--- a/e2e/test_admin_assets.py
+++ b/e2e/test_admin_assets.py
@@ -28,8 +28,15 @@ def test_admin_loads_current_release_assets_before_rendering_dynamic_content(
     expect(page.locator(".brand p")).to_have_text(
         f"Server Control · v{package_version()}"
     )
+    logo_link = page.get_by_role("link", name="Open Free Claude Code on GitHub")
+    expect(logo_link).to_be_visible()
+    expect(logo_link).to_have_attribute(
+        "href", "https://github.com/Alishahryar1/free-claude-code"
+    )
+    expect(logo_link).to_have_attribute("target", "_blank")
 
     versioned_root = f"/admin/assets/{package_version()}"
+    assert f"{versioned_root}/app-icon.svg" in requested_paths
     assert f"{versioned_root}/admin.css" in requested_paths
     assert f"{versioned_root}/chat_sessions.css" in requested_paths
     assert f"{versioned_root}/model_combobox.js" in requested_paths

--- a/e2e/test_admin_providers.py
+++ b/e2e/test_admin_providers.py
@@ -91,7 +91,15 @@ def test_configured_provider_check_keeps_readiness_and_adds_models(
     expect(meta).to_have_text("OPENROUTER_API_KEY")
 
     page.get_by_role("button", name="Model Config", exact=True).click()
+    fable = page.get_by_role(
+        "combobox",
+        name="Fable Override default",
+        exact=True,
+    )
     page.get_by_role("button", name="Show Fable Override options", exact=True).click()
+    expect(page.get_by_role("listbox").get_by_role("option")).to_have_count(1)
+    expect(page.get_by_role("option", name="None", exact=True)).to_be_visible()
+    fable.fill("vendor/model-a")
     expect(
         page.get_by_role("option", name="open_router/vendor/model-a", exact=True)
     ).to_be_visible()

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -450,6 +450,30 @@ def test_committed_send_does_not_restore_draft_when_stream_ack_is_lost(
     ).to_be_visible()
 
 
+def test_send_keeps_composer_ready_for_the_next_draft(
+    page: Page,
+    admin_base_url: str,
+) -> None:
+    _new_chat(page, admin_base_url)
+    message = page.get_by_role("textbox", name="Message", exact=True)
+
+    message.fill("first")
+    message.press("Enter")
+    expect(page.get_by_role("button", name="Regenerate")).to_be_visible()
+    expect(message).to_be_focused()
+
+    message.fill("[slow] second")
+    message.press("Enter")
+    expect(page.locator(".live-message")).to_contain_text("E2E answer")
+    expect(message).to_be_enabled()
+    expect(message).to_be_focused()
+    message.fill("next draft")
+
+    page.get_by_role("button", name="Stop").click()
+    expect(page.get_by_role("button", name="Retry")).to_be_visible()
+    expect(message).to_have_value("next draft")
+
+
 def test_chat_stop_then_retry_uses_one_operation_owner(
     page: Page,
     admin_base_url: str,

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -172,6 +172,14 @@ def test_chat_model_picker_searches_and_selects_in_one_control(
     expect(page.locator("select#chatModel")).to_have_count(0)
     expect(page.locator("#chatNotice")).to_be_hidden()
 
+    page.reload()
+    expect(model).to_have_value("open_router/e2e-default")
+    model.click()
+    options = page.get_by_role("listbox").get_by_role("option")
+    expect(options).to_have_count(1)
+    expect(options).to_have_text("open_router/e2e-default")
+    model.press("Escape")
+
     model.fill("not-a-catalog-model")
     expect(page.get_by_text("No matching models.", exact=True)).to_be_visible()
     page.get_by_label("Thinking").click()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.18.10"
+version = "5.18.11"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -31,11 +31,13 @@ from .ports import ApiServices
 router = APIRouter()
 
 STATIC_DIR = Path(__file__).resolve().parent / "admin_static"
+PACKAGE_ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
 _ADMIN_ASSET_VERSION_PLACEHOLDER = "__FCC_VERSION__"
 _ADMIN_ASSET_FILENAMES = frozenset(
     {
         "admin.css",
         "admin.js",
+        "app-icon.svg",
         "chat_sessions.css",
         "chat_sessions.js",
         "model_combobox.js",
@@ -64,7 +66,8 @@ class ConnectedAccountLoginPayload(BaseModel):
 
 
 def _asset_path(filename: str) -> Path:
-    path = STATIC_DIR / filename
+    asset_dir = PACKAGE_ASSETS_DIR if filename == "app-icon.svg" else STATIC_DIR
+    path = asset_dir / filename
     if not path.is_file():
         raise HTTPException(status_code=404, detail="Admin asset not found")
     return path

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -130,16 +130,16 @@ textarea {
 }
 
 .brand-mark {
-  display: grid;
+  display: block;
+  flex: 0 0 auto;
   width: 40px;
   height: 40px;
-  place-items: center;
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: #ffffff;
-  font-weight: 800;
-  font-size: 15px;
-  box-shadow: var(--glow-accent);
+}
+
+.brand-mark img {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .brand h1 {
@@ -195,6 +195,7 @@ button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
+.brand-mark:focus-visible,
 .nav-link:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -508,6 +508,30 @@
       textarea.scrollHeight > textarea.clientHeight ? "auto" : "hidden";
   }
 
+  function composerFocusIsUnclaimed() {
+    const active = document.activeElement;
+    return !active || active === document.body || active === document.documentElement;
+  }
+
+  function captureComposerSelection() {
+    const textarea = document.getElementById("chatComposer");
+    if (!textarea || document.activeElement !== textarea) return null;
+    return {
+      start: textarea.selectionStart,
+      end: textarea.selectionEnd,
+      direction: textarea.selectionDirection,
+    };
+  }
+
+  function restoreComposerSelection(selection) {
+    const textarea = document.getElementById("chatComposer");
+    if (!textarea || textarea.disabled || !selection) return;
+    const start = Math.min(selection.start, textarea.value.length);
+    const end = Math.min(selection.end, textarea.value.length);
+    textarea.focus({ preventScroll: true });
+    textarea.setSelectionRange(start, end, selection.direction);
+  }
+
   function renderTranscript() {
     const scroller = document.getElementById("chatTranscript");
     if (!scroller) return;
@@ -934,7 +958,7 @@
     send.disabled = Boolean(blocked) || !textarea.value.trim();
     send.hidden = Boolean(state.operation);
     stop.hidden = !state.operation;
-    textarea.disabled = Boolean(state.operation);
+    textarea.disabled = Boolean(state.operation && !state.operation.accepted);
     status.textContent =
       state.operation?.action === "compact"
         ? state.operation.status
@@ -976,6 +1000,7 @@
     if (!state.session || state.operation) return;
     invalidateEstimate();
     let failure = null;
+    const activeElementId = document.activeElement?.id;
     const operation = {
       id: crypto.randomUUID(),
       sessionId: state.session.id,
@@ -988,6 +1013,9 @@
       accepted: false,
       failureMessage: "",
       renderFrame: null,
+      returnFocusToComposer:
+        action === "send" &&
+        (activeElementId === "chatComposer" || activeElementId === "chatSend"),
     };
     if (action === "send") {
       state.draftOperationId = operation.id;
@@ -1024,8 +1052,18 @@
       if (error.name !== "AbortError") failure = error;
     } finally {
       cancelOperationRender(operation);
+      const composerSelection =
+        captureComposerSelection() ||
+        (operation.returnFocusToComposer && composerFocusIsUnclaimed()
+          ? {
+              start: state.draft.length,
+              end: state.draft.length,
+              direction: "none",
+            }
+          : null);
       if (state.operation === operation) state.operation = null;
       if (state.session?.id === operation.sessionId) await reloadSession();
+      restoreComposerSelection(composerSelection);
       const persistedFailure = state.turns[state.turns.length - 1]?.generation;
       const failureIsInline =
         operation.failureMessage &&
@@ -1090,15 +1128,21 @@
       state.session.revision = payload.revision;
     }
     let liveDelta = false;
+    let restoreComposerFocus = false;
     if (event === "turn.started") {
       operation.accepted = true;
-      if (operation.action === "send") {
+      if (
+        operation.action === "send" &&
+        state.draftOperationId === operation.id
+      ) {
         state.draft = "";
         state.draftSessionId = operation.sessionId;
         state.draftOperationId = null;
         const textarea = document.getElementById("chatComposer");
         if (textarea) textarea.value = "";
       }
+      restoreComposerFocus =
+        operation.returnFocusToComposer && composerFocusIsUnclaimed();
     } else if (event === "segment.started") {
       operation.segments[payload.ordinal] = {
         kind: payload.kind,
@@ -1130,6 +1174,18 @@
       return;
     }
     renderOperationStructure(operation);
+    if (restoreComposerFocus) {
+      const textarea = document.getElementById("chatComposer");
+      restoreComposerSelection(
+        textarea
+          ? {
+              start: textarea.value.length,
+              end: textarea.value.length,
+              direction: "none",
+            }
+          : null,
+      );
+    }
   }
 
   function commitPendingDeltas(operation) {

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -12,7 +12,15 @@
     <div class="app-shell">
       <aside class="sidebar">
         <div class="brand">
-          <div class="brand-mark">FC</div>
+          <a
+            class="brand-mark"
+            href="https://github.com/Alishahryar1/free-claude-code"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open Free Claude Code on GitHub"
+          >
+            <img src="/admin/assets/__FCC_VERSION__/app-icon.svg" alt="" />
+          </a>
           <div>
             <h1>Free Claude Code</h1>
             <p>Server Control · v__FCC_VERSION__</p>

--- a/src/free_claude_code/api/admin_static/model_combobox.js
+++ b/src/free_claude_code/api/admin_static/model_combobox.js
@@ -73,7 +73,7 @@
       return Array.from(this.listbox.querySelectorAll('[role="option"]'));
     }
 
-    open(query = "") {
+    open(query = this.input.value) {
       if (this.input.disabled) return;
       this.registry.forEach((combobox) => {
         if (combobox !== this && combobox.isOpen) combobox.close();

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -106,6 +106,11 @@ def test_admin_page_uses_installed_version(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     assert "<p>Server Control · v9.8.7</p>" in response.text
+    assert 'href="https://github.com/Alishahryar1/free-claude-code"' in response.text
+    assert 'target="_blank"' in response.text
+    assert 'rel="noopener noreferrer"' in response.text
+    assert 'aria-label="Open Free Claude Code on GitHub"' in response.text
+    assert 'src="/admin/assets/9.8.7/app-icon.svg"' in response.text
     assert 'href="/admin/assets/9.8.7/admin.css"' in response.text
     assert 'href="/admin/assets/9.8.7/chat_sessions.css"' in response.text
     assert 'src="/admin/assets/9.8.7/model_combobox.js"' in response.text
@@ -151,10 +156,29 @@ def test_admin_versioned_assets_serve_packaged_files(
     assert response.content == asset_path.read_bytes()
 
 
+def test_admin_versioned_logo_reuses_packaged_app_icon(monkeypatch, tmp_path):
+    asset_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "free_claude_code"
+        / "assets"
+        / "app-icon.svg"
+    )
+    _set_home(monkeypatch, tmp_path)
+    response = _local_client(create_test_app()).get(
+        f"/admin/assets/{package_version()}/app-icon.svg"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/svg+xml")
+    assert response.content == asset_path.read_bytes()
+
+
 @pytest.mark.parametrize(
     "path",
     (
         "/admin",
+        f"/admin/assets/{package_version()}/app-icon.svg",
         f"/admin/assets/{package_version()}/admin.css",
         f"/admin/assets/{package_version()}/admin.js",
         f"/admin/assets/{package_version()}/chat_sessions.css",

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.18.10"
+version = "5.18.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The Admin sidebar used a generic `FC` badge, Chat Sessions discarded composer focus after sending, and searchable model selectors ignored their visible value whenever they reopened.

## Changes

| Before | After |
| --- | --- |
| The sidebar displayed a non-interactive `FC` text badge. | The sidebar displays the packaged FCC logo and opens the FCC GitHub repository in a safely isolated new tab. |
| The app icon was available only to desktop surfaces. | The Admin UI serves the same canonical SVG through its versioned asset route. |
| Sending a message discarded composer focus during and after the reply. | The next draft can be typed immediately while the reply streams, and focus plus caret survive the final refresh. |
| A submitted draft and a newly typed draft could share the operation lifecycle. | Only the submitted draft is cleared when the server accepts it; a new draft remains intact when the operation stops or finishes. |
| Reopening a populated model selector showed every model until its text changed. | Every model selector filters immediately from its currently visible value, including after a page refresh. |

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Admin sidebar now serves the packaged application icon through the versioned asset route and links to the project repository. Chat Sessions retains composer focus and allows the next draft during accepted streaming responses, while populated model pickers open filtered to their current selection. Browser validation confirmed these behaviors against the running application.
</details>


<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

Browser validation exercised the versioned icon, populated model selection, accepted-stream composer focus, and draft retention behavior without reproducing a product failure.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the baseline browser validation before the PR and observed exit code 1, reflecting the three pre-PR expectations.
- Ran the browser validation after the PR and confirmed all tests passed (3 passed in 2.00s).
- Reviewed the affected implementation files and line ranges to understand how the PR changes the behavior.

<a href="https://app.greptile.com/trex/runs/21547498/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: filter model selectors on open"](https://github.com/alishahryar1/free-claude-code/commit/02fb8769910136098fe25e13e438821040e5955d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58516481)</sub>

<!-- /greptile_comment -->