### PR TITLE
Fix OpenCode session routing across FCC harnesses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "5.23.5"
+version = "5.23.6"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/cli/launchers/aider.py
+++ b/src/free_claude_code/cli/launchers/aider.py
@@ -1,6 +1,5 @@
 """Installed Aider launcher using native model settings for FCC routing."""
 
-import secrets
 from collections.abc import Sequence
 
 from free_claude_code.cli.environment import client_environment
@@ -13,11 +12,12 @@ from .runner import HarnessSpec, LaunchContext, PreparedLaunch, launch_harness
 def _configure(
     ctx: LaunchContext, args: list[str], files: LaunchResources
 ) -> PreparedLaunch:
-    key_env = f"{AIDER_API_KEY_ENV_PREFIX}{secrets.token_hex(16).upper()}"
+    key_env = f"{AIDER_API_KEY_ENV_PREFIX}{ctx.launch_id.upper()}"
     config = build_aider_config(
         ctx.models,
         messages_url=f"{ctx.proxy_root_url.rstrip('/')}/v1/messages",
         api_key_env=key_env,
+        launch_id=ctx.launch_id,
     )
     settings_path = files.write_json("model-settings.yml", config.settings)
     metadata_path = files.write_json("model-metadata.json", config.metadata)

--- a/src/free_claude_code/cli/launchers/aider_config.py
+++ b/src/free_claude_code/cli/launchers/aider_config.py
@@ -25,6 +25,7 @@ def build_aider_config(
     *,
     messages_url: str,
     api_key_env: str,
+    launch_id: str,
 ) -> AiderConfig:
     """Project a non-empty FCC Messages catalog into Aider's file contracts."""
 
@@ -47,6 +48,7 @@ def build_aider_config(
                 "model": f"anthropic/{model.wire_slug}",
                 "api_base": messages_url,
                 "api_key": f"os.environ/{api_key_env}",
+                "extra_headers": {"x-fcc-launch-id": launch_id},
             },
         }
         if model.supports_reasoning is not None:

--- a/src/free_claude_code/cli/launchers/cline.py
+++ b/src/free_claude_code/cli/launchers/cline.py
@@ -26,7 +26,10 @@ def _configure(
     ctx: LaunchContext, args: list[str], files: LaunchResources
 ) -> PreparedLaunch:
     config = build_cline_config(
-        ctx.models, proxy_root_url=ctx.proxy_root_url, auth_token=ctx.auth_token
+        ctx.models,
+        proxy_root_url=ctx.proxy_root_url,
+        auth_token=ctx.auth_token,
+        launch_id=ctx.launch_id,
     )
     providers_path = files.write_json("settings/providers.json", config.providers)
     files.write_json("settings/models.json", config.models)

--- a/src/free_claude_code/cli/launchers/cline_config.py
+++ b/src/free_claude_code/cli/launchers/cline_config.py
@@ -28,6 +28,7 @@ def build_cline_config(
     *,
     proxy_root_url: str,
     auth_token: str,
+    launch_id: str,
     now: datetime | None = None,
 ) -> ClineConfig:
     """Translate a non-empty FCC model snapshot into Cline's file contracts."""
