### PR TITLE
Fix Auto mode failures on providers that require thinking

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -75,6 +75,7 @@ class _ModelListingProvider(BaseProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         return None
 
@@ -103,6 +104,7 @@ class _ModelListingProvider(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del input_tokens, request_id, response_model
         summary = str(request.system).startswith("Summarize")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.23.3"
+version = "5.23.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/handlers/classifier_response.py
+++ b/src/free_claude_code/api/handlers/classifier_response.py
@@ -1,0 +1,66 @@
+"""Hide structured provider reasoning from Claude's classifier response."""
+
+import sys
+from collections.abc import AsyncIterator
+
+from free_claude_code.core.anthropic.stream_contracts import SSEEvent
+from free_claude_code.core.anthropic.streaming import format_sse_event
+from free_claude_code.core.anthropic.streaming.decoder import AnthropicSSEDecoder
+from free_claude_code.core.trace import close_stream_input
+
+
+async def classifier_response(source: AsyncIterator[str]) -> AsyncIterator[str]:
+    """Project block lifecycles without interpreting any classifier text."""
+    decoder = AnthropicSSEDecoder()
+    indices: dict[int, int | None] = {}
+    next_index = 0
+
+    def project(event: SSEEvent) -> str | None:
+        nonlocal next_index
+        payload = event.data
+        kind = payload.get("type", event.event)
+        if kind not in {
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+        }:
+            return event.raw + "\n\n"
+        index = payload.get("index")
+        if not isinstance(index, int):
+            return event.raw + "\n\n"
+        if kind == "content_block_start":
+            block = payload.get("content_block")
+            if isinstance(block, dict) and block.get("type") in {
+                "thinking",
+                "redacted_thinking",
+            }:
+                indices[index] = None
+            else:
+                indices[index] = next_index
+                next_index += 1
+        if index not in indices:
+            return event.raw + "\n\n"
+        visible_index = indices[index]
+        if kind == "content_block_stop":
+            del indices[index]
+        if visible_index is None:
+            return None
+        return format_sse_event(event.event, {**payload, "index": visible_index})
+
+    try:
+        async for chunk in source:
+            for event in decoder.feed(chunk):
+                projected = project(event)
+                if projected is not None:
+                    yield projected
+        for event in decoder.finish():
+            projected = project(event)
+            if projected is not None:
+                yield projected
+    finally:
+        await close_stream_input(
+            source,
+            owner="classifier_response",
+            source="api",
+            preserved_error=sys.exception(),
+        )

--- a/src/free_claude_code/api/handlers/messages.py
+++ b/src/free_claude_code/api/handlers/messages.py
@@ -38,6 +38,7 @@ from free_claude_code.api.web_tools.request import (
 from free_claude_code.api.web_tools.streaming import stream_web_server_tool_response
 from free_claude_code.application.errors import ApplicationError, InvalidRequestError
 from free_claude_code.application.execution import ProviderExecutor, TokenCounter
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.application.ports import ProviderResolver
 from free_claude_code.application.routing import ModelRouter, RoutedMessagesRequest
 from free_claude_code.config.settings import Settings
@@ -54,6 +55,8 @@ from free_claude_code.core.diagnostics import safe_exception_message
 from free_claude_code.core.failures import ExecutionFailure, find_execution_failure
 from free_claude_code.core.reasoning import ReasoningControl, ReasoningPolicy
 from free_claude_code.core.trace import trace_event
+
+from .classifier_response import classifier_response
 
 
 @dataclass(frozen=True)
@@ -83,6 +86,7 @@ class MessagesHandler:
         provider_executor: ProviderExecutor | None = None,
         generation_id: int | None = None,
         request_headers: Mapping[str, str] | None = None,
+        model_infos: tuple[ProviderModelInfo, ...] = (),
     ) -> None:
         self._settings = settings
         self._model_router = model_router or ModelRouter(settings)
@@ -94,6 +98,7 @@ class MessagesHandler:
             generation_id=generation_id,
             log_raw_payloads=settings.log_raw_api_payloads,
             request_headers=request_headers,
+            model_infos=model_infos,
         )
         self._message_intercepts: tuple[MessageIntercept, ...] = (
             self._intercept_web_server_tool,
@@ -141,6 +146,10 @@ class MessagesHandler:
                         request_id=request_id,
                     )
                 )
