### PR TITLE
Use Anthropic SDK for native Messages egress

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.1.4"
+version = "6.1.5"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
 dependencies = [
+    "anthropic>=1.4.0",
     "anyio>=4.12.1",
     "fastapi[standard]>=0.141.1",
     "uvicorn>=0.52.1",

--- a/src/free_claude_code/core/anthropic/native.py
+++ b/src/free_claude_code/core/anthropic/native.py
@@ -44,6 +44,22 @@ class NativeMessagesError(ValueError):
     """A request or event cannot preserve the native Messages contract."""
 
 
+def complete_native_tool_input(initial: JsonValue, fragments: list[str]) -> JsonObject:
+    """Decode complete tool input when constructing a reply, never inventing it."""
+    if fragments and initial:
+        raise NativeMessagesError("Tool input mixes eager content and JSON deltas.")
+    try:
+        value = json.loads("".join(fragments)) if fragments else initial
+        if not isinstance(value, dict):
+            raise NativeMessagesError("Native tool arguments must decode to an object.")
+        json.dumps(value, ensure_ascii=False, allow_nan=False).encode("utf-8")
+    except (ValueError, UnicodeError, RecursionError) as exc:
+        raise NativeMessagesError(
+            "Native tool arguments are incomplete or invalid JSON."
+        ) from exc
+    return cast(JsonObject, value)
+
+
 @dataclass(frozen=True, slots=True)
 class NativeMessagesOptions:
     """Provider-resolved wire controls; no model-name inference belongs here."""

--- a/src/free_claude_code/core/anthropic/native_stream.py
+++ b/src/free_claude_code/core/anthropic/native_stream.py
@@ -89,6 +89,13 @@ class NativeMessagesRelay:
         self.completed = False
 
     def feed(self, event_type: str, payload: Mapping[str, JsonValue]) -> str:
+        if self.completed:
+            raise NativeMessagesError("Native event arrived after message completion.")
+        if event_type == "message_start":
+            if self._started:
+                raise NativeMessagesError("Duplicate Messages start.")
+        elif event_type != "ping" and not self._started:
+            raise NativeMessagesError("Messages event arrived before message start.")
         completed = self._reasoning.feed(event_type, payload)
         if event_type in {"content_block_start", "content_block_stop"}:
             index = payload.get("index")
@@ -110,7 +117,7 @@ class NativeMessagesRelay:
             if isinstance(reason, str) and reason:
                 self._stop_reason = reason
         elif event_type == "message_stop":
-            if not self._started or self._open_blocks or self._stop_reason is None:
+            if self._open_blocks or self._stop_reason is None:
                 raise NativeMessagesError("Messages ended before content completed.")
             self.completed = True
         body = dict(payload)

--- a/src/free_claude_code/core/anthropic/native_stream.py
+++ b/src/free_claude_code/core/anthropic/native_stream.py
@@ -83,17 +83,42 @@ class NativeMessagesRelay:
         self._public_model = public_model
         self._replay_origin = replay_origin
         self._reasoning = NativeReasoningBlocks()
+        self._started = False
+        self._open_blocks: set[int] = set()
+        self._stop_reason: str | None = None
         self.completed = False
 
     def feed(self, event_type: str, payload: Mapping[str, JsonValue]) -> str:
         completed = self._reasoning.feed(event_type, payload)
-        if event_type == "message_stop":
+        if event_type in {"content_block_start", "content_block_stop"}:
+            index = payload.get("index")
+            if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+                raise NativeMessagesError("Messages content requires a block index.")
+            if event_type == "content_block_start":
+                if index in self._open_blocks:
+                    raise NativeMessagesError("Messages replaced incomplete content.")
+                self._open_blocks.add(index)
+            else:
+                if index not in self._open_blocks:
+                    raise NativeMessagesError(
+                        "Messages closed content that never started."
+                    )
+                self._open_blocks.remove(index)
+        elif event_type == "message_delta":
+            delta = payload.get("delta")
+            reason = delta.get("stop_reason") if isinstance(delta, Mapping) else None
+            if isinstance(reason, str) and reason:
+                self._stop_reason = reason
+        elif event_type == "message_stop":
+            if not self._started or self._open_blocks or self._stop_reason is None:
+                raise NativeMessagesError("Messages ended before content completed.")
             self.completed = True
         body = dict(payload)
         if event_type == "message_start":
             message = body.get("message")
             if not isinstance(message, dict):
                 raise NativeMessagesError("Messages start must contain a message.")
+            self._started = True
             body["message"] = {**message, "model": self._public_model}
             if (
                 self._replay_origin is not None

--- a/src/free_claude_code/core/anthropic/native_stream.py
+++ b/src/free_claude_code/core/anthropic/native_stream.py
@@ -1,9 +1,8 @@
-"""Native Messages event validation and identity-preserving relay."""
+"""Native Messages relay and original reasoning capture for history replay."""
 
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass, field, replace
-from typing import cast
+from dataclasses import replace
 
 from free_claude_code.core.history_replay import (
     ReplayOrigin,
@@ -14,223 +13,65 @@ from free_claude_code.core.json_types import JsonObject, JsonValue
 
 from .native import NativeMessagesError
 
-_STOP_REASONS = {
-    "end_turn",
-    "stop_sequence",
-    "tool_use",
-    "max_tokens",
-    "refusal",
-    "pause_turn",
-    "model_context_window_exceeded",
-}
 
-
-@dataclass(slots=True)
-class _Block:
-    body: JsonObject
-    parts: list[str] = field(default_factory=list)
-    fragments: dict[str, list[str]] = field(default_factory=dict)
-
-
-class NativeMessagesStreamState:
-    """Validate one upstream lifecycle without rewriting protocol identities."""
+class NativeReasoningBlocks:
+    """Collect only the original reasoning needed to write complete replay records."""
 
     def __init__(self) -> None:
-        self.started = False
-        self.completed = False
-        self.stop_reason: str | None = None
-        self._blocks: dict[int, _Block] = {}
-        self._seen: set[int] = set()
-        self._tool_ids: set[str] = set()
+        self._blocks: dict[int, JsonObject] = {}
+        self._fragments: dict[int, dict[str, list[str]]] = {}
 
-    def accept(
+    def feed(
         self, event_type: str, payload: Mapping[str, JsonValue]
     ) -> JsonObject | None:
-        if self.completed:
-            raise NativeMessagesError("Messages event arrived after message_stop.")
-        try:
-            json.dumps(dict(payload), ensure_ascii=False, allow_nan=False).encode(
-                "utf-8"
-            )
-        except (ValueError, UnicodeError, RecursionError) as exc:
-            raise NativeMessagesError(
-                "Native Messages event is not representable JSON."
-            ) from exc
-        if payload.get("type") != event_type:
-            raise NativeMessagesError("Messages event type disagrees with its payload.")
-        if event_type == "ping":
-            return None
-        if event_type == "message_start":
-            if self.started:
-                raise NativeMessagesError("Duplicate message_start.")
-            message = payload.get("message")
-            if (
-                not isinstance(message, Mapping)
-                or not isinstance(message.get("id"), str)
-                or not message["id"]
-                or message.get("role") != "assistant"
-                or message.get("content", []) != []
-            ):
-                raise NativeMessagesError("Invalid native message_start.")
-            self.started = True
-            return None
-        if not self.started:
-            raise NativeMessagesError("Messages event arrived before message_start.")
-        if event_type == "message_delta":
-            delta = payload.get("delta")
-            if not isinstance(delta, Mapping):
-                raise NativeMessagesError("Native message_delta requires an object.")
-            reason = delta.get("stop_reason")
-            if reason is not None:
-                if self._blocks:
-                    raise NativeMessagesError(
-                        "Stop reason arrived with open content blocks."
-                    )
-                if not isinstance(reason, str) or reason not in _STOP_REASONS:
-                    raise NativeMessagesError(
-                        "Unsupported native Messages stop reason."
-                    )
-                if self.stop_reason is not None:
-                    raise NativeMessagesError("Duplicate native Messages stop reason.")
-                self.stop_reason = reason
-            return None
-        if event_type == "message_stop":
-            if self._blocks or self.stop_reason is None:
-                raise NativeMessagesError(
-                    "message_stop arrived before content or stop reason completed."
-                )
-            self.completed = True
-            return None
-        if event_type not in {
-            "content_block_start",
-            "content_block_delta",
-            "content_block_stop",
-        }:
-            raise NativeMessagesError(
-                f"Unsupported native Messages event: {event_type!r}."
-            )
-        if self.stop_reason is not None:
-            raise NativeMessagesError("Content arrived after the message stop reason.")
+        if event_type == "message_stop" and self._blocks:
+            raise NativeMessagesError("Messages ended with incomplete reasoning.")
         index = payload.get("index")
         if not isinstance(index, int) or isinstance(index, bool) or index < 0:
-            raise NativeMessagesError(
-                "Messages block index must be a nonnegative integer."
-            )
+            return None
         if event_type == "content_block_start":
-            if index in self._seen:
-                raise NativeMessagesError("Duplicate Messages content block index.")
-            body = payload.get("content_block")
-            if not isinstance(body, Mapping) or not isinstance(body.get("type"), str):
-                raise NativeMessagesError("Invalid native content block.")
-            kind = body["type"]
-            if kind == "text" and not isinstance(body.get("text"), str):
-                raise NativeMessagesError("Native text block requires text.")
-            if kind == "thinking" and not isinstance(body.get("thinking"), str):
-                raise NativeMessagesError(
-                    "Native thinking block requires thinking text."
-                )
-            if (
-                kind == "thinking"
-                and "signature" in body
-                and not isinstance(body["signature"], str)
-            ):
-                raise NativeMessagesError("Native thinking signature must be a string.")
-            if kind == "redacted_thinking" and (
-                not isinstance(body.get("data"), str) or not body["data"]
-            ):
-                raise NativeMessagesError("Redacted native thinking requires its data.")
-            if kind == "tool_use":
-                tool_id = body.get("id")
-                if (
-                    not isinstance(tool_id, str)
-                    or not tool_id
-                    or tool_id in self._tool_ids
-                    or not isinstance(body.get("name"), str)
-                    or not body["name"]
-                    or not isinstance(body.get("input"), Mapping)
-                ):
-                    raise NativeMessagesError(
-                        "Invalid or duplicate native tool identity/input."
-                    )
-                self._tool_ids.add(tool_id)
-            self._blocks[index] = _Block(dict(body))
-            self._seen.add(index)
+            block = payload.get("content_block")
+            if index in self._blocks:
+                raise NativeMessagesError("Messages replaced incomplete reasoning.")
+            if isinstance(block, Mapping) and block.get("type") in {
+                "thinking",
+                "redacted_thinking",
+            }:
+                self._blocks[index] = dict(block)
+                self._fragments[index] = {}
             return None
         block = self._blocks.get(index)
         if block is None:
-            raise NativeMessagesError(
-                "Messages content event refers to a closed or unknown block."
-            )
+            return None
         if event_type == "content_block_delta":
             delta = payload.get("delta")
-            if not isinstance(delta, Mapping):
-                raise NativeMessagesError("Native content delta must be an object.")
-            kind = delta.get("type")
-            target = (
-                {
-                    "text_delta": ("text", "text"),
-                    "thinking_delta": ("thinking", "thinking"),
-                    "signature_delta": ("thinking", "signature"),
-                    "input_json_delta": ("tool_use", "partial_json"),
-                }.get(kind)
-                if isinstance(kind, str)
-                else None
-            )
-            if target is None:
-                if kind == "citations_delta" and block.body["type"] == "text":
-                    citation = delta.get("citation")
-                    citations = block.body.get("citations")
-                    if citations is None:
-                        citations = []
-                    if not isinstance(citation, Mapping) or not isinstance(
-                        citations, list
-                    ):
-                        raise NativeMessagesError("Invalid native citation delta.")
-                    block.body["citations"] = [*citations, dict(citation)]
-                    return None
-                raise NativeMessagesError("Unsupported native content delta.")
-            block_type, key = target
-            value = delta.get(key)
-            if block.body["type"] != block_type or not isinstance(value, str):
-                raise NativeMessagesError(
-                    "Native content delta does not match its block."
-                )
-            if key == "partial_json":
-                if block.body.get("input"):
-                    raise NativeMessagesError(
-                        "Tool input mixes eager content and JSON deltas."
-                    )
-                block.parts.append(value)
-            else:
-                existing = block.body.get(key, "")
-                if not isinstance(existing, str):
-                    raise NativeMessagesError("Native content field must be a string.")
-                block.fragments.setdefault(key, []).append(value)
+            if isinstance(delta, Mapping):
+                key = {
+                    "thinking_delta": "thinking",
+                    "signature_delta": "signature",
+                }.get(str(delta.get("type")))
+                if key is not None:
+                    value = delta.get(key)
+                    if block["type"] != "thinking" or not isinstance(value, str):
+                        raise NativeMessagesError("Invalid native reasoning fragment.")
+                    self._fragments[index].setdefault(key, []).append(value)
+        if event_type != "content_block_stop":
             return None
-        for key, parts in block.fragments.items():
-            initial = block.body.get(key, "")
+        for key, parts in self._fragments.pop(index).items():
+            initial = block.get(key, "")
             if not isinstance(initial, str):
-                raise AssertionError("Validated native content fields must be strings.")
-            block.body[key] = initial + "".join(parts)
-        if block.body["type"] == "thinking" and not block.body.get("signature"):
-            raise NativeMessagesError(
-                "Completed native thinking requires its signature."
-            )
-        if block.body["type"] == "tool_use" and block.parts:
-            try:
-                value = cast(JsonValue, json.loads("".join(block.parts)))
-                if not isinstance(value, Mapping):
-                    raise NativeMessagesError(
-                        "Native tool arguments must decode to an object."
-                    )
-                json.dumps(value, ensure_ascii=False, allow_nan=False).encode("utf-8")
-            except (ValueError, UnicodeError, RecursionError) as exc:
+                raise NativeMessagesError("Invalid native reasoning field.")
+            block[key] = initial + "".join(parts)
+        if block["type"] == "thinking":
+            if not isinstance(block.get("thinking"), str) or not (
+                isinstance(block.get("signature"), str) and block["signature"]
+            ):
                 raise NativeMessagesError(
-                    "Native tool arguments are incomplete or invalid JSON."
-                ) from exc
-            block.body["input"] = dict(value)
-        self._blocks.pop(index)
-        return block.body
+                    "Completed native thinking requires its signature."
+                )
+        elif not (isinstance(block.get("data"), str) and block["data"]):
+            raise NativeMessagesError("Redacted native thinking requires its data.")
+        return self._blocks.pop(index)
 
 
 class NativeMessagesRelay:
@@ -241,23 +82,18 @@ class NativeMessagesRelay:
     ) -> None:
         self._public_model = public_model
         self._replay_origin = replay_origin
-        self._state = NativeMessagesStreamState()
-
-    @property
-    def completed(self) -> bool:
-        return self._state.completed
-
-    @property
-    def stop_reason(self) -> str | None:
-        return self._state.stop_reason
+        self._reasoning = NativeReasoningBlocks()
+        self.completed = False
 
     def feed(self, event_type: str, payload: Mapping[str, JsonValue]) -> str:
-        completed = self._state.accept(event_type, payload)
+        completed = self._reasoning.feed(event_type, payload)
+        if event_type == "message_stop":
+            self.completed = True
         body = dict(payload)
         if event_type == "message_start":
             message = body.get("message")
             if not isinstance(message, dict):
-                raise AssertionError("Validated message_start must contain a message.")
+                raise NativeMessagesError("Messages start must contain a message.")
             body["message"] = {**message, "model": self._public_model}
             if (
                 self._replay_origin is not None
@@ -303,4 +139,4 @@ class NativeMessagesRelay:
 
 
 def _event(kind: str, payload: JsonObject) -> str:
-    return f"event: {kind}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
+    return f"event: {kind}\ndata: {json.dumps(payload, ensure_ascii=False, allow_nan=False)}\n\n"

--- a/src/free_claude_code/core/anthropic/sse_aggregation.py
+++ b/src/free_claude_code/core/anthropic/sse_aggregation.py
@@ -7,11 +7,11 @@ shape the real Anthropic API returns for a non-streaming ``messages.create()``
 call.
 """
 
-import json
 import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
+from .native import NativeMessagesError, complete_native_tool_input
 from .stream_contracts import SSEEvent
 from .streaming.decoder import AnthropicSSEDecoder
 
@@ -31,6 +31,7 @@ async def aggregate_anthropic_sse_to_message(
     message: dict[str, Any] = {}
     blocks: dict[int, dict[str, Any]] = {}
     parts: dict[int, list[str]] = {}
+    open_blocks: set[int] = set()
     error: dict[str, Any] | None = None
     complete = False
 
@@ -47,6 +48,9 @@ async def aggregate_anthropic_sse_to_message(
             if isinstance(idx, int) and isinstance(block, dict):
                 blocks[idx] = dict(block)
                 parts.setdefault(idx, [])
+                open_blocks.add(idx)
+        elif ptype == "content_block_stop":
+            open_blocks.discard(payload.get("index"))
         elif ptype == "content_block_delta":
             idx = payload.get("index")
             delta = payload.get("delta")
@@ -120,15 +124,21 @@ async def aggregate_anthropic_sse_to_message(
         elif btype == "thinking":
             block["thinking"] = str(block.get("thinking", "")) + accumulated
             block.setdefault("signature", "")
-        elif btype == "tool_use":
-            if accumulated.strip():
-                try:
-                    block["input"] = json.loads(accumulated)
-                except json.JSONDecodeError:
-                    block["input"] = block.get("input") or {}
-            elif not isinstance(block.get("input"), dict):
-                block["input"] = {}
+        elif btype in {"tool_use", "server_tool_use"}:
+            try:
+                block["input"] = complete_native_tool_input(
+                    block.get("input"), parts.get(idx, [])
+                )
+            except NativeMessagesError as exc:
+                error = error or {"type": "api_error", "message": str(exc)}
         content.append(block)
+
+    if open_blocks:
+        error = error or {
+            "type": "api_error",
+            "message": "Messages ended with incomplete content blocks.",
+        }
+    complete = complete and error is None
 
     message["content"] = content
     message.setdefault("id", f"msg_{uuid.uuid4()}")

--- a/src/free_claude_code/core/openai_responses/messages_stream.py
+++ b/src/free_claude_code/core/openai_responses/messages_stream.py
@@ -177,9 +177,11 @@ class AnthropicToResponsesStream:
             raise NativeMessagesError(
                 "Native event arrived after the Responses terminal event."
             )
-        completed = self._reasoning.feed(event_type, payload)
         if event_type == "ping":
             return []
+        if event_type != "message_start" and not self._started:
+            raise NativeMessagesError("Messages event arrived before message start.")
+        completed = self._reasoning.feed(event_type, payload)
         if event_type == "message_start":
             if self._started:
                 raise NativeMessagesError(
@@ -207,7 +209,7 @@ class AnthropicToResponsesStream:
             )
             return []
         if event_type == "message_stop":
-            if not self._started or self._ledger.has_active_blocks:
+            if self._ledger.has_active_blocks:
                 raise NativeMessagesError(
                     "Messages ended before converted content completed."
                 )
@@ -227,12 +229,7 @@ class AnthropicToResponsesStream:
                 return [self._events.response_incomplete(self._payload("incomplete"))]
             return [self._events.response_completed(self._payload("completed"))]
         index = payload.get("index")
-        if (
-            not self._started
-            or not isinstance(index, int)
-            or isinstance(index, bool)
-            or index < 0
-        ):
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
             raise NativeMessagesError(
                 "Messages content requires a started message and block index."
             )

--- a/src/free_claude_code/core/openai_responses/messages_stream.py
+++ b/src/free_claude_code/core/openai_responses/messages_stream.py
@@ -7,8 +7,11 @@ from collections.abc import Mapping
 from dataclasses import replace
 from typing import cast
 
-from free_claude_code.core.anthropic.native import NativeMessagesError
-from free_claude_code.core.anthropic.native_stream import NativeMessagesStreamState
+from free_claude_code.core.anthropic.native import (
+    NativeMessagesError,
+    complete_native_tool_input,
+)
+from free_claude_code.core.anthropic.native_stream import NativeReasoningBlocks
 from free_claude_code.core.failures import ExecutionFailure
 from free_claude_code.core.history_replay import (
     ReplayOrigin,
@@ -115,7 +118,10 @@ class AnthropicToResponsesStream:
         self._replay_origin = replay_origin
         self._response_id = new_response_id()
         self._created_at = int(time.time())
-        self._native = NativeMessagesStreamState()
+        self._reasoning = NativeReasoningBlocks()
+        self._stop_reason: str | None = None
+        self._tool_inputs: dict[int, JsonValue] = {}
+        self._tool_ids: set[str] = set()
         self._ledger = ResponsesOutputLedger()
         self._events = ResponseEventBuilder()
         self._usage = _NativeUsage()
@@ -130,9 +136,6 @@ class AnthropicToResponsesStream:
     @property
     def completed(self) -> bool:
         return self._terminal
-
-    def start(self) -> list[str]:
-        return []
 
     def _payload(
         self, status: str, *, failure: ExecutionFailure | None = None
@@ -174,13 +177,17 @@ class AnthropicToResponsesStream:
             raise NativeMessagesError(
                 "Native event arrived after the Responses terminal event."
             )
-        completed = self._native.accept(event_type, payload)
+        completed = self._reasoning.feed(event_type, payload)
         if event_type == "ping":
             return []
         if event_type == "message_start":
+            if self._started:
+                raise NativeMessagesError(
+                    "Duplicate Messages start cannot create another response."
+                )
             message = payload["message"]
             if not isinstance(message, Mapping):
-                raise AssertionError("Validated message_start must contain a message.")
+                raise NativeMessagesError("Messages start must contain a message.")
             self._usage.update(message.get("usage"))
             if isinstance(message.get("model"), str) and message["model"]:
                 self._replay_origin = replace(
@@ -190,6 +197,9 @@ class AnthropicToResponsesStream:
             return [self._events.response_created(self._payload("in_progress"))]
         if event_type == "message_delta":
             delta = payload.get("delta")
+            reason = delta.get("stop_reason") if isinstance(delta, Mapping) else None
+            if isinstance(reason, str):
+                self._stop_reason = reason
             self._usage.update(
                 payload.get("usage"),
                 final=isinstance(delta, Mapping)
@@ -197,7 +207,11 @@ class AnthropicToResponsesStream:
             )
             return []
         if event_type == "message_stop":
-            reason = self._native.stop_reason
+            if not self._started or self._ledger.has_active_blocks:
+                raise NativeMessagesError(
+                    "Messages ended before converted content completed."
+                )
+            reason = self._stop_reason
             if reason not in {
                 "end_turn",
                 "stop_sequence",
@@ -212,22 +226,31 @@ class AnthropicToResponsesStream:
             if reason == "max_tokens":
                 return [self._events.response_incomplete(self._payload("incomplete"))]
             return [self._events.response_completed(self._payload("completed"))]
-        index = payload["index"]
-        if not isinstance(index, int):
-            raise AssertionError("Validated native content event must have an index.")
+        index = payload.get("index")
+        if (
+            not self._started
+            or not isinstance(index, int)
+            or isinstance(index, bool)
+            or index < 0
+        ):
+            raise NativeMessagesError(
+                "Messages content requires a started message and block index."
+            )
         if event_type == "content_block_start":
-            block = payload["content_block"]
+            block = payload.get("content_block")
             if not isinstance(block, Mapping):
-                raise AssertionError("Validated content_block_start must have a block.")
+                raise NativeMessagesError("Messages content start must have a block.")
+            if self._ledger.active_block(index) is not None:
+                raise NativeMessagesError(
+                    "Messages replaced an incomplete Responses item."
+                )
             return self._start_block(index, block)
         if event_type == "content_block_delta":
-            delta = payload["delta"]
+            delta = payload.get("delta")
             if not isinstance(delta, Mapping):
-                raise AssertionError("Validated content delta must be an object.")
+                raise NativeMessagesError("Messages content delta must be an object.")
             return self._delta(index, delta)
         if event_type == "content_block_stop":
-            if completed is None:
-                raise AssertionError("Validated content stop must return its block.")
             return self._finish_block(index, completed)
         raise NativeMessagesError(f"Unsupported native event {event_type!r}.")
 
@@ -288,8 +311,17 @@ class AnthropicToResponsesStream:
             )
         name = block["name"]
         call_id = block["id"]
-        if not isinstance(name, str) or not isinstance(call_id, str):
-            raise AssertionError("Validated native tools must have string identities.")
+        if (
+            not isinstance(name, str)
+            or not name
+            or not isinstance(call_id, str)
+            or not call_id
+            or call_id in self._tool_ids
+        ):
+            raise NativeMessagesError(
+                "Native tools require unique call identities and names."
+            )
+        self._tool_ids.add(call_id)
         identity = self._identities.get(name)
         if identity is None:
             raise NativeMessagesError("Native output used an unknown tool name.")
@@ -303,6 +335,7 @@ class AnthropicToResponsesStream:
             namespace=identity.namespace,
         )
         self._ledger.set_active_block(tool)
+        self._tool_inputs[index] = block.get("input")
         return [
             self._events.output_item_added(slot, tool_item(tool, status="in_progress"))
         ]
@@ -332,25 +365,33 @@ class AnthropicToResponsesStream:
             return []
         if isinstance(state, ToolBlockState) and kind == "input_json_delta":
             # The completer emits validated arguments once, after native block stop.
+            fragment = delta.get("partial_json")
+            if not isinstance(fragment, str):
+                raise NativeMessagesError(
+                    "Native tool arguments require a JSON fragment."
+                )
+            state.argument_parts.append(fragment)
             return []
         raise NativeMessagesError(
             "Responses cannot represent the native content delta."
         )
 
-    def _finish_block(self, index: int, block: JsonObject) -> list[str]:
+    def _finish_block(self, index: int, block: JsonObject | None) -> list[str]:
         state = self._ledger.active_block(index)
         if state is None:
             raise NativeMessagesError(
                 "Native block has no corresponding Responses item."
             )
         if isinstance(state, ReasoningBlockState):
+            if block is None:
+                raise NativeMessagesError("Native reasoning is incomplete.")
             state.encrypted_content = encode_replay(
                 ReplayRecord(self._replay_origin, block)
             )
         elif isinstance(state, ToolBlockState):
-            arguments = block.get("input")
-            if not isinstance(arguments, Mapping):
-                raise NativeMessagesError("Native tool input must be an object.")
+            arguments = complete_native_tool_input(
+                self._tool_inputs.pop(index), state.argument_parts
+            )
             if state.kind == "custom" and (
                 set(arguments) != {"input"}
                 or not isinstance(arguments.get("input"), str)
@@ -358,9 +399,9 @@ class AnthropicToResponsesStream:
                 raise NativeMessagesError(
                     "Native custom tool input must contain exactly one text input."
                 )
-            state.argument_parts.append(
+            state.argument_parts[:] = [
                 json.dumps(arguments, ensure_ascii=False, separators=(",", ":"))
-            )
+            ]
         events = self._completer.complete_block(state)
         self._ledger.pop_active_block(index)
         return events
@@ -390,6 +431,8 @@ class AnthropicToResponsesStream:
                     state.item_id, "".join(state.text_parts), "incomplete"
                 )
             else:
+                # Buffered arguments are published only after successful block completion.
+                state.argument_parts.clear()
                 item = tool_item(state, status="incomplete")
             self._ledger.commit_output(state.output_index, item)
         self._terminal = True

--- a/src/free_claude_code/core/openai_responses/messages_stream.py
+++ b/src/free_claude_code/core/openai_responses/messages_stream.py
@@ -185,7 +185,7 @@ class AnthropicToResponsesStream:
                 raise NativeMessagesError(
                     "Duplicate Messages start cannot create another response."
                 )
-            message = payload["message"]
+            message = payload.get("message")
             if not isinstance(message, Mapping):
                 raise NativeMessagesError("Messages start must contain a message.")
             self._usage.update(message.get("usage"))
@@ -264,9 +264,9 @@ class AnthropicToResponsesStream:
                 raise NativeMessagesError(
                     "Responses cannot represent native text extensions."
                 )
-            text = block["text"]
+            text = block.get("text")
             if not isinstance(text, str):
-                raise AssertionError("Validated native text must be a string.")
+                raise NativeMessagesError("Native text must be a string.")
             state = TextBlockState(index, slot, new_message_item_id())
             self._ledger.set_active_block(state)
             events = [
@@ -309,8 +309,8 @@ class AnthropicToResponsesStream:
             raise NativeMessagesError(
                 "Responses cannot represent a server-managed tool caller."
             )
-        name = block["name"]
-        call_id = block["id"]
+        name = block.get("name")
+        call_id = block.get("id")
         if (
             not isinstance(name, str)
             or not name
@@ -344,17 +344,17 @@ class AnthropicToResponsesStream:
         state = self._ledger.active_block(index)
         kind = delta.get("type")
         if isinstance(state, TextBlockState) and kind == "text_delta":
-            text = delta["text"]
+            text = delta.get("text")
             if not isinstance(text, str):
-                raise AssertionError("Validated text delta must be a string.")
+                raise NativeMessagesError("Native text delta must be a string.")
             state.text_parts.append(text)
             return [
                 self._events.output_text_delta(state.item_id, state.output_index, text)
             ]
         if isinstance(state, ReasoningBlockState) and kind == "thinking_delta":
-            text = delta["thinking"]
+            text = delta.get("thinking")
             if not isinstance(text, str):
-                raise AssertionError("Validated thinking delta must be a string.")
+                raise NativeMessagesError("Native thinking delta must be a string.")
             state.text_parts.append(text)
             return [
                 self._events.reasoning_text_delta(

--- a/src/free_claude_code/core/openai_responses/streaming/ledger.py
+++ b/src/free_claude_code/core/openai_responses/streaming/ledger.py
@@ -28,6 +28,10 @@ class ResponsesOutputLedger:
     def active_block(self, index: int) -> BlockState | None:
         return self._active_blocks.get(index)
 
+    @property
+    def has_active_blocks(self) -> bool:
+        return bool(self._active_blocks)
+
     def set_active_block(self, state: BlockState) -> None:
         self._active_blocks[state.index] = state
 

--- a/src/free_claude_code/providers/anthropic_messages/transport.py
+++ b/src/free_claude_code/providers/anthropic_messages/transport.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from typing import cast
 
 import httpx2
-from anthropic import AsyncAnthropic
+from anthropic import APIStatusError, AsyncAnthropic, AsyncStream
 from anthropic.types import MessageParam
 
 from free_claude_code.application.errors import InvalidRequestError
@@ -295,11 +295,39 @@ class AnthropicMessagesTransport:
                 )
                 scope.retain(sdk_stream.response)
                 stream_opened = True
-                async for event in sdk_stream:
-                    payload = cast(
-                        JsonObject, event.model_dump(mode="json", exclude_unset=True)
-                    )
-                    event_type = event.type
+                async for event in AsyncStream.raw_events(sdk_stream.response):
+                    if event.event == "ping":
+                        if isinstance(presenter, NativeMessagesRelay):
+                            for held in recovery.push("\n".join(event.raw) + "\n\n"):
+                                yield held
+                        continue
+                    if event.event == "error":
+                        try:
+                            error_body = event.json()
+                        except json.JSONDecodeError:
+                            error_body = event.data
+                        raise APIStatusError(
+                            str(error_body)
+                            or f"Error code: {sdk_stream.response.status_code}",
+                            response=sdk_stream.response,
+                            body=error_body,
+                        )
+                    if event.event not in {
+                        "message_start",
+                        "message_delta",
+                        "message_stop",
+                        "content_block_start",
+                        "content_block_delta",
+                        "content_block_stop",
+                    }:
+                        continue
+                    payload = event.json()
+                    if not isinstance(payload, dict):
+                        raise NativeMessagesError(
+                            "Messages event must contain an object."
+                        )
+                    payload.setdefault("type", event.event)
+                    event_type = payload["type"]
                     delta = payload.get("delta")
                     if (
                         event_type == "message_delta"

--- a/src/free_claude_code/providers/anthropic_messages/transport.py
+++ b/src/free_claude_code/providers/anthropic_messages/transport.py
@@ -6,11 +6,12 @@ import sys
 from collections.abc import AsyncIterator, Callable, Mapping
 from typing import cast
 
-import httpx
+import httpx2
+from anthropic import AsyncAnthropic
+from anthropic.types import MessageParam
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.application.model_metadata import ProviderModelInfo
-from free_claude_code.core.anthropic.errors import anthropic_status_for_error_type
 from free_claude_code.core.anthropic.models import MessagesRequest
 from free_claude_code.core.anthropic.native import (
     NativeMessagesError,
@@ -18,13 +19,6 @@ from free_claude_code.core.anthropic.native import (
     build_native_messages_request,
 )
 from free_claude_code.core.anthropic.native_stream import NativeMessagesRelay
-from free_claude_code.core.anthropic.streaming.decoder import AnthropicSSEDecoder
-from free_claude_code.core.diagnostics import (
-    ERROR_DETAIL_DISPLAY_CAP_BYTES,
-    attach_upstream_error_body,
-    redact_sensitive_error_text,
-)
-from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.history_replay import ReplayOrigin, prepare_history
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import (
@@ -46,14 +40,14 @@ from free_claude_code.providers.admission import (
     ProviderExecution,
     ProviderOperationKind,
 )
-from free_claude_code.providers.endpoint import EndpointContext
+from free_claude_code.providers.endpoint import EndpointContext, RequestEndpoint
 from free_claude_code.providers.failure_policy import (
     RetryableProviderProtocolError,
     classify_provider_failure,
     context_window_exceeded_provider_failure,
-    is_context_window_error_code,
     is_context_window_finish_reason,
     is_retryable_stream_error,
+    normalize_anthropic_stream_error,
 )
 from free_claude_code.providers.history_replay import (
     history_retry_body,
@@ -85,14 +79,16 @@ class AnthropicMessagesTransport:
     def __init__(
         self,
         *,
-        client: httpx.AsyncClient,
+        client: AsyncAnthropic,
         admission: ProviderAdmissionController,
         provider_name: str,
         replay_scope: str,
         read_timeout_s: float,
+        endpoint_transport: httpx2.AsyncBaseTransport | None = None,
         capabilities: MessagesModelCapabilities = MessagesModelCapabilities(),
     ) -> None:
         self._client = client
+        self._endpoint_transport = endpoint_transport
         self._admission = admission
         self._provider_name = provider_name
         self._replay_scope = replay_scope
@@ -145,23 +141,6 @@ class AnthropicMessagesTransport:
             return build_responses_messages_request(request, options=options)
         except (NativeMessagesError, ResponsesConversionError, ValueError) as error:
             raise InvalidRequestError(str(error)) from error
-
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        self._messages_body(request, reasoning, model_info)
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        self._responses_body(request, reasoning)
 
     def stream_messages(
         self,
@@ -237,16 +216,18 @@ class AnthropicMessagesTransport:
         reasoning_correction: ReasoningCorrection | None = None,
     ) -> AsyncIterator[str]:
         execution = self._admission.start_execution(request_id=request_id)
+        endpoint = RequestEndpoint(endpoint_context, self._endpoint_transport)
         run = self._run(
             body,
             reasoning_correction=reasoning_correction,
             betas=betas,
-            endpoint_context=endpoint_context,
             execution=execution,
+            endpoint=endpoint,
             presenter_factory=presenter_factory,
         )
         try:
             async for event in run:
+                endpoint.commit()
                 yield event
         except asyncio.CancelledError, GeneratorExit:
             raise
@@ -256,22 +237,25 @@ class AnthropicMessagesTransport:
         else:
             execution.succeed()
         finally:
-            await maybe_await_aclose(run)
-            execution.abandon()
+            try:
+                await maybe_await_aclose(run)
+            finally:
+                try:
+                    await endpoint.aclose()
+                finally:
+                    execution.abandon()
 
     async def _run(
         self,
         body: JsonObject,
         *,
         betas: tuple[str, ...],
-        endpoint_context: EndpointContext,
+        endpoint: RequestEndpoint,
         execution: ProviderExecution,
         presenter_factory: Callable[[ReplayOrigin], _Presenter],
         reasoning_correction: ReasoningCorrection | None = None,
     ) -> AsyncIterator[str]:
         recovery = RecoveryController()
-        refreshed = False
-        force_refresh = False
         while execution.can_attempt:
             scope: ProviderAttemptScope | None = None
             stream_opened = False
@@ -283,55 +267,46 @@ class AnthropicMessagesTransport:
                     provider_name=self._provider_name,
                     request_id=execution.request_id,
                 )
-                endpoint = await endpoint_context.endpoint(force_refresh=force_refresh)
-                force_refresh = False
+                client = await endpoint.anthropic_client(self._client)
+                snapshot = endpoint.snapshot
+                if snapshot is None:
+                    raise RuntimeError(
+                        "Messages request requires an endpoint snapshot."
+                    )
                 origin = replay_origin(
                     self._replay_scope,
                     "messages",
                     str(body["model"]),
-                    endpoint=endpoint,
+                    endpoint=snapshot,
                 )
                 sent_body = prepare_history(body, origin)
                 presenter = presenter_factory(origin)
-                headers = httpx.Headers(
-                    {
-                        "anthropic-version": "2023-06-01",
-                        "Accept": "text/event-stream",
-                    }
+                sdk_stream = await client.messages.create(
+                    model=cast(str, sent_body["model"]),
+                    messages=cast(list[MessageParam], sent_body["messages"]),
+                    max_tokens=cast(int, sent_body["max_tokens"]),
+                    stream=True,
+                    extra_body={
+                        key: value
+                        for key, value in sent_body.items()
+                        if key not in {"model", "messages", "max_tokens", "stream"}
+                    },
+                    extra_headers=endpoint.anthropic_headers(betas),
                 )
-                headers.update(endpoint.headers)
-                if endpoint.api_key and not any(
-                    key.lower() in {"authorization", "x-api-key"} for key in headers
-                ):
-                    headers["x-api-key"] = endpoint.api_key
-                if betas:
-                    existing = headers.pop("anthropic-beta", "")
-                    headers["anthropic-beta"] = ",".join(
-                        dict.fromkeys([*filter(None, existing.split(",")), *betas])
-                    )
-                base_url = endpoint.base_url.rstrip("/")
-                path = "/messages" if base_url.endswith("/v1") else "/v1/messages"
-                response = scope.retain(
-                    await self._client.send(
-                        self._client.build_request(
-                            "POST",
-                            f"{base_url}{path}",
-                            json=sent_body,
-                            headers=headers,
-                        ),
-                        stream=True,
-                    )
-                )
-                if not response.is_success:
-                    raise await _status_error(response)
-                content_type = response.headers.get("content-type", "")
-                if "text/event-stream" not in content_type.lower():
-                    raise RetryableProviderProtocolError(
-                        "Messages upstream did not return an SSE stream."
-                    )
+                scope.retain(sdk_stream.response)
                 stream_opened = True
-                async for event_type, payload in _events(response):
-                    _check_failure(event_type, payload)
+                async for event in sdk_stream:
+                    payload = cast(
+                        JsonObject, event.model_dump(mode="json", exclude_unset=True)
+                    )
+                    event_type = event.type
+                    delta = payload.get("delta")
+                    if (
+                        event_type == "message_delta"
+                        and isinstance(delta, Mapping)
+                        and is_context_window_finish_reason(delta.get("stop_reason"))
+                    ):
+                        raise context_window_exceeded_provider_failure()
                     output = presenter.feed(event_type, payload)
                     if event_type != "ping" and not attempt.accepted:
                         await attempt.accept()
@@ -352,37 +327,24 @@ class AnthropicMessagesTransport:
             except Exception as raw_error:
                 error = (
                     RetryableProviderProtocolError(str(raw_error))
-                    if isinstance(raw_error, NativeMessagesError)
-                    else raw_error
-                )
-                status = (
-                    error.response.status_code
-                    if isinstance(error, httpx.HTTPStatusError)
-                    else error.status_code
-                    if isinstance(error, ExecutionFailure)
-                    else None
-                )
-                if (
-                    scope is not None
-                    and status in {401, 403}
-                    and not refreshed
-                    and not recovery.committed
-                ):
-                    retry = (
-                        execution.can_attempt
-                        if scope.attempt.accepted
-                        else await scope.attempt.correct(error)
-                        is ProviderCorrectionAction.RETRY
+                    if isinstance(
+                        raw_error,
+                        NativeMessagesError | json.JSONDecodeError | UnicodeDecodeError,
                     )
-                    if retry:
-                        refreshed = force_refresh = True
-                        recovery.discard()
-                        continue
+                    else normalize_anthropic_stream_error(
+                        raw_error,
+                        provider_name=self._provider_name,
+                        request_id=execution.request_id,
+                    )
+                )
+                if scope is not None and await endpoint.retry_authentication(
+                    error, scope.attempt, execution
+                ):
+                    recovery.discard()
+                    continue
                 attempt_failure = None
                 if scope is not None and not recovery.committed:
-                    corrected_history = history_retry_body(
-                        raw_error, sent_body, "messages"
-                    )
+                    corrected_history = history_retry_body(error, sent_body, "messages")
                     if corrected_history is not None:
                         retry = (
                             execution.can_attempt
@@ -459,82 +421,3 @@ class AnthropicMessagesTransport:
         if execution.last_failure is not None:
             raise execution.last_failure
         raise RuntimeError("Messages execution ended without a terminal result.")
-
-
-async def _events(response: httpx.Response) -> AsyncIterator[tuple[str, JsonObject]]:
-    decoder = AnthropicSSEDecoder()
-    async for chunk in response.aiter_text():
-        for event in decoder.feed(chunk):
-            payload = cast(JsonObject, event.data)
-            kind = event.event or payload.get("type")
-            if not isinstance(kind, str) or not kind:
-                raise RetryableProviderProtocolError(
-                    "Messages stream has an invalid event type."
-                )
-            yield kind, payload
-    for event in decoder.finish():
-        payload = cast(JsonObject, event.data)
-        kind = event.event or payload.get("type")
-        if not isinstance(kind, str) or not kind:
-            raise RetryableProviderProtocolError(
-                "Messages stream has an invalid final event."
-            )
-        yield kind, payload
-
-
-def _check_failure(event_type: str, payload: JsonObject) -> None:
-    delta = payload.get("delta")
-    if (
-        event_type == "message_delta"
-        and isinstance(delta, Mapping)
-        and is_context_window_finish_reason(delta.get("stop_reason"))
-    ):
-        raise context_window_exceeded_provider_failure()
-    if event_type != "error":
-        return
-    error = payload.get("error")
-    kind = error.get("type") if isinstance(error, Mapping) else None
-    if isinstance(error, Mapping) and any(
-        is_context_window_error_code(error.get(key)) for key in ("type", "code")
-    ):
-        raise context_window_exceeded_provider_failure()
-    status = anthropic_status_for_error_type(kind if isinstance(kind, str) else "")
-    failure_kind = {
-        400: FailureKind.INVALID_REQUEST,
-        401: FailureKind.AUTHENTICATION,
-        402: FailureKind.PERMISSION,
-        403: FailureKind.PERMISSION,
-        404: FailureKind.INVALID_REQUEST,
-        413: FailureKind.INVALID_REQUEST,
-        429: FailureKind.RATE_LIMIT,
-        504: FailureKind.TIMEOUT,
-        529: FailureKind.OVERLOADED,
-    }.get(status, FailureKind.UPSTREAM)
-    message = error.get("message") if isinstance(error, Mapping) else None
-    failure = ExecutionFailure(
-        failure_kind,
-        status,
-        redact_sensitive_error_text(message[:ERROR_DETAIL_DISPLAY_CAP_BYTES])
-        if isinstance(message, str) and message
-        else "Messages upstream returned an error.",
-        status == 429 or status >= 500,
-    )
-    attach_upstream_error_body(failure, json.dumps(payload))
-    raise failure
-
-
-async def _status_error(response: httpx.Response) -> httpx.HTTPStatusError:
-    limit = ERROR_DETAIL_DISPLAY_CAP_BYTES
-    body = bytearray()
-    async for chunk in response.aiter_bytes():
-        body.extend(chunk[: limit + 1 - len(body)])
-        if len(body) > limit:
-            break
-    try:
-        response.raise_for_status()
-    except httpx.HTTPStatusError as error:
-        attach_upstream_error_body(
-            error, bytes(body[:limit]), truncated=len(body) > limit
-        )
-        return error
-    raise AssertionError("Expected an unsuccessful Messages response.")

--- a/src/free_claude_code/providers/endpoint.py
+++ b/src/free_claude_code/providers/endpoint.py
@@ -6,6 +6,8 @@ from typing import Protocol
 
 import httpx
 import httpx2
+from anthropic import AsyncAnthropic
+from anthropic import Omit as AnthropicOmit
 from openai import AsyncOpenAI, Omit
 
 from free_claude_code.providers.admission import (
@@ -66,7 +68,7 @@ class RequestEndpoint:
         if self._http is not None:
             await self._http.aclose()
 
-    async def openai_client(self, client: AsyncOpenAI) -> AsyncOpenAI:
+    async def _resolve(self) -> tuple[HttpEndpoint, httpx2.AsyncClient]:
         endpoint = await self._context.endpoint(force_refresh=self._refresh_pending)
         self.snapshot = endpoint
         self._refresh_pending = False
@@ -79,6 +81,10 @@ class RequestEndpoint:
             )
         # An endpoint is authoritative for every attempt, including after refresh.
         self._http.cookies.clear()
+        return endpoint, self._http
+
+    async def openai_client(self, client: AsyncOpenAI) -> AsyncOpenAI:
+        endpoint, http = await self._resolve()
         headers = dict(httpx.Headers(endpoint.headers).items())
         self._omit_authorization = (
             endpoint.api_key is None and "authorization" not in headers
@@ -101,7 +107,7 @@ class RequestEndpoint:
             base_url=endpoint.base_url,
             set_default_headers=headers,
             set_default_query={},
-            http_client=self._http,
+            http_client=http,
             max_retries=0,
         )
         # SDK copy(None) inherits these values. Clear only this owned view.
@@ -112,6 +118,47 @@ class RequestEndpoint:
 
     def openai_headers(self) -> dict[str, str | Omit]:
         return {"Authorization": Omit()} if self._omit_authorization else {}
+
+    async def anthropic_client(self, client: AsyncAnthropic) -> AsyncAnthropic:
+        endpoint, http = await self._resolve()
+        base_url = endpoint.base_url.rstrip("/").removesuffix("/v1")
+        return client.with_options(
+            base_url=base_url,
+            http_client=http,
+            set_default_headers={},
+            set_default_query={},
+            max_retries=0,
+        )
+
+    def anthropic_headers(
+        self, betas: tuple[str, ...]
+    ) -> dict[str, str | AnthropicOmit]:
+        if self.snapshot is None:
+            raise RuntimeError("Messages headers require an endpoint snapshot.")
+        headers: dict[str, str | AnthropicOmit] = dict(
+            httpx2.Headers(self.snapshot.headers).items()
+        )
+        if self.snapshot.api_key and not any(
+            key in headers for key in ("authorization", "x-api-key")
+        ):
+            headers["x-api-key"] = self.snapshot.api_key
+        for key in ("authorization", "x-api-key", "cookie"):
+            headers.setdefault(key, AnthropicOmit())
+        existing = headers.get("anthropic-beta", "")
+        combined = tuple(
+            dict.fromkeys(
+                [
+                    *filter(
+                        None, existing.split(",") if isinstance(existing, str) else ()
+                    ),
+                    *betas,
+                ]
+            )
+        )
+        headers["anthropic-beta"] = ",".join(combined) if combined else AnthropicOmit()
+        headers.setdefault("anthropic-version", "2023-06-01")
+        headers.setdefault("accept", "text/event-stream")
+        return headers
 
     async def retry_authentication(
         self, error: Exception, attempt: ProviderAttempt, execution: ProviderExecution

--- a/src/free_claude_code/providers/failure_policy.py
+++ b/src/free_claude_code/providers/failure_policy.py
@@ -7,12 +7,14 @@ from contextlib import suppress
 from dataclasses import replace
 from typing import Any
 
+import anthropic
 import httpx
 import httpx2
 import openai
 
 from free_claude_code.core.anthropic.errors import anthropic_status_for_error_type
 from free_claude_code.core.diagnostics import (
+    attach_upstream_error_body,
     attached_upstream_error_body,
     extract_upstream_error_detail,
     format_execution_failure_message,
@@ -93,13 +95,29 @@ def classify_provider_failure(
             exc,
             read_timeout_s=read_timeout_s,
         )
+    detail = extract_upstream_error_detail(exc)
+    if isinstance(exc, anthropic.APIStatusError) and exc.status_code == 200:
+        detail = replace(detail, status_code=failure.status_code)
     message = format_execution_failure_message(
         failure,
-        extract_upstream_error_detail(exc),
+        detail,
         upstream_name=provider_name,
         request_id=request_id,
     )
     return replace(failure, message=message)
+
+
+def normalize_anthropic_stream_error(
+    exc: Exception, *, provider_name: str, request_id: str | None
+) -> Exception:
+    """Give streamed SDK errors their failure status before correction decisions."""
+    if not isinstance(exc, anthropic.APIStatusError) or exc.status_code != 200:
+        return exc
+    failure = classify_provider_failure(
+        exc, provider_name=provider_name, read_timeout_s=None, request_id=request_id
+    )
+    attach_upstream_error_body(failure, json.dumps(exc.body))
+    return failure
 
 
 def overloaded_provider_failure() -> ExecutionFailure:
@@ -234,7 +252,10 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
         exc,
         openai.AuthenticationError
         | openai.PermissionDeniedError
-        | openai.BadRequestError,
+        | openai.BadRequestError
+        | anthropic.AuthenticationError
+        | anthropic.PermissionDeniedError
+        | anthropic.BadRequestError,
     ):
         return False
     if retryable_transient_status(exc) is not None:
@@ -252,6 +273,8 @@ def is_retryable_provider_error(exc: BaseException) -> bool:
             httpx2.NetworkError,
             openai.APITimeoutError,
             openai.APIConnectionError,
+            anthropic.APITimeoutError,
+            anthropic.APIConnectionError,
             RetryableProviderProtocolError,
         ),
     )
@@ -263,7 +286,13 @@ def is_retryable_stream_error(exc: BaseException) -> bool:
         return True
     if isinstance(exc, ExecutionFailure):
         return exc.retryable
-    if isinstance(exc, openai.AuthenticationError | openai.BadRequestError):
+    if isinstance(
+        exc,
+        openai.AuthenticationError
+        | openai.BadRequestError
+        | anthropic.AuthenticationError
+        | anthropic.BadRequestError,
+    ):
         return False
     if retryable_transient_status(exc) is not None:
         return True
@@ -280,6 +309,8 @@ def is_retryable_stream_error(exc: BaseException) -> bool:
             httpx2.NetworkError,
             openai.APITimeoutError,
             openai.APIConnectionError,
+            anthropic.APITimeoutError,
+            anthropic.APIConnectionError,
         ),
     )
 
@@ -400,8 +431,8 @@ def _classify_provider_failure(
             is_retryable_provider_error(exc),
         )
 
-    if isinstance(exc, httpx.HTTPStatusError):
-        status = exc.response.status_code
+    if isinstance(exc, httpx.HTTPStatusError | anthropic.APIStatusError):
+        status = _reported_status(exc) or 500
         if status == 401:
             return _failure(
                 FailureKind.AUTHENTICATION, 401, _AUTHENTICATION_MESSAGE, False
@@ -412,11 +443,23 @@ def _classify_provider_failure(
             return _failure(FailureKind.PERMISSION, 403, _PERMISSION_MESSAGE, False)
         if status == 429:
             return _failure(FailureKind.RATE_LIMIT, 429, _RATE_LIMIT_MESSAGE, True)
-        if status == 400:
+        if status == 400 or (
+            isinstance(exc, anthropic.APIStatusError) and status in {404, 422}
+        ):
             return _failure(
-                FailureKind.INVALID_REQUEST, 400, _INVALID_REQUEST_MESSAGE, False
+                FailureKind.INVALID_REQUEST, status, _INVALID_REQUEST_MESSAGE, False
             )
-        if status in (502, 503, 504):
+        if (
+            isinstance(exc, anthropic.APIStatusError)
+            and exc.status_code == 200
+            and status == 504
+        ):
+            return _failure(
+                FailureKind.TIMEOUT, 504, "Provider request timed out.", True
+            )
+        if status in (502, 503, 504) or (
+            isinstance(exc, anthropic.APIStatusError) and status == 529
+        ):
             return overloaded_provider_failure()
         return _failure(
             FailureKind.UPSTREAM,
@@ -426,10 +469,20 @@ def _classify_provider_failure(
         )
 
     kind = FailureKind.UPSTREAM
-    if isinstance(exc, TimeoutError | httpx.TimeoutException | httpx2.TimeoutException):
+    if isinstance(
+        exc,
+        TimeoutError
+        | httpx.TimeoutException
+        | httpx2.TimeoutException
+        | anthropic.APITimeoutError,
+    ):
         kind = FailureKind.TIMEOUT
     elif isinstance(
-        exc, ssl.SSLWantReadError | httpx.NetworkError | httpx2.NetworkError
+        exc,
+        ssl.SSLWantReadError
+        | httpx.NetworkError
+        | httpx2.NetworkError
+        | anthropic.APIConnectionError,
     ):
         kind = FailureKind.UNAVAILABLE
     return _failure(
@@ -466,6 +519,13 @@ def _status_from_exception(exc: BaseException) -> int | None:
 
 
 def _reported_status(exc: BaseException) -> int | None:
+    if isinstance(exc, anthropic.APIStatusError) and exc.status_code == 200:
+        body = exc.body
+        if isinstance(body, Mapping):
+            error = body.get("error", body)
+            if isinstance(error, Mapping):
+                return anthropic_status_for_error_type(str(error.get("type", "")))
+        return 500
     status = _status_from_exception(exc)
     if status is not None:
         return status

--- a/src/free_claude_code/providers/github_copilot/provider.py
+++ b/src/free_claude_code/providers/github_copilot/provider.py
@@ -5,8 +5,8 @@ import sys
 from collections.abc import AsyncIterator, Mapping
 from contextlib import suppress
 
-import httpx
 import httpx2
+from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
 
 from free_claude_code.application.errors import InvalidRequestError
@@ -20,7 +20,6 @@ from free_claude_code.providers.anthropic_messages.transport import (
     AnthropicMessagesTransport,
 )
 from free_claude_code.providers.base import BaseProvider, ProviderConfig
-from free_claude_code.providers.endpoint import EndpointContext, HttpEndpoint
 from free_claude_code.providers.http import close_provider_stream
 from free_claude_code.providers.openai_chat import OpenAIChatProvider
 from free_claude_code.providers.openai_responses import OpenAIResponsesTransport
@@ -37,27 +36,6 @@ from .responses_events import CopilotResponsesEvents
 from .types import CopilotEgress, CopilotModel
 
 
-class _BorrowedMessagesPool(httpx.AsyncBaseTransport):
-    def __init__(self, pool: httpx.AsyncBaseTransport) -> None:
-        self._pool = pool
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        return await self._pool.handle_async_request(request)
-
-
-class _MessagesEndpoint:
-    """A fresh snapshot replaces all cookie state for this request's next attempt."""
-
-    def __init__(self, context: EndpointContext, client: httpx.AsyncClient) -> None:
-        self._context = context
-        self._client = client
-
-    async def endpoint(self, *, force_refresh: bool = False) -> HttpEndpoint:
-        snapshot = await self._context.endpoint(force_refresh=force_refresh)
-        self._client.cookies.clear()
-        return snapshot
-
-
 class GitHubCopilotProvider(BaseProvider):
     """Own generation HTTP resources; borrow the process account for each stream."""
 
@@ -67,18 +45,12 @@ class GitHubCopilotProvider(BaseProvider):
         *,
         auth: CopilotAuthManager,
         admission: ProviderAdmissionController,
-        messages_transport: httpx.AsyncBaseTransport | None = None,
-        openai_transport: httpx2.AsyncBaseTransport | None = None,
+        transport: httpx2.AsyncBaseTransport | None = None,
     ) -> None:
         super().__init__(config)
         self._auth = auth
         self._admission = admission
-        self._messages_pool = messages_transport or httpx.AsyncHTTPTransport(
-            proxy=config.proxy
-        )
-        self._openai_pool = openai_transport or httpx2.AsyncHTTPTransport(
-            proxy=config.proxy
-        )
+        self._pool = transport or httpx2.AsyncHTTPTransport(proxy=config.proxy)
         self._client = AsyncOpenAI(
             api_key=_endpoint_required,
             base_url=config.base_url,
@@ -89,13 +61,19 @@ class GitHubCopilotProvider(BaseProvider):
                 write=config.http_write_timeout,
             ),
         )
+        self._messages_client = AsyncAnthropic(
+            api_key="",
+            base_url=config.base_url,
+            max_retries=0,
+            timeout=self._client.timeout,
+        )
         self._responses = OpenAIResponsesTransport(
             client=self._client,
             admission=admission,
             provider_name=PROVIDER_NAME,
             read_timeout_s=config.http_read_timeout,
             log_raw_sse_events=config.log_raw_sse_events,
-            endpoint_transport=self._openai_pool,
+            endpoint_transport=self._pool,
             event_adapter_factory=CopilotResponsesEvents,
         )
         self._chats: dict[str, tuple[CopilotModel, OpenAIChatProvider]] = {}
@@ -190,7 +168,7 @@ class GitHubCopilotProvider(BaseProvider):
                 profile=chat_profile(model),
                 admission=self._admission,
                 client=self._client,
-                endpoint_transport=self._openai_pool,
+                endpoint_transport=self._pool,
             )
             self._chats[model.info.model_id] = (model, provider)
             return provider
