### PR TITLE
Prevent PowerShell script tests from creating a Microsoft folder

### DIFF
--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,16 @@
+"""Isolate caches created by installer and lifecycle test subprocesses."""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_powershell_module_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A redirected USERPROFILE can make Windows PowerShell's default cache path
+    # relative to the checkout, even when LOCALAPPDATA points at a temporary dir.
+    monkeypatch.setenv(
+        "PSModuleAnalysisCachePath", str(tmp_path / "powershell-module-cache")
+    )

--- a/tests/scripts/test_powershell_cache.py
+++ b/tests/scripts/test_powershell_cache.py
@@ -1,0 +1,69 @@
+"""Keep PowerShell's background module cache inside each test's storage."""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows PowerShell cache behavior")
+@pytest.mark.parametrize("shell_name", ["powershell", "pwsh"])
+def test_powershell_module_cache_does_not_leak_into_working_directory(
+    tmp_path: Path, shell_name: str
+) -> None:
+    shell = shutil.which(shell_name)
+    if shell is None:
+        pytest.skip(f"{shell_name} is not installed")
+
+    working_directory = tmp_path / "working-directory"
+    profile = tmp_path / "profile"
+    local_app_data = tmp_path / "local-app-data"
+    for directory in (working_directory, profile, local_app_data):
+        directory.mkdir()
+
+    cache_value = os.environ.get("PSMODULEANALYSISCACHEPATH")
+    if cache_value:
+        assert Path(cache_value).is_absolute()
+        assert Path(cache_value).is_relative_to(tmp_path)
+    leaked_cache = (
+        working_directory
+        / "Microsoft"
+        / "Windows"
+        / "PowerShell"
+        / "ModuleAnalysisCache"
+    )
+    watched_cache = Path(cache_value) if cache_value else leaked_cache
+    result = subprocess.run(
+        [
+            shell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            """$ErrorActionPreference = 'Stop'
+Get-Command fcc_nonexistent_cache_probe_command -ErrorAction SilentlyContinue
+$deadline = [DateTime]::UtcNow.AddSeconds(20)
+while (-not (Test-Path -LiteralPath $env:FCC_TEST_WATCHED_CACHE) -and [DateTime]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 100
+}
+""",
+        ],
+        cwd=working_directory,
+        env=os.environ
+        | {
+            "USERPROFILE": str(profile),
+            "LOCALAPPDATA": str(local_app_data),
+            "FCC_TEST_WATCHED_CACHE": str(watched_cache),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (working_directory / "Microsoft").exists(), "PowerShell leaked its cache"
+    assert cache_value, "PowerShell test processes need an isolated cache path"
+    assert watched_cache.is_file(), "PowerShell did not exercise its cache writer"
+    assert watched_cache.stat().st_size > 0


### PR DESCRIPTION
## Why

Windows PowerShell can write `Microsoft/Windows/PowerShell/ModuleAnalysisCache` into the checkout when installer tests redirect `USERPROFILE`. Its background cache writer can resolve the default cache location relative to the working directory even with a temporary `LOCALAPPDATA`.

## How

Set `PSModuleAnalysisCachePath` to an absolute, per-test file under `tmp_path` for script tests, so their PowerShell subprocesses inherit an isolated cache location.

Add a regression for Windows PowerShell and PowerShell 7 that exercises the background cache writer with redirected profile directories and checks that no `Microsoft` directory appears in the working directory.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PowerShell cache isolation test is added, but it is not exercised by the configured automated checks because those checks run on Ubuntu and the test only runs on Windows.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with a non-blocking coverage gap: the new Windows-specific regression is not continuously exercised.

The verified issue is limited to missing automated coverage for a Windows-only regression path.

**Files Needing Attention:** tests/scripts/test_powershell_cache.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P2 finding and referenced the review comment for details.
- T-Rex produced a proof for the posted P1 finding.
- T-Rex performed general contract validation by including the exact executed script source verbatim and reconfirming artifact references.
- The P2 proof bundle includes the executed shell script artifact and two log artifacts, accessible via URLs.

<a href="https://app.greptile.com/trex/runs/22665776/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **CI cannot detect regressions in the Windows PowerShell cache test**

   - **Bug**
     - The only configured CI test runner is Ubuntu. The full pytest job would collect this test, but both parametrizations are skipped on Ubuntu due to its Windows-only marker, so a Windows cache leak can regress without CI detection.
   - **Cause**
     - `tests/scripts/test_powershell_cache.py:11` skips unless `os.name == "nt"`, while `.github/workflows/tests.yml:47` runs the quality matrix on `ubuntu-latest`; no configured workflow declares a Windows runner.
   - **Fix**
     - Add a Windows GitHub Actions test job (for example, a `windows-latest` matrix entry) that runs this targeted test or the relevant pytest suite with PowerShell available.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fisolate-powershell-test-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fisolate-powershell-test-cache%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231675%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1675&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fisolate-powershell-test-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fisolate-powershell-test-cache%22.%0A%0A%23%23%23%20Issue%201%0Atests%2Fscripts%2Ftest_powershell_cache.py%3A11%0A**Windows%20Regression%20Is%20Unchecked**%0A%0AAll%20configured%20automated%20checks%20run%20on%20Ubuntu%2C%20while%20this%20test%20skips%20unless%20it%20runs%20on%20Windows.%20A%20future%20PowerShell%20cache%20leak%20can%20therefore%20return%20without%20this%20regression%20detecting%20it.%20This%20is%20non-blocking%2C%20but%20add%20a%20Windows%20job%20that%20runs%20this%20test%20or%20the%20relevant%20script-test%20suite%20to%20continuously%20protect%20the%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1675&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Isolate PowerShell module caches in scri..."](https://github.com/alishahryar1/free-claude-code/commit/142b9584b3bddfb6b1d0868d78513ec96cb8527e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60702775)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->