### PR TITLE
Fix Pi thinking effort translation for GitHub Copilot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.22.3"
+version = "5.22.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/pi_extension.ts
+++ b/src/free_claude_code/cli/launchers/pi_extension.ts
@@ -152,4 +152,33 @@ export default async function freeClaudeCode(pi: ExtensionAPI): Promise<void> {
 		api: "anthropic-messages",
 		models,
 	});
+
+	pi.on("before_provider_request", (event, ctx) => {
+		const payload = event.payload;
+		if (
+			ctx.model?.provider !== "free-claude-code" ||
+			ctx.model.api !== "anthropic-messages" ||
+			ctx.model.reasoning === false ||
+			!isRecord(payload) || payload.model !== ctx.model.id ||
+			!isRecord(payload.thinking) || payload.thinking.type !== "enabled" ||
+			optionalPositiveInteger(payload.thinking.budget_tokens) === undefined
+		) return;
+
+		const effort = pi.getThinkingLevel();
+		if (effort === "off") return;
+
+		// Pi synthesizes a token budget from this level. Send the original effort
+		// so FCC can choose the provider's supported thinking mode and encoding.
+		const thinking = { ...payload.thinking };
+		delete thinking.type;
+		delete thinking.budget_tokens;
+		return {
+			...payload,
+			thinking: Object.keys(thinking).length > 0 ? thinking : undefined,
+			output_config: {
+				...(isRecord(payload.output_config) ? payload.output_config : {}),
+				effort,
+			},
+		};
+	});
 }

--- a/tests/cli/test_pi_extension.py
+++ b/tests/cli/test_pi_extension.py
@@ -3,10 +3,208 @@
 import json
 import shutil
 import subprocess
+from dataclasses import replace
+from pathlib import Path
+from typing import Literal
 
 import pytest
 
