### PR TITLE
refactor: unify Responses generation lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.22.5"
+version = "5.22.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/openai_responses/provider_stream.py
+++ b/src/free_claude_code/core/openai_responses/provider_stream.py
@@ -1,5 +1,6 @@
 """Translate upstream OpenAI Responses events into Anthropic Messages SSE."""
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
@@ -15,15 +16,15 @@ class ResponsesStreamFailure(RuntimeError):
         self,
         message: str,
         *,
-        code: str | None = None,
-        event_type: str | None = None,
-        payload: dict[str, Any] | None = None,
+        event_type: str,
+        payload: dict[str, Any],
     ) -> None:
         super().__init__(message)
-        self.message = message
-        self.code = code
+        # Classification and diagnostics keep the complete original evidence.
+        # A presenter may independently normalize or discard the native payload.
+        self.body = deepcopy(payload)
         self.event_type = event_type
-        self.payload = payload
+        self.payload: dict[str, Any] | None = payload
 
 
 @dataclass(slots=True)
@@ -250,12 +251,10 @@ def responses_stream_failure_from_event(
     response = response if isinstance(response, dict) else {}
     error = response.get("error", data.get("error"))
     if not isinstance(error, dict):
-        error = data if event_type == "error" else {}
+        error = data if event_type in {"error", "response.error"} else {}
     message = error.get("message")
-    code = error.get("code", error.get("type"))
     return ResponsesStreamFailure(
         message if isinstance(message, str) and message else "OpenAI response failed.",
-        code=code if isinstance(code, str) else None,
         event_type=event_type,
         payload=data,
     )

--- a/src/free_claude_code/core/openai_responses/provider_stream.py
+++ b/src/free_claude_code/core/openai_responses/provider_stream.py
@@ -71,6 +71,10 @@ class ResponsesProviderStream:
 
         if self.completed:
             return []
+        if (
+            failure := responses_stream_failure_from_event(event_type, data)
+        ) is not None:
+            raise failure
         if event_type == "response.output_item.added":
             return self._item_added(data)
         if event_type in {
@@ -86,8 +90,6 @@ class ResponsesProviderStream:
             return self._item_done(data)
         if event_type in {"response.completed", "response.incomplete"}:
             return self._finish(data, incomplete=event_type == "response.incomplete")
-        if event_type in {"response.failed", "error", "response.error"}:
-            raise responses_stream_failure_from_event(event_type, data)
         return []
 
     def _item_added(self, data: dict[str, Any]) -> list[str]:
@@ -244,12 +246,20 @@ class ResponsesProviderStream:
 def responses_stream_failure_from_event(
     event_type: str,
     data: dict[str, Any],
-) -> ResponsesStreamFailure:
-    """Retain one native failure event for provider-owned retry decisions."""
+) -> ResponsesStreamFailure | None:
+    """Recognize failure evidence independently of transport event labels."""
 
     response = data.get("response")
     response = response if isinstance(response, dict) else {}
-    error = response.get("error", data.get("error"))
+    error = data.get("error")
+    if error is None:
+        error = response.get("error")
+    failure_types = ("response.failed", "error", "response.error")
+    payload_type = data.get("type")
+    if event_type not in failure_types and payload_type in failure_types:
+        event_type = payload_type
+    if error is None and event_type not in failure_types:
+        return None
     if not isinstance(error, dict):
         error = data if event_type in {"error", "response.error"} else {}
     message = error.get("message")

--- a/src/free_claude_code/providers/admission.py
+++ b/src/free_claude_code/providers/admission.py
@@ -191,6 +191,13 @@ class ProviderExecution:
         if self._state is ProviderExecutionState.ACTIVE:
             self._state = ProviderExecutionState.ABANDONED
 
+    async def aclose(self) -> None:
+        """End the operation after its attempts close and release recovery ownership."""
+        if self._active_claim is not None:
+            raise RuntimeError("close the active provider attempt before its execution")
+        self.abandon()
+        await self._controller._release_execution(self)
+
     def _claim_attempt(
         self,
         operation_kind: ProviderOperationKind,
@@ -889,6 +896,19 @@ class ProviderAdmissionController:
                 return
             episode.leader = None
             self._condition.notify_all()
+
+    async def _release_execution(self, execution: ProviderExecution) -> None:
+        """An execution may finish between probes without opening another attempt."""
+        async with self._condition:
+            episode = self._episode
+            if episode is None:
+                return
+            episode.waiters.discard(execution)
+            if episode.leader is execution:
+                episode.leader = None
+                episode.probe_active = False
+                # Keep the provider's backoff; the next caller inherits its probe.
+                self._condition.notify_all()
 
     def _release_concurrency(self) -> None:
         self._concurrency_sem.release()

--- a/src/free_claude_code/providers/admission.py
+++ b/src/free_claude_code/providers/admission.py
@@ -130,9 +130,11 @@ class ProviderExecution:
     async def open_attempt(
         self,
         operation_kind: ProviderOperationKind,
+        *,
+        prepare: Callable[[], Awaitable[None]] | None = None,
     ) -> ProviderAttempt:
-        """Open the sole active physical call for this execution."""
-        return await self._controller._open_attempt(self, operation_kind)
+        """Admit, prepare current credentials, then charge one physical call."""
+        return await self._controller._open_attempt(self, operation_kind, prepare)
 
     async def run_call(
         self,
@@ -476,6 +478,7 @@ class ProviderAdmissionController:
         self,
         execution: ProviderExecution,
         operation_kind: ProviderOperationKind,
+        prepare: Callable[[], Awaitable[None]] | None = None,
     ) -> ProviderAttempt:
         """Wait for provider admission and hold one active-operation slot."""
         if not isinstance(operation_kind, ProviderOperationKind):
@@ -500,6 +503,11 @@ class ProviderAdmissionController:
                     continue
                 await self._concurrency_sem.acquire()
                 slot_acquired = True
+                if self._permit_is_current(execution, permit) and prepare is not None:
+                    # Preparation may wait on account I/O, but never spends an
+                    # inference attempt. Refresh again if admission changed while
+                    # it ran; no prepared snapshot survives another queue wait.
+                    await prepare()
                 if not self._permit_is_current(execution, permit):
                     self._concurrency_sem.release()
                     slot_acquired = False

--- a/src/free_claude_code/providers/endpoint.py
+++ b/src/free_claude_code/providers/endpoint.py
@@ -8,13 +8,6 @@ import httpx
 import httpx2
 from openai import AsyncOpenAI, Omit
 
-from free_claude_code.providers.admission import (
-    ProviderAttempt,
-    ProviderCorrectionAction,
-    ProviderExecution,
-)
-from free_claude_code.providers.failure_policy import provider_authentication_status
-
 
 @dataclass(frozen=True, slots=True)
 class HttpEndpoint:
@@ -42,7 +35,7 @@ class _BorrowedTransport(httpx2.AsyncBaseTransport):
 
 
 class RequestEndpoint:
-    """Resolve one request's credentials and permit one refresh before commitment."""
+    """Prepare an isolated connection view; callers own replay and refresh policy."""
 
     def __init__(
         self,
@@ -52,13 +45,12 @@ class RequestEndpoint:
         self._context = context
         self._transport = transport
         self._http: httpx2.AsyncClient | None = None
-        self._refreshed = False
         self._refresh_pending = False
-        self._committed = False
         self._omit_authorization = False
 
-    def commit(self) -> None:
-        self._committed = True
+    def request_refresh(self) -> None:
+        """Resolve a fresh credential snapshot at the next preparation."""
+        self._refresh_pending = True
 
     async def aclose(self) -> None:
         if self._http is not None:
@@ -103,20 +95,3 @@ class RequestEndpoint:
 
     def openai_headers(self) -> dict[str, str | Omit]:
         return {"Authorization": Omit()} if self._omit_authorization else {}
-
-    async def retry_authentication(
-        self, error: Exception, attempt: ProviderAttempt, execution: ProviderExecution
-    ) -> bool:
-        if self._refreshed or self._committed:
-            return False
-        status = provider_authentication_status(error)
-        if status not in {401, 403}:
-            return False
-        allowed = (
-            execution.can_attempt
-            if attempt.accepted
-            else await attempt.correct(error) is ProviderCorrectionAction.RETRY
-        )
-        if allowed:
-            self._refreshed = self._refresh_pending = True
-        return allowed

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from typing import Any
 
 import httpx
+import httpx2
 import openai
 
 from free_claude_code.core.anthropic.errors import anthropic_status_for_error_type
@@ -17,6 +18,7 @@ from free_claude_code.core.diagnostics import (
     safe_exception_message,
 )
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.core.openai_responses import ResponsesStreamFailure
 
 ProviderFailureOverride = Callable[[Exception], ExecutionFailure | None]
 
@@ -172,13 +174,16 @@ def retryable_transient_status(exc: BaseException) -> int | None:
     if isinstance(exc, ExecutionFailure):
         status = exc.status_code
         return status if exc.retryable and _is_retryable_status(status) else None
+    if isinstance(exc, ResponsesStreamFailure):
+        failure = _responses_stream_failure(exc)
+        return failure.status_code if failure.retryable else None
     if _reports_context_window_exceeded(exc):
         return None
     if _reported_status(exc) == 413:
         return None
     if isinstance(exc, openai.RateLimitError):
         return 429
-    if isinstance(exc, httpx.HTTPStatusError):
+    if isinstance(exc, httpx.HTTPStatusError | httpx2.HTTPStatusError):
         status = exc.response.status_code
         return status if _is_retryable_status(status) else None
 
@@ -228,6 +233,8 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
         return False
     if isinstance(exc, ExecutionFailure):
         return exc.retryable
+    if isinstance(exc, ResponsesStreamFailure):
+        return _responses_stream_failure(exc).retryable
     if isinstance(
         exc,
         openai.AuthenticationError
@@ -241,12 +248,9 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
         exc,
         (
             TimeoutError,
-            httpx.TimeoutException,
-            httpx.ConnectError,
-            httpx.ReadError,
-            httpx.WriteError,
-            httpx.RemoteProtocolError,
-            httpx.NetworkError,
+            httpx.TimeoutException | httpx2.TimeoutException,
+            httpx.RemoteProtocolError | httpx2.RemoteProtocolError,
+            httpx.NetworkError | httpx2.NetworkError,
             openai.APITimeoutError,
             openai.APIConnectionError,
             RetryableProviderProtocolError,
@@ -260,6 +264,8 @@ def is_retryable_stream_error(exc: BaseException) -> bool:
         return True
     if isinstance(exc, ExecutionFailure):
         return exc.retryable
+    if isinstance(exc, ResponsesStreamFailure):
+        return _responses_stream_failure(exc).retryable
     if isinstance(exc, openai.AuthenticationError | openai.BadRequestError):
         return False
     if retryable_transient_status(exc) is not None:
@@ -268,11 +274,9 @@ def is_retryable_stream_error(exc: BaseException) -> bool:
         exc,
         (
             TimeoutError,
-            httpx.ReadTimeout,
-            httpx.ReadError,
-            httpx.RemoteProtocolError,
-            httpx.ConnectError,
-            httpx.NetworkError,
+            httpx.ReadTimeout | httpx2.ReadTimeout,
+            httpx.RemoteProtocolError | httpx2.RemoteProtocolError,
+            httpx.NetworkError | httpx2.NetworkError,
             openai.APITimeoutError,
             openai.APIConnectionError,
         ),
@@ -295,13 +299,19 @@ def provider_error_message(
         exc = underlying_provider_error(exc)
     if isinstance(exc, ExecutionFailure):
         return exc.message
-    if isinstance(exc, httpx.ReadTimeout):
+    if isinstance(exc, httpx.ReadTimeout | httpx2.ReadTimeout):
         if read_timeout_s is not None:
             return f"Provider request timed out after {read_timeout_s:g}s."
         return "Provider request timed out."
-    if isinstance(exc, httpx.ConnectTimeout | httpx.ConnectError):
+    if isinstance(
+        exc,
+        httpx.ConnectTimeout
+        | httpx.ConnectError
+        | httpx2.ConnectTimeout
+        | httpx2.ConnectError,
+    ):
         return "Could not connect to provider."
-    if isinstance(exc, httpx.RemoteProtocolError):
+    if isinstance(exc, httpx.RemoteProtocolError | httpx2.RemoteProtocolError):
         return "Provider connection was interrupted before a response was received."
     if isinstance(exc, TimeoutError):
         if read_timeout_s is not None:
@@ -325,6 +335,8 @@ def _classify_provider_failure(
 ) -> ExecutionFailure:
     if isinstance(exc, ExecutionFailure):
         return exc
+    if isinstance(exc, ResponsesStreamFailure):
+        return _responses_stream_failure(exc)
 
     if _reports_context_window_exceeded(exc):
         return context_window_exceeded_provider_failure()
@@ -387,7 +399,7 @@ def _classify_provider_failure(
             is_retryable_provider_error(exc),
         )
 
-    if isinstance(exc, httpx.HTTPStatusError):
+    if isinstance(exc, httpx.HTTPStatusError | httpx2.HTTPStatusError):
         status = exc.response.status_code
         if status == 401:
             return _failure(
@@ -413,15 +425,66 @@ def _classify_provider_failure(
         )
 
     kind = FailureKind.UPSTREAM
-    if isinstance(exc, TimeoutError | httpx.TimeoutException):
+    if isinstance(exc, TimeoutError | httpx.TimeoutException | httpx2.TimeoutException):
         kind = FailureKind.TIMEOUT
-    elif isinstance(exc, httpx.ConnectError | httpx.NetworkError):
+    elif isinstance(exc, httpx.NetworkError | httpx2.NetworkError):
         kind = FailureKind.UNAVAILABLE
     return _failure(
         kind,
         502,
         provider_error_message(exc, read_timeout_s=read_timeout_s),
         is_retryable_provider_error(exc),
+    )
+
+
+def _responses_stream_failure(exc: ResponsesStreamFailure) -> ExecutionFailure:
+    """Interpret raw Responses evidence once for retry and final classification."""
+    if _reports_context_window_exceeded(exc):
+        return context_window_exceeded_provider_failure()
+    status = _reported_status(exc)
+    if status is None:
+        status = provider_authentication_status(exc)
+    if status in {None, 503}:
+        codes = " ".join(
+            value.casefold()
+            for item in _body_candidates(exc.body)
+            if isinstance(item, Mapping)
+            for key in ("code", "type")
+            if isinstance(value := item.get(key), str)
+        )
+        if any(marker in codes for marker in ("overload", "capacity")):
+            return overloaded_provider_failure()
+        if status is None and any(
+            marker in codes
+            for marker in ("server", "internal", "unavailable", "timeout")
+        ):
+            status = 502
+    match status:
+        case 400:
+            return _failure(
+                FailureKind.INVALID_REQUEST, 400, _INVALID_REQUEST_MESSAGE, False
+            )
+        case 401:
+            return _failure(
+                FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
+            )
+        case 402:
+            return _failure(FailureKind.PERMISSION, 402, _BILLING_MESSAGE, False)
+        case 403:
+            return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
+        case 413:
+            return _failure(
+                FailureKind.INVALID_REQUEST, 413, _REQUEST_TOO_LARGE_MESSAGE, False
+            )
+        case 429:
+            return _failure(FailureKind.RATE_LIMIT, 429, _RATE_LIMIT_MESSAGE, True)
+        case 529:
+            return overloaded_provider_failure()
+    return _failure(
+        FailureKind.UPSTREAM,
+        status if status is not None and 400 <= status <= 599 else 502,
+        safe_exception_message(exc),
+        _is_retryable_status(status),
     )
 
 
@@ -482,13 +545,18 @@ def _reports_context_window_exceeded(exc: BaseException) -> bool:
 
 
 def _status_from_body(body: Any) -> int | None:
-    for item in _body_candidates(body):
+    candidates = _body_candidates(body)
+    # Explicit statuses win over type/code hints at every envelope depth.
+    for item in candidates:
         if not isinstance(item, Mapping):
             continue
         for key in ("status", "status_code", "code"):
             status = _coerce_status(item.get(key))
             if status is not None:
                 return status
+    for item in candidates:
+        if not isinstance(item, Mapping):
+            continue
         type_status = _status_from_type_fields(item)
         if type_status is not None:
             return type_status
@@ -504,15 +572,25 @@ def _body_candidates(body: Any) -> tuple[Any, ...]:
     if isinstance(body, bytes):
         return _body_candidates(body.decode("utf-8", errors="replace"))
     if isinstance(body, Mapping):
-        nested = body.get("error")
-        return (body, nested) if isinstance(nested, Mapping) else (body,)
+        response = body.get("response")
+        candidates = [body]
+        if isinstance(response, Mapping):
+            candidates.append(response)
+        return (
+            *candidates,
+            *(
+                item["error"]
+                for item in candidates
+                if isinstance(item.get("error"), Mapping)
+            ),
+        )
     return (body,)
 
 
 def _coerce_status(value: Any) -> int | None:
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool) and 400 <= value <= 599:
         return value
-    if isinstance(value, str) and value.isdigit():
+    if isinstance(value, str) and value.isdigit() and 400 <= int(value) <= 599:
         return int(value)
     return None
 

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -63,6 +63,7 @@ from free_claude_code.providers.failure_policy import (
     context_window_exceeded_provider_failure,
     is_context_window_finish_reason,
     is_retryable_stream_error,
+    provider_authentication_status,
     underlying_provider_error,
 )
 from free_claude_code.providers.http import (
@@ -784,6 +785,10 @@ class OpenAIChatProvider(BaseProvider):
         *,
         used_retry_kinds: set[str] | None = None,
         endpoint: RequestEndpoint | None = None,
+        recover_authentication: Callable[
+            [Exception, ProviderAttempt, ProviderExecution], Awaitable[bool]
+        ]
+        | None = None,
     ) -> tuple[Any, dict, ProviderAttempt]:
         """Create a streaming chat completion with bounded request fallbacks."""
         body = self._apply_learned_output_cap(body)
@@ -814,7 +819,7 @@ class OpenAIChatProvider(BaseProvider):
             except asyncio.CancelledError:
                 raise
             except Exception as error:
-                if endpoint is not None and await endpoint.retry_authentication(
+                if recover_authentication is not None and await recover_authentication(
                     error, attempt, execution
                 ):
                     continue
@@ -1012,6 +1017,8 @@ class _OpenAIChatStreamRunner:
         self._response_model = response_model
         self._reasoning = reasoning
         self._terminal_failure: ExecutionFailure | None = None
+        self._authentication_recovered = False
+        self._committed = False
         self._endpoint = (
             RequestEndpoint(endpoint_context, provider._endpoint_transport)
             if endpoint_context is not None
@@ -1026,8 +1033,7 @@ class _OpenAIChatStreamRunner:
         provider_stream = self._run_execution(execution)
         try:
             async for event in provider_stream:
-                if self._endpoint is not None:
-                    self._endpoint.commit()
+                self._committed = True
                 yield event
         except asyncio.CancelledError:
             raise
@@ -1089,6 +1095,7 @@ class _OpenAIChatStreamRunner:
                     ProviderOperationKind.GENERATION,
                     used_retry_kinds=used_retry_kinds,
                     endpoint=self._endpoint,
+                    recover_authentication=self._retry_authentication,
                 )
                 scope = ProviderAttemptScope(
                     attempt,
@@ -1194,6 +1201,23 @@ class _OpenAIChatStreamRunner:
         for event in recovery.flush():
             yield event
 
+    async def _retry_authentication(
+        self, error: Exception, attempt: ProviderAttempt, execution: ProviderExecution
+    ) -> bool:
+        if self._endpoint is None or self._authentication_recovered or self._committed:
+            return False
+        if provider_authentication_status(error) not in {401, 403}:
+            return False
+        allowed = (
+            execution.can_attempt
+            if attempt.accepted
+            else await attempt.correct(error) is ProviderCorrectionAction.RETRY
+        )
+        if allowed:
+            self._authentication_recovered = True
+            self._endpoint.request_refresh()
+        return allowed
+
     async def _resolve_attempt_failure(
         self,
         *,
@@ -1206,12 +1230,8 @@ class _OpenAIChatStreamRunner:
         req_tag: str,
     ) -> _OpenAIChatFailureResolution:
         """Resolve one failed generation attempt without owning retry policy."""
-        if (
-            scope is not None
-            and self._endpoint is not None
-            and await self._endpoint.retry_authentication(
-                error, scope.attempt, execution
-            )
+        if scope is not None and await self._retry_authentication(
+            error, scope.attempt, execution
         ):
             recovery.discard()
             return _OpenAIChatFailureResolution(outcome=_OpenAIChatFailureOutcome.RETRY)
@@ -1371,6 +1391,7 @@ class _OpenAIChatStreamRunner:
                     operation_kind,
                     used_retry_kinds=used_retry_kinds,
                     endpoint=self._endpoint,
+                    recover_authentication=self._retry_authentication,
                 )
                 scope = ProviderAttemptScope(
                     attempt,

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -1053,7 +1053,7 @@ class _OpenAIChatStreamRunner:
                     if self._endpoint is not None:
                         await self._endpoint.aclose()
                 finally:
-                    execution.abandon()
+                    await execution.aclose()
 
     async def _run_execution(
         self,

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -116,61 +116,66 @@ class OpenAICodexProvider(BaseProvider):
     async def _list_models_payload(self) -> Any:
         """Fetch one Codex model catalog with each provider GET admitted once."""
         execution = self._admission.start_execution()
-        authentication_recovered = False
-        while execution.can_attempt:
-            scope: ProviderAttemptScope | None = None
-            try:
-                access = await self._auth.access()
-                attempt = await execution.open_attempt(
-                    ProviderOperationKind.MODEL_DISCOVERY
-                )
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name="OpenAI",
-                    request_id=execution.request_id,
-                )
-                response = scope.retain(
-                    await self._client.get(
-                        "models",
-                        params={"client_version": FCC_VERSION},
-                        headers={**self._client_headers, **auth_headers(access)},
+        try:
+            authentication_recovered = False
+            while execution.can_attempt:
+                scope: ProviderAttemptScope | None = None
+                try:
+                    access = await self._auth.access()
+                    attempt = await execution.open_attempt(
+                        ProviderOperationKind.MODEL_DISCOVERY
                     )
-                )
-                if response.status_code == 401 and not authentication_recovered:
-                    error = await response_status_error(response)
-                    correction = await scope.attempt.correct(error)
-                    closing_scope = scope
-                    scope = None
-                    await closing_scope.aclose(active_error=error)
-                    if correction is ProviderCorrectionAction.FINAL:
-                        raise error
-                    await self._auth.recover_unauthorized(access.access_token)
-                    authentication_recovered = True
-                    continue
-                if not response.is_success:
-                    raise await response_status_error(response)
-                payload = response.json()
-                await scope.attempt.accept()
-                execution.succeed()
-                return payload
-            except asyncio.CancelledError:
-                execution.abandon()
-                raise
-            except Exception as error:
-                if scope is not None and not scope.attempt.accepted:
-                    decision = await scope.attempt.fail(error)
-                    if decision.retry_allowed:
+                    scope = ProviderAttemptScope(
+                        attempt,
+                        provider_name="OpenAI",
+                        request_id=execution.request_id,
+                    )
+                    response = scope.retain(
+                        await self._client.get(
+                            "models",
+                            params={"client_version": FCC_VERSION},
+                            headers={**self._client_headers, **auth_headers(access)},
+                        )
+                    )
+                    if response.status_code == 401 and not authentication_recovered:
+                        error = await response_status_error(response)
+                        correction = await scope.attempt.correct(error)
+                        closing_scope = scope
+                        scope = None
+                        await closing_scope.aclose(active_error=error)
+                        if correction is ProviderCorrectionAction.FINAL:
+                            raise error
+                        await self._auth.recover_unauthorized(access.access_token)
+                        authentication_recovered = True
                         continue
-                execution.fail(error)
-                raise
-            finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
+                    if not response.is_success:
+                        raise await response_status_error(response)
+                    payload = response.json()
+                    await scope.attempt.accept()
+                    execution.succeed()
+                    return payload
+                except asyncio.CancelledError:
+                    execution.abandon()
+                    raise
+                except Exception as error:
+                    if scope is not None and not scope.attempt.accepted:
+                        decision = await scope.attempt.fail(error)
+                        if decision.retry_allowed:
+                            continue
+                    execution.fail(error)
+                    raise
+                finally:
+                    if scope is not None:
+                        await scope.aclose(active_error=sys.exception())
 
-        if execution.last_failure is not None:
-            raise execution.last_failure
-        execution.abandon()
-        raise RuntimeError("OpenAI model discovery ended without an attempt outcome")
+            if execution.last_failure is not None:
+                raise execution.last_failure
+            execution.abandon()
+            raise RuntimeError(
+                "OpenAI model discovery ended without an attempt outcome"
+            )
+        finally:
+            await execution.aclose()
 
     def stream_messages(
         self,

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -1,7 +1,6 @@
 """ChatGPT Codex backend provider using OpenAI Responses."""
 
 import asyncio
-import json
 import sys
 import uuid
 from collections.abc import AsyncIterator
@@ -13,70 +12,45 @@ import httpx
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.anthropic.models import MessagesRequest
-from free_claude_code.core.diagnostics import (
-    ERROR_DETAIL_DISPLAY_CAP_BYTES,
-    attach_upstream_error_body,
-    extract_upstream_error_detail,
-)
-from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import (
     OpenAIResponsesRequest,
     ResponsesConversionError,
     ResponsesProviderStream,
-    ResponsesStreamFailure,
     build_native_responses_request,
     build_responses_provider_request,
-    responses_stream_failure_from_event,
 )
 from free_claude_code.core.openai_tool_names import OpenAIToolNameCodec
 from free_claude_code.core.reasoning import (
     DEFAULT_REASONING_POLICY,
     ReasoningPolicy,
 )
-from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
     ProviderCorrectionAction,
-    ProviderExecution,
     ProviderOperationKind,
 )
 from free_claude_code.providers.base import BaseProvider, ProviderConfig
-from free_claude_code.providers.failure_policy import (
-    RetryableProviderProtocolError,
-    classify_provider_failure,
-    context_window_exceeded_provider_failure,
-    is_context_window_error_code,
-    is_retryable_stream_error,
-    reports_context_window_incomplete,
-)
-from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
+from free_claude_code.providers.http import ProviderAttemptScope
 from free_claude_code.providers.model_listing import (
     optional_input_modalities,
     optional_positive_int,
 )
+from free_claude_code.providers.openai_responses.execution import run_responses_stream
 from free_claude_code.providers.openai_responses.presentation import (
     MessagesResponsesPresenter,
     NativeResponsesPresenter,
-    ResponsesExecutionOutcome,
     ResponsesPresenterFactory,
 )
-from free_claude_code.providers.stream_recovery import (
-    RecoveryController,
-    RecoveryFailureAction,
-)
 
-from .auth import OpenAIAccess, OpenAIAuthManager, OpenAIReconnectRequired
+from .auth import OpenAIAuthManager
 from .login import OPENAI_CODEX_ORIGINATOR
+from .transport import CodexResponsesBackend, auth_headers, response_status_error
 
 try:
     FCC_VERSION = version("free-claude-code")
 except PackageNotFoundError:
     FCC_VERSION = "dev"
-
-
-class _TruncatedResponsesStream(RetryableProviderProtocolError):
-    """A Responses stream ended without a terminal lifecycle event."""
 
 
 class OpenAICodexProvider(BaseProvider):
@@ -159,11 +133,11 @@ class OpenAICodexProvider(BaseProvider):
                     await self._client.get(
                         "models",
                         params={"client_version": FCC_VERSION},
-                        headers={**self._client_headers, **_auth_headers(access)},
+                        headers={**self._client_headers, **auth_headers(access)},
                     )
                 )
                 if response.status_code == 401 and not authentication_recovered:
-                    error = await _response_status_error(response)
+                    error = await response_status_error(response)
                     correction = await scope.attempt.correct(error)
                     closing_scope = scope
                     scope = None
@@ -174,7 +148,7 @@ class OpenAICodexProvider(BaseProvider):
                     authentication_recovered = True
                     continue
                 if not response.is_success:
-                    raise await _response_status_error(response)
+                    raise await response_status_error(response)
                 payload = response.json()
                 await scope.attempt.accept()
                 execution.succeed()
@@ -284,7 +258,7 @@ class OpenAICodexProvider(BaseProvider):
         body.pop("metadata", None)
         return body
 
-    async def _run_stream(
+    def _run_stream(
         self,
         body: JsonObject,
         *,
@@ -292,303 +266,22 @@ class OpenAICodexProvider(BaseProvider):
         response_model: str,
         presenter_factory: ResponsesPresenterFactory,
     ) -> AsyncIterator[str]:
-        execution = self._admission.start_execution(request_id=request_id)
-        outcome = ResponsesExecutionOutcome()
-        provider_stream = self._run_stream_execution(
-            body,
+        return run_responses_stream(
+            backend=CodexResponsesBackend(
+                client=self._client,
+                auth=self._auth,
+                body=body,
+                client_headers=self._client_headers,
+            ),
+            admission=self._admission,
+            provider_name="OpenAI",
             request_id=request_id,
             response_model=response_model,
+            body=body,
+            read_timeout_s=self._config.http_read_timeout,
             presenter_factory=presenter_factory,
-            execution=execution,
-            outcome=outcome,
+            log_error_tracebacks=self._config.log_api_error_tracebacks,
         )
-        try:
-            async for event in provider_stream:
-                yield event
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:
-            execution.fail(error)
-            raise
-        else:
-            if outcome.failure is None:
-                execution.succeed()
-            else:
-                execution.fail(outcome.failure)
-        finally:
-            await maybe_await_aclose(provider_stream)
-            execution.abandon()
-
-    async def _run_stream_execution(
-        self,
-        body: JsonObject,
-        *,
-        request_id: str | None,
-        response_model: str,
-        presenter_factory: ResponsesPresenterFactory,
-        execution: ProviderExecution,
-        outcome: ResponsesExecutionOutcome,
-    ) -> AsyncIterator[str]:
-        """Run one Codex execution while retaining Responses transport ownership."""
-        recovery = RecoveryController()
-        session_id = str(uuid.uuid4())
-        authentication_recovered = False
-        trace_event(
-            stage="provider",
-            event="provider.request.sent",
-            source="provider",
-            provider="openai",
-            request_id=request_id,
-            execution_id=execution.execution_id,
-            gateway_model=response_model,
-            downstream_model=body.get("model"),
-            item_count=len(body.get("input", [])),
-            tool_count=len(body.get("tools", [])),
-        )
-
-        while execution.can_attempt:
-            presenter = presenter_factory()
-            start_events = tuple(presenter.start())
-            presenter_started = False
-
-            scope: ProviderAttemptScope | None = None
-            stream_opened = False
-            try:
-                access = await self._auth.access()
-                attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name="OpenAI",
-                    request_id=request_id,
-                )
-                response = scope.retain(
-                    await self._client.send(
-                        self._client.build_request(
-                            "POST",
-                            "responses",
-                            json=body,
-                            headers={
-                                **self._client_headers,
-                                **_auth_headers(access),
-                                "Accept": "text/event-stream",
-                                "session_id": session_id,
-                            },
-                        ),
-                        stream=True,
-                    )
-                )
-                if response.status_code == 401 and not authentication_recovered:
-                    error = await _response_status_error(response)
-                    correction = await scope.attempt.correct(error)
-                    closing_scope = scope
-                    scope = None
-                    await closing_scope.aclose(active_error=error)
-                    if correction is ProviderCorrectionAction.FINAL:
-                        raise error
-                    recovery.discard()
-                    await self._auth.recover_unauthorized(access.access_token)
-                    authentication_recovered = True
-                    continue
-                if not response.is_success:
-                    raise await _response_status_error(response)
-                content_type = response.headers.get("content-type")
-                if content_type and "text/event-stream" not in content_type.lower():
-                    body_bytes, body_truncated = await _read_bounded_body(response)
-                    error = _TruncatedResponsesStream(
-                        "OpenAI returned a non-streaming Responses payload."
-                    )
-                    attach_upstream_error_body(
-                        error,
-                        body_bytes,
-                        truncated=body_truncated,
-                    )
-                    raise error
-                stream_opened = True
-
-                async for event_type, payload in _iter_sse(response):
-                    if not scope.attempt.accepted:
-                        await scope.attempt.accept()
-                    if not presenter_started:
-                        presenter_started = True
-                        for event in start_events:
-                            for held in recovery.push(event):
-                                yield held
-                    if reports_context_window_incomplete(event_type, payload):
-                        raise context_window_exceeded_provider_failure()
-                    if event_type in {
-                        "response.failed",
-                        "error",
-                        "response.error",
-                    }:
-                        raise responses_stream_failure_from_event(
-                            event_type,
-                            payload,
-                        )
-                    for event in presenter.feed(event_type, payload):
-                        for held in recovery.push(event):
-                            yield held
-                if not presenter.completed:
-                    raise _TruncatedResponsesStream(
-                        "OpenAI Responses stream ended without a terminal event."
-                    )
-                for event in recovery.flush():
-                    yield event
-                trace_event(
-                    stage="provider",
-                    event="provider.response.completed",
-                    source="provider",
-                    provider="openai",
-                    request_id=request_id,
-                )
-                return
-            except asyncio.CancelledError, GeneratorExit:
-                raise
-            except Exception as raw_error:
-                error = _effective_error(raw_error)
-                attempt_failure = None
-                if scope is not None and not scope.attempt.accepted:
-                    attempt_failure = await scope.attempt.fail(error)
-                if attempt_failure is not None and attempt_failure.retry_allowed:
-                    recovery.discard()
-                    trace_event(
-                        stage="provider",
-                        event="provider.recovery.early_retry",
-                        source="provider",
-                        provider="openai",
-                        request_id=request_id,
-                        attempts_started=execution.attempts_started,
-                        max_attempts=execution.max_attempts,
-                    )
-                    continue
-                retryable = (
-                    attempt_failure.retryable
-                    if attempt_failure is not None
-                    else is_retryable_stream_error(error)
-                )
-                decision = recovery.advance_failure(
-                    retryable=retryable,
-                    stream_opened=stream_opened,
-                    generated_output=recovery.committed,
-                    complete_tool_salvageable=False,
-                    attempts_remaining=execution.attempts_remaining,
-                )
-                if decision.action is RecoveryFailureAction.EARLY_RETRY:
-                    recovery.discard()
-                    trace_event(
-                        stage="provider",
-                        event="provider.recovery.early_retry",
-                        source="provider",
-                        provider="openai",
-                        request_id=request_id,
-                        attempts_started=execution.attempts_started,
-                        max_attempts=execution.max_attempts,
-                    )
-                    continue
-
-                failure = classify_provider_failure(
-                    error,
-                    provider_name="OpenAI",
-                    read_timeout_s=self._config.http_read_timeout,
-                    request_id=request_id,
-                )
-                self._log_stream_transport_error(
-                    "OPENAI",
-                    f" request_id={request_id}" if request_id else "",
-                    error,
-                    request_id=request_id,
-                )
-                if not decision.committed:
-                    recovery.discard()
-                    raise failure from raw_error
-                for event in presenter.terminal_failure(raw_error, failure):
-                    yield event
-                if presenter.terminal_failure_completes_wire:
-                    outcome.failure = failure
-                    return
-                raise failure from raw_error
-            finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
-
-        if execution.last_failure is not None:
-            raise execution.last_failure
-        raise RuntimeError("OpenAI execution ended without a terminal result.")
-
-
-async def _iter_sse(
-    response: httpx.Response,
-) -> AsyncIterator[tuple[str, dict[str, Any]]]:
-    event_type = ""
-    data_lines: list[str] = []
-    async for line in response.aiter_lines():
-        if not line:
-            if not data_lines:
-                event_type = ""
-                continue
-            raw_data = "\n".join(data_lines)
-            data_lines = []
-            if raw_data == "[DONE]":
-                return
-            try:
-                payload = json.loads(raw_data)
-            except json.JSONDecodeError as exc:
-                raise _TruncatedResponsesStream(
-                    "OpenAI returned malformed Responses SSE."
-                ) from exc
-            if not isinstance(payload, dict):
-                raise _TruncatedResponsesStream(
-                    "OpenAI returned a non-object Responses event."
-                )
-            resolved_type = event_type or payload.get("type")
-            event_type = ""
-            if isinstance(resolved_type, str) and resolved_type:
-                yield resolved_type, payload
-            continue
-        if line.startswith("event:"):
-            event_type = line[6:].strip()
-        elif line.startswith("data:"):
-            data_lines.append(line[5:].lstrip())
-    if data_lines:
-        raise _TruncatedResponsesStream(
-            "OpenAI Responses stream ended during an SSE event."
-        )
-
-
-async def _read_bounded_body(
-    response: httpx.Response,
-) -> tuple[bytes, bool]:
-    limit = ERROR_DETAIL_DISPLAY_CAP_BYTES
-    body = bytearray()
-    async for chunk in response.aiter_bytes():
-        remaining = limit + 1 - len(body)
-        if remaining <= 0:
-            break
-        body.extend(chunk[:remaining])
-        if len(body) > limit:
-            break
-    truncated = len(body) > limit
-    return bytes(body[:limit]), truncated
-
-
-async def _response_status_error(response: httpx.Response) -> httpx.HTTPStatusError:
-    """Return one bounded, diagnostic-preserving HTTP status failure."""
-    body, truncated = await _read_bounded_body(response)
-    try:
-        response.raise_for_status()
-    except httpx.HTTPStatusError as error:
-        attach_upstream_error_body(error, body, truncated=truncated)
-        return error
-    raise RuntimeError("response status is successful")
-
-
-def _auth_headers(access: OpenAIAccess) -> dict[str, str]:
-    headers = {
-        "Authorization": f"Bearer {access.access_token}",
-        "ChatGPT-Account-ID": access.account_id,
-    }
-    if access.fedramp:
-        headers["X-OpenAI-Fedramp"] = "true"
-    return headers
 
 
 def _model_infos(payload: Any) -> frozenset[ProviderModelInfo]:
@@ -637,31 +330,3 @@ def _supports_reasoning(levels: object) -> bool | None:
         if not isinstance(effort, str) or not effort.strip():
             return None
     return bool(levels)
-
-
-def _effective_error(error: Exception) -> Exception:
-    if isinstance(error, OpenAIReconnectRequired):
-        return ExecutionFailure(
-            kind=FailureKind.AUTHENTICATION,
-            status_code=401,
-            message=str(error),
-            retryable=False,
-        )
-    if isinstance(error, ResponsesStreamFailure):
-        message = (
-            extract_upstream_error_detail(error).exception_text
-            or "OpenAI response failed."
-        )
-        if is_context_window_error_code(error.code):
-            return context_window_exceeded_provider_failure()
-        code = (error.code or "").lower()
-        if "rate" in code or "429" in code:
-            return ExecutionFailure(FailureKind.RATE_LIMIT, 429, message, True)
-        if any(marker in code for marker in ("overload", "capacity", "529")):
-            return ExecutionFailure(FailureKind.OVERLOADED, 529, message, True)
-        retryable = any(
-            marker in code
-            for marker in ("server", "internal", "unavailable", "timeout")
-        )
-        return ExecutionFailure(FailureKind.UPSTREAM, 502, message, retryable)
-    return error

--- a/src/free_claude_code/providers/openai_codex/transport.py
+++ b/src/free_claude_code/providers/openai_codex/transport.py
@@ -1,0 +1,135 @@
+"""Codex subscription connection and SSE decoding for Responses generation."""
+
+import uuid
+from contextlib import AsyncExitStack
+
+import httpx
+
+from free_claude_code.core.diagnostics import (
+    ERROR_DETAIL_DISPLAY_CAP_BYTES,
+    attach_upstream_error_body,
+)
+from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.core.json_types import JsonObject
+from free_claude_code.providers.http import ProviderAttemptScope
+from free_claude_code.providers.openai_responses.events import ResponsesEventSource
+from free_claude_code.providers.openai_responses.execution import AuthenticationRecovery
+from free_claude_code.providers.stream_recovery import TruncatedProviderStreamError
+
+from .auth import OpenAIAccess, OpenAIAuthManager, OpenAIReconnectRequired
+
+
+class CodexResponsesBackend:
+    """Borrow the account and HTTP client for one logical Codex request."""
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        auth: OpenAIAuthManager,
+        body: JsonObject,
+        client_headers: dict[str, str],
+    ) -> None:
+        self._client = client
+        self._auth = auth
+        self._body = body
+        self._client_headers = client_headers
+        self._session_id = str(uuid.uuid4())
+        self._access: OpenAIAccess | None = None
+
+    async def prepare_attempt(self) -> None:
+        self._access = await self._auth.access()
+
+    async def open_attempt(self, scope: ProviderAttemptScope) -> ResponsesEventSource:
+        if self._access is None:
+            raise RuntimeError("Codex credentials have not been prepared")
+        resources = scope.retain(AsyncExitStack())
+        response = await self._client.send(
+            self._client.build_request(
+                "POST",
+                "responses",
+                json=self._body,
+                headers={
+                    **self._client_headers,
+                    **auth_headers(self._access),
+                    "Accept": "text/event-stream",
+                    "session_id": self._session_id,
+                },
+            ),
+            stream=True,
+        )
+        resources.push_async_callback(response.aclose)
+        if not response.is_success:
+            raise await response_status_error(response)
+        content_type = response.headers.get("content-type")
+        if content_type and "text/event-stream" not in content_type.lower():
+            body, truncated = await _read_bounded_body(response)
+            error = TruncatedProviderStreamError(
+                "OpenAI returned a non-streaming Responses payload."
+            )
+            attach_upstream_error_body(error, body, truncated=truncated)
+            raise error
+        source = ResponsesEventSource(response)
+        resources.push_async_callback(source.aclose)
+        return source
+
+    def authentication_recovery(
+        self, error: Exception
+    ) -> AuthenticationRecovery | None:
+        if (
+            isinstance(error, httpx.HTTPStatusError)
+            and error.response.status_code == 401
+        ):
+            return self._refresh
+        return None
+
+    async def _refresh(self) -> None:
+        if self._access is None:
+            raise RuntimeError("Codex credentials have not been prepared")
+        await self._auth.recover_unauthorized(self._access.access_token)
+
+    def normalize_error(self, error: Exception) -> Exception:
+        if isinstance(error, OpenAIReconnectRequired):
+            return ExecutionFailure(FailureKind.AUTHENTICATION, 401, str(error), False)
+        return error
+
+    async def aclose(self) -> None:
+        # The generation and account managers own the borrowed resources.
+        pass
+
+
+async def _read_bounded_body(
+    response: httpx.Response,
+) -> tuple[bytes, bool]:
+    limit = ERROR_DETAIL_DISPLAY_CAP_BYTES
+    body = bytearray()
+    async for chunk in response.aiter_bytes():
+        remaining = limit + 1 - len(body)
+        if remaining <= 0:
+            break
+        body.extend(chunk[:remaining])
+        if len(body) > limit:
+            break
+    truncated = len(body) > limit
+    return bytes(body[:limit]), truncated
+
+
+async def response_status_error(response: httpx.Response) -> httpx.HTTPStatusError:
+    """Return one bounded, diagnostic-preserving HTTP status failure."""
+    body, truncated = await _read_bounded_body(response)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as error:
+        attach_upstream_error_body(error, body, truncated=truncated)
+        return error
+    raise RuntimeError("response status is successful")
+
+
+def auth_headers(access: OpenAIAccess) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {access.access_token}",
+        "ChatGPT-Account-ID": access.account_id,
+    }
+    if access.fedramp:
+        headers["X-OpenAI-Fedramp"] = "true"
+    return headers

--- a/src/free_claude_code/providers/openai_responses/events.py
+++ b/src/free_claude_code/providers/openai_responses/events.py
@@ -1,6 +1,7 @@
 """Owned Responses SSE decoding before lifecycle policy or identity normalization."""
 
 import json
+import re
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from contextlib import aclosing
 from typing import cast
@@ -12,6 +13,7 @@ from free_claude_code.core.json_types import JsonObject
 from free_claude_code.providers.stream_recovery import TruncatedProviderStreamError
 
 type ResponsesEventAdapter = Callable[[str, JsonObject], JsonObject]
+_LINE_END = re.compile(rb"\r\n|\r|\n")
 
 
 class ResponsesEventSource:
@@ -46,7 +48,7 @@ async def _decode_sse(
 ) -> AsyncGenerator[tuple[str, JsonObject]]:
     event_type = ""
     data_lines: list[str] = []
-    async with aclosing(cast(AsyncGenerator[str], response.aiter_lines())) as lines:
+    async with aclosing(_sse_lines(response)) as lines:
         async for line in lines:
             if not line:
                 if not data_lines:
@@ -73,12 +75,43 @@ async def _decode_sse(
                 if isinstance(resolved_type, str) and resolved_type:
                     yield resolved_type, payload
                 continue
-            if line.startswith("event:"):
-                event_type = line[6:].strip()
-            elif line.startswith("data:"):
-                data_lines.append(line[5:].lstrip())
+            field, _, value = line.partition(":")
+            value = value.removeprefix(" ")
+            if field == "event":
+                event_type = value
+            elif field == "data":
+                data_lines.append(value)
 
     if data_lines:
         raise TruncatedProviderStreamError(
             "Provider Responses stream ended during an SSE event."
         )
+
+
+async def _sse_lines(
+    response: httpx.Response | httpx2.Response,
+) -> AsyncGenerator[str]:
+    """Frame CR/LF bytes before UTF-8 decoding; Unicode separators are data."""
+    parts: list[bytes] = []
+    skip_lf = False
+    encoding = "utf-8-sig"
+    async with aclosing(cast(AsyncGenerator[bytes], response.aiter_bytes())) as chunks:
+        async for chunk in chunks:
+            if not chunk:
+                continue
+            if skip_lf:
+                chunk = chunk.removeprefix(b"\n")
+                skip_lf = False
+            start = 0
+            for boundary in _LINE_END.finditer(chunk):
+                parts.append(chunk[start : boundary.start()])
+                line = b"".join(parts)
+                parts.clear()
+                start = boundary.end()
+                skip_lf = boundary.group() == b"\r" and start == len(chunk)
+                yield line.decode(encoding, errors="replace")
+                encoding = "utf-8"
+            if start < len(chunk):
+                parts.append(chunk[start:])
+    if parts:
+        yield b"".join(parts).decode(encoding, errors="replace")

--- a/src/free_claude_code/providers/openai_responses/events.py
+++ b/src/free_claude_code/providers/openai_responses/events.py
@@ -68,12 +68,11 @@ async def _decode_sse(
                     raise TruncatedProviderStreamError(
                         "Provider returned a non-object Responses event."
                     )
-                resolved_type = event_type or payload.get("type")
-                if not resolved_type and payload.get("error") is not None:
-                    resolved_type = "error"
+                # Framing carries the SSE label unchanged. The Responses
+                # interpreter owns payload types and structured error evidence.
+                resolved_type = event_type
                 event_type = ""
-                if isinstance(resolved_type, str) and resolved_type:
-                    yield resolved_type, payload
+                yield resolved_type, payload
                 continue
             field, _, value = line.partition(":")
             value = value.removeprefix(" ")

--- a/src/free_claude_code/providers/openai_responses/events.py
+++ b/src/free_claude_code/providers/openai_responses/events.py
@@ -1,0 +1,84 @@
+"""Owned Responses SSE decoding before lifecycle policy or identity normalization."""
+
+import json
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from contextlib import aclosing
+from typing import cast
+
+import httpx
+import httpx2
+
+from free_claude_code.core.json_types import JsonObject
+from free_claude_code.providers.stream_recovery import TruncatedProviderStreamError
+
+type ResponsesEventAdapter = Callable[[str, JsonObject], JsonObject]
+
+
+class ResponsesEventSource:
+    """Own one decoder; the attempt resource scope owns its HTTP response too."""
+
+    def __init__(
+        self,
+        response: httpx.Response | httpx2.Response,
+        *,
+        adapter: ResponsesEventAdapter | None = None,
+    ) -> None:
+        self._events = _decode_sse(response)
+        self._adapter = adapter
+
+    def __aiter__(self) -> AsyncIterator[tuple[str, JsonObject]]:
+        return self
+
+    async def __anext__(self) -> tuple[str, JsonObject]:
+        return await anext(self._events)
+
+    def normalize(self, event_type: str, payload: JsonObject) -> JsonObject:
+        return (
+            self._adapter(event_type, payload) if self._adapter is not None else payload
+        )
+
+    async def aclose(self) -> None:
+        await self._events.aclose()
+
+
+async def _decode_sse(
+    response: httpx.Response | httpx2.Response,
+) -> AsyncGenerator[tuple[str, JsonObject]]:
+    event_type = ""
+    data_lines: list[str] = []
+    async with aclosing(cast(AsyncGenerator[str], response.aiter_lines())) as lines:
+        async for line in lines:
+            if not line:
+                if not data_lines:
+                    event_type = ""
+                    continue
+                raw_data = "\n".join(data_lines)
+                data_lines = []
+                if raw_data == "[DONE]":
+                    return
+                try:
+                    payload = json.loads(raw_data)
+                except json.JSONDecodeError as exc:
+                    raise TruncatedProviderStreamError(
+                        "Provider returned malformed Responses SSE."
+                    ) from exc
+                if not isinstance(payload, dict):
+                    raise TruncatedProviderStreamError(
+                        "Provider returned a non-object Responses event."
+                    )
+                resolved_type = event_type or payload.get("type")
+                if not resolved_type and payload.get("error") is not None:
+                    resolved_type = "error"
+                event_type = ""
+                if isinstance(resolved_type, str) and resolved_type:
+                    yield resolved_type, payload
+                continue
+            if line.startswith("event:"):
+                event_type = line[6:].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[5:].lstrip())
+
+    if data_lines:
+        raise TruncatedProviderStreamError(
+            "Provider Responses stream ended during an SSE event."
+        )

--- a/src/free_claude_code/providers/openai_responses/execution.py
+++ b/src/free_claude_code/providers/openai_responses/execution.py
@@ -114,14 +114,20 @@ async def run_responses_stream(
                 source = await backend.open_attempt(scope)
                 stream_opened = True
                 async for event_type, payload in source:
-                    if event_type in {"response.failed", "error", "response.error"}:
-                        error = responses_stream_failure_from_event(event_type, payload)
+                    error = responses_stream_failure_from_event(event_type, payload)
+                    if error is not None:
                         try:
-                            error.payload = source.normalize(event_type, payload)
+                            error.payload = source.normalize(error.event_type, payload)
                         except RetryableProviderProtocolError:
                             # Partial failure identity must not hide the real error.
                             error.payload = None
                         raise error
+                    response_type = payload.get("type") or event_type
+                    if not isinstance(response_type, str) or not response_type:
+                        raise TruncatedProviderStreamError(
+                            "Provider returned an invalid Responses event type."
+                        )
+                    event_type = response_type
                     if reports_context_window_incomplete(event_type, payload):
                         raise context_window_exceeded_provider_failure()
                     payload = source.normalize(event_type, payload)

--- a/src/free_claude_code/providers/openai_responses/execution.py
+++ b/src/free_claude_code/providers/openai_responses/execution.py
@@ -7,14 +7,10 @@ from typing import Protocol
 
 from loguru import logger
 
-from free_claude_code.core.diagnostics import (
-    extract_upstream_error_detail,
-    redacted_exception_traceback,
-)
-from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.core.diagnostics import redacted_exception_traceback
+from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import (
-    ResponsesStreamFailure,
     responses_stream_failure_from_event,
 )
 from free_claude_code.core.trace import trace_event
@@ -28,9 +24,7 @@ from free_claude_code.providers.failure_policy import (
     RetryableProviderProtocolError,
     classify_provider_failure,
     context_window_exceeded_provider_failure,
-    is_context_window_error_code,
     is_retryable_stream_error,
-    provider_authentication_status,
     reports_context_window_incomplete,
 )
 from free_claude_code.providers.http import ProviderAttemptScope, close_provider_stream
@@ -83,7 +77,7 @@ async def run_responses_stream(
 
     def failure_for(raw_error: Exception) -> ExecutionFailure:
         return classify_provider_failure(
-            _effective_error(backend.normalize_error(raw_error)),
+            backend.normalize_error(raw_error),
             provider_name=provider_name,
             read_timeout_s=read_timeout_s,
             request_id=request_id,
@@ -102,29 +96,24 @@ async def run_responses_stream(
             transport="responses",
         )
         while execution.can_attempt:
-            # Credential I/O is not an inference attempt. Failure here is terminal
-            # for this execution, including a failed forced snapshot refresh.
-            await backend.prepare_attempt()
             presenter = presenter_factory()
             start_events = tuple(presenter.start())
             presenter_started = False
             scope: ProviderAttemptScope | None = None
             stream_opened = False
+            # Admission waits first. Credential preparation then checks current
+            # account authority without charging a generation attempt on failure.
+            # These failures escape the generation retry handler entirely.
+            attempt = await execution.open_attempt(
+                ProviderOperationKind.GENERATION, prepare=backend.prepare_attempt
+            )
             try:
-                attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
                 scope = ProviderAttemptScope(
                     attempt, provider_name=provider_name, request_id=request_id
                 )
                 source = await backend.open_attempt(scope)
                 stream_opened = True
                 async for event_type, payload in source:
-                    if not attempt.accepted:
-                        await attempt.accept()
-                    if not presenter_started:
-                        presenter_started = True
-                        for event in start_events:
-                            for held in recovery.push(event):
-                                yield held
                     if event_type in {"response.failed", "error", "response.error"}:
                         error = responses_stream_failure_from_event(event_type, payload)
                         try:
@@ -136,7 +125,15 @@ async def run_responses_stream(
                     if reports_context_window_incomplete(event_type, payload):
                         raise context_window_exceeded_provider_failure()
                     payload = source.normalize(event_type, payload)
-                    for event in presenter.feed(event_type, payload):
+                    events = tuple(presenter.feed(event_type, payload))
+                    if not attempt.accepted:
+                        await attempt.accept()
+                    if not presenter_started:
+                        presenter_started = True
+                        for event in start_events:
+                            for held in recovery.push(event):
+                                yield held
+                    for event in events:
                         for held in recovery.push(event):
                             yield held
                     if presenter.completed:
@@ -160,7 +157,7 @@ async def run_responses_stream(
             except asyncio.CancelledError, GeneratorExit:
                 raise
             except Exception as raw_error:
-                error = _effective_error(backend.normalize_error(raw_error))
+                error = backend.normalize_error(raw_error)
                 correction = (
                     backend.authentication_recovery(raw_error)
                     if scope is not None
@@ -274,33 +271,3 @@ async def run_responses_stream(
             )
         finally:
             await execution.aclose()
-
-
-def _effective_error(error: Exception) -> Exception:
-    if not isinstance(error, ResponsesStreamFailure):
-        return error
-    message = (
-        extract_upstream_error_detail(error).exception_text
-        or "Provider response failed."
-    )
-    if is_context_window_error_code(error.code):
-        return context_window_exceeded_provider_failure()
-    auth_status = provider_authentication_status(error)
-    if auth_status is not None:
-        return ExecutionFailure(
-            FailureKind.AUTHENTICATION
-            if auth_status == 401
-            else FailureKind.PERMISSION,
-            auth_status,
-            message,
-            False,
-        )
-    code = (error.code or "").lower()
-    if "rate" in code or "429" in code:
-        return ExecutionFailure(FailureKind.RATE_LIMIT, 429, message, True)
-    if any(marker in code for marker in ("overload", "capacity", "529")):
-        return ExecutionFailure(FailureKind.OVERLOADED, 529, message, True)
-    retryable = any(
-        marker in code for marker in ("server", "internal", "unavailable", "timeout")
-    )
-    return ExecutionFailure(FailureKind.UPSTREAM, 502, message, retryable)

--- a/src/free_claude_code/providers/openai_responses/execution.py
+++ b/src/free_claude_code/providers/openai_responses/execution.py
@@ -1,0 +1,306 @@
+"""One logical generation lifecycle for Responses upstreams."""
+
+import asyncio
+import sys
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Protocol
+
+from loguru import logger
+
+from free_claude_code.core.diagnostics import (
+    extract_upstream_error_detail,
+    redacted_exception_traceback,
+)
+from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.core.json_types import JsonObject
+from free_claude_code.core.openai_responses import (
+    ResponsesStreamFailure,
+    responses_stream_failure_from_event,
+)
+from free_claude_code.core.trace import trace_event
+from free_claude_code.providers.admission import (
+    ProviderAdmissionController,
+    ProviderCorrectionAction,
+    ProviderExecutionState,
+    ProviderOperationKind,
+)
+from free_claude_code.providers.failure_policy import (
+    RetryableProviderProtocolError,
+    classify_provider_failure,
+    context_window_exceeded_provider_failure,
+    is_context_window_error_code,
+    is_retryable_stream_error,
+    provider_authentication_status,
+    reports_context_window_incomplete,
+)
+from free_claude_code.providers.http import ProviderAttemptScope, close_provider_stream
+from free_claude_code.providers.stream_recovery import (
+    RecoveryController,
+    RecoveryFailureAction,
+    TruncatedProviderStreamError,
+)
+
+from .events import ResponsesEventSource
+from .presentation import ResponsesPresenterFactory
+
+type AuthenticationRecovery = Callable[[], Awaitable[None]]
+
+
+class ResponsesBackend(Protocol):
+    """Request-local connection mechanics; generation replay belongs to the runner."""
+
+    async def prepare_attempt(self) -> None: ...
+
+    async def open_attempt(
+        self, scope: ProviderAttemptScope
+    ) -> ResponsesEventSource: ...
+
+    def authentication_recovery(
+        self, error: Exception
+    ) -> AuthenticationRecovery | None: ...
+
+    def normalize_error(self, error: Exception) -> Exception: ...
+
+    async def aclose(self) -> None: ...
+
+
+async def run_responses_stream(
+    *,
+    backend: ResponsesBackend,
+    admission: ProviderAdmissionController,
+    provider_name: str,
+    request_id: str | None,
+    response_model: str,
+    body: JsonObject,
+    read_timeout_s: float,
+    presenter_factory: ResponsesPresenterFactory,
+    log_error_tracebacks: bool = False,
+) -> AsyncIterator[str]:
+    """Own admission, replay, commitment, terminal outcome, and cleanup together."""
+    execution = admission.start_execution(request_id=request_id)
+    recovery = RecoveryController()
+    authentication_recovered = False
+
+    def failure_for(raw_error: Exception) -> ExecutionFailure:
+        return classify_provider_failure(
+            _effective_error(backend.normalize_error(raw_error)),
+            provider_name=provider_name,
+            read_timeout_s=read_timeout_s,
+            request_id=request_id,
+        )
+
+    try:
+        trace_event(
+            stage="provider",
+            event="provider.request.sent",
+            source="provider",
+            provider=provider_name,
+            request_id=request_id,
+            execution_id=execution.execution_id,
+            gateway_model=response_model,
+            downstream_model=body.get("model"),
+            transport="responses",
+        )
+        while execution.can_attempt:
+            # Credential I/O is not an inference attempt. Failure here is terminal
+            # for this execution, including a failed forced snapshot refresh.
+            await backend.prepare_attempt()
+            presenter = presenter_factory()
+            start_events = tuple(presenter.start())
+            presenter_started = False
+            scope: ProviderAttemptScope | None = None
+            stream_opened = False
+            try:
+                attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
+                scope = ProviderAttemptScope(
+                    attempt, provider_name=provider_name, request_id=request_id
+                )
+                source = await backend.open_attempt(scope)
+                stream_opened = True
+                async for event_type, payload in source:
+                    if not attempt.accepted:
+                        await attempt.accept()
+                    if not presenter_started:
+                        presenter_started = True
+                        for event in start_events:
+                            for held in recovery.push(event):
+                                yield held
+                    if event_type in {"response.failed", "error", "response.error"}:
+                        error = responses_stream_failure_from_event(event_type, payload)
+                        try:
+                            error.payload = source.normalize(event_type, payload)
+                        except RetryableProviderProtocolError:
+                            # Partial failure identity must not hide the real error.
+                            error.payload = None
+                        raise error
+                    if reports_context_window_incomplete(event_type, payload):
+                        raise context_window_exceeded_provider_failure()
+                    payload = source.normalize(event_type, payload)
+                    for event in presenter.feed(event_type, payload):
+                        for held in recovery.push(event):
+                            yield held
+                    if presenter.completed:
+                        break
+                if not presenter.completed:
+                    raise TruncatedProviderStreamError(
+                        "Provider Responses stream ended without a terminal event."
+                    )
+                for event in recovery.flush():
+                    yield event
+                execution.succeed()
+                trace_event(
+                    stage="provider",
+                    event="provider.response.completed",
+                    source="provider",
+                    provider=provider_name,
+                    request_id=request_id,
+                    transport="responses",
+                )
+                return
+            except asyncio.CancelledError, GeneratorExit:
+                raise
+            except Exception as raw_error:
+                error = _effective_error(backend.normalize_error(raw_error))
+                correction = (
+                    backend.authentication_recovery(raw_error)
+                    if scope is not None
+                    and not recovery.committed
+                    and not authentication_recovered
+                    and execution.can_attempt
+                    else None
+                )
+                if correction is not None and scope is not None:
+                    allowed = scope.attempt.accepted or (
+                        await scope.attempt.correct(error)
+                        is ProviderCorrectionAction.RETRY
+                    )
+                    if allowed:
+                        closing_scope, scope = scope, None
+                        await closing_scope.aclose(active_error=raw_error)
+                        authentication_recovered = True
+                        # Exceptions in recovery escape this handler; they cannot
+                        # be reclassified as a retryable generation-open failure.
+                        await correction()
+                        recovery.discard()
+                        continue
+                attempt_failure = None
+                if scope is not None and not scope.attempt.accepted:
+                    attempt_failure = await scope.attempt.fail(error)
+                decision = recovery.advance_failure(
+                    retryable=(
+                        attempt_failure.retryable
+                        if attempt_failure is not None
+                        else is_retryable_stream_error(error)
+                    ),
+                    stream_opened=stream_opened,
+                    generated_output=recovery.committed,
+                    complete_tool_salvageable=False,
+                    attempts_remaining=execution.attempts_remaining,
+                )
+                if (
+                    attempt_failure is not None and attempt_failure.retry_allowed
+                ) or decision.action is RecoveryFailureAction.EARLY_RETRY:
+                    recovery.discard()
+                    trace_event(
+                        stage="provider",
+                        event="provider.recovery.early_retry",
+                        source="provider",
+                        provider=provider_name,
+                        request_id=request_id,
+                        transport="responses",
+                        attempts_started=execution.attempts_started,
+                        max_attempts=execution.max_attempts,
+                    )
+                    continue
+                failure = failure_for(raw_error)
+                failure.__cause__ = raw_error
+                execution.fail(failure)
+                if not recovery.committed:
+                    recovery.discard()
+                    raise failure from raw_error
+                for event in presenter.terminal_failure(raw_error, failure):
+                    yield event
+                if presenter.terminal_failure_completes_wire:
+                    return
+                raise failure from raw_error
+            finally:
+                if scope is not None:
+                    await scope.aclose(active_error=sys.exception())
+        if execution.last_failure is not None:
+            raise execution.last_failure
+        raise RuntimeError("Responses execution ended without a terminal result.")
+    except asyncio.CancelledError, GeneratorExit:
+        raise
+    except ExecutionFailure as failure:
+        execution.fail(failure)
+        raise
+    except Exception as raw_error:
+        failure = failure_for(raw_error)
+        execution.fail(failure)
+        raise failure from raw_error
+    finally:
+        try:
+            if (
+                execution.state is ProviderExecutionState.FAILED
+                and execution.last_failure is not None
+            ):
+                failure = failure_for(execution.last_failure)
+                trace_event(
+                    stage="provider",
+                    event="provider.response.error",
+                    source="provider",
+                    provider=provider_name,
+                    request_id=request_id,
+                    transport="responses",
+                    failure_kind=failure.kind.value,
+                    status_code=failure.status_code,
+                    provider_retryable=failure.retryable,
+                )
+                logger.error(
+                    "{}_ERROR request_id={} failure_kind={} status={}{}",
+                    provider_name,
+                    request_id,
+                    failure.kind.value,
+                    failure.status_code,
+                    "\n" + redacted_exception_traceback(execution.last_failure)
+                    if log_error_tracebacks
+                    else "",
+                )
+            await close_provider_stream(
+                backend,
+                active_error=sys.exception(),
+                provider_name=provider_name,
+                request_id=request_id,
+            )
+        finally:
+            await execution.aclose()
+
+
+def _effective_error(error: Exception) -> Exception:
+    if not isinstance(error, ResponsesStreamFailure):
+        return error
+    message = (
+        extract_upstream_error_detail(error).exception_text
+        or "Provider response failed."
+    )
+    if is_context_window_error_code(error.code):
+        return context_window_exceeded_provider_failure()
+    auth_status = provider_authentication_status(error)
+    if auth_status is not None:
+        return ExecutionFailure(
+            FailureKind.AUTHENTICATION
+            if auth_status == 401
+            else FailureKind.PERMISSION,
+            auth_status,
+            message,
+            False,
+        )
+    code = (error.code or "").lower()
+    if "rate" in code or "429" in code:
+        return ExecutionFailure(FailureKind.RATE_LIMIT, 429, message, True)
+    if any(marker in code for marker in ("overload", "capacity", "529")):
+        return ExecutionFailure(FailureKind.OVERLOADED, 529, message, True)
+    retryable = any(
+        marker in code for marker in ("server", "internal", "unavailable", "timeout")
+    )
+    return ExecutionFailure(FailureKind.UPSTREAM, 502, message, retryable)

--- a/src/free_claude_code/providers/openai_responses/presentation.py
+++ b/src/free_claude_code/providers/openai_responses/presentation.py
@@ -1,7 +1,6 @@
 """Client-protocol presenters shared by Responses upstream transports."""
 
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
 from typing import Protocol
 
 from free_claude_code.core.failures import ExecutionFailure
@@ -94,13 +93,6 @@ class NativeResponsesPresenter:
         ):
             return (self._relay.feed(raw_error.event_type, raw_error.payload),)
         return (self._relay.synthesize_failure(failure),)
-
-
-@dataclass(slots=True)
-class ResponsesExecutionOutcome:
-    """Provider outcome retained when terminal failure is consumed on-wire."""
-
-    failure: Exception | None = None
 
 
 type ResponsesPresenterFactory = Callable[[], ResponsesStreamPresenter]

--- a/src/free_claude_code/providers/openai_responses/sdk.py
+++ b/src/free_claude_code/providers/openai_responses/sdk.py
@@ -17,7 +17,7 @@ from .execution import AuthenticationRecovery
 
 
 class SDKResponsesBackend:
-    """Borrow a provider client and prepare isolated credentials before admission."""
+    """Borrow a provider client and resolve isolated credentials at dispatch."""
 
     def __init__(
         self,

--- a/src/free_claude_code/providers/openai_responses/sdk.py
+++ b/src/free_claude_code/providers/openai_responses/sdk.py
@@ -1,0 +1,88 @@
+"""SDK connection mechanics for one Responses generation request."""
+
+from collections.abc import Callable
+from contextlib import AsyncExitStack
+from typing import cast
+
+from openai import AsyncOpenAI
+from openai.types.responses import ResponseInputParam
+
+from free_claude_code.core.json_types import JsonObject
+from free_claude_code.providers.endpoint import RequestEndpoint
+from free_claude_code.providers.failure_policy import provider_authentication_status
+from free_claude_code.providers.http import ProviderAttemptScope
+
+from .events import ResponsesEventAdapter, ResponsesEventSource
+from .execution import AuthenticationRecovery
+
+
+class SDKResponsesBackend:
+    """Borrow a provider client and prepare isolated credentials before admission."""
+
+    def __init__(
+        self,
+        *,
+        client: AsyncOpenAI,
+        body: JsonObject,
+        endpoint: RequestEndpoint | None,
+        event_adapter_factory: Callable[[], ResponsesEventAdapter] | None,
+    ) -> None:
+        self._base_client = client
+        self._client = client
+        self._body = body
+        self._endpoint = endpoint
+        self._event_adapter_factory = event_adapter_factory
+
+    async def prepare_attempt(self) -> None:
+        if self._endpoint is not None:
+            self._client = await self._endpoint.openai_client(self._base_client)
+
+    async def open_attempt(self, scope: ProviderAttemptScope) -> ResponsesEventSource:
+        adapter = (
+            self._event_adapter_factory()
+            if self._event_adapter_factory is not None
+            else None
+        )
+        body = self._body
+        resources = scope.retain(AsyncExitStack())
+        response = await resources.enter_async_context(
+            self._client.responses.with_streaming_response.create(
+                model=cast(str, body["model"]),
+                input=cast(str | ResponseInputParam, body.get("input")),
+                stream=True,
+                store=False,
+                extra_body={
+                    key: value
+                    for key, value in body.items()
+                    if key not in {"model", "input", "stream", "store"}
+                }
+                or None,
+                extra_headers=self._endpoint.openai_headers()
+                if self._endpoint is not None
+                else None,
+            )
+        )
+        source = ResponsesEventSource(response.http_response, adapter=adapter)
+        resources.push_async_callback(source.aclose)
+        return source
+
+    def authentication_recovery(
+        self, error: Exception
+    ) -> AuthenticationRecovery | None:
+        if self._endpoint is not None and provider_authentication_status(error) in {
+            401,
+            403,
+        }:
+            return self._refresh
+        return None
+
+    async def _refresh(self) -> None:
+        if self._endpoint is not None:
+            self._endpoint.request_refresh()
+
+    def normalize_error(self, error: Exception) -> Exception:
+        return error
+
+    async def aclose(self) -> None:
+        if self._endpoint is not None:
+            await self._endpoint.aclose()

--- a/src/free_claude_code/providers/openai_responses/transport.py
+++ b/src/free_claude_code/providers/openai_responses/transport.py
@@ -1,86 +1,42 @@
-"""Standard API-key OpenAI Responses execution over the official SDK."""
+"""Responses request conversion and SDK backend composition."""
 
-import asyncio
-import sys
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import cast
 
 import httpx2
-from openai import AsyncOpenAI, AsyncStream
-from openai.types.responses import ResponseInputParam, ResponseStreamEvent
+from openai import AsyncOpenAI
 from openai.types.responses.response_create_params import ResponseCreateParamsStreaming
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.core.anthropic.models import MessagesRequest
-from free_claude_code.core.diagnostics import extract_upstream_error_detail
-from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import (
     OpenAIResponsesRequest,
     ResponsesConversionError,
     ResponsesProviderStream,
-    ResponsesStreamFailure,
     build_native_responses_request,
     build_responses_provider_request,
-    responses_stream_failure_from_event,
 )
 from free_claude_code.core.openai_tool_names import OpenAIToolNameCodec
 from free_claude_code.core.reasoning import ReasoningPolicy
-from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
-    ProviderExecution,
-    ProviderOperationKind,
 )
 from free_claude_code.providers.endpoint import EndpointContext, RequestEndpoint
-from free_claude_code.providers.failure_policy import (
-    RetryableProviderProtocolError,
-    classify_provider_failure,
-    context_window_exceeded_provider_failure,
-    is_context_window_error_code,
-    is_retryable_stream_error,
-    provider_authentication_status,
-    reports_context_window_incomplete,
-)
-from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
-from free_claude_code.providers.stream_recovery import (
-    RecoveryController,
-    RecoveryFailureAction,
-)
 
+from .events import ResponsesEventAdapter
+from .execution import run_responses_stream
 from .presentation import (
     MessagesResponsesPresenter,
     NativeResponsesPresenter,
-    ResponsesExecutionOutcome,
     ResponsesPresenterFactory,
 )
-
-type ResponsesEventAdapter = Callable[[str, JsonObject], JsonObject]
-
-
-class _TruncatedResponsesStream(RetryableProviderProtocolError):
-    """A Responses stream ended without a terminal lifecycle event."""
-
-
-class _ClosableResponsesStream(AsyncIterator[ResponseStreamEvent]):
-    """Expose the OpenAI SDK stream through the shared ``aclose`` contract."""
-
-    def __init__(self, stream: AsyncStream[ResponseStreamEvent]) -> None:
-        self._stream = stream
-
-    def __aiter__(self) -> AsyncIterator[ResponseStreamEvent]:
-        return self
-
-    async def __anext__(self) -> ResponseStreamEvent:
-        return await anext(self._stream)
-
-    async def aclose(self) -> None:
-        await self._stream.close()
+from .sdk import SDKResponsesBackend
 
 
 class OpenAIResponsesTransport:
-    """Execute public Responses requests with provider-owned retry semantics."""
+    """Compose Responses requests with the shared generation lifecycle."""
 
     def __init__(
         self,
@@ -201,7 +157,7 @@ class OpenAIResponsesTransport:
             reasoning=reasoning,
         )
 
-    async def _run_stream(
+    def _run_stream(
         self,
         body: JsonObject,
         *,
@@ -210,307 +166,20 @@ class OpenAIResponsesTransport:
         presenter_factory: ResponsesPresenterFactory,
         endpoint_context: EndpointContext | None = None,
     ) -> AsyncIterator[str]:
-        execution = self._admission.start_execution(request_id=request_id)
-        outcome = ResponsesExecutionOutcome()
-        endpoint = (
-            RequestEndpoint(endpoint_context, self._endpoint_transport)
-            if endpoint_context is not None
-            else None
-        )
-        provider_stream = self._run_execution(
-            body,
+        return run_responses_stream(
+            backend=SDKResponsesBackend(
+                client=self._client,
+                body=body,
+                endpoint=RequestEndpoint(endpoint_context, self._endpoint_transport)
+                if endpoint_context is not None
+                else None,
+                event_adapter_factory=self._event_adapter_factory,
+            ),
+            admission=self._admission,
+            provider_name=self._provider_name,
             request_id=request_id,
             response_model=response_model,
+            body=body,
+            read_timeout_s=self._read_timeout_s,
             presenter_factory=presenter_factory,
-            execution=execution,
-            outcome=outcome,
-            endpoint=endpoint,
         )
-        try:
-            async for event in provider_stream:
-                if endpoint is not None:
-                    endpoint.commit()
-                yield event
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:
-            execution.fail(error)
-            raise
-        else:
-            if outcome.failure is None:
-                execution.succeed()
-            else:
-                execution.fail(outcome.failure)
-        finally:
-            try:
-                await maybe_await_aclose(provider_stream)
-            finally:
-                try:
-                    if endpoint is not None:
-                        await endpoint.aclose()
-                finally:
-                    execution.abandon()
-
-    async def _run_execution(
-        self,
-        body: JsonObject,
-        *,
-        request_id: str | None,
-        response_model: str,
-        presenter_factory: ResponsesPresenterFactory,
-        execution: ProviderExecution,
-        outcome: ResponsesExecutionOutcome,
-        endpoint: RequestEndpoint | None = None,
-    ) -> AsyncIterator[str]:
-        recovery = RecoveryController()
-        trace_event(
-            stage="provider",
-            event="provider.request.sent",
-            source="provider",
-            provider=self._provider_name,
-            request_id=request_id,
-            execution_id=execution.execution_id,
-            gateway_model=response_model,
-            downstream_model=body.get("model"),
-            transport="responses",
-        )
-
-        while execution.can_attempt:
-            presenter = presenter_factory()
-            start_events = tuple(presenter.start())
-            presenter_started = False
-            adapt_event = (
-                self._event_adapter_factory()
-                if self._event_adapter_factory is not None
-                else None
-            )
-
-            scope: ProviderAttemptScope | None = None
-            stream_opened = False
-            try:
-                attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name=self._provider_name,
-                    request_id=request_id,
-                )
-                sdk_stream = await self._create_sdk_stream(body, endpoint=endpoint)
-                stream = scope.retain(_ClosableResponsesStream(sdk_stream))
-                stream_opened = True
-
-                async for upstream_event in stream:
-                    if not scope.attempt.accepted:
-                        await scope.attempt.accept()
-                    if not presenter_started:
-                        presenter_started = True
-                        for event in start_events:
-                            for held in recovery.push(event):
-                                yield held
-                    payload = cast(
-                        JsonObject,
-                        upstream_event.to_dict(mode="json"),
-                    )
-                    if upstream_event.type in {
-                        "response.failed",
-                        "error",
-                        "response.error",
-                    }:
-                        stream_failure = responses_stream_failure_from_event(
-                            upstream_event.type,
-                            payload,
-                        )
-                        if adapt_event is not None:
-                            try:
-                                stream_failure.payload = adapt_event(
-                                    upstream_event.type, payload
-                                )
-                            except RetryableProviderProtocolError:
-                                # Preserve the upstream failure classification.
-                                # Synthesize the terminal event if partial output
-                                # cannot retain a consistent public identity.
-                                stream_failure.payload = None
-                        raise stream_failure
-                    if reports_context_window_incomplete(
-                        upstream_event.type,
-                        payload,
-                    ):
-                        raise context_window_exceeded_provider_failure()
-                    if adapt_event is not None:
-                        payload = adapt_event(upstream_event.type, payload)
-                    for event in presenter.feed(upstream_event.type, payload):
-                        for held in recovery.push(event):
-                            yield held
-                    if presenter.completed:
-                        break
-                if not presenter.completed:
-                    raise _TruncatedResponsesStream(
-                        "Provider Responses stream ended without a terminal event."
-                    )
-                for event in recovery.flush():
-                    yield event
-                trace_event(
-                    stage="provider",
-                    event="provider.response.completed",
-                    source="provider",
-                    provider=self._provider_name,
-                    request_id=request_id,
-                    transport="responses",
-                )
-                return
-            except asyncio.CancelledError, GeneratorExit:
-                raise
-            except Exception as raw_error:
-                error = _effective_error(raw_error)
-                if (
-                    scope is not None
-                    and endpoint is not None
-                    and await endpoint.retry_authentication(
-                        error, scope.attempt, execution
-                    )
-                ):
-                    recovery.discard()
-                    continue
-                attempt_failure = None
-                if scope is not None and not scope.attempt.accepted:
-                    attempt_failure = await scope.attempt.fail(error)
-                if attempt_failure is not None and attempt_failure.retry_allowed:
-                    recovery.discard()
-                    _trace_early_retry(
-                        provider_name=self._provider_name,
-                        request_id=request_id,
-                        execution=execution,
-                    )
-                    continue
-
-                retryable = (
-                    attempt_failure.retryable
-                    if attempt_failure is not None
-                    else is_retryable_stream_error(error)
-                )
-                decision = recovery.advance_failure(
-                    retryable=retryable,
-                    stream_opened=stream_opened,
-                    generated_output=recovery.committed,
-                    complete_tool_salvageable=False,
-                    attempts_remaining=execution.attempts_remaining,
-                )
-                if decision.action is RecoveryFailureAction.EARLY_RETRY:
-                    recovery.discard()
-                    _trace_early_retry(
-                        provider_name=self._provider_name,
-                        request_id=request_id,
-                        execution=execution,
-                    )
-                    continue
-
-                failure = classify_provider_failure(
-                    error,
-                    provider_name=self._provider_name,
-                    read_timeout_s=self._read_timeout_s,
-                    request_id=request_id,
-                )
-                trace_event(
-                    stage="provider",
-                    event="provider.response.error",
-                    source="provider",
-                    provider=self._provider_name,
-                    request_id=request_id,
-                    transport="responses",
-                    exc_type=type(error).__name__,
-                    failure_kind=failure.kind.value,
-                    status_code=failure.status_code,
-                    provider_retryable=failure.retryable,
-                )
-                if not decision.committed:
-                    recovery.discard()
-                    raise failure from raw_error
-                for event in presenter.terminal_failure(raw_error, failure):
-                    yield event
-                if presenter.terminal_failure_completes_wire:
-                    outcome.failure = failure
-                    return
-                raise failure from raw_error
-            finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
-
-        if execution.last_failure is not None:
-            raise execution.last_failure
-        raise RuntimeError("Responses execution ended without a terminal result.")
-
-    async def _create_sdk_stream(
-        self,
-        body: JsonObject,
-        *,
-        endpoint: RequestEndpoint | None = None,
-    ) -> AsyncStream[ResponseStreamEvent]:
-        model = body.get("model")
-        if not isinstance(model, str) or not model:
-            raise InvalidRequestError("Responses request model must not be empty.")
-        input_value = cast(str | ResponseInputParam, body.get("input"))
-        extra_body = {
-            key: value
-            for key, value in body.items()
-            if key not in {"model", "input", "stream", "store"}
-        }
-        client = (
-            await endpoint.openai_client(self._client)
-            if endpoint is not None
-            else self._client
-        )
-        return await client.responses.create(
-            model=model,
-            input=input_value,
-            stream=True,
-            store=False,
-            extra_body=extra_body or None,
-            extra_headers=endpoint.openai_headers() if endpoint is not None else None,
-        )
-
-
-def _effective_error(error: Exception) -> Exception:
-    if not isinstance(error, ResponsesStreamFailure):
-        return error
-    message = (
-        extract_upstream_error_detail(error).exception_text
-        or "Provider response failed."
-    )
-    if is_context_window_error_code(error.code):
-        return context_window_exceeded_provider_failure()
-    auth_status = provider_authentication_status(error)
-    if auth_status is not None:
-        return ExecutionFailure(
-            FailureKind.AUTHENTICATION
-            if auth_status == 401
-            else FailureKind.PERMISSION,
-            auth_status,
-            message,
-            False,
-        )
-    code = (error.code or "").lower()
-    if "rate" in code or "429" in code:
-        return ExecutionFailure(FailureKind.RATE_LIMIT, 429, message, True)
-    if any(marker in code for marker in ("overload", "capacity", "529")):
-        return ExecutionFailure(FailureKind.OVERLOADED, 529, message, True)
-    retryable = any(
-        marker in code for marker in ("server", "internal", "unavailable", "timeout")
-    )
-    return ExecutionFailure(FailureKind.UPSTREAM, 502, message, retryable)
-
-
-def _trace_early_retry(
-    *,
-    provider_name: str,
-    request_id: str | None,
-    execution: ProviderExecution,
-) -> None:
-    trace_event(
-        stage="provider",
-        event="provider.recovery.early_retry",
-        source="provider",
-        provider=provider_name,
-        request_id=request_id,
-        transport="responses",
-        attempts_started=execution.attempts_started,
-        max_attempts=execution.max_attempts,
-    )

--- a/tests/core/openai_responses/test_provider_stream.py
+++ b/tests/core/openai_responses/test_provider_stream.py
@@ -311,7 +311,7 @@ def test_responses_provider_stream_surfaces_failed_event() -> None:
             },
         )
 
-    assert exc_info.value.code == "server_error"
+    assert exc_info.value.body["response"]["error"]["code"] == "server_error"
 
 
 def test_responses_provider_stream_restores_added_and_done_only_tool_names() -> None:

--- a/tests/providers/support.py
+++ b/tests/providers/support.py
@@ -84,13 +84,14 @@ def immediate_admission(
     *,
     provider_name: str = "TEST",
     max_attempts: int = 5,
+    max_concurrency: int = 1_000,
 ) -> ProviderAdmissionController:
     """Return a real controller with deterministic zero-delay recovery."""
     return ProviderAdmissionController(
         provider_name=provider_name,
         rate_limit=1_000_000,
         rate_window=1.0,
-        max_concurrency=1_000,
+        max_concurrency=max_concurrency,
         max_attempts=max_attempts,
         base_delay=0.0,
         max_delay=0.0,

--- a/tests/providers/test_endpoint_context_transports.py
+++ b/tests/providers/test_endpoint_context_transports.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from collections.abc import AsyncIterator
 
+import httpx
 import httpx2
 import pytest
 from openai import AsyncOpenAI
@@ -13,6 +14,10 @@ from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY
+from free_claude_code.providers.admission import (
+    ProviderExecution,
+    ProviderExecutionState,
+)
 from free_claude_code.providers.endpoint import HttpEndpoint
 from free_claude_code.providers.openai_chat import (
     NO_REASONING,
@@ -133,6 +138,119 @@ def _stream(
 
 async def _consume(stream: AsyncIterator[str]) -> None:
     assert [event async for event in stream]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("force_failure", [False, True])
+async def test_responses_credential_failure_is_outside_generation_budget(
+    force_failure: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = 0
+    executions: list[ProviderExecution] = []
+
+    class FailingContext(Context):
+        async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
+            endpoint = await super().endpoint(force_refresh=force_refresh)
+            if force_refresh or not force_failure:
+                raise httpx.ReadError("credential service unavailable")
+            return endpoint
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal calls
+        calls += 1
+        return httpx2.Response(401, json={"error": {"message": "expired"}})
+
+    pool = httpx2.MockTransport(handler)
+    async with AsyncOpenAI(
+        api_key="base", http_client=httpx2.AsyncClient(transport=pool)
+    ) as client:
+        transport = _transport(client, responses=True, pool=pool)
+        start_execution = transport._admission.start_execution
+
+        def record_execution(*, request_id: str | None = None) -> ProviderExecution:
+            execution = start_execution(request_id=request_id)
+            executions.append(execution)
+            return execution
+
+        monkeypatch.setattr(transport._admission, "start_execution", record_execution)
+        context = FailingContext("a")
+        with pytest.raises(ExecutionFailure):
+            await _consume(_stream(transport, context, responses_ingress=True))
+    assert calls == int(force_failure)
+    assert context.calls == ([False, True] if force_failure else [False])
+    assert len(executions) == 1
+    assert executions[0].attempts_started == int(force_failure)
+    assert executions[0].state is ProviderExecutionState.FAILED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+@pytest.mark.parametrize("forced_refresh", [False, True])
+async def test_preparation_exit_releases_recovery_for_other_requests(
+    cancel: bool,
+    forced_refresh: bool,
+) -> None:
+    calls = 0
+    preparing = asyncio.Event()
+    finish_preparation = asyncio.Event()
+    healthy_prepared = asyncio.Event()
+
+    class InterruptedContext(Context):
+        async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
+            endpoint = await super().endpoint(force_refresh=force_refresh)
+            if force_refresh if forced_refresh else len(self.calls) == 2:
+                preparing.set()
+                await finish_preparation.wait()
+                raise httpx.ReadError("credential service unavailable")
+            return endpoint
+
+    class HealthyContext(Context):
+        async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
+            endpoint = await super().endpoint(force_refresh=force_refresh)
+            healthy_prepared.set()
+            return endpoint
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx2.Response(503, json={"error": {"message": "unavailable"}})
+        if forced_refresh and calls == 2:
+            return httpx2.Response(401, json={"error": {"message": "expired"}})
+        return _response(request)
+
+    pool = httpx2.MockTransport(handler)
+    async with AsyncOpenAI(
+        api_key="base", http_client=httpx2.AsyncClient(transport=pool)
+    ) as client:
+        transport = _transport(client, responses=True, pool=pool)
+        first = asyncio.create_task(
+            _consume(
+                _stream(transport, InterruptedContext("a"), responses_ingress=True)
+            )
+        )
+        async with asyncio.timeout(2):
+            await preparing.wait()
+            waiting = asyncio.create_task(
+                _consume(
+                    _stream(
+                        transport, HealthyContext("healthy"), responses_ingress=True
+                    )
+                )
+            )
+            await healthy_prepared.wait()
+            assert not waiting.done()
+            if cancel:
+                first.cancel()
+            else:
+                finish_preparation.set()
+            with pytest.raises(asyncio.CancelledError if cancel else ExecutionFailure):
+                await first
+            await waiting
+            await _consume(
+                _stream(transport, Context("healthy"), responses_ingress=True)
+            )
+    assert calls == (4 if forced_refresh else 3)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_endpoint_context_transports.py
+++ b/tests/providers/test_endpoint_context_transports.py
@@ -189,11 +189,12 @@ async def test_responses_credential_failure_is_outside_generation_budget(
 async def test_preparation_exit_releases_recovery_for_other_requests(
     cancel: bool,
     forced_refresh: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls = 0
     preparing = asyncio.Event()
     finish_preparation = asyncio.Event()
-    healthy_prepared = asyncio.Event()
+    healthy_waiting = asyncio.Event()
 
     class InterruptedContext(Context):
         async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
@@ -202,12 +203,6 @@ async def test_preparation_exit_releases_recovery_for_other_requests(
                 preparing.set()
                 await finish_preparation.wait()
                 raise httpx.ReadError("credential service unavailable")
-            return endpoint
-
-    class HealthyContext(Context):
-        async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
-            endpoint = await super().endpoint(force_refresh=force_refresh)
-            healthy_prepared.set()
             return endpoint
 
     def handler(request: httpx2.Request) -> httpx2.Response:
@@ -231,14 +226,17 @@ async def test_preparation_exit_releases_recovery_for_other_requests(
         )
         async with asyncio.timeout(2):
             await preparing.wait()
+            wait_for_gate = transport._admission._wait_for_gate
+
+            async def enter_gate(execution: ProviderExecution):
+                healthy_waiting.set()
+                return await wait_for_gate(execution)
+
+            monkeypatch.setattr(transport._admission, "_wait_for_gate", enter_gate)
             waiting = asyncio.create_task(
-                _consume(
-                    _stream(
-                        transport, HealthyContext("healthy"), responses_ingress=True
-                    )
-                )
+                _consume(_stream(transport, Context("healthy"), responses_ingress=True))
             )
-            await healthy_prepared.wait()
+            await healthy_waiting.wait()
             assert not waiting.done()
             if cancel:
                 first.cancel()

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from types import ModuleType
 
 import httpx
 import httpx2
@@ -76,15 +77,18 @@ def test_stream_retry_classification_distinguishes_protocol_and_status() -> None
     assert not is_retryable_stream_error(_http_status_error(400, "bad request"))
 
 
-def test_stream_retry_classification_only_accepts_post_open_timeouts() -> None:
-    request = httpx.Request("POST", "https://provider.test/v1/messages")
+@pytest.mark.parametrize("http", [httpx, httpx2])
+def test_stream_retry_classification_only_accepts_post_open_timeouts(
+    http: ModuleType,
+) -> None:
+    request = http.Request("POST", "https://provider.test/v1/messages")
 
-    assert is_retryable_stream_error(httpx.ReadTimeout("read", request=request))
+    assert is_retryable_stream_error(http.ReadTimeout("read", request=request))
     assert not is_retryable_stream_error(
-        httpx.ConnectTimeout("connect", request=request)
+        http.ConnectTimeout("connect", request=request)
     )
-    assert not is_retryable_stream_error(httpx.WriteTimeout("write", request=request))
-    assert not is_retryable_stream_error(httpx.PoolTimeout("pool", request=request))
+    assert not is_retryable_stream_error(http.WriteTimeout("write", request=request))
+    assert not is_retryable_stream_error(http.PoolTimeout("pool", request=request))
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/test_github_copilot_provider.py
+++ b/tests/providers/test_github_copilot_provider.py
@@ -32,10 +32,12 @@ from free_claude_code.core.reasoning import (
     ReasoningEffort,
     ReasoningPolicy,
 )
+from free_claude_code.providers.admission import ProviderOperationKind
 from free_claude_code.providers.anthropic_messages.request_policy import (
     MessagesModelCapabilities,
 )
 from free_claude_code.providers.endpoint import HttpEndpoint
+from free_claude_code.providers.github_copilot import broker as copilot_broker
 from free_claude_code.providers.github_copilot.auth import CopilotAuthManager
 from free_claude_code.providers.github_copilot.provider import GitHubCopilotProvider
 from free_claude_code.providers.github_copilot.types import (
@@ -54,6 +56,103 @@ from tests.providers.test_openai_responses_transport import (
 from tests.providers.test_openai_responses_transport import (
     _sse as responses_sse,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["disconnect", "identity", "expiry"])
+async def test_queued_responses_revalidates_account_before_dispatch(
+    change: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = Harness(tmp_path, CopilotEgress.RESPONSES)
+    admission = immediate_admission(max_attempts=2, max_concurrency=1)
+    harness.provider._responses._admission = admission
+    now = 1_000.0
+    monkeypatch.setattr(copilot_broker.time, "time", lambda: now)
+    create_session = harness.runtime.session
+
+    async def session(model_id: str) -> FakeSession:
+        value = await create_session(model_id)
+        value.value = replace(value.value, expires_at=now + 60)
+        return value
+
+    monkeypatch.setattr(harness.runtime, "session", session)
+    occupied = admission.start_execution()
+    attempt = await occupied.open_attempt(ProviderOperationKind.GENERATION)
+    queued = asyncio.Event()
+    acquire = admission._concurrency_sem.acquire
+
+    async def acquire_slot() -> bool:
+        queued.set()
+        return await acquire()
+
+    monkeypatch.setattr(admission._concurrency_sem, "acquire", acquire_slot)
+    task = asyncio.create_task(_collect_queued_responses(harness))
+    disconnect: asyncio.Task[object] | None = None
+    try:
+        async with asyncio.timeout(3):
+            await queued.wait()
+            assert not harness.seen
+            if change == "disconnect":
+                disabled = asyncio.Event()
+                disable = harness.auth._disable
+
+                def record_disable() -> bool:
+                    result = disable()
+                    disabled.set()
+                    return result
+
+                monkeypatch.setattr(harness.auth, "_disable", record_disable)
+                disconnect = asyncio.create_task(harness.auth.disconnect())
+                await disabled.wait()
+            elif change == "identity":
+                harness.runtime.current_identity = None
+            else:
+                now += 90
+                active = harness.runtime.sessions[0]
+                active.value = replace(
+                    active.value,
+                    http=HttpEndpoint(
+                        "https://copilot.invalid", {}, "fresh-credential"
+                    ),
+                    expires_at=now + 60,
+                )
+            await attempt.aclose()
+            await occupied.aclose()
+            if change == "expiry":
+                await task
+                assert len(harness.seen) == 1
+                assert (
+                    harness.seen[0].headers["Authorization"]
+                    == "Bearer fresh-credential"
+                )
+            else:
+                with pytest.raises(ExecutionFailure) as caught:
+                    await task
+                assert caught.value.status_code == 401
+                assert not harness.seen
+            if disconnect is not None:
+                await disconnect
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        await attempt.aclose()
+        await occupied.aclose()
+        await harness.provider.cleanup()
+        await harness.auth.close()
+        if disconnect is not None:
+            await disconnect
+    assert all(session.closed for session in harness.runtime.sessions)
+
+
+async def _collect_queued_responses(harness: Harness) -> list[str]:
+    return [
+        event
+        async for event in harness.provider.stream_responses(
+            OpenAIResponsesRequest(model=harness.runtime.name, input="hello")
+        )
+    ]
 
 
 class Wire(httpx.AsyncByteStream, httpx2.AsyncByteStream):

--- a/tests/providers/test_github_copilot_provider.py
+++ b/tests/providers/test_github_copilot_provider.py
@@ -155,6 +155,67 @@ async def _collect_queued_responses(harness: Harness) -> list[str]:
     ]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("responses", [False, True])
+@pytest.mark.parametrize("probing", [False, True])
+@pytest.mark.parametrize(
+    "label,payload_type",
+    [
+        (None, None),
+        ("message", None),
+        (None, "envelope"),
+        ("response.completed", "response.completed"),
+    ],
+)
+async def test_sse_labels_cannot_hide_copilot_authentication_failure(
+    responses: bool,
+    probing: bool,
+    label: str | None,
+    payload_type: str | None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = Harness(tmp_path, CopilotEgress.RESPONSES)
+    admission = harness.provider._admission
+    payload: JsonObject = {
+        "error": {"code": "invalid_api_key", "message": "expired"},
+        "request_id": "upstream-auth-rejection",
+    }
+    if payload_type is not None:
+        payload["type"] = payload_type
+    harness.responses_content = (
+        (f"event: {label}\n" if label else "") + f"data: {json.dumps(payload)}\n\n"
+    ).encode()
+    if probing:
+        owner = admission.start_execution()
+        initial = await owner.open_attempt(ProviderOperationKind.GENERATION)
+        await initial.fail(httpx.ReadError("provider offline"))
+        await initial.aclose()
+        await owner.aclose()
+    accepted = 0
+    accept = admission._attempt_accepted
+
+    async def record_accept(execution, permit):
+        nonlocal accepted
+        accepted += 1
+        await accept(execution, permit)
+
+    monkeypatch.setattr(admission, "_attempt_accepted", record_accept)
+    try:
+        with pytest.raises(ExecutionFailure) as caught:
+            _ = [event async for event in harness.stream(responses)]
+        assert caught.value.status_code == 401 and not caught.value.retryable
+        assert "upstream-auth-rejection" in caught.value.message
+        assert len(harness.seen) == 2
+        assert harness.runtime.sessions[0].endpoint_calls == 2
+        assert not harness.auth.is_connected()
+        assert accepted == 0 and admission._episode is None
+        assert all(wire.closed for wire in harness.wires)
+    finally:
+        await harness.provider.cleanup()
+        await harness.auth.close()
+
+
 class Wire(httpx.AsyncByteStream, httpx2.AsyncByteStream):
     def __init__(self, content: bytes) -> None:
         self.content = content

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -20,7 +20,10 @@ from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.model_capabilities import ModelInputModality
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
-from free_claude_code.providers.admission import ProviderAdmissionController
+from free_claude_code.providers.admission import (
+    ProviderAdmissionController,
+    ProviderOperationKind,
+)
 from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_codex.auth import (
     OpenAIAccess,
@@ -28,6 +31,63 @@ from free_claude_code.providers.openai_codex.auth import (
 )
 from free_claude_code.providers.openai_codex.provider import OpenAICodexProvider
 from tests.providers.support import make_provider_config
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_catalog_credential_exit_releases_idle_recovery_leader(
+    cancel: bool,
+) -> None:
+    preparing = asyncio.Event()
+    finish = asyncio.Event()
+
+    class InterruptedAuth(_FakeAuth):
+        async def access(self, *, force_refresh: bool = False) -> OpenAIAccess:
+            access = await super().access(force_refresh=force_refresh)
+            if self.access_calls == 2:
+                preparing.set()
+                await finish.wait()
+                raise RuntimeError("credential lookup failed")
+            return access
+
+    admission = _admission(max_concurrency=1)
+    async with httpx.AsyncClient(
+        base_url=_config().base_url,
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(503, json={"error": "unavailable"})
+        ),
+    ) as client:
+        provider = OpenAICodexProvider(
+            _config(), auth=InterruptedAuth(), admission=admission, client=client
+        )
+        first = asyncio.create_task(provider.list_model_infos())
+        follower = admission.start_execution()
+        waiting = None
+        try:
+            async with asyncio.timeout(2):
+                await preparing.wait()
+                waiting = asyncio.create_task(
+                    follower.open_attempt(ProviderOperationKind.GENERATION)
+                )
+                if cancel:
+                    first.cancel()
+                else:
+                    finish.set()
+                with pytest.raises(asyncio.CancelledError if cancel else RuntimeError):
+                    await first
+                probe = await waiting
+                await probe.accept()
+                await probe.aclose()
+        finally:
+            first.cancel()
+            if waiting is not None:
+                waiting.cancel()
+            await asyncio.gather(
+                first,
+                *([waiting] if waiting is not None else []),
+                return_exceptions=True,
+            )
+            await follower.aclose()
 
 
 class _FakeAuth(OpenAIAuthManager):

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -189,6 +189,99 @@ async def _collect(stream: AsyncIterator[str]) -> str:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "trailing", ['data: {"type": "ping"}\n\n', "data: invalid\n\n"]
+)
+async def test_native_terminal_stops_before_trailing_data(trailing: str) -> None:
+    response = _CloseTrackingResponse(
+        200,
+        headers={"content-type": "text/event-stream"},
+        stream=_StaticAsyncBody(
+            (
+                _sse(
+                    (
+                        "response.completed",
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_done",
+                                "status": "completed",
+                                "output": [],
+                            },
+                        },
+                    )
+                )
+                + trailing
+            ).encode()
+        ),
+    )
+    async with httpx.AsyncClient(
+        base_url=_config().base_url,
+        transport=httpx.MockTransport(lambda request: response),
+    ) as client:
+        provider = OpenAICodexProvider(
+            _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        )
+        events = parse_sse_text(
+            await _collect(provider.stream_responses(_responses_request()))
+        )
+    assert [event.event for event in events] == ["response.completed"]
+    assert response.close_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize(
+    "code,status,kind",
+    [
+        ("invalid_api_key", 401, FailureKind.AUTHENTICATION),
+        ("permission_denied", 403, FailureKind.PERMISSION),
+    ],
+)
+async def test_structured_auth_failure_is_canonical_without_oauth_recovery(
+    native: bool, code: str, status: int, kind: FailureKind
+) -> None:
+    auth = _FakeAuth()
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=_sse(
+                (
+                    "response.failed",
+                    {
+                        "type": "response.failed",
+                        "response": {
+                            "id": "resp_failure",
+                            "error": {"code": code, "message": "credential rejected"},
+                        },
+                    },
+                )
+            ),
+        )
+
+    async with httpx.AsyncClient(
+        base_url=_config().base_url, transport=httpx.MockTransport(handler)
+    ) as client:
+        provider = OpenAICodexProvider(
+            _config(), auth=auth, admission=_admission(), client=client
+        )
+        with pytest.raises(ExecutionFailure) as caught:
+            await _collect(
+                provider.stream_responses(_responses_request())
+                if native
+                else provider.stream_messages(_request())
+            )
+    assert (caught.value.kind, caught.value.status_code) == (kind, status)
+    assert not caught.value.retryable
+    assert calls == 1 and auth.recovery_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_provider_uses_subscription_headers_and_visible_model_catalog() -> None:
     requests: list[httpx.Request] = []
 

--- a/tests/providers/test_provider_admission.py
+++ b/tests/providers/test_provider_admission.py
@@ -68,6 +68,52 @@ async def _open(execution: ProviderExecution) -> ProviderAttempt:
     return await execution.open_attempt(ProviderOperationKind.GENERATION)
 
 
+@pytest.mark.asyncio
+async def test_preparation_is_repeated_when_admission_changes_before_dispatch() -> None:
+    controller = _controller(max_concurrency=2)
+    leader = controller.start_execution()
+    active = await _open(leader)
+    execution = controller.start_execution()
+    preparing = asyncio.Event()
+    finish = asyncio.Event()
+    snapshots = 0
+
+    async def prepare() -> None:
+        nonlocal snapshots
+        snapshots += 1
+        preparing.set()
+        await finish.wait()
+
+    pending = asyncio.create_task(
+        execution.open_attempt(ProviderOperationKind.GENERATION, prepare=prepare)
+    )
+    try:
+        async with asyncio.timeout(2):
+            await preparing.wait()
+            await active.fail(_status_error(503))
+            await active.aclose()
+            finish.set()
+            while (
+                controller._episode is not None
+                and execution not in controller._episode.waiters
+            ):
+                await asyncio.sleep(0)
+            assert execution.attempts_started == 0
+            assert snapshots == 1 and not pending.done()
+            probe = await _open(leader)
+            await probe.accept()
+            await probe.aclose()
+            admitted = await pending
+            assert execution.attempts_started == 1 and snapshots == 2
+            await admitted.aclose()
+    finally:
+        pending.cancel()
+        await asyncio.gather(pending, return_exceptions=True)
+        await active.aclose()
+        await leader.aclose()
+        await execution.aclose()
+
+
 @pytest.mark.parametrize(
     ("factory", "message"),
     [

--- a/tests/providers/test_responses_execution.py
+++ b/tests/providers/test_responses_execution.py
@@ -1,6 +1,7 @@
 """Lifecycle ownership through both real Responses backends and client projections."""
 
 import asyncio
+import json
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -13,7 +14,7 @@ from openai import AsyncOpenAI
 
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
-from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY
@@ -21,6 +22,7 @@ from free_claude_code.providers.admission import (
     ProviderAttempt,
     ProviderExecution,
     ProviderExecutionState,
+    ProviderOperationKind,
 )
 from free_claude_code.providers.http import maybe_await_aclose
 from free_claude_code.providers.openai_codex.provider import OpenAICodexProvider
@@ -192,7 +194,7 @@ async def collect(stream: AsyncIterator[str]) -> str:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backend", ["sdk", "codex"])
-async def test_decoded_error_accepts_attempt_before_classification(
+async def test_first_frame_rejection_does_not_accept_provider_recovery(
     backend: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     accepted: list[ProviderAttempt] = []
@@ -219,15 +221,260 @@ async def test_decoded_error_accepts_attempt_before_classification(
         )
         harness.bodies.append(Body(_sse(response_event("response.completed"))))
         await collect(harness.stream(True))
-        assert len(accepted) == 2
+        assert len(accepted) == 1
         assert len(harness.requests) == 2
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backend", ["sdk", "codex"])
 @pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize(
+    "details,kind,status,retryable",
+    [
+        ({"status": 401}, FailureKind.AUTHENTICATION, 401, False),
+        (
+            {"code": None, "type": "authentication_error"},
+            FailureKind.AUTHENTICATION,
+            401,
+            False,
+        ),
+        ({"status_code": "403"}, FailureKind.PERMISSION, 403, False),
+        ({"code": 429}, FailureKind.RATE_LIMIT, 429, True),
+        (
+            {"status": 429, "type": "rate_limit_error", "code": "quota_exceeded"},
+            FailureKind.RATE_LIMIT,
+            429,
+            True,
+        ),
+        (
+            {"status": 413, "code": "rate_limit_exceeded"},
+            FailureKind.INVALID_REQUEST,
+            413,
+            False,
+        ),
+        (
+            {"status": 429, "code": "context_length_exceeded"},
+            FailureKind.CONTEXT_WINDOW_EXCEEDED,
+            400,
+            False,
+        ),
+        ({"code": 402}, FailureKind.PERMISSION, 402, False),
+        (
+            {"status": 400, "type": "server_error"},
+            FailureKind.INVALID_REQUEST,
+            400,
+            False,
+        ),
+        ({"code": "unknown_error"}, FailureKind.UPSTREAM, 502, False),
+        ({"code": "overloaded_error"}, FailureKind.OVERLOADED, 529, True),
+    ],
+)
+async def test_structured_failure_keeps_classification_and_safe_diagnostics(
+    backend: str,
+    native: bool,
+    details: JsonObject,
+    kind: FailureKind,
+    status: int,
+    retryable: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with harness_for(backend, monkeypatch) as harness:
+        payload = auth_failure()
+        response = payload["response"]
+        assert isinstance(response, dict)
+        response["error"] = {
+            **details,
+            "message": "upstream rejected",
+            "api_key": "SECRET",
+        }
+        payload["request_id"] = "upstream-diagnostic-id"
+        harness.bodies.extend(Body(_sse(payload)) for _ in range(3))
+
+        # A presentation adapter may rewrite or even discard the native envelope.
+        def rewrite(event_type: str, data: JsonObject) -> JsonObject:
+            data.clear()
+            return {"type": event_type}
+
+        monkeypatch.setattr(
+            responses_events.ResponsesEventSource,
+            "normalize",
+            lambda self, event_type, data: rewrite(event_type, data),
+        )
+        with pytest.raises(ExecutionFailure) as caught:
+            await collect(harness.stream(native))
+        failure = caught.value
+        assert (failure.kind, failure.status_code, failure.retryable) == (
+            kind,
+            status,
+            retryable,
+        )
+        assert "upstream-diagnostic-id" in failure.message
+        assert "SECRET" not in failure.message and "<redacted>" in failure.message
+        refresh = backend == "sdk" and status in {401, 403}
+        assert len(harness.requests) == (3 if retryable else 2 if refresh else 1)
+        if backend == "sdk":
+            assert harness.context.calls == (
+                [False, True] if refresh else [False] * len(harness.requests)
+            )
+        else:
+            assert not harness.context.calls
+        assert harness.auth.recovery_calls == 0
+        assert all(body.closed for body in harness.bodies[: len(harness.requests)])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize("phase", ["first_frame", "held", "committed"])
+@pytest.mark.parametrize(
+    "error_name", ["ReadTimeout", "ReadError", "RemoteProtocolError"]
+)
+async def test_transport_failure_retries_only_before_commit(
+    backend: str,
+    native: bool,
+    phase: str,
+    error_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    http = httpx2 if backend == "sdk" else httpx
+    error = getattr(http, error_name)("connection lost")
+    committed = phase == "committed"
+
+    class BrokenBody(Body):
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            yield self.text.encode()
+            raise error
+
+    async with harness_for(backend, monkeypatch) as harness:
+        harness.bodies.extend(
+            [
+                BrokenBody(
+                    ""
+                    if phase == "first_frame"
+                    else _sse(
+                        response_event("response.created"),
+                        _text_delta("x" * 70_000 if committed else "hidden"),
+                    )
+                ),
+                Body(
+                    _sse(
+                        _text_delta("replacement"), response_event("response.completed")
+                    )
+                ),
+            ]
+        )
+        if committed and not native:
+            with pytest.raises(ExecutionFailure) as caught:
+                await collect(harness.stream(native))
+            assert caught.value.retryable
+            assert caught.value.__cause__ is error
+        else:
+            events = parse_sse_text(await collect(harness.stream(native)))
+            assert events[-1].event == (
+                "response.failed"
+                if committed
+                else "response.completed"
+                if native
+                else "message_stop"
+            )
+        assert len(harness.requests) == (1 if committed else 2)
+        assert harness.bodies[0].closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"])
+async def test_sse_framing_preserves_unicode_across_single_byte_chunks(
+    backend: str,
+    native: bool,
+    newline: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    value = "A\u0085B\u2028C\u2029D"
+
+    class FragmentedBody(Body):
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            for byte in self.text.encode():
+                yield bytes([byte])
+
+    # Literal Unicode and split CRLF/UTF-8 bytes exercise framing, not JSON escapes.
+    arguments = json.dumps({"value": value}, ensure_ascii=False)
+    payloads = [
+        response_event("response.created"),
+        _text_delta(value),
+        {"type": "response.reasoning_summary_text.delta", "delta": value},
+        {
+            "type": "response.output_item.added",
+            "output_index": 1,
+            "item": {
+                "type": "function_call",
+                "id": "fc_unicode",
+                "call_id": "call_unicode",
+                "name": "inspect",
+                "arguments": "",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_unicode",
+            "output_index": 1,
+            "delta": arguments,
+        },
+        response_event("response.completed"),
+    ]
+    wire = "\ufeff: comment" + newline + newline
+    wire += "".join(
+        "data: " + json.dumps(event, ensure_ascii=False) + newline * 2
+        for event in payloads
+    )
+    async with harness_for(backend, monkeypatch) as harness:
+        harness.bodies.extend(FragmentedBody(wire) for _ in range(3))
+        events = parse_sse_text(await collect(harness.stream(native)))
+        deltas = [event.data.get("delta") for event in events]
+        assert (
+            value in deltas
+            if native
+            else {"type": "text_delta", "text": value} in deltas
+        )
+        if native:
+            assert deltas.count(value) == 2 and arguments in deltas
+        else:
+            assert {"type": "thinking_delta", "thinking": value} in deltas
+            assert {"type": "input_json_delta", "partial_json": arguments} in deltas
+        assert len(harness.requests) == 1 and harness.bodies[0].closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+async def test_rejected_probe_does_not_release_waiters_as_success(
+    backend: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with harness_for(backend, monkeypatch) as harness:
+        admission = harness.provider._admission
+        owner = admission.start_execution()
+        initial = await owner.open_attempt(ProviderOperationKind.GENERATION)
+        await initial.fail(httpx.ReadError("offline"))
+        await initial.aclose()
+        await owner.aclose()
+        failure = {
+            "type": "error",
+            "error": {"code": "rate_limit_exceeded", "message": "retry shortly"},
+        }
+        harness.bodies.extend(Body(_sse(failure)) for _ in range(3))
+        with pytest.raises(ExecutionFailure):
+            await collect(harness.stream(True))
+        assert admission._episode is not None
+        assert admission._episode.terminal_until is not None
+        assert len(harness.requests) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
 @pytest.mark.parametrize("complete", [False, True])
-async def test_parser_finishes_before_physical_response_release(
+async def test_attempt_release_finishes_parser_and_physical_response(
     backend: str, native: bool, complete: bool, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     parsers: list[AsyncGeneratorType] = []
@@ -241,19 +488,26 @@ async def test_parser_finishes_before_physical_response_release(
         parsers.append(parser)
         return parser
 
-    class ParserAwareBody(Body):
-        async def aclose(self) -> None:
-            assert parsers and all(parser.ag_frame is None for parser in parsers)
-            await super().aclose()
-
     monkeypatch.setattr(responses_events, "_decode_sse", record)
     async with harness_for(backend, monkeypatch) as harness:
-        body = ParserAwareBody(
+        body = Body(
             _sse(response_event("response.completed"))
             if complete
             else _sse(response_event("response.created"), _text_delta("x" * 70_000))
         )
         harness.bodies.append(body)
+        release = harness.provider._admission._release_concurrency
+
+        def release_slot() -> None:
+            # httpx2 closes its physical response while unwinding the byte
+            # iterator. Both lifetimes must end before the attempt releases.
+            assert body.closed
+            assert parsers and all(parser.ag_frame is None for parser in parsers)
+            release()
+
+        monkeypatch.setattr(
+            harness.provider._admission, "_release_concurrency", release_slot
+        )
         stream = harness.stream(native)
         if complete:
             await collect(stream)

--- a/tests/providers/test_responses_execution.py
+++ b/tests/providers/test_responses_execution.py
@@ -194,6 +194,32 @@ async def collect(stream: AsyncIterator[str]) -> str:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize("label", ["message", "envelope"])
+async def test_responses_payload_type_controls_successful_presentation(
+    backend: str,
+    native: bool,
+    label: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wire = "".join(
+        f"event: {label}\ndata: {json.dumps(event)}\n\n"
+        for event in [
+            response_event("response.created"),
+            _text_delta("preserved"),
+            response_event("response.completed"),
+        ]
+    )
+    async with harness_for(backend, monkeypatch) as harness:
+        harness.bodies.extend(Body(wire) for _ in range(3))
+        events = parse_sse_text(await collect(harness.stream(native)))
+        assert events[-1].event == ("response.completed" if native else "message_stop")
+        assert "preserved" in json.dumps([event.data for event in events])
+        assert len(harness.requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
 async def test_first_frame_rejection_does_not_accept_provider_recovery(
     backend: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/providers/test_responses_execution.py
+++ b/tests/providers/test_responses_execution.py
@@ -1,0 +1,415 @@
+"""Lifecycle ownership through both real Responses backends and client projections."""
+
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from types import AsyncGeneratorType
+
+import httpx
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.failures import ExecutionFailure
+from free_claude_code.core.json_types import JsonObject
+from free_claude_code.core.openai_responses import OpenAIResponsesRequest
+from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY
+from free_claude_code.providers.admission import (
+    ProviderAttempt,
+    ProviderExecution,
+    ProviderExecutionState,
+)
+from free_claude_code.providers.http import maybe_await_aclose
+from free_claude_code.providers.openai_codex.provider import OpenAICodexProvider
+from free_claude_code.providers.openai_responses import OpenAIResponsesTransport
+from free_claude_code.providers.openai_responses import events as responses_events
+from tests.providers.support import immediate_admission
+from tests.providers.test_endpoint_context_transports import Context
+from tests.providers.test_openai_codex_provider import _config, _FakeAuth
+from tests.providers.test_openai_responses_transport import (
+    _completed_response,
+    _sse,
+    _text_delta,
+)
+
+
+class Body(httpx.AsyncByteStream, httpx2.AsyncByteStream):
+    """One wire response with an observable read/close boundary."""
+
+    def __init__(self, text: str, *, block: bool = False, close_error: bool = False):
+        self.text = text
+        self.block = block
+        self.close_error = close_error
+        self.read_tail = asyncio.Event()
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield self.text.encode()
+        self.read_tail.set()
+        if self.block:
+            await asyncio.Future()
+
+    async def aclose(self) -> None:
+        self.closed = True
+        if self.close_error:
+            raise RuntimeError("physical close failed")
+
+
+@dataclass
+class Harness:
+    provider: OpenAIResponsesTransport | OpenAICodexProvider
+    context: Context
+    auth: _FakeAuth
+    bodies: list[Body] = field(default_factory=list)
+    requests: list[httpx.Request | httpx2.Request] = field(default_factory=list)
+    executions: list[ProviderExecution] = field(default_factory=list)
+
+    def stream(self, native: bool) -> AsyncIterator[str]:
+        kwargs = (
+            {"endpoint_context": self.context}
+            if isinstance(self.provider, OpenAIResponsesTransport)
+            else {}
+        )
+        if native:
+            return self.provider.stream_responses(
+                OpenAIResponsesRequest(model="upstream", input="hello"),
+                input_tokens=1,
+                request_id="req_lifecycle",
+                response_model="public",
+                reasoning=DEFAULT_REASONING_POLICY,
+                **kwargs,
+            )
+        return self.provider.stream_messages(
+            MessagesRequest(
+                model="upstream", messages=[{"role": "user", "content": "hello"}]
+            ),
+            input_tokens=1,
+            request_id="req_lifecycle",
+            response_model="public",
+            reasoning=DEFAULT_REASONING_POLICY,
+            **kwargs,
+        )
+
+
+@asynccontextmanager
+async def harness_for(
+    backend: str, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[Harness]:
+    admission = immediate_admission(max_attempts=3, max_concurrency=1)
+    context, auth = Context("session"), _FakeAuth()
+
+    def wire(request: httpx.Request | httpx2.Request) -> Body:
+        index = len(harness.requests)
+        if index:
+            assert harness.bodies[index - 1].closed
+        harness.requests.append(request)
+        return harness.bodies[index]
+
+    if backend == "sdk":
+        pool = httpx2.MockTransport(
+            lambda request: httpx2.Response(
+                200, headers={"content-type": "text/event-stream"}, stream=wire(request)
+            )
+        )
+        client = AsyncOpenAI(
+            api_key="test",
+            http_client=httpx2.AsyncClient(transport=pool),
+            max_retries=0,
+        )
+        provider = OpenAIResponsesTransport(
+            client=client,
+            endpoint_transport=pool,
+            admission=admission,
+            provider_name="test",
+            read_timeout_s=1,
+            log_raw_sse_events=False,
+        )
+    else:
+        client = httpx.AsyncClient(
+            base_url=_config().base_url,
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    stream=wire(request),
+                )
+            ),
+        )
+        provider = OpenAICodexProvider(
+            _config(), client=client, auth=auth, admission=admission
+        )
+    harness = Harness(provider, context, auth)
+    start_execution = admission.start_execution
+
+    def record(*, request_id: str | None = None) -> ProviderExecution:
+        execution = start_execution(request_id=request_id)
+        harness.executions.append(execution)
+        return execution
+
+    monkeypatch.setattr(admission, "start_execution", record)
+    try:
+        yield harness
+    finally:
+        if isinstance(client, AsyncOpenAI):
+            await client.close()
+        else:
+            await client.aclose()
+
+
+def response_event(
+    event_type: str, response_id: str = "resp_visible"
+) -> dict[str, object]:
+    return {
+        "type": event_type,
+        "response": {
+            **_completed_response(),
+            "id": response_id,
+            "status": "completed"
+            if event_type == "response.completed"
+            else "in_progress",
+        },
+    }
+
+
+def auth_failure() -> dict[str, object]:
+    return {
+        "type": "response.failed",
+        "response": {
+            **_completed_response(),
+            "id": "resp_visible",
+            "status": "failed",
+            "error": {"code": "invalid_api_key", "message": "expired"},
+        },
+    }
+
+
+async def collect(stream: AsyncIterator[str]) -> str:
+    return "".join([chunk async for chunk in stream])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+async def test_decoded_error_accepts_attempt_before_classification(
+    backend: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    accepted: list[ProviderAttempt] = []
+    accept = ProviderAttempt.accept
+
+    async def record(attempt: ProviderAttempt) -> None:
+        await accept(attempt)
+        accepted.append(attempt)
+
+    monkeypatch.setattr(ProviderAttempt, "accept", record)
+    async with harness_for(backend, monkeypatch) as harness:
+        harness.bodies.append(
+            Body(
+                _sse(
+                    {
+                        "type": "error",
+                        "error": {
+                            "code": "server_error",
+                            "message": "try again",
+                        },
+                    }
+                )
+            )
+        )
+        harness.bodies.append(Body(_sse(response_event("response.completed"))))
+        await collect(harness.stream(True))
+        assert len(accepted) == 2
+        assert len(harness.requests) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize("complete", [False, True])
+async def test_parser_finishes_before_physical_response_release(
+    backend: str, native: bool, complete: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parsers: list[AsyncGeneratorType] = []
+    decode = responses_events._decode_sse
+
+    def record(
+        response: httpx.Response | httpx2.Response,
+    ) -> AsyncGenerator[tuple[str, JsonObject]]:
+        parser = decode(response)
+        assert isinstance(parser, AsyncGeneratorType)
+        parsers.append(parser)
+        return parser
+
+    class ParserAwareBody(Body):
+        async def aclose(self) -> None:
+            assert parsers and all(parser.ag_frame is None for parser in parsers)
+            await super().aclose()
+
+    monkeypatch.setattr(responses_events, "_decode_sse", record)
+    async with harness_for(backend, monkeypatch) as harness:
+        body = ParserAwareBody(
+            _sse(response_event("response.completed"))
+            if complete
+            else _sse(response_event("response.created"), _text_delta("x" * 70_000))
+        )
+        harness.bodies.append(body)
+        stream = harness.stream(native)
+        if complete:
+            await collect(stream)
+        else:
+            await anext(stream)
+            await maybe_await_aclose(stream)
+        assert body.closed
+        assert len(parsers) == 1 and parsers[0].ag_frame is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+async def test_terminal_ends_without_reading_tail_and_releases_permit(
+    backend: str, native: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with harness_for(backend, monkeypatch) as harness:
+        first = Body(_sse(response_event("response.completed")), block=True)
+        harness.bodies.extend([first, Body(first.text)])
+        async with asyncio.timeout(2):
+            await collect(harness.stream(native))
+            await collect(harness.stream(native))
+        assert first.closed and not first.read_tail.is_set()
+        assert all(
+            execution.state is ProviderExecutionState.SUCCEEDED
+            for execution in harness.executions
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+async def test_hidden_retry_replaces_attempt_identity_and_keeps_logical_session(
+    backend: str, native: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with harness_for(backend, monkeypatch) as harness:
+        harness.bodies.extend(
+            [
+                Body(_sse(response_event("response.created", "resp_hidden"))),
+                Body(
+                    _sse(
+                        response_event("response.created"),
+                        response_event("response.completed"),
+                    )
+                ),
+            ]
+        )
+        text = await collect(harness.stream(native))
+        assert "resp_hidden" not in text
+        events = parse_sse_text(text)
+        assert (
+            sum(
+                event.event == ("response.created" if native else "message_start")
+                for event in events
+            )
+            == 1
+        )
+        if native:
+            assert all(
+                event.data["response"]["id"] == "resp_visible" for event in events
+            )
+        assert len(harness.requests) == 2
+        if backend == "codex":
+            assert (
+                harness.requests[0].headers["session_id"]
+                == harness.requests[1].headers["session_id"]
+            )
+        (execution,) = harness.executions
+        assert execution.attempts_started == 2
+        assert execution.state is ProviderExecutionState.SUCCEEDED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+async def test_committed_auth_failure_cannot_replay_or_refresh_and_records_failure(
+    backend: str, native: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with harness_for(backend, monkeypatch) as harness:
+        harness.bodies.append(
+            Body(
+                _sse(
+                    response_event("response.created"),
+                    _text_delta("x" * 70_000),
+                    auth_failure(),
+                )
+            )
+        )
+        chunks: list[str] = []
+
+        async def consume() -> None:
+            async for chunk in harness.stream(native):
+                assert chunk
+                chunks.append(chunk)
+
+        if native:
+            await consume()
+            events = parse_sse_text("".join(chunks))
+            assert sum(event.event == "response.failed" for event in events) == 1
+            assert events[-1].data["response"]["id"] == "resp_visible"
+        else:
+            with pytest.raises(ExecutionFailure):
+                await consume()
+            assert parse_sse_text("".join(chunks))[-1].event == "content_block_stop"
+        assert len(harness.requests) == 1 and harness.bodies[0].closed
+        assert harness.auth.recovery_calls == 0
+        assert harness.context.calls == ([False] if backend == "sdk" else [])
+        assert harness.executions[0].state is ProviderExecutionState.FAILED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_consumer_exit_closes_physical_stream_and_abandons_operation(
+    backend: str, native: bool, cancel: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with harness_for(backend, monkeypatch) as harness:
+        first = Body(
+            _sse(
+                response_event("response.created"),
+                _text_delta("x" if cancel else "x" * 70_000),
+            ),
+            block=True,
+        )
+        harness.bodies.extend([first, Body(_sse(response_event("response.completed")))])
+        stream = harness.stream(native)
+        async with asyncio.timeout(2):
+            if cancel:
+                task = asyncio.create_task(collect(stream))
+                await first.read_tail.wait()
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            else:
+                await anext(stream)
+                await maybe_await_aclose(stream)
+            assert first.closed
+            assert harness.executions[0].state is ProviderExecutionState.ABANDONED
+            await collect(harness.stream(native))
+        assert harness.executions[1].state is ProviderExecutionState.SUCCEEDED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["sdk", "codex"])
+@pytest.mark.parametrize("native", [False, True])
+async def test_close_failure_preserves_success_and_permit_reuse(
+    backend: str, native: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with harness_for(backend, monkeypatch) as harness:
+        body = _sse(response_event("response.completed"))
+        harness.bodies.extend([Body(body, close_error=True), Body(body)])
+        async with asyncio.timeout(2):
+            await collect(harness.stream(native))
+            await collect(harness.stream(native))
+        assert all(
+            execution.state is ProviderExecutionState.SUCCEEDED
+            for execution in harness.executions
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.22.5"
+version = "5.22.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

SDK-backed Responses and Codex separately owned admission, retries, terminal handling, and cleanup. That duplication allowed completed responses to fail, structured errors to lose their recovery meaning, and credential failures to consume inference attempts.

## How

Give Responses generation one lifecycle owner, with backend adapters for connection and authentication mechanics and separate Messages and native Responses presenters. Resolve credentials after admission waiting and before charging an inference attempt, so queued requests recheck account authority and expiry before dispatch.

Decode SSE using its byte framing rules. Keep complete raw failure evidence separate from normalized presentation payloads, and classify it through shared provider policy. Recognize both HTTP transport libraries, distinguish provider rejection from acceptance, and retain bounded recovery before public output commitment.

Close request resources and recovery ownership when execution ends, including Codex model discovery. Remove duplicate runners and endpoint-owned replay policy. Add regressions for both backends and ingress formats covering text, reasoning, tools, queued account changes, failure classification, retries, and cleanup. Bump the package once from 5.22.5 to 5.22.6.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update consolidates provider execution lifecycle handling across SDK-backed and Codex Responses transports. It also updates streaming, retry, authentication recovery, terminal cleanup, transport adapters, and related test coverage, with the package version updated to 5.22.6.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge.

There are no outstanding findings.

**Files Needing Attention:** None.

<sub>Reviews (3): Last reviewed commit: ["fix: interpret Responses evidence indepe..."](https://github.com/alishahryar1/free-claude-code/commit/f591194530445a8aa3ad779569675e66603155df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60819200)</sub>

<!-- /greptile_comment -->