### PR TITLE
feat: add picker alias engine for Claude Desktop model discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.19.0"
+version = "5.20.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -13,6 +13,7 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.core.gateway_model_ids import (
     gateway_model_id,
     no_thinking_gateway_model_id,
+    picker_alias_for,
 )
 from free_claude_code.core.model_capabilities import ModelInputModality
 
@@ -133,15 +134,26 @@ def build_models_list_response(
     runtime: RequestRuntimePort,
     *,
     view: ModelCatalogView = ModelCatalogView.CLAUDE,
+    picker_aliases: bool = False,
 ) -> ModelsListResponse:
-    """Return the application model inventory in the requested client view."""
+    """Return the application model inventory in the requested client view.
+
+    ``picker_aliases`` opts into Claude Desktop picker alias ids; only the
+    desktop-scoped API mount enables it, so every other FCC client sees raw
+    provider refs regardless of seeded alias state.
+    """
     if view is ModelCatalogView.CLAUDE:
-        return _build_claude_models_response(settings, runtime)
+        return _build_claude_models_response(
+            settings, runtime, picker_aliases=picker_aliases
+        )
     return _build_direct_models_response(settings, runtime, view=view)
 
 
 def _build_claude_models_response(
-    settings: Settings, runtime: RequestRuntimePort
+    settings: Settings,
+    runtime: RequestRuntimePort,
+    *,
+    picker_aliases: bool,
 ) -> ModelsListResponse:
     """Preserve the established Claude-compatible catalog exactly."""
     models: list[ModelResponse] = []
@@ -156,6 +168,7 @@ def _build_claude_models_response(
             supports_thinking=(
                 model_info.supports_thinking if model_info is not None else None
             ),
+            picker_aliases=picker_aliases,
         )
 
     for model_info in runtime.cached_prefixed_model_infos():
@@ -164,6 +177,7 @@ def _build_claude_models_response(
             seen,
             model_info.model_id,
             supports_thinking=model_info.supports_thinking,
+            picker_aliases=picker_aliases,
         )
 
     for model in SUPPORTED_CLAUDE_MODELS:
@@ -319,13 +333,22 @@ def _append_provider_model_variants(
     provider_model_ref: str,
     *,
     supports_thinking: bool | None = None,
+    picker_aliases: bool = False,
 ) -> None:
+    thinking_id = (
+        picker_alias_for(provider_model_ref) if picker_aliases else None
+    ) or gateway_model_id(provider_model_ref)
+    no_thinking_id = (
+        picker_alias_for(provider_model_ref, force_reasoning_off=True)
+        if picker_aliases
+        else None
+    ) or no_thinking_gateway_model_id(provider_model_ref)
     if supports_thinking is not False:
         _append_unique_model(
             models,
             seen,
             _discovered_model_response(
-                gateway_model_id(provider_model_ref),
+                thinking_id,
                 display_name=provider_model_ref,
             ),
         )
@@ -333,7 +356,7 @@ def _append_provider_model_variants(
         models,
         seen,
         _discovered_model_response(
-            no_thinking_gateway_model_id(provider_model_ref),
+            no_thinking_id,
             display_name=f"{provider_model_ref} (no thinking)",
         ),
     )

--- a/src/free_claude_code/application/routing.py
+++ b/src/free_claude_code/application/routing.py
@@ -13,7 +13,10 @@ from free_claude_code.config.provider_catalog import (
 from free_claude_code.config.reasoning import ReasoningPreference
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest, TokenCountRequest
-from free_claude_code.core.gateway_model_ids import decode_gateway_model_id
+from free_claude_code.core.gateway_model_ids import (
+    decode_gateway_model_id,
+    resolve_picker_alias,
+)
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import ReasoningPolicy
 
@@ -146,6 +149,18 @@ class ModelRouter:
     def _direct_provider_model(
         self, model_name: str
     ) -> tuple[str | None, str | None, bool]:
+        alias_resolution = resolve_picker_alias(model_name)
+        if alias_resolution is not None:
+            aliased_ref, force_reasoning_off = alias_resolution
+            provider_id, separator, provider_model = aliased_ref.partition("/")
+            if (
+                not separator
+                or provider_id not in SUPPORTED_PROVIDER_IDS
+                or not provider_model
+            ):
+                return None, None, False
+            return provider_id, provider_model, force_reasoning_off
+
         decoded = decode_gateway_model_id(model_name)
         if decoded is not None:
             if decoded.provider_id not in SUPPORTED_PROVIDER_IDS:

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -703,6 +703,19 @@ class Settings(BaseModel):
         default="freecc",
         validation_alias="ANTHROPIC_AUTH_TOKEN",
     )
