### PR TITLE
Fix fragmented Qwen Cloud streaming answers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.23.2"
+version = "5.23.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -236,6 +236,7 @@ class _OpenAIChatStreamAssembler:
         )
         self._finish_reason: Any = None
         self._usage_info: Any = None
+        self._native_reasoning_seen = False
         self._tool_argument_aliases: dict[str, dict[str, str]] = {}
         self._tool_argument_alias_buffers: dict[int, str] = {}
         self._tool_name_buffers: dict[int, str] = {}
@@ -325,7 +326,12 @@ class _OpenAIChatStreamAssembler:
                     self._output,
                     native_reasoning=reasoning,
                 )
-            elif reasoning is not None:
+            elif reasoning is not None and (
+                reasoning or not self._native_reasoning_seen
+            ):
+                # Preserve initial empty reasoning for replay; later empty fields
+                # are placeholders and must not interrupt text or tool output.
+                self._native_reasoning_seen = True
                 yield from self._output.ensure_reasoning_block()
                 if reasoning:
                     yield self._output.emit_reasoning_delta(reasoning)

--- a/tests/providers/test_streaming_errors.py
+++ b/tests/providers/test_streaming_errors.py
@@ -12,6 +12,7 @@ import pytest
 
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.core.anthropic.stream_contracts import (
+    assert_anthropic_stream_contract,
     parse_sse_text,
 )
 from free_claude_code.core.anthropic.streaming import (
@@ -46,6 +47,7 @@ from tests.providers.support import (
     REASONING_OFF,
     immediate_admission,
     make_provider_config,
+    profiled_provider,
 )
 
 
@@ -647,6 +649,97 @@ class TestStreamingExceptionHandling:
         assert len(thinking_starts) == 1
         assert thinking_deltas == []
         assert parsed[-1].event == "message_stop"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("wire", ["messages", "responses"])
+    @pytest.mark.parametrize(
+        ("deltas", "expected"),
+        [
+            pytest.param(
+                [("plan", ""), ("", "The quick"), ("", " brown fox"), ("", "")],
+                [("reasoning", "plan"), ("text", "The quick brown fox")],
+                id="empty-placeholders-after-reasoning",
+            ),
+            pytest.param(
+                [("", "The quick"), ("", " brown fox"), ("", "")],
+                [("reasoning", ""), ("text", "The quick brown fox")],
+                id="first-empty-reasoning-is-preserved",
+            ),
+            pytest.param(
+                [(None, "The quick"), (None, " brown fox")],
+                [("text", "The quick brown fox")],
+                id="no-reasoning-is-invented",
+            ),
+            pytest.param(
+                [("", None), ("", "first"), ("more", None), ("", "second")],
+                [
+                    ("reasoning", ""),
+                    ("text", "first"),
+                    ("reasoning", "more"),
+                    ("text", "second"),
+                ],
+                id="nonempty-reasoning-can-resume",
+            ),
+        ],
+    )
+    async def test_empty_reasoning_placeholders_preserve_content_blocks(
+        self, wire, deltas, expected
+    ):
+        provider = profiled_provider(
+            "qwencloud",
+            make_provider_config(api_key="test", base_url="https://provider.invalid"),
+        )
+        chunks = [
+            _make_chunk(reasoning_content=reasoning, content=content)
+            for reasoning, content in deltas
+        ] + [_make_chunk(finish_reason="stop")]
+        try:
+            with patch.object(
+                provider._client.chat.completions,
+                "create",
+                new_callable=AsyncMock,
+                side_effect=lambda **kwargs: AsyncStreamMock(chunks),
+            ):
+                # Each request must preserve its own first explicit reasoning value.
+                for _ in range(2):
+                    if wire == "messages":
+                        stream = provider.stream_messages(_make_request())
+                    else:
+                        stream = provider.stream_responses(
+                            OpenAIResponsesRequest(model="test-model", input="Hello")
+                        )
+                    events = parse_sse_text("".join([frame async for frame in stream]))
+                    if wire == "messages":
+                        assert_anthropic_stream_contract(events)
+                        actual = [
+                            (
+                                "reasoning"
+                                if start.data["content_block"]["type"] == "thinking"
+                                else start.data["content_block"]["type"],
+                                "".join(
+                                    event.data["delta"].get(
+                                        "thinking", event.data["delta"].get("text", "")
+                                    )
+                                    for event in events
+                                    if event.event == "content_block_delta"
+                                    and event.data["index"] == start.data["index"]
+                                ),
+                            )
+                            for start in events
+                            if start.event == "content_block_start"
+                        ]
+                    else:
+                        assert events[-1].event == "response.completed"
+                        actual = [
+                            (
+                                "text" if item["type"] == "message" else item["type"],
+                                "".join(part["text"] for part in item["content"]),
+                            )
+                            for item in events[-1].data["response"]["output"]
+                        ]
+                    assert actual == expected
+        finally:
+            await provider.cleanup()
 
     @pytest.mark.asyncio
     async def test_stream_with_reasoning_content_suppressed_when_disabled(self):

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.23.2"
+version = "5.23.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Qwen Cloud sends empty `reasoning_content` fields alongside streamed answer text. FCC treats each empty field as a switch back to thinking, splitting one answer into separate text blocks. Claude Code displays those blocks as broken paragraphs, sometimes splitting words.

Fixes #1699.

## How

The shared OpenAI Chat stream assembler remembers whether the current stream has received a reasoning value. It preserves the first value, including an empty string needed for tool-call replay, and ignores later empty values when opening content blocks. Nonempty reasoning can still resume after text.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The shared OpenAI-compatible stream assembler now preserves the initial reasoning block while ignoring later empty reasoning placeholders, so streamed text and tool calls remain continuous for both Anthropic Messages and OpenAI Responses clients. The package version is updated to 5.23.3.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge. The targeted stream behavior preserves the intended reasoning, text, and tool ordering across both supported output contracts.

No issues were found. The before-and-after mocked-stream check confirmed that the change removes empty placeholder blocks, and the targeted regression matrix passed all eight cases.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline revision d601599 showed empty placeholder fields and caused harness failures.
- Head revision 0d75613 produced reasoning(plan) → text(Alpha) → tool\_use messages and responses from reasoning(plan) → text(Alpha) → function\_call with successful terminal events.
- The narrow deterministic matrix finished with exit code 0 and 8 tests passing in 2.08s.
- Artifacts were captured to enable review, including Python and shell harness scripts and accessible test logs.

<a href="https://app.greptile.com/trex/runs/22870617/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix text fragmentation from empty reason..."](https://github.com/alishahryar1/free-claude-code/commit/0d7561387b59f89da8e3eafa29d8ff737ea723e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61132491)</sub>

**Context used:**

- Knowledge Base — [Provider integration layer](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/provider-integrations.md)
- Knowledge Base — [Protocol adaptation and streaming](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/protocol-adapters.md)

<!-- /greptile_comment -->