### PR TITLE
Update CONTRIBUTING.md to remove ARCHITECTURE reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,5 +59,3 @@ GitHub CI runs Ruff in check-only mode and also bans `# type: ignore`, `# ty: ig
 ## Versioning
 
 Changes to runtime code, packaging, dependencies, or install/CI scripts require a semantic version bump in `pyproject.toml` and a matching `uv lock` update in the same commit. Documentation, tests, smoke coverage, and repository configuration do not require a version bump by themselves.
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for extension checklists and the full system design.


### PR DESCRIPTION
Removed reference to ARCHITECTURE.md for extension checklists.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation update removes one obsolete ARCHITECTURE.md reference, but CONTRIBUTING.md still contains another link to that missing file. Contributors following the remaining guidance will reach a nonexistent page.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge from a runtime and security perspective, but the remaining broken contributor-documentation link should be corrected.

An executed check confirmed one non-blocking documentation defect in CONTRIBUTING.md.

**Files Needing Attention:** CONTRIBUTING.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P2 finding and attached a shell-script artifact and a log with a URL.
- T-Rex produced another finding-comment proof for the same posted P2 finding.
- T-Rex ran the requested contract-validation verification, but its local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/22663636/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (2)</h3>

1. `CONTRIBUTING.md`, line 11 ([link](https://github.com/alishahryar1/free-claude-code/blob/60e0fe66957f56ef691ecfa9e810cc7139b3f6f1/CONTRIBUTING.md#L11)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Remaining dead architecture link**

   `CONTRIBUTING.md` still directs contributors to read `ARCHITECTURE.md`, but that relative file is absent. Contributors following this guidance reach a missing page; remove or update this remaining link. This is non-blocking, but it leaves contributor guidance incomplete.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Evidence from the check](https://app.greptile.com/trex/artifacts/a1dfd3e0-fa0f-4497-9fc9-bb8b45b171cd)**

   - Authored Bash script checks the HEAD tree for the absent target and the exact remaining link in the named contributor section, proving the compared conditions.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/cb4795e2-47a2-4814-95ef-0af2f0ce3c07)**

   - Captured command output from \`/home/user/repo\` records exit code 0, PR head SHA, both passing checks, and the dead-link conclusion.

   <a href="https://app.greptile.com/trex/runs/22663636/artifacts?artifact=a1dfd3e0-fa0f-4497-9fc9-bb8b45b171cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22Alishahryar1-patch-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22Alishahryar1-patch-1%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CONTRIBUTING.md%0ALine%3A%2011%0A%0AComment%3A%0A**Remaining%20dead%20architecture%20link**%0A%0A%60CONTRIBUTING.md%60%20still%20directs%20contributors%20to%20read%20%60ARCHITECTURE.md%60%2C%20but%20that%20relative%20file%20is%20absent.%20Contributors%20following%20this%20guidance%20reach%20a%20missing%20page%3B%20remove%20or%20update%20this%20remaining%20link.%20This%20is%20non-blocking%2C%20but%20it%20leaves%20contributor%20guidance%20incomplete.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1673&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **CONTRIBUTING.md retains a link to absent ARCHITECTURE.md**

   - **Bug**
     - At PR head `60e0fe66957f56ef691ecfa9e810cc7139b3f6f1`, the `Before Opening A Pull Request` section retains `[ARCHITECTURE.md](ARCHITECTURE.md)`, but `ARCHITECTURE.md` does not exist in the HEAD tree. Users following the contributor guidance reach a missing relative target.
   - **Cause**
     - The PR removed one ARCHITECTURE reference but left the remaining Markdown link in CONTRIBUTING.md after the target document had been removed.
   - **Fix**
     - Remove the remaining link or restore/update the target to a valid documentation location.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22Alishahryar1-patch-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22Alishahryar1-patch-1%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231673%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1673&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22Alishahryar1-patch-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22Alishahryar1-patch-1%22.%0A%0A%23%23%23%20Issue%201%0ACONTRIBUTING.md%3A11%0A**Remaining%20dead%20architecture%20link**%0A%0A%60CONTRIBUTING.md%60%20still%20directs%20contributors%20to%20read%20%60ARCHITECTURE.md%60%2C%20but%20that%20relative%20file%20is%20absent.%20Contributors%20following%20this%20guidance%20reach%20a%20missing%20page%3B%20remove%20or%20update%20this%20remaining%20link.%20This%20is%20non-blocking%2C%20but%20it%20leaves%20contributor%20guidance%20incomplete.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1673&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update CONTRIBUTING.md to remove ARCHITE..."](https://github.com/alishahryar1/free-claude-code/commit/60e0fe66957f56ef691ecfa9e810cc7139b3f6f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60698101)</sub>

<!-- /greptile_comment -->