### PR TITLE
Use six effort options in Code Sessions

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -782,7 +782,30 @@ def send_from_other_client(page, url, text):
     return response.json()["id"]
 
 
-def test_model_default_clears_effort_when_all_choices_disappear(
+@pytest.mark.parametrize("choice", ["off", "low", "medium", "high", "xhigh", "max"])
+def test_effort_options_persist_and_reach_the_harness(
+    page, admin_base_url, tmp_path, code_control, choice
+):
+    create_session(page, admin_base_url, tmp_path)
+    effort = page.get_by_role("combobox", name="Effort", exact=True)
+    expect(effort.locator("option")).to_have_text(
+        ["off", "low", "medium", "high", "xhigh", "max"]
+    )
+    expect(effort).to_have_value("medium")
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "PATCH" and "/api/code/sessions/" in response.url
+        )
+    ) as changed:
+        effort.select_option(choice)
+    assert changed.value.json()["reasoning_effort"] == choice
+    page.reload()
+    expect(effort).to_have_value(choice)
+    send(page, "Use this effort")
+    assert code_control.connection().efforts == [choice]
+
+
+def test_off_clears_effort_when_reasoning_becomes_unavailable(
     page, context, admin_base_url, tmp_path, code_control
 ):
     url = create_session(page, admin_base_url, tmp_path)
@@ -790,12 +813,15 @@ def test_model_default_clears_effort_when_all_choices_disappear(
     effort.select_option("high")
     expect(effort).to_be_enabled()
     page.locator("#codeComposer").fill("Preserve this draft")
-    code_control.harness.efforts = ()
-    code_control.harness.default_effort = None
+    code_control.harness.efforts = ("off",)
+    code_control.harness.default_effort = "off"
     page.evaluate("window.CodeSessions.refresh()")
     expect(page.locator("#codeComposerStatus")).to_contain_text("unavailable")
     expect(effort).to_have_value("high")
-    expect(effort.locator("option:checked")).to_have_text("high (unavailable)")
+    expect(effort.locator("option:checked")).to_have_text("high")
+    expect(effort.locator("option:disabled")).to_have_text(
+        ["low", "medium", "high", "xhigh", "max"]
+    )
     expect(page.locator("#codeSend")).to_be_disabled()
     expect(effort).to_be_enabled()
     patches = []
@@ -812,24 +838,22 @@ def test_model_default_clears_effort_when_all_choices_disappear(
             response.request.method == "PATCH" and "/api/code/sessions/" in response.url
         )
     ) as reset:
-        effort.select_option("")
-    assert reset.value.json()["reasoning_effort"] is None
-    assert len(patches) == 1 and patches[0]["reasoning_effort"] is None
-    expect(effort).to_be_disabled()
+        effort.select_option("off")
+    assert reset.value.json()["reasoning_effort"] == "off"
+    assert len(patches) == 1 and patches[0]["reasoning_effort"] == "off"
     expect(page.locator("#codeComposerStatus")).not_to_contain_text("unavailable")
     expect(page.locator("#codeSend")).to_be_enabled()
     page.reload()
-    expect(effort).to_have_value("")
-    expect(effort).to_be_disabled()
+    expect(effort).to_have_value("off")
     expect(page.locator("#codeComposer")).to_have_value("Preserve this draft")
     second = context.new_page()
     try:
         second.goto(url)
-        expect(second.locator("#codeReasoning")).to_have_value("")
+        expect(second.locator("#codeReasoning")).to_have_value("off")
         expect(second.locator("#codeModel")).to_have_value("provider/model")
         page.locator("#codeSend").click()
         connection = code_control.connection()
-        assert connection.efforts == [None]
+        assert connection.efforts == ["off"]
         assert connection.inputs[0][1:] == ("Preserve this draft", "provider/model")
     finally:
         second.close()
@@ -1087,8 +1111,8 @@ def test_model_effort_picker_syncs_tabs_and_keeps_missing_selection(
         expect(page.locator("#codeModel")).to_be_disabled()
         expect(second.locator("#codeReasoning")).to_be_disabled()
         code_control.run(connection.finish("turn-1"))
-        page.locator("#codeReasoning").select_option("")
-        expect(second.locator("#codeReasoning")).to_have_value("")
+        page.locator("#codeReasoning").select_option("medium")
+        expect(second.locator("#codeReasoning")).to_have_value("medium")
         page.get_by_role("textbox", name="Message", exact=True).fill("Preserve me")
         code_control.harness.configurations.pop("provider/other")
         if refresh_first:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.1.1"
+version = "6.1.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -716,7 +716,7 @@
       record.session.reasoning_effort &&
       !model.reasoning_efforts.includes(record.session.reasoning_effort)
     )