+    desktop_gateway_prefix: NonEmptyString = Field(
+        default="claude-desktop",
+        validation_alias="DESKTOP_GATEWAY_PREFIX",
+    )
+
+    @field_validator("desktop_gateway_prefix")
+    @classmethod
+    def normalize_desktop_gateway_prefix(cls, v: str) -> str:
+        """Strip boundary slashes so the prefix mounts as a single ``/{prefix}``."""
+        prefix = v.strip("/")
+        if not prefix:
+            raise ValueError("DESKTOP_GATEWAY_PREFIX must contain a path segment")
+        return prefix
 
     @field_validator("max_message_log_entries_per_chat", mode="before")
     @classmethod

--- a/src/free_claude_code/core/gateway_model_ids.py
+++ b/src/free_claude_code/core/gateway_model_ids.py
@@ -1,5 +1,6 @@
 """Gateway-safe model ID encoding shared by API and CLI adapters."""
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 GATEWAY_MODEL_ID_PREFIX = "anthropic"
@@ -8,6 +9,47 @@ GATEWAY_MODEL_ID_PREFIX = "anthropic"
 # supporting thinking. This intentionally uses that client-side capability
 # heuristic while keeping the real provider/model ref reversible for routing.
 NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
+
+PICKER_ALIAS_PREFIX = "claude-sonnet-nim"
+_PICKER_ALIAS_NO_THINKING_SUFFIX = "-no-thinking"
+_PICKER_ALIAS_WIDTH = 4
+
+
+@dataclass(frozen=True, slots=True)
+class _PickerAliasMaps:
+    """Immutable alias snapshot shared by catalog output and request routing.
+
+    Published as a single module-global assignment so concurrent readers can
+    never observe a torn state mixing refs from two different inventories.
+    """
+
+    alias_to_ref: Mapping[str, str]
+    alias_to_ref_no_thinking: Mapping[str, str]
+    ref_to_alias: Mapping[str, str]
+    ref_to_alias_no_thinking: Mapping[str, str]
+
+
+_EMPTY_PICKER_ALIAS_MAPS = _PickerAliasMaps({}, {}, {}, {})
+
+# Seeded at startup with the sorted refs from the runtime cached model catalog,
+# then republished whenever the model cache is mutated. Tests call
+# ``clear_picker_aliases()`` between runs to restore the inert empty snapshot.
+_picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+
+# Sticky ref-to-alias assignments that survive reseeds: once an alias has been
+# advertised for a ref, that alias is never re-pointed to a different ref, so
+# a desktop picker holding a stale catalog cannot silently route to another
+# model. Numbers of retired refs stay consumed; a returning ref regains its
+# previous alias. Reset only by ``clear_picker_aliases()``.
+_sticky_ref_to_alias: dict[str, str] = {}
+_used_alias_numbers: set[int] = set()
+
+
+def _next_unused_alias_number(used_numbers: set[int]) -> int:
+    candidate = 1
+    while candidate in used_numbers:
+        candidate += 1
+    return candidate
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,3 +91,96 @@ def decode_gateway_model_id(model_name: str) -> DecodedGatewayModelId | None:
         provider_model=provider_model,
         force_reasoning_off=force_reasoning_off,
     )