@@ -210,31 +188,21 @@ class GitHubCopilotProvider(BaseProvider):
         try:
             async with self._auth.lease(request.model) as lease:
                 selected: AsyncIterator[str] | None = None
-                http: httpx.AsyncClient | None = None
                 try:
                     if lease.egress is CopilotEgress.MESSAGES:
-                        http = httpx.AsyncClient(
-                            transport=_BorrowedMessagesPool(self._messages_pool),
-                            follow_redirects=False,
-                            timeout=httpx.Timeout(
-                                self._config.http_read_timeout,
-                                connect=self._config.http_connect_timeout,
-                                write=self._config.http_write_timeout,
-                            ),
-                        )
                         native = AnthropicMessagesTransport(
-                            client=http,
+                            client=self._messages_client,
+                            endpoint_transport=self._pool,
                             admission=self._admission,
                             provider_name=PROVIDER_NAME,
                             replay_scope=REPLAY_SCOPE,
                             read_timeout_s=self._config.http_read_timeout,
                             capabilities=lease.model.messages,
                         )
-                        endpoint = _MessagesEndpoint(lease, http)
                         if isinstance(request, MessagesRequest):
                             selected = native.stream_messages(
                                 request,
-                                endpoint_context=endpoint,
+                                endpoint_context=lease,
                                 request_id=request_id,
                                 response_model=response_model,
                                 reasoning=reasoning,
@@ -243,7 +211,7 @@ class GitHubCopilotProvider(BaseProvider):
                         else:
                             selected = native.stream_responses(
                                 request,
-                                endpoint_context=endpoint,
+                                endpoint_context=lease,
                                 request_id=request_id,
                                 response_model=response_model,
                                 reasoning=reasoning,
@@ -300,7 +268,6 @@ class GitHubCopilotProvider(BaseProvider):
                         asyncio.create_task(
                             _close_request(
                                 selected,
-                                http,
                                 active_error=sys.exception(),
                                 request_id=request_id,
                             )
@@ -324,8 +291,8 @@ class GitHubCopilotProvider(BaseProvider):
             await self._condition.wait_for(lambda: self._active == 0)
         results = await asyncio.gather(
             self._client.close(),
-            self._messages_pool.aclose(),
-            self._openai_pool.aclose(),
+            self._messages_client.close(),
+            self._pool.aclose(),
             return_exceptions=True,
         )
         failures = [result for result in results if isinstance(result, Exception)]
@@ -337,22 +304,17 @@ class GitHubCopilotProvider(BaseProvider):
 
 async def _close_request(
     stream: AsyncIterator[str] | None,
-    client: httpx.AsyncClient | None,
     *,
     active_error: BaseException | None,
     request_id: str | None,
 ) -> None:
-    try:
-        if stream is not None:
-            await close_provider_stream(
-                stream,
-                active_error=active_error,
-                provider_name=PROVIDER_NAME,
-                request_id=request_id,
-            )
-    finally:
-        if client is not None:
-            await client.aclose()
+    if stream is not None:
+        await close_provider_stream(
+            stream,
+            active_error=active_error,
+            provider_name=PROVIDER_NAME,
+            request_id=request_id,
+        )
 
 
 async def _endpoint_required() -> str:

--- a/tests/contracts/test_import_boundaries.py
+++ b/tests/contracts/test_import_boundaries.py
@@ -503,7 +503,7 @@ def test_anthropic_request_boundaries_use_the_protocol_model() -> None:
 
 
 def test_core_does_not_import_provider_transport_sdks() -> None:
-    forbidden_roots = {"aiohttp", "httpx", "openai"}
+    forbidden_roots = {"aiohttp", "anthropic", "httpx", "openai"}
     offenders = [
         record.describe()
         for record in _scan_imports(_PACKAGE_ROOT)

--- a/tests/core/anthropic/test_native_messages_stream.py
+++ b/tests/core/anthropic/test_native_messages_stream.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import pytest
 
+from free_claude_code.core.anthropic.native import NativeMessagesError
 from free_claude_code.core.anthropic.native_stream import (
     NativeMessagesRelay,
 )
@@ -93,6 +94,34 @@ def test_relay_preserves_native_identity_and_extensions_without_mutating_input()
         parse_sse_lines(relay.feed("content_block_start", block).splitlines())[0].data
         == block
     )
+    assert not relay.completed
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"type": "text", "text": "partial"},
+        {"type": "tool_use", "id": "call-a", "name": "lookup", "input": {}},
+        {"type": "server_tool_use", "id": "call-a", "name": "lookup", "input": {}},
+    ],
+)
+def test_native_stop_requires_every_started_block_to_close(block: JsonObject) -> None:
+    relay = NativeMessagesRelay(public_model="public")
+    events: list[JsonObject] = [
+        _START,
+        {"type": "content_block_start", "index": 3, "content_block": block},
+        {
+            "type": "content_block_start",
+            "index": 9,
+            "content_block": {"type": "text", "text": "done"},
+        },
+        {"type": "content_block_stop", "index": 9},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+    ]
+    for event in events:
+        relay.feed(cast(str, event["type"]), event)
+    with pytest.raises(NativeMessagesError):
+        relay.feed("message_stop", {"type": "message_stop"})
     assert not relay.completed
 
 