-      return "Selected thinking effort is unavailable. Choose another effort or Model default.";
+      return "Selected effort is unavailable. Choose another effort.";
     return "";
   }
 
@@ -783,7 +783,7 @@
         [],
         "",
         (value) => {
-          void updateSettings({ reasoning_effort: value || null });
+          void updateSettings({ reasoning_effort: value });
         },
       );
       controls.append(modelControl.group, reasoningControl.group);
@@ -1035,21 +1035,15 @@
       !catalogLoaded;
     modelControl.update(record?.session?.model || "", disabled);
     const model = catalog.find((model) => model.id === record?.session?.model),
-      effort = record?.session?.reasoning_effort;
-    const options = [
-      [
-        "",
-        model?.default_reasoning_effort
-          ? `Model default (${model.default_reasoning_effort})`
-          : "Model default",
-      ],
-      ...(model?.reasoning_efforts || []).map((value) => [value, value]),
-    ];
-    if (effort && !model?.reasoning_efforts.includes(effort))
-      options.push([effort, `${effort} (unavailable)`]);
-    reasoningControl.update(options, effort || "");
-    reasoningControl.select.disabled =
-      disabled || !model || (!model.reasoning_efforts.length && !effort);
+      effort =
+        record?.session?.reasoning_effort || model?.default_reasoning_effort || "off";
+    const options = ["off", "low", "medium", "high", "xhigh", "max"].map(
+      (value) => [value, value],
+    );
+    reasoningControl.update(options, effort);
+    for (const option of reasoningControl.select.options)
+      option.disabled = !model?.reasoning_efforts.includes(option.value);
+    reasoningControl.select.disabled = disabled || !model;
     root.querySelector("#codeComposerStatus").textContent =
       record?.session?.error ||
       selectionError(record) ||

--- a/src/free_claude_code/api/admin_static/session_ui.js
+++ b/src/free_claude_code/api/admin_static/session_ui.js
@@ -133,7 +133,7 @@
     };
     update(options, value);
     select.addEventListener("change", () => onChange(select.value));