+from free_claude_code.application.reasoning import client_reasoning_policy
 from free_claude_code.cli.launchers.pi import pi_extension_path
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.providers.github_copilot.types import CopilotEgress
+from tests.providers.test_github_copilot_provider import Harness, collect
+
+
+def _pi_request_payloads(cases: list[dict[str, object]]) -> list[dict[str, object]]:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+
+    script = """
+const { default: extension } = await import(process.argv[1]);
+const handlers = new Map();
+let level;
+process.env.FCC_PI_BASE_URL = "http://fcc.invalid";
+process.env.FCC_PI_API_KEY = "test-key";
+globalThis.fetch = async () => new Response(JSON.stringify({
+    object: "list",
+    data: [{ id: "github_copilot/gpt-5.6-luna", provider_model_ref: "github_copilot/gpt-5.6-luna" }],
+}));
+await extension({
+    registerProvider() {},
+    on(event, handler) { handlers.set(event, handler); },
+    getThinkingLevel() { return level; },
+});
+const results = [];
+for (const entry of JSON.parse(process.argv[2])) {
+    level = entry.level;
+    const payload = structuredClone(entry.payload);
+    const handler = handlers.get("before_provider_request");
+    const replacement = await handler?.({ payload }, { model: entry.model });
+    results.push(replacement ?? payload);
+}
+console.log(JSON.stringify(results));
+"""
+    result = subprocess.run(
+        [
+            node,
+            "--experimental-strip-types",
+            "--input-type=module",
+            "--eval",
+            script,
+            pi_extension_path().as_uri(),
+            json.dumps(cases),
+        ],
+        capture_output=True,
+        check=False,
+        encoding="utf-8",
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_pi_sends_selected_effort_without_an_exact_budget_or_native_thinking_mode() -> (
+    None
+):
+    model = {
+        "id": "github_copilot/gpt-5.6-luna",
+        "provider": "free-claude-code",
+        "api": "anthropic-messages",
+        "reasoning": True,
+    }
+    payload = {
+        "model": model["id"],
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 16384,
+        "stream": True,
+        "thinking": {"type": "enabled", "budget_tokens": 8192, "display": "summarized"},
+        "output_config": {"format": {"type": "text"}},
+    }
+    levels = ["minimal", "low", "medium", "high", "xhigh", "max"]
+    results = _pi_request_payloads(
+        [{"model": model, "payload": payload, "level": level} for level in levels]
+    )
+    for level, result in zip(levels, results, strict=True):
+        assert result == payload | {
+            "thinking": {"display": "summarized"},
+            "output_config": {"format": {"type": "text"}, "effort": level},
+        }
+
+
+def test_pi_preserves_disabled_thinking_and_requests_outside_its_budget_translation() -> (
+    None
+):
+    model = {
+        "id": "github_copilot/gpt-5.6-luna",
+        "provider": "free-claude-code",
+        "api": "anthropic-messages",
+        "reasoning": True,
+    }
+    payload = {
+        "model": model["id"],
+        "thinking": {"type": "enabled", "budget_tokens": 8192},
+    }
+    cases: list[dict[str, object]] = [
+        {
+            "model": model,
+            "level": "off",
+            "payload": payload | {"thinking": {"type": "disabled"}},
+        },
+        {"model": model, "level": "high", "payload": {"model": model["id"]}},
+        {
+            "model": model,
+            "level": "high",
+            "payload": payload
+            | {"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}},
+        },
+        {
+            "model": model | {"provider": "anthropic"},
+            "level": "high",
+            "payload": payload,
+        },
+        {
+            "model": model | {"api": "openai-responses"},
+            "level": "high",
+            "payload": payload,
+        },
+        {"model": model | {"reasoning": False}, "level": "high", "payload": payload},
+        {
+            "model": model,
+            "level": "high",
+            "payload": payload | {"model": "another-model"},
+        },
+    ]
+    assert _pi_request_payloads(cases) == [case["payload"] for case in cases]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "egress,adaptive",
+    [
+        (CopilotEgress.CHAT, "optional"),
+        (CopilotEgress.RESPONSES, "optional"),
+        (CopilotEgress.MESSAGES, "required"),
+        (CopilotEgress.MESSAGES, "unsupported"),
+    ],
+)
+async def test_pi_named_effort_reaches_each_copilot_transport(
+    tmp_path: Path,
+    egress: CopilotEgress,
+    adaptive: Literal["optional", "required", "unsupported"],
+) -> None:
+    model_id = "github_copilot/gpt-5.6-luna"
+    payload = _pi_request_payloads(
+        [
+            {
+                "model": {
+                    "id": model_id,
+                    "provider": "free-claude-code",
+                    "api": "anthropic-messages",
+                    "reasoning": True,
+                },
+                "level": "high",
+                "payload": {
+                    "model": model_id,
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "max_tokens": 16384,
+                    "stream": True,
+                    "thinking": {"type": "enabled", "budget_tokens": 8192},
+                },
+            }
+        ]
+    )[0]
+    harness = Harness(tmp_path, egress)
+    advertised_model = harness.runtime.available[0]
+    harness.runtime.available = (
+        replace(
+            advertised_model,
+            messages=replace(advertised_model.messages, adaptive_thinking=adaptive),
+        ),
+    )
+    try:
+        request = MessagesRequest.model_validate(
+            payload | {"model": harness.runtime.name}
+        )
+        await collect(
+            harness.provider.stream_messages(
+                request, reasoning=client_reasoning_policy(request)
+            )
+        )
+        body = json.loads(harness.seen[0].content)
+        if egress is CopilotEgress.CHAT:
+            assert body["reasoning_effort"] == "high"
+        elif egress is CopilotEgress.RESPONSES:
+            assert body["reasoning"]["effort"] == "high"
+        elif adaptive == "required":
+            assert body["thinking"] == {"type": "adaptive"}
+            assert body["output_config"]["effort"] == "high"
+        else:
+            assert body["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+    finally:
+        await harness.close()
 
 
 def test_pi_extension_projects_known_capabilities_and_preserves_unknown_defaults() -> (

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.22.3"
+version = "5.22.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Selecting `github_copilot/gpt-5.6-luna` in `fcc-pi` with thinking enabled and sending `hello` returns HTTP 400: `This Copilot endpoint cannot represent an exact thinking token budget.` Pi turns its named thinking level into an Anthropic token budget, which Copilot's Chat and Responses endpoints cannot express.

## How

Translate Pi's synthesized thinking budget back to the selected named effort in the bundled extension. Send `output_config.effort` and let FCC choose the provider's supported thinking mode, preserving display options and other request fields. Limit the translation to the active FCC model's Anthropic Messages requests and preserve disabled thinking.

Add regression coverage for Pi's effort levels and Copilot's Chat, Responses, and native Messages transports, including adaptive and manual thinking models. Bump FCC to 5.22.4.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary

The Pi request hook converts enabled Anthropic thinking requests into named effort for all eligible FCC reasoning models. For Novita-routed requests, that conversion removes the boolean thinking control Novita needs, so an explicitly enabled-thinking request is sent without that control. This must be fixed before merging.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge until enabled-thinking requests retain explicit Novita reasoning control.

A focused request-encoding check reproduced the changed behavior and showed that the outgoing Novita request no longer contains its enabled-thinking field.

**Files Needing Attention:** src/free_claude_code/cli/launchers/pi_extension.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and attached three artifacts to support the proof.
- T-Rex produced a second proof for a posted P1 finding.
- T-Rex validated contract behavior by comparing pre-change and post-change extension logic, noting that the current-run assertion failed due to a missing enable\_thinking field.

<a href="https://app.greptile.com/trex/runs/22666914/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pi effort rewrite drops Novita's enabled-thinking wire control**

   - **Bug**
     - For a non-Copilot FCC model routed to Novita, Pi's synthesized Anthropic thinking budget is removed and replaced by `output_config.effort`. Novita supports boolean `enable_thinking`, not named effort. The resulting policy is no longer explicitly ON, so Novita emits no `enable_thinking` field; the provider default controls thinking instead of the user's enabled-thinking request.
   - **Cause**
     - `pi_extension.ts:156-182` applies the named-effort rewrite to all eligible FCC `anthropic-messages` reasoning models without restricting it to providers whose downstream encoder accepts named effort. Novita's encoder has no named-effort mappings and only emits its enabled boolean for explicitly ON reasoning.
   - **Fix**
     - Restrict the Pi named-effort rewrite to provider/model routes that support named effort, or preserve an explicit enabled-thinking signal for boolean-only providers such as Novita so the downstream policy remains ON and encodes `enable_thinking: true`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-pi-copilot-reasoning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-pi-copilot-reasoning%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231676%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1676&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-pi-copilot-reasoning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-pi-copilot-reasoning%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fcli%2Flaunchers%2Fpi_extension.ts%3A172-180%0A**Preserve%20Novita%20thinking%20control**%0A%0AThis%20hook%20removes%20an%20explicitly%20enabled%20%60thinking%60%20request%20for%20every%20FCC%20reasoning%20model%20and%20replaces%20it%20with%20named%20effort.%20Novita%20does%20not%20consume%20named%20effort%3A%20its%20encoder%20sends%20%60enable_thinking%3A%20true%60%20only%20when%20the%20policy%20remains%20explicitly%20enabled.%20A%20Pi%20request%20with%20enabled%20thinking%20and%20a%20synthesized%20budget%20therefore%20reaches%20Novita%20without%20%60enable_thinking%60%2C%20leaving%20reasoning%20behavior%20to%20the%20provider%20default%20instead%20of%20honoring%20the%20user's%20selection.%20Restrict%20this%20conversion%20to%20routes%20that%20support%20named%20effort%2C%20or%20retain%20explicit%20enabled-thinking%20control%20for%20boolean-only%20routes%20such%20as%20Novita.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Preserve Pi thinking effort for Copilot ..."](https://github.com/alishahryar1/free-claude-code/commit/91642074877cee6c9e6f73ae89e2a73b74a2c674) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60704932)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->