--- a/tests/core/anthropic/test_native_messages_stream.py
+++ b/tests/core/anthropic/test_native_messages_stream.py
@@ -125,6 +125,38 @@ def test_native_stop_requires_every_started_block_to_close(block: JsonObject) ->
     assert not relay.completed
 
 
+def test_relay_rejects_prestart_reasoning_before_collecting_it() -> None:
+    relay = NativeMessagesRelay(public_model="public")
+    with pytest.raises(NativeMessagesError):
+        relay.feed(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 3,
+                "content_block": {"type": "thinking", "thinking": "unstarted"},
+            },
+        )
+    # Rejected input must not leave an open reasoning block in the relay.
+    relay.feed("message_start", _START)
+    relay.feed(
+        "message_delta", {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}
+    )
+    relay.feed("message_stop", {"type": "message_stop"})
+    assert relay.completed
+
+
+@pytest.mark.parametrize("event", [_START, {"type": "ping"}, {"type": "message_stop"}])
+def test_completed_relay_cannot_emit_more_events(event: JsonObject) -> None:
+    relay = NativeMessagesRelay(public_model="public")
+    relay.feed("message_start", _START)
+    relay.feed(
+        "message_delta", {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}
+    )
+    relay.feed("message_stop", {"type": "message_stop"})
+    with pytest.raises(NativeMessagesError):
+        relay.feed(cast(str, event["type"]), event)
+
+
 @pytest.mark.asyncio
 async def test_fragmented_native_relay_preserves_nonstreaming_thinking_and_usage() -> (
     None

--- a/tests/core/anthropic/test_native_messages_stream.py
+++ b/tests/core/anthropic/test_native_messages_stream.py
@@ -1,14 +1,13 @@
 """Native relay validation never rewrites identities or completes a truncated stream."""
 
+import json
 from collections.abc import AsyncIterator
 from typing import cast
 
 import pytest
 
-from free_claude_code.core.anthropic.native import NativeMessagesError
 from free_claude_code.core.anthropic.native_stream import (
     NativeMessagesRelay,
-    NativeMessagesStreamState,
 )
 from free_claude_code.core.anthropic.sse_aggregation import (
     aggregate_anthropic_sse_to_message,
@@ -63,13 +62,6 @@ async def test_native_citations_survive_block_completion_and_fragmented_aggregat
         },
         {"type": "message_stop"},
     ]
