### PR TITLE
feat: add OmniRoute OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,11 @@ TOKENROUTER_BASE_URL="https://api.tokenrouter.com/v1"
 NARAROUTE_BASE_URL="https://router.bynara.id/v1"
 
 
+# OmniRoute Config (openAI-compatible Chat Completions gateway at localhost:20128/v1)
+# OMNIROUTE_API_KEY=<your-token>
+OMNIROUTE_BASE_URL="http://localhost:20128/v1"
+
+
 # Poolside AI (OpenAI-compatible Chat Completions at inference.poolside.ai/v1)
 # POOLSIDE_API_KEY=<your-token>
 
@@ -196,7 +201,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # Default model and optional Claude tier overrides
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "poolside" | "llm7"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "github_models" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "poolside" | "llm7" | "omniroute"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -237,6 +242,7 @@ MODEL="nvidia_nim/nvidia/nemotron-3-super-120b-a12b"
 # FCC_SMOKE_MODEL_ZAI_API=<provider/model-id>
 # FCC_SMOKE_MODEL_TOKENROUTER=<your-token>
 # FCC_SMOKE_MODEL_NARAROUTE=<provider/model-id>
+# FCC_SMOKE_MODEL_OMNIROUTE=<provider/model-id>
 # FCC_SMOKE_MODEL_POOLSIDE=<provider/model-id>
 # FCC_SMOKE_MODEL_LLM7=<provider/model-id>
 # FCC_SMOKE_MODEL_FIREWORKS=<provider/model-id>
@@ -314,6 +320,7 @@ REASONING_HAIKU=inherit
 # ZAI_API_PROXY=<http-or-socks-url>
 # TOKENROUTER_PROXY=<http-or-socks-url>
 # NARAROUTE_PROXY=<http-or-socks-url>