@@ -42,6 +43,7 @@ def build_cline_config(
     provider_settings: JsonObject = {
         "provider": CLINE_PROVIDER_ID,
         "apiKey": auth_token,
+        "headers": {"x-fcc-launch-id": launch_id},
         "model": default_model,
         "protocol": "openai-responses",
         "baseUrl": proxy_v1_url(proxy_root_url),

--- a/src/free_claude_code/cli/launchers/hermes.py
+++ b/src/free_claude_code/cli/launchers/hermes.py
@@ -3,7 +3,6 @@
 import json
 import os
 import re
-import secrets
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -44,7 +43,7 @@ def _configure(
     if os.name != "nt" and Path("/etc/hermes").exists():
         raise ValueError("An existing Hermes managed policy cannot be replaced by FCC.")
     managed = build_hermes_managed_config(
-        ctx.models, proxy_root_url=ctx.proxy_root_url, nonce=secrets.token_hex(16)
+        ctx.models, proxy_root_url=ctx.proxy_root_url, nonce=ctx.launch_id
     )
     path = files.write_json("config.yaml", managed.config)
     env = client_environment(

--- a/src/free_claude_code/cli/launchers/hermes_config.py
+++ b/src/free_claude_code/cli/launchers/hermes_config.py
@@ -92,6 +92,7 @@ def build_hermes_managed_config(
             "base_url": "",
             "api_key": "",
             "api_mode": "codex_responses",
+            "default_headers": {"x-fcc-launch-id": nonce},
         },
         "fallback_providers": [],
         "fallback_model": [],

--- a/src/free_claude_code/cli/launchers/pi.py
+++ b/src/free_claude_code/cli/launchers/pi.py
@@ -1,5 +1,6 @@
 """Installed Pi launcher using the bundled FCC provider extension."""
 
+import re
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -13,7 +14,10 @@ from .runner import (
     NativeCheck,
     PreparedLaunch,
     launch_harness,
+    version_at_least,
 )
+
+_VERSION_PATTERN = re.compile(r"(?m)^\s*(\d+)\.(\d+)\.(\d+)\s*$")
 
 
 def pi_extension_path() -> Path:
@@ -61,9 +65,9 @@ SPEC = HarnessSpec(
     install_hint=pi_install_hint(),
     configure=_configure,
     compatibility_check=NativeCheck(
-        ("--help",),
-        lambda output: all(marker in output for marker in ("--extension", "--models")),
-        "The 'pi' command is not a compatible Pi Coding Agent.",
+        ("--version",),
+        lambda output: version_at_least(output, _VERSION_PATTERN, (0, 80, 4)),
+        "FCC requires Pi 0.80.4 or newer for provider request headers.",
     ),
 )
 

--- a/src/free_claude_code/cli/launchers/pi_extension.ts
+++ b/src/free_claude_code/cli/launchers/pi_extension.ts
@@ -153,6 +153,12 @@ export default async function freeClaudeCode(pi: ExtensionAPI): Promise<void> {
 		models,
 	});
 
+	pi.on("before_provider_headers", (event, ctx) => {
+		if (ctx.model?.provider === "free-claude-code") {
+			event.headers["x-opencode-session"] = ctx.sessionManager.getSessionId();
+		}
+	});
+
 	pi.on("before_provider_request", (event, ctx) => {
 		const payload = event.payload;
 		if (

--- a/src/free_claude_code/cli/launchers/runner.py
+++ b/src/free_claude_code/cli/launchers/runner.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import secrets
 import subprocess
 import sys
 from collections.abc import Callable, Mapping, Sequence
@@ -40,6 +41,7 @@ class LaunchContext:
     auth_token: str = field(repr=False)
     base_env: Mapping[str, str] = field(repr=False)
     models: tuple[ClientModel, ...]
+    launch_id: str = field(default_factory=lambda: secrets.token_hex(16))
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/free_claude_code/providers/opencode/provider.py
+++ b/src/free_claude_code/providers/opencode/provider.py
@@ -138,6 +138,11 @@ class OpenCodeProvider(OpenAIChatProvider):
             "session-id",
             "x-session-id",
             "x-claude-code-session-id",
+            "session_id",
+            "x-grok-session-id",
+            "x-meta-ai-gateway-session-id",
+            "x-tbh-session-id",
+            "x-fcc-launch-id",
         ):
             session_id = headers.get(name)
             if session_id and session_id.strip():

--- a/tests/api/test_opencode_session_headers.py
+++ b/tests/api/test_opencode_session_headers.py
@@ -127,6 +127,10 @@ async def test_existing_session_id_reaches_opencode_without_forwarding_other_hea
             "X-OpenCode-Session",
             "X-Session-Id",
             "X-Claude-Code-Session-Id",
+            "session_id",
+            "X-Grok-Session-Id",
+            "X-Meta-Ai-Gateway-Session-Id",
+            "X-Tbh-Session-Id",
         ):
             for conversation in ("conversation-a", "conversation-a", "conversation-b"):
                 response = await client.post(
@@ -134,6 +138,7 @@ async def test_existing_session_id_reaches_opencode_without_forwarding_other_hea
                     json=payload(ingress, provider_id, selector),
                     headers=[
                         (name.encode(), conversation.encode()),
+                        (b"X-Fcc-Launch-Id", b"launcher-fallback"),
                         (b"Cookie", b"private=cookie"),
                         (b"X-Private", b"caf\xe9"),
                     ],
@@ -144,6 +149,7 @@ async def test_existing_session_id_reaches_opencode_without_forwarding_other_hea
                 assert upstream.headers["authorization"] == "Bearer test_opencode_key"
                 assert "cookie" not in upstream.headers
                 assert "x-private" not in upstream.headers
+                assert "x-fcc-launch-id" not in upstream.headers
         assert {
             name: value
             for name, value in provider._client.default_headers.items()
@@ -165,6 +171,10 @@ async def test_session_header_precedence_and_absence_do_not_invent_or_reuse_iden
                 "x-opencode-session": "explicit-session",
                 "session-id": "native-session",
                 "X-Claude-Code-Session-Id": "claude-session",
+                "session_id": "dsh-session",
+                "x-grok-session-id": "grok-session",
+                "x-meta-ai-gateway-session-id": "muse-session",
+                "x-fcc-launch-id": "launcher-fallback",
             },
         )
         assert response.status_code == 200, response.text
@@ -179,7 +189,42 @@ async def test_session_header_precedence_and_absence_do_not_invent_or_reuse_iden
 
 
 @pytest.mark.parametrize("selector", ["responses-selector", "chat-selector"])
-@pytest.mark.parametrize("session_header", ["session-id", "X-Claude-Code-Session-Id"])
+@pytest.mark.parametrize("ingress", ["responses", "messages"])
+async def test_launch_fallback_is_stable_until_a_native_conversation_id_is_available(
+    selector, ingress
+):
+    async with wire_client() as (client, _provider, requests, _catalogs):
+        for launch_id, native_id in (
+            ("launch-a", ""),
+            ("launch-a", ""),
+            ("launch-a", "native-conversation"),
+            ("launch-b", ""),
+        ):
+            response = await client.post(
+                f"/v1/{ingress}",
+                json=payload(ingress, "opencode_zen", selector),
+                headers={"x-fcc-launch-id": launch_id, "session-id": native_id},
+            )
+            assert response.status_code == 200, response.text
+            assert requests[-1].headers["x-opencode-session"] == (
+                native_id or launch_id
+            )
+            assert "x-fcc-launch-id" not in requests[-1].headers
+
+
+@pytest.mark.parametrize("selector", ["responses-selector", "chat-selector"])
+@pytest.mark.parametrize(
+    "session_header",
+    [
+        "session-id",
+        "X-Claude-Code-Session-Id",
+        "session_id",
+        "X-Grok-Session-Id",
+        "X-Meta-Ai-Gateway-Session-Id",
+        "X-Tbh-Session-Id",
+        "x-fcc-launch-id",
+    ],
+)
 async def test_concurrent_conversations_keep_their_session_ids_during_retry(
     selector, session_header
 ):

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -44,7 +44,7 @@ class LaunchCapture:
     exit_code: int = 23
     versions: dict[str, str] = field(
         default_factory=lambda: {
-            "pi": "Pi Coding Agent --extension --models",
+            "pi": "0.80.4",
             "opencode": "1.18.18",
             "cline": "3.0.55",
             "hermes": "Hermes Agent 0.20.4",

--- a/tests/cli/test_aider_config.py
+++ b/tests/cli/test_aider_config.py
@@ -44,6 +44,7 @@ def test_aider_config_projects_messages_route_and_canonical_catalog() -> None:
         _models(),
         messages_url="http://127.0.0.1:9191/v1/messages",
         api_key_env="FCC_AIDER_PROXY_AUTH_A1B2C3",
+        launch_id="launch-a",
     )
 
     expected_metadata = {
@@ -77,6 +78,7 @@ def test_aider_config_projects_messages_route_and_canonical_catalog() -> None:
                 "model": f"anthropic/{wire_name}",
                 "api_base": "http://127.0.0.1:9191/v1/messages",
                 "api_key": "os.environ/FCC_AIDER_PROXY_AUTH_A1B2C3",
+                "extra_headers": {"x-fcc-launch-id": "launch-a"},
             }
     assert entries["nvidia_nim/vendor/model"]["accepts_settings"] == [
         "reasoning_effort"
@@ -106,6 +108,7 @@ def test_aider_config_rejects_empty_catalog() -> None:
             (),
             messages_url="http://127.0.0.1:9191/v1/messages",
             api_key_env="FCC_AIDER_PROXY_AUTH_A1B2C3",
+            launch_id="launch-a",
         )
 
 
@@ -120,6 +123,7 @@ def test_aider_catalog_ids_take_precedence_over_generated_transport_spellings() 
         models,
         messages_url="http://localhost:8182/v1/messages",
         api_key_env="FCC_AIDER_PROXY_AUTH_COLLISION",
+        launch_id="launch-a",
     )
     entries = {entry["name"]: entry for entry in config.settings}
     extra = entries["anthropic/provider/model"]["extra_params"]
@@ -147,4 +151,5 @@ def test_aider_config_rejects_invalid_api_key_environment_name(
             _models(),
             messages_url="http://127.0.0.1:9191/v1/messages",
             api_key_env=api_key_env,
+            launch_id="launch-a",
         )

--- a/tests/cli/test_aider_launcher.py
+++ b/tests/cli/test_aider_launcher.py
@@ -15,6 +15,7 @@ def test_aider_receives_native_files_and_a_private_credential_reference(
     monkeypatch.setenv("fcc_aider_proxy_auth_stale", "stale-secret")
     monkeypatch.setenv("USER_SETTING", "preserved")
     key_names: list[str] = []
+    launch_ids: list[str] = []
 
     def inspect(command, env):
         settings_path = Path(env["AIDER_MODEL_SETTINGS_FILE"])
@@ -30,10 +31,18 @@ def test_aider_receives_native_files_and_a_private_credential_reference(
         assert env[key_name] == "launcher-test-token"
         key_names.append(key_name)
         bare = next(entry for entry in settings if entry["name"] == env["AIDER_MODEL"])
+        launch_id = bare["extra_params"]["extra_headers"]["x-fcc-launch-id"]
+        assert launch_id
+        launch_ids.append(launch_id)
+        assert all(
+            entry["extra_params"]["extra_headers"] == {"x-fcc-launch-id": launch_id}
+            for entry in settings
+        )
         assert bare["extra_params"] == {
             "model": "anthropic/nvidia_nim/catalog-model:variant",
             "api_base": "http://127.0.0.1:8182/v1/messages",
             "api_key": f"os.environ/{key_name}",
+            "extra_headers": {"x-fcc-launch-id": launch_id},
         }
         assert env["AIDER_MODEL"] in metadata
         assert "launcher-test-token" not in settings_path.read_text()
@@ -55,3 +64,4 @@ def test_aider_receives_native_files_and_a_private_credential_reference(
     assert launch_capture.commands[0][-len(args) :] == args
     launch("aider", [])
     assert key_names[0] != key_names[1]
+    assert launch_ids[0] != launch_ids[1]

--- a/tests/cli/test_cline_launcher.py
+++ b/tests/cli/test_cline_launcher.py
@@ -45,6 +45,7 @@ def test_cline_config_uses_responses_and_only_known_metadata() -> None:
         ),
         proxy_root_url="http://127.0.0.1:9191/",
         auth_token="proxy-token",
+        launch_id="launch-a",
         now=datetime(2026, 8, 15, 12, 30, tzinfo=UTC),
     )
 
@@ -57,6 +58,7 @@ def test_cline_config_uses_responses_and_only_known_metadata() -> None:
                 "settings": {
                     "provider": "openai-native",
                     "apiKey": "proxy-token",
+                    "headers": {"x-fcc-launch-id": "launch-a"},
                     "model": "nvidia_nim/vendor/model",
                     "protocol": "openai-responses",
                     "baseUrl": "http://127.0.0.1:9191/v1",
@@ -127,11 +129,14 @@ def test_cline_config_rejects_empty_model_catalog() -> None:
             (),
             proxy_root_url="http://127.0.0.1:9191",
             auth_token="proxy-token",
+            launch_id="launch-a",
         )
 
 
 def test_cline_native_configuration_is_available_to_child(launch_capture) -> None:
     from tests.cli.test_launcher_workflow import launch
+
+    launch_ids = []
 
     def inspect(command, env):
         providers_path = Path(env["CLINE_PROVIDER_SETTINGS_PATH"])
@@ -140,6 +145,8 @@ def test_cline_native_configuration_is_available_to_child(launch_capture) -> Non
         settings = providers["providers"][CLINE_PROVIDER_ID]["settings"]
         assert settings["baseUrl"] == "http://127.0.0.1:8182/v1"
         assert settings["apiKey"] == "launcher-test-token"
+        launch_ids.append(settings["headers"]["x-fcc-launch-id"])
+        assert launch_ids[-1]
         assert settings["model"] in models["providers"][CLINE_PROVIDER_ID]["models"]
         assert env["CLINE_SESSION_BACKEND_MODE"] == "local"
         assert command[:3] == ["cline", "--provider", "openai-native"]
@@ -148,3 +155,5 @@ def test_cline_native_configuration_is_available_to_child(launch_capture) -> Non
     args = ["--model", "native-selection", "--data-dir", "native-data-dir"]
     launch("cline", args)
     assert launch_capture.commands[0][-len(args) :] == args
+    launch("cline", [])
+    assert launch_ids[0] != launch_ids[1]

--- a/tests/cli/test_hermes_config.py
+++ b/tests/cli/test_hermes_config.py
@@ -77,6 +77,7 @@ def test_hermes_config_pins_responses_catalog_and_fallbacks() -> None:
         "base_url": "",
         "api_key": "",
         "api_mode": "codex_responses",
+        "default_headers": {"x-fcc-launch-id": "a1b2c3"},
     }
     assert managed.config["fallback_providers"] == []
     assert managed.config["fallback_model"] == []

--- a/tests/cli/test_hermes_launcher.py
+++ b/tests/cli/test_hermes_launcher.py
@@ -15,6 +15,8 @@ from tests.cli.test_launcher_workflow import launch
 def test_hermes_uses_native_defaults_and_keeps_user_commands(
     launch_capture: LaunchCapture,
 ) -> None:
+    launch_ids = []
+
     def inspect(command, env):
         config = json.loads(
             (Path(env["HERMES_MANAGED_DIR"]) / "config.yaml").read_text()
@@ -26,6 +28,8 @@ def test_hermes_uses_native_defaults_and_keeps_user_commands(
         assert entry["transport"] == "codex_responses"
         assert entry["api"] == "http://127.0.0.1:8182/v1"
         assert env[entry["key_env"]] == "launcher-test-token"
+        launch_ids.append(config["model"]["default_headers"]["x-fcc-launch-id"])
+        assert launch_ids[-1]
         assert all(aux["provider"] == provider for aux in config["auxiliary"].values())
         assert "launcher-test-token" not in json.dumps(config)
 
@@ -47,6 +51,8 @@ def test_hermes_uses_native_defaults_and_keeps_user_commands(
         "model.provider",
         "--json",
     ]
+    launch("hermes", [])
+    assert launch_ids[0] != launch_ids[1]
 
 
 @pytest.mark.parametrize("output", ['"other-provider"', "{}", "", "not json"])

--- a/tests/cli/test_launcher_checks.py
+++ b/tests/cli/test_launcher_checks.py
@@ -37,9 +37,11 @@ from tests.cli.test_launcher_workflow import HARNESSES, launch
         ("muse", "Muse Code 0.2.1", True),
         ("muse", "Muse Code 1.0.3 (1.0.3-R2198.1)", True),
         ("muse", "Muse Code 0.2.0", False),
-        ("pi", "--extension --models", True),
-        ("pi", "--extension", False),
-        ("pi", "--models", False),
+        ("pi", "0.80.4", True),
+        ("pi", "0.85.0", True),
+        ("pi", "0.80.3", False),
+        ("pi", "0.80.4-beta", False),
+        ("pi", "--extension --models", False),
     ],
 )
 def test_native_compatibility_precedes_fcc_setup(

--- a/tests/cli/test_launcher_workflow.py
+++ b/tests/cli/test_launcher_workflow.py
@@ -129,6 +129,7 @@ def test_aider_native_settings_resolve_bare_and_transport_names_without_rewritin
         (ClientModel(wire_name, wire_name, "Model", False),),
         messages_url="http://localhost:8182/v1/messages",
         api_key_env="FCC_AIDER_PROXY_AUTH_TEST123",
+        launch_id="launch-a",
     )
     entries = {entry["name"]: entry for entry in config.settings}
     for name in (wire_name, f"anthropic/{wire_name}"):

--- a/tests/cli/test_pi_extension.py
+++ b/tests/cli/test_pi_extension.py
@@ -16,6 +16,65 @@ from free_claude_code.providers.github_copilot.types import CopilotEgress
 from tests.providers.test_github_copilot_provider import Harness, collect
 
 
+def test_pi_sends_current_conversation_id_only_on_fcc_requests() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+    script = """
+const { default: extension } = await import(process.argv[1]);
+const handlers = new Map();
+process.env.FCC_PI_BASE_URL = "http://fcc.invalid";
+process.env.FCC_PI_API_KEY = "test-key";
+globalThis.fetch = async () => new Response(JSON.stringify({
+    object: "list",
+    data: [{ id: "opencode_zen/test", provider_model_ref: "opencode_zen/test" }],
+}));
+await extension({
+    registerProvider() {},
+    on(event, handler) { handlers.set(event, handler); },
+});
+const results = [];
+for (const [provider, session] of [
+    ["free-claude-code", "conversation-a"],
+    ["free-claude-code", "conversation-a"],
+    ["free-claude-code", "conversation-b"],
+    ["free-claude-code", "conversation-a"],
+    ["another-provider", "another-session"],
+]) {
+    const headers = { "x-existing": "preserve" };
+    await handlers.get("before_provider_headers")?.({ headers }, {
+        model: { provider },
+        sessionManager: { getSessionId() { return session; } },
+    });
+    results.push(headers);
+}
+console.log(JSON.stringify(results));
+"""
+    result = subprocess.run(
+        [
+            node,
+            "--experimental-strip-types",
+            "--input-type=module",
+            "--eval",
+            script,
+            pi_extension_path().as_uri(),
+        ],
+        capture_output=True,
+        check=False,
+        encoding="utf-8",
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [
+        {"x-existing": "preserve", "x-opencode-session": "conversation-a"},
+        {"x-existing": "preserve", "x-opencode-session": "conversation-a"},
+        {"x-existing": "preserve", "x-opencode-session": "conversation-b"},
+        {"x-existing": "preserve", "x-opencode-session": "conversation-a"},
+        {"x-existing": "preserve"},
+    ]
+
+
 def _pi_request_payloads(cases: list[dict[str, object]]) -> list[dict[str, object]]:
     node = shutil.which("node")
     if node is None:

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "5.23.5"
+version = "5.23.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

OpenCode Zen and Go reject requests without a session ID. FCC forwarded the IDs from Codex, Claude Code, and OpenCode, but missed DSH, Grok, and Muse's header names. Pi, Cline, Hermes, and Aider sent no usable ID through their FCC configuration.

## How

- Translate DSH, Grok, and Muse's native session headers to `x-opencode-session`.
- Have Pi's FCC extension send the current conversation ID on each request. Require Pi 0.80.4 or newer for that hook.
- Give Cline, Hermes, and Aider one fallback ID per launcher run through their native settings. Hermes uses the setting shared by its main and auxiliary requests.
- Prefer native conversation IDs over the fallback. The fallback stays the same within a launcher run and changes when the wrapper starts again.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change adds per-launch fallback session identifiers for native clients, extends OpenCode session-header translation, and forwards Pi conversation identifiers through its provider hook.

### T-Rex validation blocked
Live native-client header delivery could not be exercised because Aider is not installed, and installing it requires a Fortran compiler that is unavailable in this environment.
</details>


<h3>Confidence Score: 4/5</h3>

The change is safe to merge with a non-blocking coverage gap: generated configuration is verified, but native-client request header delivery remains unverified.

One non-blocking concern remains: the tests do not observe a real native-client request carrying the configured launch header.

**Files Needing Attention:** tests/cli/test_aider_launcher.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I inspected the Aider configuration and related assertions for the extra\_headers contract, ran the focused Aider/Cline/Hermes launcher tests, and confirmed all 26 tests passed; I attempted a local HTTP-recorder validation but could not observe live requests because Aider was unavailable and the SciPy-fortran compiler was missing.
- I authored a focused harness that loads and invokes the Pi launcher compatibility check at both revisions and ran it against the parent revision to capture earlier compatibility behavior, then against the changed revision to verify version parsing and the minimum-version threshold.
- I created and ran the aider-live-header-validation.py harness, which recorded the blocker in the corresponding log and produced deterministic changed-path results and an installation diagnostic for review.
- The verdict concluded the claimed prefixed/build-metadata outputs are not compatible Pi --version output; the after-run results show the actual compiled version regex and acceptance results, while the before-run results show that pi --help did not perform version acceptance, making the behavior change traceable.

<a href="https://app.greptile.com/trex/runs/22979057/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-harness-opencode-sessions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-harness-opencode-sessions%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231708%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1708&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Ffix-harness-opencode-sessions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Ffix-harness-opencode-sessions%22.%0A%0A%23%23%23%20Issue%201%0Atests%2Fcli%2Ftest_aider_launcher.py%3A34-45%0A**Live%20Header%20Coverage%20Missing**%0A%0AThe%20tests%20confirm%20that%20Aider%2C%20Cline%2C%20and%20Hermes%20configuration%20includes%20%60x-fcc-launch-id%60%2C%20but%20they%20do%20not%20confirm%20that%20the%20native%20clients%20send%20that%20header%20on%20a%20request.%20A%20client%20could%20ignore%20or%20drop%20the%20setting%20while%20these%20tests%20still%20pass%2C%20leaving%20per-launch%20session%20routing%20ineffective.%20This%20is%20non-blocking%2C%20but%20it%20makes%20regressions%20in%20real%20client%20behavior%20costly%20to%20detect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1708&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix OpenCode session routing across FCC ..."](https://github.com/alishahryar1/free-claude-code/commit/3b161020026f368c220365f39abb21b5ce85f6b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61362030)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->