-    group.append(node("span", "", "Thinking"), select);
+    group.append(node("span", "", "Effort"), select);
     return { group, select, update };
   }
   function composer(id, draft, placeholder, onInput, onSend, onStop) {

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -368,7 +368,7 @@ class CodeService:
                     effort = None
                 if effort is not None and effort not in entry.reasoning_efforts:
                     raise CodeValidationError(
-                        "This reasoning effort is unavailable. Choose another effort or Model default."
+                        "This effort is unavailable. Choose another effort."
                     )
                 updates.update(model=model, reasoning_effort=effort)
             session = await self._store.update_settings(

--- a/src/free_claude_code/cli/launchers/codex_model_catalog.py
+++ b/src/free_claude_code/cli/launchers/codex_model_catalog.py
@@ -11,6 +11,7 @@ from free_claude_code.core.model_capabilities import ModelInputModality
 from .model_catalog import ClientModel
 
 SUPPORTED_REASONING_LEVELS: list[JsonObject] = [
+    {"effort": "none", "description": "Turn reasoning off"},
     {"effort": "low", "description": "Fast responses with lighter reasoning"},
     {
         "effort": "medium",
@@ -21,6 +22,7 @@ SUPPORTED_REASONING_LEVELS: list[JsonObject] = [
         "effort": "xhigh",
         "description": "Extra high reasoning depth for complex problems",
     },
+    {"effort": "max", "description": "Maximum reasoning effort"},
 ]
 
 CODEX_BASE_INSTRUCTIONS = (

--- a/src/free_claude_code/runtime/codex_app_server.py
+++ b/src/free_claude_code/runtime/codex_app_server.py
@@ -168,8 +168,9 @@ class CodexAppServer:
             "model": model,
         }
         if self._reasoning.get(selection.model, True):
-            params["summary"] = "auto"
-            params["effort"] = selection.reasoning_effort
+            off = selection.reasoning_effort == "off"
+            params["summary"] = "none" if off else "auto"
+            params["effort"] = "none" if off else selection.reasoning_effort
         result = await self.rpc("turn/start", params)
         turn_id = string_value(object_value(result.get("turn")).get("id"))
         if not turn_id:
@@ -594,7 +595,7 @@ class CodexHarnessFactory:
             and reasoning_effort not in option.reasoning_efforts
         ):
             raise CodeValidationError(
-                "This reasoning effort is unavailable. Choose another effort or Model default."
+                "This effort is unavailable. Choose another effort."
             )
         effort = reasoning_effort or option.default_reasoning_effort
         fingerprints = {
@@ -631,15 +632,19 @@ class CodexHarnessFactory:
 
 
 def _model_option(model: str, entry: JsonObject) -> CodeModel:
+    efforts = tuple(
+        string_value(object_value(level).get("effort"))
+        for level in array_value(entry.get("supported_reasoning_levels"))
+    )
     return CodeModel(
         id=model,
         display_name=string_value(entry.get("display_name")) or model,
         reasoning_efforts=tuple(
-            string_value(object_value(level).get("effort"))
-            for level in array_value(entry.get("supported_reasoning_levels"))
-        ),
+            "off" if effort == "none" else effort for effort in efforts
+        )
+        or ("off",),
         default_reasoning_effort=string_value(entry.get("default_reasoning_level"))
-        or None,
+        or "off",
     )
 
 

--- a/tests/code_sessions_support.py
+++ b/tests/code_sessions_support.py
@@ -27,7 +27,7 @@ class FakeHarness:
         self.connections: list[FakeConnection] = []
         self.model = "provider/model"
         self.configurations = {self.model: "capabilities-1"}
-        self.efforts = ("low", "medium", "high", "xhigh")
+        self.efforts = ("off", "low", "medium", "high", "xhigh", "max")
         self.default_effort = "medium"
         self.creation_gate = asyncio.Event()
         self.start_gate = asyncio.Event()

--- a/tests/runtime/test_codex_app_server.py
+++ b/tests/runtime/test_codex_app_server.py
@@ -181,12 +181,15 @@ async def test_turn_start_resets_sticky_effort_and_preserves_client_identity(
 
     monkeypatch.setattr(native, "rpc", rpc)
     harness = FakeHarness()
-    for effort in (None, "high", None):
+    for effort in (None, "high", "off", "max", None):
         await native.start_turn(
             "hello", harness.prepare("provider/model", effort), "operation"
         )
     assert [request.get("effort") for request in requests] == (
-        ["medium", "high", "medium"] if reasoning else [None, None, None]
+        ["medium", "high", "none", "max", "medium"] if reasoning else [None] * 5
+    )
+    assert [request.get("summary") for request in requests] == (
+        ["auto", "auto", "none", "auto", "auto"] if reasoning else [None] * 5
     )
     assert all(
         request["clientUserMessageId"] == "operation"

--- a/tests/runtime/test_codex_catalog.py
+++ b/tests/runtime/test_codex_catalog.py
@@ -111,12 +111,32 @@ def test_code_picker_and_native_selection_use_the_same_advertised_efforts():
     advertised = factory.catalog()
     assert advertised.default_model == "nvidia_nim/configured"
     model = advertised.models[1]
+    assert model.reasoning_efforts == ("off", "low", "medium", "high", "xhigh", "max")
     selected = factory.prepare(model.id, None)
     assert selected.model == model.id
     assert selected.context.settings.model == model.id
     assert selected.reasoning_effort == model.default_reasoning_effort == "medium"
-    assert factory.prepare(model.id, "high").reasoning_effort == "high"
+    for effort in model.reasoning_efforts:
+        assert factory.prepare(model.id, effort).reasoning_effort == effort
     with pytest.raises(CodeValidationError, match="effort"):
         factory.prepare(model.id, "unsupported")
     with pytest.raises(CodeValidationError, match="model"):
         factory.prepare("missing/model", None)
+
+
+def test_non_reasoning_model_off_selection_is_available():
+    runtime = FakeRequestRuntime(
+        settings=Settings().model_copy(update={"model": "nvidia_nim/configured"}),
+        cached_infos=(
+            ProviderModelInfo("open_router/text-only", supports_thinking=False),
+        ),
+    )
+    factory = CodexHarnessFactory(runtime, binary="codex")
+    model = next(
+        entry
+        for entry in factory.catalog().models
+        if entry.id == "open_router/text-only"
+    )
+    assert model.reasoning_efforts == ("off",)
+    assert model.default_reasoning_effort == "off"
+    assert factory.prepare(model.id, "off").reasoning_effort == "off"

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.1.1"
+version = "6.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

The Code Sessions selector is labelled Thinking, includes a Model default option, and is missing off and max.

## How

Rename the selector to Effort and show only off, low, medium, high, xhigh, and max. Keep medium as the initial selection for models with reasoning. Disable unsupported choices while keeping off available for models without reasoning.

Add none and max to the shared Codex catalog. Send off to Codex as none with reasoning summaries disabled, and pass max through unchanged.

Bump the version to 6.1.2.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary

The Codex model catalog now presents reasoning-effort choices that some selected upstream models do not advertise. A model that supports only `high` can be offered `off` and `max`, and those choices are forwarded as unsupported `none` or `max` turn parameters.

## Merge safety

Do not merge until the catalog carries and presents each model's actual supported reasoning efforts. Otherwise, users can select a visible option that causes their turn to be rejected.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge because an advertised reasoning option can be invalid for the selected model and cause a turn request to fail.

The failure was reproduced with an upstream model that advertises only `high`: the updated catalog exposed `off` and `max`, and the runtime forwarded them as `none` and `max` turn efforts.

**Files Needing Attention:** src/free_claude_code/cli/launchers/codex_model_catalog.py needs to preserve per-model reasoning effort capabilities; the upstream capability metadata flow also needs to retain those values.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-comment-proof for a posted P1 finding.
- T-Rex produced a second finding-comment-proof for another posted P1 finding.
- Validated the contract by showing that off and max become selectable and that runtime emits turn/start with upstream efforts none and max, and explained how the catalog projects the universal list for a reproduction with a model advertising only high.

<a href="https://app.greptile.com/trex/runs/23001341/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (2)</h3>

1. `src/free_claude_code/cli/launchers/codex_model_catalog.py`, line 83 ([link](https://github.com/alishahryar1/free-claude-code/blob/5c4b4b3474003511cf037822fecaeef024bd343a/src/free_claude_code/cli/launchers/codex_model_catalog.py#L83)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Preserve model effort capabilities**

   This assigns the same `none` through `max` list to every reasoning-capable model, even though upstream model metadata can advertise a narrower set of efforts. For a model that advertises only `high`, Code Sessions now allows `off` and `max` and forwards `none` or `max` in the turn request. That sends an effort the selected model does not support, so affected turns can be rejected instead of running. Carry each model's advertised reasoning levels through the catalog rather than assigning the universal list.

   **Knowledge Base Used:**
   - [Codex app-server integration](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/codex-app-server-integration.md)
   - [CLI launchers and managed processes](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/cli-launchers-and-managed-processes.md)
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Evidence from the check](https://app.greptile.com/trex/artifacts/f2741b03-c2cc-4601-8199-d1e4567ec20b)**
   
   - The authored script loads the pre-change and post-change catalog builders, supplies upstream metadata advertising only high, and captures the actual Codex turn parameters; it demonstrates the contract comparison.
   
   **[Command output from the check](https://app.greptile.com/trex/artifacts/04200e44-5d5f-4f77-ac5c-bf5e63373e4b)**
   
   - The pre-change reproduction command completed with exit code 0 and shows off and max were not selectable; it establishes the baseline.
   
   **[Command output from the check](https://app.greptile.com/trex/artifacts/1fba4983-f2df-4e9b-83b3-756928898de8)**
   
   - The post-change reproduction command completed with exit code 0 and shows off and max are selectable and emitted to Codex despite upstream advertising only high; it confirms the defect.
   
   **[Command output from the check](https://app.greptile.com/trex/artifacts/0b9c3729-166d-4079-b692-32f85914092c)**
   
   - The focused catalog and runtime pytest command completed with exit code 0 and reports 14 passed and 1 skipped; existing tests permit the over-advertisement.
   
   <a href="https://app.greptile.com/trex/runs/23001341/artifacts?artifact=f2741b03-c2cc-4601-8199-d1e4567ec20b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcode-session-effort%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcode-session-effort%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Ffree_claude_code%2Fcli%2Flaunchers%2Fcodex_model_catalog.py%0ALine%3A%2083%0A%0AComment%3A%0A**Preserve%20model%20effort%20capabilities**%0A%0AThis%20assigns%20the%20same%20%60none%60%20through%20%60max%60%20list%20to%20every%20reasoning-capable%20model%2C%20even%20though%20upstream%20model%20metadata%20can%20advertise%20a%20narrower%20set%20of%20efforts.%20For%20a%20model%20that%20advertises%20only%20%60high%60%2C%20Code%20Sessions%20now%20allows%20%60off%60%20and%20%60max%60%20and%20forwards%20%60none%60%20or%20%60max%60%20in%20the%20turn%20request.%20That%20sends%20an%20effort%20the%20selected%20model%20does%20not%20support%2C%20so%20affected%20turns%20can%20be%20rejected%20instead%20of%20running.%20Carry%20each%20model's%20advertised%20reasoning%20levels%20through%20the%20catalog%20rather%20than%20assigning%20the%20universal%20list.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BCodex%20app-server%20integration%5D%28https%3A%2F%2Fapp.greptile.com%2Falishahryar1%2F-%2Fcustom-context%2Fknowledge-base%2Falishahryar1%2Ffree-claude-code%2F-%2Fdocs%2Fcodex-app-server-integration.md%29%0A-%20%5BCLI%20launchers%20and%20managed%20processes%5D%28https%3A%2F%2Fapp.greptile.com%2Falishahryar1%2F-%2Fcustom-context%2Fknowledge-base%2Falishahryar1%2Ffree-claude-code%2F-%2Fdocs%2Fcli-launchers-and-managed-processes.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Codex catalog advertises unsupported none and max reasoning efforts**

   - **Bug**
     - At `src/free_claude_code/cli/launchers/codex_model_catalog.py:13-26,83`, the PR adds `none` and `max` to a universal list and assigns it to every `ClientModel` where `supports_reasoning is not False`. A runtime reproduction with an upstream Codex model that advertises only `high` shows that the post-change Code Session offers `off` and `max`; selecting them reaches `CodexAppServer.start_turn` and emits `turn/start` parameters `effort=none` and `effort=max` respectively (`src/free_claude_code/runtime/codex_app_server.py:170-174`).
   - **Cause**
     - The model capability flow retains only the coarse boolean `supportsReasoning` in `ClientModel` (`src/free_claude_code/cli/launchers/model_catalog.py:107-116`). Although the upstream Codex parser reads `supported_reasoning_levels`, `ProviderModelInfo` does not retain individual efforts (`src/free_claude_code/providers/openai_codex/provider.py:234-248`; `src/free_claude_code/application/model_metadata.py:10-18`), so `build_codex_model_catalog` cannot make a model-specific projection.
   - **Fix**
     - Carry validated supported reasoning efforts from provider metadata through the `/v1/models` response into `ClientModel`, then build `supported_reasoning_levels` from that per-model data. Do not advertise an effort when upstream metadata is absent; retain only the existing explicit non-reasoning fallback for `supports_reasoning=False`. Add contract coverage using a model advertising only `high` to ensure `none`/`max` are neither selectable nor emitted.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcode-session-effort%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcode-session-effort%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231715%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1715&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcode-session-effort%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcode-session-effort%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fcli%2Flaunchers%2Fcodex_model_catalog.py%3A83%0A**Preserve%20model%20effort%20capabilities**%0A%0AThis%20assigns%20the%20same%20%60none%60%20through%20%60max%60%20list%20to%20every%20reasoning-capable%20model%2C%20even%20though%20upstream%20model%20metadata%20can%20advertise%20a%20narrower%20set%20of%20efforts.%20For%20a%20model%20that%20advertises%20only%20%60high%60%2C%20Code%20Sessions%20now%20allows%20%60off%60%20and%20%60max%60%20and%20forwards%20%60none%60%20or%20%60max%60%20in%20the%20turn%20request.%20That%20sends%20an%20effort%20the%20selected%20model%20does%20not%20support%2C%20so%20affected%20turns%20can%20be%20rejected%20instead%20of%20running.%20Carry%20each%20model's%20advertised%20reasoning%20levels%20through%20the%20catalog%20rather%20than%20assigning%20the%20universal%20list.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Use six effort options in Code Sessions"](https://github.com/alishahryar1/free-claude-code/commit/5c4b4b3474003511cf037822fecaeef024bd343a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61408054)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Administrative API and web tools](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/api-admin-and-web-tools.md)
- Knowledge Base — [Code session management](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/code-sessions.md)
- Knowledge Base — [Code session API and persistence](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/code-session-api-and-persistence.md)
- Knowledge Base — [Codex app-server integration](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/codex-app-server-integration.md)
- Knowledge Base — [CLI launchers and managed processes](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/cli-launchers-and-managed-processes.md)
</details>


<!-- /greptile_comment -->