### PR TITLE
Fix Muse model catalog visibility and metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.22.2"
+version = "5.22.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -205,7 +205,7 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
             "tests/cli/test_muse_launcher.py",
             "tests/api/test_model_listing.py",
         ),
-        ("test_muse_model_catalog_is_the_fixed_responses_projection",),
+        ("test_muse_model_catalog_marks_every_routable_model_visible",),
         ("test_muse_cli_headless_e2e",),
         ("clients",),
         ("Muse Code 0.2.1+",),

--- a/smoke/product/test_client_product_live.py
+++ b/smoke/product/test_client_product_live.py
@@ -823,6 +823,19 @@ def test_muse_cli_headless_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> Non
     assert auth_token not in combined
     assert "GET /v1/models?view=responses" in server_log
     assert "GET /muse-code/models" in server_log
+    # Muse accepts a generic OpenAI list but hides rows without its native
+    # metadata. Inspect the actual CLI's parsed catalog, not just HTTP success.
+    catalog_files = list(
+        (isolated_home / "data" / "muse" / "model-catalog").glob("*.json")
+    )
+    assert catalog_files, "Muse did not persist its parsed provider catalog"
+    visible_models = {
+        row["model_id"]
+        for catalog_file in catalog_files
+        for row in json.loads(catalog_file.read_text(encoding="utf-8"))["rows"]
+        if row["visibility"] == "visible"
+    }
+    assert full_model in visible_models, "Muse hides the configured FCC model"
     responses_count = server_log.count("POST /v1/responses")
     assert responses_count >= 1
     assert responses_count == len(provider_requests)

--- a/src/free_claude_code/api/model_catalog.py
+++ b/src/free_claude_code/api/model_catalog.py
@@ -29,6 +29,24 @@ class ModelCatalogView(StrEnum):
     RESPONSES = "responses"
 
 
+class MuseModelLimits(BaseModel):
+    context: int | None = None
+    output: int | None = None
+
+
+class MuseModelMetadata(BaseModel):
+    """Muse's native model visibility and capability metadata."""
+
+    name: str
+    is_hidden: Literal[False] = False
+    reasoning: bool | None = None
+    limit: MuseModelLimits | None = None
+
+
+class MuseMetadataEnvelope(BaseModel):
+    muse_code: MuseModelMetadata = Field(serialization_alias="muse-code")
+
+
 class ModelResponse(BaseModel):
     object: Literal["model"] = "model"
     created: int = 0
@@ -65,6 +83,7 @@ class ModelResponse(BaseModel):
     inference_idle_timeout_seconds: int | None = Field(
         default=None, serialization_alias="inferenceIdleTimeoutSecs"
     )
+    metadata: MuseMetadataEnvelope | None = None
 
 
 class ModelsListResponse(BaseModel):