-    state = NativeMessagesStreamState()
-    completed = None
-    for event in events:
-        block = state.accept(cast(str, event["type"]), event)
-        if block is not None:
-            completed = block
-    assert completed is not None and completed["citations"] == [citation]
     relay = NativeMessagesRelay(public_model="public")
 
     async def stream() -> AsyncIterator[str]:
@@ -150,77 +142,94 @@ async def test_fragmented_native_relay_preserves_nonstreaming_thinking_and_usage
     assert message["usage"] == {"input_tokens": 3, "output_tokens": 8}
 
 
-@pytest.mark.parametrize(
-    "event",
-    [
-        _START,
-        {"type": "message_stop"},
-        {
-            "type": "content_block_delta",
-            "index": 0,
-            "delta": {"type": "text_delta", "text": "orphan"},
-        },
-        {
-            "type": "content_block_start",
-            "index": True,
-            "content_block": {"type": "text", "text": ""},
-        },
-        {"type": "message_delta", "delta": {"stop_reason": "unknown"}},
-    ],
-)
-def test_invalid_lifecycles_are_not_reported_as_success(event: JsonObject) -> None:
-    relay = NativeMessagesRelay(public_model="public")
-    relay.feed("message_start", _START)
-    with pytest.raises(NativeMessagesError):
-        relay.feed(cast(str, event["type"]), event)
-    assert not relay.completed
-
-
-def test_reused_block_indexes_and_events_after_terminal_are_rejected() -> None:
-    relay = NativeMessagesRelay(public_model="public")
-    relay.feed("message_start", _START)
-    start: JsonObject = {
-        "type": "content_block_start",
-        "index": 0,
-        "content_block": {"type": "text", "text": ""},
-    }
-    relay.feed("content_block_start", start)
-    relay.feed("content_block_stop", {"type": "content_block_stop", "index": 0})
-    with pytest.raises(NativeMessagesError, match="Duplicate"):
-        relay.feed("content_block_start", start)
-    relay.feed(
-        "message_delta", {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}
-    )
-    relay.feed("message_stop", {"type": "message_stop"})
-    with pytest.raises(NativeMessagesError, match="after message_stop"):
-        relay.feed("message_stop", {"type": "message_stop"})
-
-
-@pytest.mark.parametrize("partial", ['{"x":', "[]", '{"x":NaN}'])
-def test_invalid_json_tools_never_complete(partial: str) -> None:
-    relay = NativeMessagesRelay(public_model="public")
-    relay.feed("message_start", _START)
-    relay.feed(
-        "content_block_start",
-        {
-            "type": "content_block_start",
-            "index": 0,
-            "content_block": {
-                "type": "tool_use",
-                "id": "c",
-                "name": "lookup",
-                "input": {},
+def _tool_events(
+    kind: str,
+    fragments: list[str],
+    *,
+    initial: JsonObject | None = None,
+    close: bool = True,
+) -> list[JsonObject]:
+    return cast(
+        list[JsonObject],
+        [
+            _START,
+            {
+                "type": "content_block_start",
+                "index": 4,
+                "content_block": {
+                    "type": kind,
+                    "id": "call-native",
+                    "name": "lookup",
+                    "input": initial or {},
+                },
             },
-        },
+            *[
+                {
+                    "type": "content_block_delta",
+                    "index": 4,
+                    "delta": {"type": "input_json_delta", "partial_json": fragment},
+                }
+                for fragment in fragments
+            ],
+            *([{"type": "content_block_stop", "index": 4}] if close else []),
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 7},
+            },
+            {"type": "message_stop"},
+        ],
     )
