### PR TITLE
Fix blurry Windows folder picker and tray menu

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -170,6 +170,7 @@ def test_browse_fills_only_its_tab_and_waits_for_create(
         expect(
             form.get_by_role("button", name="Create session", exact=True)
         ).to_be_disabled()
+        expect(form.get_by_role("status")).to_be_hidden()
         other.get_by_role("button", name="Browse…", exact=True).click()
         expect(
             other.get_by_text("A folder picker is already open", exact=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.1.0"
+version = "6.1.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -625,7 +625,7 @@
           if (!context.isOpen() || context.isBusy()) return;
           const initial = readFolder();
           context.setBusy(true);
-          context.message("Choose a folder in the open folder picker.");
+          context.message("");
           try {
             const result = await api(`${base}/folder-picker`, {
               method: "POST",

--- a/src/free_claude_code/cli/desktop_entrypoint.py
+++ b/src/free_claude_code/cli/desktop_entrypoint.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from free_claude_code.cli.desktop_assets import export_app_icon
+from free_claude_code.core.windows_dpi import enable_dpi_awareness
 
 
 def launch(argv: Sequence[str] | None = None) -> None:
@@ -20,6 +21,8 @@ def launch(argv: Sequence[str] | None = None) -> None:
     if sys.platform not in {"darwin", "win32"}:
         print("FCC Desktop is supported on Windows and macOS.", file=sys.stderr)
         raise SystemExit(1)
+
+    enable_dpi_awareness()
 
     from free_claude_code.cli.desktop_tray import launch as launch_tray
 

--- a/src/free_claude_code/core/windows_dpi.py
+++ b/src/free_claude_code/core/windows_dpi.py
@@ -1,0 +1,27 @@
+"""Windows scaling setup shared by native UI entrypoints."""
+
+import ctypes
+import sys
+
+_PER_MONITOR_AWARE_V2 = -4
+_ERROR_ACCESS_DENIED = 5
+
+
+def enable_dpi_awareness() -> None:
+    """Use native monitor scaling before creating windows in this process."""
+    if sys.platform != "win32":
+        return
+
+    set_awareness = ctypes.WinDLL(
+        "user32", use_last_error=True
+    ).SetProcessDpiAwarenessContext
+    set_awareness.argtypes = (ctypes.c_void_p,)
+    set_awareness.restype = ctypes.c_int
+    if set_awareness(ctypes.c_void_p(_PER_MONITOR_AWARE_V2)):
+        return
+
+    error = ctypes.get_last_error()
+    # Windows rejects subsequent changes, including a mode set by the host's
+    # manifest. Respect that choice and allow repeated initialization.
+    if error != _ERROR_ACCESS_DENIED:
+        raise ctypes.WinError(error)

--- a/src/free_claude_code/runtime/native_folder_dialog.py
+++ b/src/free_claude_code/runtime/native_folder_dialog.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from free_claude_code.core.windows_dpi import enable_dpi_awareness
+
 _TITLE = "Choose a Code Session folder"
 _MAC_SCRIPT = """
 on run argv
@@ -43,6 +45,8 @@ def _initial_directory(value: str) -> str | None:
 
 
 def _windows(initial: str | None) -> str | None:
+    enable_dpi_awareness()
+
     import tkinter
     from tkinter import filedialog
 

--- a/tests/cli/test_desktop_assets.py
+++ b/tests/cli/test_desktop_assets.py
@@ -1,7 +1,9 @@
 """Packaged desktop icon and export contracts."""
 
+import builtins
 import struct
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -55,3 +57,24 @@ def test_desktop_entrypoint_rejects_unknown_arguments(
 
     assert exc_info.value.code == 2
     assert "Usage: fcc-desktop" in capsys.readouterr().err
+
+
+def test_desktop_sets_scaling_before_importing_native_tray(monkeypatch):
+    calls = []
+    monkeypatch.setattr(desktop_entrypoint.sys, "platform", "win32")
+    monkeypatch.setattr(
+        desktop_entrypoint,
+        "enable_dpi_awareness",
+        lambda: calls.append("scaling"),
+    )
+    original_import = builtins.__import__
+
+    def import_module(name, *args, **kwargs):
+        if name == "free_claude_code.cli.desktop_tray":
+            assert calls == ["scaling"]
+            return SimpleNamespace(launch=lambda: calls.append("tray"))
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_module)
+    desktop_entrypoint.launch([])
+    assert calls == ["scaling", "tray"]

--- a/tests/core/test_windows_dpi.py
+++ b/tests/core/test_windows_dpi.py
@@ -1,0 +1,64 @@
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin"])
+def test_other_platforms_do_not_load_windows_ui(monkeypatch, platform):
+    from free_claude_code.core import windows_dpi
+
+    def load_windows(*_args, **_kwargs):
+        pytest.fail("Windows UI library loaded on another platform")
+
+    monkeypatch.setattr(windows_dpi.sys, "platform", platform)
+    monkeypatch.setattr(windows_dpi.ctypes, "WinDLL", load_windows, raising=False)
+    windows_dpi.enable_dpi_awareness()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows DPI APIs")
+@pytest.mark.parametrize("preset", ["none", "system", "per-monitor"])
+def test_native_windows_use_scaling_and_respect_existing_awareness(preset):
+    # DPI awareness is process-wide and can only be set once. Each case needs
+    # its own process so other tests and the test runner keep their own mode.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import ctypes
+import sys
+from ctypes import wintypes
+
+user32 = ctypes.WinDLL('user32', use_last_error=True)
+user32.SetProcessDpiAwarenessContext.argtypes = [ctypes.c_void_p]
+user32.SetProcessDpiAwarenessContext.restype = wintypes.BOOL
+user32.GetWindowDpiAwarenessContext.argtypes = [wintypes.HWND]
+user32.GetWindowDpiAwarenessContext.restype = ctypes.c_void_p
+user32.AreDpiAwarenessContextsEqual.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+user32.AreDpiAwarenessContextsEqual.restype = wintypes.BOOL
+expected = -2 if sys.argv[1] == 'system' else -4
+if sys.argv[1] != 'none':
+    assert user32.SetProcessDpiAwarenessContext(ctypes.c_void_p(expected))
+
+from free_claude_code.core.windows_dpi import enable_dpi_awareness
+enable_dpi_awareness()
+enable_dpi_awareness()
+
+import tkinter
+root = tkinter.Tk()
+root.withdraw()
+try:
+    context = user32.GetWindowDpiAwarenessContext(root.winfo_id())
+    assert user32.AreDpiAwarenessContextsEqual(context, ctypes.c_void_p(expected))
+finally:
+    root.destroy()
+""",
+            preset,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/runtime/test_native_folder_dialog.py
+++ b/tests/runtime/test_native_folder_dialog.py
@@ -89,18 +89,24 @@ def test_macos_passes_the_hint_as_data_and_preserves_path_characters(monkeypatch
 @pytest.mark.parametrize("selection", ["", "C:/Projects/café"])
 def test_windows_destroys_hidden_parent_after_selection(monkeypatch, selection):
     calls = []
+    monkeypatch.setattr(native, "enable_dpi_awareness", lambda: calls.append("scaling"))
     root = SimpleNamespace(
         withdraw=lambda: calls.append("hidden"),
         attributes=lambda *_args: None,
         destroy=lambda: calls.append("destroyed"),
     )
+
+    def create_parent():
+        calls.append("created")
+        return root
+
     module = SimpleNamespace(
-        Tk=lambda: root,
+        Tk=create_parent,
         filedialog=SimpleNamespace(askdirectory=lambda **_kwargs: selection),
     )
     monkeypatch.setitem(native.sys.modules, "tkinter", module)
     assert native._windows(None) == (selection or None)
-    assert calls == ["hidden", "destroyed"]
+    assert calls == ["scaling", "created", "hidden", "destroyed"]
 
 
 def test_folder_hint_is_optional_and_checked_in_helper(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.1.0"
+version = "6.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

The Windows folder picker and tray menu look blurry on scaled displays because FCC creates their windows without enabling DPI awareness. Windows then stretches the rendered UI to fit the display.

Code Sessions also shows an unwanted instruction while the folder picker is open.

## How

Enable per-monitor DPI awareness before creating native UI in both the folder-picker process and the desktop launcher, using one shared Windows helper. Respect any awareness mode already selected by the process.

Remove the Browse instruction and release the fixes as version 6.1.1.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary

This update enables Windows DPI awareness before native desktop UI starts and simplifies the Code Sessions folder-picker message.

## Merge safety

Do not merge yet. On Windows systems without `SetProcessDpiAwarenessContext`, the new initialization prevents both the folder picker and desktop tray from opening.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge until native UI startup remains available when the newer Windows DPI API is absent.

A reproduced native desktop startup failure affects Windows systems that do not export the newly assumed DPI function.

**Files Needing Attention:** src/free_claude_code/core/windows_dpi.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked it to the corresponding review comment.
- Artifacts were prepared to support the P1 finding, including a missing DPI export reproduction script and a missing DPI export output, enabling review of the reproducibility setup.
- A general-contract-validation-proof run was executed to reproduce the DPI export workflow; the command was PYTHONPATH=src /opt/greptile/trusted-bin/python trex-artifacts/windows-dpi-missing-export-repro.py and it exited with code 0 while the output showed AttributeError: 'User32WithoutDpiExport' object has no attribute 'SetProcessDpiAwarenessContext', indicating the missing DPI export support occurs before tkinter or desktop tray import.

<a href="https://app.greptile.com/trex/runs/22999703/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fnative-ui-dpi%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fnative-ui-dpi%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231714%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1714&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fnative-ui-dpi%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fnative-ui-dpi%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fcore%2Fwindows_dpi.py%3A15-17%0A**Support%20older%20Windows%20APIs**%0A%0AIf%20FCC%20runs%20on%20a%20Windows%20release%20whose%20%60user32%60%20does%20not%20export%20%60SetProcessDpiAwarenessContext%60%2C%20this%20code%20raises%20%60AttributeError%60%20before%20the%20folder%20picker%20imports%20tkinter%20or%20the%20desktop%20launcher%20imports%20the%20tray.%20The%20new%20DPI%20setup%20therefore%20prevents%20both%20native%20UI%20entry%20points%20from%20starting%20on%20those%20Windows%20versions.%20Check%20that%20the%20export%20exists%20and%20use%20a%20compatible%20DPI-awareness%20API%2C%20or%20continue%20without%20the%20per-monitor-v2%20setting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1714&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix native Windows scaling and remove fo..."](https://github.com/alishahryar1/free-claude-code/commit/e4acdb3fc3973ff89464a60cc496ffc8faf8186a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61404766)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [CLI and desktop runtime](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/cli-and-desktop-runtime.md)
- Knowledge Base — [Code session management](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/code-sessions.md)

<!-- /greptile_comment -->