@@ -138,6 +157,33 @@ def build_models_list_response(
     if view is ModelCatalogView.CLAUDE:
         return _build_claude_models_response(settings, runtime)
     return _build_direct_models_response(settings, runtime, view=view)
+
+
+def build_muse_models_list_response(
+    settings: Settings, runtime: RequestRuntimePort
+) -> ModelsListResponse:
+    """Keep routable IDs while making them visible to Muse's native picker."""
+    catalog = build_models_list_response(
+        settings, runtime, view=ModelCatalogView.RESPONSES
+    )
+    for model in catalog.data:
+        limits = (
+            MuseModelLimits(
+                context=model.context_window_tokens,
+                output=model.max_output_tokens,
+            )
+            if model.context_window_tokens is not None
+            or model.max_output_tokens is not None
+            else None
+        )
+        model.metadata = MuseMetadataEnvelope(
+            muse_code=MuseModelMetadata(
+                name=model.display_name,
+                reasoning=model.supports_reasoning,
+                limit=limits,
+            )
+        )
+    return catalog
 
 
 def _build_claude_models_response(

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -27,6 +27,7 @@ from .model_catalog import (
     ModelCatalogView,
     ModelsListResponse,
     build_models_list_response,
+    build_muse_models_list_response,
 )
 from .ports import ApiServices
 from .request_errors import ordinary_application_error_response
@@ -219,11 +220,7 @@ async def list_muse_models(
 ):
     """List the direct Responses models expected by Muse Code."""
     trace_event(stage="ingress", event="free_claude_code.api.models.list", source="api")
-    return build_models_list_response(
-        settings,
-        services.requests,
-        view=ModelCatalogView.RESPONSES,
-    )
+    return build_muse_models_list_response(settings, services.requests)
 
 
 @router.post("/stop")

--- a/tests/api/test_model_listing.py
+++ b/tests/api/test_model_listing.py
@@ -309,7 +309,7 @@ def test_claude_model_view_does_not_expose_capability_fields():
     )
 
 
-def test_muse_model_catalog_is_the_fixed_responses_projection():
+def test_muse_model_catalog_marks_every_routable_model_visible():
     app = create_test_app(_settings(model_opus=None, model_haiku=None))
     manager = provider_manager_for_app(app)
     manager.cache_model_infos(
@@ -326,12 +326,60 @@ def test_muse_model_catalog_is_the_fixed_responses_projection():
 
     assert responses.status_code == 200
     assert muse.status_code == 200
-    assert muse.json() == responses.json()
+    assert all("metadata" not in row for row in responses.json()["data"])
+    for row in muse.json()["data"]:
+        metadata = row["metadata"]["muse-code"]
+        assert metadata["is_hidden"] is False
+        assert metadata["name"] == row["display_name"]
+        assert "limit" not in metadata
+        original = {key: value for key, value in row.items() if key != "metadata"}
+        assert original in responses.json()["data"]
     assert [row["id"] for row in muse.json()["data"]] == [
         "deepseek/deepseek-chat",
         "claude-3-freecc-no-thinking/open_router/plain-model",
         "open_router/reasoning-model",
     ]
+
+
+def test_muse_catalog_uses_native_metadata_for_known_limits_and_reasoning():
+    app = create_test_app(_settings(model_opus=None, model_haiku=None))
+    provider_manager_for_app(app).cache_model_infos(
+        "open_router",
+        {
+            ProviderModelInfo(
+                "reasoning-model",
+                supports_thinking=True,
+                context_window_tokens=131072,
+                max_output_tokens=8192,
+            ),
+            ProviderModelInfo(
+                "plain-model",
+                supports_thinking=False,
+                context_window_tokens=65536,
+            ),
+        },
+    )
+    rows = {
+        row["provider_model_ref"]: row["metadata"]["muse-code"]
+        for row in TestClient(app).get("/muse-code/models").json()["data"]
+    }
+
+    assert rows["open_router/reasoning-model"] == {
+        "name": "open_router/reasoning-model",
+        "is_hidden": False,
+        "reasoning": True,
+        "limit": {"context": 131072, "output": 8192},
+    }
+    assert rows["open_router/plain-model"] == {
+        "name": "open_router/plain-model (no thinking)",
+        "is_hidden": False,
+        "reasoning": False,
+        "limit": {"context": 65536},
+    }
+    assert rows["deepseek/deepseek-chat"] == {
+        "name": "deepseek/deepseek-chat",
+        "is_hidden": False,
+    }
 
 
 def test_responses_model_view_rounds_timeout_up_before_margin():

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.22.2"
+version = "5.22.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Muse Code 1.0.3 receives HTTP 200 from FCC's model catalog but shows no visible models in `/model`. FCC omits the native `metadata["muse-code"]` block, so Muse marks every model hidden and cannot read its advertised token limits.

## How

- Add Muse-specific visibility, display names, reasoning support, and known token limits to `/muse-code/models`. Preserve routable model IDs and the existing generic model-list responses; omit unknown capabilities and limits.
- Replace the catalog-equality test with native metadata regressions. Strengthen the real Muse smoke test to assert that Muse's parsed catalog contains the configured model as visible, and update its feature-manifest reference.
- Bump FCC to 5.22.3 with the matching lockfile update.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Muse model metadata is now available through the dedicated catalog endpoint while the generic Responses catalog remains unchanged. No issues were found that would prevent merging.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge.

The dedicated Muse catalog returned every routable Responses model with the expected visibility and capability metadata, and the generic Responses endpoint remained metadata-free.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the dedicated Muse catalog before and after this change using the same deterministic cached model inventory.
- Confirmed that /muse-code/models returns all three routable Responses model IDs with visible Muse metadata.
- Confirmed that /v1/models?view=responses returns successfully and contains no Muse metadata.
- Ran the two focused Muse catalog route tests and observed successful results.
- After the change, /muse-code/models returned all three Responses IDs with visible Muse metadata; known context and reasoning values were correctly projected.

<a href="https://app.greptile.com/trex/runs/22664487/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Muse model catalog visibility and me..."](https://github.com/alishahryar1/free-claude-code/commit/826251628c37d309f740c4ae23064866c6182286) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60699699)</sub>

<!-- /greptile_comment -->