+# OMNIROUTE_PROXY=<http-or-socks-url>
 # POOLSIDE_PROXY=<http-or-socks-url>
 # LLM7_PROXY=<http-or-socks-url>
 # FIREWORKS_PROXY=<http-or-socks-url>

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ from more than one provider before succeeding.
 | [Poolside AI](https://platform.poolside.ai/) | `POOLSIDE_API_KEY` | `poolside/poolside/laguna-s-2.1` |
 | [LLM7.io](https://dash.llm7.io/) | `LLM7_API_KEY` | `llm7/default` |
 | [Ollama Cloud](https://ollama.com/settings/keys) | `OLLAMA_API_KEY` | `ollama_cloud/qwen3-coder:480b` |
+| [OmniRoute](https://omniroute.ai) | `OMNIROUTE_API_KEY` | `omniroute/auto/best-coding` |
 | [LM Studio](https://lmstudio.ai/) | `LM_STUDIO_BASE_URL` | `lmstudio/<model-id>` |
 | [llama.cpp](https://github.com/ggml-org/llama.cpp) | `LLAMACPP_BASE_URL` | `llamacpp/<model-id>` |
 | [Ollama](https://ollama.com/) | `OLLAMA_BASE_URL` | `ollama/<model-tag>` |
@@ -267,6 +268,9 @@ from more than one provider before succeeding.
   files and attached service accounts also work. Set `VERTEX_PROJECT_ID`, and
   optionally change `VERTEX_LOCATION` from its `global` default.
 - Cloudflare requires both its API token and account ID.
+- OmniRoute runs a local OpenAI-compatible gateway at `http://localhost:20128/v1`;
+  set `OMNIROUTE_API_KEY` and select an `auto/`-prefixed model from the picker
+  (override `OMNIROUTE_BASE_URL` if needed).
 - For Ollama Cloud, use the exact model IDs shown in the model picker. Local
   Ollama uses the separate `ollama/` prefix.
 - Prefer tool-capable models for coding agents. Local models also need enough context for the agent's system prompt and tool definitions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.17.0"
+version = "5.18.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -28,6 +28,8 @@ CODESTRAL_DEFAULT_BASE = "https://codestral.mistral.ai/v1"
 LMSTUDIO_DEFAULT_BASE = "http://localhost:1234/v1"
 LLAMACPP_DEFAULT_BASE = "http://localhost:8080/v1"
 OLLAMA_DEFAULT_BASE = "http://localhost:11434"
+# OmniRoute local gateway OpenAI-compatible Chat Completions endpoint.
+OMNIROUTE_DEFAULT_BASE = "http://localhost:20128/v1"
 OLLAMA_CLOUD_DEFAULT_BASE = "https://ollama.com/v1"
 OPENCODE_ZEN_DEFAULT_BASE = "https://opencode.ai/zen/v1"
 OPENCODE_GO_DEFAULT_BASE = "https://opencode.ai/zen/go/v1"
@@ -557,6 +559,15 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         credential_attr="ollama_api_key",
         default_base_url=OLLAMA_CLOUD_DEFAULT_BASE,
         proxy_attr="ollama_cloud_proxy",
+    ),
+    "omniroute": ProviderDescriptor(
+        provider_id="omniroute",
+        display_name="OmniRoute",
+        credential_env="OMNIROUTE_API_KEY",
+        credential_attr="omniroute_api_key",
+        default_base_url=OMNIROUTE_DEFAULT_BASE,
+        base_url_attr="omniroute_base_url",
+        proxy_attr="omniroute_proxy",
     ),
     "lmstudio": ProviderDescriptor(
         provider_id="lmstudio",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -17,6 +17,7 @@ from .nim import NimSettings
 from .provider_catalog import (
     BEDROCK_DEFAULT_BASE,
     NARAROUTE_DEFAULT_BASE,
+    OMNIROUTE_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
     TOKENROUTER_DEFAULT_BASE,
 )
@@ -194,6 +195,15 @@ class Settings(BaseModel):
     nararoute_base_url: NonEmptyString = Field(
         default=NARAROUTE_DEFAULT_BASE,
         validation_alias="NARAROUTE_BASE_URL",
+    )
+
+    # ==================== OmniRoute Config ====================
+    omniroute_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="OMNIROUTE_API_KEY"
+    )
+    omniroute_base_url: NonEmptyString = Field(
+        default=OMNIROUTE_DEFAULT_BASE,
+        validation_alias="OMNIROUTE_BASE_URL",
     )
 
     # ==================== Poolside AI (OpenAI-compatible) ====================
@@ -491,6 +501,9 @@ class Settings(BaseModel):
     )
     nararoute_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="NARAROUTE_PROXY"
+    )
+    omniroute_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="OMNIROUTE_PROXY"
     )
     poolside_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="POOLSIDE_PROXY"

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -738,4 +738,17 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
         normalize_base_url=True,
         reasoning_delta_field="reasoning",
     ),
+    "omniroute": OpenAIChatProfile(
+        _policy(
+            "OMNIROUTE",
+            ReasoningReplayMode.REASONING_CONTENT,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        NO_REASONING,
+        model_listing=OpenAIModelListing(
+            thinking_boolean_path=("capabilities", "reasoning"),
+            context_window_tokens_path=("context_length",),
+            max_output_tokens_path=("max_output_tokens",),
+        ),
+    ),
 }

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -53,6 +53,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "poolside",
     "llm7",
     "ollama_cloud",
+    "omniroute",
     "lmstudio",
     "llamacpp",
     "ollama",

--- a/tests/providers/test_omniroute.py
+++ b/tests/providers/test_omniroute.py
@@ -1,0 +1,101 @@
+"""Tests for OmniRoute's OpenAI-compatible model catalog."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import OMNIROUTE_DEFAULT_BASE
+from tests.providers.support import (
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+)
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_extracts_reasoning_and_context_limits() -> None:
+    provider = profiled_provider(
+        "omniroute",
+        make_provider_config(
+            api_key="test-omniroute-key",
+            base_url=OMNIROUTE_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="omniroute"),
+    )
+    provider._client.models.list = AsyncMock(
+        return_value=SimpleNamespace(
+            data=[
+                {
+                    "id": "auto/best-coding",
+                    "context_length": 1000000,
+                    "max_output_tokens": 384000,
+                    "capabilities": {"reasoning": True},
+                },
+                {
+                    "id": "auto/best-fast",
+                    "context_length": 1000000,
+                    "max_output_tokens": 384000,
+                    "capabilities": {"reasoning": False},
+                },
+                {
+                    "id": "plain",
+                    "capabilities": {"reasoning": "true"},
+                },
+            ]
+        )
+    )
+    try:
+        infos = await provider.list_model_infos()
+    finally:
+        await provider.cleanup()
+
+    assert infos == frozenset(
+        {
+            ProviderModelInfo(
+                "auto/best-coding",
+                supports_thinking=True,
+                context_window_tokens=1000000,
+                max_output_tokens=384000,
+            ),
+            ProviderModelInfo(
+                "auto/best-fast",
+                supports_thinking=False,
+                context_window_tokens=1000000,
+                max_output_tokens=384000,
+            ),
+            ProviderModelInfo("plain"),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_missing_id_rejected() -> None:
+    provider = profiled_provider(
+        "omniroute",
+        make_provider_config(
+            api_key="test-omniroute-key",
+            base_url=OMNIROUTE_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="omniroute"),
+    )
+    provider._client.models.list = AsyncMock(
+        return_value=SimpleNamespace(
+            data=[
+                {
+                    "context_length": 1000000,
+                    "capabilities": {"reasoning": True},
+                }
+            ]
+        )
+    )
+    try:
+        with pytest.raises(ValueError):
+            await provider.list_model_infos()
+    finally:
+        await provider.cleanup()

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -26,6 +26,7 @@ from free_claude_code.config.provider_catalog import (
     NARAROUTE_DEFAULT_BASE,
     NEBIUS_DEFAULT_BASE,
     OLLAMA_CLOUD_DEFAULT_BASE,
+    OMNIROUTE_DEFAULT_BASE,
     POOLSIDE_DEFAULT_BASE,
     PROVIDER_CATALOG,
     QWENCLOUD_CODING_DEFAULT_BASE,
@@ -103,6 +104,8 @@ def _make_settings(**overrides):
     mock.tokenrouter_base_url = TOKENROUTER_DEFAULT_BASE
     mock.nararoute_api_key = "test_nararoute_key"
     mock.nararoute_base_url = NARAROUTE_DEFAULT_BASE
+    mock.omniroute_api_key = "test_omniroute_key"
+    mock.omniroute_base_url = OMNIROUTE_DEFAULT_BASE
     mock.agnes_api_key = "test_agnes_key"
     mock.zenmux_api_key = "test_zenmux_key"
     mock.wandb_api_key = "test_wandb_key"
@@ -135,6 +138,7 @@ def _make_settings(**overrides):
     mock.zai_api_proxy = None
     mock.tokenrouter_proxy = None
     mock.nararoute_proxy = None
+    mock.omniroute_proxy = None
     mock.agnes_proxy = None
     mock.zenmux_proxy = None
     mock.wandb_proxy = None
@@ -912,6 +916,7 @@ def test_create_provider_instantiates_each_builtin():
         "zai_api": OpenAIChatProvider,
         "tokenrouter": OpenAIChatProvider,
         "nararoute": OpenAIChatProvider,
+        "omniroute": OpenAIChatProvider,
         "agnes": OpenAIChatProvider,
         "zenmux": OpenAIChatProvider,
         "wandb": OpenAIChatProvider,

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.17.0"
+version = "5.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds OmniRoute as an OpenAI-compatible provider with configuration, model metadata, documentation, and runtime coverage. Two user-facing issues were reproduced: configured OmniRoute smoke runs fall back to an unsupported `omniroute/smoke-default` model, and missing-key API responses omit the documented OmniRoute setup link. The affected smoke configuration, provider runtime, and API error paths were exercised successfully.

<h3>Confidence Score: 4/5</h3>

The change should not merge until OmniRoute receives a valid automatic smoke-model default, because configured deployments will otherwise submit an unsupported model identifier.

Both reported behaviors were reproduced through deterministic runtime paths with captured script sources, response output, and focused regression results. The credential-link omission is directly attributable to the new provider descriptor.

**Files Needing Attention:** `smoke/lib/config.py` needs an OmniRoute-specific smoke default and coverage; `src/free_claude_code/config/provider_catalog.py` needs the documented credential URL and missing-key response coverage.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the OmniRoute smoke-selection reproduction and captured the focused smoke-configuration contract test results to validate the P1 finding.
- T-Rex produced focused OmniRoute missing-key reproducer and regression test outputs to validate the P2 finding.
- T-Rex validated the P1 contract validation by noting the repro script usage and the before/after API key behavior, and documented the recommended fix.
- T-Rex compared the descriptor behavior before and after adding the documented URL, confirmed the 503 response behavior, and noted that the reproducer source was uploaded along with the captures.

<a href="https://app.greptile.com/trex/runs/21722732/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (3)</h3>

1. `smoke/lib/config.py`, line 328-337 ([link](https://github.com/alishahryar1/free-claude-code/blob/e78b83127f59852554dba7820b9e32cadde766d7/smoke/lib/config.py#L328-L337)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **OmniRoute smoke fallback uses an unsupported model**

   When `OMNIROUTE_API_KEY` is configured without `FCC_SMOKE_MODEL_OMNIROUTE`, this fallback selects `omniroute/smoke-default`. OmniRoute supports `auto` and named `auto/*` selectors such as `auto/best-coding`, but not `smoke-default`, so a live automatic smoke run submits an invalid model ID. Add an OmniRoute entry to `PROVIDER_SMOKE_DEFAULT_MODELS`, such as `omniroute/auto/best-coding`, and cover the no-override path.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Standalone OmniRoute smoke-selection reproduction script](https://app.greptile.com/trex/artifacts/6875d995-7055-4a85-9f59-aa4668831a88)**

   - A deterministic no-network script that constructs the OmniRoute smoke configuration and asserts both key-absent and key-present selection outcomes, proving the selection path.

   **[Captured source for the OmniRoute smoke-selection reproduction script](https://app.greptile.com/trex/artifacts/e5c81a56-775e-4299-ad37-53eb42c278d4)**

   - The executed command captured the uploaded reproduction script source, showing the exact isolated configuration setup and assertions used to prove the behavior.

   **[OmniRoute smoke selection before configuring an API key](https://app.greptile.com/trex/artifacts/1d540708-b2c5-43a8-8f4b-1dc6adbf6c52)**

   - The executed no-key run selected no OmniRoute provider smoke model while the override was absent, establishing the comparison baseline.

   **[OmniRoute smoke selection after configuring an API key](https://app.greptile.com/trex/artifacts/291abad2-cdd4-43e5-816e-c90a9ed5cfd2)**

   - The executed synthetic-key run selected \`omniroute/smoke-default\` with \`provider\_default\` provenance while the override was absent, confirming the defect.

   **[Focused smoke-configuration contract test results](https://app.greptile.com/trex/artifacts/a2ef9f00-d74e-44bb-b204-591bae0a0e28)**

   - The focused smoke configuration suite completed with 66 passing tests, showing the repository's existing contracts pass despite the untested OmniRoute default gap.

   <a href="https://app.greptile.com/trex/runs/21722732/artifacts?artifact=6875d995-7055-4a85-9f59-aa4668831a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **OmniRoute smoke enumeration creates unsupported smoke-default model**

   - **Bug**
     - When an OmniRoute API key is configured but `FCC_SMOKE_MODEL_OMNIROUTE` is absent, automatic provider smoke includes `omniroute/smoke-default`. The deterministic executed reproduction confirms this exact output. OmniRoute's documented Auto-Combo model catalog supports `auto` and named `auto/*` selectors such as `auto/best-coding` and `auto/coding`, but not `smoke-default`; a live provider smoke will therefore submit an invalid model ID.
   - **Cause**
     - `smoke/lib/config.py:328-337` uses a generic fallback when a configured provider has no entry in `PROVIDER_SMOKE_DEFAULT_MODELS`. OmniRoute is absent from that mapping at `smoke/lib/config.py:51-99`, so line 336 formats `omniroute/smoke-default`.
   - **Fix**
     - Add `"omniroute": "omniroute/auto/best-coding"` to `PROVIDER_SMOKE_DEFAULT_MODELS` (consistent with `README.md:236`) and add a contract test covering a configured OmniRoute key with no `FCC_SMOKE_MODEL_OMNIROUTE` override.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


3. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **OmniRoute missing-key error omits the documented setup link**

   - **Bug**
     - `PROVIDER_CATALOG["omniroute"]` supplies `credential_env` and `credential_attr` but no `credential_url` at `src/free_claude_code/config/provider_catalog.py:563-571`. The shared missing-credential path at `src/free_claude_code/providers/runtime/config.py:46-49` conditionally appends `Get a key at …`, so an API request for `omniroute/auto/best-coding` with no key returns a 503 that tells the user only to add the key in Admin UI. README documents OmniRoute at `https://omniroute.ai` (`README.md:236`), but that link is absent from the user-facing error.
   - **Cause**
     - The OmniRoute descriptor was added without its `credential_url`, while the error formatter relies exclusively on that descriptor field for setup guidance.
   - **Fix**
     - Add `credential_url="https://omniroute.ai"` to the OmniRoute `ProviderDescriptor`, and add a focused missing-credential assertion covering the resulting 503 message.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: add OmniRoute OpenAI-compatible pr..."](https://github.com/alishahryar1/free-claude-code/commit/e78b83127f59852554dba7820b9e32cadde766d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58865718)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->