### PR TITLE
Fix Grok response timestamps and README provider count

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## What You Get
 
-- **49 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
+- **50 ToS-friendly providers. 1.3B+ free tokens every month.** Use free, paid, subscription, and local models from one searchable UI without putting your account at risk. FCC follows provider terms and removes integrations if they stop being allowed.
 - **10 coding agents. One model catalog.** Run [Claude Code](https://code.claude.com/docs/en/overview), [Codex](https://github.com/openai/codex), [Pi](https://github.com/earendil-works/pi), [OpenCode](https://github.com/anomalyco/opencode), [Cline](https://github.com/cline/cline), [Hermes](https://github.com/NousResearch/hermes-agent), [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), [Grok Build](https://github.com/xai-org/grok-build), [Muse Code](https://research.meta.ai/blog/introducing-muse-code-and-muse-spark-1-2/), or [Aider](https://aider.chat/) with your FCC models.
 - **Keep coding through provider outages.** After retries are exhausted, FCC automatically tries your next configured model without making you restart the turn—across every client.
 - **Up to 90% fewer terminal-output tokens.** Optional [RTK](https://github.com/rtk-ai/rtk) filters common command output, while five FCC optimizations handle quota probes, command-prefix detection, titles, suggestions, and filepaths without calling a provider.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.22.1"
+version = "5.22.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/openai_responses/native.py
+++ b/src/free_claude_code/core/openai_responses/native.py
@@ -68,7 +68,7 @@ class NativeResponsesRelay:
         return self._terminal_type is not None
 
     def feed(self, event_type: str, payload: Mapping[str, object]) -> str:
-        """Format one upstream event after rewriting FCC-owned model metadata."""
+        """Format public model metadata and canonical whole-second timestamps."""
 
         if self._terminal_type is not None:
             raise ValueError(
@@ -79,6 +79,12 @@ class NativeResponsesRelay:
         response = data.get("response")
         if isinstance(response, dict):
             response["model"] = self._public_model
+            # SDK models coerce integer timestamps to floats; strict clients
+            # require JSON integers. Preserve any actual fractional precision.
+            for field in ("created_at", "completed_at"):
+                timestamp = response.get(field)
+                if isinstance(timestamp, float) and timestamp.is_integer():
+                    response[field] = int(timestamp)
             self._response = cast(JsonObject, deepcopy(response))
             response_id = response.get("id")
             if isinstance(response_id, str) and response_id:

--- a/tests/core/openai_responses/test_native.py
+++ b/tests/core/openai_responses/test_native.py
@@ -231,6 +231,45 @@ def test_native_relay_preserves_payload_and_rewrites_only_response_model() -> No
     assert relay.terminal_type == "response.completed"
 
 
+@pytest.mark.parametrize(
+    ("timestamp", "expected_type"),
+    [
+        (1788587503.0, int),
+        (1788587503, int),
+        (1788587503.25, float),
+        (None, type(None)),
+    ],
+)
+@pytest.mark.parametrize("event_type", ["response.created", "response.failed"])
+def test_native_relay_serializes_whole_second_timestamps_as_integers(
+    timestamp: float | int | None, expected_type: type, event_type: str
+) -> None:
+    relay = NativeResponsesRelay(public_model="gateway-model")
+    original = {
+        "type": event_type,
+        "response": {
+            "id": "resp_upstream",
+            "created_at": timestamp,
+            "completed_at": timestamp,
+            "temperature": 1.0,
+            "metadata": {"created_at": 1788587503.0},
+        },
+    }
+
+    _, payload = _event_payload(relay.feed(event_type, original))
+
+    response = payload["response"]
+    assert isinstance(response, dict)
+    for key in ("created_at", "completed_at"):
+        assert type(response[key]) is expected_type
+        assert response[key] == timestamp
+        assert type(original["response"][key]) is type(timestamp)
+    assert type(response["temperature"]) is float
+    metadata = response["metadata"]
+    assert isinstance(metadata, dict)
+    assert type(metadata["created_at"]) is float
+
+
 def test_native_relay_rejects_events_after_one_terminal() -> None:
     relay = NativeResponsesRelay(public_model="gateway-model")
     relay.feed(

--- a/tests/providers/test_openai_responses_transport.py
+++ b/tests/providers/test_openai_responses_transport.py
@@ -169,6 +169,7 @@ async def test_native_responses_preserves_request_and_upstream_event_identity() 
     captured: list[dict[str, object]] = []
     created_response = {
         **_completed_response(model="upstream-model"),
+        "created_at": 1788587503,
         "status": "in_progress",
         "output": [],
         "usage": None,
@@ -179,7 +180,14 @@ async def test_native_responses_preserves_request_and_upstream_event_identity() 
         "response": created_response,
     }
     delta = _text_delta("hello", sequence=1)
-    completed = _completed_event(sequence=2)
+    completed = {
+        **_completed_event(sequence=2),
+        "response": {
+            **_completed_response(),
+            "created_at": 1788587503,
+            "completed_at": 1788587504,
+        },
+    }
 
     def handler(request: httpx2.Request) -> httpx2.Response:
         payload = json.loads(request.content)
@@ -224,8 +232,14 @@ async def test_native_responses_preserves_request_and_upstream_event_identity() 
     ]
     assert events[0].data["response"]["id"] == "resp_test"
     assert events[0].data["response"]["model"] == "public-model"
+    for event in (events[0], events[2]):
+        timestamp = event.data["response"]["created_at"]
+        assert type(timestamp) is int
+        assert timestamp == 1788587503
     assert events[1].data == delta
     assert events[2].data["response"]["model"] == "public-model"
+    assert type(events[2].data["response"]["completed_at"]) is int
+    assert events[2].data["response"]["completed_at"] == 1788587504
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.22.1"
+version = "5.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Grok Build cannot read a response when FCC serializes a whole-second timestamp as a JSON float, such as `1788587503.0`. The OpenAI SDK converts upstream integer timestamps to floats before FCC relays them. The README also still says 49 providers after Copilot brought the catalog back to 50.

## How

- Serialize integral `created_at` and `completed_at` values as integers in the native Responses relay. Preserve fractional timestamps and unrelated numeric fields.
- Add regression coverage through the real SDK parser and for creation/failure events, null values, fractional precision, and input preservation.
- Bump the patch version to 5.22.2 with the matching lockfile update.
- Restore the README's provider count to 50, verified against `PROVIDER_CATALOG`.

Validation: all six local CI checks pass, including 4,947 deterministic tests (148 skipped) and 65 browser tests. Installed Grok Build 1.0.13 reproduces the exact serialization error before the fix and successfully reads the same FCC-generated stream afterward, using isolated state and no upstream inference.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds GitHub Copilot as an Admin-managed connected account, retires the legacy GitHub Models API-key provider, and updates related routing, persistence, documentation, tests, and release metadata.

The Copilot account API was exercised for status, device login, cancellation, disconnect, unsupported login modes, loopback protection, and provider-construction safeguards. Those checks completed successfully. No merge-blocking defect was established.

### T-Rex validation blocked
Rendered browser verification of the Copilot device-login card could not start because the repository virtual environment referenced a missing temporary Python 3.14 runtime, and the available replacement Python runtime did not have pytest installed.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge based on the completed API contract checks and the absence of established defects.

No confirmed findings require changes before merging. The blocked browser check does not establish a product defect.

**Files Needing Attention:** No files require corrective changes. Re-run the rendered Copilot device-login coverage after restoring the local Python test environment.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Authored the browser-validation test file and its execution script, and captured the blocked output because Python/pytest were unavailable in the environment.
- Created an executable harness for the connected-account contract and collected before/after runtime logs along with the pytest run output.
- Validated that the process was blocked before any browser interaction, with environment failures documented in the captured output showing missing Python and pytest.

<a href="https://app.greptile.com/trex/runs/22662115/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: restore provider count to 50"](https://github.com/alishahryar1/free-claude-code/commit/8ecb167668ea6df87d375b816ca7c555329a88a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60694877)</sub>

**Context used:**

- Knowledge Base — [Protocol adaptation and streaming](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/protocol-adapters.md)

<!-- /greptile_comment -->