+
+
+def _format_picker_alias(index: int, *, no_thinking: bool) -> str:
+    suffix = _PICKER_ALIAS_NO_THINKING_SUFFIX if no_thinking else ""
+    return f"{PICKER_ALIAS_PREFIX}-{index:0{_PICKER_ALIAS_WIDTH}d}{suffix}"
+
+
+def seed_picker_aliases(provider_model_refs: Iterable[str]) -> None:
+    """Publish a fresh immutable alias snapshot built from the supplied refs.
+
+    Aliases are stable across reseeds: a ref that already holds an alias keeps
+    it, and new refs take previously unused numbers, so an alias already shown
+    in a client picker can never silently resolve to a different model.
+    Numbering is deterministic on restart when starting from the same initial
+    inventory (counters assigned by ``sorted(refs)`` order).
+
+    An empty inventory publishes the inert empty snapshot so a cold-start
+    ``/v1/models`` request still falls back to the canonical
+    ``gateway_model_id`` wrappers, while sticky assignments and consumed
+    alias numbers are preserved so a later refresh can never re-point a
+    previously advertised alias.
+    """
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+
+    wanted = [ref for ref in sorted(set(provider_model_refs)) if ref]
+    if not wanted:
+        _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+        return
+
+    thinking_aliases: dict[str, str] = {}
+    no_thinking_aliases: dict[str, str] = {}
+    ref_to_thinking: dict[str, str] = {}
+    ref_to_no_thinking: dict[str, str] = {}
+    used_numbers = set(_used_alias_numbers)
+
+    for ref in wanted:
+        alias = _sticky_ref_to_alias.get(ref)
+        if alias is None:
+            number = _next_unused_alias_number(used_numbers)
+            used_numbers.add(number)
+            alias = _format_picker_alias(number, no_thinking=False)
+        thinking_aliases[alias] = ref
+        alias_no_thinking = f"{alias}{_PICKER_ALIAS_NO_THINKING_SUFFIX}"
+        no_thinking_aliases[alias_no_thinking] = ref
+        ref_to_thinking[ref] = alias
+        ref_to_no_thinking[ref] = alias_no_thinking
+
+    _sticky_ref_to_alias = {**_sticky_ref_to_alias, **ref_to_thinking}
+    _used_alias_numbers = used_numbers
+    _picker_aliases = _PickerAliasMaps(
+        alias_to_ref=thinking_aliases,
+        alias_to_ref_no_thinking=no_thinking_aliases,
+        ref_to_alias=ref_to_thinking,
+        ref_to_alias_no_thinking=ref_to_no_thinking,
+    )
+
+
+def picker_alias_for(
+    provider_model_ref: str, *, force_reasoning_off: bool = False
+) -> str | None:
+    """Return the picker alias for ``provider_model_ref``, if seeded."""
+    maps = _picker_aliases
+    if force_reasoning_off:
+        return maps.ref_to_alias_no_thinking.get(provider_model_ref)
+    return maps.ref_to_alias.get(provider_model_ref)
+
+
+def resolve_picker_alias(model_name: str) -> tuple[str, bool] | None:
+    """Reverse-lookup alias. Returns ``(provider_ref, force_reasoning_off)``."""
+    if not model_name:
+        return None
+    maps = _picker_aliases
+    ref = maps.alias_to_ref_no_thinking.get(model_name)
+    if ref is not None:
+        return ref, True
+    ref = maps.alias_to_ref.get(model_name)
+    if ref is not None:
+        return ref, False
+    return None
+
+
+def has_picker_aliases() -> bool:
+    """Whether ``seed_picker_aliases`` has populated the snapshot."""
+    maps = _picker_aliases
+    return bool(maps.alias_to_ref) or bool(maps.alias_to_ref_no_thinking)
+
+
+def clear_picker_aliases() -> None:
+    """Drop every alias entry and sticky assignment. Tests and hardening."""
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+    _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+    _sticky_ref_to_alias = {}
+    _used_alias_numbers = set()

--- a/src/free_claude_code/runtime/provider_manager.py
+++ b/src/free_claude_code/runtime/provider_manager.py
@@ -13,7 +13,9 @@ from free_claude_code.application.model_metadata import (
     ProviderModelRefreshResult,
 )
 from free_claude_code.application.ports import RequestRuntimePort
+from free_claude_code.config.model_refs import configured_chat_model_refs
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.gateway_model_ids import seed_picker_aliases
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.runtime import ProviderRuntime
@@ -366,7 +368,27 @@ class ProviderRuntimeManager:
             return
         self._run_model_catalog_publication(publisher.ensure_exists)
 
