### PR TITLE
Fix Claude Code session forwarding to OpenCode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.23.4"
+version = "5.23.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/opencode/provider.py
+++ b/src/free_claude_code/providers/opencode/provider.py
@@ -133,7 +133,12 @@ class OpenCodeProvider(OpenAIChatProvider):
         self, request_headers: Mapping[str, str]
     ) -> Mapping[str, str]:
         headers = {name.lower(): value for name, value in request_headers.items()}
-        for name in ("x-opencode-session", "session-id", "x-session-id"):
+        for name in (
+            "x-opencode-session",
+            "session-id",
+            "x-session-id",
+            "x-claude-code-session-id",
+        ):
             session_id = headers.get(name)
             if session_id and session_id.strip():
                 return {"x-opencode-session": session_id}

--- a/tests/api/test_opencode_session_headers.py
+++ b/tests/api/test_opencode_session_headers.py
@@ -122,7 +122,12 @@ async def test_existing_session_id_reaches_opencode_without_forwarding_other_hea
             for name, value in provider._client.default_headers.items()
             if isinstance(value, str)
         }
-        for name in ("Session-Id", "X-OpenCode-Session", "X-Session-Id"):
+        for name in (
+            "Session-Id",
+            "X-OpenCode-Session",
+            "X-Session-Id",
+            "X-Claude-Code-Session-Id",
+        ):
             for conversation in ("conversation-a", "conversation-a", "conversation-b"):
                 response = await client.post(
                     f"/v1/{ingress}",
@@ -159,6 +164,7 @@ async def test_session_header_precedence_and_absence_do_not_invent_or_reuse_iden
             headers={
                 "x-opencode-session": "explicit-session",
                 "session-id": "native-session",
+                "X-Claude-Code-Session-Id": "claude-session",
             },
         )
         assert response.status_code == 200, response.text
@@ -173,7 +179,10 @@ async def test_session_header_precedence_and_absence_do_not_invent_or_reuse_iden
 
 
 @pytest.mark.parametrize("selector", ["responses-selector", "chat-selector"])
-async def test_concurrent_conversations_keep_their_session_ids_during_retry(selector):
+@pytest.mark.parametrize("session_header", ["session-id", "X-Claude-Code-Session-Id"])
+async def test_concurrent_conversations_keep_their_session_ids_during_retry(
+    selector, session_header
+):
     first_arrived = asyncio.Event()
     second_arrived = asyncio.Event()
     attempts = []
@@ -201,7 +210,7 @@ async def test_concurrent_conversations_keep_their_session_ids_during_retry(sele
                 client.post(
                     "/v1/responses",
                     json=request,
-                    headers={"session-id": "conversation-a"},
+                    headers={session_header: "conversation-a"},
                 )
             )
             try:
@@ -209,7 +218,7 @@ async def test_concurrent_conversations_keep_their_session_ids_during_retry(sele
                 second = await client.post(
                     "/v1/responses",
                     json=request,
-                    headers={"session-id": "conversation-b"},
+                    headers={session_header: "conversation-b"},
                 )
                 assert second.status_code == 200, second.text
                 result = await first

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.23.4"
+version = "5.23.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

FCC discarded Claude Code's `X-Claude-Code-Session-Id` header. OpenCode therefore received no conversation ID and could reject requests with `MissingSessionID`.

Fixes #1702.

## How

Recognize Claude Code's header in the existing OpenCode adapter and forward its value as `x-opencode-session`. This applies to both Zen and Go, through both Chat and Responses.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR forwards Claude Code’s session identifier to OpenCode using the provider’s expected `x-opencode-session` header.
- Adds `X-Claude-Code-Session-Id` to the existing ordered session-header aliases.
- Covers OpenCode Zen and Go across Chat and Responses transports, including retries and concurrent conversations.
- Bumps the package and lockfile metadata version to 5.23.5.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the new header alias is forwarded across all claimed provider and transport paths with focused regression coverage.

No actionable failure remains: dynamic dispatch applies the OpenCode translation to both Chat and Responses transports, tests cover Zen and Go, and the version metadata is synchronized.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/free_claude_code/providers/opencode/provider.py | Adds Claude Code’s session header as the lowest-priority accepted alias and forwards it under OpenCode’s expected header name. |
| tests/api/test_opencode_session_headers.py | Extends propagation, precedence, retry, concurrency, provider, and transport coverage to the Claude Code header. |
| pyproject.toml | Bumps the project version from 5.23.4 to 5.23.5. |
| uv.lock | Keeps editable package metadata synchronized with the project version without changing dependency resolution. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Claude Code
    participant G as FCC API
    participant P as OpenCodeProvider
    participant O as OpenCode Zen/Go
    C->>G: "Chat or Responses request<br/>X-Claude-Code-Session-Id"
    G->>P: request_headers
    P->>P: Select session-header alias
    P->>O: x-opencode-session
    O-->>P: Model response
    P-->>C: Gateway response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Claude Code session forwarding to Op..."](https://github.com/alishahryar1/free-claude-code/commit/9cb352bcd449132392dac94197236b11858da9eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61190145)</sub>

**Context used:**

- Knowledge Base — [Provider integration layer](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/provider-integrations.md)

<!-- /greptile_comment -->