### PR TITLE
Parallelize browser CI and fix chat scroll reset after Stop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
             run: uv run pytest -v --tb=short
           - id: playwright
             run: >-
-              uv run pytest e2e -n 0 -v --tb=short
+              uv run pytest e2e -v --tb=short
               --tracing=retain-on-failure --screenshot=only-on-failure
               --full-page-screenshot --output=test-results
     steps:

--- a/e2e/test_chat_sessions.py
+++ b/e2e/test_chat_sessions.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from playwright.sync_api import Page, Request, expect
+from playwright.sync_api import Page, Request, Route, expect
 
 
 def _new_chat(page: Page, admin_base_url: str) -> None:
@@ -955,6 +955,7 @@ def test_long_transcript_keeps_composer_visible_and_preserves_reader_scroll_posi
     message.fill(long_message)
     page.get_by_role("button", name="Send").click()
     expect(page.get_by_role("button", name="Stop")).to_be_visible()
+    expect(page.get_by_text("E2E answer", exact=True)).to_be_visible()
     scroller = page.locator("#chatTranscript")
     page.wait_for_function(
         """() => {
@@ -962,17 +963,37 @@ def test_long_transcript_keeps_composer_visible_and_preserves_reader_scroll_posi
           return node && node.scrollHeight > node.clientHeight;
         }"""
     )
-    composer_is_fully_visible = message.evaluate(
-        "node => { const box = node.getBoundingClientRect(); "
-        "return box.top >= 0 && box.bottom <= window.innerHeight; }"
-    )
-    scroller.evaluate("node => { node.scrollTop = 0; }")
+    expect(message).to_be_in_viewport(ratio=1)
+    page.evaluate("document.getElementById('chatTranscript').scrollTop = 0")
 
-    page.get_by_role("button", name="Stop").click()
+    session_id = page.url.rsplit("/", 1)[-1]
+    detail_url = f"{admin_base_url}/admin/api/chat/sessions/{session_id}"
+    held_details: list[Route] = []
+    page.route(detail_url, lambda route: held_details.append(route))
+    try:
+        with page.expect_request(detail_url):
+            page.get_by_role("button", name="Stop").click()
+
+        detail = page.request.get(detail_url).json()
+        renamed = page.request.patch(
+            detail_url,
+            data={
+                "expected_revision": detail["session"]["revision"],
+                "title": "Renamed while the stopped conversation reloads",
+            },
+        )
+        assert renamed.ok
+        expect(page.get_by_label("Chat title")).to_have_value(
+            "Renamed while the stopped conversation reloads"
+        )
+        expect(scroller).to_contain_text(long_message)
+    finally:
+        for held_detail in held_details:
+            held_detail.continue_()
+        page.unroute(detail_url)
 
     expect(page.get_by_role("button", name="Retry")).to_be_visible()