-    relay.feed(
-        "content_block_delta",
+
+
+async def _wire(events: list[JsonObject]) -> AsyncIterator[str]:
+    for event in events:
+        yield f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+
+
+@pytest.mark.asyncio
+async def test_native_server_tool_arguments_are_forwarded_and_aggregated() -> None:
+    events = _tool_events("server_tool_use", ['{"query":', '"weather"}'])
+    relay = NativeMessagesRelay(public_model="public")
+    output = [
+        parse_sse_lines(relay.feed(cast(str, event["type"]), event).splitlines())[
+            0
+        ].data
+        for event in events
+    ]
+    assert output[1:] == events[1:]
+    message, error, complete = await aggregate_anthropic_sse_to_message(_wire(output))
+    assert complete and error is None
+    assert message["content"] == [
         {
-            "type": "content_block_delta",
-            "index": 0,
-            "delta": {"type": "input_json_delta", "partial_json": partial},
-        },
+            "type": "server_tool_use",
+            "id": "call-native",
+            "name": "lookup",
+            "input": {"query": "weather"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["tool_use", "server_tool_use"])
+@pytest.mark.parametrize("fragment", ['{"query":', "[]", '{"x":NaN}', '{"x":Infinity}'])
+async def test_aggregation_rejects_invalid_complete_tool_arguments(
+    kind: str, fragment: str
+) -> None:
+    _, error, complete = await aggregate_anthropic_sse_to_message(
+        _wire(_tool_events(kind, [fragment]))
     )
-    with pytest.raises(NativeMessagesError, match="arguments"):
-        relay.feed("content_block_stop", {"type": "content_block_stop", "index": 0})
-    assert not relay.completed
+    assert error is not None and not complete
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("close", [False, True])
+async def test_aggregation_rejects_unclosed_or_mixed_tool_input(close: bool) -> None:
+    _, error, complete = await aggregate_anthropic_sse_to_message(
+        _wire(
+            _tool_events(
+                "tool_use", ['{"query":"new"}'], initial={"query": "old"}, close=close
+            )
+        )
+    )
+    assert error is not None and not complete

--- a/tests/core/openai_responses/test_responses_from_messages_stream.py
+++ b/tests/core/openai_responses/test_responses_from_messages_stream.py
@@ -85,6 +85,19 @@ def _end(
     return events
 
 
+def test_prestart_reasoning_is_rejected_without_retaining_a_block() -> None:
+    stream = _stream()
+    with pytest.raises(NativeMessagesError):
+        _feed(
+            stream,
+            "content_block_start",
+            index=3,
+            content_block={"type": "thinking", "thinking": "unstarted"},
+        )
+    _start(stream)
+    assert _end(stream)[-1]["type"] == "response.completed"
+
+
 def test_text_thinking_and_redacted_blocks_keep_order_replay_and_exact_usage() -> None:
     stream = _stream()
     events = _start(stream)

--- a/tests/core/openai_responses/test_responses_from_messages_stream.py
+++ b/tests/core/openai_responses/test_responses_from_messages_stream.py
@@ -417,3 +417,86 @@ def test_terminal_usage_omits_missing_cache_and_provisional_thinking_details() -
         "output_tokens": 19,
         "total_tokens": 22,
     }
+
+
+@pytest.mark.parametrize(
+    "fragment", ['{"q":', "[]", '"text"', '{"q":NaN}', '{"q":1e999}']
+)
+def test_function_arguments_must_be_complete_finite_objects(fragment: str) -> None:
+    stream = _stream(tools=[{"type": "function", "name": "lookup"}])
+    _start(stream)
+    _feed(
+        stream,
+        "content_block_start",
+        index=4,
+        content_block={
+            "type": "tool_use",
+            "id": "c",
+            "name": "lookup",
+            "input": {},
+        },
+    )
+    _feed(
+        stream,
+        "content_block_delta",
+        index=4,
+        delta={
+            "type": "input_json_delta",
+            "partial_json": fragment,
+        },
+    )
+    with pytest.raises(NativeMessagesError, match="arguments"):
+        _feed(stream, "content_block_stop", index=4)
+    assert not stream.completed
+
+
+@pytest.mark.parametrize("fragment", [None, '{"q":"changed"}'])
+def test_eager_tool_input_is_preserved_without_mixing_fragmented_input(
+    fragment: str | None,
+) -> None:
+    stream = _stream(tools=[{"type": "function", "name": "lookup"}])
+    _start(stream)
+    _feed(
+        stream,
+        "content_block_start",
+        index=4,
+        content_block={
+            "type": "tool_use",
+            "id": "c",
+            "name": "lookup",
+            "input": {"q": "original"},
+        },
+    )
+    if fragment is not None:
+        _feed(
+            stream,
+            "content_block_delta",
+            index=4,
+            delta={"type": "input_json_delta", "partial_json": fragment},
+        )
+        with pytest.raises(NativeMessagesError, match="mixes"):
+            _feed(stream, "content_block_stop", index=4)
+    else:
+        events = _feed(stream, "content_block_stop", index=4) + _end(stream, "tool_use")
+        response = cast(JsonObject, events[-1]["response"])
+        output = cast(list[JsonObject], response["output"])
+        assert output[0]["arguments"] == '{"q":"original"}'
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"type": "text", "text": "partial"},
+        {"type": "thinking", "thinking": "thought", "signature": "sig"},
+        {"type": "tool_use", "id": "c", "name": "lookup", "input": {}},
+    ],
+)
+def test_native_stop_cannot_complete_an_unfinished_responses_item(
+    block: JsonObject,
+) -> None:
+    stream = _stream(tools=[{"type": "function", "name": "lookup"}])
+    _start(stream)
+    _feed(stream, "content_block_start", index=3, content_block=block)
+    with pytest.raises(NativeMessagesError, match=r"incomplete|before converted"):
+        _end(stream)
+    assert not stream.completed

