### PR TITLE
Handle SSLWantReadError during provider stream recovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.1.2"
+version = "6.1.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -314,7 +314,9 @@ def provider_error_message(
         return "Could not connect to provider."
     if isinstance(exc, httpx.RemoteProtocolError | httpx2.RemoteProtocolError):
         return "Provider connection was interrupted before a response was received."
-    if isinstance(exc, TimeoutError | ssl.SSLWantReadError):
+    if isinstance(exc, ssl.SSLWantReadError):
+        return "Could not read the provider response."
+    if isinstance(exc, TimeoutError):
         if read_timeout_s is not None:
             return f"Provider request timed out after {read_timeout_s:g}s."
         return "Request timed out."
@@ -424,15 +426,11 @@ def _classify_provider_failure(
         )
 
     kind = FailureKind.UPSTREAM
-    if isinstance(
-        exc,
-        TimeoutError
-        | ssl.SSLWantReadError
-        | httpx.TimeoutException
-        | httpx2.TimeoutException,
-    ):
+    if isinstance(exc, TimeoutError | httpx.TimeoutException | httpx2.TimeoutException):
         kind = FailureKind.TIMEOUT
-    elif isinstance(exc, httpx.NetworkError | httpx2.NetworkError):
+    elif isinstance(
+        exc, ssl.SSLWantReadError | httpx.NetworkError | httpx2.NetworkError
+    ):
         kind = FailureKind.UNAVAILABLE
     return _failure(
         kind,

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -1,6 +1,7 @@
 """Provider-owned SDK classification and retry qualification."""
 
 import json
+import ssl
 from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import replace
@@ -242,6 +243,7 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
         exc,
         (
             TimeoutError,
+            ssl.SSLWantReadError,
             httpx.TimeoutException,
             httpx2.TimeoutException,
             httpx.RemoteProtocolError,
@@ -269,6 +271,7 @@ def is_retryable_stream_error(exc: BaseException) -> bool:
         exc,
         (
             TimeoutError,
+            ssl.SSLWantReadError,
             httpx.ReadTimeout,
             httpx2.ReadTimeout,
             httpx.RemoteProtocolError,
@@ -311,7 +314,7 @@ def provider_error_message(
         return "Could not connect to provider."
     if isinstance(exc, httpx.RemoteProtocolError | httpx2.RemoteProtocolError):
         return "Provider connection was interrupted before a response was received."
-    if isinstance(exc, TimeoutError):
+    if isinstance(exc, TimeoutError | ssl.SSLWantReadError):
         if read_timeout_s is not None:
             return f"Provider request timed out after {read_timeout_s:g}s."
         return "Request timed out."
@@ -421,7 +424,13 @@ def _classify_provider_failure(
         )
 
     kind = FailureKind.UPSTREAM
-    if isinstance(exc, TimeoutError | httpx.TimeoutException | httpx2.TimeoutException):
+    if isinstance(
+        exc,
+        TimeoutError
+        | ssl.SSLWantReadError
+        | httpx.TimeoutException
+        | httpx2.TimeoutException,
+    ):
         kind = FailureKind.TIMEOUT
     elif isinstance(exc, httpx.NetworkError | httpx2.NetworkError):
         kind = FailureKind.UNAVAILABLE

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -1,5 +1,6 @@
 """Raw provider failure classification into the canonical neutral model."""
 
+import ssl
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 
@@ -118,6 +119,20 @@ def test_stream_retry_classification_only_accepts_post_open_timeouts() -> None:
     )
     assert not is_retryable_stream_error(httpx.WriteTimeout("write", request=request))
     assert not is_retryable_stream_error(httpx.PoolTimeout("pool", request=request))
+
+
+def test_ssl_want_read_error_uses_stream_failure_policy() -> None:
+    error = ssl.SSLWantReadError("the operation did not complete")
+
+    assert is_retryable_stream_error(error)
+    assert is_retryable_provider_error(error)
+    failure = classify_provider_failure(
+        error, provider_name="NIM", read_timeout_s=120, request_id="request"
+    )
+    assert failure.kind is FailureKind.TIMEOUT
+    assert failure.status_code == 502
+    assert failure.retryable
+    assert "timed out after 120s" in failure.message
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/test_failure_policy.py
+++ b/tests/providers/test_failure_policy.py
@@ -121,18 +121,22 @@ def test_stream_retry_classification_only_accepts_post_open_timeouts() -> None:
     assert not is_retryable_stream_error(httpx.PoolTimeout("pool", request=request))
 
 
-def test_ssl_want_read_error_uses_stream_failure_policy() -> None:
+@pytest.mark.parametrize("read_timeout_s", [None, 120])
+def test_ssl_want_read_error_uses_stream_failure_policy(
+    read_timeout_s: float | None,
+) -> None:
     error = ssl.SSLWantReadError("the operation did not complete")
 
     assert is_retryable_stream_error(error)
     assert is_retryable_provider_error(error)
     failure = classify_provider_failure(
-        error, provider_name="NIM", read_timeout_s=120, request_id="request"
+        error, provider_name="NIM", read_timeout_s=read_timeout_s, request_id="request"
     )
-    assert failure.kind is FailureKind.TIMEOUT
+    assert failure.kind is FailureKind.UNAVAILABLE
     assert failure.status_code == 502
     assert failure.retryable
-    assert "timed out after 120s" in failure.message
+    assert "Could not read the provider response." in failure.message
+    assert "timed out" not in failure.message
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/test_provider_admission.py
+++ b/tests/providers/test_provider_admission.py
@@ -1,6 +1,7 @@
 """Provider-owned admission and coordinated recovery contracts."""
 
 import asyncio
+import ssl
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
@@ -286,17 +287,21 @@ async def test_attempt_cancellation_releases_concurrency() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_call_uses_one_five_attempt_budget() -> None:
+@pytest.mark.parametrize(
+    "error",
+    [_status_error(503), ssl.SSLWantReadError("read would block")],
+    ids=["http_503", "tls_want_read"],
+)
+async def test_run_call_uses_one_five_attempt_budget(error: Exception) -> None:
     controller = _controller()
     attempts = 0
-    error = _status_error(503)
 
     async def fail() -> None:
         nonlocal attempts
         attempts += 1
         raise error
 
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+    with pytest.raises(type(error)) as exc_info:
         await controller.start_execution().run_call(
             fail,
             operation_kind=ProviderOperationKind.GENERATION,
@@ -307,7 +312,12 @@ async def test_run_call_uses_one_five_attempt_budget() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_call_succeeds_without_multiplying_attempts() -> None:
+@pytest.mark.parametrize(
+    "error",
+    [_status_error(429), ssl.SSLWantReadError("read would block")],
+    ids=["http_429", "tls_want_read"],
+)
+async def test_run_call_succeeds_without_multiplying_attempts(error: Exception) -> None:
     controller = _controller(max_concurrency=1)
     attempts = 0
 
@@ -315,7 +325,7 @@ async def test_run_call_succeeds_without_multiplying_attempts() -> None:
         nonlocal attempts
         attempts += 1
         if attempts < 3:
-            raise _status_error(429)
+            raise error
         return "recovered"
 
     assert (

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.1.2"
+version = "6.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

An SSLWantReadError that reaches FCC currently ends the provider request immediately. Allow this transient TLS read condition to use the existing retry handling.

Related report: #1651.

## How

Treat SSLWantReadError as retryable for provider requests and opened streams, using the existing attempt limits and stream recovery rules.

If retries are exhausted, report a temporary provider connection failure with "Could not read the provider response." This error does not establish that a timeout expired.

Bump the version to 6.1.3.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes transient TLS `SSLWantReadError` failures eligible for the existing bounded provider and opened-stream recovery mechanisms, reports exhausted retries as an unavailable provider response rather than a timeout, extends coverage for those paths, and updates the package version to 6.1.3.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

There are no outstanding findings requiring changes.

<sub>Reviews (2): Last reviewed commit: ["Keep TLS read retries without reporting ..."](https://github.com/alishahryar1/free-claude-code/commit/e5c48d2d57a26af88100ed3224a3c93f33a4dea1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61391968)</sub>

**Context used:**

- Knowledge Base — [Provider integration layer](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/provider-integrations.md)

<!-- /greptile_comment -->