### PR TITLE
Keep README focused on user-facing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,6 @@ from more than one provider before succeeding.
 <details>
 <summary><strong>Provider catalog</strong></summary>
 
-[GitHub Models retired on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). FCC automatically resets retired model
-selections to your configured default, or the built-in default when `MODEL` itself
-is retired. Configure that default provider in Admin if its credentials are missing.
-GitHub Copilot is a separate service; connect it through **Connected accounts** in Admin.
-
 | Provider | Admin UI setting | Example `MODEL` |
 | --- | --- | --- |
 | [NVIDIA NIM](https://build.nvidia.com/settings/api-keys) | `NVIDIA_NIM_API_KEY` | `nvidia_nim/nvidia/nemotron-3-super-120b-a12b` |
@@ -342,13 +337,6 @@ Providers that do not support a selected control retain their own behavior.
 For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`,
 `fcc-pi`, `fcc-opencode`, `fcc-cline`, `fcc-hermes`, `fcc-dsh`, `fcc-grok`,
 `fcc-muse`, or `fcc-aider`.
-These wrappers configure the FCC connection and pass your commands and options
-to the native harness. Interactive and headless use share the same setup.
-Every wrapper launch requires FCC to be available, including help and version
-requests. Launches that need a model catalog stop if it cannot be loaded.
-
-Each Codex CLI launch uses its own temporary catalog. FCC also publishes the
-stable catalog used by the Codex App and editor configurations below.
 
 Use the guides below for editor integrations.
 


### PR DESCRIPTION
## Why

The README includes internal migration and launcher details that distract from setup and usage instructions.

## How

Remove the GitHub Models retirement and selection-reset paragraph, plus the wrapper startup and Codex catalog implementation paragraphs.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary
- Removes historical provider-retirement notes and implementation-level launcher/catalog details from the README.
- Retains the current provider selection and client configuration instructions.
- The remaining Codex App catalog-path instruction works because FCC publishes the catalog during startup.

## Merge safety
Safe to merge.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; no outstanding issues were found in the documentation changes.

No actionable findings remain after verifying that the documented Codex App catalog path is created during FCC startup.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before startup, the catalog path was absent, establishing the baseline for validation.
- During startup and shutdown, FCC completed the sequence and published a parseable catalog that includes nvidia\_nim/integration-check-model.
- The stable catalog was generated exactly at the path referenced by the Codex App instructions, confirming the intended location.
- Logs were inspected and corroborate the publication and path placement of the catalog, and the accompanying Python validation artifact was linked for review.

<a href="https://app.greptile.com/trex/runs/22759974/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Keep README focused on user-facing instr..."](https://github.com/alishahryar1/free-claude-code/commit/f55a382b0bb93989a8eaeea16631c0801546533b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60905140)</sub>

<!-- /greptile_comment -->