### PR TITLE
feat: scope picker aliases to a desktop-only API mount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -347,6 +347,12 @@ PROXY_AUTH_ENABLED=false
 ANTHROPIC_AUTH_TOKEN="freecc"
 
 
+# Path prefix that scopes Claude Desktop onto the alias-emitting API mount
+# (e.g. http://localhost:8082/claude-desktop). Bare paths keep serving raw
+# provider refs to every other client.
+DESKTOP_GATEWAY_PREFIX=claude-desktop
+
+
 # Open /admin in the default browser when fcc-server becomes healthy (set 0/false/no to disable)
 FCC_OPEN_BROWSER=true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.20.0"
+version = "5.21.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.19.0"
+version = "5.20.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/app.py
+++ b/src/free_claude_code/api/app.py
@@ -52,6 +52,12 @@ def create_app(services: ApiServices) -> FastAPI:
     app.include_router(admin_router)
     app.include_router(chat_router)
     app.include_router(router)
+    # Claude Desktop-only alias mount: same handlers under the desktop path
+    # prefix; the models handler serves picker aliases only on this mount.
+    app.include_router(
+        router,
+        prefix=f"/{services.requests.current_settings().desktop_gateway_prefix}",
+    )
 
     @app.exception_handler(ChatError)
     async def chat_error_handler(request: Request, exc: ChatError):

--- a/src/free_claude_code/api/dependencies.py
+++ b/src/free_claude_code/api/dependencies.py
@@ -13,6 +13,28 @@ from free_claude_code.config.settings import Settings
 from .ports import ApiServices
 
 
+def _extract_proxy_token(request: Request) -> str | None:
+    """Token from an ``Authorization: Bearer`` header, else ``x-api-key``.
+
+    Anthropic-native clients (including Claude Desktop's inference gateway)
+    authenticate with ``x-api-key``, so it is accepted as an equal scheme.
+    A malformed Authorization header wins and yields nothing; without one,
+    the ``x-api-key`` value is used as-is.
+    """
+
+    authorization = request.headers.get("authorization")
+    if authorization is not None:
+        parts = authorization.strip().split(maxsplit=1)
+        if len(parts) == 2 and parts[0].casefold() == "bearer":
+            token = parts[1].strip()
+            return token or None
+        return None
+    api_key = request.headers.get("x-api-key")
+    if api_key is None:
+        return None
+    return api_key.strip() or None
+
+
 def get_services(request: Request) -> ApiServices:
     """Return the complete services supplied when the app was constructed."""
     return request.app.state.services
@@ -48,21 +70,26 @@ def require_proxy_auth(
     request: Request,
     settings: Settings = Depends(get_settings),
 ) -> None:
-    """Require the configured proxy token as HTTP bearer authorization."""
+    """Require the configured proxy token as Bearer or Anthropic-style auth."""
     if not settings.proxy_auth_enabled:
         return
 
-    authorization = request.headers.get("authorization")
-    if not authorization:
+    token = _extract_proxy_token(request)
+    if token is None:
+        # A present-but-malformed Authorization header is a bad credential,
+        # not a missing one; with no Authorization at all it's just missing.
         raise HTTPException(
             status_code=401,
-            detail="Missing proxy authentication token",
+            detail=(
+                "Invalid proxy authentication token"
+                if request.headers.get("authorization")
+                else "Missing proxy authentication token"
+            ),
         )
 