--- a/tests/providers/test_anthropic_messages_transport.py
+++ b/tests/providers/test_anthropic_messages_transport.py
@@ -381,16 +381,21 @@ async def test_repeated_unauthorized_cannot_create_unbounded_auth_retry() -> Non
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("responses", [False, True])
 @pytest.mark.parametrize(
     "first",
     [
         b"event: content_block_delta\ndata: {bad}\n\n",
         _sse(*_events()[:3]),
         b'event: error\ndata: {"type":"error","error":{"type":"overloaded_error"}}\n\n',
+        pytest.param(_sse(*_events()[:3], *_events()[4:]), id="unclosed-block"),
+        pytest.param(_sse(*_events()[:4], _events()[-1]), id="missing-stop-reason"),
+        pytest.param(_sse(*_events()[-2:]), id="missing-message-start"),
     ],
 )
 async def test_early_malformed_truncated_and_overloaded_attempts_retry_invisibly(
     first: bytes,
+    responses: bool,
 ) -> None:
     calls = 0
     wires: list[Wire] = []
@@ -409,30 +414,155 @@ async def test_early_malformed_truncated_and_overloaded_attempts_retry_invisibly
             [
                 event
                 async for event in _stream(
-                    _transport(client), Endpoint(), responses=True
+                    _transport(client), Endpoint(), responses=responses
                 )
             ]
         )
     events = parse_sse_text(result)
     assert calls == 2 and all(wire.closed for wire in wires)
-    assert sum(event.event == "response.created" for event in events) == 1
+    start = "response.created" if responses else "message_start"
+    stop = "response.completed" if responses else "message_stop"
+    assert sum(event.event == start for event in events) == 1
+    assert events[-1].event == stop
     assert "final" in result and "hello" not in result
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("missing", [False, True])
+@pytest.mark.parametrize(
+    "kind,field",
+    [
+        ("message_start", "message"),
+        ("text", "text"),
+        ("text_delta", "text"),
+        ("thinking_delta", "thinking"),
+        ("tool_use", "name"),
+        ("tool_use", "id"),
+    ],
+)
+async def test_malformed_converted_fields_retry_without_leaking_first_attempt(
+    kind: str, field: str, missing: bool
+) -> None:
+    first = _events()[:3]
+    malformed: JsonObject
+    if kind == "message_start":
+        first = first[:1]
+        malformed = first[0]
+    elif kind in {"text", "tool_use"}:
+        first = first[:2]
+        malformed = (
+            {"type": "text", "text": ""}
+            if kind == "text"
+            else {"type": "tool_use", "id": "call-a", "name": "lookup", "input": {}}
+        )
+        first[1]["content_block"] = malformed
+    else:
+        first[1]["content_block"] = {
+            "type": "thinking" if kind == "thinking_delta" else "text",
+            field: "",
+        }
+        malformed = {"type": kind, field: ""}
+        first[2]["delta"] = malformed
+    if missing:
+        malformed.pop(field)
+    else:
+        malformed[field] = None
+    wires: list[Wire] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        wire = Wire([_sse(*first) if not wires else _sse(*_events("final"))])
+        wires.append(wire)
+        return httpx2.Response(
+            200, headers={"content-type": "text/event-stream"}, stream=wire
+        )
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
+        events = parse_sse_text(
+            "".join(
+                [
+                    event
+                    async for event in _stream(
+                        _transport(client), Endpoint(), responses=True
+                    )
+                ]
+            )
+        )
+    assert len(wires) == 2 and all(wire.closed for wire in wires)
+    assert sum(event.event == "response.created" for event in events) == 1
+    assert events[-1].event == "response.completed"
+    assert events[-1].data["response"]["output"][0]["content"][0]["text"] == "final"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", [False, True])
+async def test_committed_malformed_text_preserves_output_without_retry(
+    missing: bool,
+) -> None:
+    delta: JsonObject = {"type": "text_delta"}
+    if not missing:
+        delta["text"] = None
+    wire = Wire(
+        [
+            _sse(*_events("x" * 70_000)[:3]),
+            _sse({"type": "content_block_delta", "index": 0, "delta": delta}),
+        ]
+    )
+    calls = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal calls
+        calls += 1
+        return httpx2.Response(
+            200, headers={"content-type": "text/event-stream"}, stream=wire
+        )
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
+        events = parse_sse_text(
+            "".join(
+                [
+                    event
+                    async for event in _stream(
+                        _transport(client), Endpoint(), responses=True
+                    )
+                ]
+            )
+        )
+    assert calls == 1 and wire.closed
+    assert sum(event.event == "response.failed" for event in events) == 1
+    assert not any(event.event == "response.completed" for event in events)
+    response = events[-1].data["response"]
+    assert response["status"] == "failed"
+    assert response["output"][0]["status"] == "incomplete"
+    assert response["output"][0]["content"][0]["text"] == "x" * 70_000
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("responses", [False, True])
-@pytest.mark.parametrize("auth", [False, True])
+@pytest.mark.parametrize(
+    "failure,item_status",
+    [
+        pytest.param(httpx2.ReadTimeout("stalled"), "incomplete", id="timeout"),
+        pytest.param(
+            _sse({"type": "error", "error": {"type": "authentication_error"}}),
+            "incomplete",
+            id="authentication",
+        ),
+        pytest.param(_sse(*_events()[4:]), "incomplete", id="unclosed-block"),
+        pytest.param(
+            _sse(_events()[3], _events()[-1]), "completed", id="missing-stop-reason"
+        ),
+    ],
+)
 async def test_committed_failure_never_retries_or_emits_success(
     responses: bool,
-    auth: bool,
+    failure: bytes | Exception,
+    item_status: str,
 ) -> None:
     calls = 0
     wire = Wire(
         [
             _sse(*_events("x" * 70_000)[:3]),
-            _sse({"type": "error", "error": {"type": "authentication_error"}})
-            if auth
-            else httpx2.ReadTimeout("stalled"),
+            failure,
         ]
     )
 
@@ -459,7 +589,8 @@ async def test_committed_failure_never_retries_or_emits_success(
     )
     if responses:
         assert sum(event.event == "response.failed" for event in events) == 1
-        assert events[-1].data["response"]["output"][0]["status"] == "incomplete"
+        assert events[-1].data["response"]["status"] == "failed"
+        assert events[-1].data["response"]["output"][0]["status"] == item_status
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_anthropic_messages_transport.py
+++ b/tests/providers/test_anthropic_messages_transport.py
@@ -4,8 +4,9 @@ import asyncio
 import json
 from collections.abc import AsyncIterator, Callable
 
-import httpx
+import httpx2
 import pytest
+from anthropic import AsyncAnthropic
 
 from free_claude_code.application.errors import InvalidRequestError
 from free_claude_code.core.anthropic.models import MessagesRequest
@@ -18,7 +19,7 @@ from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.anthropic_messages.transport import (
     AnthropicMessagesTransport,
 )
-from free_claude_code.providers.endpoint import HttpEndpoint
+from free_claude_code.providers.endpoint import HttpEndpoint, RequestEndpoint
 from free_claude_code.providers.http import maybe_await_aclose
 from tests.providers.support import immediate_admission
 
