### PR TITLE
Keep Code session prompts in conversation order

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -368,6 +368,21 @@ def test_prompt_claim_syncs_tabs_and_stop_keeps_output(
         expect(second.get_by_role("button", name="Allow", exact=True)).to_be_enabled()
         page.get_by_role("button", name="Allow", exact=True).click()
         expect(second.get_by_role("button", name="Allow", exact=True)).to_be_disabled()
+        code_control.run(
+            connection.text("turn-1", "after", "Output after approval", complete=True)
+        )
+        expect(
+            second.locator(
+                "#codeTranscript .code-prose, #codeTranscript .code-prompt h3"
+            )
+        ).to_have_text(
+            [
+                "Run a command",
+                "Output before approval",
+                "Run command?",
+                "Output after approval",
+            ]
+        )
         page.get_by_role("button", name="Stop", exact=True).click()
         page.get_by_role("textbox", name="Message", exact=True).fill("Follow up")
         expect(page.get_by_role("button", name="Send", exact=True)).to_be_enabled()
@@ -407,6 +422,10 @@ def test_old_detail_cannot_replace_streamed_output(
     expect(page.get_by_text("Old output", exact=True)).to_have_count(0)
     expect(page.get_by_role("button", name="Send", exact=True)).to_be_visible()
     expect(page.get_by_role("button", name="Allow", exact=True)).to_be_disabled()
+
+    expect(page.locator(".code-prompt")).to_have_count(1)
+    expect(page.locator(".code-run-items > .code-prompt")).to_have_count(1)
+    expect(page.locator(".code-prompt-state")).to_have_text("Resolved")
 
 
 def test_competing_tabs_keep_the_rejected_draft(
@@ -499,6 +518,87 @@ def test_rename_and_delete_sync_library_without_touching_project(
         second.close()
 
 
+def test_answered_question_keeps_its_place_across_turns_tabs_and_refresh(
+    page, context, admin_base_url, tmp_path, code_control
+):
+    url = create_session(page, admin_base_url, tmp_path)
+    send(page, "First request")
+    connection = code_control.connection()
+    code_control.run(
+        connection.text("turn-1", "before", "Before question", complete=True)
+    )
+    prompt = PromptRequest(
+        7,
+        "questions",
+        {
+            "title": "Question at this point",
+            "questions": [
+                {
+                    "id": "task",
+                    "label": "Which task?",
+                    "options": [{"label": "Search", "description": "Search docs"}],
+                    "allow_other": False,
+                    "secret": False,
+                }
+            ],
+        },
+        {},
+        "turn-1",
+        "question-without-a-native-transcript-item",
+    )
+
+    async def ask():
+        connection.requests[7] = prompt
+        await connection.sink(
+            HarnessEvent(
+                connection.generation,
+                connection.thread_id,
+                "prompt",
+                turn_id="turn-1",
+                prompt=prompt,
+            )
+        )
+
+    code_control.run(ask())
+    second = context.new_page()
+    try:
+        second.goto(url)
+        expect(second.get_by_text("Which task?", exact=True)).to_be_visible()
+        page.get_by_role("radio").check()
+        page.get_by_role("button", name="Submit answers", exact=True).click()
+        expect(second.locator(".code-prompt-state")).to_have_text("Resolved")
+        code_control.run(
+            connection.text("turn-1", "after", "After answer", complete=True)
+        )
+        code_control.run(connection.finish("turn-1"))
+        send(page, "Second request")
+        code_control.run(code_control.harness.wait_inputs(2))
+        code_control.run(
+            connection.text("turn-2", "reply", "Second reply", complete=True)
+        )
+        code_control.run(connection.finish("turn-2"))
+        expected = [
+            "First request",
+            "Before question",
+            "Which task?",
+            "After answer",
+            "Second request",
+            "Second reply",
+        ]
+        for tab in (page, second):
+            expect(tab.get_by_text("Second reply", exact=True)).to_be_visible()
+            entries = tab.locator(
+                "#codeTranscript .code-prose, #codeTranscript .code-prompt legend"
+            )
+            expect(entries).to_have_text(expected)
+            tab.reload()
+            expect(entries).to_have_text(expected)
+            expect(tab.locator(".code-prompt-state")).to_have_text("Resolved")
+        assert connection.answers == [(7, {"answers": {"task": ["Search"]}})]
+    finally:
+        second.close()
+
+
 def test_question_input_survives_streaming_and_secret_answer_is_not_stored(
     page, admin_base_url, tmp_path, code_control
 ):
@@ -547,16 +647,36 @@ def test_question_input_survives_streaming_and_secret_answer_is_not_stored(
     secret = page.get_by_label("Your answer", exact=True)
     secret.fill("private-answer")
     expect(secret).to_have_attribute("type", "password")
+    secret.focus()
+    secret.evaluate(
+        "input => { window.savedPromptInput = input; input.setSelectionRange(2, 6); }"
+    )
     code_control.run(
         connection.text("turn-1", "stream", "Still checking", complete=True)
     )
     expect(page.get_by_text("Still checking", exact=True)).to_be_visible()
     expect(secret).to_have_value("private-answer")
+    expect(secret).to_be_focused()
+    assert secret.evaluate(
+        "input => input === window.savedPromptInput && input.selectionStart === 2 && input.selectionEnd === 6"
+    )
     page.evaluate("window.codeFeed.onerror(new Event('error'))")
     expect(
         page.get_by_role("button", name="Submit answers", exact=True)
     ).to_be_enabled()
     expect(secret).to_have_value("private-answer")
+    assert secret.evaluate(
+        "input => input === window.savedPromptInput && input.selectionStart === 2 && input.selectionEnd === 6"
+    )
+    expect(
+        page.locator("#codeTranscript .code-prompt legend, #codeTranscript .code-prose")
+    ).to_have_text(
+        [
+            "Ask me a question",
+            "Which destination?",
+            "Still checking",
+        ]
+    )
     page.get_by_role("button", name="Submit answers", exact=True).click()
     expect(
         page.get_by_role("button", name="Submit answers", exact=True)
@@ -568,7 +688,8 @@ def test_question_input_survives_streaming_and_secret_answer_is_not_stored(
         code_control.service.get_detail(page.url.rsplit("/", 1)[1])
     )
     assert all(
-        "private-answer" not in value.model_dump_json() for value in detail.prompts
+        "private-answer" not in value.model_dump_json()
+        for value in (*detail.prompts, *detail.items)
     )
 
 

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -827,11 +827,7 @@
         "secondary-button session-older",
       );
       older.id = "codeOlder";
-      transcript.append(
-        older,
-        element("div", undefined, "code-items"),
-        element("div", undefined, "code-prompts"),
-      );
+      transcript.append(older, element("div", undefined, "code-items"));
       const composer = UI.composer(
         "code",
         saved(id).draft || "",
@@ -986,9 +982,6 @@
         run.error ||
         (run.status === "interrupted" ? "Turn stopped." : "This turn failed.");
     }
-    const prompts = root.querySelector(".code-prompts");
-    for (const { value: prompt } of record?.prompts.values() || [])
-      renderPrompt(prompts, prompt);
     if (bottom) transcript.scrollTop = transcript.scrollHeight;
     root.querySelector("#codeOlder").hidden = !record?.nextBefore;
     renderControls();
@@ -1069,6 +1062,11 @@
   }
 
   function renderItem(parent, item) {
+    if (item.kind === "prompt") {
+      const prompt = records.get(selected).prompts.get(item.id)?.value;
+      if (prompt) renderPrompt(parent, prompt, item.sequence);
+      return;
+    }
     let node = parent.querySelector(`[data-id="${CSS.escape(item.id)}"]`);
     if (!node) {
       node = UI.message(
@@ -1095,11 +1093,7 @@
         ),
         element("pre", "", "code-item-detail"),
       );
-      node.dataset.sequence = item.sequence;
-      const next = [...parent.children].find(
-        (child) => Number(child.dataset.sequence) > item.sequence,
-      );
-      parent.insertBefore(node, next || null);
+      insertEntry(parent, node, item.sequence);
     }
     const content = node.querySelector(".code-prose"),
       value = item.html ?? item.text;
@@ -1113,7 +1107,15 @@
     detail.hidden = !item.detail;
   }
 
-  function renderPrompt(parent, prompt) {
+  function insertEntry(parent, node, sequence) {
+    node.dataset.sequence = sequence;
+    const next = [...parent.children].find(
+      (child) => Number(child.dataset.sequence) > sequence,
+    );
+    parent.insertBefore(node, next || null);
+  }
+
+  function renderPrompt(parent, prompt, sequence) {
     let node = parent.querySelector(`[data-id="${CSS.escape(prompt.id)}"]`);
     if (!node) {
       node = element("form", undefined, "code-prompt");
@@ -1124,7 +1126,7 @@
       );
       buildPrompt(node, prompt);
       node.append(element("p", "", "code-prompt-state"));
-      parent.append(node);
+      insertEntry(parent, node, sequence);
     }
     node.querySelector(".code-prompt-state").textContent =
       prompt.error ||

--- a/src/free_claude_code/application/code_sessions/models.py
+++ b/src/free_claude_code/application/code_sessions/models.py
@@ -72,6 +72,8 @@ class CodeItem(Record):
 
 
 class CodePrompt(Record):
+    """Form and response state for the prompt CodeItem with the same session/id."""
+
     id: str
     session_id: str
     generation: str

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -285,20 +285,19 @@ class CodeService:
             active = [
                 item
                 for item in owner.items.values()
-                if owner.busy and owner.run and item.run_id == owner.run.id
+                if (owner.busy and owner.run and item.run_id == owner.run.id)
+                or (
+                    item.kind == "prompt"
+                    and owner.prompts[item.id].status in {"pending", "answering"}
+                )
             ]
             selected = sorted(
                 {item.id: item for item in [*page.items, *active]}.values(),
                 key=lambda item: (owner.runs[item.run_id].ordinal, item.sequence),
             )
-            turns = {item.native_turn_id for item in selected if item.native_turn_id}
-            if owner.run and owner.run.native_turn_id:
-                turns.add(owner.run.native_turn_id)
+            prompt_ids = {item.id for item in selected if item.kind == "prompt"}
             prompts = tuple(
-                prompt
-                for prompt in owner.prompts.values()
-                if prompt.status in {"pending", "answering"}
-                or prompt.native_turn_id in turns
+                prompt for prompt in owner.prompts.values() if prompt.id in prompt_ids
             )
             return CodeDetail(
                 owner.session,
@@ -312,7 +311,11 @@ class CodeService:
                 tuple(
                     {
                         run.id: run
-                        for run in (*page.runs, *((owner.run,) if owner.run else ()))
+                        for run in (
+                            *page.runs,
+                            *(owner.runs[item.run_id] for item in active),
+                            *((owner.run,) if owner.run else ()),
+                        )
                     }.values()
                 ),
                 tuple(
@@ -518,9 +521,7 @@ class CodeService:
                 session_id, prompt_id, response_id, connection.generation
             )
             owner.prompts[prompt_id] = claimed
-            self._publish(
-                owner, "prompt.updated", prompt=claimed.model_dump(mode="json")
-            )
+            self._publish_prompt(owner, claimed)
             self._job(self._deliver_answer(owner, claimed, response))
             return claimed
 
@@ -800,9 +801,7 @@ class CodeService:
                     resolved = current.model_copy(update={"status": "resolved"})
                     await self._persist(owner, owner.session, prompts=(resolved,))
                     owner.prompts[prompt.id] = resolved
-                    self._publish(
-                        owner, "prompt.updated", prompt=resolved.model_dump(mode="json")
-                    )
+                    self._publish_prompt(owner, resolved)
         except CodeConflictError:
             async with owner.lock:
                 current = owner.prompts.get(prompt.id)
@@ -810,9 +809,7 @@ class CodeService:
                     expired = current.model_copy(update={"status": "expired"})
                     await self._persist(owner, owner.session, prompts=(expired,))
                     owner.prompts[prompt.id] = expired
-                    self._publish(
-                        owner, "prompt.updated", prompt=expired.model_dump(mode="json")
-                    )
+                    self._publish_prompt(owner, expired)
         except Exception as exc:
             if owner.run and owner.busy:
                 await self._fail(
@@ -900,11 +897,25 @@ class CodeService:
                         form=request.form,
                         raw=request.raw,
                     )
-                    await self._persist(owner, owner.session, prompts=(prompt,))
-                    owner.prompts[prompt.id] = prompt
-                    self._publish(
-                        owner, "prompt.updated", prompt=prompt.model_dump(mode="json")
+                    if run is None:
+                        raise CodeUnavailableError(
+                            "Codex returned a prompt without a saved turn."
+                        )
+                    item = CodeItem(
+                        id=prompt.id,
+                        session_id=owner.session.id,
+                        run_id=run.id,
+                        sequence=owner.sequence + 1,
+                        kind="prompt",
+                        complete=True,
                     )
+                    await self._persist(
+                        owner, owner.session, items=(item,), prompts=(prompt,)
+                    )
+                    owner.items[item.id] = item
+                    owner.sequence = item.sequence
+                    owner.prompts[prompt.id] = prompt
+                    self._publish_prompt(owner, prompt)
                 elif event.kind == "resolved":
                     for prompt in tuple(owner.prompts.values()):
                         if (
@@ -917,11 +928,7 @@ class CodeService:
                                 owner, owner.session, prompts=(resolved,)
                             )
                             owner.prompts[prompt.id] = resolved
-                            self._publish(
-                                owner,
-                                "prompt.updated",
-                                prompt=resolved.model_dump(mode="json"),
-                            )
+                            self._publish_prompt(owner, resolved)
                 elif event.kind == "error" and matches:
                     self._publish(
                         owner,
@@ -1080,9 +1087,7 @@ class CodeService:
         await self._persist(owner, owner.session, prompts=prompts)
         for prompt in prompts:
             owner.prompts[prompt.id] = prompt
-            self._publish(
-                owner, "prompt.updated", prompt=prompt.model_dump(mode="json")
-            )
+            self._publish_prompt(owner, prompt)
 
     async def _persist(
         self,
@@ -1256,6 +1261,16 @@ class CodeService:
         for key, value in data.items():
             payload[key] = value
         self._events.publish(event, payload)
+
+    def _publish_prompt(self, owner: _Owner, prompt: CodePrompt) -> None:
+        item = owner.items[prompt.id]
+        self._publish(
+            owner,
+            "prompt.updated",
+            prompt=prompt.model_dump(mode="json"),
+            item=item.model_dump(mode="json"),
+            runs=[owner.runs[item.run_id].model_dump(mode="json")],
+        )
 
 
 def _validate_id(value: str) -> None:

--- a/src/free_claude_code/runtime/code_sessions_sqlite.py
+++ b/src/free_claude_code/runtime/code_sessions_sqlite.py
@@ -240,6 +240,12 @@ def _write_item(connection: sqlite3.Connection, item: CodeItem) -> None:
 
 
 def _write_prompt(connection: sqlite3.Connection, prompt: CodePrompt) -> None:
+    item = connection.execute(
+        "SELECT kind FROM code_items WHERE session_id = ? AND id = ?",
+        (prompt.session_id, prompt.id),
+    ).fetchone()
+    if item is None or item["kind"] != "prompt":
+        raise CodeConflictError("This prompt requires its own transcript entry.")
     row = connection.execute(
         "SELECT * FROM code_prompts WHERE session_id = ? AND id = ?",
         (prompt.session_id, prompt.id),
@@ -276,6 +282,55 @@ def _write_prompt(connection: sqlite3.Connection, prompt: CodePrompt) -> None:
         "session_id = ? AND id = ? AND status = ?",
         (prompt.session_id, prompt.id, previous.status),
     )
+
+
+def _migrate_prompt_entries(connection: sqlite3.Connection) -> None:
+    """Give old prompts a permanent run-end position without rewriting history."""
+    for row in connection.execute(
+        "SELECT * FROM code_prompts ORDER BY rowid"
+    ).fetchall():
+        prompt = _record(CodePrompt, row)
+        run = connection.execute(
+            "SELECT id FROM code_runs WHERE session_id = ? AND native_turn_id = ?",
+            (prompt.session_id, prompt.native_turn_id),
+        ).fetchone()
+        if run is None and prompt.native_item_id is not None:
+            matches = connection.execute(
+                "SELECT DISTINCT run_id AS id FROM code_items WHERE session_id = ? AND native_item_id = ?",
+                (prompt.session_id, prompt.native_item_id),
+            ).fetchall()
+            if len(matches) == 1:
+                run = matches[0]
+        if run is None:
+            run = connection.execute(
+                "SELECT id FROM code_runs WHERE session_id = ? ORDER BY ordinal DESC LIMIT 1",
+                (prompt.session_id,),
+            ).fetchone()
+        if run is None:
+            raise CodeUnavailableError("A saved prompt has no saved conversation turn.")
+        sequence = connection.execute(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 FROM code_items WHERE session_id = ?",
+            (prompt.session_id,),
+        ).fetchone()[0]
+        _insert(
+            connection,
+            "code_items",
+            CodeItem(
+                id=prompt.id,
+                session_id=prompt.session_id,
+                run_id=run["id"],
+                sequence=sequence,
+                kind="prompt",
+                complete=True,
+            ),
+        )
+    connection.execute("CREATE TABLE code_prompts_new" + _PROMPT_COLUMNS)
+    connection.execute("INSERT INTO code_prompts_new SELECT * FROM code_prompts")
+    connection.execute("DROP TABLE code_prompts")
+    connection.execute("ALTER TABLE code_prompts_new RENAME TO code_prompts")
+    if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+        raise CodeUnavailableError("Code session history has an invalid record link.")
+    connection.execute("PRAGMA user_version = 1")
 
 
 class SQLiteCodeStore:
@@ -346,6 +401,8 @@ class SQLiteCodeStore:
         connection.execute("PRAGMA journal_mode = WAL")
         connection.executescript(_SCHEMA)
         connection.execute("BEGIN IMMEDIATE")
+        if connection.execute("PRAGMA user_version").fetchone()[0] == 0:
+            _migrate_prompt_entries(connection)
         connection.execute(
             "UPDATE code_runs SET status = 'interrupted', finished_at = ?, error = ? "
             "WHERE status IN ('preparing','running','stopping')",
@@ -645,7 +702,17 @@ class SQLiteCodeStore:
         await self._run(operation)
 
 
-_SCHEMA = """
+_PROMPT_COLUMNS = """(
+    session_id TEXT NOT NULL REFERENCES code_sessions(id) ON DELETE CASCADE, id TEXT NOT NULL,
+    generation TEXT NOT NULL, request_id TEXT NOT NULL, native_turn_id TEXT, native_item_id TEXT,
+    kind TEXT NOT NULL, form TEXT NOT NULL, raw TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('pending','answering','resolved','expired')), response_id TEXT, error TEXT,
+    PRIMARY KEY(session_id,id), UNIQUE(session_id,generation,request_id), UNIQUE(session_id,response_id),
+    FOREIGN KEY(session_id,id) REFERENCES code_items(session_id,id) ON DELETE CASCADE
+)"""
+
+_SCHEMA = (
+    """
 CREATE TABLE IF NOT EXISTS code_sessions(
     id TEXT PRIMARY KEY NOT NULL, cwd TEXT NOT NULL, model TEXT NOT NULL, reasoning_effort TEXT,
     harness TEXT NOT NULL CHECK(harness = 'codex'), title TEXT NOT NULL, title_search TEXT NOT NULL,
@@ -675,12 +742,9 @@ CREATE TABLE IF NOT EXISTS code_items(
     UNIQUE(session_id,sequence), UNIQUE(session_id,native_turn_id,native_item_id)
 );
 CREATE INDEX IF NOT EXISTS code_items_run ON code_items(session_id,run_id,sequence);
-CREATE TABLE IF NOT EXISTS code_prompts(
-    session_id TEXT NOT NULL REFERENCES code_sessions(id) ON DELETE CASCADE, id TEXT NOT NULL,
-    generation TEXT NOT NULL, request_id TEXT NOT NULL, native_turn_id TEXT, native_item_id TEXT,
-    kind TEXT NOT NULL, form TEXT NOT NULL, raw TEXT NOT NULL,
-    status TEXT NOT NULL CHECK(status IN ('pending','answering','resolved','expired')), response_id TEXT, error TEXT,
-    PRIMARY KEY(session_id,id), UNIQUE(session_id,generation,request_id), UNIQUE(session_id,response_id)
-);
 CREATE TABLE IF NOT EXISTS code_deleted(id TEXT PRIMARY KEY NOT NULL);
 """
+    + "CREATE TABLE IF NOT EXISTS code_prompts"
+    + _PROMPT_COLUMNS
+    + ";"
+)

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -10,6 +10,7 @@ from free_claude_code.application.code_sessions.models import (
     CodeValidationError,
     HarnessEvent,
     ItemUpdate,
+    PromptRequest,
 )
 from free_claude_code.runtime.code_sessions_sqlite import SQLiteCodeStore
 from tests.code_sessions_support import FakeConnection, FakeHarness
@@ -872,6 +873,147 @@ async def test_two_answers_claim_one_native_prompt(code):
     await harness.answered.wait()
     assert len(connection.answers) == 1
     assert (await service.get_detail(session.id)).prompts[0].status == "resolved"
+
+
+@pytest.mark.asyncio
+async def test_prompt_arrival_has_one_durable_position_despite_repeated_native_item(
+    code,
+):
+    service, harness, directory = code
+    session = await session_for(code)
+    run = await service.send(
+        session.id, new_id(), session.revision, "Work", expected_epoch=service.epoch
+    )
+    await harness.started.wait()
+    connection = harness.connections[0]
+    await connection.text("turn-1", "shared-tool", "Before approval", kind="tool")
+    subscription, _ = await service.subscribe()
+    try:
+        for request_id in (1, 1, "1"):
+            prompt = PromptRequest(
+                request_id, "approval", {}, {}, "turn-1", "shared-tool"
+            )
+            connection.requests[request_id] = prompt
+            await connection.sink(
+                HarnessEvent(
+                    connection.generation,
+                    connection.thread_id,
+                    "prompt",
+                    turn_id="turn-1",
+                    prompt=prompt,
+                )
+            )
+        detail = await service.get_detail(session.id)
+        entries = [item for item in detail.items if item.kind == "prompt"]
+        assert len(entries) == len(detail.prompts) == 2
+        assert [item.sequence for item in entries] == [3, 4]
+        assert {item.id for item in entries} == {prompt.id for prompt in detail.prompts}
+        events = subscription.__aiter__()
+        async with asyncio.timeout(2):
+            for _ in range(2):
+                event = await anext(events)
+                if event.event == "item.updated":
+                    event = await anext(events)
+                assert event.event == "prompt.updated"
+                assert event.data["item"]["id"] == event.data["prompt"]["id"]
+                assert event.data["runs"][0]["id"] == run.id
+        for request_id in (1, "1"):
+            await connection.resolve(request_id)
+        await connection.text(
+            "turn-1", "shared-tool", "Complete output", kind="tool", complete=True
+        )
+        await connection.text("turn-1", "after", "After approvals", complete=True)
+        await connection.finish("turn-1")
+        await service.close()
+        restored = CodeService(
+            SQLiteCodeStore(directory / "code.db", directory / "code.lock"), harness
+        )
+        await restored.start()
+        try:
+            saved = await restored.get_detail(session.id)
+            assert [item for item in saved.items if item.kind == "prompt"] == entries
+            assert [item.sequence for item in saved.items] == [1, 2, 3, 4, 5]
+            assert all(prompt.status == "resolved" for prompt in saved.prompts)
+            await restored.send(
+                session.id,
+                new_id(),
+                saved.session.revision,
+                "Continue",
+                expected_epoch=restored.epoch,
+            )
+            await harness.wait_inputs(2)
+            await harness.connections[-1].finish("turn-2")
+            recovered = await restored.get_detail(session.id)
+            assert [
+                item for item in recovered.items if item.kind == "prompt"
+            ] == entries
+            assert (
+                len(
+                    [
+                        item
+                        for item in recovered.items
+                        if item.native_item_id == "shared-tool"
+                    ]
+                )
+                == 1
+            )
+        finally:
+            await restored.close()
+    finally:
+        await subscription.aclose()
+
+
+@pytest.mark.asyncio
+async def test_active_prompt_outside_page_keeps_its_entry_run_and_older_cursor(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    run = await service.send(
+        session.id, new_id(), session.revision, "Work", expected_epoch=service.epoch
+    )
+    await harness.started.wait()
+    connection = harness.connections[0]
+    await connection.prompt(0, turn_id=None)
+    prompt = (await service.get_detail(session.id)).prompts[0]
+    for index in range(55):
+        await connection.text("turn-1", str(index), f"Output {index}", complete=True)
+    await connection.finish("turn-1")
+    newest = await service.get_detail(session.id)
+    assert newest.next_before is not None
+    assert len(newest.items) == 51
+    assert newest.items[0].id == prompt.id
+    assert newest.items[0].run_id == run.id
+    assert newest.active_prompt_ids == (prompt.id,)
+    await connection.resolve(0)
+    resolved = await service.get_detail(session.id)
+    assert resolved.active_prompt_ids == () and resolved.prompts == ()
+    assert resolved.next_before == newest.next_before
+    older = await service.get_detail(session.id, before=newest.next_before)
+    assert older.prompts[0].id == prompt.id and older.prompts[0].status == "resolved"
+    by_id = {item.id: item for item in (*older.items, *newest.items)}
+    assert sorted(item.sequence for item in by_id.values()) == list(range(1, 58))
+
+
+@pytest.mark.asyncio
+async def test_prompt_during_thread_creation_has_a_saved_run_without_native_ids(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    harness.creation_gate.clear()
+    run = await service.send(
+        session.id, new_id(), session.revision, "Start", expected_epoch=service.epoch
+    )
+    await harness.creating.wait()
+    connection = harness.connections[0]
+    try:
+        await connection.prompt(0, turn_id=None)
+        detail = await service.get_detail(session.id)
+        assert detail.run.native_turn_id is None
+        assert detail.items[-1].id == detail.prompts[0].id
+        assert detail.items[-1].run_id == run.id
+        assert detail.items[-1].sequence == 2
+        assert detail.prompts[0].native_turn_id is None
+        await connection.resolve(0)
+    finally:
+        harness.creation_gate.set()
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_code_sessions_sqlite.py
+++ b/tests/runtime/test_code_sessions_sqlite.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 import sqlite3
 import threading
 import uuid
 from contextlib import closing
+from typing import Literal
 
 import pytest
 import pytest_asyncio
@@ -202,7 +204,10 @@ async def test_schema_rejects_second_active_run_and_cross_session_item_link(
 
 @pytest.mark.asyncio
 async def test_prompt_claim_and_settings_are_guarded_in_storage(store):
-    session = await _session(store)
+    session, run = await _admit(store, await _session(store))
+    await store.save_progress(
+        session, session.revision, run=run.model_copy(update={"status": "completed"})
+    )
     prompts = tuple(
         CodePrompt(
             id=str(uuid.uuid4()),
@@ -215,7 +220,18 @@ async def test_prompt_claim_and_settings_are_guarded_in_storage(store):
         )
         for request_id in (1, "1")
     )
-    await store.save_progress(session, session.revision, prompts=prompts)
+    items = tuple(
+        CodeItem(
+            id=prompt.id,
+            session_id=session.id,
+            run_id=run.id,
+            sequence=index + 2,
+            kind="prompt",
+            complete=True,
+        )
+        for index, prompt in enumerate(prompts)
+    )
+    await store.save_progress(session, session.revision, items=items, prompts=prompts)
     results = await asyncio.gather(
         *(
             store.claim_prompt(session.id, prompts[0].id, str(uuid.uuid4()), "g")
@@ -275,3 +291,228 @@ async def test_recovered_old_output_pages_with_its_original_run_outcome(store):
     assert page.next_before == (old.ordinal, 3)
     older = await store.item_page(session.id, page.next_before, 2)
     assert [item.sequence for item in older.items] == [1]
+
+
+@pytest.mark.asyncio
+async def test_prompt_entry_and_form_are_atomic_and_linked_in_storage(store, tmp_path):
+    session, run = await _admit(store, await _session(store))
+    prompt = CodePrompt(
+        id=str(uuid.uuid4()),
+        session_id=session.id,
+        generation="g",
+        request_id=1,
+        kind="questions",
+        form={},
+        raw={},
+    )
+    item = CodeItem(
+        id=prompt.id,
+        session_id=session.id,
+        run_id=run.id,
+        sequence=2,
+        kind="prompt",
+        complete=True,
+    )
+    with pytest.raises(CodeConflictError):
+        await store.save_progress(session, session.revision, prompts=(prompt,))
+    with pytest.raises(CodeConflictError):
+        await store.save_progress(
+            session,
+            session.revision,
+            items=(item.model_copy(update={"kind": "text"}),),
+            prompts=(prompt,),
+        )
+    assert await store.prompts(session.id) == ()
+    assert len(await store.items(session.id, None, None)) == 1
+    await store.save_progress(
+        session, session.revision, items=(item,), prompts=(prompt,)
+    )
+    other = await _session(store)
+    with closing(sqlite3.connect(tmp_path / "code.db")) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute("UPDATE code_prompts SET session_id = ?", (other.id,))
+        connection.rollback()
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute("UPDATE code_prompts SET id = 'unlinked'")
+    assert await store.prompts(session.id) == (prompt,)
+
+
+_LEGACY_PROMPTS = """
+CREATE TABLE code_prompts(
+    session_id TEXT NOT NULL REFERENCES code_sessions(id) ON DELETE CASCADE,
+    id TEXT NOT NULL, generation TEXT NOT NULL, request_id TEXT NOT NULL,
+    native_turn_id TEXT, native_item_id TEXT, kind TEXT NOT NULL,
+    form TEXT NOT NULL, raw TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('pending','answering','resolved','expired')),
+    response_id TEXT, error TEXT,
+    PRIMARY KEY(session_id,id), UNIQUE(session_id,generation,request_id),
+    UNIQUE(session_id,response_id)
+)
+"""
+
+
+async def _legacy_prompt_database(store, path):
+    session, old = await _admit(store, await _session(store))
+    await store.save_progress(
+        session,
+        session.revision,
+        run=old.model_copy(
+            update={
+                "native_turn_id": "old-turn",
+                "submission_started": True,
+                "status": "completed",
+            }
+        ),
+    )
+    tool = CodeItem(
+        id=str(uuid.uuid4()),
+        session_id=session.id,
+        run_id=old.id,
+        sequence=2,
+        native_turn_id="old-turn",
+        native_item_id="shared-tool",
+        kind="tool",
+        text="Original tool output",
+        complete=True,
+    )
+    await store.save_progress(session, session.revision, items=(tool,))
+    session, latest = await _admit(store, session, text="Later turn", sequence=3)
+    await store.save_progress(
+        session,
+        session.revision,
+        run=latest.model_copy(
+            update={
+                "status": "completed",
+            }
+        ),
+    )
+    original = await store.items(session.id, None, None)
+    await store.close()
+    cases: list[
+        tuple[str | None, str | None, Literal["resolved", "expired", "pending"]]
+    ] = [
+        ("old-turn", None, "resolved"),
+        (None, "shared-tool", "expired"),
+        (None, None, "resolved"),
+        ("missing-turn", None, "pending"),
+        ("old-turn", None, "expired"),
+    ]
+    prompts = tuple(
+        CodePrompt(
+            id=str(uuid.uuid4()),
+            session_id=session.id,
+            generation="g",
+            request_id=index,
+            native_turn_id=turn,
+            native_item_id=item,
+            kind="questions",
+            form={"title": "Old question"},
+            raw={"keep": "native payload"},
+            status=status,
+            response_id=str(uuid.uuid4()) if status == "resolved" else None,
+        )
+        for index, (turn, item, status) in enumerate(cases)
+    )
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute("DROP TABLE code_prompts")
+        connection.execute(_LEGACY_PROMPTS)
+        connection.execute("PRAGMA user_version = 0")
+        for prompt in prompts:
+            connection.execute(
+                "INSERT INTO code_prompts VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    session.id,
+                    prompt.id,
+                    prompt.generation,
+                    json.dumps(prompt.request_id),
+                    prompt.native_turn_id,
+                    prompt.native_item_id,
+                    prompt.kind,
+                    json.dumps(prompt.form),
+                    json.dumps(prompt.raw),
+                    prompt.status,
+                    prompt.response_id,
+                    prompt.error,
+                ),
+            )
+    return session, old, latest, original, prompts
+
+
+@pytest.mark.asyncio
+async def test_legacy_prompts_migrate_once_to_run_ends_without_resequencing(
+    store, tmp_path
+):
+    path = tmp_path / "code.db"
+    session, old, latest, original, prompts = await _legacy_prompt_database(store, path)
+    for _ in range(2):
+        await store.start()
+        items = await store.items(session.id, None, None)
+        assert [item.id for item in items] == [
+            original[0].id,
+            original[1].id,
+            prompts[0].id,
+            prompts[1].id,
+            prompts[4].id,
+            original[2].id,
+            prompts[2].id,
+            prompts[3].id,
+        ]
+        assert [item for item in items if item.kind != "prompt"] == list(original)
+        entries = {item.id: item for item in items if item.kind == "prompt"}
+        for index, prompt in enumerate(prompts):
+            entry = entries[prompt.id]
+            assert entry.run_id == (old.id if index in (0, 1, 4) else latest.id)
+            assert entry.sequence == len(original) + index + 1
+            assert entry.native_item_id is None and entry.native_turn_id is None
+            assert entry.raw == {} and entry.text == ""
+        saved = {prompt.id: prompt for prompt in await store.prompts(session.id)}
+        for prompt in prompts:
+            expected = (
+                prompt.model_copy(update={"status": "expired"})
+                if prompt.status == "pending"
+                else prompt
+            )
+            assert saved[prompt.id] == expected
+        with closing(sqlite3.connect(path)) as connection:
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+            assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+            assert any(
+                row[2] == "code_items"
+                for row in connection.execute("PRAGMA foreign_key_list(code_prompts)")
+            )
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_prompt_migration_rolls_back_items_schema_and_version(
+    store, tmp_path
+):
+    path = tmp_path / "code.db"
+    _, _, _, original, prompts = await _legacy_prompt_database(store, path)
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute(
+            "CREATE TRIGGER refuse_second_prompt BEFORE INSERT ON code_items "
+            "WHEN NEW.id = '"
+            + prompts[1].id
+            + "' BEGIN SELECT RAISE(ABORT, 'blocked'); END"
+        )
+    with pytest.raises(CodeConflictError):
+        await store.start()
+    with closing(sqlite3.connect(path)) as connection, connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 0
+        assert connection.execute("SELECT count(*) FROM code_items").fetchone()[
+            0
+        ] == len(original)
+        assert connection.execute("SELECT count(*) FROM code_prompts").fetchone()[
+            0
+        ] == len(prompts)
+        assert not any(
+            row[2] == "code_items"
+            for row in connection.execute("PRAGMA foreign_key_list(code_prompts)")
+        )
+        connection.execute("DROP TRIGGER refuse_second_prompt")
+    await store.start()
+    assert len(await store.items(prompts[0].session_id, None, None)) == len(
+        original
+    ) + len(prompts)


### PR DESCRIPTION
## Why

After a Code session answers a question or approves an action, its card stays below the conversation. Every later reply and user message appears above it. FCC also stores prompts without a transcript position, so refreshing cannot put them back where they were asked.

## How

Save each prompt together with an ordered transcript entry in one SQLite transaction. Render the card among messages and tools, reusing its form when its status changes. Include its saved position in live updates and paginated snapshots so tabs and refreshes show the same order.

Give existing cards a position at the end of their original turn. When that turn cannot be identified, place them at the end of the saved conversation. Preserve existing messages, prompt states and IDs during the upgrade.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary

- Prompt forms can be rendered after output that arrived after the prompt, leaving the transcript in the wrong conversational order.
- Prompt persistence, legacy migration rollback, prompt event context, pagination, reconnect handling, and cross-tab restoration were exercised successfully.
- The transcript-ordering issue must be fixed before merging.
</details>


<h3>Confidence Score: 4/5</h3>

Not safe to merge: an inline prompt can appear after output that was produced only after that prompt.

A reproduced functional issue affects the Code-session transcript’s ordering, while the persistence, migration, event-context, pagination, and reconnect paths were successfully exercised.

**Files Needing Attention:** src/free_claude_code/api/admin_static/code_sessions.js

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verifications for proofs 0, 2, and 3, but its local artifact references were not uploaded.
- T-Rex produced proof for a posted P1 finding; see the corresponding review comment for details.
- T-Rex executed the end-to-end prompt placement test using after-command scripts, observed the transcript order mismatch, and documented the discrepancy between actual and expected ordering for this prompt path.
- T-Rex ran the Trex prompt-linked-context test suite and confirmed multiple tests passed, while the baseline scenario showed prompts were empty before the change, illustrating the new behavior across commands and services.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcode-prompt-order%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcode-prompt-order%22.%0A%0AGreploop%20alishahryar1%2Ffree-claude-code%20PR%20%231720%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=alishahryar1%2Ffree-claude-code&pr=1720&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcode-prompt-order%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcode-prompt-order%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fapi%2Fadmin_static%2Fcode_sessions.js%3A1064-1068%0A**Prompt%20order%20is%20wrong**%0A%0AWhen%20a%20question%20prompt%20arrives%20between%20two%20streamed%20transcript%20entries%2C%20the%20changed%20renderer%20leaves%20its%20form%20after%20the%20later%20output%20instead%20of%20inserting%20it%20at%20the%20prompt%E2%80%99s%20transcript%20position.%20Users%20can%20therefore%20answer%20a%20question%20that%20visually%20appears%20to%20have%20occurred%20after%20output%20which%20was%20actually%20produced%20only%20after%20the%20answer%2C%20making%20an%20active%20Code-session%20transcript%20misleading.%20This%20must%20be%20fixed%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1720&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Keep Code session prompts in conversatio..."](https://github.com/alishahryar1/free-claude-code/commit/a7d353dce5a0f7ee81bec95d7c5195b133dea6a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61546383)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Code session management](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/code-sessions.md)
- Knowledge Base — [Code session API and persistence](https://app.greptile.com/alishahryar1/-/custom-context/knowledge-base/alishahryar1/free-claude-code/-/docs/code-session-api-and-persistence.md)

<!-- /greptile_comment -->