-    if not _proxy_token_matches(
-        authorization,
-        settings.proxy_auth_token,
-        require_bearer=True,
+    if not secrets.compare_digest(
+        token.encode("utf-8"),
+        settings.proxy_auth_token.encode("utf-8"),
     ):
         raise HTTPException(
             status_code=401,

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -13,6 +13,7 @@ from free_claude_code.config.settings import Settings
 from free_claude_code.core.gateway_model_ids import (
     gateway_model_id,
     no_thinking_gateway_model_id,
+    picker_alias_for,
 )
 from free_claude_code.core.model_capabilities import ModelInputModality
 
@@ -133,15 +134,26 @@ def build_models_list_response(
     runtime: RequestRuntimePort,
     *,
     view: ModelCatalogView = ModelCatalogView.CLAUDE,
+    picker_aliases: bool = False,
 ) -> ModelsListResponse:
-    """Return the application model inventory in the requested client view."""
+    """Return the application model inventory in the requested client view.
+
+    ``picker_aliases`` opts into Claude Desktop picker alias ids; only the
+    desktop-scoped API mount enables it, so every other FCC client sees raw
+    provider refs regardless of seeded alias state.
+    """
     if view is ModelCatalogView.CLAUDE:
-        return _build_claude_models_response(settings, runtime)
+        return _build_claude_models_response(
+            settings, runtime, picker_aliases=picker_aliases
+        )
     return _build_direct_models_response(settings, runtime, view=view)
 
 
 def _build_claude_models_response(
-    settings: Settings, runtime: RequestRuntimePort
+    settings: Settings,
+    runtime: RequestRuntimePort,
+    *,
+    picker_aliases: bool,
 ) -> ModelsListResponse:
     """Preserve the established Claude-compatible catalog exactly."""
     models: list[ModelResponse] = []
@@ -156,6 +168,7 @@ def _build_claude_models_response(
             supports_thinking=(
                 model_info.supports_thinking if model_info is not None else None
             ),
+            picker_aliases=picker_aliases,
         )
 
     for model_info in runtime.cached_prefixed_model_infos():
@@ -164,6 +177,7 @@ def _build_claude_models_response(
             seen,
             model_info.model_id,
             supports_thinking=model_info.supports_thinking,
+            picker_aliases=picker_aliases,
         )
 
     for model in SUPPORTED_CLAUDE_MODELS:
@@ -319,13 +333,22 @@ def _append_provider_model_variants(
     provider_model_ref: str,
     *,
     supports_thinking: bool | None = None,
+    picker_aliases: bool = False,
 ) -> None:
+    thinking_id = (
+        picker_alias_for(provider_model_ref) if picker_aliases else None
+    ) or gateway_model_id(provider_model_ref)
+    no_thinking_id = (
+        picker_alias_for(provider_model_ref, force_reasoning_off=True)
+        if picker_aliases
+        else None
+    ) or no_thinking_gateway_model_id(provider_model_ref)
     if supports_thinking is not False:
         _append_unique_model(
             models,
             seen,
             _discovered_model_response(
-                gateway_model_id(provider_model_ref),
+                thinking_id,
                 display_name=provider_model_ref,
             ),
         )
@@ -333,7 +356,7 @@ def _append_provider_model_variants(
         models,
         seen,
         _discovered_model_response(
-            no_thinking_gateway_model_id(provider_model_ref),
+            no_thinking_id,
             display_name=f"{provider_model_ref} (no thinking)",
         ),
     )

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -197,14 +197,31 @@ async def probe_health():
     response_model_exclude_none=True,
 )
 async def list_models(
+    request: Request,
     view: ModelCatalogView = ModelCatalogView.CLAUDE,
     services: ApiServices = Depends(get_services),
     settings: Settings = Depends(get_settings),
     _auth=Depends(require_proxy_auth),
 ):
-    """List the model ids this proxy advertises to compatible clients."""
+    """List the model ids this proxy advertises to compatible clients.
+
+    Served both bare and under the desktop path prefix. Picker aliases are
+    emitted only on the prefixed mount so Claude Code, Codex, Pi and every
+    other FCC client keep seeing raw provider refs. The mount is identified
+    by exact path equality, not by a prefix sniff: a
+    ``DESKTOP_GATEWAY_PREFIX`` of ``v1`` would otherwise make the bare
+    ``/v1/models`` path satisfy a ``startswith`` check and leak Desktop-only
+    aliases to every client.
+    """
     trace_event(stage="ingress", event="free_claude_code.api.models.list", source="api")
-    return build_models_list_response(settings, services.requests, view=view)
+    desktop_mount_path = f"/{settings.desktop_gateway_prefix}/v1/models"
+    picker_aliases = request.url.path == desktop_mount_path
+    return build_models_list_response(
+        settings,
+        services.requests,
+        view=view,
+        picker_aliases=picker_aliases,
+    )
 
 
 @router.get(

--- a/src/free_claude_code/application/routing.py
+++ b/src/free_claude_code/application/routing.py
@@ -13,7 +13,10 @@ from free_claude_code.config.provider_catalog import (
 from free_claude_code.config.reasoning import ReasoningPreference
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest, TokenCountRequest
-from free_claude_code.core.gateway_model_ids import decode_gateway_model_id
+from free_claude_code.core.gateway_model_ids import (
+    decode_gateway_model_id,
+    resolve_picker_alias,
+)
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import ReasoningPolicy
 
@@ -146,6 +149,18 @@ class ModelRouter:
     def _direct_provider_model(
         self, model_name: str
     ) -> tuple[str | None, str | None, bool]:
+        alias_resolution = resolve_picker_alias(model_name)
+        if alias_resolution is not None:
+            aliased_ref, force_reasoning_off = alias_resolution
+            provider_id, separator, provider_model = aliased_ref.partition("/")
+            if (
+                not separator
+                or provider_id not in SUPPORTED_PROVIDER_IDS
+                or not provider_model
+            ):
+                return None, None, False
+            return provider_id, provider_model, force_reasoning_off
+
         decoded = decode_gateway_model_id(model_name)
         if decoded is not None:
             if decoded.provider_id not in SUPPORTED_PROVIDER_IDS:

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -703,6 +703,19 @@ class Settings(BaseModel):
         default="freecc",
         validation_alias="ANTHROPIC_AUTH_TOKEN",
     )
+    desktop_gateway_prefix: NonEmptyString = Field(
+        default="claude-desktop",
+        validation_alias="DESKTOP_GATEWAY_PREFIX",
+    )
+
+    @field_validator("desktop_gateway_prefix")
+    @classmethod
+    def normalize_desktop_gateway_prefix(cls, v: str) -> str:
+        """Strip boundary slashes so the prefix mounts as a single ``/{prefix}``."""
+        prefix = v.strip("/")
+        if not prefix:
+            raise ValueError("DESKTOP_GATEWAY_PREFIX must contain a path segment")
+        return prefix
 
     @field_validator("max_message_log_entries_per_chat", mode="before")
     @classmethod

--- a/src/free_claude_code/core/gateway_model_ids.py
+++ b/src/free_claude_code/core/gateway_model_ids.py
@@ -1,5 +1,6 @@
 """Gateway-safe model ID encoding shared by API and CLI adapters."""
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 GATEWAY_MODEL_ID_PREFIX = "anthropic"
@@ -8,6 +9,47 @@ GATEWAY_MODEL_ID_PREFIX = "anthropic"
 # supporting thinking. This intentionally uses that client-side capability
 # heuristic while keeping the real provider/model ref reversible for routing.
 NO_THINKING_GATEWAY_MODEL_ID_PREFIX = "claude-3-freecc-no-thinking"
+
+PICKER_ALIAS_PREFIX = "claude-sonnet-nim"
+_PICKER_ALIAS_NO_THINKING_SUFFIX = "-no-thinking"
+_PICKER_ALIAS_WIDTH = 4
+
+
+@dataclass(frozen=True, slots=True)
+class _PickerAliasMaps:
+    """Immutable alias snapshot shared by catalog output and request routing.
+
+    Published as a single module-global assignment so concurrent readers can
+    never observe a torn state mixing refs from two different inventories.
+    """
+
+    alias_to_ref: Mapping[str, str]
+    alias_to_ref_no_thinking: Mapping[str, str]
+    ref_to_alias: Mapping[str, str]
+    ref_to_alias_no_thinking: Mapping[str, str]
+
+
+_EMPTY_PICKER_ALIAS_MAPS = _PickerAliasMaps({}, {}, {}, {})
+
+# Seeded at startup with the sorted refs from the runtime cached model catalog,
+# then republished whenever the model cache is mutated. Tests call
+# ``clear_picker_aliases()`` between runs to restore the inert empty snapshot.
+_picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+
+# Sticky ref-to-alias assignments that survive reseeds: once an alias has been
+# advertised for a ref, that alias is never re-pointed to a different ref, so
+# a desktop picker holding a stale catalog cannot silently route to another
+# model. Numbers of retired refs stay consumed; a returning ref regains its
+# previous alias. Reset only by ``clear_picker_aliases()``.
+_sticky_ref_to_alias: dict[str, str] = {}
+_used_alias_numbers: set[int] = set()
+
+
+def _next_unused_alias_number(used_numbers: set[int]) -> int:
+    candidate = 1
+    while candidate in used_numbers:
+        candidate += 1
+    return candidate
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,3 +91,96 @@ def decode_gateway_model_id(model_name: str) -> DecodedGatewayModelId | None:
         provider_model=provider_model,
         force_reasoning_off=force_reasoning_off,
     )
+
+
+def _format_picker_alias(index: int, *, no_thinking: bool) -> str:
+    suffix = _PICKER_ALIAS_NO_THINKING_SUFFIX if no_thinking else ""
+    return f"{PICKER_ALIAS_PREFIX}-{index:0{_PICKER_ALIAS_WIDTH}d}{suffix}"
+
+
+def seed_picker_aliases(provider_model_refs: Iterable[str]) -> None:
+    """Publish a fresh immutable alias snapshot built from the supplied refs.
+
+    Aliases are stable across reseeds: a ref that already holds an alias keeps
+    it, and new refs take previously unused numbers, so an alias already shown
+    in a client picker can never silently resolve to a different model.
+    Numbering is deterministic on restart when starting from the same initial
+    inventory (counters assigned by ``sorted(refs)`` order).
+
+    An empty inventory publishes the inert empty snapshot so a cold-start
+    ``/v1/models`` request still falls back to the canonical
+    ``gateway_model_id`` wrappers, while sticky assignments and consumed
+    alias numbers are preserved so a later refresh can never re-point a
+    previously advertised alias.
+    """
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+
+    wanted = [ref for ref in sorted(set(provider_model_refs)) if ref]
+    if not wanted:
+        _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+        return
+
+    thinking_aliases: dict[str, str] = {}
+    no_thinking_aliases: dict[str, str] = {}
+    ref_to_thinking: dict[str, str] = {}
+    ref_to_no_thinking: dict[str, str] = {}
+    used_numbers = set(_used_alias_numbers)
+
+    for ref in wanted:
+        alias = _sticky_ref_to_alias.get(ref)
+        if alias is None:
+            number = _next_unused_alias_number(used_numbers)
+            used_numbers.add(number)
+            alias = _format_picker_alias(number, no_thinking=False)
+        thinking_aliases[alias] = ref
+        alias_no_thinking = f"{alias}{_PICKER_ALIAS_NO_THINKING_SUFFIX}"
+        no_thinking_aliases[alias_no_thinking] = ref
+        ref_to_thinking[ref] = alias
+        ref_to_no_thinking[ref] = alias_no_thinking
+
+    _sticky_ref_to_alias = {**_sticky_ref_to_alias, **ref_to_thinking}
+    _used_alias_numbers = used_numbers
+    _picker_aliases = _PickerAliasMaps(
+        alias_to_ref=thinking_aliases,
+        alias_to_ref_no_thinking=no_thinking_aliases,
+        ref_to_alias=ref_to_thinking,
+        ref_to_alias_no_thinking=ref_to_no_thinking,
+    )
+
+
+def picker_alias_for(
+    provider_model_ref: str, *, force_reasoning_off: bool = False
+) -> str | None:
+    """Return the picker alias for ``provider_model_ref``, if seeded."""
+    maps = _picker_aliases
+    if force_reasoning_off:
+        return maps.ref_to_alias_no_thinking.get(provider_model_ref)
+    return maps.ref_to_alias.get(provider_model_ref)
+
+
+def resolve_picker_alias(model_name: str) -> tuple[str, bool] | None:
+    """Reverse-lookup alias. Returns ``(provider_ref, force_reasoning_off)``."""
+    if not model_name:
+        return None
+    maps = _picker_aliases
+    ref = maps.alias_to_ref_no_thinking.get(model_name)
+    if ref is not None:
+        return ref, True
+    ref = maps.alias_to_ref.get(model_name)
+    if ref is not None:
+        return ref, False
+    return None
+
+
+def has_picker_aliases() -> bool:
+    """Whether ``seed_picker_aliases`` has populated the snapshot."""
+    maps = _picker_aliases
+    return bool(maps.alias_to_ref) or bool(maps.alias_to_ref_no_thinking)
+
+
+def clear_picker_aliases() -> None:
+    """Drop every alias entry and sticky assignment. Tests and hardening."""
+    global _picker_aliases, _sticky_ref_to_alias, _used_alias_numbers
+    _picker_aliases = _EMPTY_PICKER_ALIAS_MAPS
+    _sticky_ref_to_alias = {}
+    _used_alias_numbers = set()

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -147,6 +147,7 @@ class ApplicationRuntime:
             self.provider_manager.start_model_list_refresh()
             if self._chat_service is not None:
                 await self._chat_service.start()
+            self._seed_picker_aliases_from_cache()
             await self._start_messaging_if_configured()
             logging.getLogger("uvicorn.error").info(
                 "Admin UI: %s (local-only)",
@@ -341,6 +342,14 @@ class ApplicationRuntime:
             "admin_url": local_admin_url(settings) if automatic else None,
             "fields": list(fields),
         }
+
+    def _seed_picker_aliases_from_cache(self) -> None:
+        """Publish picker aliases for exactly the cached model inventory.
+
+        Delegates to the provider manager so startup seeding and every later
+        model-catalog republication share one ownership path.
+        """
+        self.provider_manager.refresh_picker_aliases()
 
     async def _start_messaging_if_configured(self) -> None:
         try:

--- a/src/free_claude_code/runtime/provider_manager.py
+++ b/src/free_claude_code/runtime/provider_manager.py
@@ -13,7 +13,9 @@ from free_claude_code.application.model_metadata import (
     ProviderModelRefreshResult,
 )
 from free_claude_code.application.ports import RequestRuntimePort
+from free_claude_code.config.model_refs import configured_chat_model_refs
 from free_claude_code.config.settings import Settings
+from free_claude_code.core.gateway_model_ids import seed_picker_aliases
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.runtime import ProviderRuntime
@@ -366,7 +368,27 @@ class ProviderRuntimeManager:
             return
         self._run_model_catalog_publication(publisher.ensure_exists)
 
+    def refresh_picker_aliases(self) -> None:
+        """Re-point the process-global picker aliases at the current inventory.
+
+        Seeds the union of configured chat model refs and cached discovery
+        refs so a configured model absent from the discovery cache (cold or
+        incomplete provider discovery) still gets a picker alias instead of
+        being advertised as a raw gateway identifier.
+
+        Sticky ref-to-alias assignments make reseeds stable: already
+        advertised aliases keep routing to the same model, newly discovered
+        refs gain aliases immediately, and refs removed from the inventory
+        retire instead of routing to stale targets.
+        """
+        configured = (
+            ref.model_ref for ref in configured_chat_model_refs(self.current_settings())
+        )
+        cached = (info.model_id for info in self.cached_prefixed_model_infos())
+        seed_picker_aliases((*configured, *cached))
+
     def _publish_model_catalog(self) -> None:
+        self.refresh_picker_aliases()
         publisher = self._model_catalog_publisher
         if publisher is None:
             return

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -114,7 +114,12 @@ def test_messages_auth_gives_authorization_precedence_over_x_api_key():
     app.dependency_overrides.clear()
 
 
-def test_x_api_key_remains_rejected_on_non_messages_routes():
+def test_x_api_key_is_accepted_on_all_proxy_auth_routes():
+    # Claude Desktop authenticates to the inference gateway with an
+    # Anthropic-native ``x-api-key`` header, and its model discovery reads the
+    # models route. Every proxy-authenticated route therefore accepts
+    # ``x-api-key`` as an equal scheme alongside Bearer, while a wrong key is
+    # still rejected.
     client = TestClient(app)
     settings = Settings(proxy_auth_enabled=True, proxy_auth_token="route-token")
     app.dependency_overrides[get_settings] = lambda: settings
@@ -125,7 +130,10 @@ def test_x_api_key_remains_rejected_on_non_messages_routes():
         (client.get, "/"),
     ):
         response = method(path, headers={"X-API-Key": "route-token"})