+            if routed.reasoning.control is ReasoningControl.PREFER_OFF and isinstance(
+                result, _MessagesStreamResult
+            ):
+                result = _MessagesStreamResult(classifier_response(result.body))
             return await self._to_public_response(
                 result,
                 stream=request_data.stream,
@@ -312,7 +321,7 @@ class MessagesHandler:
         if classifier_stop_sequence is None:
             return routed
 
-        reasoning_changed = routed.reasoning.control is not ReasoningControl.OFF
+        reasoning_changed = routed.reasoning.control is not ReasoningControl.PREFER_OFF
         stop_sequences = routed.request.stop_sequences
         remaining_stop_sequences = (
             [
@@ -345,7 +354,7 @@ class MessagesHandler:
             routed,
             request=request,
             reasoning=(
-                ReasoningPolicy.off() if reasoning_changed else routed.reasoning
+                ReasoningPolicy.prefer_off() if reasoning_changed else routed.reasoning
             ),
         )
 

--- a/src/free_claude_code/api/routes.py
+++ b/src/free_claude_code/api/routes.py
@@ -52,13 +52,14 @@ async def _create_messages_response(
 ) -> object:
     lease: RequestRuntimeLease | None = None
     try:
-        lease = await services.requests.acquire()
+        lease = await services.requests.acquire(include_model_infos=True)
         handler = MessagesHandler(
             lease.settings,
             provider_resolver=_provider_resolver(lease),
             token_counter=get_token_count,
             generation_id=lease.generation_id,
             request_headers=request_headers,
+            model_infos=lease.model_infos,
         )
         response = await handler.create(request_data, request_id=request_id)
     except ApplicationError as exc:

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -29,6 +29,7 @@ from free_claude_code.core.trace import (
     traced_async_stream,
 )
 
+from .model_metadata import ProviderModelInfo
 from .ports import ProviderResolver
 from .routing import (
     ProviderModelTarget,
@@ -61,10 +62,12 @@ class ProviderExecutor:
         generation_id: int | None = None,
         log_raw_payloads: bool = False,
         request_headers: Mapping[str, str] | None = None,
+        model_infos: tuple[ProviderModelInfo, ...] = (),
     ) -> None:
         if not math.isfinite(progress_timeout_seconds) or progress_timeout_seconds <= 0:
             raise ValueError("progress_timeout_seconds must be finite and positive")
         self._provider_resolver = provider_resolver
+        self._model_infos = {info.model_id: info for info in model_infos}
         self._token_counter = token_counter
         self._responses_token_counter = responses_token_counter
         self._generation_id = generation_id
@@ -179,6 +182,7 @@ class ProviderExecutor:
             primary_provider.preflight_messages(
                 primary_request,
                 reasoning=routed.reasoning,
+                model_info=self._model_infos.get(primary.provider_model_ref),
             )
         except ExecutionFailure as failure:
             primary_failure = failure
@@ -208,13 +212,18 @@ class ProviderExecutor:
             if index == 0 and primary_failure is not None:
                 raise primary_failure
             if index > 0:
-                provider.preflight_messages(request, reasoning=routed.reasoning)
+                provider.preflight_messages(
+                    request,
+                    reasoning=routed.reasoning,
+                    model_info=self._model_infos.get(target.provider_model_ref),
+                )
             return provider.stream_messages(
                 request,
                 input_tokens=input_tokens,
                 request_id=request_id,
                 response_model=routed.resolved.original_model,
                 reasoning=routed.reasoning,
+                model_info=self._model_infos.get(target.provider_model_ref),
                 request_headers=self._request_headers,
             )
 

--- a/src/free_claude_code/application/model_metadata.py
+++ b/src/free_claude_code/application/model_metadata.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from free_claude_code.core.model_capabilities import ModelInputModality
+from free_claude_code.core.reasoning import ReasoningCapability
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,6 +15,7 @@ class ProviderModelInfo:
     input_modalities: frozenset[ModelInputModality] | None = None
     context_window_tokens: int | None = None
     max_output_tokens: int | None = None
+    reasoning_capability: ReasoningCapability = ReasoningCapability.UNKNOWN
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/free_claude_code/application/ports.py
+++ b/src/free_claude_code/application/ports.py
@@ -20,6 +20,7 @@ class ProviderPort(Protocol):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None: ...
 
     def stream_messages(
@@ -31,6 +32,7 @@ class ProviderPort(Protocol):
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]: ...
 
     def preflight_responses(

--- a/src/free_claude_code/core/diagnostics.py
+++ b/src/free_claude_code/core/diagnostics.py
@@ -64,6 +64,7 @@ class UpstreamErrorDetail:
             "invalid_request_error",
             "invalid_request",
             "unsupported_parameter",
+            "unsupported_value",
         }
         return self.category_hint in codes or (isinstance(code, str) and code in codes)
 

--- a/src/free_claude_code/core/diagnostics.py
+++ b/src/free_claude_code/core/diagnostics.py
@@ -56,6 +56,17 @@ class UpstreamErrorDetail:
     category_hint: str | None = None
     body_truncated: bool = False
 
+    def is_invalid_request(self, *, code: object = None) -> bool:
+        """Recognize HTTP validation failures and explicit streamed equivalents."""
+        if self.status_code is not None:
+            return self.status_code in {400, 422}
+        codes = {
+            "invalid_request_error",
+            "invalid_request",
+            "unsupported_parameter",
+        }
+        return self.category_hint in codes or (isinstance(code, str) and code in codes)
+
 
 def redact_sensitive_error_text(text: str) -> str:
     """Redact recognizable credentials while preserving diagnostic context."""

--- a/src/free_claude_code/core/reasoning.py
+++ b/src/free_claude_code/core/reasoning.py
@@ -9,7 +9,17 @@ class ReasoningControl(StrEnum):
 
     DEFAULT = "default"
     OFF = "off"
+    PREFER_OFF = "prefer_off"
     ON = "on"
+
+
+class ReasoningCapability(StrEnum):
+    """Explicit provider facts; absent computation controls remain unknown."""
+
+    UNKNOWN = "unknown"
+    NONE = "none"
+    OPTIONAL = "optional"
+    REQUIRED = "required"
 
 
 class ReasoningEffort(StrEnum):
@@ -75,6 +85,11 @@ class ReasoningPolicy:
         return cls(control=ReasoningControl.OFF)
 
     @classmethod
+    def prefer_off(cls) -> ReasoningPolicy:
+        """Prefer disabling computation, allowing provider defaults if necessary."""
+        return cls(control=ReasoningControl.PREFER_OFF)
+
+    @classmethod
     def on(
         cls,
         *,
@@ -91,7 +106,7 @@ class ReasoningPolicy:
 
     @property
     def output_enabled(self) -> bool:
-        """Return whether provider reasoning may be exposed to the client."""
+        """Allow normalized reasoning; classifier ingress owns its public filter."""
 
         return self.control is not ReasoningControl.OFF
 

--- a/src/free_claude_code/providers/anthropic_messages/transport.py
+++ b/src/free_claude_code/providers/anthropic_messages/transport.py
@@ -1,6 +1,7 @@
 """Native Messages HTTP execution with one admitted recovery budget."""
 
 import asyncio
+import json
 import sys
 from collections.abc import AsyncIterator, Callable, Mapping
 from typing import cast
@@ -482,7 +483,7 @@ def _check_failure(event_type: str, payload: JsonObject) -> None:
         529: FailureKind.OVERLOADED,
     }.get(status, FailureKind.UPSTREAM)
     message = error.get("message") if isinstance(error, Mapping) else None
-    raise ExecutionFailure(
+    failure = ExecutionFailure(
         failure_kind,
         status,
         redact_sensitive_error_text(message[:ERROR_DETAIL_DISPLAY_CAP_BYTES])
@@ -490,6 +491,8 @@ def _check_failure(event_type: str, payload: JsonObject) -> None:
         else "Messages upstream returned an error.",
         status == 429 or status >= 500,
     )
+    attach_upstream_error_body(failure, json.dumps(payload))
+    raise failure
 
 
 async def _status_error(response: httpx.Response) -> httpx.HTTPStatusError:

--- a/src/free_claude_code/providers/anthropic_messages/transport.py
+++ b/src/free_claude_code/providers/anthropic_messages/transport.py
@@ -8,6 +8,7 @@ from typing import cast
 import httpx
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.anthropic.errors import anthropic_status_for_error_type
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.native import (
@@ -32,7 +33,11 @@ from free_claude_code.core.openai_responses import (
     ResponsesMessagesRequest,
     build_responses_messages_request,
 )
-from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
+from free_claude_code.core.reasoning import (
+    DEFAULT_REASONING_POLICY,
+    ReasoningControl,
+    ReasoningPolicy,
+)
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
@@ -50,12 +55,20 @@ from free_claude_code.providers.failure_policy import (
     is_retryable_stream_error,
 )
 from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
+from free_claude_code.providers.reasoning_compatibility import (
+    ReasoningCorrection,
+    prepare_messages_reasoning,
+)
 from free_claude_code.providers.stream_recovery import (
     RecoveryController,
     RecoveryFailureAction,
 )
 
-from .request_policy import MessagesModelCapabilities, resolve_messages_options
+from .request_policy import (
+    DEFAULT_MESSAGES_OUTPUT_TOKENS,
+    MessagesModelCapabilities,
+    resolve_messages_options,
+)
 
 type _Presenter = NativeMessagesRelay | AnthropicToResponsesStream
 
@@ -81,8 +94,18 @@ class AnthropicMessagesTransport:
         self._capabilities = capabilities
 
     def _messages_body(
-        self, request: MessagesRequest, reasoning: ReasoningPolicy
+        self,
+        request: MessagesRequest,
+        reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> PreparedMessagesRequest:
+        request, reasoning = prepare_messages_reasoning(
+            request,
+            reasoning,
+            model_info=model_info,
+            can_disable=True,
+            normal_max_tokens=DEFAULT_MESSAGES_OUTPUT_TOKENS,
+        )
         try:
             options = resolve_messages_options(
                 model=request.model,
@@ -122,8 +145,9 @@ class AnthropicMessagesTransport:
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
-        self._messages_body(request, reasoning)
+        self._messages_body(request, reasoning, model_info)
 
     def preflight_responses(
         self,
@@ -141,10 +165,30 @@ class AnthropicMessagesTransport:
         request_id: str | None = None,
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
-        prepared = self._messages_body(request, reasoning)
+        prepared_request, wire_reasoning = prepare_messages_reasoning(
+            request,
+            reasoning,
+            model_info=model_info,
+            can_disable=True,
+            normal_max_tokens=DEFAULT_MESSAGES_OUTPUT_TOKENS,
+        )
+        prepared = self._messages_body(prepared_request, wire_reasoning)
+        correction = (
+            ReasoningCorrection(
+                (("thinking",),),
+                "max_tokens",
+                DEFAULT_MESSAGES_OUTPUT_TOKENS,
+                self._capabilities.max_output_tokens,
+            )
+            if reasoning.control is ReasoningControl.PREFER_OFF
+            and wire_reasoning.control is ReasoningControl.OFF
+            else None
+        )
         return self._stream(
             prepared.body,
+            reasoning_correction=correction,
             betas=prepared.betas,
             endpoint_context=endpoint_context,
             request_id=request_id,
@@ -184,10 +228,12 @@ class AnthropicMessagesTransport:
         endpoint_context: EndpointContext,
         request_id: str | None,
         presenter_factory: Callable[[], _Presenter],
+        reasoning_correction: ReasoningCorrection | None = None,
     ) -> AsyncIterator[str]:
         execution = self._admission.start_execution(request_id=request_id)
         run = self._run(
             body,
+            reasoning_correction=reasoning_correction,
             betas=betas,
             endpoint_context=endpoint_context,
             execution=execution,
@@ -215,6 +261,7 @@ class AnthropicMessagesTransport:
         endpoint_context: EndpointContext,
         execution: ProviderExecution,
         presenter_factory: Callable[[], _Presenter],
+        reasoning_correction: ReasoningCorrection | None = None,
     ) -> AsyncIterator[str]:
         recovery = RecoveryController()
         refreshed = False
@@ -318,6 +365,24 @@ class AnthropicMessagesTransport:
                         recovery.discard()
                         continue
                 attempt_failure = None
+                if (
+                    scope is not None
+                    and reasoning_correction is not None
+                    and not recovery.committed
+                ):
+                    corrected_body = reasoning_correction.retry_body(error, body)
+                    if corrected_body is not None:
+                        retry = (
+                            execution.can_attempt
+                            if scope.attempt.accepted
+                            else await scope.attempt.correct(error)
+                            is ProviderCorrectionAction.RETRY
+                        )
+                        reasoning_correction = None
+                        if retry:
+                            body = corrected_body
+                            recovery.discard()
+                            continue
                 if scope is not None and not scope.attempt.accepted:
                     attempt_failure = await scope.attempt.fail(error)
                 if attempt_failure is not None and attempt_failure.retry_allowed:

--- a/src/free_claude_code/providers/base.py
+++ b/src/free_claude_code/providers/base.py
@@ -50,6 +50,7 @@ class BaseProvider(ABC):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         """Validate a Messages request before opening its SSE stream."""
 
@@ -123,6 +124,7 @@ class BaseProvider(ABC):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         """Stream response in Anthropic SSE format."""
 

--- a/src/free_claude_code/providers/deepseek/client.py
+++ b/src/free_claude_code/providers/deepseek/client.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
 from free_claude_code.providers.admission import ProviderAdmissionController
@@ -49,6 +51,14 @@ def _deepseek_cache_partition(
 class DeepSeekProvider(OpenAIChatProvider):
     """DeepSeek using ``https://api.deepseek.com`` Chat Completions."""
 
+    @property
+    def _reasoning_off_fields(self) -> tuple[tuple[str, ...], ...]:
+        return (("extra_body", "thinking"),)
+
+    @property
+    def _normal_max_tokens(self) -> int:
+        return ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+
     def __init__(
         self, config: ProviderConfig, *, admission: ProviderAdmissionController
     ):
@@ -63,7 +73,11 @@ class DeepSeekProvider(OpenAIChatProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> dict:
+        request, reasoning = self._prepare_messages_reasoning(
+            request, reasoning, model_info
+        )
         return build_deepseek_request_body(
             request,
             reasoning=reasoning,

--- a/src/free_claude_code/providers/github_copilot/provider.py
+++ b/src/free_claude_code/providers/github_copilot/provider.py
@@ -120,6 +120,7 @@ class GitHubCopilotProvider(BaseProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         # Endpoint family and capabilities belong to the current account lease.
         # Conversion runs after acquisition and before opening the physical stream.
@@ -151,6 +152,7 @@ class GitHubCopilotProvider(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         self.preflight_messages(request, reasoning=reasoning)
         return self._dispatch(
@@ -236,6 +238,7 @@ class GitHubCopilotProvider(BaseProvider):
                                 request_id=request_id,
                                 response_model=response_model,
                                 reasoning=reasoning,
+                                model_info=lease.model.info,
                             )
                         else:
                             selected = native.stream_responses(
@@ -255,14 +258,28 @@ class GitHubCopilotProvider(BaseProvider):
                             else self._chat(lease.model)
                         )
                         if isinstance(request, MessagesRequest):
-                            selected = transport.stream_messages(
-                                request,
-                                input_tokens=input_tokens,
-                                request_id=request_id,
-                                response_model=response_model,
-                                reasoning=resolved,
-                                endpoint_context=lease,
-                            )
+                            if lease.egress is CopilotEgress.RESPONSES:
+                                selected = self._responses.stream_messages(
+                                    request,
+                                    input_tokens=input_tokens,
+                                    request_id=request_id,
+                                    response_model=response_model,
+                                    reasoning=resolved,
+                                    endpoint_context=lease,
+                                    model_info=lease.model.info,
+                                    can_disable_reasoning="none"
+                                    in (lease.model.supported_efforts or ()),
+                                )
+                            else:
+                                selected = self._chat(lease.model).stream_messages(
+                                    request,
+                                    input_tokens=input_tokens,
+                                    request_id=request_id,
+                                    response_model=response_model,
+                                    reasoning=resolved,
+                                    endpoint_context=lease,
+                                    model_info=lease.model.info,
+                                )
                         else:
                             selected = transport.stream_responses(
                                 request,

--- a/src/free_claude_code/providers/github_copilot/request_policy.py
+++ b/src/free_claude_code/providers/github_copilot/request_policy.py
@@ -16,6 +16,9 @@ from free_claude_code.providers.openai_chat import (
     OpenAIChatProfile,
     OpenAIChatRequestPolicy,
 )
+from free_claude_code.providers.reasoning_compatibility import (
+    prepare_messages_reasoning,
+)
 
 from .types import CopilotModel
 
@@ -52,6 +55,18 @@ def non_messages_reasoning(
     model: CopilotModel,
 ) -> ReasoningPolicy:
     """Reject controls these egresses cannot encode before any inference."""
+    if policy.control is ReasoningControl.PREFER_OFF and isinstance(
+        request, MessagesRequest
+    ):
+        prepared, wire_policy = prepare_messages_reasoning(
+            request,
+            policy,
+            model_info=model.info,
+            can_disable="none" in (model.supported_efforts or ()),
+            normal_max_tokens=None,
+        )
+        non_messages_reasoning(prepared, wire_policy, model)
+        return policy
     raw_effort = (
         (request.output_config.get("effort") if request.output_config else None)
         if isinstance(request, MessagesRequest)

--- a/src/free_claude_code/providers/github_copilot/sdk.py
+++ b/src/free_claude_code/providers/github_copilot/sdk.py
@@ -42,6 +42,7 @@ from free_claude_code.providers.anthropic_messages.request_policy import (
     MessagesModelCapabilities,
 )
 from free_claude_code.providers.endpoint import HttpEndpoint
+from free_claude_code.providers.model_listing import reasoning_capability_from_options
 
 from .lifecycle import drain_owned
 from .types import (
@@ -444,6 +445,9 @@ def _model(model: Model) -> CopilotModel:
     context = limits.max_context_window_tokens if limits is not None else None
     info = ProviderModelInfo(
         model_id=model.id,
+        reasoning_capability=reasoning_capability_from_options(
+            {"supported_efforts": efforts}
+        ),
         supports_thinking=True
         if effort_support is True or adaptive in {"optional", "required"}
         else None,

--- a/src/free_claude_code/providers/google_openai/reasoning.py
+++ b/src/free_claude_code/providers/google_openai/reasoning.py
@@ -33,6 +33,8 @@ _THINKING_CONFIG_CONFLICT = (
 class GeminiReasoningEncoder:
     """Choose one Gemini API reasoning channel for each resolved policy."""
 
+    off_field = ("reasoning_effort",)
+
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         if _preserve_caller_thinking_config(body, policy):
             return
@@ -58,6 +60,8 @@ class GeminiReasoningEncoder:
 @dataclass(frozen=True, slots=True)
 class VertexReasoningEncoder:
     """Encode Vertex reasoning through one Google thinking-config object."""
+
+    off_field = ("extra_body", "extra_body", "google", "thinking_config")
 
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         if _preserve_caller_thinking_config(body, policy):

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -118,6 +118,10 @@ class GroqProvider(OpenAIChatProvider):
             return body
         return _rewrite_reasoning_effort(body, accepted) or body
 
+    def _reasoning_disable_rejected(self, error: Exception) -> bool:
+        accepted = _parse_reasoning_vocabulary(error)
+        return accepted is not None and "none" not in accepted
+
     def _get_retry_request_body(
         self, error: Exception, body: dict[str, Any]
     ) -> dict[str, Any] | None:

--- a/src/free_claude_code/providers/groq/client.py
+++ b/src/free_claude_code/providers/groq/client.py
@@ -25,6 +25,7 @@ from free_claude_code.providers.openai_chat import (
     OpenAIModelListing,
     validate_extra_body_does_not_override_reasoning_fields,
 )
+from free_claude_code.providers.reasoning_compatibility import ReasoningCorrection
 
 from .tpm import correct_tpm_completion_budget
 
@@ -143,8 +144,17 @@ class GroqProvider(OpenAIChatProvider):
         error: Exception,
         body: JsonObject,
         used_retry_kinds: set[str],
+        *,
+        reasoning_correction: ReasoningCorrection | None = None,
+        sent_body: Mapping[str, Any] | None = None,
     ) -> JsonObject | None:
-        retry_body = super()._next_create_retry_body(error, body, used_retry_kinds)
+        retry_body = super()._next_create_retry_body(
+            error,
+            body,
+            used_retry_kinds,
+            reasoning_correction=reasoning_correction,
+            sent_body=sent_body,
+        )
         if retry_body is not None or "groq_tpm" in used_retry_kinds:
             return retry_body
 

--- a/src/free_claude_code/providers/lmstudio/client.py
+++ b/src/free_claude_code/providers/lmstudio/client.py
@@ -16,6 +16,7 @@ import time
 import httpx
 from loguru import logger
 
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.anthropic import ReasoningReplayMode, get_token_count
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.openai_responses import (
@@ -85,8 +86,9 @@ class LMStudioProvider(OpenAIChatProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
-        super().preflight_messages(request, reasoning=reasoning)
+        super().preflight_messages(request, reasoning=reasoning, model_info=model_info)
         self._preflight_context_budget(
             get_token_count(request.messages, request.system, request.tools)
         )

--- a/src/free_claude_code/providers/mistral/client.py
+++ b/src/free_claude_code/providers/mistral/client.py
@@ -48,6 +48,10 @@ _PROFILE = OpenAIChatProfile(
 class MistralProvider(OpenAIChatProvider):
     """Mistral API using ``https://api.mistral.ai/v1/chat/completions``."""
 
+    @property
+    def _reasoning_off_fields(self) -> tuple[tuple[str, ...], ...]:
+        return (("reasoning_effort",),)
+
     def __init__(
         self, config: ProviderConfig, *, admission: ProviderAdmissionController
     ):

--- a/src/free_claude_code/providers/model_listing.py
+++ b/src/free_claude_code/providers/model_listing.py
@@ -8,6 +8,7 @@ from free_claude_code.application.model_metadata import (
     ProviderModelInfo as _ProviderModelInfo,
 )
 from free_claude_code.core.model_capabilities import ModelInputModality
+from free_claude_code.core.reasoning import ReasoningCapability
 
 type ModelListScalar = str | bool
 type RequiredPathValues = tuple[
@@ -124,11 +125,16 @@ def extract_openai_model_infos(
             continue
 
         supports_thinking: bool | None = None
+        intrinsic_facts: set[bool] = set()
         if tags_field is not None:
             tags_value = _field(item, tags_field)
             tags = _optional_string_sequence(tags_value)
             if tags is not None:
                 tag_set = frozenset(tags)
+                if thinking_tag in tag_set:
+                    intrinsic_facts.add(True)
+                if non_thinking_tag is not None and non_thinking_tag in tag_set:
+                    intrinsic_facts.add(False)
                 if thinking_tag in tag_set:
                     supports_thinking = True
                 elif non_thinking_tag is not None and non_thinking_tag in tag_set:
@@ -138,6 +144,7 @@ def extract_openai_model_infos(
             capability = _path(item, thinking_boolean_path)
             if isinstance(capability, bool):
                 supports_thinking = capability
+                intrinsic_facts.add(capability)
 
         if thinking_sequence_path is not None:
             values = _optional_string_sequence(_path(item, thinking_sequence_path))
@@ -162,6 +169,9 @@ def extract_openai_model_infos(
 
         model_info = _ProviderModelInfo(
             model_id=model_id,
+            reasoning_capability=ReasoningCapability.NONE
+            if intrinsic_facts == {False}
+            else ReasoningCapability.UNKNOWN,
             supports_thinking=supports_thinking,
             input_modalities=input_modalities,
             context_window_tokens=context_window_tokens,
@@ -216,6 +226,9 @@ def extract_tool_capable_model_infos(
         model_infos.add(
             _ProviderModelInfo(
                 model_id=model_id,
+                reasoning_capability=reasoning_capability_from_options(
+                    _field(item, "reasoning")
+                ),
                 supports_thinking=(
                     "reasoning" in capability_parameters
                     if capability_parameters is not None
@@ -234,6 +247,24 @@ def extract_tool_capable_model_infos(
         )
 
     return frozenset(model_infos)
+
+
+def reasoning_capability_from_options(options: object) -> ReasoningCapability:
+    """Retain explicit gateway computation facts; missing controls prove nothing."""
+    if not isinstance(options, Mapping):
+        return ReasoningCapability.UNKNOWN
+    mandatory = options.get("mandatory")
+    efforts = options.get("supported_efforts")
+    if mandatory is not None and not isinstance(mandatory, bool):
+        return ReasoningCapability.UNKNOWN
+    if efforts is not None and _optional_string_sequence(efforts) is None:
+        return ReasoningCapability.UNKNOWN
+    can_disable = isinstance(efforts, (list, tuple)) and "none" in efforts
+    if mandatory is True:
+        return (
+            ReasoningCapability.UNKNOWN if can_disable else ReasoningCapability.REQUIRED
+        )
+    return ReasoningCapability.OPTIONAL if can_disable else ReasoningCapability.UNKNOWN
 
 
 def model_list_items(

--- a/src/free_claude_code/providers/nvidia_nim/client.py
+++ b/src/free_claude_code/providers/nvidia_nim/client.py
@@ -8,6 +8,7 @@ from typing import Any
 import openai
 from loguru import logger
 
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.failures import ExecutionFailure
@@ -54,6 +55,17 @@ _PROFILE = OpenAIChatProfile(
 class NvidiaNimProvider(OpenAIChatProvider):
     """NVIDIA NIM provider using official OpenAI client."""
 
+    @property
+    def _reasoning_off_fields(self) -> tuple[tuple[str, ...], ...]:
+        return (
+            ("extra_body", "chat_template_kwargs", "thinking"),
+            ("extra_body", "chat_template_kwargs", "enable_thinking"),
+        )
+
+    @property
+    def _normal_max_tokens(self) -> int | None:
+        return self._nim_settings.max_tokens
+
     def __init__(
         self,
         config: ProviderConfig,
@@ -73,8 +85,12 @@ class NvidiaNimProvider(OpenAIChatProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> dict:
         """Internal helper for tests and shared building."""
+        request, reasoning = self._prepare_messages_reasoning(
+            request, reasoning, model_info
+        )
         return build_nim_request_body(
             request,
             self._nim_settings,

--- a/src/free_claude_code/providers/open_router/client.py
+++ b/src/free_claude_code/providers/open_router/client.py
@@ -1,8 +1,11 @@
 """OpenRouter provider implementation."""
 
+import json
+
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 from free_claude_code.core.anthropic import ReasoningReplayMode
+from free_claude_code.core.diagnostics import extract_upstream_error_detail
 from free_claude_code.core.reasoning import ReasoningEffort
 from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.base import ProviderConfig
@@ -14,6 +17,9 @@ from free_claude_code.providers.openai_chat import (
     ReasoningObject,
     apply_reasoning_details_replay,
     validate_extra_body_does_not_override_canonical_fields,
+)
+from free_claude_code.providers.reasoning_compatibility import (
+    reasoning_control_rejected,
 )
 
 _REQUEST_POLICY = OpenAIChatRequestPolicy(
@@ -35,6 +41,26 @@ class OpenRouterProvider(OpenAIChatProvider):
             config,
             profile=_PROFILE,
             admission=admission,
+        )
+
+    def _reasoning_disable_rejected(self, error: Exception) -> bool:
+        detail = extract_upstream_error_detail(error)
+        if detail.status_code not in {None, 200}:
+            return False
+        try:
+            payload = json.loads(detail.body_text or "")
+        except ValueError:
+            return False
+        if not isinstance(payload, dict):
+            return False
+        error_body = payload.get("error", payload)
+        if not isinstance(error_body, dict):
+            return False
+        code = error_body.get("code")
+        return (
+            isinstance(code, int)
+            and code == 400
+            and reasoning_control_rejected(error_body, ("reasoning",))
         )
 
     async def list_model_infos(self) -> frozenset[ProviderModelInfo]:

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -46,7 +46,11 @@ from free_claude_code.core.openai_tool_names import (
     OpenAIToolNameCodec,
     encode_openai_chat_tool_names,
 )
-from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
+from free_claude_code.core.reasoning import (
+    DEFAULT_REASONING_POLICY,
+    ReasoningControl,
+    ReasoningPolicy,
+)
 from free_claude_code.core.trace import provider_chat_body_snapshot, trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
@@ -75,6 +79,10 @@ from free_claude_code.providers.model_listing import (
     merge_model_list_pages,
     model_infos_from_ids,
     validate_model_list_page,
+)
+from free_claude_code.providers.reasoning_compatibility import (
+    ReasoningCorrection,
+    prepare_messages_reasoning,
 )
 from free_claude_code.providers.stream_recovery import (
     RecoveryController,
@@ -665,8 +673,12 @@ class OpenAIChatProvider(BaseProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> dict[str, Any]:
         """Build a provider request from the immutable profile."""
+        request, reasoning = self._prepare_messages_reasoning(
+            request, reasoning, model_info
+        )
         body = build_openai_chat_request_body(
             request,
             reasoning=reasoning,
@@ -674,6 +686,29 @@ class OpenAIChatProvider(BaseProvider):
             postprocessors=self._profile.request_postprocessors,
         )
         return self._finalize_chat_body(body, reasoning=reasoning)
+
+    @property
+    def _reasoning_off_fields(self) -> tuple[tuple[str, ...], ...]:
+        field = self._profile.reasoning.off_field
+        return (field,) if field is not None else ()
+
+    @property
+    def _normal_max_tokens(self) -> int | None:
+        return self._profile.request_policy.default_max_tokens
+
+    def _prepare_messages_reasoning(
+        self,
+        request: MessagesRequest,
+        reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None,
+    ) -> tuple[MessagesRequest, ReasoningPolicy]:
+        return prepare_messages_reasoning(
+            request,
+            reasoning,
+            model_info=model_info,
+            can_disable=bool(self._reasoning_off_fields),
+            normal_max_tokens=self._normal_max_tokens,
+        )
 
     def _build_responses_request_body(
         self,
@@ -718,9 +753,10 @@ class OpenAIChatProvider(BaseProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         """Validate OpenAI-chat request conversion before streaming."""
-        self._build_request_body(request, reasoning=reasoning)
+        self._build_request_body(request, reasoning=reasoning, model_info=model_info)
 
     def preflight_responses(
         self,
@@ -797,7 +833,8 @@ class OpenAIChatProvider(BaseProvider):
         used_retry_kinds: set[str] | None = None,
         endpoint: RequestEndpoint | None = None,
         extra_headers: Mapping[str, str] | None = None,
-    ) -> tuple[Any, dict, ProviderAttempt]:
+        reasoning_correction: ReasoningCorrection | None = None,
+    ) -> tuple[Any, dict, ProviderAttempt, dict]:
         """Create a streaming chat completion with bounded request fallbacks."""
         body = self._apply_learned_output_cap(body)
         if used_retry_kinds is None:
@@ -807,6 +844,7 @@ class OpenAIChatProvider(BaseProvider):
             attempt = await execution.open_attempt(operation_kind)
             stream: Any | None = None
             retain_attempt = False
+            create_body = body
             try:
                 create_body = self._prepare_create_body(body)
                 client = (
@@ -827,7 +865,7 @@ class OpenAIChatProvider(BaseProvider):
                 )
                 stream = self._normalize_stream(stream, body)
                 retain_attempt = True
-                return stream, body, attempt
+                return stream, body, attempt, create_body
             except asyncio.CancelledError:
                 raise
             except Exception as error:
@@ -835,11 +873,17 @@ class OpenAIChatProvider(BaseProvider):
                     error, attempt, execution
                 ):
                     continue
-                retry_body = self._next_create_retry_body(error, body, used_retry_kinds)
+                retry_body = self._next_create_retry_body(
+                    error,
+                    body,
+                    used_retry_kinds,
+                    reasoning_correction=reasoning_correction,
+                    sent_body=create_body,
+                )
                 if retry_body is not None:
                     correction = await attempt.correct(error)
                     if correction is ProviderCorrectionAction.RETRY:
-                        body = retry_body
+                        body = self._apply_learned_output_cap(retry_body)
                         continue
                     raise
                 decision = await attempt.fail(
@@ -872,7 +916,17 @@ class OpenAIChatProvider(BaseProvider):
         error: Exception,
         body: dict,
         used_retry_kinds: set[str],
+        *,
+        reasoning_correction: ReasoningCorrection | None = None,
+        sent_body: Mapping[str, Any] | None = None,
     ) -> dict | None:
+        if reasoning_correction is not None and "reasoning" not in used_retry_kinds:
+            retry_body = reasoning_correction.retry_body(
+                error, body, sent_body=sent_body
+            )
+            if retry_body is not None:
+                used_retry_kinds.add("reasoning")
+                return retry_body
         retry_body = self._retry_body_for_output_cap(error, body)
         if retry_body is not None:
             return retry_body
@@ -935,11 +989,27 @@ class OpenAIChatProvider(BaseProvider):
         request_id: str | None = None,
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
         endpoint_context: EndpointContext | None = None,
         request_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
         """Stream response in Anthropic SSE format."""
-        body = self._build_request_body(request, reasoning=reasoning)
+        prepared_request, wire_reasoning = self._prepare_messages_reasoning(
+            request, reasoning, model_info
+        )
+        body = self._build_request_body(prepared_request, reasoning=wire_reasoning)
+        off_fields = self._reasoning_off_fields
+        correction = (
+            ReasoningCorrection(
+                off_fields,
+                self._profile.request_policy.max_tokens_field,
+                self._normal_max_tokens,
+            )
+            if reasoning.control is ReasoningControl.PREFER_OFF
+            and wire_reasoning.control is ReasoningControl.OFF
+            and off_fields
+            else None
+        )
         tool_names = OpenAIToolNameCodec.from_request(request)
         message_id = f"msg_{uuid.uuid4()}"
         runner = _OpenAIChatStreamRunner(
@@ -962,6 +1032,7 @@ class OpenAIChatProvider(BaseProvider):
             reasoning=reasoning,
             endpoint_context=endpoint_context,
             extra_headers=self._upstream_headers(request_headers or {}),
+            reasoning_correction=correction,
         )
         return runner.run()
 
@@ -1022,6 +1093,7 @@ class _OpenAIChatStreamRunner:
         reasoning: ReasoningPolicy,
         endpoint_context: EndpointContext | None = None,
         extra_headers: Mapping[str, str] | None = None,
+        reasoning_correction: ReasoningCorrection | None = None,
     ) -> None:
         self._provider = provider
         self._body = body
@@ -1033,6 +1105,7 @@ class _OpenAIChatStreamRunner:
         self._request_id = request_id
         self._response_model = response_model
         self._reasoning = reasoning
+        self._reasoning_correction = reasoning_correction
         self._extra_headers = dict(extra_headers or {})
         self._terminal_failure: ExecutionFailure | None = None
         self._endpoint = (
@@ -1106,13 +1179,14 @@ class _OpenAIChatStreamRunner:
             assembler = self._new_stream_assembler(output_reasoning=output_reasoning)
             scope: ProviderAttemptScope | None = None
             try:
-                stream, body, attempt = await self._provider._create_stream(
+                stream, body, attempt, sent_body = await self._provider._create_stream(
                     body,
                     execution,
                     ProviderOperationKind.GENERATION,
                     used_retry_kinds=used_retry_kinds,
                     endpoint=self._endpoint,
                     extra_headers=self._extra_headers,
+                    reasoning_correction=self._reasoning_correction,
                 )
                 scope = ProviderAttemptScope(
                     attempt,
@@ -1141,6 +1215,29 @@ class _OpenAIChatStreamRunner:
             except asyncio.CancelledError, GeneratorExit:
                 raise
             except Exception as error:
+                if (
+                    scope is not None
+                    and not recovery.committed
+                    and self._reasoning_correction is not None
+                    and "reasoning" not in used_retry_kinds
+                ):
+                    corrected_body = self._reasoning_correction.retry_body(
+                        error, body, sent_body=sent_body
+                    )
+                    if corrected_body is not None:
+                        used_retry_kinds.add("reasoning")
+                        retry = (
+                            execution.can_attempt
+                            if scope.attempt.accepted
+                            else await scope.attempt.correct(error)
+                            is ProviderCorrectionAction.RETRY
+                        )
+                        if retry:
+                            body = self._provider._apply_learned_output_cap(
+                                corrected_body
+                            )
+                            recovery.discard()
+                            continue
                 resolution = await self._resolve_attempt_failure(
                     error=error,
                     scope=scope,
@@ -1389,7 +1486,7 @@ class _OpenAIChatStreamRunner:
         while execution.can_attempt:
             scope: ProviderAttemptScope | None = None
             try:
-                stream, body, attempt = await self._provider._create_stream(
+                stream, body, attempt, _sent_body = await self._provider._create_stream(
                     body,
                     execution,
                     operation_kind,

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -777,6 +777,10 @@ class OpenAIChatProvider(BaseProvider):
         """Return a modified request body for one retry, or None."""
         return None
 
+    def _reasoning_disable_rejected(self, error: Exception) -> bool:
+        """Recognize provider-owned OFF rejection formats without learning state."""
+        return False
+
     def _provider_failure_override(self, error: Exception) -> ExecutionFailure | None:
         """Return provider-specific failure semantics, or defer to shared policy."""
         return None
@@ -1004,6 +1008,7 @@ class OpenAIChatProvider(BaseProvider):
                 off_fields,
                 self._profile.request_policy.max_tokens_field,
                 self._normal_max_tokens,
+                provider_rejection=self._reasoning_disable_rejected,
             )
             if reasoning.control is ReasoningControl.PREFER_OFF
             and wire_reasoning.control is ReasoningControl.OFF

--- a/src/free_claude_code/providers/openai_chat/reasoning.py
+++ b/src/free_claude_code/providers/openai_chat/reasoning.py
@@ -17,10 +17,15 @@ class ReasoningEncoder(Protocol):
 
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None: ...
 
+    @property
+    def off_field(self) -> tuple[str, ...] | None: ...
+
 
 @dataclass(frozen=True, slots=True)
 class NoReasoning:
     """Leave reasoning computation entirely to the upstream provider."""
+
+    off_field = None
 
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         return
@@ -36,6 +41,12 @@ class NamedEffortReasoning:
     field: str = "reasoning_effort"
     budget_field: str | None = None
     use_extra_body: bool = False
+
+    @property
+    def off_field(self) -> tuple[str, ...] | None:
+        if self.disabled_value is None:
+            return None
+        return ("extra_body", self.field) if self.use_extra_body else (self.field,)
 
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         target = _extra_body(body) if self.use_extra_body else body
@@ -64,6 +75,8 @@ class ReasoningObject:
     efforts: EffortValues
     supports_budget: bool = True
 
+    off_field = ("extra_body", "reasoning")
+
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         if policy.control is ReasoningControl.OFF:
             _extra_body(body)["reasoning"] = {"enabled": False}
@@ -88,6 +101,8 @@ class ThinkingObjectReasoning:
     enabled: dict[str, Any]
     disabled: dict[str, Any]
 
+    off_field = ("extra_body", "thinking")
+
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         if policy.control is ReasoningControl.OFF:
             _extra_body(body)["thinking"] = dict(self.disabled)
@@ -101,6 +116,10 @@ class ChatTemplateReasoning:
 
     field: str = "thinking"
 
+    @property
+    def off_field(self) -> tuple[str, ...]:
+        return ("extra_body", "chat_template_kwargs", self.field)
+
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         if not policy.requests_reasoning and policy.control is not ReasoningControl.OFF:
             return
@@ -112,6 +131,8 @@ class ChatTemplateReasoning:
 class LlamaCppReasoning:
     """Encode llama.cpp's per-request numeric thinking budget."""
 
+    off_field = ("extra_body", "thinking_budget_tokens")
+
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         if policy.control is ReasoningControl.OFF:
             _extra_body(body)["thinking_budget_tokens"] = 0
@@ -122,6 +143,8 @@ class LlamaCppReasoning:
 @dataclass(frozen=True, slots=True)
 class SplitReasoningOutput:
     """Request separate reasoning output where compute is not controllable."""
+
+    off_field = None
 
     def encode(self, body: dict[str, Any], policy: ReasoningPolicy) -> None:
         _extra_body(body)["reasoning_split"] = True

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -24,6 +24,7 @@ from free_claude_code.providers.http import ProviderAttemptScope
 from free_claude_code.providers.model_listing import (
     optional_input_modalities,
     optional_positive_int,
+    reasoning_capability_from_options,
 )
 from free_claude_code.providers.openai_responses import OpenAIResponsesTransport
 
@@ -96,8 +97,11 @@ class OpenAICodexProvider(BaseProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
-        self._responses.preflight_messages(request, reasoning=reasoning)
+        self._responses.preflight_messages(
+            request, reasoning=reasoning, model_info=model_info
+        )
 
     def preflight_responses(
         self,
@@ -174,6 +178,7 @@ class OpenAICodexProvider(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         return self._responses.stream_messages(
             request,
@@ -182,6 +187,7 @@ class OpenAICodexProvider(BaseProvider):
             response_model=response_model or request.model,
             reasoning=reasoning,
             endpoint_context=self._endpoint(session_id=str(uuid.uuid4())),
+            model_info=model_info,
         )
 
     def stream_responses(
@@ -233,6 +239,13 @@ def _model_infos(payload: Any) -> frozenset[ProviderModelInfo]:
             ProviderModelInfo(
                 model_id=model_id,
                 supports_thinking=_supports_reasoning(efforts),
+                reasoning_capability=reasoning_capability_from_options(
+                    {
+                        "supported_efforts": [level["effort"] for level in efforts]
+                        if _supports_reasoning(efforts) is not None
+                        else None,
+                    }
+                ),
                 input_modalities=optional_input_modalities(
                     model.get("input_modalities")
                 ),

--- a/src/free_claude_code/providers/openai_responses/transport.py
+++ b/src/free_claude_code/providers/openai_responses/transport.py
@@ -12,6 +12,7 @@ from openai.types.responses import ResponseInputParam, ResponseStreamEvent
 from openai.types.responses.response_create_params import ResponseCreateParamsStreaming
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.diagnostics import extract_upstream_error_detail
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
@@ -28,10 +29,11 @@ from free_claude_code.core.openai_responses import (
     responses_stream_failure_from_event,
 )
 from free_claude_code.core.openai_tool_names import OpenAIToolNameCodec
-from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.core.reasoning import ReasoningControl, ReasoningPolicy
 from free_claude_code.core.trace import trace_event
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
+    ProviderCorrectionAction,
     ProviderExecution,
     ProviderOperationKind,
 )
@@ -46,6 +48,10 @@ from free_claude_code.providers.failure_policy import (
     reports_context_window_incomplete,
 )
 from free_claude_code.providers.http import ProviderAttemptScope, maybe_await_aclose
+from free_claude_code.providers.reasoning_compatibility import (
+    ReasoningCorrection,
+    prepare_messages_reasoning,
+)
 from free_claude_code.providers.stream_recovery import (
     RecoveryController,
     RecoveryFailureAction,
@@ -112,8 +118,15 @@ class OpenAIResponsesTransport:
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
+        can_disable_reasoning: bool = True,
     ) -> None:
-        self._build_messages_body(request, reasoning=reasoning)
+        self._build_messages_body(
+            request,
+            reasoning=reasoning,
+            model_info=model_info,
+            can_disable_reasoning=can_disable_reasoning,
+        )
 
     def stream_messages(
         self,
@@ -125,12 +138,28 @@ class OpenAIResponsesTransport:
         reasoning: ReasoningPolicy,
         endpoint_context: EndpointContext | None = None,
         extra_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
+        can_disable_reasoning: bool = True,
     ) -> AsyncIterator[str]:
-        body = self._build_messages_body(request, reasoning=reasoning)
+        prepared, wire_reasoning = prepare_messages_reasoning(
+            request,
+            reasoning,
+            model_info=model_info,
+            can_disable=can_disable_reasoning,
+            normal_max_tokens=None,
+        )
+        body = self._build_messages_body(prepared, reasoning=wire_reasoning)
+        correction = (
+            ReasoningCorrection((("reasoning",),), "max_output_tokens", None)
+            if reasoning.control is ReasoningControl.PREFER_OFF
+            and wire_reasoning.control is ReasoningControl.OFF
+            else None
+        )
         tool_names = OpenAIToolNameCodec.from_request(request)
         message_id = f"msg_{uuid.uuid4()}"
         return self._run_stream(
             body,
+            reasoning_correction=correction,
             endpoint_context=endpoint_context,
             extra_headers=dict(extra_headers or {}),
             request_id=request_id,
@@ -183,7 +212,16 @@ class OpenAIResponsesTransport:
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
+        can_disable_reasoning: bool = True,
     ) -> JsonObject:
+        request, reasoning = prepare_messages_reasoning(
+            request,
+            reasoning,
+            model_info=model_info,
+            can_disable=can_disable_reasoning,
+            normal_max_tokens=None,
+        )
         try:
             return self._prepare_body(
                 cast(
@@ -234,6 +272,7 @@ class OpenAIResponsesTransport:
         presenter_factory: ResponsesPresenterFactory,
         endpoint_context: EndpointContext | None = None,
         extra_headers: Mapping[str, str] | None = None,
+        reasoning_correction: ReasoningCorrection | None = None,
     ) -> AsyncIterator[str]:
         execution = self._admission.start_execution(request_id=request_id)
         outcome = ResponsesExecutionOutcome()
@@ -244,6 +283,7 @@ class OpenAIResponsesTransport:
         )
         provider_stream = self._run_execution(
             body,
+            reasoning_correction=reasoning_correction,
             request_id=request_id,
             response_model=response_model,
             presenter_factory=presenter_factory,
@@ -288,6 +328,7 @@ class OpenAIResponsesTransport:
         outcome: ResponsesExecutionOutcome,
         endpoint: RequestEndpoint | None = None,
         extra_headers: Mapping[str, str] | None = None,
+        reasoning_correction: ReasoningCorrection | None = None,
     ) -> AsyncIterator[str]:
         recovery = RecoveryController()
         trace_event(
@@ -404,6 +445,24 @@ class OpenAIResponsesTransport:
                 ):
                     recovery.discard()
                     continue
+                if (
+                    scope is not None
+                    and reasoning_correction is not None
+                    and not recovery.committed
+                ):
+                    corrected_body = reasoning_correction.retry_body(raw_error, body)
+                    if corrected_body is not None:
+                        retry = (
+                            execution.can_attempt
+                            if scope.attempt.accepted
+                            else await scope.attempt.correct(error)
+                            is ProviderCorrectionAction.RETRY
+                        )
+                        reasoning_correction = None
+                        if retry:
+                            body = corrected_body
+                            recovery.discard()
+                            continue
                 attempt_failure = None
                 if scope is not None and not scope.attempt.accepted:
                     attempt_failure = await scope.attempt.fail(error)

--- a/src/free_claude_code/providers/opencode/catalog.py
+++ b/src/free_claude_code/providers/opencode/catalog.py
@@ -10,6 +10,7 @@ import httpx
 
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.model_capabilities import ModelInputModality
+from free_claude_code.core.reasoning import ReasoningCapability
 from free_claude_code.providers.admission import (
     ProviderAdmissionController,
     ProviderOperationKind,
@@ -47,6 +48,19 @@ class OpenCodeModelRoute:
     input_modalities: frozenset[ModelInputModality] | None
     context_window_tokens: int | None
     max_output_tokens: int | None
+
+    @property
+    def model_info(self) -> ProviderModelInfo:
+        return ProviderModelInfo(
+            model_id=self.selector_id,
+            supports_thinking=self.supports_thinking,
+            input_modalities=self.input_modalities,
+            context_window_tokens=self.context_window_tokens,
+            max_output_tokens=self.max_output_tokens,
+            reasoning_capability=ReasoningCapability.NONE
+            if self.supports_thinking is False
+            else ReasoningCapability.UNKNOWN,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -159,16 +173,7 @@ def parse_open_code_catalog(
 
     if not routes:
         raise _catalog_error(provider_name, "no active or beta models")
-    model_infos = frozenset(
-        ProviderModelInfo(
-            model_id=route.selector_id,
-            supports_thinking=route.supports_thinking,
-            input_modalities=route.input_modalities,
-            context_window_tokens=route.context_window_tokens,
-            max_output_tokens=route.max_output_tokens,
-        )
-        for route in routes.values()
-    )
+    model_infos = frozenset(route.model_info for route in routes.values())
     return OpenCodeCatalogSnapshot(
         routes=MappingProxyType(routes),
         model_infos=model_infos,

--- a/src/free_claude_code/providers/opencode/provider.py
+++ b/src/free_claude_code/providers/opencode/provider.py
@@ -144,6 +144,7 @@ class OpenCodeProvider(OpenAIChatProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         """Validate synchronously when a route snapshot is already warm."""
         snapshot = self._catalog.current_snapshot
@@ -152,9 +153,13 @@ class OpenCodeProvider(OpenAIChatProvider):
         route = self._require_route(snapshot, request.model)
         routed = _routed_messages_request(request, route)
         if route.transport is OpenCodeUpstreamTransport.RESPONSES:
-            self._responses.preflight_messages(routed, reasoning=reasoning)
+            self._responses.preflight_messages(
+                routed, reasoning=reasoning, model_info=route.model_info
+            )
             return
-        super().preflight_messages(routed, reasoning=reasoning)
+        super().preflight_messages(
+            routed, reasoning=reasoning, model_info=route.model_info
+        )
 
     def preflight_responses(
         self,
@@ -183,6 +188,7 @@ class OpenCodeProvider(OpenAIChatProvider):
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         endpoint_context: EndpointContext | None = None,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         return self._dispatch_stream(
             request,
@@ -211,7 +217,9 @@ class OpenCodeProvider(OpenAIChatProvider):
         selected_stream: AsyncIterator[str] | None = None
         try:
             if route.transport is OpenCodeUpstreamTransport.RESPONSES:
-                self._responses.preflight_messages(routed, reasoning=reasoning)
+                self._responses.preflight_messages(
+                    routed, reasoning=reasoning, model_info=route.model_info
+                )
                 selected_stream = self._responses.stream_messages(
                     routed,
                     input_tokens=input_tokens,
@@ -220,9 +228,12 @@ class OpenCodeProvider(OpenAIChatProvider):
                     reasoning=reasoning,
                     endpoint_context=endpoint_context,
                     extra_headers=self._upstream_headers(request_headers or {}),
+                    model_info=route.model_info,
                 )
             else:
-                super().preflight_messages(routed, reasoning=reasoning)
+                super().preflight_messages(
+                    routed, reasoning=reasoning, model_info=route.model_info
+                )
                 selected_stream = super().stream_messages(
                     routed,
                     input_tokens=input_tokens,
@@ -231,6 +242,7 @@ class OpenCodeProvider(OpenAIChatProvider):
                     reasoning=reasoning,
                     endpoint_context=endpoint_context,
                     request_headers=request_headers,
+                    model_info=route.model_info,
                 )
             async for event in selected_stream:
                 yield event

--- a/src/free_claude_code/providers/reasoning_compatibility.py
+++ b/src/free_claude_code/providers/reasoning_compatibility.py
@@ -1,0 +1,190 @@
+"""Prepare tolerant computation intent without guessing backend identity."""
+
+import json
+import re
+from collections.abc import Iterator, Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.diagnostics import extract_upstream_error_detail
+from free_claude_code.core.reasoning import (
+    ReasoningCapability,
+    ReasoningControl,
+    ReasoningPolicy,
+)
+
+
+def prepare_messages_reasoning(
+    request: MessagesRequest,
+    reasoning: ReasoningPolicy,
+    *,
+    model_info: ProviderModelInfo | None,
+    can_disable: bool,
+    normal_max_tokens: int | None,
+) -> tuple[MessagesRequest, ReasoningPolicy]:
+    """Resolve only tolerant intent; retain original intent in execution owners."""
+    if reasoning.control is not ReasoningControl.PREFER_OFF:
+        return request, reasoning
+    capability = (
+        model_info.reasoning_capability if model_info else ReasoningCapability.UNKNOWN
+    )
+    disable = can_disable and capability not in {
+        ReasoningCapability.NONE,
+        ReasoningCapability.REQUIRED,
+    }
+    normal_allowance = capability not in {
+        ReasoningCapability.NONE,
+        ReasoningCapability.OPTIONAL,
+    } or (capability is ReasoningCapability.OPTIONAL and not can_disable)
+    output_config = dict(request.output_config or {})
+    output_config.pop("effort", None)
+    limit = request.max_tokens
+    if normal_allowance:
+        limit = (
+            max(limit or 0, normal_max_tokens)
+            if normal_max_tokens is not None
+            else None
+        )
+    return request.model_copy(
+        update={
+            "thinking": None,
+            "output_config": output_config or None,
+            "max_tokens": limit,
+        }
+    ), ReasoningPolicy.off() if disable else ReasoningPolicy.provider_default()
+
+
+@dataclass(frozen=True, slots=True)
+class ReasoningCorrection:
+    """One request's owned OFF field and normal output allowance."""
+
+    off_fields: tuple[tuple[str, ...], ...]
+    limit_field: str
+    normal_max_tokens: int | None
+    output_cap: int | None = None
+
+    def retry_body(
+        self,
+        error: Exception,
+        body: dict[str, Any],
+        *,
+        sent_body: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Remove the sent control only after an explicit validation rejection."""
+        present = []
+        for path in self.off_fields:
+            target: object = body
+            sent: object = body if sent_body is None else sent_body
+            for key in path:
+                if (
+                    not isinstance(target, Mapping)
+                    or key not in target
+                    or not isinstance(sent, Mapping)
+                    or key not in sent
+                ):
+                    break
+                target = target[key]
+                sent = sent[key]
+            else:
+                if target == sent:
+                    present.append(path)
+        if not any(_disable_rejected(error, path) for path in present):
+            return None
+        result = deepcopy(body)
+        for path in present:
+            parents = []
+            current = result
+            for key in path[:-1]:
+                parents.append((current, key))
+                current = current[key]
+            del current[path[-1]]
+            for parent, key in reversed(parents):
+                if not parent[key]:
+                    del parent[key]
+        if self.normal_max_tokens is None:
+            result.pop(self.limit_field, None)
+        else:
+            existing = result.get(self.limit_field)
+            limit = max(
+                existing if isinstance(existing, int) else 0, self.normal_max_tokens
+            )
+            result[self.limit_field] = (
+                min(limit, self.output_cap) if self.output_cap is not None else limit
+            )
+        return result
+
+
+def _disable_rejected(error: Exception, field: tuple[str, ...]) -> bool:
+    detail = extract_upstream_error_detail(error)
+    if not detail.is_invalid_request(code=getattr(error, "code", None)):
+        return False
+    text = detail.body_text or detail.exception_text or ""
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        payload = {"message": text}
+    return any(
+        _record_rejects_control(record, field) for record in _error_records(payload)
+    )
+
+
+def _error_records(payload: object) -> Iterator[Mapping[str, object]]:
+    if isinstance(payload, Mapping):
+        if any(
+            isinstance(payload.get(key), str) for key in ("message", "msg", "detail")
+        ):
+            yield payload
+        for key in ("error", "errors", "detail"):
+            if key in payload:
+                yield from _error_records(payload[key])
+    elif isinstance(payload, list):
+        for item in payload:
+            yield from _error_records(item)
+
+
+def _record_rejects_control(
+    record: Mapping[str, object], field: tuple[str, ...]
+) -> bool:
+    message = next(
+        (
+            record[key]
+            for key in ("message", "msg", "detail")
+            if isinstance(record.get(key), str)
+        ),
+        "",
+    )
+    text = str(message).lower()
+    param = record.get("param", record.get("loc"))
+    rejected = r"(?:not supported|unsupported|unknown parameter|unrecognized|extra inputs are not permitted|must be one of|not allowed|invalid value)"
+    if param is not None:
+        parts = re.findall(r"[a-z_][a-z_0-9]*", str(param).lower())
+        while parts and parts[0] in {"body", "request", "extra_body"}:
+            parts.pop(0)
+        expected = [part for part in field if part != "extra_body"]
+        matches = parts[: len(expected)] == expected or parts == [field[-1]]
+        if not matches:
+            return False
+        return bool(re.search(rejected, text) or _mandatory_reasoning(text))
+    if _mandatory_reasoning(text):
+        return True
+    name = re.escape(field[-1]) + r"(?:\.[a-z_][a-z_0-9]*)*"
+    return bool(
+        re.search(
+            rf"\b{name}\b['\"\s:]*(?:(?:parameter|field|value)\s+)?(?:is\s+)?{rejected}"
+            rf"|\b(?:unsupported|unrecognized|unknown)(?:\s+(?:parameter|field|argument))?[:\s'\"]+{name}\b"
+            rf"|\bdoes not support\s+['\"]?{name}\b",
+            text,
+        )
+    )
+
+
+def _mandatory_reasoning(text: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(?:reasoning|thinking)\s+(?:is\s+)?(?:mandatory|required|cannot be disabled|can't be disabled)\b",
+            text,
+        )
+    )

--- a/src/free_claude_code/providers/reasoning_compatibility.py
+++ b/src/free_claude_code/providers/reasoning_compatibility.py
@@ -130,6 +130,11 @@ def _disable_rejected(error: Exception, field: tuple[str, ...]) -> bool:
         payload = json.loads(text)
     except ValueError:
         payload = {"message": text}
+    return reasoning_control_rejected(payload, field)
+
+
+def reasoning_control_rejected(payload: object, field: tuple[str, ...]) -> bool:
+    """Match an explicit rejection tied to an owned field in an error payload."""
     return any(
         _record_rejects_control(record, field) for record in _error_records(payload)
     )

--- a/src/free_claude_code/providers/reasoning_compatibility.py
+++ b/src/free_claude_code/providers/reasoning_compatibility.py
@@ -2,7 +2,7 @@
 
 import json
 import re
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
@@ -65,6 +65,7 @@ class ReasoningCorrection:
     limit_field: str
     normal_max_tokens: int | None
     output_cap: int | None = None
+    provider_rejection: Callable[[Exception], bool] | None = None
 
     def retry_body(
         self,
@@ -91,7 +92,10 @@ class ReasoningCorrection:
             else:
                 if target == sent:
                     present.append(path)
-        if not any(_disable_rejected(error, path) for path in present):
+        if not present or not (
+            any(_disable_rejected(error, path) for path in present)
+            or (self.provider_rejection is not None and self.provider_rejection(error))
+        ):
             return None
         result = deepcopy(body)
         for path in present:

--- a/tests/api/model_fallback_support.py
+++ b/tests/api/model_fallback_support.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest
 from free_claude_code.core.anthropic.streaming import format_sse_event
@@ -206,6 +207,7 @@ class ControlledFallbackProvider:
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         del reasoning
         self.preflight_models.append(request.model)
@@ -221,6 +223,7 @@ class ControlledFallbackProvider:
         response_model: str | None = None,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del input_tokens, request_id, reasoning
         self.stream_models.append(request.model)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -193,7 +193,7 @@ def test_auto_mode_classifier_without_stream_returns_json(client: TestClient):
     assert body["usage"] == {"input_tokens": 0, "output_tokens": 0}
     routed_request = _stream_messages_calls[0][0][0]
     assert routed_request.stream is False
-    assert _stream_messages_calls[0][1]["reasoning"] == ReasoningPolicy.off()
+    assert _stream_messages_calls[0][1]["reasoning"] == ReasoningPolicy.prefer_off()
 
 
 def test_create_message_ingress_error_has_request_id_without_terminal_header(

--- a/tests/api/test_api_handlers.py
+++ b/tests/api/test_api_handlers.py
@@ -52,7 +52,11 @@ class FakeProvider:
         ]
 
     def preflight_messages(
-        self, request: MessagesRequest, *, reasoning: ReasoningPolicy
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         self.preflight_calls.append((request, reasoning))
 
@@ -76,6 +80,7 @@ class FakeProvider:
         response_model: str | None = None,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         self.requests.append(request)
         self.stream_kwargs.append(
@@ -170,6 +175,7 @@ async def test_messages_handler_preflight_invalid_request_stays_http_error(
             request: MessagesRequest,
             *,
             reasoning: ReasoningPolicy,
+            model_info: ProviderModelInfo | None = None,
         ) -> None:
             raise InvalidRequestError("bad tool shape")
 
@@ -379,6 +385,7 @@ async def test_messages_handler_stream_false_provider_exception_keeps_status() -
             response_model: str | None = None,
             reasoning: ReasoningPolicy,
             request_headers: Mapping[str, str] | None = None,
+            model_info: ProviderModelInfo | None = None,
         ) -> AsyncIterator[str]:
             self.requests.append(request)
             self.stream_kwargs.append(
@@ -446,8 +453,8 @@ async def test_messages_handler_normalizes_safety_classifier_policy(
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.off()
-    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.off()
+    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
     assert provider.requests[0].model == "test-model"
     assert provider.requests[0].system == system
     assert provider.preflight_calls[0][0].stop_sequences is None
@@ -507,7 +514,7 @@ async def test_messages_handler_preserves_thinking_for_non_classifier() -> None:
 
 
 @pytest.mark.asyncio
-async def test_messages_handler_keeps_existing_no_thinking_for_classifier() -> None:
+async def test_messages_handler_tolerates_required_thinking_for_classifier() -> None:
     provider = FakeProvider()
     handler = MessagesHandler(Settings(), provider_resolver=lambda _: provider)
     request = MessagesRequest(
@@ -524,8 +531,8 @@ async def test_messages_handler_keeps_existing_no_thinking_for_classifier() -> N
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.off()
-    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.off()
+    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
     assert provider.requests[0].stop_sequences is None
     assert request.stop_sequences == ["</block>"]
     assert _trace_events(
@@ -537,14 +544,14 @@ async def test_messages_handler_keeps_existing_no_thinking_for_classifier() -> N
             "source": "api",
             "model": "claude-3-freecc-no-thinking/nvidia_nim/test-model",
             "classifier_stop_sequence": "</block>",
-            "reasoning_changed": False,
+            "reasoning_changed": True,
             "stop_sequence_removed": True,
         }
     ]
 
 
 @pytest.mark.asyncio
-async def test_messages_handler_forces_no_thinking_without_classifier_stop_hint() -> (
+async def test_messages_handler_prefers_no_thinking_without_classifier_stop_hint() -> (
     None
 ):
     provider = FakeProvider()
@@ -562,7 +569,7 @@ async def test_messages_handler_forces_no_thinking_without_classifier_stop_hint(
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.off()
+    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
     assert provider.requests[0].stop_sequences is None
     assert _trace_events(
         trace_mock, "free_claude_code.api.route.safety_classifier_policy"
@@ -597,7 +604,7 @@ async def test_messages_handler_preserves_unowned_classifier_stop_sequences() ->
     assert isinstance(response, StreamingResponse)
     await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.off()
+    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
     assert provider.preflight_calls[0][0].stop_sequences == [
         "custom",
         "custom",

--- a/tests/api/test_classifier_provider_compatibility.py
+++ b/tests/api/test_classifier_provider_compatibility.py
@@ -1,0 +1,215 @@
+"""Claude Auto mode exercises the real handler/provider request boundary."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx2 as httpx
+import pytest
+from fastapi.responses import JSONResponse, StreamingResponse
+from openai import APIError, BadRequestError
+
+from free_claude_code.api.handlers import MessagesHandler
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.settings import Settings
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.anthropic.stream_contracts import (
+    parse_sse_text,
+    text_content,
+    thinking_content,
+)
+from free_claude_code.core.reasoning import ReasoningCapability
+from free_claude_code.providers.open_router import OpenRouterProvider
+from tests.providers.support import immediate_admission, make_provider_config
+
+
+class ClassifierStream:
+    def __init__(self, *, starved: bool = False, error: Exception | None = None):
+        self.starved = starved
+        self.error = error
+        self.closed = False
+
+    async def __aiter__(self):
+        if self.error is not None:
+            raise self.error
+        for text, reasoning, finish in (
+            (None, "Internal provider analysis", None),
+            (None if self.starved else "<severity>0</severity>", None, None),
+            (None, None, "length" if self.starved else "stop"),
+        ):
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            content=text,
+                            reasoning=reasoning,
+                            reasoning_content=reasoning,
+                            tool_calls=None,
+                        ),
+                        finish_reason=finish,
+                    )
+                ],
+                usage=None,
+            )
+
+    async def aclose(self):
+        self.closed = True
+
+
+def classifier_request():
+    return MessagesRequest.model_validate(
+        {
+            "model": "open_router/dynamic-route",
+            "system": "Output <severity>N</severity> for this command's safety.",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "<transcript>Read the requested file.</transcript>",
+                }
+            ],
+            "max_tokens": 64,
+            "thinking": {"type": "disabled"},
+            "stop_sequences": ["</severity>"],
+            "stream": False,
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    "reject_off",
+    [False, True, "stream"],
+    ids=["off-ignored", "off-rejected", "off-stream-rejected"],
+)
+async def test_classifier_mandatory_reasoning_still_returns_verdict(reject_off, stream):
+    provider = OpenRouterProvider(
+        make_provider_config(api_key="test", base_url="https://openrouter.test/v1"),
+        admission=immediate_admission(),
+    )
+    bodies = []
+    streams = []
+
+    async def upstream(**body):
+        bodies.append(body)
+        if (
+            reject_off
+            and body.get("extra_body", {}).get("reasoning", {}).get("enabled") is False
+        ):
+            error = {
+                "error": {
+                    "code": "invalid_request_error",
+                    "message": "Reasoning is mandatory for this endpoint and cannot be disabled.",
+                }
+            }
+            if reject_off == "stream":
+                rejected = ClassifierStream(
+                    error=APIError(
+                        error["error"]["message"],
+                        request=httpx.Request(
+                            "POST", "https://openrouter.test/v1/chat/completions"
+                        ),
+                        body=error["error"],
+                    )
+                )
+                streams.append(rejected)
+                return rejected
+            raise BadRequestError(
+                error["error"]["message"],
+                response=httpx.Response(
+                    400,
+                    request=httpx.Request(
+                        "POST", "https://openrouter.test/v1/chat/completions"
+                    ),
+                    json=error,
+                ),
+                body=error,
+            )
+        result = ClassifierStream(starved=body.get("max_tokens", 0) < 2048)
+        streams.append(result)
+        return result
+
+    try:
+        handler = MessagesHandler(Settings(), provider_resolver=lambda _: provider)
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new=AsyncMock(side_effect=upstream),
+        ):
+            response = await handler.create(
+                classifier_request().model_copy(update={"stream": stream})
+            )
+            assert isinstance(response, (JSONResponse, StreamingResponse))
+            assert response.status_code == 200
+            if stream:
+                assert isinstance(response, StreamingResponse)
+                raw = "".join([str(chunk) async for chunk in response.body_iterator])
+                events = parse_sse_text(raw)
+                assert text_content(events) == "<severity>0</severity>"
+                assert thinking_content(events) == ""
+                assert events[-1].event == "message_stop"
+            else:
+                assert isinstance(response, JSONResponse)
+                message = json.loads(bytes(response.body))
+                assert message["content"] == [
+                    {"type": "text", "text": "<severity>0</severity>"}
+                ]
+                assert message["stop_reason"] == "end_turn"
+        assert bodies[0]["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+        assert len(bodies) == (2 if reject_off else 1)
+        assert all(stream.closed for stream in streams)
+    finally:
+        await provider.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("capability", "off", "limit"),
+    [
+        ("none", False, 64),
+        ("optional", True, 64),
+        ("required", False, 81920),
+        ("unknown", True, 81920),
+    ],
+)
+async def test_handler_uses_cached_capabilities_for_the_selected_provider(
+    capability, off, limit
+):
+    provider = OpenRouterProvider(
+        make_provider_config("test", "https://provider.invalid/v1"),
+        admission=immediate_admission(),
+    )
+    bodies = []
+
+    async def upstream(**body):
+        bodies.append(body)
+        return ClassifierStream()
+
+    try:
+        handler = MessagesHandler(
+            Settings(),
+            provider_resolver=lambda _: provider,
+            model_infos=(
+                ProviderModelInfo(
+                    "open_router/dynamic-route",
+                    reasoning_capability=ReasoningCapability(capability),
+                ),
+            ),
+        )
+        with patch.object(
+            provider._client.chat.completions,
+            "create",
+            new=AsyncMock(side_effect=upstream),
+        ):
+            response = await handler.create(classifier_request())
+        assert isinstance(response, JSONResponse) and response.status_code == 200
+        assert json.loads(bytes(response.body))["content"] == [
+            {"type": "text", "text": "<severity>0</severity>"}
+        ]
+        assert (
+            bodies[0].get("extra_body", {}).get("reasoning", {}).get("enabled") is False
+        ) is off
+        assert bodies[0]["max_tokens"] == limit
+    finally:
+        await provider.cleanup()

--- a/tests/api/test_classifier_provider_compatibility.py
+++ b/tests/api/test_classifier_provider_compatibility.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import httpx2 as httpx
 import pytest
 from fastapi.responses import JSONResponse, StreamingResponse
-from openai import APIError, BadRequestError
+from openai import APIError, AsyncOpenAI, BadRequestError
 
 from free_claude_code.api.handlers import MessagesHandler
 from free_claude_code.application.model_metadata import ProviderModelInfo
@@ -74,6 +74,91 @@ def classifier_request():
             "stream": False,
         }
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "corrects"),
+    [
+        ({"code": 400, "message": "Reasoning cannot be disabled."}, True),
+        (
+            {
+                "code": 400,
+                "message": "Reasoning cannot be disabled.",
+                "metadata": {"error_type": "invalid_request"},
+            },
+            True,
+        ),
+        ({"code": 400, "message": "Messages contain an invalid role."}, False),
+        (
+            {"code": 400, "param": "tools", "message": "Reasoning is required."},
+            False,
+        ),
+        ({"code": 403, "message": "Reasoning cannot be disabled."}, False),
+    ],
+    ids=["numeric", "metadata", "unrelated", "other-field", "permission"],
+)
+async def test_openrouter_numeric_sse_rejection_uses_classifier_correction(
+    error, corrects
+):
+    bodies = []
+
+    def upstream(request):
+        bodies.append(json.loads(request.content))
+        chunk = {
+            "id": "gen-test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "dynamic-route",
+            "provider": "test",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "<severity>0</severity>"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        if len(bodies) == 1:
+            chunk["error"] = error
+            chunk["choices"] = [
+                {"index": 0, "delta": {"content": ""}, "finish_reason": "error"}
+            ]
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n",
+        )
+
+    provider = OpenRouterProvider(
+        make_provider_config("test", "https://provider.invalid/v1"),
+        admission=immediate_admission(),
+    )
+    try:
+        async with AsyncOpenAI(
+            api_key="test",
+            base_url="https://provider.invalid/v1",
+            max_retries=0,
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(upstream)),
+        ) as client:
+            with patch.object(provider, "_client", client):
+                response = await MessagesHandler(
+                    Settings(), provider_resolver=lambda _: provider
+                ).create(classifier_request())
+        assert isinstance(response, JSONResponse)
+        assert len(bodies) == (2 if corrects else 1)
+        if corrects:
+            assert response.status_code == 200
+            assert json.loads(bytes(response.body))["content"] == [
+                {"type": "text", "text": "<severity>0</severity>"}
+            ]
+            assert bodies[0]["reasoning"] == {"enabled": False}
+            assert "reasoning" not in bodies[1]
+            assert bodies[1]["max_tokens"] == 81920
+        else:
+            assert response.status_code >= 400
+    finally:
+        await provider.cleanup()
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_classifier_response.py
+++ b/tests/api/test_classifier_response.py
@@ -1,0 +1,207 @@
+import asyncio
+import json
+
+import pytest
+
+from free_claude_code.api.handlers.classifier_response import classifier_response
+from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
+from free_claude_code.core.anthropic.streaming import format_sse_event
+
+
+def wire(payloads):
+    return "".join(format_sse_event(payload["type"], payload) for payload in payloads)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunk_size", [1, 17, 10000])
+async def test_projection_preserves_text_extensions_and_sparse_interleaved_blocks(
+    chunk_size,
+):
+    literal = "<thinking>Classifier explanation</thinking><severity>0</severity>"
+    start = {
+        "type": "message_start",
+        "message": {
+            "id": "original",
+            "model": "public",
+            "content": [],
+            "usage": {"input_tokens": 3},
+        },
+        "extension": {"a": 1},
+    }
+    terminal = {
+        "type": "message_delta",
+        "delta": {"stop_reason": "stop_sequence", "stop_sequence": "custom"},
+        "usage": {"output_tokens": 50, "extra": 7},
+    }
+    payloads = [
+        start,
+        {
+            "type": "content_block_start",
+            "index": 5,
+            "content_block": {"type": "thinking", "thinking": "hidden"},
+        },
+        {
+            "type": "content_block_start",
+            "index": 9,
+            "content_block": {
+                "type": "text",
+                "text": literal,
+                "citations": [],
+                "extension": {"index": 9},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 5,
+            "delta": {"type": "signature_delta", "signature": "hidden"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 9,
+            "delta": {
+                "type": "text_delta",
+                "text": "<reason>fine</reason><category>read</category>",
+            },
+        },
+        {"type": "content_block_stop", "index": 5},
+        {
+            "type": "content_block_start",
+            "index": 12,
+            "content_block": {"type": "redacted_thinking", "data": "opaque"},
+        },
+        {"type": "content_block_stop", "index": 12},
+        {
+            "type": "content_block_start",
+            "index": 3,
+            "content_block": {
+                "type": "tool_use",
+                "id": "tool-id",
+                "name": "read",
+                "input": {},
+            },
+        },
+        {"type": "content_block_stop", "index": 9},
+        {"type": "content_block_stop", "index": 3},
+        {"type": "ping", "extension": 1},
+        terminal,
+        {"type": "message_stop"},
+    ]
+    raw = wire(payloads)
+    closed = False
+
+    async def source():
+        nonlocal closed
+        try:
+            for offset in range(0, len(raw), chunk_size):
+                yield raw[offset : offset + chunk_size]
+        finally:
+            closed = True
+
+    output = "".join([chunk async for chunk in classifier_response(source())])
+    actual = [event.data for event in parse_sse_text(output)]
+    assert actual == [
+        start,
+        {**payloads[2], "index": 0},
+        {**payloads[4], "index": 0},
+        {**payloads[8], "index": 1},
+        {**payloads[9], "index": 0},
+        {**payloads[10], "index": 1},
+        payloads[11],
+        terminal,
+        payloads[13],
+    ]
+    assert closed
+
+
+@pytest.mark.asyncio
+async def test_reasoning_only_completion_stays_empty_with_original_termination():
+    start = {"type": "message_start", "message": {"content": []}}
+    end = {
+        "type": "message_delta",
+        "delta": {"stop_reason": "max_tokens"},
+        "usage": {"output_tokens": 64},
+    }
+
+    async def source():
+        yield wire(
+            [
+                start,
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "thinking", "thinking": "analysis"},
+                },
+                {"type": "content_block_stop", "index": 0},
+                end,
+                {"type": "message_stop"},
+            ]
+        )
+
+    output = [
+        event.data
+        for event in parse_sse_text(
+            "".join([chunk async for chunk in classifier_response(source())])
+        )
+    ]
+    assert output == [start, end, {"type": "message_stop"}]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_hidden_reasoning_closes_input():
+    blocked = asyncio.Event()
+    closed = asyncio.Event()
+
+    async def source():
+        try:
+            yield wire([{"type": "message_start", "message": {"content": []}}])
+            yield wire(
+                [
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {"type": "thinking", "thinking": ""},
+                    }
+                ]
+            )
+            blocked.set()
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    filtered = classifier_response(source())
+    assert "message_start" in await anext(filtered)
+
+    async def advance():
+        return await anext(filtered)
+
+    pending = asyncio.create_task(advance())
+    await asyncio.wait_for(blocked.wait(), 1)
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    assert closed.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fails", [False, True])
+async def test_only_normal_exhaustion_flushes_unterminated_event(fails):
+    failure = RuntimeError("upstream failed")
+    raw = "event: error\ndata: " + json.dumps(
+        {"type": "error", "error": {"message": "unchanged"}}
+    )
+
+    async def source():
+        yield raw
+        if fails:
+            raise failure
+
+    if fails:
+        with pytest.raises(RuntimeError) as caught:
+            _ = [chunk async for chunk in classifier_response(source())]
+        assert caught.value is failure
+    else:
+        output = "".join([chunk async for chunk in classifier_response(source())])
+        assert parse_sse_text(output)[0].data == {
+            "type": "error",
+            "error": {"message": "unchanged"},
+        }

--- a/tests/api/test_execution_failure_contract.py
+++ b/tests/api/test_execution_failure_contract.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.anthropic import MessagesRequest
 from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
@@ -106,6 +107,7 @@ class StalledProvider:
         _request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         del reasoning
 
@@ -126,6 +128,7 @@ class StalledProvider:
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del input_tokens, request_id, response_model, reasoning
         try:

--- a/tests/api/test_request_lifetime.py
+++ b/tests/api/test_request_lifetime.py
@@ -398,6 +398,7 @@ class _ControlledProvider:
         _request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         del reasoning
 
@@ -418,6 +419,7 @@ class _ControlledProvider:
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del input_tokens, response_model, reasoning
         self.request_ids.append(request_id)
@@ -478,7 +480,7 @@ class _Requests:
     async def acquire(
         self, *, include_model_infos: bool = False
     ) -> RequestRuntimeLease:
-        assert include_model_infos is False
+        del include_model_infos
         return self._lease
 
     def current_settings(self) -> Settings:

--- a/tests/api/test_web_server_tools.py
+++ b/tests/api/test_web_server_tools.py
@@ -29,6 +29,7 @@ from free_claude_code.api.web_tools.request import (
 )
 from free_claude_code.api.web_tools.streaming import stream_web_server_tool_response
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.application.routing import (
     ModelRouter,
     ProviderModelTarget,
@@ -128,7 +129,11 @@ class ScriptedSelectionProvider:
         self.close_count = 0
 
     def preflight_messages(
-        self, request: MessagesRequest, *, reasoning: ReasoningPolicy
+        self,
+        request: MessagesRequest,
+        *,
+        reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         return None
 
@@ -162,6 +167,7 @@ class ScriptedSelectionProvider:
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         self.requests.append(request)
         self.stream_kwargs.append(

--- a/tests/application/test_chat_service.py
+++ b/tests/application/test_chat_service.py
@@ -212,6 +212,7 @@ class FakeChatProvider:
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         del reasoning
         self.requests.append(request)
@@ -233,6 +234,7 @@ class FakeChatProvider:
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del input_tokens, request_id, response_model, reasoning
         text = "summary" if str(request.system).startswith("Summarize") else "answer"
@@ -344,6 +346,7 @@ class ContextRecoveryProvider(FakeChatProvider):
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         is_summary = str(request.system).startswith("Summarize")
         if is_summary:
@@ -405,6 +408,7 @@ class MixedFallbackFailureProvider(ContextRecoveryProvider):
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         if self.fail_candidates and not str(request.system).startswith("Summarize"):
             if request.model == "model":
@@ -437,6 +441,7 @@ class BackpressuredCompletionProvider(FakeChatProvider):
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del request, input_tokens, request_id, response_model, reasoning
         yield format_sse_event(

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -8,6 +8,7 @@ import pytest
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.application.execution import ProviderExecutor
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.application.routing import (
     ProviderModelTarget,
     ResolvedModelRoute,
@@ -19,7 +20,7 @@ from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.core.async_iterators import AsyncCloseable
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
-from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.core.reasoning import ReasoningCapability, ReasoningPolicy
 
 
 class FakeProvider:
@@ -33,6 +34,7 @@ class FakeProvider:
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         self.preflight_calls.append((request, reasoning))
 
@@ -53,6 +55,7 @@ class FakeProvider:
         response_model: str | None = None,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         self._record_stream_call(
             request,
@@ -118,6 +121,7 @@ class ResponsesFakeProvider:
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         raise AssertionError("Responses test provider received a Messages request")
 
@@ -130,6 +134,7 @@ class ResponsesFakeProvider:
         response_model: str,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         raise AssertionError("Responses test provider received a Messages request")
         yield ""
@@ -194,6 +199,7 @@ class ControlledProvider(FakeProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         self._record_stream_call(
             request,
@@ -226,6 +232,7 @@ class FailingPreflightProvider(FakeProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         raise ValueError("invalid provider request")
 
@@ -240,6 +247,7 @@ class ApplicationErrorPreflightProvider(FakeProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         raise self._error
 
@@ -254,6 +262,7 @@ class ExecutionFailurePreflightProvider(FakeProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         super().preflight_messages(request, reasoning=reasoning)
         raise self._failure
@@ -269,6 +278,7 @@ class FailingStreamConstructionProvider(FakeProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         raise RuntimeError("stream construction failed")
 
@@ -287,6 +297,7 @@ class ExecutionFailureStreamConstructionProvider(FakeProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del request, input_tokens, request_id, response_model, reasoning
         raise self._failure
@@ -315,6 +326,7 @@ class CloseControlledProvider(FakeProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         self._record_stream_call(
             request,
@@ -367,6 +379,52 @@ def _routed_request(
         ),
         reasoning=ReasoningPolicy.on(),
     )
+
+
+@pytest.mark.asyncio
+async def test_fallback_receives_its_own_cached_capability_in_preflight_and_stream():
+    seen = []
+
+    class MetadataProvider(ControlledProvider):
+        def preflight_messages(self, request, **kwargs):
+            seen.append(("preflight", request.model, kwargs["model_info"]))
+
+        async def stream_messages(self, request, input_tokens=0, **kwargs):
+            seen.append(("stream", request.model, kwargs["model_info"]))
+            async for event in super().stream_messages(request, input_tokens, **kwargs):
+                yield event
+
+    primary_info = ProviderModelInfo(
+        "provider/provider-model", reasoning_capability=ReasoningCapability.NONE
+    )
+    fallback_info = ProviderModelInfo(
+        "fallback/fallback-model", reasoning_capability=ReasoningCapability.REQUIRED
+    )
+    primary = MetadataProvider(
+        [ExecutionFailure(FailureKind.UNAVAILABLE, 503, "unavailable", True)]
+    )
+    fallback = MetadataProvider(["verdict"])
+    providers = {"provider": primary, "fallback": fallback}
+    executor = ProviderExecutor(
+        lambda name: providers[name],
+        progress_timeout_seconds=10,
+        model_infos=(primary_info, fallback_info),
+    )
+    output = [
+        event
+        async for event in executor.stream_messages(
+            _routed_request(_target("fallback", "fallback-model")),
+            raw_log_payload={},
+            request_id="capability-fallback",
+        )
+    ]
+    assert output == ["verdict"]
+    assert seen == [
+        ("preflight", "provider-model", primary_info),
+        ("stream", "provider-model", primary_info),
+        ("preflight", "fallback-model", fallback_info),
+        ("stream", "fallback-model", fallback_info),
+    ]
 
 
 def _routed_responses_request(
@@ -924,6 +982,7 @@ async def test_candidate_requests_are_isolated_from_provider_mutation() -> None:
             response_model: str | None = None,
             reasoning: ReasoningPolicy,
             request_headers: Mapping[str, str] | None = None,
+            model_info: ProviderModelInfo | None = None,
         ) -> AsyncIterator[str]:
             request.messages[0].content = "mutated"
             async for chunk in super().stream_messages(

--- a/tests/providers/test_anthropic_messages_transport.py
+++ b/tests/providers/test_anthropic_messages_transport.py
@@ -13,6 +13,7 @@ from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
+from free_claude_code.core.reasoning import ReasoningPolicy
 from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.anthropic_messages.transport import (
     AnthropicMessagesTransport,
@@ -20,6 +21,54 @@ from free_claude_code.providers.anthropic_messages.transport import (
 from free_claude_code.providers.endpoint import HttpEndpoint
 from free_claude_code.providers.http import maybe_await_aclose
 from tests.providers.support import immediate_admission
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_error", [False, True])
+async def test_tolerant_classifier_corrects_required_reasoning(stream_error):
+    bodies = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        bodies.append(body)
+        if body.get("thinking", {}).get("type") == "disabled":
+            error = {
+                "type": "invalid_request_error",
+                "message": "Reasoning is mandatory and cannot be disabled.",
+            }
+            if stream_error:
+                return httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    stream=Wire([_sse({"type": "error", "error": error})]),
+                )
+            return httpx.Response(400, json={"error": error})
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=Wire([_sse(*_events("<severity>0</severity>"))]),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        output = [
+            event
+            async for event in _transport(client).stream_messages(
+                MessagesRequest.model_validate(
+                    {
+                        "model": "route",
+                        "messages": [{"role": "user", "content": "classify"}],
+                        "max_tokens": 64,
+                        "thinking": {"type": "disabled"},
+                    }
+                ),
+                endpoint_context=Endpoint(),
+                reasoning=ReasoningPolicy.prefer_off(),
+            )
+        ]
+    assert "<severity>0</severity>" in "".join(output)
+    assert len(bodies) == 2
+    assert bodies[0]["max_tokens"] == 8192
+    assert "thinking" not in bodies[1]
 
 
 class Endpoint:

--- a/tests/providers/test_anthropic_messages_transport.py
+++ b/tests/providers/test_anthropic_messages_transport.py
@@ -25,17 +25,33 @@ from tests.providers.support import immediate_admission
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stream_error", [False, True])
-async def test_tolerant_classifier_corrects_required_reasoning(stream_error):
+@pytest.mark.parametrize(
+    "error",
+    [
+        {
+            "type": "invalid_request_error",
+            "message": "Reasoning is mandatory and cannot be disabled.",
+        },
+        {
+            "type": "invalid_request_error",
+            "param": "thinking.type",
+            "message": "Value 'disabled' is not supported",
+        },
+        {
+            "type": "invalid_request_error",
+            "loc": ["body", "thinking", "type"],
+            "message": "Value 'disabled' is not supported",
+        },
+    ],
+    ids=["mandatory", "param", "loc"],
+)
+async def test_tolerant_classifier_corrects_required_reasoning(stream_error, error):
     bodies = []
 
     def handler(request):
         body = json.loads(request.content)
         bodies.append(body)
         if body.get("thinking", {}).get("type") == "disabled":
-            error = {
-                "type": "invalid_request_error",
-                "message": "Reasoning is mandatory and cannot be disabled.",
-            }
             if stream_error:
                 return httpx.Response(
                     200,

--- a/tests/providers/test_deepinfra.py
+++ b/tests/providers/test_deepinfra.py
@@ -13,7 +13,11 @@ from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
 from free_claude_code.config.provider_catalog import DEEPINFRA_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import MessagesRequest
-from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.core.reasoning import (
+    ReasoningCapability,
+    ReasoningEffort,
+    ReasoningPolicy,
+)
 from free_claude_code.providers.model_listing import ModelListResponseError
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from tests.providers.support import (
@@ -245,7 +249,11 @@ async def test_lists_only_active_text_models_with_thinking_metadata(
     assert model_infos == frozenset(
         {
             ProviderModelInfo("reasoning-model", supports_thinking=True),
-            ProviderModelInfo("plain-model", supports_thinking=False),
+            ProviderModelInfo(
+                "plain-model",
+                supports_thinking=False,
+                reasoning_capability=ReasoningCapability.NONE,
+            ),
             ProviderModelInfo("hybrid-model", supports_thinking=True),
             ProviderModelInfo("unknown-model"),
         }

--- a/tests/providers/test_github_copilot_provider.py
+++ b/tests/providers/test_github_copilot_provider.py
@@ -29,6 +29,7 @@ from free_claude_code.core.openai_responses.reasoning_replay import (
 )
 from free_claude_code.core.reasoning import (
     DEFAULT_REASONING_POLICY,
+    ReasoningCapability,
     ReasoningEffort,
     ReasoningPolicy,
 )
@@ -244,6 +245,66 @@ class Harness:
         await self.provider.cleanup()
         assert self.runtime.close_calls == 0
         await self.auth.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("egress", list(CopilotEgress))
+@pytest.mark.parametrize("supports_off", [False, True])
+async def test_classifier_uses_current_lease_controls_and_clears_raw_hints(
+    tmp_path, egress, supports_off
+):
+    harness = Harness(tmp_path, egress)
+    current = harness.runtime.available[0]
+    efforts = ("none", "high") if supports_off else ("high",)
+    harness.runtime.available = (
+        replace(
+            current,
+            supported_efforts=efforts,
+            info=replace(
+                current.info,
+                reasoning_capability=ReasoningCapability.OPTIONAL
+                if supports_off
+                else ReasoningCapability.UNKNOWN,
+            ),
+        ),
+    )
+    request = MessagesRequest.model_validate(
+        {
+            "model": harness.runtime.name,
+            "messages": [{"role": "user", "content": "classify"}],
+            "max_tokens": 64,
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+            "output_config": {"effort": "xhigh"},
+        }
+    )
+    try:
+        output = [
+            event
+            async for event in harness.provider.stream_messages(
+                request,
+                reasoning=ReasoningPolicy.prefer_off(),
+                model_info=ProviderModelInfo(
+                    harness.runtime.name, reasoning_capability=ReasoningCapability.NONE
+                ),
+            )
+        ]
+        assert text_content(parse_sse_text("".join(output))) == "ok"
+        body = json.loads(harness.seen[0].content)
+        if egress is CopilotEgress.MESSAGES:
+            assert body["thinking"] == {"type": "disabled"}
+            assert body["max_tokens"] == (64 if supports_off else 4096)
+        elif egress is CopilotEgress.RESPONSES:
+            assert body.get("reasoning") == (
+                {"effort": "none"} if supports_off else None
+            )
+            assert body.get("max_output_tokens") == (64 if supports_off else None)
+        else:
+            assert body.get("reasoning_effort") == ("none" if supports_off else None)
+            assert body.get("max_tokens") == (64 if supports_off else None)
+        assert request.thinking is not None and request.thinking.budget_tokens == 1024
+        assert all(wire.closed for wire in harness.wires)
+    finally:
+        await harness.close()
 
 
 def _request(

--- a/tests/providers/test_groq_reasoning.py
+++ b/tests/providers/test_groq_reasoning.py
@@ -346,7 +346,7 @@ async def test_exact_issue_retries_with_default_and_learns_model() -> None:
     create = AsyncMock(side_effect=[_vocabulary_error(), object()])
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await provider._create_stream(
+        _stream, used_body, attempt, _sent_body = await provider._create_stream(
             body,
             provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,
@@ -365,7 +365,12 @@ async def test_exact_issue_retries_with_default_and_learns_model() -> None:
     assert next_body["reasoning_effort"] == "default"
     next_create = AsyncMock(return_value=object())
     with patch.object(provider._client.chat.completions, "create", next_create):
-        _stream, next_used_body, next_attempt = await provider._create_stream(
+        (
+            _stream,
+            next_used_body,
+            next_attempt,
+            _sent_body,
+        ) = await provider._create_stream(
             next_body,
             provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,
@@ -435,7 +440,7 @@ async def test_unknown_vocabulary_retries_without_effort_and_negative_caches() -
     )
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await provider._create_stream(
+        _stream, used_body, attempt, _sent_body = await provider._create_stream(
             body,
             provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,
@@ -490,7 +495,7 @@ async def test_concurrent_first_requests_can_learn_without_state_corruption() ->
         return object()
 
     async def execute(body: dict):
-        _stream, used_body, attempt = await provider._create_stream(
+        _stream, used_body, attempt, _sent_body = await provider._create_stream(
             body,
             provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,
@@ -526,7 +531,7 @@ async def test_stale_cache_self_heals_without_guessing_original_effort() -> None
     )
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, corrected_body, attempt = await provider._create_stream(
+        _stream, corrected_body, attempt, _sent_body = await provider._create_stream(
             cached_body,
             provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,
@@ -657,7 +662,7 @@ async def test_output_cap_and_reasoning_corrections_share_one_session() -> None:
     execution = provider._admission.start_execution()
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await provider._create_stream(
+        _stream, used_body, attempt, _sent_body = await provider._create_stream(
             body,
             execution,
             ProviderOperationKind.GENERATION,

--- a/tests/providers/test_groq_reasoning.py
+++ b/tests/providers/test_groq_reasoning.py
@@ -8,9 +8,17 @@ import httpx2
 import openai
 import pytest
 
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.provider_catalog import GROQ_DEFAULT_BASE
-from free_claude_code.core.anthropic.stream_contracts import parse_sse_text
-from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.core.anthropic.stream_contracts import (
+    parse_sse_text,
+    text_content,
+)
+from free_claude_code.core.reasoning import (
+    ReasoningCapability,
+    ReasoningEffort,
+    ReasoningPolicy,
+)
 from free_claude_code.providers.admission import ProviderOperationKind
 from free_claude_code.providers.groq import GroqProvider
 from free_claude_code.providers.groq.client import (
@@ -89,6 +97,61 @@ def _chunk(*, content: str | None = None, finish_reason: str | None = None):
 async def _successful_stream(text: str = "visible"):
     yield _chunk(content=text)
     yield _chunk(finish_reason="stop")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "`reasoning_effort` must be one of `default`",
+        "reasoning_effort value `none` must be one of `default`",
+        "accepted options for reasoning_effort include default",
+    ],
+)
+async def test_classifier_correction_does_not_change_later_requests(message):
+    provider = _provider()
+    sent = []
+
+    async def create(**body):
+        sent.append(body)
+        if len(sent) == 1:
+            raise _BadRequest(message, body={"message": message})
+        return _successful_stream("<severity>0</severity>")
+
+    try:
+        with patch.object(provider._client.chat.completions, "create", create):
+            classifier = "".join(
+                [
+                    event
+                    async for event in provider.stream_messages(
+                        make_messages_request(_MODEL, max_tokens=64),
+                        reasoning=ReasoningPolicy.prefer_off(),
+                        model_info=ProviderModelInfo(
+                            _MODEL, reasoning_capability=ReasoningCapability.OPTIONAL
+                        ),
+                    )
+                ]
+            )
+            ordinary = "".join(
+                [
+                    event
+                    async for event in provider.stream_messages(
+                        _request(),
+                        reasoning=ReasoningPolicy.on(effort=ReasoningEffort.HIGH),
+                    )
+                ]
+            )
+    finally:
+        await provider.cleanup()
+
+    assert text_content(parse_sse_text(classifier)) == "<severity>0</severity>"
+    assert text_content(parse_sse_text(ordinary)) == "<severity>0</severity>"
+    assert len(sent) == 3
+    assert sent[2]["reasoning_effort"] == "high"
+    assert sent[0]["reasoning_effort"] == "none"
+    assert sent[0]["max_completion_tokens"] == 64
+    assert "reasoning_effort" not in sent[1]
+    assert "max_completion_tokens" not in sent[1]
 
 
 def test_parse_exact_issue_vocabulary_excludes_rejected_value() -> None:

--- a/tests/providers/test_groq_tpm.py
+++ b/tests/providers/test_groq_tpm.py
@@ -308,7 +308,7 @@ async def test_tpm_and_reasoning_corrections_compose(
     execution = provider._admission.start_execution()
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, accepted_body, attempt = await provider._create_stream(
+        _stream, accepted_body, attempt, _sent_body = await provider._create_stream(
             body,
             execution,
             ProviderOperationKind.GENERATION,
@@ -331,14 +331,19 @@ async def test_distinct_bodies_get_independent_tpm_corrections() -> None:
     create = AsyncMock(side_effect=[_status_error(), object(), second_error, object()])
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream, first_body, first_attempt = await provider._create_stream(
+        _stream, first_body, first_attempt, _sent_body = await provider._create_stream(
             _body(),
             execution,
             ProviderOperationKind.CONTINUATION,
         )
         await first_attempt.accept()
         await first_attempt.aclose()
-        _stream, second_body, second_attempt = await provider._create_stream(
+        (
+            _stream,
+            second_body,
+            second_attempt,
+            _sent_body,
+        ) = await provider._create_stream(
             _body(20_000),
             execution,
             ProviderOperationKind.TOOL_REPAIR,

--- a/tests/providers/test_llm7.py
+++ b/tests/providers/test_llm7.py
@@ -12,7 +12,7 @@ from free_claude_code.config.provider_catalog import LLM7_DEFAULT_BASE
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.json_types import JsonObject, JsonValue
 from free_claude_code.core.model_capabilities import ModelInputModality
-from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.core.reasoning import ReasoningCapability, ReasoningPolicy
 from free_claude_code.providers.model_listing import ModelListResponseError
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from tests.providers.support import (
@@ -218,6 +218,7 @@ async def test_filters_catalog_and_adds_live_authoritative_selectors(
             ProviderModelInfo(
                 "plain-model",
                 supports_thinking=False,
+                reasoning_capability=ReasoningCapability.NONE,
                 input_modalities=frozenset({ModelInputModality.TEXT}),
             ),
             ProviderModelInfo(

--- a/tests/providers/test_lmstudio.py
+++ b/tests/providers/test_lmstudio.py
@@ -119,8 +119,9 @@ def test_preflight_builds_before_context_budget_and_preserves_policy(
     request = make_request()
     calls: list[tuple[str, object]] = []
 
-    def build(request_arg, *, reasoning):
+    def build(request_arg, *, reasoning, model_info):
         assert request_arg is request
+        assert model_info is None
         calls.append(("build", reasoning))
         return {}
 

--- a/tests/providers/test_model_discovery.py
+++ b/tests/providers/test_model_discovery.py
@@ -359,6 +359,7 @@ class FakeProvider(BaseProvider):
         request: Any,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         return None
 
@@ -395,6 +396,7 @@ class FakeProvider(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         if False:
             yield ""

--- a/tests/providers/test_nararoute.py
+++ b/tests/providers/test_nararoute.py
@@ -7,6 +7,7 @@ import pytest
 
 from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.config.provider_catalog import NARAROUTE_DEFAULT_BASE
+from free_claude_code.core.reasoning import ReasoningCapability
 from tests.providers.support import (
     immediate_admission,
     make_provider_config,
@@ -44,7 +45,11 @@ async def test_model_catalog_extracts_strict_optional_reasoning_boolean() -> Non
     assert infos == frozenset(
         {
             ProviderModelInfo("reasoning", supports_thinking=True),
-            ProviderModelInfo("plain", supports_thinking=False),
+            ProviderModelInfo(
+                "plain",
+                supports_thinking=False,
+                reasoning_capability=ReasoningCapability.NONE,
+            ),
             ProviderModelInfo("unknown"),
             ProviderModelInfo("malformed"),
         }

--- a/tests/providers/test_openai_chat_output_cap.py
+++ b/tests/providers/test_openai_chat_output_cap.py
@@ -265,7 +265,7 @@ async def test_create_stream_clamps_and_learns_on_cap_rejection(groq_provider):
     create = AsyncMock(side_effect=[error, object()])
 
     with patch.object(groq_provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await groq_provider._create_stream(
+        _stream, used_body, attempt, _sent_body = await groq_provider._create_stream(
             body,
             groq_provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,
@@ -292,7 +292,7 @@ async def test_learned_cap_clamps_next_request_without_a_400(groq_provider):
 
     create = AsyncMock(return_value=object())
     with patch.object(groq_provider._client.chat.completions, "create", create):
-        _stream, used_body, attempt = await groq_provider._create_stream(
+        _stream, used_body, attempt, _sent_body = await groq_provider._create_stream(
             body,
             groq_provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,

--- a/tests/providers/test_openai_chat_usage.py
+++ b/tests/providers/test_openai_chat_usage.py
@@ -9,6 +9,7 @@ import pytest
 from httpx2 import Request, Response
 from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
 
+from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.anthropic import ReasoningReplayMode
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.sse_aggregation import (
@@ -61,6 +62,7 @@ class _UsageTestProvider(OpenAIChatProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> dict:
         return {"model": request.model, "messages": [{"role": "user", "content": "x"}]}
 
@@ -533,7 +535,7 @@ async def test_openai_chat_stream_retries_without_usage_when_option_is_rejected(
     )
 
     with patch.object(provider._client.chat.completions, "create", create):
-        _stream_obj, used_body, attempt = await provider._create_stream(
+        _stream_obj, used_body, attempt, _sent_body = await provider._create_stream(
             body,
             provider._admission.start_execution(),
             ProviderOperationKind.GENERATION,

--- a/tests/providers/test_openai_responses_transport.py
+++ b/tests/providers/test_openai_responses_transport.py
@@ -26,6 +26,53 @@ from free_claude_code.providers.openai_responses import OpenAIResponsesTransport
 from tests.providers.support import REASONING_ON, immediate_admission
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_error", [False, True])
+async def test_tolerant_classifier_corrects_required_reasoning(stream_error):
+    bodies = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        bodies.append(body)
+        if body.get("reasoning", {}).get("effort") == "none":
+            error = {
+                "code": "invalid_request_error",
+                "message": "Reasoning is mandatory and cannot be disabled.",
+            }
+            if stream_error:
+                return httpx2.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    text=_sse({"type": "error", **error, "sequence_number": 0}),
+                )
+            return httpx2.Response(400, json={"error": error})
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=_sse(_text_delta("<severity>0</severity>"), _completed_event()),
+        )
+
+    client = _client(handler)
+    try:
+        output = [
+            event
+            async for event in _transport(client).stream_messages(
+                _request(max_tokens=64, thinking={"type": "disabled"}),
+                input_tokens=11,
+                request_id="classifier",
+                response_model="public",
+                reasoning=ReasoningPolicy.prefer_off(),
+            )
+        ]
+        assert text_content(parse_sse_text("".join(output))) == "<severity>0</severity>"
+        assert len(bodies) == 2
+        assert bodies[0]["reasoning"]["effort"] == "none"
+        assert "max_output_tokens" not in bodies[0]
+        assert "reasoning" not in bodies[1]
+    finally:
+        await client.close()
+
+
 def _request(**overrides: object) -> MessagesRequest:
     payload: dict[str, object] = {
         "model": "upstream-model",

--- a/tests/providers/test_openai_responses_transport.py
+++ b/tests/providers/test_openai_responses_transport.py
@@ -28,17 +28,28 @@ from tests.providers.support import REASONING_ON, immediate_admission
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stream_error", [False, True])
-async def test_tolerant_classifier_corrects_required_reasoning(stream_error):
+@pytest.mark.parametrize(
+    "error",
+    [
+        {
+            "code": "invalid_request_error",
+            "message": "Reasoning is mandatory and cannot be disabled.",
+        },
+        {
+            "code": "unsupported_value",
+            "param": "reasoning.effort",
+            "message": "Value 'none' is not supported",
+        },
+    ],
+    ids=["mandatory", "unsupported_value"],
+)
+async def test_tolerant_classifier_corrects_required_reasoning(stream_error, error):
     bodies = []
 
     def handler(request):
         body = json.loads(request.content)
         bodies.append(body)
         if body.get("reasoning", {}).get("effort") == "none":
-            error = {
-                "code": "invalid_request_error",
-                "message": "Reasoning is mandatory and cannot be disabled.",
-            }
             if stream_error:
                 return httpx2.Response(
                     200,

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -31,7 +31,10 @@ from free_claude_code.core.anthropic.stream_contracts import (
 from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.model_capabilities import ModelInputModality
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
-from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY
+from free_claude_code.core.reasoning import (
+    DEFAULT_REASONING_POLICY,
+    ReasoningCapability,
+)
 from free_claude_code.providers.model_listing import ModelListResponseError
 from free_claude_code.providers.opencode import (
     OpenCodeProvider,
@@ -384,6 +387,7 @@ def test_catalog_resolves_package_precedence_status_alias_and_reasoning() -> Non
             ProviderModelInfo(
                 "provider-default",
                 supports_thinking=False,
+                reasoning_capability=ReasoningCapability.NONE,
                 input_modalities=frozenset({ModelInputModality.TEXT}),
                 context_window_tokens=131072,
                 max_output_tokens=8192,
@@ -1169,7 +1173,11 @@ async def test_model_listing_and_dispatch_use_same_snapshot() -> None:
 
     assert infos == frozenset(
         {
-            ProviderModelInfo("chat-selector", supports_thinking=False),
+            ProviderModelInfo(
+                "chat-selector",
+                supports_thinking=False,
+                reasoning_capability=ReasoningCapability.NONE,
+            ),
             ProviderModelInfo("responses-selector", supports_thinking=True),
         }
     )

--- a/tests/providers/test_preflight_contract.py
+++ b/tests/providers/test_preflight_contract.py
@@ -21,6 +21,7 @@ class RecordingOpenAIProvider(OpenAIChatProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> dict:
         self.build_calls.append((request, reasoning))
         return {}
@@ -42,6 +43,7 @@ class ProviderWithoutPreflight(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         if False:
             yield ""

--- a/tests/providers/test_reasoning_capabilities.py
+++ b/tests/providers/test_reasoning_capabilities.py
@@ -1,0 +1,64 @@
+import pytest
+
+from free_claude_code.providers.model_listing import (
+    extract_openai_model_infos,
+    extract_tool_capable_model_infos,
+)
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "expected"),
+    [
+        ({"mandatory": True}, "required"),
+        ({"supported_efforts": ["none", "high"]}, "optional"),
+        ({"mandatory": True, "supported_efforts": ["none"]}, "unknown"),
+        ({"mandatory": "true"}, "unknown"),
+        ({"mandatory": False}, "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_explicit_gateway_reasoning_capability(reasoning, expected):
+    infos = extract_tool_capable_model_infos(
+        {
+            "data": [
+                {
+                    "id": "route",
+                    "supported_parameters": ["tools"],
+                    "reasoning": reasoning,
+                }
+            ]
+        },
+        provider_name="GATEWAY",
+    )
+    assert next(iter(infos)).reasoning_capability.value == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "options", "expected"),
+    [
+        ({"reasoning": False}, {"thinking_boolean_path": ("reasoning",)}, "none"),
+        ({"reasoning": True}, {"thinking_boolean_path": ("reasoning",)}, "unknown"),
+        (
+            {"tags": ["non-reasoning"]},
+            {"tags_field": "tags", "non_thinking_tag": "non-reasoning"},
+            "none",
+        ),
+        (
+            {"tags": ["non-reasoning", "reasoning"]},
+            {"tags_field": "tags", "non_thinking_tag": "non-reasoning"},
+            "unknown",
+        ),
+        (
+            {"supported_parameters": ["tools"]},
+            {"thinking_sequence_path": ("supported_parameters",)},
+            "unknown",
+        ),
+    ],
+)
+def test_intrinsic_capability_is_distinct_from_available_controls(
+    payload, options, expected
+):
+    infos = extract_openai_model_infos(
+        {"data": [{"id": "route", **payload}]}, provider_name="TEST", **options
+    )
+    assert next(iter(infos)).reasoning_capability.value == expected

--- a/tests/providers/test_reasoning_compatibility.py
+++ b/tests/providers/test_reasoning_compatibility.py
@@ -1,0 +1,171 @@
+from copy import deepcopy
+
+import httpx2
+import pytest
+from openai import BadRequestError
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.core.reasoning import ReasoningCapability, ReasoningPolicy
+from free_claude_code.providers.reasoning_compatibility import (
+    ReasoningCorrection,
+    prepare_messages_reasoning,
+)
+from tests.providers.request_factory import make_messages_request
+
+
+@pytest.mark.parametrize(
+    ("capability", "can_disable", "control", "limit"),
+    [
+        ("none", True, "default", 64),
+        ("optional", True, "off", 64),
+        ("optional", False, "default", 8192),
+        ("required", True, "default", 8192),
+        ("unknown", True, "off", 8192),
+        ("unknown", False, "default", 8192),
+    ],
+)
+def test_prepare_uses_explicit_capability_and_available_encoding(
+    capability, can_disable, control, limit
+):
+    request = make_messages_request(
+        "arbitrary",
+        max_tokens=64,
+        thinking={"type": "disabled"},
+        output_config={"effort": "high", "format": {"type": "text"}},
+    )
+    prepared, policy = prepare_messages_reasoning(
+        request,
+        ReasoningPolicy.prefer_off(),
+        model_info=ProviderModelInfo(
+            "arbitrary", reasoning_capability=ReasoningCapability(capability)
+        ),
+        can_disable=can_disable,
+        normal_max_tokens=8192,
+    )
+    assert policy.control.value == control
+    assert prepared.max_tokens == limit
+    assert prepared.thinking is None
+    assert prepared.output_config == {"format": {"type": "text"}}
+    assert request.max_tokens == 64
+    assert request.thinking is not None and request.thinking.type == "disabled"
+
+
+@pytest.mark.parametrize(
+    ("requested", "normal", "expected"), [(12000, 8192, 12000), (12000, None, None)]
+)
+def test_normal_allowance_preserves_larger_limits_or_omission(
+    requested, normal, expected
+):
+    request = make_messages_request("route", max_tokens=requested)
+    prepared, _ = prepare_messages_reasoning(
+        request,
+        ReasoningPolicy.prefer_off(),
+        model_info=None,
+        can_disable=True,
+        normal_max_tokens=normal,
+    )
+    assert prepared.max_tokens == expected
+
+
+@pytest.mark.parametrize(
+    ("message", "param", "correct"),
+    [
+        (
+            "Reasoning is mandatory for this endpoint and cannot be disabled.",
+            None,
+            True,
+        ),
+        ("Thinking cannot be disabled for this endpoint.", None, True),
+        ("Unsupported parameter: reasoning_effort", None, True),
+        ("Value 'none' is not supported", "reasoning_effort", True),
+        ("Value must be one of: low, high", "reasoning_effort", True),
+        (
+            "Use reasoning_effort for thinking. The response_format parameter is unsupported.",
+            "response_format",
+            False,
+        ),
+        (
+            "Reasoning is enabled. This response_format cannot be disabled.",
+            "response_format",
+            False,
+        ),
+        ("Tool schema required fields missing", "tools", False),
+        ("Unknown error", None, False),
+    ],
+)
+def test_correction_requires_rejection_of_the_sent_control(message, param, correct):
+    body = {
+        "model": "route",
+        "messages": [{"role": "user", "content": "classify"}],
+        "reasoning_effort": "none",
+        "max_tokens": 64,
+        "stream_options": {"include_usage": True},
+    }
+    original = deepcopy(body)
+    error = BadRequestError(
+        message,
+        response=httpx2.Response(
+            400, request=httpx2.Request("POST", "https://test.invalid")
+        ),
+        body={"error": {"message": message, "param": param}},
+    )
+    result = ReasoningCorrection(
+        (("reasoning_effort",),), "max_tokens", 8192
+    ).retry_body(error, body)
+    assert (result is not None) is correct
+    if result is not None:
+        assert result == {
+            key: value
+            for key, value in original.items()
+            if key not in {"max_tokens", "reasoning_effort"}
+        } | {"max_tokens": 8192}
+    assert body == original
+
+
+@pytest.mark.parametrize("sent", [{}, {"reasoning_effort": "high"}])
+def test_correction_requires_the_off_control_to_have_reached_the_wire(sent):
+    error = BadRequestError(
+        "Reasoning cannot be disabled",
+        response=httpx2.Response(
+            400, request=httpx2.Request("POST", "https://test.invalid")
+        ),
+        body={"message": "Reasoning cannot be disabled"},
+    )
+    correction = ReasoningCorrection((("reasoning_effort",),), "max_tokens", 8192)
+    assert (
+        correction.retry_body(error, {"reasoning_effort": "none"}, sent_body=sent)
+        is None
+    )
+
+
+def test_correction_removes_both_template_controls_preserving_other_options():
+    error = BadRequestError(
+        "Thinking cannot be disabled",
+        response=httpx2.Response(
+            400, request=httpx2.Request("POST", "https://test.invalid")
+        ),
+        body={"message": "Thinking cannot be disabled"},
+    )
+    body = {
+        "extra_body": {
+            "chat_template_kwargs": {
+                "thinking": False,
+                "enable_thinking": False,
+                "other": 1,
+            }
+        },
+        "max_tokens": 64,
+    }
+    correction = ReasoningCorrection(
+        (
+            ("extra_body", "chat_template_kwargs", "thinking"),
+            ("extra_body", "chat_template_kwargs", "enable_thinking"),
+        ),
+        "max_tokens",
+        8192,
+        output_cap=4096,
+    )
+    assert correction.retry_body(error, body) == {
+        "extra_body": {"chat_template_kwargs": {"other": 1}},
+        "max_tokens": 4096,
+    }

--- a/tests/providers/test_zenmux.py
+++ b/tests/providers/test_zenmux.py
@@ -19,7 +19,11 @@ from free_claude_code.core.anthropic.stream_contracts import (
     thinking_content,
 )
 from free_claude_code.core.model_capabilities import ModelInputModality
-from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
+from free_claude_code.core.reasoning import (
+    ReasoningCapability,
+    ReasoningEffort,
+    ReasoningPolicy,
+)
 from free_claude_code.providers.model_listing import ModelListResponseError
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from tests.providers.support import (
@@ -403,6 +407,7 @@ async def test_model_catalog_filters_modalities_and_maps_reasoning_capability(
             ProviderModelInfo(
                 "plain-chat",
                 supports_thinking=False,
+                reasoning_capability=ReasoningCapability.NONE,
                 input_modalities=frozenset({ModelInputModality.TEXT}),
             ),
             ProviderModelInfo(

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -70,6 +70,7 @@ class AdminModelProvider(BaseProvider):
         request: MessagesRequest,
         *,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
+        model_info: ProviderModelInfo | None = None,
     ) -> None:
         return None
 
@@ -98,6 +99,7 @@ class AdminModelProvider(BaseProvider):
         response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
+        model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         if False:
             yield ""

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.23.3"
+version = "5.23.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Claude Code's Auto mode safety check asks for thinking to be disabled and gives the first check only 64 output tokens. Providers that require thinking reject that request. Simply allowing thinking can also leave no room for the verdict within that short limit. This causes Auto mode to fail even when ordinary conversations work.

Fixes #1698.

## How

For these safety checks, FCC uses provider capability data to disable thinking when supported, omit thinking controls when unsupported, and allow provider defaults when thinking is required. Required or uncertain cases receive the provider's normal output allowance. If a provider explicitly rejects disabling thinking, FCC removes that control and corrects the request once within the existing attempt limit.

FCC removes structured thinking blocks from the safety-check response before returning it to Claude. Verdict text, including Claude's own text tags, remains intact. Shared request preparation handles all three egress protocols; provider-specific controls stay with their providers.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Auto-mode classifier requests compatible with providers that require or have uncertain reasoning behavior.
- Adds provider-model reasoning capability metadata and propagates it through request execution.
- Introduces a prefer-off policy that disables reasoning when supported while preserving provider defaults otherwise.
- Adds bounded correction when a provider rejects the disable control.
- Filters structured thinking blocks from classifier responses while preserving verdict text.
- Extends provider-specific implementations and tests across Anthropic, OpenAI Chat, OpenAI Responses, Copilot, OpenRouter, Groq, and related providers.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no established correctness, security, or repository-rule violations remaining.

The latest changes add targeted handling and coverage for OpenRouter’s streamed numeric rejection format, and the broader implementation consistently bounds correction to one retry while preserving classifier verdict text and filtering structured reasoning.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/reasoning_compatibility.py | Centralizes capability-aware reasoning preparation, output-budget restoration, rejection matching, and bounded request correction. |
| src/free_claude_code/api/handlers/classifier_response.py | Projects Anthropic SSE block indices while removing thinking and redacted-thinking blocks from classifier responses. |
| src/free_claude_code/api/handlers/messages.py | Applies prefer-off reasoning and response filtering specifically to classifier requests. |
| src/free_claude_code/providers/openai_chat/provider.py | Integrates reasoning preparation and correction into OpenAI-compatible request creation and stream recovery. |
| src/free_claude_code/providers/anthropic_messages/transport.py | Adds capability-aware request preparation and one-shot correction for native Anthropic Messages egress. |
| src/free_claude_code/providers/openai_responses/transport.py | Extends the shared reasoning-compatibility behavior to OpenAI Responses egress. |
| src/free_claude_code/providers/open_router/client.py | Recognizes OpenRouter’s numeric streamed rejection format so classifier requests can be corrected once. |
| tests/api/test_classifier_provider_compatibility.py | Covers provider capability handling, correction behavior, and OpenRouter HTTP-200 streamed errors. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Claude Auto-mode classifier request] --> B[MessagesHandler selects prefer-off reasoning]
    B --> C[ProviderExecutor attaches model capability metadata]
    C --> D{Reasoning capability}
    D -->|None or optional| E[Send provider-specific disable control]
    D -->|Required or unknown| F[Omit disable control and restore normal output allowance]
    E --> G{Provider rejects disable control?}
    G -->|Yes| H[Remove control and retry once]
    G -->|No| I[Stream classifier response]
    H --> I
    F --> I
    I --> J[Remove structured thinking blocks]
    J --> K[Return verdict text to Claude]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Recognize OpenRouter numeric streamed re..."](https://github.com/alishahryar1/free-claude-code/commit/7465049946cadce03c566edcd3a10cb89b5069b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61158088)</sub>

<!-- /greptile_comment -->