+    def refresh_picker_aliases(self) -> None:
+        """Re-point the process-global picker aliases at the current inventory.
+
+        Seeds the union of configured chat model refs and cached discovery
+        refs so a configured model absent from the discovery cache (cold or
+        incomplete provider discovery) still gets a picker alias instead of
+        being advertised as a raw gateway identifier.
+
+        Sticky ref-to-alias assignments make reseeds stable: already
+        advertised aliases keep routing to the same model, newly discovered
+        refs gain aliases immediately, and refs removed from the inventory
+        retire instead of routing to stale targets.
+        """
+        configured = (
+            ref.model_ref for ref in configured_chat_model_refs(self.current_settings())
+        )
+        cached = (info.model_id for info in self.cached_prefixed_model_infos())
+        seed_picker_aliases((*configured, *cached))
+
     def _publish_model_catalog(self) -> None:
+        self.refresh_picker_aliases()
         publisher = self._model_catalog_publisher
         if publisher is None:
             return

--- a/tests/api/test_model_catalog_aliases.py
+++ b/tests/api/test_model_catalog_aliases.py
@@ -1,0 +1,129 @@
+"""Picker alias selection in ``free_claude_code.api.model_catalog``."""
+
+import pytest
+
+from free_claude_code.api import model_catalog
+from free_claude_code.application.ports import RequestRuntimeLease
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+class _StubRuntime:
+    async def acquire(
+        self, *, include_model_infos: bool = False
+    ) -> RequestRuntimeLease:
+        raise NotImplementedError("catalog construction never acquires a lease")
+
+    def current_settings(self) -> Settings:
+        raise NotImplementedError
+
+    def cached_model_info(self, provider_id: str, model_id: str):
+        return None
+
+    def cached_prefixed_model_infos(self):
+        return ()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+_MODEL_SLOTS = ("model", "model_fable", "model_opus", "model_sonnet", "model_haiku")
+
+
+def _settings_with_refs(*refs):
+    slots = {
+        slot: (refs[index] if index < len(refs) else None)
+        for index, slot in enumerate(_MODEL_SLOTS)
+    }
+    return Settings.model_construct(
+        **slots,
+        reasoning_policy=ReasoningPreference.CLIENT,
+    )
+
+
+def _ids(response: model_catalog.ModelsListResponse) -> list[str]:
+    return [item.id for item in response.data]
+
+
+def test_unseeded_state_uses_gateway_wrapper_ids():
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    picker_ids = [
+        item.id for item in response.data if item.id.startswith("claude-sonnet-nim")
+    ]
+    assert picker_ids == []
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in _ids(response)
+    assert "claude-3-freecc-no-thinking/nvidia_nim/01-ai/yi-large" in _ids(response)
+
+
+def test_seeded_state_prefers_alias_for_thinking_variant():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    ids = _ids(response)
+    assert "claude-sonnet-nim-0001" in ids
+    assert "claude-sonnet-nim-0001-no-thinking" in ids
+    # Wrapper id is suppressed because the alias covers the same slot.
+    assert "anthropic/nvidia_nim/01-ai/yi-large" not in ids
+
+
+def test_seed_only_nim_uses_wrapper_for_other_providers():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("openai_chat/anthropic/claude-3-5-sonnet-20241022")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    # Non-NIM ref falls through to the original wrapper ids.
+    assert "anthropic/openai_chat/anthropic/claude-3-5-sonnet-20241022" in ids
+    assert (
+        "claude-3-freecc-no-thinking/openai_chat/anthropic/claude-3-5-sonnet-20241022"
+        in ids
+    )
+    # And no alias leaked from the seeded NIM ref into the unrelated entry.
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+
+
+def test_display_name_is_provider_model_ref_when_using_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    alias_entries = [
+        item for item in response.data if item.id.startswith("claude-sonnet-nim-0001")
+    ]
+    # Thinking entry exposes the canonical provider ref; the no-thinking
+    # variant keeps the established "(no thinking)" label suffix.
+    assert {item.display_name for item in alias_entries} == {
+        "nvidia_nim/01-ai/yi-large",
+        "nvidia_nim/01-ai/yi-large (no thinking)",
+    }
+
+
+def test_seeded_aliases_are_hidden_without_opt_in():
+    """Claude Code / Codex / Pi path: aliases must never leak, even when seeded."""
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in ids