-    assert composer_is_fully_visible
-    assert scroller.evaluate("node => node.scrollTop") < 10
+    assert page.evaluate("document.getElementById('chatTranscript').scrollTop") < 10
 
 
 def test_chat_composer_is_one_compact_surface_and_grows_to_six_lines(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.22.7"
+version = "5.22.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -171,7 +171,7 @@ function Invoke-PlaywrightCheck {
     Write-Step "playwright"
     Invoke-CiCommand -FilePath "uv" -Arguments @("run", "playwright", "install", "chromium")
     Invoke-CiCommand -FilePath "uv" -Arguments @(
-        "run", "pytest", "e2e", "-n", "0", "-v", "--tb=short",
+        "run", "pytest", "e2e", "-v", "--tb=short",
         "--tracing=retain-on-failure", "--screenshot=only-on-failure",
         "--full-page-screenshot", "--output=test-results"
     )

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -160,7 +160,7 @@ run_pytest() {
 run_playwright() {
     step "playwright"
     run uv run playwright install chromium
-    run uv run pytest e2e -n 0 -v --tb=short \
+    run uv run pytest e2e -v --tb=short \
         --tracing=retain-on-failure --screenshot=only-on-failure \
         --full-page-screenshot --output=test-results
 }

--- a/src/free_claude_code/api/admin_static/chat_sessions.js
+++ b/src/free_claude_code/api/admin_static/chat_sessions.js
@@ -602,14 +602,17 @@
       if (!state.session && chatIsVisible()) renderLibraryItems();
       return;
     }
-    selectVisibleOperation();
     if (type === "operation.failed") {
+      selectVisibleOperation();
       if (payload.kind === "send") rejectSubmittedDraft(operationId);
       renderSessionPreservingScroll();
       setNotice(payload.message || "Chat operation failed.", "error");
       return;
     }
+    // Keep the visible answer until the saved turns replace it.
     await reloadSession();
+    selectVisibleOperation();
+    refreshComposerState();
     if (type === "compaction.failed") {
       setNotice(payload.message || "Compaction failed.", "error");
     }

--- a/tests/scripts/test_ci_scripts.py
+++ b/tests/scripts/test_ci_scripts.py
@@ -76,7 +76,7 @@ def test_ci_sh_runs_ci_checks_in_order() -> None:
     assert "uv run ty check" in text
     assert "uv run pytest -v --tb=short" in text
     assert "uv run playwright install chromium" in text
-    assert "uv run pytest e2e -n 0" in text
+    assert "uv run pytest e2e -v --tb=short" in text
     assert "--only" in text
     assert "--skip" in text
     assert "--dry-run" in text
@@ -125,7 +125,7 @@ def test_ci_sh_playwright_dry_run_prints_browser_and_test_commands() -> None:
 
     assert result.returncode == 0
     assert "+ uv run playwright install chromium" in result.stdout
-    assert "+ uv run pytest e2e -n 0" in result.stdout
+    assert "+ uv run pytest e2e -v --tb=short" in result.stdout
     assert "uv is required" not in result.stderr
 
 
@@ -234,7 +234,7 @@ def test_ci_ps1_runs_ci_checks_in_order() -> None:
     assert '"run", "ruff", "check", "--fix"' in text
     assert '"-v", "--tb=short"' in text
     assert '"run", "playwright", "install", "chromium"' in text
-    assert '"run", "pytest", "e2e", "-n", "0"' in text
+    assert '"run", "pytest", "e2e", "-v", "--tb=short"' in text
     assert "-Only" in text
     assert "-Skip" in text
     assert "-DryRun" in text
@@ -287,7 +287,7 @@ def test_ci_ps1_playwright_dry_run_prints_browser_and_test_commands() -> None:
 
     assert result.returncode == 0
     assert "+ uv run playwright install chromium" in result.stdout
-    assert "+ uv run pytest e2e -n 0" in result.stdout
+    assert "+ uv run pytest e2e -v --tb=short" in result.stdout
     assert "uv is required" not in result.stderr
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.22.7"
+version = "5.22.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Browser checks force serial execution despite the project's automatic pytest parallelism. Running them in parallel also exposed a chat bug: a title update after Stop could briefly clear the conversation before saved turns finished loading, resetting the reader's scroll position.

## How

Let both local CI scripts and GitHub Actions inherit `-n auto`. Keep the visible answer until saved turns replace it, then refresh the operation controls. Update the existing scroll test to hold the reload while the title changes, wait for the reply to start before stopping, and scroll the current panel. Update the existing CI command assertions and bump the package to 5.22.8.

The scroll test fails against the original UI and passes 96 repetitions with 24 workers after the fix.

The complete local CI run passed: formatting, lint, typing, 4,828 regular tests (146 skipped), and all 65 browser tests.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This update enables automatic pytest worker parallelism for browser checks, preserves the visible chat transcript while persisted session details are loading, extends the related browser regression coverage, and updates package metadata to version 5.22.8.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge. The remaining test-coverage concern is non-blocking.

The previous thread remains outstanding: `tests/scripts/test_ci_scripts.py` checks the expected Playwright command prefixes but does not explicitly reject a restored `-n 0` serial override. A future serial-execution regression could therefore pass these assertions, but this concern does not block merging the current change.

<sub>Reviews (2): Last reviewed commit: ["Preserve the chat transcript while stopp..."](https://github.com/alishahryar1/free-claude-code/commit/833a6354b32cc7ff6bf36cabad2e9e931e9ddaf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60908184)</sub>

**Context used:**

- Knowledge Base — [Administrative API and web tools](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/api-admin-and-web-tools.md)

<!-- /greptile_comment -->