-        assert response.status_code == 401
+        assert response.status_code in (200, 204)
+
+        wrong = method(path, headers={"X-API-Key": "wrong"})
+        assert wrong.status_code == 401
 
     app.dependency_overrides.clear()
 

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -132,7 +132,7 @@ def test_require_proxy_auth_rejects_missing_authorization():
     assert exc_info.value.detail == "Missing proxy authentication token"
 
 
-@pytest.mark.parametrize("header_name", ["x-api-key", "anthropic-auth-token"])
+@pytest.mark.parametrize("header_name", ["anthropic-auth-token"])
 def test_require_proxy_auth_rejects_legacy_header_only(header_name: str):
     request, settings = _request(headers={header_name: "secret"}, token="secret")
 
@@ -141,6 +141,22 @@ def test_require_proxy_auth_rejects_legacy_header_only(header_name: str):
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "Missing proxy authentication token"
+
+
+def test_require_proxy_auth_accepts_exact_x_api_key_token():
+    request, settings = _request(headers={"x-api-key": "secret"}, token="secret")
+
+    require_proxy_auth(request, settings)
+
+
+def test_require_proxy_auth_rejects_wrong_x_api_key_token():
+    request, settings = _request(headers={"x-api-key": "wrong"}, token="secret")
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_proxy_auth(request, settings)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid proxy authentication token"
 
 
 def test_require_proxy_auth_accepts_exact_bearer_token():

