### PR TITLE
Auto-start the local FCC server when launchers find the proxy down

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.19.2"
+version = "5.20.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.20.0"
+version = "5.20.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.20.1"
+version = "5.20.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/aider.py
+++ b/src/free_claude_code/cli/launchers/aider.py
@@ -22,7 +22,12 @@ from .aider_config import (
     AiderConfig,
     build_aider_config,
 )
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import (
+    _ensure_fcc_server_running,
+    preflight_proxy,
+    resolve_client_binary,
+    run_client_process,
+)
 from .model_catalog import (
     ClientModel,
     client_models_from_response,
@@ -86,7 +91,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(1)
 
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/claude.py
+++ b/src/free_claude_code/cli/launchers/claude.py
@@ -11,7 +11,12 @@ from free_claude_code.cli.claude_env import (
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import (
+    _ensure_fcc_server_running,
+    preflight_proxy,
+    resolve_client_binary,
+    run_client_process,
+)
 
 _DISPLAY_NAME = "Claude Code"
 _INSTALL_HINT = "Install Claude Code with: npm install -g @anthropic-ai/claude-code"
@@ -25,7 +30,11 @@ def launch(argv: Sequence[str] | None = None) -> None:
 
     settings = get_settings()
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+
+    # First check if server is already reachable
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/cline.py
+++ b/src/free_claude_code/cli/launchers/cline.py
@@ -15,7 +15,12 @@ from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 
 from .cline_config import CLINE_PROVIDER_ID, ClineConfig, build_cline_config
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import (
+    _ensure_fcc_server_running,
+    preflight_proxy,
+    resolve_client_binary,
+    run_client_process,
+)
 from .model_catalog import client_models_from_response, fetch_proxy_models_response
 
 _BINARY_NAME = "cline"
@@ -131,7 +136,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(1)
 
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/codex.py
+++ b/src/free_claude_code/cli/launchers/codex.py
@@ -14,6 +14,7 @@ from free_claude_code.config.settings import Settings
 
 from .codex_model_catalog import build_codex_model_catalog, write_codex_model_catalog
 from .common import (
+    _ensure_fcc_server_running,
     preflight_proxy,
     resolve_client_binary,
     run_client_process,
@@ -56,7 +57,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
         return
 
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/common.py
+++ b/src/free_claude_code/cli/launchers/common.py
@@ -115,35 +115,70 @@ def _ensure_fcc_server_running(proxy_root_url: str) -> bool:
 
     lock_path = config_dir_path() / _SERVER_STARTUP_LOCK_FILENAME
     lock = InterprocessFileLock(lock_path)
+    deadline = time.monotonic() + _SERVER_START_TIMEOUT_SECONDS
 
-    # Try to acquire the lock without blocking.
+    # Become the designated starter: hold the lock until the server is ready
+    # (or startup definitively fails) so peers never spawn a second server.
     if lock.acquire(wait=False):
         try:
-            # Re-check because another process may have started the server
-            # before this process acquired the lock.
-            if preflight_proxy(proxy_root_url) is None:
-                return True
-
-            # Spawn exactly one fcc-server subprocess here.
-            log_path = server_log_path()
-            log_path.parent.mkdir(parents=True, exist_ok=True)
-            with log_path.open("a", buffering=1) as log_file:
-                subprocess.Popen(
-                    [sys.executable, "-m", "free_claude_code.cli.entrypoints", "serve"],
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                )
+            return _start_server_and_wait_until_ready(proxy_root_url, deadline)
         finally:
             lock.release()
 
-    # Whether we started the server or another launcher did, wait for it to become ready.
-    return _wait_for_server_ready(proxy_root_url)
+    # Another launcher owns startup. Wait for its server to become ready and,
+    # if that starter gives up or dies, take over the startup role ourselves.
+    while True:
+        if preflight_proxy(proxy_root_url) is None:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_SERVER_START_POLL_INTERVAL_SECONDS)
+        if lock.acquire(wait=False):
+            try:
+                if time.monotonic() >= deadline:
+                    return False
+                return _start_server_and_wait_until_ready(proxy_root_url, deadline)
+            finally:
+                lock.release()
 
 
-def _wait_for_server_ready(proxy_root_url: str) -> bool:
-    """Poll the health endpoint until the server is ready or timeout expires."""
-    start_time = time.monotonic()
-    while time.monotonic() - start_time < _SERVER_START_TIMEOUT_SECONDS:
+def _start_server_and_wait_until_ready(proxy_root_url: str, deadline: float) -> bool:
+    """Start the server if needed and return True once it is reachable."""
+
+    # Re-check because another process may have started the server while we
+    # waited for the lock.
+    if preflight_proxy(proxy_root_url) is None:
+        return True
+    if not _spawn_server_process():
+        return False
+    return _wait_for_server_ready(proxy_root_url, deadline)
+
+
+def _spawn_server_process() -> bool:
+    """Spawn one detached fcc-server subprocess.
+
+    Return False when the subprocess cannot be created (for example a
+    read-only or full configuration directory) so callers surface the normal
+    proxy-unreachable message instead of a traceback.
+    """
+    try:
+        log_path = server_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", buffering=1) as log_file:
+            subprocess.Popen(
+                [sys.executable, "-m", "free_claude_code.cli.entrypoints", "serve"],
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+    except OSError:
+        return False
+    return True
+
+
+def _wait_for_server_ready(proxy_root_url: str, deadline: float) -> bool:
+    """Poll the health endpoint until the server is ready or the deadline passes."""
+    while time.monotonic() < deadline:
         if preflight_proxy(proxy_root_url) is None:
             return True
         time.sleep(_SERVER_START_POLL_INTERVAL_SECONDS)

--- a/src/free_claude_code/cli/launchers/common.py
+++ b/src/free_claude_code/cli/launchers/common.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Mapping
+from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request
 
@@ -19,9 +20,21 @@ from free_claude_code.core.interprocess_lock import InterprocessFileLock
 
 PROXY_PREFLIGHT_PATH = "/health"
 PROXY_PREFLIGHT_TIMEOUT_SECONDS = 1.5
+# Maximum time to wait for server startup (seconds)
 _SERVER_START_TIMEOUT_SECONDS = 30.0
+# Interval between health checks during server startup (seconds)
 _SERVER_START_POLL_INTERVAL_SECONDS = 0.5
-_SERVER_STARTUP_LOCK_FILENAME = "server.startup.lock"
+
+
+def _startup_lock_path_for(proxy_root_url: str) -> Path:
+    """Return the interprocess startup lock path scoped to one server endpoint.
+
+    Two launchers targeting different local proxies (for example different
+    ``settings.port`` values) do not block each other's startup.
+    """
+    normalized = proxy_root_url.rstrip("/").lower()
+    safe = normalized.replace(":", "_").replace("/", "_").replace("..", "_")
+    return config_dir_path() / f"{safe}.server.startup.lock"
 
 
 def proxy_v1_url(proxy_root_url: str) -> str:
@@ -113,20 +126,22 @@ def _ensure_fcc_server_running(proxy_root_url: str) -> bool:
     if preflight_proxy(proxy_root_url) is None:
         return True
 
-    lock_path = config_dir_path() / _SERVER_STARTUP_LOCK_FILENAME
+    lock_path = _startup_lock_path_for(proxy_root_url)
     lock = InterprocessFileLock(lock_path)
     deadline = time.monotonic() + _SERVER_START_TIMEOUT_SECONDS
 
     # Become the designated starter: hold the lock until the server is ready
-    # (or startup definitively fails) so peers never spawn a second server.
+    # (or startup definitively fails) so peers for this endpoint never spawn a
+    # second server.
     if lock.acquire(wait=False):
         try:
             return _start_server_and_wait_until_ready(proxy_root_url, deadline)
         finally:
             lock.release()
 
-    # Another launcher owns startup. Wait for its server to become ready and,
-    # if that starter gives up or dies, take over the startup role ourselves.
+    # Another launcher owns startup for this endpoint. Wait for its server to
+    # become ready and, if that starter gives up or dies, take over the startup
+    # role ourselves.
     while True:
         if preflight_proxy(proxy_root_url) is None:
             return True

--- a/src/free_claude_code/cli/launchers/common.py
+++ b/src/free_claude_code/cli/launchers/common.py
@@ -3,6 +3,7 @@
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Mapping
 from urllib.error import HTTPError, URLError
 from urllib.request import Request
@@ -13,9 +14,14 @@ from free_claude_code.cli.process_registry import (
     register_pid,
     unregister_pid,
 )
+from free_claude_code.config.paths import config_dir_path, server_log_path
+from free_claude_code.core.interprocess_lock import InterprocessFileLock
 
 PROXY_PREFLIGHT_PATH = "/health"
 PROXY_PREFLIGHT_TIMEOUT_SECONDS = 1.5
+_SERVER_START_TIMEOUT_SECONDS = 30.0
+_SERVER_START_POLL_INTERVAL_SECONDS = 0.5
+_SERVER_STARTUP_LOCK_FILENAME = "server.startup.lock"
 
 
 def proxy_v1_url(proxy_root_url: str) -> str:
@@ -99,3 +105,46 @@ def run_client_process(
             unregister_pid(process.pid)
 
     raise SystemExit(return_code)
+
+
+def _ensure_fcc_server_running(proxy_root_url: str) -> bool:
+    """Return True if the FCC server is reachable (starting it if needed)."""
+    # Fast path: if already reachable, do nothing.
+    if preflight_proxy(proxy_root_url) is None:
+        return True
+
+    lock_path = config_dir_path() / _SERVER_STARTUP_LOCK_FILENAME
+    lock = InterprocessFileLock(lock_path)
+
+    # Try to acquire the lock without blocking.
+    if lock.acquire(wait=False):
+        try:
+            # Re-check because another process may have started the server
+            # before this process acquired the lock.
+            if preflight_proxy(proxy_root_url) is None:
+                return True
+
+            # Spawn exactly one fcc-server subprocess here.
+            log_path = server_log_path()
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a", buffering=1) as log_file:
+                subprocess.Popen(
+                    [sys.executable, "-m", "free_claude_code.cli.entrypoints", "serve"],
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                )
+        finally:
+            lock.release()
+
+    # Whether we started the server or another launcher did, wait for it to become ready.
+    return _wait_for_server_ready(proxy_root_url)
+
+
+def _wait_for_server_ready(proxy_root_url: str) -> bool:
+    """Poll the health endpoint until the server is ready or timeout expires."""
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < _SERVER_START_TIMEOUT_SECONDS:
+        if preflight_proxy(proxy_root_url) is None:
+            return True
+        time.sleep(_SERVER_START_POLL_INTERVAL_SECONDS)
+    return False

--- a/src/free_claude_code/cli/launchers/dsh.py
+++ b/src/free_claude_code/cli/launchers/dsh.py
@@ -16,7 +16,12 @@ from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 from free_claude_code.core.json_types import JsonValue
 
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import (
+    _ensure_fcc_server_running,
+    preflight_proxy,
+    resolve_client_binary,
+    run_client_process,
+)
 from .dsh_config import (
     DSH_API_KEY_ENV,
     DSH_ENV_PREFIX,
@@ -78,7 +83,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(1)
 
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/grok.py
+++ b/src/free_claude_code/cli/launchers/grok.py
@@ -16,6 +16,7 @@ from free_claude_code.config.server_urls import local_proxy_root_url
 from free_claude_code.core.json_types import JsonValue
 
 from .common import (
+    _ensure_fcc_server_running,
     preflight_proxy,
     proxy_v1_url,
     resolve_client_binary,
@@ -181,7 +182,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(1)
 
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/hermes.py
+++ b/src/free_claude_code/cli/launchers/hermes.py
@@ -15,7 +15,12 @@ from free_claude_code.cli.local_http import with_local_proxy_bypass
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import (
+    _ensure_fcc_server_running,
+    preflight_proxy,
+    resolve_client_binary,
+    run_client_process,
+)
 from .hermes_config import (
     HERMES_KEY_ENV_PREFIX,
     HermesManagedConfig,
@@ -117,7 +122,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(1)
 
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/opencode.py
+++ b/src/free_claude_code/cli/launchers/opencode.py
@@ -15,7 +15,12 @@ from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 from free_claude_code.core.json_types import JsonValue
 
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import (
+    _ensure_fcc_server_running,
+    preflight_proxy,
+    resolve_client_binary,
+    run_client_process,
+)
 from .model_catalog import client_models_from_response, fetch_proxy_models_response
 from .opencode_config import OPENCODE_API_KEY_ENV, OpenCodeConfig, build_opencode_config
 
@@ -66,7 +71,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(1)
 
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/src/free_claude_code/cli/launchers/pi.py
+++ b/src/free_claude_code/cli/launchers/pi.py
@@ -10,7 +10,12 @@ from free_claude_code.cli.local_http import with_local_proxy_bypass
 from free_claude_code.config.loader import get_settings
 from free_claude_code.config.server_urls import local_proxy_root_url
 
-from .common import preflight_proxy, resolve_client_binary, run_client_process
+from .common import (
+    _ensure_fcc_server_running,
+    preflight_proxy,
+    resolve_client_binary,
+    run_client_process,
+)
 
 _API_KEY_ENV = "FCC_PI_API_KEY"
 _BASE_URL_ENV = "FCC_PI_BASE_URL"
@@ -55,7 +60,9 @@ def launch(argv: Sequence[str] | None = None) -> None:
 
     settings = get_settings()
     proxy_root_url = local_proxy_root_url(settings)
-    if error := preflight_proxy(proxy_root_url):
+    if (
+        error := preflight_proxy(proxy_root_url)
+    ) is not None and not _ensure_fcc_server_running(proxy_root_url):
         print(
             f"Free Claude Code proxy is not reachable at {proxy_root_url}: {error}",
             file=sys.stderr,

--- a/tests/cli/test_aider_launcher.py
+++ b/tests/cli/test_aider_launcher.py
@@ -519,6 +519,7 @@ def test_aider_launch_fails_before_child_for_invalid_preparation(
         patch.object(aider, "resolve_client_binary", return_value="resolved-aider"),
         patch.object(aider, "get_settings", return_value=_settings(token=token)),
         patch.object(aider, "preflight_proxy", return_value=preflight_error),
+        patch.object(aider, "_ensure_fcc_server_running", return_value=False),
         patch.object(
             aider,
             "fetch_proxy_models_response",

--- a/tests/cli/test_claude_launcher.py
+++ b/tests/cli/test_claude_launcher.py
@@ -1,6 +1,23 @@
+from unittest.mock import patch
+
 import pytest
 
-from free_claude_code.cli.launchers.claude import build_claude_launcher_command
+from free_claude_code.cli.launchers.claude import (
+    build_claude_launcher_command,
+    launch,
+)
+from free_claude_code.config.settings import Settings
+
+
+def _launcher_settings(*, port: int = 9191, token: str = "proxy-token") -> Settings:
+    return Settings(
+        host="0.0.0.0",
+        port=port,
+        proxy_auth_enabled=False,
+        proxy_auth_token=token,
+        model="nvidia_nim/test-model",
+        open_admin_browser=True,
+    )
 
 
 def test_claude_launcher_defaults_to_non_auto_permission_mode() -> None:
@@ -53,3 +70,76 @@ def test_claude_launcher_does_not_treat_prompt_text_as_a_permission_choice(
         "default",
         *argv,
     ]
+
+
+def test_launch_claude_fails_when_proxy_is_unreachable_and_auto_start_fails(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    settings = _launcher_settings(port=9393)
+
+    with (
+        patch(
+            "free_claude_code.cli.launchers.claude.get_settings", return_value=settings
+        ),
+        patch(
+            "free_claude_code.cli.launchers.claude.preflight_proxy",
+            return_value="connection refused",
+        ),
+        patch(
+            "free_claude_code.cli.launchers.claude._ensure_fcc_server_running",
+            return_value=False,
+        ) as ensure_server,
+        patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        launch([])
+
+    assert exc_info.value.code == 1
+    ensure_server.assert_called_once_with("http://127.0.0.1:9393")
+    popen.assert_not_called()
+    captured = capsys.readouterr()
+    assert "http://127.0.0.1:9393" in captured.err
+    assert "fcc-server" in captured.err
+
+
+def test_launch_claude_proceeds_when_proxy_auto_start_recovers() -> None:
+    settings = _launcher_settings()
+
+    with (
+        patch(
+            "free_claude_code.cli.launchers.claude.get_settings", return_value=settings
+        ),
+        patch(
+            "free_claude_code.cli.launchers.claude.preflight_proxy",
+            return_value="connection refused",
+        ),
+        patch(
+            "free_claude_code.cli.launchers.claude._ensure_fcc_server_running",
+            return_value=True,
+        ) as ensure_server,
+        patch(
+            "free_claude_code.cli.launchers.common.shutil.which",
+            return_value="resolved-claude.cmd",
+        ),
+        patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
+        patch("free_claude_code.cli.launchers.common.register_pid") as register_pid,
+        patch("free_claude_code.cli.launchers.common.unregister_pid") as unregister_pid,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        process = popen.return_value
+        process.pid = 12345
+        process.wait.return_value = 0
+        launch(["--model", "sonnet"])
+
+    assert exc_info.value.code == 0
+    ensure_server.assert_called_once_with("http://127.0.0.1:9191")
+    popen.assert_called_once()
+    assert popen.call_args.args[0] == [
+        "resolved-claude.cmd",
+        "--permission-mode",
+        "default",
+        "--model",
+        "sonnet",
+    ]
+    register_pid.assert_called_once_with(12345)
+    unregister_pid.assert_called_once_with(12345)

--- a/tests/cli/test_cline_launcher.py
+++ b/tests/cli/test_cline_launcher.py
@@ -474,6 +474,7 @@ def test_cline_fails_closed_when_proxy_is_unreachable(
         patch.object(cline, "require_compatible_cline"),
         patch.object(cline, "get_settings", return_value=_settings()),
         patch.object(cline, "preflight_proxy", return_value="connection refused"),
+        patch.object(cline, "_ensure_fcc_server_running", return_value=False),
         patch.object(cline, "fetch_proxy_models_response") as fetch_models,
         patch.object(cline, "run_client_process") as run_client_process,
         pytest.raises(SystemExit) as exc_info,

--- a/tests/cli/test_dsh_launcher.py
+++ b/tests/cli/test_dsh_launcher.py
@@ -273,6 +273,7 @@ def test_dsh_proxy_failure_does_not_fetch_catalog(
         patch.object(dsh, "require_compatible_dsh"),
         patch.object(dsh, "get_settings", return_value=_settings()),
         patch.object(dsh, "preflight_proxy", return_value="connection refused"),
+        patch.object(dsh, "_ensure_fcc_server_running", return_value=False),
         patch.object(dsh, "fetch_proxy_models_response") as fetch_models,
         pytest.raises(SystemExit) as exc_info,
     ):

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -1179,6 +1179,10 @@ def test_launch_claude_unreachable_proxy_exits_with_hint(
             "free_claude_code.cli.launchers.claude.preflight_proxy",
             return_value="connection refused",
         ),
+        patch(
+            "free_claude_code.cli.launchers.claude._ensure_fcc_server_running",
+            return_value=False,
+        ),
         patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
         pytest.raises(SystemExit) as exc_info,
     ):

--- a/tests/cli/test_grok_launcher.py
+++ b/tests/cli/test_grok_launcher.py
@@ -451,6 +451,7 @@ def test_proxy_or_catalog_failure_never_starts_grok() -> None:
         patch.object(grok, "require_compatible_grok"),
         patch.object(grok, "get_settings", return_value=_settings()),
         patch.object(grok, "preflight_proxy", return_value="connection refused"),
+        patch.object(grok, "_ensure_fcc_server_running", return_value=False),
         patch.object(grok, "fetch_proxy_models_response") as fetch_models,
         patch.object(grok, "run_client_process") as run_client_process,
         pytest.raises(SystemExit) as exc_info,

--- a/tests/cli/test_hermes_launcher.py
+++ b/tests/cli/test_hermes_launcher.py
@@ -350,6 +350,7 @@ def test_hermes_proxy_failure_does_not_fetch_catalog(
         patch.object(hermes, "_system_policy_exists", return_value=False),
         patch.object(hermes, "get_settings", return_value=_settings()),
         patch.object(hermes, "preflight_proxy", return_value="connection refused"),
+        patch.object(hermes, "_ensure_fcc_server_running", return_value=False),
         patch.object(hermes, "fetch_proxy_models_response") as fetch_models,
         pytest.raises(SystemExit) as exc_info,
     ):

--- a/tests/cli/test_launcher_common.py
+++ b/tests/cli/test_launcher_common.py
@@ -63,6 +63,7 @@ def test_ensure_server_running_starts_server_and_waits_until_ready(
     assert health_calls == [_PROXY_URL, _PROXY_URL, _PROXY_URL]
     popen.assert_called_once()
     assert popen.call_args.args[0] == _SERVER_COMMAND
+    assert popen.call_args.kwargs["start_new_session"] is True
     lock.acquire.assert_called_once_with(wait=False)
     lock.release.assert_called_once()
     lock_path = lock_cls.call_args.args[0]
@@ -114,9 +115,78 @@ def test_ensure_server_running_waits_for_peer_when_startup_lock_is_held() -> Non
     ):
         assert common._ensure_fcc_server_running(_PROXY_URL) is True
 
+    assert lock.acquire.call_count >= 2
+    lock.acquire.assert_called_with(wait=False)
     popen.assert_not_called()
-    lock.acquire.assert_called_once_with(wait=False)
     lock.release.assert_not_called()
+
+
+def test_ensure_server_running_takes_over_when_starter_gives_up(
+    tmp_path: Path,
+) -> None:
+    health_results: Iterator[str | None] = iter(
+        [
+            "connection refused",
+            "connection refused",
+            "connection refused",
+            None,
+        ]
+    )
+
+    def fake_preflight(_proxy_root_url: str) -> str | None:
+        return next(health_results)
+
+    def fake_popen(*_args: object, **_kwargs: object) -> MagicMock:
+        return MagicMock()
+
+    lock = MagicMock()
+    # The starter is alive for the first poll, then gives up and releases.
+    lock.acquire.side_effect = [False, True]
+
+    with (
+        patch.object(common, "preflight_proxy", side_effect=fake_preflight),
+        patch.object(common, "InterprocessFileLock", return_value=lock),
+        patch.object(common, "config_dir_path", return_value=tmp_path),
+        patch.object(
+            common,
+            "server_log_path",
+            return_value=tmp_path / "logs" / "server.log",
+        ),
+        patch(
+            "free_claude_code.cli.launchers.common.subprocess.Popen",
+            side_effect=fake_popen,
+        ) as popen,
+        patch.object(common.time, "sleep"),
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is True
+
+    popen.assert_called_once()
+    assert popen.call_args.args[0] == _SERVER_COMMAND
+    lock.release.assert_called_once()
+
+
+def test_ensure_server_running_returns_false_when_server_cannot_be_spawned(
+    tmp_path: Path,
+) -> None:
+    lock = MagicMock()
+    lock.acquire.return_value = True
+
+    with (
+        patch.object(common, "preflight_proxy", return_value="connection refused"),
+        patch.object(common, "InterprocessFileLock", return_value=lock),
+        patch.object(common, "config_dir_path", return_value=tmp_path),
+        patch.object(
+            common, "server_log_path", return_value=tmp_path / "logs" / "server.log"
+        ),
+        patch(
+            "free_claude_code.cli.launchers.common.subprocess.Popen",
+            side_effect=OSError("disk full"),
+        ) as popen,
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is False
+
+    popen.assert_called_once()
+    lock.release.assert_called_once()
 
 
 def test_ensure_server_running_fails_when_proxy_never_becomes_ready(
@@ -140,3 +210,20 @@ def test_ensure_server_running_fails_when_proxy_never_becomes_ready(
     popen.assert_called_once()
     assert popen.call_args.args[0] == _SERVER_COMMAND
     lock.release.assert_called_once()
+
+
+def test_ensure_server_running_loser_gives_up_when_never_ready() -> None:
+    lock = MagicMock()
+    lock.acquire.return_value = False
+
+    with (
+        patch.object(common, "preflight_proxy", return_value="connection refused"),
+        patch.object(common, "InterprocessFileLock", return_value=lock),
+        patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
+        patch.object(common.time, "sleep"),
+        patch.object(common, "_SERVER_START_TIMEOUT_SECONDS", 0.05),
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is False
+
+    popen.assert_not_called()
+    lock.release.assert_not_called()

--- a/tests/cli/test_launcher_common.py
+++ b/tests/cli/test_launcher_common.py
@@ -1,0 +1,142 @@
+"""Unit tests for shared installed-client launcher process helpers."""
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from free_claude_code.cli.launchers import common
+
+_PROXY_URL = "http://127.0.0.1:9191"
+_SERVER_COMMAND = [
+    sys.executable,
+    "-m",
+    "free_claude_code.cli.entrypoints",
+    "serve",
+]
+
+
+def test_ensure_server_running_true_when_proxy_already_healthy() -> None:
+    with (
+        patch.object(common, "preflight_proxy", return_value=None),
+        patch.object(common, "InterprocessFileLock") as lock_cls,
+        patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is True
+
+    lock_cls.assert_not_called()
+    popen.assert_not_called()
+
+
+def test_ensure_server_running_starts_server_and_waits_until_ready(
+    tmp_path: Path,
+) -> None:
+    server_ready = False
+    health_calls: list[str] = []
+
+    def fake_preflight(_proxy_root_url: str) -> str | None:
+        health_calls.append(_proxy_root_url)
+        return None if server_ready else "connection refused"
+
+    def fake_popen(*_args: object, **_kwargs: object) -> MagicMock:
+        nonlocal server_ready
+        server_ready = True
+        return MagicMock()
+
+    lock = MagicMock()
+    lock.acquire.return_value = True
+
+    with (
+        patch.object(common, "preflight_proxy", side_effect=fake_preflight),
+        patch.object(common, "InterprocessFileLock", return_value=lock) as lock_cls,
+        patch.object(common, "config_dir_path", return_value=tmp_path),
+        patch.object(
+            common, "server_log_path", return_value=tmp_path / "logs" / "server.log"
+        ),
+        patch(
+            "free_claude_code.cli.launchers.common.subprocess.Popen",
+            side_effect=fake_popen,
+        ) as popen,
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is True
+
+    assert health_calls == [_PROXY_URL, _PROXY_URL, _PROXY_URL]
+    popen.assert_called_once()
+    assert popen.call_args.args[0] == _SERVER_COMMAND
+    lock.acquire.assert_called_once_with(wait=False)
+    lock.release.assert_called_once()
+    lock_path = lock_cls.call_args.args[0]
+    assert lock_path == tmp_path / "server.startup.lock"
+    assert (tmp_path / "logs" / "server.log").exists()
+
+
+def test_ensure_server_running_skips_spawn_when_proxy_becomes_ready_after_lock(
+    tmp_path: Path,
+) -> None:
+    health_calls: list[str] = []
+
+    def fake_preflight(_proxy_root_url: str) -> str | None:
+        health_calls.append(_proxy_root_url)
+        return "connection refused" if len(health_calls) == 1 else None
+
+    lock = MagicMock()
+    lock.acquire.return_value = True
+
+    with (
+        patch.object(common, "preflight_proxy", side_effect=fake_preflight),
+        patch.object(common, "InterprocessFileLock", return_value=lock),
+        patch.object(common, "config_dir_path", return_value=tmp_path),
+        patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is True
+
+    assert len(health_calls) == 2
+    popen.assert_not_called()
+    lock.release.assert_called_once()
+
+
+def test_ensure_server_running_waits_for_peer_when_startup_lock_is_held() -> None:
+    health_results: Iterator[str | None] = iter(
+        ["connection refused", "connection refused", None]
+    )
+
+    def fake_preflight(_proxy_root_url: str) -> str | None:
+        return next(health_results)
+
+    lock = MagicMock()
+    lock.acquire.return_value = False
+
+    with (
+        patch.object(common, "preflight_proxy", side_effect=fake_preflight),
+        patch.object(common, "InterprocessFileLock", return_value=lock),
+        patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
+        patch.object(common.time, "sleep"),
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is True
+
+    popen.assert_not_called()
+    lock.acquire.assert_called_once_with(wait=False)
+    lock.release.assert_not_called()
+
+
+def test_ensure_server_running_fails_when_proxy_never_becomes_ready(
+    tmp_path: Path,
+) -> None:
+    lock = MagicMock()
+    lock.acquire.return_value = True
+
+    with (
+        patch.object(common, "preflight_proxy", return_value="connection refused"),
+        patch.object(common, "InterprocessFileLock", return_value=lock),
+        patch.object(common, "config_dir_path", return_value=tmp_path),
+        patch.object(
+            common, "server_log_path", return_value=tmp_path / "logs" / "server.log"
+        ),
+        patch("free_claude_code.cli.launchers.common.subprocess.Popen") as popen,
+        patch.object(common, "_SERVER_START_TIMEOUT_SECONDS", 0.05),
+    ):
+        assert common._ensure_fcc_server_running(_PROXY_URL) is False
+
+    popen.assert_called_once()
+    assert popen.call_args.args[0] == _SERVER_COMMAND
+    lock.release.assert_called_once()

--- a/tests/cli/test_launcher_common.py
+++ b/tests/cli/test_launcher_common.py
@@ -7,13 +7,20 @@ from unittest.mock import MagicMock, patch
 
 from free_claude_code.cli.launchers import common
 
-_PROXY_URL = "http://127.0.0.1:9191"
+_PROXY_A = "http://127.0.0.1:9191"
+_PROXY_B = "http://127.0.0.1:9192"
+_PROXY_URL = _PROXY_A
 _SERVER_COMMAND = [
     sys.executable,
     "-m",
     "free_claude_code.cli.entrypoints",
     "serve",
 ]
+
+
+def _lock_path_for(proxy_root_url: str) -> Path:
+    safe = proxy_root_url.rstrip("/").lower().replace(":", "_").replace("/", "_")
+    return common.config_dir_path() / f"{safe}.server.startup.lock"
 
 
 def test_ensure_server_running_true_when_proxy_already_healthy() -> None:
@@ -67,7 +74,11 @@ def test_ensure_server_running_starts_server_and_waits_until_ready(
     lock.acquire.assert_called_once_with(wait=False)
     lock.release.assert_called_once()
     lock_path = lock_cls.call_args.args[0]
-    assert lock_path == tmp_path / "server.startup.lock"
+    assert (
+        lock_path
+        == tmp_path
+        / f"{_PROXY_URL.replace(':', '_').replace('/', '_')}.server.startup.lock"
+    )
     assert (tmp_path / "logs" / "server.log").exists()
 
 

--- a/tests/cli/test_opencode_launcher.py
+++ b/tests/cli/test_opencode_launcher.py
@@ -383,6 +383,7 @@ def test_opencode_fails_closed_when_proxy_is_unreachable(
         patch.object(opencode, "require_compatible_opencode"),
         patch.object(opencode, "get_settings", return_value=_settings()),
         patch.object(opencode, "preflight_proxy", return_value="connection refused"),
+        patch.object(opencode, "_ensure_fcc_server_running", return_value=False),
         patch.object(opencode, "fetch_proxy_models_response") as fetch_models,
         patch.object(opencode, "run_client_process") as run_client_process,
         pytest.raises(SystemExit) as exc_info,

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.19.2"
+version = "5.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.20.0"
+version = "5.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #1690

## Summary

Installed client launchers (`fcc-claude`, `fcc-aider`, `fcc-cline`, `fcc-codex`, `fcc-dsh`, `fcc-grok`, `fcc-hermes`, `fcc-opencode`, `fcc-pi`) now start the local FCC server on demand instead of failing immediately when the proxy preflight fails.

- Adds `_ensure_fcc_server_running()` / `_wait_for_server_ready()` to `cli/launchers/common.py`: a health fast-path, then a single `fcc-server` spawn guarded by an interprocess startup lock (`server.startup.lock`), then polling of `/health` until ready (bounded 30s timeout).
- Concurrent launcher invocations cannot race to start duplicate servers: the loser waits for the winner's server to become ready.
- Existing "proxy unreachable" launcher tests now stub the auto-start helper so they keep exercising the failure path without touching real processes.

## Tests

- `tests/cli/test_launcher_common.py`: unit tests for the auto-start helper covering the healthy fast path, on-demand start, the post-lock recheck, startup lock contention, and the startup timeout.
- `tests/cli/test_claude_launcher.py`: launch-level tests for the auto-start gate (fails with the existing hint when the server cannot start; proceeds to run the child when auto-start recovers).
- Updated existing unreachable-proxy tests in the aider/cline/dsh/grok/hermes/opencode launcher suites and `test_entrypoints.py`.

Validation: `ruff format --check`, `ruff check`, `ty check`, and `tests/cli` pass locally. The only local `pytest` failures are pre-existing `tests/scripts` installer-script tests that hit a sandbox disk-quota error while downloading Python 3.12 — unrelated to this change and covered by GitHub CI.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Installed client launchers now start and wait for the local FCC server when its health check is unavailable. The shared startup flow coordinates launchers per endpoint, retries after a failed starter, handles spawn failures without a traceback, and runs the server independently of the client process.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no outstanding issues require changes.

greptile-apps[bot] manually resolved the server-startup coordination thread without explanation. greptile-apps[bot] manually resolved the startup-error handling thread without explanation. greptile-apps[bot] manually resolved the background-server detachment thread without explanation. greptile-apps[bot] manually resolved the endpoint-specific lock scoping thread without explanation. mukeshraju2006 resolved the required minor-version thread without explanation.

<sub>Reviews (4): Last reviewed commit: ["Update pyproject.toml"](https://github.com/alishahryar1/free-claude-code/commit/63e9afb32ebbae632fcfeeb7d944906217001a63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60938386)</sub>

**Context used:**

- Knowledge Base — [Configuration and runtime composition](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/configuration-and-runtime.md)

<!-- /greptile_comment -->