--- a/tests/application/test_routing_aliases.py
+++ b/tests/application/test_routing_aliases.py
@@ -1,0 +1,108 @@
+"""Picker alias decoding routed through ``application.routing.ModelRouter``."""
+
+import pytest
+
+from free_claude_code.application.routing import ModelRouter
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture
+def settings():
+    settings = Settings()
+    settings.model = "nvidia_nim/fallback-model"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    settings.reasoning_policy = ReasoningPreference.CLIENT
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_resolves_alias_before_gateway_prefix(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.original_model == "claude-sonnet-nim-0001"
+    assert resolved.reasoning_preference is ReasoningPreference.CLIENT
+
+
+def test_resolves_alias_no_thinking_variant_forces_reasoning_off(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001-no-thinking")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.reasoning_preference is ReasoningPreference.OFF
+
+
+def test_alias_takes_priority_over_anthropic_prefix(settings):
+    # The same underlying ref exists both as an alias and as an
+    # ``anthropic/<ref>`` gateway id. The alias must win on the picker shape,
+    # and both code paths resolve to the same upstream model.
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    alias_resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+    gateway_resolved = ModelRouter(settings).resolve(
+        "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct"
+    )
+
+    assert (
+        alias_resolved.primary.provider_id
+        == gateway_resolved.primary.provider_id
+        == "nvidia_nim"
+    )
+    assert (
+        alias_resolved.primary.provider_model
+        == gateway_resolved.primary.provider_model
+        == "meta/llama-3.3-70b-instruct"
+    )
+
+
+def test_alias_for_unknown_provider_falls_through_to_existing_chain(settings):
+    # An alias pointing at an unsupported provider must not silently match;
+    # the alias resolver returns the ref and routing layer validates it.
+    # After validation, ``resolve`` falls through to the existing route
+    # table, so ``claude-sonnet-nim-NNNN`` lands on the configured fallback.
+    gmi.seed_picker_aliases(["bogus_provider/some-model"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    # Not the bogus provider we accidentally aliased to.
+    assert resolved.primary.provider_id != "bogus_provider"
+    # Falls through to the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"
+
+
+def test_unknown_alias_falls_through_to_existing_routing(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-9999")
+
+    # 9999 is not a seeded alias; the routing layer should fall through.
+    # With no alias match, unknown alias falls back to model name parsing,
+    # which raises because ``claude-sonnet-nim-9999`` doesn't match a route.
+    assert resolved.original_model == "claude-sonnet-nim-9999"
+
+
+def test_unseeded_alias_returns_none_from_resolver(settings):
+    # Cold-start path: no aliases seeded, alias-shaped id should not produce
+    # a routing hit. Falls through to the existing fallback chain.
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0500")
+
+    # Falls through and lands on the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,3 +241,13 @@ def _propagate_loguru_to_caplog():
         loguru_logger.remove(
             handler_id
         )  # Handler already removed (e.g. by test_logging_config)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_picker_alias_state():
+    """Keep the process-global picker alias maps inert between tests."""
+    from free_claude_code.core import gateway_model_ids as gmi
+
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()

--- a/tests/core/test_gateway_model_ids_aliases.py
+++ b/tests/core/test_gateway_model_ids_aliases.py
@@ -1,0 +1,251 @@
+"""Tests for picker aliasing in ``free_claude_code.core.gateway_model_ids``."""
+
+import pytest
+
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    """Reset module-scope alias maps before/after each test."""
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_picker_alias_prefix_is_anthropic_safe():
+    assert gmi.PICKER_ALIAS_PREFIX == "claude-sonnet-nim"
+
+
+def test_has_picker_aliases_false_before_seed():
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_populates_maps_and_marks_seeded():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    assert gmi.has_picker_aliases() is True
+
+
+def test_alias_counter_is_deterministic_from_sorted_input():
+    first = ["nvidia_nim/z-provider/z-model", "nvidia_nim/a-provider/a-model"]
+    second = list(reversed(first))
+
+    gmi.seed_picker_aliases(first)
+    a_first = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    gmi.seed_picker_aliases(second)
+    a_second = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert a_first == a_second == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/z-provider/z-model")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_reseed_keeps_existing_refs_on_their_alias():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    # A refresh that adds a ref must not renumber the advertised ones.
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+            "openai/gpt-x",
+        ]
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == (
+        "claude-sonnet-nim-0001"
+    )
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+    assert gmi.picker_alias_for("openai/gpt-x") == "claude-sonnet-nim-0003"
+
+
+def test_alias_lookup_thinking_and_no_thinking_variants():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+
+
+def test_alias_lookup_unknown_ref_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/missing/model") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/missing/model", force_reasoning_off=True)
+        is None
+    )
+
+
+def test_resolve_picker_alias_round_trip():
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        False,
+    )
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001-no-thinking") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        True,
+    )
+
+
+def test_resolve_picker_alias_unknown_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999-no-thinking") is None
+    assert gmi.resolve_picker_alias("claude-haiku-nim-0001") is None
+
+
+def test_resolve_picker_alias_for_prefix_only_when_seeded_empty():
+    # Maps are empty by default (cold-start window).
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_clear_resets_state():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.has_picker_aliases() is True
+
+    gmi.clear_picker_aliases()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_empty_iterable_keeps_state_empty():
+    gmi.seed_picker_aliases([])
+
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_replaces_previous_aliases_without_slot_reuse():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    # The removed ref's alias is retired, never recycled onto the new ref.
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_returning_ref_regains_its_previous_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    original = gmi.picker_alias_for("nvidia_nim/01-ai/yi-large")
+    assert original is not None
+
+    gmi.seed_picker_aliases(["openai/gpt-x"])
+    assert gmi.resolve_picker_alias(original) is None
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large", "openai/gpt-x"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == original
+
+
+def test_empty_refresh_keeps_retired_numbers_consumed():
+    """Disconnect-everything must not recycle aliases on the next refresh."""
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+    assert advertised is not None
+
+    # Inventory drains to empty (final provider disconnected)...
+    gmi.seed_picker_aliases([])
+    assert gmi.has_picker_aliases() is False
+    assert gmi.resolve_picker_alias(advertised) is None
+
+    # ...and a different model arrives later.
+    gmi.seed_picker_aliases(["openai/new/model"])
+
+    new_alias = gmi.picker_alias_for("openai/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(advertised) is None
+
+
+def test_aliases_are_four_digit_zero_padded():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(15)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [
+        alias for ref in refs if (alias := gmi.picker_alias_for(ref)) is not None
+    ]
+
+    assert len(aliases) == 15
+    for alias in aliases:
+        # All aliases share the same prefix and 4-digit counter width.
+        assert alias.startswith("claude-sonnet-nim-")
+        counter = alias.removeprefix("claude-sonnet-nim-").split("-")[0]
+        assert len(counter) == 4
+        assert counter.isdigit()
+
+
+def test_seed_assigns_unique_aliases_per_ref():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(10)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [gmi.picker_alias_for(ref) for ref in refs]
+
+    assert len(set(aliases)) == len(refs)
+    assert all(alias is not None for alias in aliases)
+
+
+def test_reseed_publishes_one_consistent_snapshot():
+    """Catalog output and routing must agree after an inventory swap.
+
+    Regression guard for torn publication: a reader binding the snapshot
+    before a reseed sees one self-consistent inventory, and a reader binding
+    it afterwards sees the other — never a mix of old and new maps. Sticky
+    assignments additionally guarantee the pre-reseed alias keeps resolving
+    to the same ref it advertised (or retires entirely).
+    """
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+
+    gmi.seed_picker_aliases(["nvidia_nim/new/model"])
+
+    assert advertised is not None
+    # The previously advertised alias either still routes to its original ref
+    # or is retired outright; it can never re-point to another model.
+    assert gmi.resolve_picker_alias(advertised) in {
+        ("nvidia_nim/old/model", False),
+        None,
+    }
+    # Both directions of the new snapshot are aligned with each other.
+    new_alias = gmi.picker_alias_for("nvidia_nim/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(new_alias) == ("nvidia_nim/new/model", False)
+    no_thinking_alias = gmi.picker_alias_for(
+        "nvidia_nim/new/model", force_reasoning_off=True
+    )
+    assert no_thinking_alias is not None
+    assert gmi.resolve_picker_alias(no_thinking_alias) == (
+        "nvidia_nim/new/model",
+        True,
+    )

--- a/tests/runtime/test_provider_manager_picker_aliases.py
+++ b/tests/runtime/test_provider_manager_picker_aliases.py
@@ -1,0 +1,87 @@
+"""Picker-alias reseeding on model-catalog republication."""
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _manager(model: str) -> ProviderRuntimeManager:
+    settings = Settings().model_copy(
+        update={"model": model, "nvidia_nim_api_key": "test-key"}
+    )
+    return ProviderRuntimeManager(settings)
+
+
+def _info(model_id: str) -> ProviderModelInfo:
+    return ProviderModelInfo(model_id=model_id, supports_thinking=None)
+
+
+def test_refresh_picker_aliases_seeds_current_cache_snapshot() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0001"
+    )
+    gmi.clear_picker_aliases()
+
+
+def test_cache_publication_reseeds_aliases_atomically() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    first_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+
+    # A refreshed inventory keeps the sticky assignment and adds new refs.
+    manager.cache_model_infos(
+        "nvidia_nim",
+        [
+            _info("meta/llama-3.3-70b-instruct"),
+            _info("01-ai/yi-large"),
+        ],
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct") == first_alias
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is not None
+
+
+def test_configured_ref_gets_alias_without_discovery_cache() -> None:
+    manager = _manager("nvidia_nim/one")
+
+    # No discovery cache yet: the configured model still gains a picker alias
+    # so a cold /v1/models request never advertises a raw gateway identifier.
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert gmi.picker_alias_for("nvidia_nim/one") is not None
+
+
+def test_empty_cache_retires_discovery_only_aliases_but_keeps_configured() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    configured_alias = gmi.picker_alias_for("nvidia_nim/one")
+    discovery_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+    assert configured_alias is not None
+    assert discovery_alias is not None
+
+    manager.cache_model_infos("nvidia_nim", [])
+
+    # The discovery-only ref retires; the configured ref keeps its alias.
+    assert gmi.has_picker_aliases() is True
+    assert gmi.resolve_picker_alias(discovery_alias) is None
+    assert gmi.picker_alias_for("nvidia_nim/one") == configured_alias

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.19.0"
+version = "5.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Replaces #1557 (v2 stack). Wires the picker alias engine into routing, runtime seeding, and the model catalog so Claude Desktop model discovery serves stable, picker-friendly alias ids:

- **Sticky alias numbering** — a published alias never re-points to another model; already advertised aliases keep routing to the same target across reseeds, new refs gain aliases immediately, retired refs drop out.
- **No-thinking variants** — every aliased model also advertises a `*-no-thinking` alias that forces reasoning off at route time.
- **Union seeding on catalog publication** — `ProviderManager.refresh_picker_aliases()` seeds from the union of configured chat model refs and cached discovery refs on every `_publish_model_catalog`, so a configured model absent from the discovery cache (cold or incomplete provider discovery) still gets a picker alias instead of being advertised as a raw gateway identifier.

Routing is alias-first: `ModelRouter._direct_provider_model` resolves a picker alias before the gateway-prefix and bare `provider/model` chains. The catalog only emits alias ids when the caller opts in (`build_models_list_response(..., picker_aliases=True)`) — every other FCC client keeps seeing raw provider refs regardless of seeded alias state. The `desktop_gateway_prefix` setting (env `DESKTOP_GATEWAY_PREFIX`, default `claude-desktop`) is added for the desktop-scoped mount.

Design: docs/superpowers/specs/2026-09-01-desktop-rerouting-v2-design.md (on fork).

## Verification

- [x] `uv run ruff format .` — 585 files unchanged
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ty check` — all checks passed
- [x] `uv run pytest -q` — 4250 passed, 176 skipped; only pre-existing environmental failure `test_install_sh_noninteractive_skips_dsh_without_node` (root npm env, fails on unmodified tree too)
- [x] New alias tests: 33 passed (routing 6, provider manager 4, model catalog 5, engine 18)
- [x] `git diff upstream/main` per source file shows only the picker-alias delta (routing +16/-1, provider_manager +22/-0, model_catalog +28/-5, settings +13/-0)

<!-- greptile_comment -->


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The change introduces stable picker aliases and a configurable desktop gateway prefix. Desktop model discovery is not yet usable through that prefix: the configured prefixed `/v1/models` route is absent, while the existing route continues to return raw gateway model references. The new test fixture also needs to follow the repository's top-level first-party import convention.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until Claude Desktop can reach an alias-enabled model-discovery endpoint.

There is one verified non-security P1 finding and one P2 repository-rule finding. Under the scoring table, one non-security P1 results in a score of 4; the P2 finding does not change that result.

**Files Needing Attention:** src/free_claude_code/api/app.py and the model-catalog route registration need a desktop-prefixed alias-enabled endpoint. tests/conftest.py needs its first-party import moved to module scope.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex generated a finding-comment-proof for the posted P1 finding and attached the desktop model-discovery validation source.
- T-Rex captured the validation source log and confirmed that the root discovery returns a raw model reference during the validation run.
- T-Rex inspected routing and settings to confirm that desktop-prefixed discovery is missing, helping validate the intended discovery path.

<a href="https://app.greptile.com/trex/runs/21938259/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `src/free_claude_code/api/app.py`, line 52-54 ([link](https://github.com/alishahryar1/free-claude-code/blob/85b0f205ecea9b793d9dae2b17eb514d9bee773c/src/free_claude_code/api/app.py#L52-L54)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Desktop alias catalog is unreachable**

   `desktop_gateway_prefix` is never mounted into the application, so Claude Desktop cannot reach a catalog endpoint that enables `picker_aliases`. With `desktop_gateway_prefix=desktop-scope`, `/v1/models` still returns raw gateway references, while `/desktop-scope/v1/models` returns 404. Mount a desktop-scoped catalog route that passes `picker_aliases=True` while retaining the current unprefixed route for other clients.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Desktop model-discovery validation source](https://app.greptile.com/trex/artifacts/6d13d777-ce29-4074-bea1-353ef03d4a74)**

   - A deterministic FastAPI validation script seeds an alias-producing configured model and requests both root and desktop-prefix discovery paths, with the takeaway that the intended desktop route is exercised directly.

   **[Captured validation source](https://app.greptile.com/trex/artifacts/b7aa8c47-c166-44e4-865c-a25fc4e21add)**

   - Captured command output records the exact validation source executed against the production FastAPI application path, with the takeaway that the test setup is reproducible.

   **[Root discovery returns raw model reference](https://app.greptile.com/trex/artifacts/6971f3a1-684a-4a2b-ad80-9354a1773701)**

   - The executed root \`/v1/models\` request returned 200 with the raw configured gateway ID and without the seeded picker alias, with the takeaway that the ordinary catalog route is not alias-enabled.

   **[Desktop-prefixed discovery is missing](https://app.greptile.com/trex/artifacts/d7f46e78-1867-43fe-953f-365d1ac8565e)**

   - The executed \`/desktop-scope/v1/models\` request returned 404 despite the configured desktop prefix, with the takeaway that the desktop-scoped discovery API is not mounted.

   **[Routing and setting inspection](https://app.greptile.com/trex/artifacts/8a8f983f-8494-4c2f-b26d-030071400997)**

   - Captured numbered source output shows only the unprefixed router is included, the catalog route has no alias opt-in, and the desktop prefix is only defined, with the takeaway that the affected locations are \`api/app.py:52-54\`, \`api/routes.py:194-207\`, and \`config/settings.py:706-718\`.

   <a href="https://app.greptile.com/trex/runs/21938259/artifacts?artifact=6d13d777-ce29-4074-bea1-353ef03d4a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: wire picker aliases into routing, ..."](https://github.com/alishahryar1/free-claude-code/commit/85b0f205ecea9b793d9dae2b17eb514d9bee773c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59276439)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->