--- a/tests/api/test_desktop_scoped_models.py
+++ b/tests/api/test_desktop_scoped_models.py
@@ -1,0 +1,191 @@
+"""End-to-end scoping of picker aliases to the desktop-only API mount."""
+
+from fastapi.testclient import TestClient
+
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from tests.api.support import create_test_app
+
+
+def _settings() -> Settings:
+    settings = Settings()
+    settings.model = "deepseek/deepseek-chat"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    return settings
+
+
+def setup_function(_: object) -> None:
+    gmi.seed_picker_aliases(["deepseek/deepseek-chat"])
+
+
+def teardown_function(_: object) -> None:
+    gmi.clear_picker_aliases()
+
+
+def test_bare_models_route_never_serves_aliases() -> None:
+    app = create_test_app(_settings())
+
+    ids = [m["id"] for m in TestClient(app).get("/v1/models").json()["data"]]
+
+    assert all(not i.startswith("claude-sonnet-nim") for i in ids)
+    assert "anthropic/deepseek/deepseek-chat" in ids
+
+
+def test_prefixed_models_route_serves_aliases() -> None:
+    app = create_test_app(_settings())
+
+    response = TestClient(app).get("/claude-desktop/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = [m["id"] for m in data["data"]]
+    # The alias replaces the wrapper id for the same ref.
+    assert "claude-sonnet-nim-0001" in ids
+    assert "anthropic/deepseek/deepseek-chat" not in ids
+    labels = {
+        m["display_name"]
+        for m in data["data"]
+        if m["id"].startswith("claude-sonnet-nim")
+    }
+    assert "deepseek/deepseek-chat" in labels
+
+
+def test_custom_prefix_is_honored_from_settings() -> None:
+    app = create_test_app(
+        Settings.model_construct(
+            desktop_gateway_prefix="my-gateway",
+            model="deepseek/deepseek-chat",
+            model_fable=None,
+            model_opus=None,
+            model_sonnet=None,
+            model_haiku=None,
+        )
+    )
+
+    bare = TestClient(app).get("/v1/models")
+    prefixed = TestClient(app).get("/my-gateway/v1/models")
+
+    assert all(not m["id"].startswith("claude-sonnet-nim") for m in bare.json()["data"])
+    assert any(m["id"].startswith("claude-sonnet-nim") for m in prefixed.json()["data"])
+
+
+def test_prefix_with_boundary_slashes_is_normalized() -> None:
+    """FastAPI rejects router prefixes ending in '/', so a configured value
+    like '/desktop/' must be normalized or app startup crashes."""
+    settings = Settings(desktop_gateway_prefix="/desktop/")
+    settings.model = "deepseek/deepseek-chat"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+
+    response = TestClient(create_test_app(settings)).get("/desktop/v1/models")
+
+    assert response.status_code == 200
+    assert any(m["id"].startswith("claude-sonnet-nim") for m in response.json()["data"])
+
+
+def test_lookalike_prefixed_path_does_not_serve_aliases() -> None:
+    """Only the exact desktop prefix mount emits aliases; paths that merely
+    start with the same text must never leak picker aliases."""
+    app = create_test_app(_settings())
+
+    response = TestClient(app).get("/claude-desktop-evil/v1/models")
+
+    assert response.status_code == 404
+
+
+def test_prefix_equal_to_bare_v1_does_not_leak_aliases() -> None:
+    """A ``DESKTOP_GATEWAY_PREFIX`` of ``v1`` must not capture the bare catalog.
+
+    The bare ``/v1/models`` path starts with ``/v1/`` — a prefix-sniffing
+    check would treat it as the desktop mount and serve Desktop-only aliases
+    to Claude Code, Codex, Pi and every other client. Alias emission must be
+    gated on the exact mounted path instead.
+    """
+    app = create_test_app(
+        Settings.model_construct(
+            desktop_gateway_prefix="v1",
+            model="deepseek/deepseek-chat",
+            model_fable=None,
+            model_opus=None,
+            model_sonnet=None,
+            model_haiku=None,
+        )
+    )
+
+    client = TestClient(app)
+    bare = [m["id"] for m in client.get("/v1/models").json()["data"]]
+    mounted = [m["id"] for m in client.get("/v1/v1/models").json()["data"]]
+
+    assert all(not i.startswith("claude-sonnet-nim") for i in bare)
+    assert "anthropic/deepseek/deepseek-chat" in bare
+    assert any(i.startswith("claude-sonnet-nim") for i in mounted)
+
+
+def test_messages_round_trip_works_under_desktop_prefix() -> None:
+    """Claude Desktop chats against the prefixed base URL, so the full API
+    surface must exist under the prefix too."""
+    from unittest.mock import patch
+
+    app = create_test_app()
+
+    with (
+        patch(
+            "free_claude_code.api.routes.get_token_count",
+            return_value=1,
+        ),
+    ):
+        response = TestClient(app).post(
+            "/claude-desktop/v1/messages/count_tokens",
+            json={
+                "model": "claude-3-sonnet",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+
+
+def test_advertised_alias_routes_through_prefixed_api() -> None:
+    """An alias served by the desktop catalog must be routable end to end."""
+    from unittest.mock import patch
+
+    from free_claude_code.application.routing import (
+        ModelRouter,
+        RoutedTokenCountRequest,
+    )
+    from free_claude_code.core.anthropic import TokenCountRequest
+
+    app = create_test_app(_settings())
+    routed_refs: list[str] = []
+    original_resolver = ModelRouter.resolve_token_count_request
+
+    def spy(self: ModelRouter, request: TokenCountRequest) -> RoutedTokenCountRequest:
+        routed = original_resolver(self, request)
+        routed_refs.append(routed.resolved.primary.provider_model_ref)
+        return routed
+
+    with (
+        patch("free_claude_code.api.routes.get_token_count", return_value=1),
+        patch.object(
+            ModelRouter,
+            "resolve_token_count_request",
+            autospec=True,
+            side_effect=spy,
+        ),
+    ):
+        response = TestClient(app).post(
+            "/claude-desktop/v1/messages/count_tokens",
+            json={
+                "model": "claude-sonnet-nim-0001",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert response.status_code == 200
+    # The advertised alias reached the router and resolved to its seeded ref.
+    assert routed_refs == ["deepseek/deepseek-chat"]

--- a/tests/api/test_desktop_startup_aliases.py
+++ b/tests/api/test_desktop_startup_aliases.py
@@ -1,0 +1,84 @@
+"""Production startup path: the desktop mount serves seeded picker aliases.
+
+Regression guard for the Greptile P1 "picker aliases remain inactive"
+finding: ``ApplicationRuntime.start()`` seeds the process-global alias
+snapshot from the warmed model cache, and the desktop-prefixed
+``/v1/models`` mount serves those aliases while the bare mount keeps raw
+provider refs for every other FCC client.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from free_claude_code.api.app import create_app
+from free_claude_code.api.ports import ApiServices
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.application import ApplicationRuntime
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _settings() -> Settings:
+    return Settings().model_copy(
+        update={
+            "model": "nvidia_nim/meta/llama-3.3-70b-instruct",
+            "nvidia_nim_api_key": "test-key",
+            "messaging_platform": "none",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_startup_seeds_aliases_served_by_desktop_mount() -> None:
+    settings = _settings()
+    manager = ProviderRuntimeManager(settings)
+    runtime = ApplicationRuntime(manager, transcriber=None)
+    manager.cache_model_infos(
+        "nvidia_nim",
+        [
+            ProviderModelInfo(
+                model_id="meta/llama-3.3-70b-instruct", supports_thinking=None
+            )
+        ],
+    )
+    # Drop the publication side effect so only ``start()`` can reseed.
+    gmi.clear_picker_aliases()
+    assert gmi.has_picker_aliases() is False
+
+    with (
+        patch.object(manager, "warm_referenced_model_cache", new=AsyncMock()),
+        patch.object(manager, "start_model_list_refresh"),
+        patch.object(manager, "close", new=AsyncMock()),
+    ):
+        await runtime.start()
+        try:
+            assert gmi.has_picker_aliases() is True
+
+            app = create_app(
+                ApiServices(requests=manager, admin=runtime, tasks=runtime)
+            )
+            client = TestClient(app)
+
+            desktop = client.get("/claude-desktop/v1/models")
+            assert desktop.status_code == 200
+            desktop_ids = [m["id"] for m in desktop.json()["data"]]
+            assert "claude-sonnet-nim-0001" in desktop_ids
+            assert "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct" not in desktop_ids
+
+            bare = client.get("/v1/models")
+            assert bare.status_code == 200
+            bare_ids = [m["id"] for m in bare.json()["data"]]
+            assert "claude-sonnet-nim-0001" not in bare_ids
+            assert "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct" in bare_ids
+        finally:
+            await runtime.close()

--- a/tests/api/test_model_catalog_aliases.py
+++ b/tests/api/test_model_catalog_aliases.py
@@ -1,0 +1,129 @@
+"""Picker alias selection in ``free_claude_code.api.model_catalog``."""
+
+import pytest
+
+from free_claude_code.api import model_catalog
+from free_claude_code.application.ports import RequestRuntimeLease
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+class _StubRuntime:
+    async def acquire(
+        self, *, include_model_infos: bool = False
+    ) -> RequestRuntimeLease:
+        raise NotImplementedError("catalog construction never acquires a lease")
+
+    def current_settings(self) -> Settings:
+        raise NotImplementedError
+
+    def cached_model_info(self, provider_id: str, model_id: str):
+        return None
+
+    def cached_prefixed_model_infos(self):
+        return ()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+_MODEL_SLOTS = ("model", "model_fable", "model_opus", "model_sonnet", "model_haiku")
+
+
+def _settings_with_refs(*refs):
+    slots = {
+        slot: (refs[index] if index < len(refs) else None)
+        for index, slot in enumerate(_MODEL_SLOTS)
+    }
+    return Settings.model_construct(
+        **slots,
+        reasoning_policy=ReasoningPreference.CLIENT,
+    )
+
+
+def _ids(response: model_catalog.ModelsListResponse) -> list[str]:
+    return [item.id for item in response.data]
+
+
+def test_unseeded_state_uses_gateway_wrapper_ids():
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    picker_ids = [
+        item.id for item in response.data if item.id.startswith("claude-sonnet-nim")
+    ]
+    assert picker_ids == []
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in _ids(response)
+    assert "claude-3-freecc-no-thinking/nvidia_nim/01-ai/yi-large" in _ids(response)
+
+
+def test_seeded_state_prefers_alias_for_thinking_variant():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    ids = _ids(response)
+    assert "claude-sonnet-nim-0001" in ids
+    assert "claude-sonnet-nim-0001-no-thinking" in ids
+    # Wrapper id is suppressed because the alias covers the same slot.
+    assert "anthropic/nvidia_nim/01-ai/yi-large" not in ids
+
+
+def test_seed_only_nim_uses_wrapper_for_other_providers():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("openai_chat/anthropic/claude-3-5-sonnet-20241022")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    # Non-NIM ref falls through to the original wrapper ids.
+    assert "anthropic/openai_chat/anthropic/claude-3-5-sonnet-20241022" in ids
+    assert (
+        "claude-3-freecc-no-thinking/openai_chat/anthropic/claude-3-5-sonnet-20241022"
+        in ids
+    )
+    # And no alias leaked from the seeded NIM ref into the unrelated entry.
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+
+
+def test_display_name_is_provider_model_ref_when_using_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(
+        settings, _StubRuntime(), picker_aliases=True
+    )
+
+    alias_entries = [
+        item for item in response.data if item.id.startswith("claude-sonnet-nim-0001")
+    ]
+    # Thinking entry exposes the canonical provider ref; the no-thinking
+    # variant keeps the established "(no thinking)" label suffix.
+    assert {item.display_name for item in alias_entries} == {
+        "nvidia_nim/01-ai/yi-large",
+        "nvidia_nim/01-ai/yi-large (no thinking)",
+    }
+
+
+def test_seeded_aliases_are_hidden_without_opt_in():
+    """Claude Code / Codex / Pi path: aliases must never leak, even when seeded."""
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    settings = _settings_with_refs("nvidia_nim/01-ai/yi-large")
+
+    response = model_catalog.build_models_list_response(settings, _StubRuntime())
+
+    ids = _ids(response)
+    assert all(not item.startswith("claude-sonnet-nim") for item in ids)
+    assert "anthropic/nvidia_nim/01-ai/yi-large" in ids

--- a/tests/application/test_routing_aliases.py
+++ b/tests/application/test_routing_aliases.py
@@ -1,0 +1,108 @@
+"""Picker alias decoding routed through ``application.routing.ModelRouter``."""
+
+import pytest
+
+from free_claude_code.application.routing import ModelRouter
+from free_claude_code.config.reasoning import ReasoningPreference
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture
+def settings():
+    settings = Settings()
+    settings.model = "nvidia_nim/fallback-model"
+    settings.model_fable = None
+    settings.model_opus = None
+    settings.model_sonnet = None
+    settings.model_haiku = None
+    settings.reasoning_policy = ReasoningPreference.CLIENT
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_resolves_alias_before_gateway_prefix(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.original_model == "claude-sonnet-nim-0001"
+    assert resolved.reasoning_preference is ReasoningPreference.CLIENT
+
+
+def test_resolves_alias_no_thinking_variant_forces_reasoning_off(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001-no-thinking")
+
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "meta/llama-3.3-70b-instruct"
+    assert resolved.reasoning_preference is ReasoningPreference.OFF
+
+
+def test_alias_takes_priority_over_anthropic_prefix(settings):
+    # The same underlying ref exists both as an alias and as an
+    # ``anthropic/<ref>`` gateway id. The alias must win on the picker shape,
+    # and both code paths resolve to the same upstream model.
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    alias_resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+    gateway_resolved = ModelRouter(settings).resolve(
+        "anthropic/nvidia_nim/meta/llama-3.3-70b-instruct"
+    )
+
+    assert (
+        alias_resolved.primary.provider_id
+        == gateway_resolved.primary.provider_id
+        == "nvidia_nim"
+    )
+    assert (
+        alias_resolved.primary.provider_model
+        == gateway_resolved.primary.provider_model
+        == "meta/llama-3.3-70b-instruct"
+    )
+
+
+def test_alias_for_unknown_provider_falls_through_to_existing_chain(settings):
+    # An alias pointing at an unsupported provider must not silently match;
+    # the alias resolver returns the ref and routing layer validates it.
+    # After validation, ``resolve`` falls through to the existing route
+    # table, so ``claude-sonnet-nim-NNNN`` lands on the configured fallback.
+    gmi.seed_picker_aliases(["bogus_provider/some-model"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0001")
+
+    # Not the bogus provider we accidentally aliased to.
+    assert resolved.primary.provider_id != "bogus_provider"
+    # Falls through to the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"
+
+
+def test_unknown_alias_falls_through_to_existing_routing(settings):
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-9999")
+
+    # 9999 is not a seeded alias; the routing layer should fall through.
+    # With no alias match, unknown alias falls back to model name parsing,
+    # which raises because ``claude-sonnet-nim-9999`` doesn't match a route.
+    assert resolved.original_model == "claude-sonnet-nim-9999"
+
+
+def test_unseeded_alias_returns_none_from_resolver(settings):
+    # Cold-start path: no aliases seeded, alias-shaped id should not produce
+    # a routing hit. Falls through to the existing fallback chain.
+    resolved = ModelRouter(settings).resolve("claude-sonnet-nim-0500")
+
+    # Falls through and lands on the configured default.
+    assert resolved.primary.provider_id == "nvidia_nim"
+    assert resolved.primary.provider_model == "fallback-model"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,3 +241,13 @@ def _propagate_loguru_to_caplog():
         loguru_logger.remove(
             handler_id
         )  # Handler already removed (e.g. by test_logging_config)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_picker_alias_state():
+    """Keep the process-global picker alias maps inert between tests."""
+    from free_claude_code.core import gateway_model_ids as gmi
+
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()

--- a/tests/core/test_gateway_model_ids_aliases.py
+++ b/tests/core/test_gateway_model_ids_aliases.py
@@ -1,0 +1,251 @@
+"""Tests for picker aliasing in ``free_claude_code.core.gateway_model_ids``."""
+
+import pytest
+
+from free_claude_code.core import gateway_model_ids as gmi
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    """Reset module-scope alias maps before/after each test."""
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def test_picker_alias_prefix_is_anthropic_safe():
+    assert gmi.PICKER_ALIAS_PREFIX == "claude-sonnet-nim"
+
+
+def test_has_picker_aliases_false_before_seed():
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_populates_maps_and_marks_seeded():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    assert gmi.has_picker_aliases() is True
+
+
+def test_alias_counter_is_deterministic_from_sorted_input():
+    first = ["nvidia_nim/z-provider/z-model", "nvidia_nim/a-provider/a-model"]
+    second = list(reversed(first))
+
+    gmi.seed_picker_aliases(first)
+    a_first = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+    gmi.clear_picker_aliases()
+
+    gmi.seed_picker_aliases(second)
+    a_second = gmi.picker_alias_for("nvidia_nim/a-provider/a-model")
+
+    assert a_first == a_second == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/z-provider/z-model")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_reseed_keeps_existing_refs_on_their_alias():
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+        ]
+    )
+
+    # A refresh that adds a ref must not renumber the advertised ones.
+    gmi.seed_picker_aliases(
+        [
+            "nvidia_nim/01-ai/yi-large",
+            "nvidia_nim/meta/llama-3.3-70b-instruct",
+            "openai/gpt-x",
+        ]
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == (
+        "claude-sonnet-nim-0001"
+    )
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+    assert gmi.picker_alias_for("openai/gpt-x") == "claude-sonnet-nim-0003"
+
+
+def test_alias_lookup_thinking_and_no_thinking_variants():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+    assert (
+        gmi.picker_alias_for("nvidia_nim/01-ai/yi-large", force_reasoning_off=True)
+        == "claude-sonnet-nim-0001-no-thinking"
+    )
+
+
+def test_alias_lookup_unknown_ref_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.picker_alias_for("nvidia_nim/missing/model") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/missing/model", force_reasoning_off=True)
+        is None
+    )
+
+
+def test_resolve_picker_alias_round_trip():
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        False,
+    )
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001-no-thinking") == (
+        "nvidia_nim/meta/llama-3.3-70b-instruct",
+        True,
+    )
+
+
+def test_resolve_picker_alias_unknown_returns_none():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-9999-no-thinking") is None
+    assert gmi.resolve_picker_alias("claude-haiku-nim-0001") is None
+
+
+def test_resolve_picker_alias_for_prefix_only_when_seeded_empty():
+    # Maps are empty by default (cold-start window).
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_clear_resets_state():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.has_picker_aliases() is True
+
+    gmi.clear_picker_aliases()
+
+    assert gmi.has_picker_aliases() is False
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+
+
+def test_seed_empty_iterable_keeps_state_empty():
+    gmi.seed_picker_aliases([])
+
+    assert gmi.has_picker_aliases() is False
+
+
+def test_seed_replaces_previous_aliases_without_slot_reuse():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == "claude-sonnet-nim-0001"
+
+    gmi.seed_picker_aliases(["nvidia_nim/meta/llama-3.3-70b-instruct"])
+
+    # The removed ref's alias is retired, never recycled onto the new ref.
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is None
+    assert gmi.resolve_picker_alias("claude-sonnet-nim-0001") is None
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0002"
+    )
+
+
+def test_returning_ref_regains_its_previous_alias():
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large"])
+    original = gmi.picker_alias_for("nvidia_nim/01-ai/yi-large")
+    assert original is not None
+
+    gmi.seed_picker_aliases(["openai/gpt-x"])
+    assert gmi.resolve_picker_alias(original) is None
+
+    gmi.seed_picker_aliases(["nvidia_nim/01-ai/yi-large", "openai/gpt-x"])
+
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") == original
+
+
+def test_empty_refresh_keeps_retired_numbers_consumed():
+    """Disconnect-everything must not recycle aliases on the next refresh."""
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+    assert advertised is not None
+
+    # Inventory drains to empty (final provider disconnected)...
+    gmi.seed_picker_aliases([])
+    assert gmi.has_picker_aliases() is False
+    assert gmi.resolve_picker_alias(advertised) is None
+
+    # ...and a different model arrives later.
+    gmi.seed_picker_aliases(["openai/new/model"])
+
+    new_alias = gmi.picker_alias_for("openai/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(advertised) is None
+
+
+def test_aliases_are_four_digit_zero_padded():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(15)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [
+        alias for ref in refs if (alias := gmi.picker_alias_for(ref)) is not None
+    ]
+
+    assert len(aliases) == 15
+    for alias in aliases:
+        # All aliases share the same prefix and 4-digit counter width.
+        assert alias.startswith("claude-sonnet-nim-")
+        counter = alias.removeprefix("claude-sonnet-nim-").split("-")[0]
+        assert len(counter) == 4
+        assert counter.isdigit()
+
+
+def test_seed_assigns_unique_aliases_per_ref():
+    refs = [f"openai_chat/provider-{i}/model" for i in range(10)]
+    gmi.seed_picker_aliases(refs)
+
+    aliases = [gmi.picker_alias_for(ref) for ref in refs]
+
+    assert len(set(aliases)) == len(refs)
+    assert all(alias is not None for alias in aliases)
+
+
+def test_reseed_publishes_one_consistent_snapshot():
+    """Catalog output and routing must agree after an inventory swap.
+
+    Regression guard for torn publication: a reader binding the snapshot
+    before a reseed sees one self-consistent inventory, and a reader binding
+    it afterwards sees the other — never a mix of old and new maps. Sticky
+    assignments additionally guarantee the pre-reseed alias keeps resolving
+    to the same ref it advertised (or retires entirely).
+    """
+    gmi.seed_picker_aliases(["nvidia_nim/old/model"])
+    advertised = gmi.picker_alias_for("nvidia_nim/old/model")
+
+    gmi.seed_picker_aliases(["nvidia_nim/new/model"])
+
+    assert advertised is not None
+    # The previously advertised alias either still routes to its original ref
+    # or is retired outright; it can never re-point to another model.
+    assert gmi.resolve_picker_alias(advertised) in {
+        ("nvidia_nim/old/model", False),
+        None,
+    }
+    # Both directions of the new snapshot are aligned with each other.
+    new_alias = gmi.picker_alias_for("nvidia_nim/new/model")
+    assert new_alias is not None
+    assert new_alias != advertised
+    assert gmi.resolve_picker_alias(new_alias) == ("nvidia_nim/new/model", False)
+    no_thinking_alias = gmi.picker_alias_for(
+        "nvidia_nim/new/model", force_reasoning_off=True
+    )
+    assert no_thinking_alias is not None
+    assert gmi.resolve_picker_alias(no_thinking_alias) == (
+        "nvidia_nim/new/model",
+        True,
+    )

--- a/tests/runtime/test_provider_manager.py
+++ b/tests/runtime/test_provider_manager.py
@@ -8,6 +8,7 @@ from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.application.ports import RequestRuntimePort
 from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
 from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.nvidia_nim import NvidiaNimProvider
 from free_claude_code.providers.runtime import ProviderRuntime
@@ -240,6 +241,47 @@ async def test_catalog_publication_tracks_replacement_and_its_refresh() -> None:
         ("nvidia_nim/two", ()),
     ]
     await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_publish_reconciles_picker_aliases_with_cache_mutations() -> None:
+    gmi.clear_picker_aliases()
+    try:
+        factory = RuntimeFactory()
+        connected: set[str] = set()
+        manager = ProviderRuntimeManager(
+            _settings("nvidia_nim/one"),
+            runtime_factory=factory,
+            connected_provider_ids=lambda: tuple(connected),
+            model_catalog_publisher=RecordingModelCatalogPublisher(),
+        )
+        factory.runtimes[0].provider.list_model_infos = AsyncMock(
+            return_value=frozenset(
+                {ProviderModelInfo(model_id="old-model", supports_thinking=True)}
+            )
+        )
+
+        connected.add("openai")
+        await manager.connected_provider_changed("openai", connected=True)
+        old_alias = gmi.picker_alias_for("openai/old-model")
+        assert old_alias is not None
+
+        # A later cache mutation replaces the inventory: the new ref must gain
+        # an alias immediately, and the removed ref's alias retires instead of
+        # silently re-pointing at the replacement model.
+        manager.cache_model_infos(
+            "openai",
+            [ProviderModelInfo(model_id="new-model", supports_thinking=None)],
+        )
+
+        new_alias = gmi.picker_alias_for("openai/new-model")
+        assert new_alias is not None
+        assert gmi.picker_alias_for("openai/old-model") is None
+        assert new_alias != old_alias
+        assert gmi.resolve_picker_alias(old_alias) is None
+        await manager.close()
+    finally:
+        gmi.clear_picker_aliases()
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_manager_picker_aliases.py
+++ b/tests/runtime/test_provider_manager_picker_aliases.py
@@ -1,0 +1,87 @@
+"""Picker-alias reseeding on model-catalog republication."""
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.settings import Settings
+from free_claude_code.core import gateway_model_ids as gmi
+from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_state():
+    gmi.clear_picker_aliases()
+    yield
+    gmi.clear_picker_aliases()
+
+
+def _manager(model: str) -> ProviderRuntimeManager:
+    settings = Settings().model_copy(
+        update={"model": model, "nvidia_nim_api_key": "test-key"}
+    )
+    return ProviderRuntimeManager(settings)
+
+
+def _info(model_id: str) -> ProviderModelInfo:
+    return ProviderModelInfo(model_id=model_id, supports_thinking=None)
+
+
+def test_refresh_picker_aliases_seeds_current_cache_snapshot() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert (
+        gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+        == "claude-sonnet-nim-0001"
+    )
+    gmi.clear_picker_aliases()
+
+
+def test_cache_publication_reseeds_aliases_atomically() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    first_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+
+    # A refreshed inventory keeps the sticky assignment and adds new refs.
+    manager.cache_model_infos(
+        "nvidia_nim",
+        [
+            _info("meta/llama-3.3-70b-instruct"),
+            _info("01-ai/yi-large"),
+        ],
+    )
+
+    assert gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct") == first_alias
+    assert gmi.picker_alias_for("nvidia_nim/01-ai/yi-large") is not None
+
+
+def test_configured_ref_gets_alias_without_discovery_cache() -> None:
+    manager = _manager("nvidia_nim/one")
+
+    # No discovery cache yet: the configured model still gains a picker alias
+    # so a cold /v1/models request never advertises a raw gateway identifier.
+    manager.refresh_picker_aliases()
+
+    assert gmi.has_picker_aliases() is True
+    assert gmi.picker_alias_for("nvidia_nim/one") is not None
+
+
+def test_empty_cache_retires_discovery_only_aliases_but_keeps_configured() -> None:
+    manager = _manager("nvidia_nim/one")
+    manager.cache_model_infos("nvidia_nim", [_info("meta/llama-3.3-70b-instruct")])
+    assert gmi.has_picker_aliases() is True
+    configured_alias = gmi.picker_alias_for("nvidia_nim/one")
+    discovery_alias = gmi.picker_alias_for("nvidia_nim/meta/llama-3.3-70b-instruct")
+    assert configured_alias is not None
+    assert discovery_alias is not None
+
+    manager.cache_model_infos("nvidia_nim", [])
+
+    # The discovery-only ref retires; the configured ref keeps its alias.
+    assert gmi.has_picker_aliases() is True
+    assert gmi.resolve_picker_alias(discovery_alias) is None
+    assert gmi.picker_alias_for("nvidia_nim/one") == configured_alias

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.20.0"
+version = "5.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.19.0"
+version = "5.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Stacked on cd/alias-engine-v2 (#1646). Replaces #1558.

Serves picker aliases on a desktop-scoped API mount and accepts `x-api-key` as an equal auth scheme:

- **Desktop mount** — `create_app()` mounts the same router a second time under `/{DESKTOP_GATEWAY_PREFIX}` (default `claude-desktop`), so Claude Desktop can point its base URL at `http://localhost:8082/claude-desktop` and get the full API surface (models, messages, count_tokens) under the prefix.
- **Alias-only on the mount** — `list_models` now detects the desktop mount by exact path equality (`request.url.path == f"/{settings.desktop_gateway_prefix}/v1/models"`) and opts into `build_models_list_response(..., picker_aliases=True)` only there. Bare `/v1/models` and every other FCC client (Claude Code, Codex, Pi) keep seeing raw provider refs regardless of seeded alias state. Exact equality, not a prefix sniff, prevents a `DESKTOP_GATEWAY_PREFIX=v1` from leaking aliases onto the bare catalog, and lookalike paths (`/claude-desktop-evil/...`) 404.
- **`x-api-key` as an equal scheme** — `require_proxy_auth` now extracts the credential via `_extract_proxy_token`: a well-formed `Authorization: Bearer` header wins, otherwise `x-api-key` is used as-is (Claude Desktop's inference gateway authenticates with the Anthropic-native `x-api-key` header, and its model discovery reads `/v1/models`). A present-but-malformed Authorization header is a bad credential (401 "Invalid"), no Authorization at all with no `x-api-key` is missing (401 "Missing").
- **Startup seeding** — `ApplicationRuntime.start()` now calls `_seed_picker_aliases_from_cache()`, delegating to `ProviderRuntimeManager.refresh_picker_aliases()` so aliases are live at boot without waiting for a first model-catalog publication; startup seeding and later republications share one ownership path.

New env: `DESKTOP_GATEWAY_PREFIX=claude-desktop` (validated to strip boundary slashes; FastAPI rejects router prefixes ending in `/`).

Design: docs/superpowers/specs/2026-09-01-desktop-rerouting-v2-design.md (on fork).

## Verification

- [x] `uv run ruff format .` — 587 files unchanged
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ty check` — all checks passed
- [x] `uv run pytest -q` — 4261 passed, 176 skipped; only the pre-existing environmental failure `test_install_sh_noninteractive_skips_dsh_without_node` (root npm env; fails on the unmodified tree too)
- [x] Ported+new tests in isolation: 80 passed (test_desktop_scoped_models 7, test_desktop_startup_aliases 1, test_auth 26, test_dependencies 24, test_provider_manager 22)
- [x] `git diff 85b0f20 --stat` per file shows only the expected delta (app.py +6, routes.py +19/-2, dependencies.py +35/-8, runtime/application.py +9, .env.example +6)
- [x] Addresses the P1 from #1646's Greptile review: alias-enabled model discovery is now reachable at the desktop-prefixed mount

<!-- greptile_comment -->


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a Claude Desktop API mount with stable desktop-only model aliases, resolves those aliases back to provider model IDs, supports proxy authentication through `x-api-key`, and publishes aliases during startup and catalog updates.

One P2 repository-rule issue remains: first-party imports added in tests must be moved from function bodies to module scope. The product behavior covered by the updated API, routing, catalog, authentication, and startup tests is otherwise ready to merge after that cleanup.

<h3>Confidence Score: 4/5</h3>

The change is merge-safe with respect to product behavior, subject to resolving the repository-required test import placement.

There is one independent P2, non-security finding and no P0 or P1 findings, which maps to a score of 4.

**Files Needing Attention:** tests/api/test_desktop_scoped_models.py and tests/conftest.py need first-party imports moved to module scope.

<sub>Reviews (1): Last reviewed commit: ["feat: serve picker aliases on a desktop-..."](https://github.com/alishahryar1/free-claude-code/commit/b3635a9ef04b003f905d09d90cceca0d5ed4026d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59287441)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/alishahryar1/free-claude-code/blob/main/CLAUDE.md))

<!-- /greptile_comment -->