### PR TITLE
Consolidate Codex Responses on the shared SDK transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.22.5"
+version = "5.22.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/core/openai_responses/provider_stream.py
+++ b/src/free_claude_code/core/openai_responses/provider_stream.py
@@ -16,12 +16,14 @@ class ResponsesStreamFailure(RuntimeError):
         message: str,
         *,
         code: str | None = None,
+        body: dict[str, Any] | None = None,
         event_type: str | None = None,
         payload: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(message)
         self.message = message
         self.code = code
+        self.body = body
         self.event_type = event_type
         self.payload = payload
 
@@ -252,10 +254,11 @@ def responses_stream_failure_from_event(
     if not isinstance(error, dict):
         error = data if event_type == "error" else {}
     message = error.get("message")
-    code = error.get("code", error.get("type"))
+    code = error.get("code") or error.get("type")
     return ResponsesStreamFailure(
         message if isinstance(message, str) and message else "OpenAI response failed.",
         code=code if isinstance(code, str) else None,
+        body=dict(error),
         event_type=event_type,
         payload=data,
     )

--- a/src/free_claude_code/providers/endpoint.py
+++ b/src/free_claude_code/providers/endpoint.py
@@ -80,8 +80,14 @@ class RequestEndpoint:
         self._omit_authorization = (
             endpoint.api_key is None and "authorization" not in headers
         )
-        if "authorization" in headers:
-            headers["Authorization"] = headers.pop("authorization")
+        # SDK defaults are merged as a case-sensitive mapping before HTTP parsing.
+        # Match their spelling so an endpoint replaces, rather than duplicates, them.
+        sdk_header_names = {"authorization": "Authorization"}
+        for name in client.default_headers:
+            sdk_header_names.setdefault(name.lower(), name)
+        headers = {
+            sdk_header_names.get(name, name): value for name, value in headers.items()
+        }
 
         async def credential() -> str:
             # A callable also overrides an inherited key with an empty credential.

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from typing import Any
 
 import httpx
+import httpx2
 import openai
 
 from free_claude_code.core.anthropic.errors import anthropic_status_for_error_type
@@ -242,11 +243,11 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
         (
             TimeoutError,
             httpx.TimeoutException,
-            httpx.ConnectError,
-            httpx.ReadError,
-            httpx.WriteError,
+            httpx2.TimeoutException,
             httpx.RemoteProtocolError,
+            httpx2.RemoteProtocolError,
             httpx.NetworkError,
+            httpx2.NetworkError,
             openai.APITimeoutError,
             openai.APIConnectionError,
             RetryableProviderProtocolError,
@@ -269,10 +270,11 @@ def is_retryable_stream_error(exc: BaseException) -> bool:
         (
             TimeoutError,
             httpx.ReadTimeout,
-            httpx.ReadError,
+            httpx2.ReadTimeout,
             httpx.RemoteProtocolError,
-            httpx.ConnectError,
+            httpx2.RemoteProtocolError,
             httpx.NetworkError,
+            httpx2.NetworkError,
             openai.APITimeoutError,
             openai.APIConnectionError,
         ),
@@ -295,13 +297,19 @@ def provider_error_message(
         exc = underlying_provider_error(exc)
     if isinstance(exc, ExecutionFailure):
         return exc.message
-    if isinstance(exc, httpx.ReadTimeout):
+    if isinstance(exc, httpx.ReadTimeout | httpx2.ReadTimeout):
         if read_timeout_s is not None:
             return f"Provider request timed out after {read_timeout_s:g}s."
         return "Provider request timed out."
-    if isinstance(exc, httpx.ConnectTimeout | httpx.ConnectError):
+    if isinstance(
+        exc,
+        httpx.ConnectTimeout
+        | httpx2.ConnectTimeout
+        | httpx.ConnectError
+        | httpx2.ConnectError,
+    ):
         return "Could not connect to provider."
-    if isinstance(exc, httpx.RemoteProtocolError):
+    if isinstance(exc, httpx.RemoteProtocolError | httpx2.RemoteProtocolError):
         return "Provider connection was interrupted before a response was received."
     if isinstance(exc, TimeoutError):
         if read_timeout_s is not None:
@@ -413,9 +421,9 @@ def _classify_provider_failure(
         )
 
     kind = FailureKind.UPSTREAM
-    if isinstance(exc, TimeoutError | httpx.TimeoutException):
+    if isinstance(exc, TimeoutError | httpx.TimeoutException | httpx2.TimeoutException):
         kind = FailureKind.TIMEOUT
-    elif isinstance(exc, httpx.ConnectError | httpx.NetworkError):
+    elif isinstance(exc, httpx.NetworkError | httpx2.NetworkError):
         kind = FailureKind.UNAVAILABLE
     return _failure(
         kind,

--- a/src/free_claude_code/providers/openai_codex/endpoint.py
+++ b/src/free_claude_code/providers/openai_codex/endpoint.py
@@ -1,0 +1,53 @@
+"""Request-scoped subscription credentials for the Codex backend."""
+
+from collections.abc import Mapping
+
+from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.providers.endpoint import HttpEndpoint
+
+from .auth import OpenAIAccess, OpenAIAuthManager, OpenAIReconnectRequired
+
+
+class CodexEndpointContext:
+    """Borrow credentials and recover the token rejected by this request."""
+
+    def __init__(
+        self,
+        auth: OpenAIAuthManager,
+        *,
+        base_url: str,
+        headers: Mapping[str, str],
+        session_id: str | None = None,
+    ) -> None:
+        self._auth = auth
+        self._base_url = base_url
+        self._headers = dict(headers)
+        if session_id is not None:
+            self._headers.update(
+                {"session_id": session_id, "Accept": "text/event-stream"}
+            )
+        self._access: OpenAIAccess | None = None
+
+    async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
+        try:
+            if force_refresh:
+                if self._access is None:
+                    raise RuntimeError("Codex recovery requires a rejected credential.")
+                access = await self._auth.recover_unauthorized(
+                    self._access.access_token
+                )
+            else:
+                access = await self._auth.access()
+        except OpenAIReconnectRequired as error:
+            raise ExecutionFailure(
+                FailureKind.AUTHENTICATION, 401, str(error), False
+            ) from error
+        self._access = access
+        headers = {
+            **self._headers,
+            "Authorization": f"Bearer {access.access_token}",
+            "ChatGPT-Account-ID": access.account_id,
+        }
+        if access.fedramp:
+            headers["X-OpenAI-Fedramp"] = "true"
+        return HttpEndpoint(self._base_url, headers)

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -1,72 +1,34 @@
-"""ChatGPT Codex backend provider using OpenAI Responses."""
+"""ChatGPT Codex provider backed by shared SDK Responses execution."""
 
 import asyncio
-import json
 import sys
 import uuid
 from collections.abc import AsyncIterator
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-import httpx
+import httpx2
+from openai import AsyncOpenAI
 
-from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.anthropic.models import MessagesRequest
-from free_claude_code.core.diagnostics import (
-    ERROR_DETAIL_DISPLAY_CAP_BYTES,
-    attach_upstream_error_body,
-    extract_upstream_error_detail,
-)
-from free_claude_code.core.failures import ExecutionFailure, FailureKind
-from free_claude_code.core.json_types import JsonObject
-from free_claude_code.core.openai_responses import (
-    OpenAIResponsesRequest,
-    ResponsesConversionError,
-    ResponsesProviderStream,
-    ResponsesStreamFailure,
-    build_native_responses_request,
-    build_responses_provider_request,
-    responses_stream_failure_from_event,
-)
-from free_claude_code.core.openai_tool_names import OpenAIToolNameCodec
-from free_claude_code.core.reasoning import (
-    DEFAULT_REASONING_POLICY,
-    ReasoningPolicy,
-)
-from free_claude_code.core.trace import trace_event
+from free_claude_code.core.openai_responses import OpenAIResponsesRequest
+from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
-    ProviderCorrectionAction,
-    ProviderExecution,
     ProviderOperationKind,
 )
 from free_claude_code.providers.base import BaseProvider, ProviderConfig
-from free_claude_code.providers.failure_policy import (
-    RetryableProviderProtocolError,
-    classify_provider_failure,
-    context_window_exceeded_provider_failure,
-    is_context_window_error_code,
-    is_retryable_stream_error,
-    reports_context_window_incomplete,
-)
-from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
+from free_claude_code.providers.endpoint import RequestEndpoint
+from free_claude_code.providers.http import ProviderAttemptScope
 from free_claude_code.providers.model_listing import (
     optional_input_modalities,
     optional_positive_int,
 )
-from free_claude_code.providers.openai_responses.presentation import (
-    MessagesResponsesPresenter,
-    NativeResponsesPresenter,
-    ResponsesExecutionOutcome,
-    ResponsesPresenterFactory,
-)
-from free_claude_code.providers.stream_recovery import (
-    RecoveryController,
-    RecoveryFailureAction,
-)
+from free_claude_code.providers.openai_responses import OpenAIResponsesTransport
 
-from .auth import OpenAIAccess, OpenAIAuthManager, OpenAIReconnectRequired
+from .auth import OpenAIAuthManager
+from .endpoint import CodexEndpointContext
 from .login import OPENAI_CODEX_ORIGINATOR
 
 try:
@@ -75,12 +37,8 @@ except PackageNotFoundError:
     FCC_VERSION = "dev"
 
 
-class _TruncatedResponsesStream(RetryableProviderProtocolError):
-    """A Responses stream ended without a terminal lifecycle event."""
-
-
 class OpenAICodexProvider(BaseProvider):
-    """Use a ChatGPT subscription through OpenAI's Codex backend."""
+    """Own SDK resources and supply the Codex backend's request requirements."""
 
     def __init__(
         self,
@@ -88,7 +46,7 @@ class OpenAICodexProvider(BaseProvider):
         *,
         auth: OpenAIAuthManager,
         admission: ProviderAdmissionController,
-        client: httpx.AsyncClient | None = None,
+        transport: httpx2.AsyncBaseTransport | None = None,
     ) -> None:
         super().__init__(config)
         self._auth = auth
@@ -98,17 +56,40 @@ class OpenAICodexProvider(BaseProvider):
             "originator": OPENAI_CODEX_ORIGINATOR,
             "version": FCC_VERSION,
         }
-        self._client = client or httpx.AsyncClient(
-            base_url=f"{config.base_url.rstrip('/')}/",
-            proxy=config.proxy,
-            timeout=httpx.Timeout(
-                config.http_read_timeout,
-                connect=config.http_connect_timeout,
-                write=config.http_write_timeout,
-            ),
-            headers=self._client_headers,
+        self._pool = (
+            transport
+            if transport is not None
+            else httpx2.AsyncHTTPTransport(proxy=config.proxy)
         )
-        self._owns_client = client is None
+        timeout = httpx2.Timeout(
+            config.http_read_timeout,
+            connect=config.http_connect_timeout,
+            write=config.http_write_timeout,
+        )
+        self._client = AsyncOpenAI(
+            api_key=_endpoint_required,
+            base_url=config.base_url,
+            max_retries=0,
+            timeout=timeout,
+            http_client=httpx2.AsyncClient(transport=self._pool, timeout=timeout),
+        )
+        self._responses = OpenAIResponsesTransport(
+            client=self._client,
+            admission=admission,
+            provider_name="OpenAI",
+            read_timeout_s=config.http_read_timeout,
+            log_raw_sse_events=config.log_raw_sse_events,
+            endpoint_transport=self._pool,
+            omitted_request_fields=frozenset({"max_output_tokens", "metadata"}),
+        )
+
+    def _endpoint(self, *, session_id: str | None = None) -> CodexEndpointContext:
+        return CodexEndpointContext(
+            self._auth,
+            base_url=self._config.base_url,
+            headers=self._client_headers,
+            session_id=session_id,
+        )
 
     def preflight_messages(
         self,
@@ -116,9 +97,7 @@ class OpenAICodexProvider(BaseProvider):
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
     ) -> None:
-        """Validate and adapt the private Codex request before upstream I/O."""
-
-        self._build_body(request, reasoning=reasoning)
+        self._responses.preflight_messages(request, reasoning=reasoning)
 
     def preflight_responses(
         self,
@@ -126,77 +105,65 @@ class OpenAICodexProvider(BaseProvider):
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
     ) -> None:
-        """Validate one native Responses request before upstream I/O."""
-        self._build_native_body(request, reasoning=reasoning)
+        self._responses.preflight_responses(request, reasoning=reasoning)
 
     async def cleanup(self) -> None:
-        """Close only provider-owned transport resources."""
-
-        if self._owns_client:
-            await self._client.aclose()
+        await self._client.close()
 
     async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
         """Discover models visible to the currently connected ChatGPT account."""
         return _model_infos(await self._list_models_payload())
 
     async def _list_models_payload(self) -> Any:
-        """Fetch one Codex model catalog with each provider GET admitted once."""
+        """Admit each catalog GET while borrowing request-scoped SDK credentials."""
         execution = self._admission.start_execution()
-        authentication_recovered = False
-        while execution.can_attempt:
-            scope: ProviderAttemptScope | None = None
-            try:
-                access = await self._auth.access()
-                attempt = await execution.open_attempt(
-                    ProviderOperationKind.MODEL_DISCOVERY
-                )
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name="OpenAI",
-                    request_id=execution.request_id,
-                )
-                response = scope.retain(
-                    await self._client.get(
-                        "models",
-                        params={"client_version": FCC_VERSION},
-                        headers={**self._client_headers, **_auth_headers(access)},
+        endpoint = RequestEndpoint(self._endpoint(), self._pool)
+        try:
+            while execution.can_attempt:
+                scope: ProviderAttemptScope | None = None
+                try:
+                    client = await endpoint.openai_client(self._client)
+                    attempt = await execution.open_attempt(
+                        ProviderOperationKind.MODEL_DISCOVERY
                     )
-                )
-                if response.status_code == 401 and not authentication_recovered:
-                    error = await _response_status_error(response)
-                    correction = await scope.attempt.correct(error)
-                    closing_scope = scope
-                    scope = None
-                    await closing_scope.aclose(active_error=error)
-                    if correction is ProviderCorrectionAction.FINAL:
-                        raise error
-                    await self._auth.recover_unauthorized(access.access_token)
-                    authentication_recovered = True
-                    continue
-                if not response.is_success:
-                    raise await _response_status_error(response)
-                payload = response.json()
-                await scope.attempt.accept()
-                execution.succeed()
-                return payload
-            except asyncio.CancelledError:
-                execution.abandon()
-                raise
-            except Exception as error:
-                if scope is not None and not scope.attempt.accepted:
-                    decision = await scope.attempt.fail(error)
-                    if decision.retry_allowed:
-                        continue
-                execution.fail(error)
-                raise
+                    scope = ProviderAttemptScope(
+                        attempt,
+                        provider_name="OpenAI",
+                        request_id=execution.request_id,
+                    )
+                    payload = await client.get(
+                        "models",
+                        cast_to=object,
+                        options={"params": {"client_version": FCC_VERSION}},
+                    )
+                    await attempt.accept()
+                    execution.succeed()
+                    return payload
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    if scope is not None:
+                        if await endpoint.retry_authentication(
+                            error, scope.attempt, execution
+                        ):
+                            continue
+                        if not scope.attempt.accepted:
+                            decision = await scope.attempt.fail(error)
+                            if decision.retry_allowed:
+                                continue
+                    execution.fail(error)
+                    raise
+                finally:
+                    if scope is not None:
+                        await scope.aclose(active_error=sys.exception())
+            if execution.last_failure is not None:
+                raise execution.last_failure
+            raise RuntimeError("OpenAI model discovery ended without an outcome.")
+        finally:
+            try:
+                await endpoint.aclose()
             finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
-
-        if execution.last_failure is not None:
-            raise execution.last_failure
-        execution.abandon()
-        raise RuntimeError("OpenAI model discovery ended without an attempt outcome")
+                execution.abandon()
 
     def stream_messages(
         self,
@@ -207,24 +174,13 @@ class OpenAICodexProvider(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
     ) -> AsyncIterator[str]:
-        """Stream Responses output in Anthropic Messages format."""
-
-        tool_names = OpenAIToolNameCodec.from_request(request)
-        body = self._build_body(request, reasoning=reasoning)
-        message_id = f"msg_{uuid.uuid4()}"
-        return self._run_stream(
-            body,
+        return self._responses.stream_messages(
+            request,
+            input_tokens=input_tokens,
             request_id=request_id,
             response_model=response_model or request.model,
-            presenter_factory=lambda: MessagesResponsesPresenter(
-                ResponsesProviderStream(
-                    message_id=message_id,
-                    model=response_model or request.model,
-                    input_tokens=input_tokens,
-                    log_raw_events=self._config.log_raw_sse_events,
-                    tool_names=tool_names,
-                )
-            ),
+            reasoning=reasoning,
+            endpoint_context=self._endpoint(session_id=str(uuid.uuid4())),
         )
 
     def stream_responses(
@@ -236,359 +192,20 @@ class OpenAICodexProvider(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
     ) -> AsyncIterator[str]:
-        """Relay the private Codex Responses stream as native Responses SSE."""
-        del input_tokens
-        body = self._build_native_body(request, reasoning=reasoning)
-        public_model = response_model or request.model
-        return self._run_stream(
-            body,
-            request_id=request_id,
-            response_model=public_model,
-            presenter_factory=lambda: NativeResponsesPresenter(
-                public_model=public_model
-            ),
-        )
-
-    @staticmethod
-    def _build_body(
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> dict[str, Any]:
-        try:
-            body = build_responses_provider_request(request, reasoning=reasoning)
-        except ResponsesConversionError as exc:
-            raise InvalidRequestError(str(exc)) from exc
-        # The private Codex backend rejects these public Responses fields.
-        # Codex itself omits the output cap and uses separate internal metadata.
-        body.pop("max_output_tokens", None)
-        body.pop("metadata", None)
-        return body
-
-    @staticmethod
-    def _build_native_body(
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> JsonObject:
-        if not request.model.strip():
-            raise InvalidRequestError("Responses request model must not be empty.")
-        if request.input is None or request.input == "" or request.input == []:
-            raise InvalidRequestError("Responses request input must not be empty.")
-        body = build_native_responses_request(
+        return self._responses.stream_responses(
             request,
-            model=request.model,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            response_model=response_model or request.model,
             reasoning=reasoning,
-        )
-        body.pop("max_output_tokens", None)
-        body.pop("metadata", None)
-        return body
-
-    async def _run_stream(
-        self,
-        body: JsonObject,
-        *,
-        request_id: str | None,
-        response_model: str,
-        presenter_factory: ResponsesPresenterFactory,
-    ) -> AsyncIterator[str]:
-        execution = self._admission.start_execution(request_id=request_id)
-        outcome = ResponsesExecutionOutcome()
-        provider_stream = self._run_stream_execution(
-            body,
-            request_id=request_id,
-            response_model=response_model,
-            presenter_factory=presenter_factory,
-            execution=execution,
-            outcome=outcome,
-        )
-        try:
-            async for event in provider_stream:
-                yield event
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:
-            execution.fail(error)
-            raise
-        else:
-            if outcome.failure is None:
-                execution.succeed()
-            else:
-                execution.fail(outcome.failure)
-        finally:
-            await maybe_await_aclose(provider_stream)
-            execution.abandon()
-
-    async def _run_stream_execution(
-        self,
-        body: JsonObject,
-        *,
-        request_id: str | None,
-        response_model: str,
-        presenter_factory: ResponsesPresenterFactory,
-        execution: ProviderExecution,
-        outcome: ResponsesExecutionOutcome,
-    ) -> AsyncIterator[str]:
-        """Run one Codex execution while retaining Responses transport ownership."""
-        recovery = RecoveryController()
-        session_id = str(uuid.uuid4())
-        authentication_recovered = False
-        trace_event(
-            stage="provider",
-            event="provider.request.sent",
-            source="provider",
-            provider="openai",
-            request_id=request_id,
-            execution_id=execution.execution_id,
-            gateway_model=response_model,
-            downstream_model=body.get("model"),
-            item_count=len(body.get("input", [])),
-            tool_count=len(body.get("tools", [])),
-        )
-
-        while execution.can_attempt:
-            presenter = presenter_factory()
-            start_events = tuple(presenter.start())
-            presenter_started = False
-
-            scope: ProviderAttemptScope | None = None
-            stream_opened = False
-            try:
-                access = await self._auth.access()
-                attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
-                scope = ProviderAttemptScope(
-                    attempt,
-                    provider_name="OpenAI",
-                    request_id=request_id,
-                )
-                response = scope.retain(
-                    await self._client.send(
-                        self._client.build_request(
-                            "POST",
-                            "responses",
-                            json=body,
-                            headers={
-                                **self._client_headers,
-                                **_auth_headers(access),
-                                "Accept": "text/event-stream",
-                                "session_id": session_id,
-                            },
-                        ),
-                        stream=True,
-                    )
-                )
-                if response.status_code == 401 and not authentication_recovered:
-                    error = await _response_status_error(response)
-                    correction = await scope.attempt.correct(error)
-                    closing_scope = scope
-                    scope = None
-                    await closing_scope.aclose(active_error=error)
-                    if correction is ProviderCorrectionAction.FINAL:
-                        raise error
-                    recovery.discard()
-                    await self._auth.recover_unauthorized(access.access_token)
-                    authentication_recovered = True
-                    continue
-                if not response.is_success:
-                    raise await _response_status_error(response)
-                content_type = response.headers.get("content-type")
-                if content_type and "text/event-stream" not in content_type.lower():
-                    body_bytes, body_truncated = await _read_bounded_body(response)
-                    error = _TruncatedResponsesStream(
-                        "OpenAI returned a non-streaming Responses payload."
-                    )
-                    attach_upstream_error_body(
-                        error,
-                        body_bytes,
-                        truncated=body_truncated,
-                    )
-                    raise error
-                stream_opened = True
-
-                async for event_type, payload in _iter_sse(response):
-                    if not scope.attempt.accepted:
-                        await scope.attempt.accept()
-                    if not presenter_started:
-                        presenter_started = True
-                        for event in start_events:
-                            for held in recovery.push(event):
-                                yield held
-                    if reports_context_window_incomplete(event_type, payload):
-                        raise context_window_exceeded_provider_failure()
-                    if event_type in {
-                        "response.failed",
-                        "error",
-                        "response.error",
-                    }:
-                        raise responses_stream_failure_from_event(
-                            event_type,
-                            payload,
-                        )
-                    for event in presenter.feed(event_type, payload):
-                        for held in recovery.push(event):
-                            yield held
-                if not presenter.completed:
-                    raise _TruncatedResponsesStream(
-                        "OpenAI Responses stream ended without a terminal event."
-                    )
-                for event in recovery.flush():
-                    yield event
-                trace_event(
-                    stage="provider",
-                    event="provider.response.completed",
-                    source="provider",
-                    provider="openai",
-                    request_id=request_id,
-                )
-                return
-            except asyncio.CancelledError, GeneratorExit:
-                raise
-            except Exception as raw_error:
-                error = _effective_error(raw_error)
-                attempt_failure = None
-                if scope is not None and not scope.attempt.accepted:
-                    attempt_failure = await scope.attempt.fail(error)
-                if attempt_failure is not None and attempt_failure.retry_allowed:
-                    recovery.discard()
-                    trace_event(
-                        stage="provider",
-                        event="provider.recovery.early_retry",
-                        source="provider",
-                        provider="openai",
-                        request_id=request_id,
-                        attempts_started=execution.attempts_started,
-                        max_attempts=execution.max_attempts,
-                    )
-                    continue
-                retryable = (
-                    attempt_failure.retryable
-                    if attempt_failure is not None
-                    else is_retryable_stream_error(error)
-                )
-                decision = recovery.advance_failure(
-                    retryable=retryable,
-                    stream_opened=stream_opened,
-                    generated_output=recovery.committed,
-                    complete_tool_salvageable=False,
-                    attempts_remaining=execution.attempts_remaining,
-                )
-                if decision.action is RecoveryFailureAction.EARLY_RETRY:
-                    recovery.discard()
-                    trace_event(
-                        stage="provider",
-                        event="provider.recovery.early_retry",
-                        source="provider",
-                        provider="openai",
-                        request_id=request_id,
-                        attempts_started=execution.attempts_started,
-                        max_attempts=execution.max_attempts,
-                    )
-                    continue
-
-                failure = classify_provider_failure(
-                    error,
-                    provider_name="OpenAI",
-                    read_timeout_s=self._config.http_read_timeout,
-                    request_id=request_id,
-                )
-                self._log_stream_transport_error(
-                    "OPENAI",
-                    f" request_id={request_id}" if request_id else "",
-                    error,
-                    request_id=request_id,
-                )
-                if not decision.committed:
-                    recovery.discard()
-                    raise failure from raw_error
-                for event in presenter.terminal_failure(raw_error, failure):
-                    yield event
-                if presenter.terminal_failure_completes_wire:
-                    outcome.failure = failure
-                    return
-                raise failure from raw_error
-            finally:
-                if scope is not None:
-                    await scope.aclose(active_error=sys.exception())
-
-        if execution.last_failure is not None:
-            raise execution.last_failure
-        raise RuntimeError("OpenAI execution ended without a terminal result.")
-
-
-async def _iter_sse(
-    response: httpx.Response,
-) -> AsyncIterator[tuple[str, dict[str, Any]]]:
-    event_type = ""
-    data_lines: list[str] = []
-    async for line in response.aiter_lines():
-        if not line:
-            if not data_lines:
-                event_type = ""
-                continue
-            raw_data = "\n".join(data_lines)
-            data_lines = []
-            if raw_data == "[DONE]":
-                return
-            try:
-                payload = json.loads(raw_data)
-            except json.JSONDecodeError as exc:
-                raise _TruncatedResponsesStream(
-                    "OpenAI returned malformed Responses SSE."
-                ) from exc
-            if not isinstance(payload, dict):
-                raise _TruncatedResponsesStream(
-                    "OpenAI returned a non-object Responses event."
-                )
-            resolved_type = event_type or payload.get("type")
-            event_type = ""
-            if isinstance(resolved_type, str) and resolved_type:
-                yield resolved_type, payload
-            continue
-        if line.startswith("event:"):
-            event_type = line[6:].strip()
-        elif line.startswith("data:"):
-            data_lines.append(line[5:].lstrip())
-    if data_lines:
-        raise _TruncatedResponsesStream(
-            "OpenAI Responses stream ended during an SSE event."
+            endpoint_context=self._endpoint(session_id=str(uuid.uuid4())),
         )
 
 
-async def _read_bounded_body(
-    response: httpx.Response,
-) -> tuple[bytes, bool]:
-    limit = ERROR_DETAIL_DISPLAY_CAP_BYTES
-    body = bytearray()
-    async for chunk in response.aiter_bytes():
-        remaining = limit + 1 - len(body)
-        if remaining <= 0:
-            break
-        body.extend(chunk[:remaining])
-        if len(body) > limit:
-            break
-    truncated = len(body) > limit
-    return bytes(body[:limit]), truncated
-
-
-async def _response_status_error(response: httpx.Response) -> httpx.HTTPStatusError:
-    """Return one bounded, diagnostic-preserving HTTP status failure."""
-    body, truncated = await _read_bounded_body(response)
-    try:
-        response.raise_for_status()
-    except httpx.HTTPStatusError as error:
-        attach_upstream_error_body(error, body, truncated=truncated)
-        return error
-    raise RuntimeError("response status is successful")
-
-
-def _auth_headers(access: OpenAIAccess) -> dict[str, str]:
-    headers = {
-        "Authorization": f"Bearer {access.access_token}",
-        "ChatGPT-Account-ID": access.account_id,
-    }
-    if access.fedramp:
-        headers["X-OpenAI-Fedramp"] = "true"
-    return headers
+async def _endpoint_required() -> str:
+    raise RuntimeError(
+        "Codex requests require request-scoped subscription credentials."
+    )
 
 
 def _model_infos(payload: Any) -> frozenset[ProviderModelInfo]:
@@ -637,31 +254,3 @@ def _supports_reasoning(levels: object) -> bool | None:
         if not isinstance(effort, str) or not effort.strip():
             return None
     return bool(levels)
-
-
-def _effective_error(error: Exception) -> Exception:
-    if isinstance(error, OpenAIReconnectRequired):
-        return ExecutionFailure(
-            kind=FailureKind.AUTHENTICATION,
-            status_code=401,
-            message=str(error),
-            retryable=False,
-        )
-    if isinstance(error, ResponsesStreamFailure):
-        message = (
-            extract_upstream_error_detail(error).exception_text
-            or "OpenAI response failed."
-        )
-        if is_context_window_error_code(error.code):
-            return context_window_exceeded_provider_failure()
-        code = (error.code or "").lower()
-        if "rate" in code or "429" in code:
-            return ExecutionFailure(FailureKind.RATE_LIMIT, 429, message, True)
-        if any(marker in code for marker in ("overload", "capacity", "529")):
-            return ExecutionFailure(FailureKind.OVERLOADED, 529, message, True)
-        retryable = any(
-            marker in code
-            for marker in ("server", "internal", "unavailable", "timeout")
-        )
-        return ExecutionFailure(FailureKind.UPSTREAM, 502, message, retryable)
-    return error

--- a/src/free_claude_code/providers/openai_responses/__init__.py
+++ b/src/free_claude_code/providers/openai_responses/__init__.py
@@ -1,4 +1,4 @@
-"""Standard OpenAI Responses provider transport."""
+"""Shared OpenAI Responses provider transport."""
 
 from .transport import OpenAIResponsesTransport
 

--- a/src/free_claude_code/providers/openai_responses/presentation.py
+++ b/src/free_claude_code/providers/openai_responses/presentation.py
@@ -1,4 +1,4 @@
-"""Client-protocol presenters shared by Responses upstream transports."""
+"""Client-protocol presenters for the shared Responses transport."""
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass

--- a/src/free_claude_code/providers/openai_responses/transport.py
+++ b/src/free_claude_code/providers/openai_responses/transport.py
@@ -1,4 +1,4 @@
-"""Standard API-key OpenAI Responses execution over the official SDK."""
+"""Shared OpenAI Responses execution over the official SDK."""
 
 import asyncio
 import sys
@@ -92,10 +92,12 @@ class OpenAIResponsesTransport:
         log_raw_sse_events: bool,
         endpoint_transport: httpx2.AsyncBaseTransport | None = None,
         event_adapter_factory: Callable[[], ResponsesEventAdapter] | None = None,
+        omitted_request_fields: frozenset[str] = frozenset(),
     ) -> None:
         self._client = client
         self._endpoint_transport = endpoint_transport
         self._event_adapter_factory = event_adapter_factory
+        self._omitted_request_fields = omitted_request_fields
         self._admission = admission
         self._provider_name = provider_name
         self._read_timeout_s = read_timeout_s
@@ -168,25 +170,27 @@ class OpenAIResponsesTransport:
             ),
         )
 
-    @staticmethod
     def _build_messages_body(
+        self,
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
     ) -> JsonObject:
         try:
-            return cast(
-                JsonObject,
+            return self._prepare_body(
                 cast(
-                    ResponseCreateParamsStreaming,
-                    build_responses_provider_request(request, reasoning=reasoning),
-                ),
+                    JsonObject,
+                    cast(
+                        ResponseCreateParamsStreaming,
+                        build_responses_provider_request(request, reasoning=reasoning),
+                    ),
+                )
             )
         except ResponsesConversionError as exc:
             raise InvalidRequestError(str(exc)) from exc
 
-    @staticmethod
     def _build_native_body(
+        self,
         request: OpenAIResponsesRequest,
         *,
         reasoning: ReasoningPolicy,
@@ -195,11 +199,18 @@ class OpenAIResponsesTransport:
             raise InvalidRequestError("Responses request model must not be empty.")
         if request.input is None or request.input == "" or request.input == []:
             raise InvalidRequestError("Responses request input must not be empty.")
-        return build_native_responses_request(
-            request,
-            model=request.model,
-            reasoning=reasoning,
+        return self._prepare_body(
+            build_native_responses_request(
+                request,
+                model=request.model,
+                reasoning=reasoning,
+            )
         )
+
+    def _prepare_body(self, body: JsonObject) -> JsonObject:
+        for field in self._omitted_request_fields:
+            body.pop(field, None)
+        return body
 
     async def _run_stream(
         self,
@@ -288,13 +299,20 @@ class OpenAIResponsesTransport:
             scope: ProviderAttemptScope | None = None
             stream_opened = False
             try:
+                client = (
+                    await endpoint.openai_client(self._client)
+                    if endpoint is not None
+                    else self._client
+                )
                 attempt = await execution.open_attempt(ProviderOperationKind.GENERATION)
                 scope = ProviderAttemptScope(
                     attempt,
                     provider_name=self._provider_name,
                     request_id=request_id,
                 )
-                sdk_stream = await self._create_sdk_stream(body, endpoint=endpoint)
+                sdk_stream = await self._create_sdk_stream(
+                    body, client=client, endpoint=endpoint
+                )
                 stream = scope.retain(_ClosableResponsesStream(sdk_stream))
                 stream_opened = True
 
@@ -442,6 +460,7 @@ class OpenAIResponsesTransport:
         self,
         body: JsonObject,
         *,
+        client: AsyncOpenAI,
         endpoint: RequestEndpoint | None = None,
     ) -> AsyncStream[ResponseStreamEvent]:
         model = body.get("model")
@@ -453,11 +472,6 @@ class OpenAIResponsesTransport:
             for key, value in body.items()
             if key not in {"model", "input", "stream", "store"}
         }
-        client = (
-            await endpoint.openai_client(self._client)
-            if endpoint is not None
-            else self._client
-        )
         return await client.responses.create(
             model=model,
             input=input_value,

--- a/tests/api/test_openai_codex_compatibility.py
+++ b/tests/api/test_openai_codex_compatibility.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 import pytest
 from fastapi.testclient import TestClient
 
@@ -55,22 +55,18 @@ def _complete_stream(text: str) -> str:
 
 
 def _openai_provider(
-    upstream_requests: list[httpx.Request],
+    upstream_requests: list[httpx2.Request],
     *,
     response_text: str,
-) -> tuple[OpenAICodexProvider, httpx.AsyncClient]:
-    def handler(request: httpx.Request) -> httpx.Response:
+) -> OpenAICodexProvider:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         upstream_requests.append(request)
-        return httpx.Response(
+        return httpx2.Response(
             200,
             content=_complete_stream(response_text).encode(),
             request=request,
         )
 
-    upstream_client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
     provider = OpenAICodexProvider(
         make_provider_config(
             api_key="",
@@ -89,15 +85,15 @@ def _openai_provider(
             max_delay=0,
             jitter=0,
         ),
-        client=upstream_client,
+        transport=httpx2.MockTransport(handler),
     )
-    return provider, upstream_client
+    return provider
 
 
 @pytest.mark.asyncio
 async def test_messages_accepts_current_claude_controls_for_openai_provider() -> None:
-    upstream_requests: list[httpx.Request] = []
-    provider, upstream_client = _openai_provider(
+    upstream_requests: list[httpx2.Request] = []
+    provider = _openai_provider(
         upstream_requests,
         response_text="hello",
     )
@@ -126,7 +122,7 @@ async def test_messages_accepts_current_claude_controls_for_openai_provider() ->
                 },
             )
     finally:
-        await upstream_client.aclose()
+        await provider.cleanup()
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/event-stream")
@@ -145,8 +141,8 @@ async def test_messages_accepts_current_claude_controls_for_openai_provider() ->
 
 @pytest.mark.asyncio
 async def test_messages_auto_mode_classifier_composes_with_openai_provider() -> None:
-    upstream_requests: list[httpx.Request] = []
-    provider, upstream_client = _openai_provider(
+    upstream_requests: list[httpx2.Request] = []
+    provider = _openai_provider(
         upstream_requests,
         response_text="<severity>0</severity>",
     )
@@ -177,7 +173,7 @@ async def test_messages_auto_mode_classifier_composes_with_openai_provider() -> 
                 },
             )
     finally:
-        await upstream_client.aclose()
+        await provider.cleanup()
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
@@ -194,8 +190,8 @@ async def test_messages_auto_mode_classifier_composes_with_openai_provider() -> 
 
 @pytest.mark.asyncio
 async def test_messages_non_classifier_stop_remains_lossy_for_openai_provider() -> None:
-    upstream_requests: list[httpx.Request] = []
-    provider, upstream_client = _openai_provider(
+    upstream_requests: list[httpx2.Request] = []
+    provider = _openai_provider(
         upstream_requests,
         response_text="unreachable",
     )
@@ -213,7 +209,7 @@ async def test_messages_non_classifier_stop_remains_lossy_for_openai_provider() 
                 },
             )
     finally:
-        await upstream_client.aclose()
+        await provider.cleanup()
 
     assert response.status_code == 400
     body = response.json()

--- a/tests/providers/test_endpoint_context_transports.py
+++ b/tests/providers/test_endpoint_context_transports.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from collections.abc import AsyncIterator
 
+import httpx
 import httpx2
 import pytest
 from openai import AsyncOpenAI
@@ -35,7 +36,11 @@ class Context:
 
     async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
         self.calls.append(force_refresh)
-        headers = {"X-Session": self.name}
+        headers = {
+            "X-Session": self.name,
+            "uSeR-AgEnT": f"context-{self.name}",
+            "accept": "text/event-stream",
+        }
         if self.authorization:
             headers["authorization"] = self.authorization
         return HttpEndpoint(
@@ -136,6 +141,45 @@ async def _consume(stream: AsyncIterator[str]) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("refresh", [False, True])
+@pytest.mark.parametrize("responses_ingress", [False, True])
+async def test_responses_credential_failure_does_not_retry_generation(
+    refresh: bool,
+    responses_ingress: bool,
+) -> None:
+    class FailingContext(Context):
+        async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
+            if not refresh or force_refresh:
+                self.calls.append(force_refresh)
+                raise httpx.ReadError("credential service unavailable")
+            return await super().endpoint(force_refresh=force_refresh)
+
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(401, json={"error": {"message": "expired"}})
+
+    pool = httpx2.MockTransport(handler)
+    async with AsyncOpenAI(
+        api_key="base",
+        http_client=httpx2.AsyncClient(transport=pool),
+        max_retries=0,
+    ) as client:
+        context = FailingContext("a")
+        with pytest.raises(ExecutionFailure, match="credential service unavailable"):
+            await _consume(
+                _stream(
+                    _transport(client, responses=True, pool=pool),
+                    context,
+                    responses_ingress=responses_ingress,
+                )
+            )
+    assert len(requests) == int(refresh)
+    assert context.calls == ([False, True] if refresh else [False])
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("responses", [False, True])
 @pytest.mark.parametrize("responses_ingress", [False, True])
 async def test_concurrent_endpoint_views_do_not_share_headers_or_close_base(
@@ -153,7 +197,11 @@ async def test_concurrent_endpoint_views_do_not_share_headers_or_close_base(
         organization="old-org",
         project="old-project",
         base_url="https://original.invalid",
-        default_headers={"X-Old": "base"},
+        default_headers={
+            "X-Old": "base",
+            "accept": "application/json",
+            "user-agent": "base-client",
+        },
         default_query={"old": "secret"},
         http_client=httpx2.AsyncClient(
             transport=pool,
@@ -171,6 +219,10 @@ async def test_concurrent_endpoint_views_do_not_share_headers_or_close_base(
             _consume(_stream(transport, b, responses_ingress=responses_ingress)),
         )
         for request in seen:
+            assert request.headers.get_list("accept") == ["text/event-stream"]
+            assert request.headers.get_list("user-agent") == [
+                f"context-{request.headers['X-Session']}"
+            ]
             assert "X-Old" not in request.headers and not request.url.query
             assert "X-Secret" not in request.headers and "Cookie" not in request.headers
             assert (

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -1,7 +1,7 @@
 """Raw provider failure classification into the canonical neutral model."""
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import httpx
 import httpx2
@@ -74,6 +74,39 @@ def test_stream_retry_classification_distinguishes_protocol_and_status() -> None
     assert is_retryable_stream_error(httpx.ReadError("disconnected"))
     assert is_retryable_stream_error(_http_status_error(503, "unavailable"))
     assert not is_retryable_stream_error(_http_status_error(400, "bad request"))
+
+
+@pytest.mark.parametrize(
+    "error_name",
+    [
+        "ReadError",
+        "ReadTimeout",
+        "ConnectError",
+        "ConnectTimeout",
+        "WriteError",
+        "WriteTimeout",
+        "PoolTimeout",
+        "RemoteProtocolError",
+    ],
+)
+def test_http_client_network_errors_have_the_same_failure_policy(
+    error_name: str,
+) -> None:
+    errors = [
+        getattr(module, error_name)("connection interrupted")
+        for module in (httpx, httpx2)
+    ]
+    failures = [
+        classify_provider_failure(
+            error, provider_name="TEST", read_timeout_s=10, request_id="request"
+        )
+        for error in errors
+    ]
+    assert asdict(failures[0]) == asdict(failures[1])
+    assert is_retryable_provider_error(errors[0]) == is_retryable_provider_error(
+        errors[1]
+    )
+    assert is_retryable_stream_error(errors[0]) == is_retryable_stream_error(errors[1])
 
 
 def test_stream_retry_classification_only_accepts_post_open_timeouts() -> None:

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -842,6 +842,72 @@ async def test_concurrent_credentials_keep_request_identity_and_pool_ownership()
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("responses_ingress", [False, True])
+@pytest.mark.parametrize("code", [None, "token_expired"])
+@pytest.mark.parametrize(
+    ("error_type", "status", "kind"),
+    [
+        ("authentication_error", 401, FailureKind.AUTHENTICATION),
+        ("permission_error", 403, FailureKind.PERMISSION),
+    ],
+)
+async def test_nested_authentication_error_keeps_its_type(
+    responses_ingress: bool,
+    code: str | None,
+    error_type: str,
+    status: int,
+    kind: FailureKind,
+) -> None:
+    authorizations: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        authorizations.append(request.headers["authorization"])
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=_sse(
+                (
+                    "response.failed",
+                    {
+                        "type": "response.failed",
+                        "response": {
+                            "id": "resp_failed",
+                            "status": "failed",
+                            "error": {
+                                "code": code,
+                                "type": error_type,
+                                "message": "expired",
+                            },
+                        },
+                    },
+                )
+            ),
+        )
+
+    auth = _FakeAuth()
+    provider = OpenAICodexProvider(
+        _config(),
+        auth=auth,
+        admission=immediate_admission(max_attempts=2),
+        transport=httpx2.MockTransport(handler),
+    )
+    try:
+        stream = (
+            provider.stream_responses(_responses_request())
+            if responses_ingress
+            else provider.stream_messages(_request())
+        )
+        with pytest.raises(ExecutionFailure) as failure:
+            await _collect(stream)
+        assert failure.value.status_code == status
+        assert failure.value.kind is kind
+        assert auth.recovery_calls == 1
+        assert authorizations == ["Bearer access_1", "Bearer access_2"]
+    finally:
+        await provider.cleanup()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("operation", ["messages", "responses", "catalog"])
 async def test_disconnected_account_never_opens_or_refreshes_a_request(
     operation: str,

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -5,7 +5,9 @@ from typing import Any
 from unittest.mock import patch
 
 import httpx
+import httpx2
 import pytest
+from openai import AuthenticationError
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.application.model_metadata import ProviderModelInfo
@@ -15,7 +17,6 @@ from free_claude_code.core.anthropic.stream_contracts import (
     parse_sse_text,
     text_content,
 )
-from free_claude_code.core.diagnostics import ERROR_DETAIL_DISPLAY_CAP_BYTES
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.model_capabilities import ModelInputModality
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
@@ -25,9 +26,10 @@ from free_claude_code.providers.base import ProviderConfig
 from free_claude_code.providers.openai_codex.auth import (
     OpenAIAccess,
     OpenAIAuthManager,
+    OpenAIReconnectRequired,
 )
 from free_claude_code.providers.openai_codex.provider import OpenAICodexProvider
-from tests.providers.support import make_provider_config
+from tests.providers.support import immediate_admission, make_provider_config
 
 
 class _FakeAuth(OpenAIAuthManager):
@@ -47,7 +49,7 @@ class _FakeAuth(OpenAIAuthManager):
         return OpenAIAccess(self.current_token, "account_1", False)
 
 
-class _CloseTrackingResponse(httpx.Response):
+class _CloseTrackingResponse(httpx2.Response):
     """HTTPX response that records close order and can fail during cleanup."""
 
     def __init__(
@@ -68,7 +70,7 @@ class _CloseTrackingResponse(httpx.Response):
             raise self._close_error
 
 
-class _StaticAsyncBody(httpx.AsyncByteStream):
+class _StaticAsyncBody(httpx2.AsyncByteStream):
     def __init__(self, body: bytes) -> None:
         self._body = body
 
@@ -82,7 +84,7 @@ class _CloseAwareAuth(_FakeAuth):
         self._responses = responses
 
     async def recover_unauthorized(self, rejected_token: str) -> OpenAIAccess:
-        assert self._responses[-1].close_calls == 1
+        assert self._responses[-1].is_closed
         return await super().recover_unauthorized(rejected_token)
 
 
@@ -189,13 +191,82 @@ async def _collect(stream: AsyncIterator[str]) -> str:
 
 
 @pytest.mark.asyncio
-async def test_provider_uses_subscription_headers_and_visible_model_catalog() -> None:
-    requests: list[httpx.Request] = []
+@pytest.mark.parametrize("responses_ingress", [False, True])
+async def test_completion_followed_by_ping_stays_successful(
+    responses_ingress: bool,
+) -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=_complete_stream("hello") + _sse(("ping", {"type": "ping"})),
+        )
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    pool = httpx2.MockTransport(handler)
+    provider = OpenAICodexProvider(
+        _config(),
+        auth=_FakeAuth(),
+        admission=immediate_admission(max_attempts=1),
+        transport=pool,
+    )
+    stream = (
+        provider.stream_responses(_responses_request())
+        if responses_ingress
+        else provider.stream_messages(_request())
+    )
+    events = parse_sse_text(await _collect(stream))
+    await provider.cleanup()
+    terminal = "response.completed" if responses_ingress else "message_stop"
+    assert [event.event for event in events].count(terminal) == 1
+    assert events[-1].event == terminal
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("responses_ingress", [False, True])
+async def test_streamed_authentication_error_has_authentication_status(
+    responses_ingress: bool,
+) -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=_sse(
+                (
+                    "error",
+                    {"type": "error", "code": "invalid_api_key", "message": "expired"},
+                ),
+            ),
+        )
+
+    auth = _FakeAuth()
+    pool = httpx2.MockTransport(handler)
+    provider = OpenAICodexProvider(
+        _config(),
+        auth=auth,
+        admission=immediate_admission(max_attempts=1),
+        transport=pool,
+    )
+    stream = (
+        provider.stream_responses(_responses_request())
+        if responses_ingress
+        else provider.stream_messages(_request())
+    )
+    with pytest.raises(ExecutionFailure) as failure:
+        await _collect(stream)
+    await provider.cleanup()
+    assert failure.value.status_code == 401
+    assert failure.value.kind is FailureKind.AUTHENTICATION
+    assert auth.recovery_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_uses_subscription_headers_and_visible_model_catalog() -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
         requests.append(request)
         if request.url.path.endswith("/models"):
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "models": [
@@ -223,19 +294,16 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
                 request=request,
             )
         assert request.url.path.endswith("/responses")
-        return httpx.Response(
+        return httpx2.Response(
             200,
             content=_complete_stream("hello").encode(),
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     auth = _FakeAuth()
     provider = OpenAICodexProvider(
-        _config(), auth=auth, admission=_admission(), client=client
+        _config(), auth=auth, admission=_admission(), transport=pool
     )
 
     infos = await provider.list_model_infos()
@@ -275,56 +343,14 @@ async def test_provider_uses_subscription_headers_and_visible_model_catalog() ->
     events = parse_sse_text(body)
     assert_anthropic_stream_contract(events)
     assert text_content(events) == "hello"
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-async def test_model_discovery_close_failure_preserves_success_and_permit() -> None:
-    responses: list[_CloseTrackingResponse] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        response = _CloseTrackingResponse(
-            200,
-            json={
-                "models": [
-                    {
-                        "slug": "gpt-visible",
-                        "visibility": "list",
-                        "supported_in_api": False,
-                    }
-                ]
-            },
-            request=request,
-            close_error=RuntimeError("cleanup failed"),
-        )
-        responses.append(response)
-        return response
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(),
-        auth=_FakeAuth(),
-        admission=_admission(max_concurrency=1),
-        client=client,
-    )
-
-    first = await asyncio.wait_for(provider.list_model_infos(), timeout=1)
-    second = await asyncio.wait_for(provider.list_model_infos(), timeout=1)
-
-    assert {info.model_id for info in first} == {"gpt-visible"}
-    assert {info.model_id for info in second} == {"gpt-visible"}
-    assert [response.close_calls for response in responses] == [1, 1]
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_generation_close_failure_preserves_success_and_permit() -> None:
     responses: list[_CloseTrackingResponse] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         response = _CloseTrackingResponse(
             200,
             text=_complete_stream("hello"),
@@ -335,15 +361,12 @@ async def test_generation_close_failure_preserves_success_and_permit() -> None:
         responses.append(response)
         return response
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
         _config(),
         auth=_FakeAuth(),
         admission=_admission(max_concurrency=1),
-        client=client,
+        transport=pool,
     )
 
     first = await asyncio.wait_for(
@@ -357,15 +380,15 @@ async def test_generation_close_failure_preserves_success_and_permit() -> None:
 
     assert text_content(parse_sse_text(first)) == "hello"
     assert text_content(parse_sse_text(second)) == "hello"
-    assert [response.close_calls for response in responses] == [1, 1]
-    await client.aclose()
+    assert all(response.is_closed for response in responses)
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_generation_close_failure_preserves_provider_failure() -> None:
     responses: list[_CloseTrackingResponse] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         response = _CloseTrackingResponse(
             400,
             json={"error": {"message": "original provider failure"}},
@@ -375,12 +398,9 @@ async def test_generation_close_failure_preserves_provider_failure() -> None:
         responses.append(response)
         return response
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        _config(), auth=_FakeAuth(), admission=_admission(), transport=pool
     )
 
     with pytest.raises(ExecutionFailure) as exc_info:
@@ -395,29 +415,26 @@ async def test_generation_close_failure_preserves_provider_failure() -> None:
     assert exc_info.value.status_code == 400
     assert "original provider failure" in exc_info.value.message
     assert "cleanup failed" not in exc_info.value.message
-    assert [response.close_calls for response in responses] == [1]
-    await client.aclose()
+    assert all(response.is_closed for response in responses)
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_provider_accepts_claude_client_controls_before_upstream_io() -> None:
-    requests: list[httpx.Request] = []
+    requests: list[httpx2.Request] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         requests.append(request)
-        return httpx.Response(
+        return httpx2.Response(
             200,
             text=_complete_stream("hello"),
             headers={"content-type": "text/event-stream"},
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        _config(), auth=_FakeAuth(), admission=_admission(), transport=pool
     )
     request = _client_control_request()
     original_request = request.model_dump()
@@ -447,28 +464,25 @@ async def test_provider_accepts_claude_client_controls_before_upstream_io() -> N
     assert "output_config" not in payload
     assert request.model_dump() == original_request
     assert_anthropic_stream_contract(parse_sse_text(body))
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_provider_relays_native_responses_with_private_field_policy() -> None:
-    requests: list[httpx.Request] = []
+    requests: list[httpx2.Request] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         requests.append(request)
-        return httpx.Response(
+        return httpx2.Response(
             200,
             text=_complete_stream("hello"),
             headers={"content-type": "text/event-stream"},
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        _config(), auth=_FakeAuth(), admission=_admission(), transport=pool
     )
     request = _responses_request()
     original = request.model_dump()
@@ -505,7 +519,7 @@ async def test_provider_relays_native_responses_with_private_field_policy() -> N
     assert events[0].data["response"]["model"] == "openai/gpt-test"
     assert events[-1].data["response"]["id"] == "resp_1"
     assert events[-1].data["response"]["model"] == "openai/gpt-test"
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
@@ -536,18 +550,15 @@ async def test_provider_preflight_rejects_unrepresentable_client_controls(
     value: object,
     error_path: str,
 ) -> None:
-    requests: list[httpx.Request] = []
+    requests: list[httpx2.Request] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         requests.append(request)
-        return httpx.Response(500, request=request)
+        return httpx2.Response(500, request=request)
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        _config(), auth=_FakeAuth(), admission=_admission(), transport=pool
     )
     payload = {
         "model": "gpt-test",
@@ -559,7 +570,7 @@ async def test_provider_preflight_rejects_unrepresentable_client_controls(
         provider.preflight_messages(MessagesRequest.model_validate(payload))
 
     assert requests == []
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
@@ -581,7 +592,7 @@ async def test_provider_round_trips_portable_tool_name_alias() -> None:
     )
     payloads: list[dict[str, Any]] = []
 
-    def handler(http_request: httpx.Request) -> httpx.Response:
+    def handler(http_request: httpx2.Request) -> httpx2.Response:
         payload = json.loads(http_request.content)
         payloads.append(payload)
         alias = payload["tools"][0]["name"]
@@ -622,19 +633,16 @@ async def test_provider_round_trips_portable_tool_name_alias() -> None:
                 },
             ),
         )
-        return httpx.Response(
+        return httpx2.Response(
             200,
             text=body,
             headers={"content-type": "text/event-stream"},
             request=http_request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        _config(), auth=_FakeAuth(), admission=_admission(), transport=pool
     )
 
     body = await _collect(provider.stream_messages(request))
@@ -653,130 +661,26 @@ async def test_provider_round_trips_portable_tool_name_alias() -> None:
     )
     assert tool_start["name"] == original
     assert alias not in body
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
-async def test_early_truncated_attempt_is_retried_without_duplicate_output() -> None:
+async def test_non_streaming_success_cannot_complete_generation() -> None:
     attempts = 0
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal attempts
         attempts += 1
-        if attempts == 1:
-            body = _sse(
-                (
-                    "response.created",
-                    {"type": "response.created", "response": {"id": "first"}},
-                ),
-                (
-                    "response.output_text.delta",
-                    {"type": "response.output_text.delta", "delta": "abandoned"},
-                ),
-            )
-        else:
-            body = _complete_stream("kept")
-        return httpx.Response(
+        return httpx2.Response(
             200,
-            text=body,
-            headers={"content-type": "text/event-stream"},
-            request=request,
-        )
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    body = await _collect(
-        provider.stream_messages(
-            _request(),
-            request_id="req_retry",
-            response_model="claude-opus-4",
-        )
-    )
-
-    events = parse_sse_text(body)
-    assert_anthropic_stream_contract(events)
-    assert attempts == 2
-    assert text_content(events) == "kept"
-    assert "abandoned" not in body
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-async def test_pre_stream_retry_discards_held_message_start() -> None:
-    attempts = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            return httpx.Response(
-                429,
-                json={"error": {"message": "try again"}},
-                request=request,
-            )
-        return httpx.Response(
-            200,
-            text=_complete_stream("kept"),
-            headers={"content-type": "text/event-stream"},
-            request=request,
-        )
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    body = await _collect(
-        provider.stream_messages(
-            _request(),
-            request_id="req_pre_stream",
-            response_model="claude-opus-4",
-        )
-    )
-
-    events = parse_sse_text(body)
-    assert_anthropic_stream_contract(events)
-    assert attempts == 2
-    assert body.count("event: message_start") == 1
-    assert text_content(events) == "kept"
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> None:
-    attempts = 0
-    tail_sentinel = "must-not-escape-the-diagnostic-cap"
-    upstream_body = (
-        "upstream contract changed\n"
-        + "x" * ERROR_DETAIL_DISPLAY_CAP_BYTES
-        + tail_sentinel
-    ).encode()
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        return httpx.Response(
-            200,
-            content=upstream_body,
+            json={"message": "upstream contract changed"},
             headers={"content-type": "application/json"},
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        _config(), auth=_FakeAuth(), admission=_admission(), transport=pool
     )
 
     with pytest.raises(ExecutionFailure) as exc_info:
@@ -789,110 +693,187 @@ async def test_non_streaming_success_is_retried_then_reports_bounded_body() -> N
         )
 
     assert attempts > 1
-    assert "upstream contract changed" in exc_info.value.message
-    assert f"truncated after {ERROR_DETAIL_DISPLAY_CAP_BYTES} bytes" in (
-        exc_info.value.message
-    )
-    assert tail_sentinel not in exc_info.value.message
+    assert exc_info.value.status_code == 502
     assert "Request ID: req_non_stream" in exc_info.value.message
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
-async def test_truncated_attempt_after_commit_is_not_retried_or_duplicated() -> None:
-    attempts = 0
-    committed_text = "x" * 70_000
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        return httpx.Response(
-            200,
-            text=_sse(
-                (
-                    "response.created",
-                    {"type": "response.created", "response": {"id": "first"}},
-                ),
-                (
-                    "response.output_text.delta",
-                    {
-                        "type": "response.output_text.delta",
-                        "delta": committed_text,
-                    },
-                ),
-            ),
-            headers={"content-type": "text/event-stream"},
-            request=request,
-        )
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-    chunks: list[str] = []
-
-    with pytest.raises(ExecutionFailure):
-        async for chunk in provider.stream_messages(
-            _request(),
-            request_id="req_committed",
-            response_model="claude-opus-4",
-        ):
-            chunks.extend((chunk,))
-
-    body = "".join(chunks)
-    assert attempts == 1
-    assert body.count(committed_text) == 1
-    assert body.count("event: message_start") == 1
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-async def test_unauthorized_response_forces_one_auth_refresh() -> None:
+@pytest.mark.parametrize("responses_ingress", [False, True])
+@pytest.mark.parametrize("rejection", ["http_401", "http_403", "flat", "wrapped"])
+async def test_unauthorized_response_forces_one_auth_refresh(
+    responses_ingress: bool,
+    rejection: str,
+) -> None:
     authorizations: list[str] = []
+    sessions: list[str] = []
     unauthorized_responses: list[_CloseTrackingResponse] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         authorizations.append(request.headers["authorization"])
+        sessions.append(request.headers["session_id"])
         if len(authorizations) == 1:
+            error = {"code": "invalid_api_key", "message": "expired"}
+            if rejection.startswith("http_"):
+                status = int(rejection.removeprefix("http_"))
+                body = json.dumps({"error": error})
+            else:
+                status = 200
+                payload = (
+                    {"error": error}
+                    if rejection == "wrapped"
+                    else {"type": "error", **error}
+                )
+                body = f"data: {json.dumps(payload)}\n\n"
             response = _CloseTrackingResponse(
-                401,
-                json={"error": {"message": "expired"}},
+                status,
+                stream=_StaticAsyncBody(body.encode()),
+                headers={"content-type": "text/event-stream"},
                 request=request,
             )
             unauthorized_responses.append(response)
             return response
-        return httpx.Response(
+        return httpx2.Response(
             200,
             text=_complete_stream("recovered"),
             headers={"content-type": "text/event-stream"},
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     auth = _CloseAwareAuth(unauthorized_responses)
     provider = OpenAICodexProvider(
-        _config(), auth=auth, admission=_admission(), client=client
+        _config(), auth=auth, admission=_admission(), transport=pool
     )
 
     body = await _collect(
-        provider.stream_messages(
-            _request(),
-            request_id="req_auth",
-            response_model="claude-opus-4",
-        )
+        provider.stream_responses(_responses_request(), request_id="req_auth")
+        if responses_ingress
+        else provider.stream_messages(_request(), request_id="req_auth")
     )
 
     assert authorizations == ["Bearer access_1", "Bearer access_2"]
     assert auth.recovery_calls == 1
-    assert unauthorized_responses[0].close_calls == 1
-    assert text_content(parse_sse_text(body)) == "recovered"
-    await client.aclose()
+    assert sessions[0] == sessions[1]
+    assert unauthorized_responses[0].is_closed
+    if responses_ingress:
+        assert [event.event for event in parse_sse_text(body)].count(
+            "response.completed"
+        ) == 1
+    else:
+        assert text_content(parse_sse_text(body)) == "recovered"
+    await provider.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_credentials_keep_request_identity_and_pool_ownership() -> (
+    None
+):
+    class ConcurrentAuth(_FakeAuth):
+        async def access(self, *, force_refresh: bool = False) -> OpenAIAccess:
+            self.access_calls += 1
+            return OpenAIAccess(
+                f"access_{self.access_calls}", f"account_{self.access_calls}", False
+            )
+
+        async def recover_unauthorized(self, rejected_token: str) -> OpenAIAccess:
+            assert rejected_token == "access_1"
+            self.recovery_calls += 1
+            return OpenAIAccess("access_3", "account_3", True)
+
+        async def close(self) -> None:
+            raise AssertionError("Provider must not close the runtime-owned account")
+
+    class Pool(httpx2.MockTransport):
+        closes = 0
+
+        async def aclose(self) -> None:
+            self.closes += 1
+            await super().aclose()
+
+    second_started = asyncio.Event()
+    requests: dict[str, httpx2.Request] = {}
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        token = request.headers["authorization"]
+        requests[token] = request
+        if token == "Bearer access_1":
+            await second_started.wait()
+            return httpx2.Response(401, json={"error": {"message": "expired"}})
+        if token == "Bearer access_2":
+            second_started.set()
+        return httpx2.Response(
+            200,
+            text=_complete_stream("hello"),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    auth = ConcurrentAuth()
+    pool = Pool(handler)
+    provider = OpenAICodexProvider(
+        _config(), auth=auth, admission=_admission(), transport=pool
+    )
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                _collect(provider.stream_messages(_request())),
+                _collect(provider.stream_messages(_request())),
+            ),
+            timeout=3,
+        )
+        assert all(
+            text_content(parse_sse_text(result)) == "hello" for result in results
+        )
+        first, second, refreshed = (
+            requests[f"Bearer access_{number}"] for number in (1, 2, 3)
+        )
+        assert first.headers["session_id"] == refreshed.headers["session_id"]
+        assert first.headers["session_id"] != second.headers["session_id"]
+        for number, request in enumerate((first, second, refreshed), start=1):
+            assert request.headers["chatgpt-account-id"] == f"account_{number}"
+        assert "x-openai-fedramp" not in first.headers
+        assert "x-openai-fedramp" not in second.headers
+        assert refreshed.headers["x-openai-fedramp"] == "true"
+        assert auth.recovery_calls == 1
+        assert pool.closes == 0
+    finally:
+        await provider.cleanup()
+    assert pool.closes == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["messages", "responses", "catalog"])
+async def test_disconnected_account_never_opens_or_refreshes_a_request(
+    operation: str,
+) -> None:
+    class DisconnectedAuth(_FakeAuth):
+        async def access(self, *, force_refresh: bool = False) -> OpenAIAccess:
+            self.access_calls += 1
+            raise OpenAIReconnectRequired("Reconnect in Admin.")
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        raise AssertionError("Disconnected accounts must not send a provider request")
+
+    auth = DisconnectedAuth()
+    provider = OpenAICodexProvider(
+        _config(),
+        auth=auth,
+        admission=_admission(),
+        transport=httpx2.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(ExecutionFailure, match="Reconnect in Admin") as failure:
+            if operation == "catalog":
+                await provider.list_model_infos()
+            elif operation == "responses":
+                await _collect(provider.stream_responses(_responses_request()))
+            else:
+                await _collect(provider.stream_messages(_request()))
+        assert failure.value.kind is FailureKind.AUTHENTICATION
+        assert auth.access_calls == 1
+        assert auth.recovery_calls == 0
+    finally:
+        await provider.cleanup()
 
 
 @pytest.mark.asyncio
@@ -900,13 +881,13 @@ async def test_model_discovery_re_request_is_a_second_admitted_attempt() -> None
     authorizations: list[str] = []
     unauthorized_responses: list[_CloseTrackingResponse] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         authorizations.append(request.headers["authorization"])
         if len(authorizations) == 1:
             response = _CloseTrackingResponse(401, request=request)
             unauthorized_responses.append(response)
             return response
-        return httpx.Response(
+        return httpx2.Response(
             200,
             json={
                 "models": [
@@ -921,13 +902,10 @@ async def test_model_discovery_re_request_is_a_second_admitted_attempt() -> None
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     auth = _CloseAwareAuth(unauthorized_responses)
     provider = OpenAICodexProvider(
-        _config(), auth=auth, admission=_admission(), client=client
+        _config(), auth=auth, admission=_admission(), transport=pool
     )
 
     with patch("free_claude_code.providers.admission.trace_event") as trace:
@@ -936,7 +914,7 @@ async def test_model_discovery_re_request_is_a_second_admitted_attempt() -> None
     assert {info.model_id for info in infos} == {"gpt-visible"}
     assert authorizations == ["Bearer access_1", "Bearer access_2"]
     assert auth.recovery_calls == 1
-    assert unauthorized_responses[0].close_calls == 1
+    assert unauthorized_responses[0].is_closed
     attempt_rows = [
         call.kwargs
         for call in trace.call_args_list
@@ -956,7 +934,7 @@ async def test_model_discovery_re_request_is_a_second_admitted_attempt() -> None
         "accepted",
     ]
     assert len({row["execution_id"] for row in attempt_rows}) == 1
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
@@ -972,25 +950,22 @@ async def test_auth_refresh_failure_does_not_repeat_rejected_provider_call() -> 
 
     authorizations: list[str] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         authorization = request.headers["authorization"]
         authorizations.append(authorization)
         if authorization == "Bearer access_1":
-            return httpx.Response(401, request=request)
-        return httpx.Response(
+            return httpx2.Response(401, request=request)
+        return httpx2.Response(
             200,
             text=_complete_stream("recovered"),
             headers={"content-type": "text/event-stream"},
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     auth = FailingRecoveryAuth()
     provider = OpenAICodexProvider(
-        _config(), auth=auth, admission=_admission(), client=client
+        _config(), auth=auth, admission=_admission(), transport=pool
     )
 
     with pytest.raises(ExecutionFailure, match="refresh interrupted") as exc_info:
@@ -1005,28 +980,25 @@ async def test_auth_refresh_failure_does_not_repeat_rejected_provider_call() -> 
     assert isinstance(exc_info.value.__cause__, httpx.ReadError)
     assert authorizations == ["Bearer access_1"]
     assert auth.recovery_calls == 1
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_second_unauthorized_response_is_terminal_without_refresh_loop() -> None:
     authorizations: list[str] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         authorizations.append(request.headers["authorization"])
-        return httpx.Response(
+        return httpx2.Response(
             401,
             json={"error": {"message": "still expired"}},
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     auth = _FakeAuth()
     provider = OpenAICodexProvider(
-        _config(), auth=auth, admission=_admission(), client=client
+        _config(), auth=auth, admission=_admission(), transport=pool
     )
 
     with pytest.raises(ExecutionFailure) as exc_info:
@@ -1041,30 +1013,27 @@ async def test_second_unauthorized_response_is_terminal_without_refresh_loop() -
     assert exc_info.value.status_code == 401
     assert authorizations == ["Bearer access_1", "Bearer access_2"]
     assert auth.recovery_calls == 1
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_final_attempt_unauthorized_preserves_the_provider_401() -> None:
     attempts = 0
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal attempts
         attempts += 1
         status = 503 if attempts < 5 else 401
-        return httpx.Response(
+        return httpx2.Response(
             status,
             json={"error": {"message": f"attempt {attempts}"}},
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     auth = _FakeAuth()
     provider = OpenAICodexProvider(
-        _config(), auth=auth, admission=_admission(), client=client
+        _config(), auth=auth, admission=_admission(), transport=pool
     )
 
     with pytest.raises(ExecutionFailure) as exc_info:
@@ -1080,15 +1049,15 @@ async def test_final_attempt_unauthorized_preserves_the_provider_401() -> None:
     assert auth.recovery_calls == 0
     assert exc_info.value.status_code == 401
     assert "Request ID: req_final_401" in str(exc_info.value)
-    assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+    assert isinstance(exc_info.value.__cause__, AuthenticationError)
     assert exc_info.value.__cause__.response.status_code == 401
-    await client.aclose()
+    await provider.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_stream_failure_redacts_credentials_from_customer_diagnostic() -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
             200,
             text=_sse(
                 (
@@ -1111,12 +1080,9 @@ async def test_stream_failure_redacts_credentials_from_customer_diagnostic() -> 
             request=request,
         )
 
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
+    pool = httpx2.MockTransport(handler)
     provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
+        _config(), auth=_FakeAuth(), admission=_admission(), transport=pool
     )
 
     with pytest.raises(ExecutionFailure) as exc_info:
@@ -1130,198 +1096,4 @@ async def test_stream_failure_redacts_credentials_from_customer_diagnostic() -> 
 
     assert "sk-this-must-never-be-returned" not in exc_info.value.message
     assert "Authorization: <redacted>" in exc_info.value.message
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("wire_api", ["messages", "responses"])
-@pytest.mark.parametrize(
-    ("event_type", "response_fields"),
-    [
-        (
-            "response.failed",
-            {
-                "status": "failed",
-                "error": {
-                    "code": "context_length_exceeded",
-                    "message": "maximum context length exceeded",
-                },
-            },
-        ),
-        (
-            "response.incomplete",
-            {
-                "status": "incomplete",
-                "incomplete_details": {"reason": "model_context_window_exceeded"},
-                "usage": {"input_tokens": 10, "output_tokens": 0},
-            },
-        ),
-    ],
-)
-async def test_context_terminals_have_canonical_failure_semantics(
-    wire_api: str,
-    event_type: str,
-    response_fields: dict[str, Any],
-) -> None:
-    calls = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal calls
-        calls += 1
-        return httpx.Response(
-            200,
-            text=_sse(
-                (
-                    event_type,
-                    {
-                        "type": event_type,
-                        "response": {"id": "resp_context", **response_fields},
-                    },
-                )
-            ),
-            headers={"content-type": "text/event-stream"},
-            request=request,
-        )
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    stream = (
-        provider.stream_messages(
-            _request(),
-            request_id=f"req_context_{wire_api}",
-            response_model="claude-opus-4",
-        )
-        if wire_api == "messages"
-        else provider.stream_responses(
-            _responses_request(),
-            request_id=f"req_context_{wire_api}",
-            response_model="openai/gpt-test",
-        )
-    )
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await _collect(stream)
-
-    assert exc_info.value.kind is FailureKind.CONTEXT_WINDOW_EXCEEDED
-    assert exc_info.value.retryable is False
-    assert calls == 1
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("wire_api", ["messages", "responses"])
-async def test_top_level_context_error_has_canonical_failure_semantics(
-    wire_api: str,
-) -> None:
-    calls = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal calls
-        calls += 1
-        return httpx.Response(
-            200,
-            text=_sse(
-                (
-                    "error",
-                    {
-                        "type": "error",
-                        "sequence_number": 0,
-                        "code": "context_length_exceeded",
-                        "message": "maximum context length exceeded",
-                        "param": None,
-                    },
-                )
-            ),
-            headers={"content-type": "text/event-stream"},
-            request=request,
-        )
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    stream = (
-        provider.stream_messages(
-            _request(),
-            request_id=f"req_top_level_context_{wire_api}",
-            response_model="claude-opus-4",
-        )
-        if wire_api == "messages"
-        else provider.stream_responses(
-            _responses_request(),
-            request_id=f"req_top_level_context_{wire_api}",
-            response_model="openai/gpt-test",
-        )
-    )
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await _collect(stream)
-
-    assert exc_info.value.kind is FailureKind.CONTEXT_WINDOW_EXCEEDED
-    assert exc_info.value.retryable is False
-    assert calls == 1
-    await client.aclose()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("wire_api", ["messages", "responses"])
-async def test_streamed_context_http_error_has_canonical_failure_semantics(
-    wire_api: str,
-) -> None:
-    calls = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal calls
-        calls += 1
-        return httpx.Response(
-            400,
-            stream=_StaticAsyncBody(
-                json.dumps(
-                    {
-                        "error": {
-                            "code": "context_length_exceeded",
-                            "message": "maximum context length exceeded",
-                        }
-                    }
-                ).encode()
-            ),
-            headers={"content-type": "application/json"},
-            request=request,
-        )
-
-    client = httpx.AsyncClient(
-        base_url="https://chatgpt.com/backend-api/codex/",
-        transport=httpx.MockTransport(handler),
-    )
-    provider = OpenAICodexProvider(
-        _config(), auth=_FakeAuth(), admission=_admission(), client=client
-    )
-
-    stream = (
-        provider.stream_messages(
-            _request(),
-            request_id=f"req_context_http_{wire_api}",
-            response_model="claude-opus-4",
-        )
-        if wire_api == "messages"
-        else provider.stream_responses(
-            _responses_request(),
-            request_id=f"req_context_http_{wire_api}",
-            response_model="openai/gpt-test",
-        )
-    )
-    with pytest.raises(ExecutionFailure) as exc_info:
-        await _collect(stream)
-
-    assert exc_info.value.kind is FailureKind.CONTEXT_WINDOW_EXCEEDED
-    assert exc_info.value.retryable is False
-    assert calls == 1
-    await client.aclose()
+    await provider.cleanup()

--- a/tests/providers/test_openai_responses_transport.py
+++ b/tests/providers/test_openai_responses_transport.py
@@ -744,6 +744,64 @@ async def test_early_truncated_retry_has_one_visible_lifecycle() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("wire_api", ["messages", "responses"])
+@pytest.mark.parametrize("buffered", [False, True])
+@pytest.mark.parametrize(
+    "error_type", [httpx2.ReadError, httpx2.ReadTimeout, httpx2.RemoteProtocolError]
+)
+async def test_sdk_stream_interruptions_retry_before_commit(
+    wire_api: str,
+    buffered: bool,
+    error_type: type[Exception],
+) -> None:
+    class InterruptedBody(httpx2.AsyncByteStream):
+        async def __aiter__(self):
+            if buffered:
+                yield _sse(
+                    {
+                        "type": "response.created",
+                        "sequence_number": 0,
+                        "response": {**_completed_response(), "status": "in_progress"},
+                    }
+                ).encode()
+            raise error_type("connection interrupted")
+
+    requests = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal requests
+        requests += 1
+        if requests == 1:
+            return httpx2.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=InterruptedBody(),
+            )
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=_sse(_text_delta("recovered"), _completed_event()),
+        )
+
+    client = _client(handler)
+    try:
+        transport = _transport(client, max_attempts=2)
+        chunks = (
+            await _collect(transport)
+            if wire_api == "messages"
+            else await _collect_native(
+                transport, OpenAIResponsesRequest(model="upstream-model", input="hello")
+            )
+        )
+    finally:
+        await client.close()
+    assert requests == 2
+    events = parse_sse_text("".join(chunks))
+    terminal = "message_stop" if wire_api == "messages" else "response.completed"
+    assert [event.event for event in events].count(terminal) == 1
+
+
+@pytest.mark.asyncio
 async def test_exhausted_5xx_uses_exact_attempt_budget() -> None:
     attempts = 0
 

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -915,6 +915,7 @@ def test_create_provider_instantiates_each_builtin():
     with (
         patch("free_claude_code.providers.openai_chat.provider.AsyncOpenAI"),
         patch("free_claude_code.providers.github_copilot.provider.AsyncOpenAI"),
+        patch("free_claude_code.providers.openai_codex.provider.AsyncOpenAI"),
         patch("httpx.AsyncClient"),
         patch(
             "free_claude_code.providers.runtime.factory.ProviderAdmissionController",

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.22.5"
+version = "5.22.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Codex maintained a separate Responses execution loop from OpenCode and Copilot. It could turn a completed stream into a 502 after a trailing ping and misclassify streamed authentication errors as generic upstream failures. Keeping two implementations also duplicated retries, parsing, and cleanup.

## How

Route Codex generation through the shared OpenAI SDK Responses transport and use its SDK client for catalog requests. Keep subscription credentials, session headers, token-aware refresh, and backend field omissions in Codex. Remove its raw HTTP/SSE implementation and bounded error reader.

Resolve credentials before inference admission so credential-service failures cannot enter generation retries. Replace SDK default headers case-insensitively. Classify SDK transport exceptions consistently with HTTPX, and retain nested error fields so null or specific codes cannot hide authentication types. Keep shared admission, output commitment, and stream cleanup without model-specific branches or internal compatibility wrappers.

Add regressions for interrupted streams, terminal events, nested authentication errors, concurrent credentials, and pool ownership. Update provider/API fixtures, remove duplicate transport tests, and bump the package and lockfile to 5.22.6.

Validation: the full local CI sequence passed with 5,040 tests, 148 skipped, and 65 Admin browser tests, including lint and type checks. The 362 focused failure-policy, Responses, authentication, and protocol tests also passed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates Codex generation and model discovery onto the shared OpenAI Responses transport while preserving Codex-specific credentials, headers, request omissions, authentication recovery, admission control, and cleanup. It also aligns transport-failure classification and adds focused regression coverage for streaming, credential isolation, header replacement, and transport ownership.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge.

There are no outstanding findings.

<sub>Reviews (2): Last reviewed commit: ["Fix shared SDK transport and authenticat..."](https://github.com/alishahryar1/free-claude-code/commit/6dde896f8950d29ba9a0a292ffa61cfdb9560901) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60860188)</sub>

<!-- /greptile_comment -->