@@ -53,19 +54,19 @@ async def test_tolerant_classifier_corrects_required_reasoning(stream_error, err
         bodies.append(body)
         if body.get("thinking", {}).get("type") == "disabled":
             if stream_error:
-                return httpx.Response(
+                return httpx2.Response(
                     200,
                     headers={"content-type": "text/event-stream"},
                     stream=Wire([_sse({"type": "error", "error": error})]),
                 )
-            return httpx.Response(400, json={"error": error})
-        return httpx.Response(
+            return httpx2.Response(400, json={"error": error})
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             stream=Wire([_sse(*_events("<severity>0</severity>"))]),
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         output = [
             event
             async for event in _transport(client).stream_messages(
@@ -114,7 +115,7 @@ async def test_precommit_sse_auth_failure_refreshes_once(
 ) -> None:
     calls = 0
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal calls
         calls += 1
         events = (
@@ -125,14 +126,14 @@ async def test_precommit_sse_auth_failure_refreshes_once(
                 {"type": "error", "error": {"type": kind}},
             ]
         )
-        return httpx.Response(
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             stream=Wire([_sse(*events)]),
         )
 
     endpoint = Endpoint()
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         result = parse_sse_text(
             "".join(
                 [
@@ -151,9 +152,9 @@ async def test_precommit_sse_auth_failure_refreshes_once(
 @pytest.mark.parametrize("separator", ["\u2028", "\u2029", "\u0085"])
 async def test_unicode_line_characters_remain_inside_sse_text(separator: str) -> None:
     text = f"left{separator}right"
-    async with httpx.AsyncClient(
-        transport=httpx.MockTransport(
-            lambda _: httpx.Response(
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(
+            lambda _: httpx2.Response(
                 200,
                 headers={"content-type": "text/event-stream"},
                 stream=Wire([_sse(*_events(text))]),
@@ -175,7 +176,7 @@ async def test_unicode_line_characters_remain_inside_sse_text(separator: str) ->
     assert output[-1].data["response"]["output"][0]["content"][0]["text"] == text
 
 
-class Wire(httpx.AsyncByteStream):
+class Wire(httpx2.AsyncByteStream):
     def __init__(
         self,
         chunks: list[bytes | Exception],
@@ -243,10 +244,17 @@ def _events(text: str = "hello", stop: str = "end_turn") -> list[JsonObject]:
 
 
 def _transport(
-    client: httpx.AsyncClient, admission: ProviderAdmissionController | None = None
+    client: httpx2.AsyncClient, admission: ProviderAdmissionController | None = None
 ) -> AnthropicMessagesTransport:
     return AnthropicMessagesTransport(
-        client=client,
+        client=AsyncAnthropic(
+            api_key="",
+            base_url="https://unused.invalid",
+            http_client=client,
+            max_retries=0,
+            timeout=3,
+        ),
+        endpoint_transport=client._transport,
         admission=admission or immediate_admission(max_attempts=2),
         provider_name="TEST",
         replay_scope="test/messages",
@@ -283,15 +291,15 @@ async def test_fragmented_messages_http_keeps_native_path_and_public_identity(
 ) -> None:
     raw = _sse(*_events())
     wire = Wire([raw[index : index + 7] for index in range(0, len(raw), 7)])
-    requests: list[httpx.Request] = []
+    requests: list[httpx2.Request] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         requests.append(request)
-        return httpx.Response(
+        return httpx2.Response(
             200, headers={"content-type": "text/event-stream"}, stream=wire
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         endpoint = Endpoint()
         endpoint.base_url = (
             "https://native.invalid/v1/" if versioned_base else "https://native.invalid"
@@ -333,19 +341,19 @@ async def test_unauthorized_refresh_uses_same_budget_and_closes_before_next_requ
     endpoint = Endpoint()
     wires: list[Wire] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         if wires:
             assert wires[0].closed
             assert request.headers["Authorization"] == "Bearer fresh"
         wire = Wire([b'{"error":"expired"}' if not wires else _sse(*_events())])
         wires.append(wire)
-        return httpx.Response(
+        return httpx2.Response(
             status if len(wires) == 1 else 200,
             headers={"content-type": "text/event-stream"},
             stream=wire,
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         assert [
             item async for item in _stream(_transport(client), endpoint, responses=True)
         ]
@@ -356,13 +364,13 @@ async def test_unauthorized_refresh_uses_same_budget_and_closes_before_next_requ
 async def test_repeated_unauthorized_cannot_create_unbounded_auth_retry() -> None:
     calls = 0
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal calls
         calls += 1
-        return httpx.Response(401, json={"error": {"type": "authentication_error"}})
+        return httpx2.Response(401, json={"error": {"type": "authentication_error"}})
 
     endpoint = Endpoint()
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         with pytest.raises(ExecutionFailure) as caught:
             _ = [
                 event
@@ -387,16 +395,16 @@ async def test_early_malformed_truncated_and_overloaded_attempts_retry_invisibly
     calls = 0
     wires: list[Wire] = []
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal calls
         calls += 1
         wire = Wire([first if calls == 1 else _sse(*_events("final"))])
         wires.append(wire)
-        return httpx.Response(
+        return httpx2.Response(
             200, headers={"content-type": "text/event-stream"}, stream=wire
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         result = "".join(
             [
                 event
@@ -424,19 +432,19 @@ async def test_committed_failure_never_retries_or_emits_success(
             _sse(*_events("x" * 70_000)[:3]),
             _sse({"type": "error", "error": {"type": "authentication_error"}})
             if auth
-            else httpx.ReadTimeout("stalled"),
+            else httpx2.ReadTimeout("stalled"),
         ]
     )
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal calls
         calls += 1
-        return httpx.Response(
+        return httpx2.Response(
             200, headers={"content-type": "text/event-stream"}, stream=wire
         )
 
     chunks: list[str] = []
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         stream = _stream(_transport(client), Endpoint(), responses=responses)
         if responses:
             chunks = [chunk async for chunk in stream]
@@ -461,10 +469,10 @@ async def test_context_window_stop_is_nonretryable_canonical_failure(
 ) -> None:
     calls = 0
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal calls
         calls += 1
-        return httpx.Response(
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             stream=Wire(
@@ -484,7 +492,7 @@ async def test_context_window_stop_is_nonretryable_canonical_failure(
             ),
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         with pytest.raises(ExecutionFailure) as caught:
             _ = [
                 event
@@ -501,12 +509,12 @@ async def test_cancelled_consumer_closes_response_before_releasing_admission() -
     first = Wire([_sse(*_events("x" * 70_000))], close_gate=gate)
     calls = 0
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         nonlocal calls
         calls += 1
         if calls == 2:
             assert request.headers["Authorization"] == "Bearer new"
-        return httpx.Response(
+        return httpx2.Response(
             200,
             headers={"content-type": "text/event-stream"},
             stream=first if calls == 1 else Wire([_sse(*_events())]),
@@ -522,7 +530,7 @@ async def test_cancelled_consumer_closes_response_before_releasing_admission() -
         max_delay=0,
         jitter=0,
     )
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as client:
         transport = _transport(client, admission)
         stream = _stream(transport, Endpoint(), responses=True)
         assert await anext(stream)
@@ -553,9 +561,9 @@ async def test_task_cancellation_closes_live_http_response() -> None:
             await asyncio.Event().wait()
 
     wire = BlockingWire([])
-    async with httpx.AsyncClient(
-        transport=httpx.MockTransport(
-            lambda _: httpx.Response(
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(
+            lambda _: httpx2.Response(
                 200, headers={"content-type": "text/event-stream"}, stream=wire
             )
         )
@@ -577,9 +585,9 @@ async def test_task_cancellation_closes_live_http_response() -> None:
 @pytest.mark.asyncio
 async def test_auth_refresh_cannot_exceed_single_attempt_budget() -> None:
     endpoint = Endpoint()
-    async with httpx.AsyncClient(
-        transport=httpx.MockTransport(
-            lambda _: httpx.Response(401, json={"error": "expired"})
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(
+            lambda _: httpx2.Response(401, json={"error": "expired"})
         )
     ) as client:
         with pytest.raises(ExecutionFailure):
@@ -596,11 +604,243 @@ async def test_auth_refresh_cannot_exceed_single_attempt_budget() -> None:
 
 @pytest.mark.asyncio
 async def test_preflight_rejects_invalid_conversion_without_request_io() -> None:
-    async with httpx.AsyncClient() as client:
+    async with httpx2.AsyncClient() as client:
         transport = _transport(client)
         with pytest.raises(InvalidRequestError):
-            transport.preflight_responses(
+            transport.stream_responses(
                 OpenAIResponsesRequest(
                     model="native", input=[{"type": "input_file", "file_id": "remote"}]
-                )
+                ),
+                endpoint_context=Endpoint(),
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("headers", "key", "auth", "api_key"),
+    [
+        ({"Authorization": "Bearer selected"}, "unused", "Bearer selected", None),
+        ({"x-API-KEY": "header-key"}, "unused", None, "header-key"),
+        ({}, "fallback-key", None, "fallback-key"),
+        ({}, None, None, None),
+    ],
+)
+async def test_sdk_endpoint_headers_override_ambient_credentials_and_cookies(
+    monkeypatch, headers, key, auth, api_key
+):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "ambient-token")
+    monkeypatch.setenv(
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "Authorization: Bearer ambient\nX-API-KEY: ambient\nCookie: ambient-cookie",
+    )
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx2.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "set-cookie": "old=account; Path=/",
+            },
+            stream=Wire([_sse(*_events())]),
+        )
+
+    class Account:
+        async def endpoint(self, *, force_refresh=False):
+            return HttpEndpoint(
+                "https://native.invalid/v1/",
+                {
+                    **headers,
+                    "ANTHROPIC-BETA": "endpoint-beta,test-beta",
+                    "Anthropic-Version": "custom-version",
+                },
+                key,
+            )
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(respond)) as http:
+        provider = _transport(http)
+        endpoint = RequestEndpoint(Account(), http._transport)
+        try:
+            for _ in range(2):
+                client = await endpoint.anthropic_client(provider._client)
+                stream = await client.messages.create(
+                    model="generic",
+                    messages=[{"role": "user", "content": "hi"}],
+                    max_tokens=32,
+                    stream=True,
+                    extra_headers=endpoint.anthropic_headers(
+                        ("test-beta", "request-beta")
+                    ),
+                )
+                async with stream:
+                    _ = [event async for event in stream]
+        finally:
+            await endpoint.aclose()
+    assert len(requests) == 2
+    for request in requests:
+        assert request.headers.get("authorization") == auth
+        assert request.headers.get("x-api-key") == api_key
+        assert "cookie" not in request.headers
+        assert (
+            request.headers["anthropic-beta"] == "endpoint-beta,test-beta,request-beta"
+        )
+        assert request.headers.get_list("anthropic-version") == ["custom-version"]
+        assert request.url.path == "/v1/messages"
+    assert provider._client.api_key == "" and provider._client.auth_token is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize(
+    ("status", "kind", "failure_kind", "expected_status"),
+    [
+        (400, "invalid_request_error", FailureKind.INVALID_REQUEST, 400),
+        (401, "authentication_error", FailureKind.AUTHENTICATION, 401),
+        (402, "billing_error", FailureKind.PERMISSION, 402),
+        (403, "permission_error", FailureKind.PERMISSION, 403),
+        (404, "not_found_error", FailureKind.INVALID_REQUEST, 404),
+        (413, "request_too_large", FailureKind.INVALID_REQUEST, 413),
+        (429, "rate_limit_error", FailureKind.RATE_LIMIT, 429),
+        (500, "api_error", FailureKind.UPSTREAM, 500),
+        (529, "overloaded_error", FailureKind.OVERLOADED, 529),
+    ],
+)
+async def test_sdk_failure_status_details_and_single_attempt_budget(
+    streamed, status, kind, failure_kind, expected_status
+):
+    requests = []
+    error = {
+        "type": kind,
+        "message": "synthetic provider detail",
+        "param": "test_parameter",
+    }
+
+    def respond(request):
+        requests.append(request)
+        if streamed:
+            return httpx2.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=Wire([_sse({"type": "error", "error": error})]),
+            )
+        return httpx2.Response(status, json={"error": error})
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(respond)) as client:
+        with pytest.raises(ExecutionFailure) as caught:
+            _ = [
+                event
+                async for event in _transport(
+                    client, immediate_admission(max_attempts=1)
+                ).stream_messages(
+                    MessagesRequest(
+                        model="generic", messages=[{"role": "user", "content": "hi"}]
+                    ),
+                    endpoint_context=Endpoint(),
+                    request_id="sdk-failure-test",
+                )
+            ]
+    assert len(requests) == 1
+    assert (
+        caught.value.kind is failure_kind
+        and caught.value.status_code == expected_status
+    )
+    assert "synthetic provider detail" in caught.value.message
+    assert "test_parameter" in caught.value.message
+    assert "Request ID: sdk-failure-test" in caught.value.message
+    assert "HTTP 200" not in caught.value.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("responses", [False, True])
+@pytest.mark.parametrize("error_type", [httpx2.ConnectError, httpx2.ConnectTimeout])
+async def test_sdk_connection_failures_use_fcc_retry_budget(responses, error_type):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        if len(requests) == 1:
+            raise error_type("synthetic connection failure", request=request)
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=Wire([_sse(*_events())]),
+        )
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(respond)) as client:
+        _ = [
+            event
+            async for event in _stream(
+                _transport(client), Endpoint(), responses=responses
+            )
+        ]
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_sdk_native_server_tools_and_extra_fields_reach_the_client():
+    events: list[JsonObject] = [
+        _events()[0],
+        {"type": "provider_progress", "ignored": True},
+        {
+            "type": "content_block_start",
+            "index": 4,
+            "content_block": {
+                "type": "server_tool_use",
+                "id": "srvtoolu_1",
+                "name": "web_search",
+                "input": {},
+                "extension": 17,
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 4,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": '{"query":"weather"}',
+            },
+        },
+        {"type": "content_block_stop", "index": 4},
+        {
+            "type": "content_block_start",
+            "index": 6,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_1",
+                "content": [],
+                "extension": "kept",
+            },
+        },
+        {"type": "content_block_stop", "index": 6},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "future_reason"},
+            "usage": {"output_tokens": 7, "vendor_usage": 13},
+        },
+        {"type": "message_stop"},
+    ]
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=Wire([_sse(*events)]),
+        )
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(respond)) as client:
+        output = parse_sse_text(
+            "".join(
+                [
+                    event
+                    async for event in _stream(
+                        _transport(client), Endpoint(), responses=False
+                    )
+                ]
+            )
+        )
+    assert len(requests) == 1
+    assert [event.data for event in output][1:] == events[2:]

--- a/tests/providers/test_anthropic_messages_transport.py
+++ b/tests/providers/test_anthropic_messages_transport.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 from collections.abc import AsyncIterator, Callable
+from types import SimpleNamespace
 
 import httpx2
 import pytest
@@ -15,6 +16,7 @@ from free_claude_code.core.failures import ExecutionFailure, FailureKind
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.openai_responses import OpenAIResponsesRequest
 from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers import stream_recovery
 from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.anthropic_messages.transport import (
     AnthropicMessagesTransport,
@@ -174,6 +176,172 @@ async def test_unicode_line_characters_remain_inside_sse_text(separator: str) ->
         )
     assert endpoint.refreshes == [False]
     assert output[-1].data["response"]["output"][0]["content"][0]["text"] == text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("responses", [False, True])
+@pytest.mark.parametrize(
+    "ping,expected",
+    [
+        (b"event: ping\n\n", "event: ping\n\n"),
+        (b"event: ping\ndata:\n\n", "event: ping\ndata:\n\n"),
+        (
+            b'event: ping\ndata: {"type":"ping"}\n\n',
+            'event: ping\ndata: {"type":"ping"}\n\n',
+        ),
+        (b"event: ping\ndata: still here\n\n", "event: ping\ndata: still here\n\n"),
+        (
+            b": alive\r\nevent: ping\r\nid: heartbeat\r\nretry: 1000\r\nextra: kept\r\ndata: \xc3\xa9\r\n\r\n",
+            ": alive\nevent: ping\nid: heartbeat\nretry: 1000\nextra: kept\ndata: é\n\n",
+        ),
+    ],
+    ids=["no-data", "empty-data", "json", "text", "metadata-and-utf8"],
+)
+async def test_native_pings_preserve_decoded_lines_before_and_after_start(
+    responses: bool, ping: bytes, expected: str
+) -> None:
+    raw = ping + _sse(_events()[0]) + ping + _sse(*_events()[1:])
+    wire = Wire([raw[index : index + 1] for index in range(len(raw))])
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(
+            lambda _: httpx2.Response(
+                200, headers={"content-type": "text/event-stream"}, stream=wire
+            )
+        )
+    ) as client:
+        chunks = [
+            chunk
+            async for chunk in _stream(
+                _transport(client), Endpoint(), responses=responses
+            )
+        ]
+    assert wire.closed
+    assert chunks.count(expected) == (0 if responses else 2)
+    assert sum("event: message_start\n" in chunk for chunk in chunks) == (
+        0 if responses else 1
+    )
+    terminal = "response.completed" if responses else "message_stop"
+    assert chunks[-1].startswith(f"event: {terminal}\n")
+
+
+@pytest.mark.asyncio
+async def test_native_pings_release_held_start_before_answer_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = [0.0]
+    monkeypatch.setattr(
+        stream_recovery, "time", SimpleNamespace(monotonic=lambda: now[0])
+    )
+    release_answer = asyncio.Event()
+    ping = b'event: ping\ndata: {"type":"ping"}\n\n'
+
+    class PausingWire(Wire):
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            yield _sse(_events()[0])
+            now[0] = 1.0
+            yield ping
+            yield ping
+            await release_answer.wait()
+            yield _sse(*_events()[1:])
+
+    wire = PausingWire([])
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(
+            lambda _: httpx2.Response(
+                200, headers={"content-type": "text/event-stream"}, stream=wire
+            )
+        )
+    ) as client:
+        stream = _stream(_transport(client), Endpoint(), responses=False)
+        try:
+            async with asyncio.timeout(2):
+                assert (await anext(stream)).startswith("event: message_start\n")
+                assert await anext(stream) == ping.decode()
+                assert await anext(stream) == ping.decode()
+            assert not release_answer.is_set() and not wire.closed
+            release_answer.set()
+            tail = [chunk async for chunk in stream]
+        finally:
+            release_answer.set()
+            await maybe_await_aclose(stream)
+    assert wire.closed
+    assert tail[-1].startswith("event: message_stop\n")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("responses", [False, True])
+async def test_sdk_reader_ignores_unknown_frames_and_supplies_missing_types(responses):
+    raw = b"event: future_event\ndata: {invalid}\n\ndata: {invalid}\n\n"
+    for event in _events():
+        payload = {key: value for key, value in event.items() if key != "type"}
+        raw += f"event: {event['type']}\ndata: {json.dumps(payload)}\n\n".encode()
+    wire = Wire([raw])
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(
+            lambda _: httpx2.Response(
+                200, headers={"content-type": "text/event-stream"}, stream=wire
+            )
+        )
+    ) as client:
+        output = "".join(
+            [
+                event
+                async for event in _stream(
+                    _transport(client), Endpoint(), responses=responses
+                )
+            ]
+        )
+    events = parse_sse_text(output)
+    assert wire.closed and "future_event" not in output
+    assert events[-1].event == ("response.completed" if responses else "message_stop")
+    assert "hello" in output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("responses", [False, True])
+@pytest.mark.parametrize("close_fails", [False, True])
+@pytest.mark.parametrize(
+    "data,kind,status",
+    [
+        (
+            b'{"type":"error","error":{"type":"overloaded_error","message":"upstream diagnostic"}}',
+            FailureKind.OVERLOADED,
+            529,
+        ),
+        (b"upstream diagnostic", FailureKind.UPSTREAM, 500),
+    ],
+    ids=["json", "text"],
+)
+async def test_sdk_stream_error_keeps_its_details_when_response_close_fails(
+    responses, close_fails, data, kind, status
+):
+    def fail_close():
+        raise RuntimeError("synthetic cleanup failure")
+
+    wire = Wire(
+        [b"event: error\ndata: " + data + b"\n\n"],
+        closed=fail_close if close_fails else None,
+    )
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(
+            lambda _: httpx2.Response(
+                200, headers={"content-type": "text/event-stream"}, stream=wire
+            )
+        )
+    ) as client:
+        with pytest.raises(ExecutionFailure) as caught:
+            _ = [
+                event
+                async for event in _stream(
+                    _transport(client, immediate_admission(max_attempts=1)),
+                    Endpoint(),
+                    responses=responses,
+                )
+            ]
+    assert wire.closed
+    assert caught.value.kind is kind and caught.value.status_code == status
+    assert "upstream diagnostic" in caught.value.message
+    assert "synthetic cleanup failure" not in caught.value.message
 
 
 class Wire(httpx2.AsyncByteStream):
@@ -391,6 +559,16 @@ async def test_repeated_unauthorized_cannot_create_unbounded_auth_retry() -> Non
         pytest.param(_sse(*_events()[:3], *_events()[4:]), id="unclosed-block"),
         pytest.param(_sse(*_events()[:4], _events()[-1]), id="missing-stop-reason"),
         pytest.param(_sse(*_events()[-2:]), id="missing-message-start"),
+        pytest.param(
+            _sse(_events()[1], _events()[3], _events()[4], _events()[0], _events()[5]),
+            id="content-before-start",
+        ),
+        pytest.param(
+            _sse(_events()[4], _events()[0], _events()[5]), id="delta-before-start"
+        ),
+        pytest.param(_sse(_events()[0], *_events()), id="duplicate-start"),
+        pytest.param(b"event: message_start\ndata: null\n\n", id="null-event"),
+        pytest.param(b"event: message_start\ndata: []\n\n", id="array-event"),
     ],
 )
 async def test_early_malformed_truncated_and_overloaded_attempts_retry_invisibly(
@@ -548,6 +726,7 @@ async def test_committed_malformed_text_preserves_output_without_retry(
             id="authentication",
         ),
         pytest.param(_sse(*_events()[4:]), "incomplete", id="unclosed-block"),
+        pytest.param(_sse(_events()[0]), "incomplete", id="duplicate-start"),
         pytest.param(
             _sse(_events()[3], _events()[-1]), "completed", id="missing-stop-reason"
         ),
@@ -584,6 +763,8 @@ async def test_committed_failure_never_retries_or_emits_success(
                     chunks.append(chunk)
     events = parse_sse_text("".join(chunks))
     assert calls == 1 and wire.closed
+    start = "response.created" if responses else "message_start"
+    assert sum(event.event == start for event in events) == 1
     assert not any(
         event.event in {"message_stop", "response.completed"} for event in events
     )

--- a/tests/providers/test_github_copilot_provider.py
+++ b/tests/providers/test_github_copilot_provider.py
@@ -6,7 +6,6 @@ from collections.abc import AsyncIterator
 from dataclasses import replace
 from pathlib import Path
 
-import httpx
 import httpx2
 import pytest
 
@@ -58,7 +57,7 @@ from tests.providers.test_openai_responses_transport import (
 )
 
 
-class Wire(httpx.AsyncByteStream, httpx2.AsyncByteStream):
+class Wire(httpx2.AsyncByteStream):
     def __init__(self, content: bytes) -> None:
         self.content = content
         self.closed = False
@@ -78,6 +77,53 @@ class Wire(httpx.AsyncByteStream, httpx2.AsyncByteStream):
         self.close_entered.set()
         await self.close_gate.wait()
         self.closed = True
+
+
+class Pool(httpx2.MockTransport):
+    close_calls = 0
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        await super().aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("egress", list(CopilotEgress))
+async def test_shutdown_waits_for_concurrent_streams_and_cancel_keeps_shared_pool_open(
+    tmp_path, egress
+):
+    harness = Harness(tmp_path, egress)
+    harness.block_read = True
+
+    async def consume():
+        return [event async for event in harness.stream(True)]
+
+    first = asyncio.create_task(consume())
+    first_wire = await harness.opened.get()
+    second = asyncio.create_task(consume())
+    second_wire = await harness.opened.get()
+    cleanup = asyncio.create_task(harness.provider.cleanup())
+    try:
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        assert first_wire.closed and not second_wire.closed
+        assert not cleanup.done() and harness.pool.close_calls == 0
+        second_wire.read_gate.set()
+        assert await second
+        await cleanup
+        assert second_wire.closed and harness.pool.close_calls == 1
+        assert harness.auth.is_connected() and harness.runtime.close_calls == 0
+    finally:
+        for wire in harness.wires:
+            wire.read_gate.set()
+            wire.close_gate.set()
+        first.cancel()
+        second.cancel()
+        await asyncio.gather(first, second, return_exceptions=True)
+        await cleanup
+        await harness.close()
+    assert all(session.closed for session in harness.runtime.sessions)
 
 
 class Runtime(FakeRuntime):
@@ -133,8 +179,9 @@ class Harness:
         self.auth = CopilotAuthManager(
             state_path=state, runtime_factory=lambda: self.runtime
         )
-        self.seen: list[httpx.Request | httpx2.Request] = []
+        self.seen: list[httpx2.Request] = []
         self.wires: list[Wire] = []
+        self.opened: asyncio.Queue[Wire] = asyncio.Queue()
         self.statuses: list[int] = []
         self.block_close = False
         self.block_read = False
@@ -166,14 +213,14 @@ class Harness:
             )
             + "\n\ndata: [DONE]\n\n"
         ).encode()
+        self.pool = Pool(self.reply)
         self.provider = GitHubCopilotProvider(
             make_provider_config(
                 None, "https://configuration.invalid", http_read_timeout=3
             ),
             auth=self.auth,
             admission=immediate_admission(max_attempts=2),
-            messages_transport=httpx.MockTransport(self.messages),
-            openai_transport=httpx2.MockTransport(self.openai),
+            transport=self.pool,
         )
 
     def wire(self, content: bytes) -> Wire:
@@ -183,27 +230,10 @@ class Harness:
         if self.block_read:
             wire.read_gate.clear()
         self.wires.append(wire)
+        self.opened.put_nowait(wire)
         return wire
 
-    def messages(self, request: httpx.Request) -> httpx.Response:
-        self.seen.append(request)
-        status = self.statuses.pop(0) if self.statuses else 200
-        if status != 200:
-            return httpx.Response(
-                status,
-                headers={"set-cookie": "inherited=secret; Path=/"},
-                json={"error": {"message": "expired"}},
-            )
-        return httpx.Response(
-            200,
-            headers={
-                "content-type": "text/event-stream",
-                "set-cookie": "inherited=secret; Path=/",
-            },
-            stream=self.wire(self.messages_content),
-        )
-
-    def openai(self, request: httpx2.Request) -> httpx2.Response:
+    def reply(self, request: httpx2.Request) -> httpx2.Response:
         self.seen.append(request)
         status = self.statuses.pop(0) if self.statuses else 200
         if status != 200:
@@ -213,7 +243,9 @@ class Harness:
                 json={"error": {"message": "expired"}},
             )
         content = (
-            self.responses_content
+            self.messages_content
+            if request.url.path.endswith("/messages")
+            else self.responses_content
             if request.url.path.endswith("/responses")
             else self.chat_content
         )

--- a/tests/providers/test_github_copilot_responses_identity.py
+++ b/tests/providers/test_github_copilot_responses_identity.py
@@ -495,10 +495,10 @@ async def test_copilot_partial_failure_output_does_not_mask_authentication_refre
     _item(recovered[2])["id"] = "recovered-tool"
 
     class RefreshHarness(Harness):
-        def openai(self, request: httpx2.Request) -> httpx2.Response:
+        def reply(self, request: httpx2.Request) -> httpx2.Response:
             if self.runtime.sessions[0].endpoint_calls > 1:
                 self.responses_content = responses_sse(*recovered).encode()
-            return super().openai(request)
+            return super().reply(request)
 
     harness = RefreshHarness(tmp_path, CopilotEgress.RESPONSES)
     harness.responses_content = responses_sse(*capture[:3], failed).encode()

--- a/tests/providers/test_history_transports.py
+++ b/tests/providers/test_history_transports.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 from copy import deepcopy
 from typing import Any
 
-import httpx
 import httpx2
 import pytest
 
@@ -138,20 +137,19 @@ async def _harness(protocol, responder=None, *, key="a", chat_provider=None):
         status, payload = (
             responder(bodies) if responder else (200, _events_for(protocol))
         )
-        module = httpx if protocol == "messages" else httpx2
         if status != 200:
-            return module.Response(status, json={"error": payload})
+            return httpx2.Response(status, json={"error": payload})
         raw = "".join(
             (f"event: {event['type']}\n" if protocol == "messages" else "")
             + f"data: {json.dumps(event)}\n\n"
             for event in payload
         )
-        return module.Response(
+        return httpx2.Response(
             200, headers={"content-type": "text/event-stream"}, content=raw
         )
 
     if protocol == "messages":
-        client = httpx.AsyncClient(transport=httpx.MockTransport(reply))
+        client = httpx2.AsyncClient(transport=httpx2.MockTransport(reply))
         provider = messages_transport(client, immediate_admission(max_attempts=5))
         endpoint = Endpoint()
         endpoint.token = key
@@ -198,7 +196,7 @@ async def _harness(protocol, responder=None, *, key="a", chat_provider=None):
     try:
         yield stream, bodies
     finally:
-        if isinstance(client, httpx.AsyncClient):
+        if isinstance(client, httpx2.AsyncClient):
             await client.aclose()
         else:
             await client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -118,6 +118,24 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "docstring-parser" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/6d/793f5cfe2cd444c43b4eeb4cb7c3cc55ebcb38929fdfe81aa1f2fced7326/anthropic-1.4.0.tar.gz", hash = "sha256:f0d017e901e48b343520b5d458f8240c283c8d850bf6d119834c622207e0a74c", size = 1150831, upload-time = "2026-09-04T22:20:31.355Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/e3/34a88f0e1e854022a352d67f72ca9baa8b952d4541315088411ba2bfbc2a/anthropic-1.4.0-py3-none-any.whl", hash = "sha256:590e85bff75b713a123b03f586d68f02266b5fdc49f70dd75f721ced93a4716c", size = 1300390, upload-time = "2026-09-04T22:20:33.078Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -458,6 +476,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -598,10 +625,11 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.1.4"
+version = "6.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "anthropic" },
     { name = "anyio" },
     { name = "discord-py" },
     { name = "fastapi", extra = ["standard"] },
@@ -651,6 +679,7 @@ dev = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'voice-local'", specifier = ">=1.14.0" },
     { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "anthropic", specifier = ">=1.4.0" },
     { name = "anyio", specifier = ">=4.12.1" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.141.1" },


### PR DESCRIPTION
## Why

FCC implements Anthropic HTTP requests and SSE decoding itself. Its reply validator also rejects valid server-tool argument updates because it expects an ordinary tool block.

## How

Use the Anthropic Python SDK for requests and SSE decoding. Read its decoded events so native keepalive pings reach clients. Use one Messages request loop for both native output and Responses conversion.

Require the message to start before collecting reply state and finish with closed content blocks and a stop reason. Preserve signed reasoning for history replay, and validate fields where FCC converts them.

Keep retries, authentication refresh, and history correction within FCC's existing attempt budget. Malformed replies can retry before an answer reaches the client; failures after that end the reply without restarting it. Share Copilot's connection pool across its three egresses.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary
- Native keepalive frames can be released before validated response output, which may prevent a later malformed upstream stream from being retried invisibly.

## T-Rex validation blocked
- The focused check confirmed that held native ping output can be released before an answer is available. The ping-then-malformed-stream reproduction did not complete the required path, so it could not establish the subsequent retry behavior.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge until keepalive frames cannot make a recoverable malformed native stream visible to the client before valid response output is available.

One blocking response-stream concern remains in the Messages transport. The three earlier stream-lifecycle threads were resolved without explanation by greptile-apps[bot]. Because the supplied Greptile bot login is greptile-apps and differs from the resolver login, greptile-apps[bot] manually resolved them without explanation.

**Files Needing Attention:** src/free_claude_code/providers/anthropic_messages/transport.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex validation was blocked because the available evidence does not establish the claimed retry behavior.
- A focused native-ping release check passed, confirming the release of held native ping output before an answer is available.
- The authored ping-then-malformed-stream reproduction exited before producing a visible ping or attempting a retry, due to a 502 execution failure caused by malformed JSON.
- Available execution records show a before-run test completed (1 passed in 0.03s) and an after-run that exited with a 502 ExecutionFailure, not exercising the visible-ping path.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fanthropic-sdk-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fanthropic-sdk-egress%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231718%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1718&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fanthropic-sdk-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fanthropic-sdk-egress%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fproviders%2Fanthropic_messages%2Ftransport.py%3A299-303%0A**Keepalives%20Disable%20Invisible%20Retries**%0A%0AA%20native%20keepalive%20ping%20can%20fill%20or%20outlast%20the%20recovery%20holdback%20before%20any%20validated%20answer%20arrives.%20The%20ping%20is%20then%20yielded%2C%20which%20commits%20the%20endpoint%20and%20exposes%20data%20from%20that%20attempt.%20If%20the%20remaining%20upstream%20stream%20is%20malformed%20or%20truncated%2C%20it%20can%20no%20longer%20retry%20invisibly%20and%20instead%20terminates%20the%20client%20stream.%20Keepalive%20frames%20should%20not%20commit%20an%20attempt%20before%20validated%20reply%20output%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1718&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Preserve native Messages pings and rejec..."](https://github.com/alishahryar1/free-claude-code/commit/fbad0cb1c15d8581d3e2b463bdcd9caf6e481548) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61480478)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->