### PR TITLE
Add provider and permission-mode controls to Code sessions

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -9,6 +9,208 @@ from free_claude_code.application.code_sessions.models import (
     HarnessEvent,
     PromptRequest,
 )
+from free_claude_code.runtime.codex_protocol import CodexProtocol
+
+
+@pytest.mark.parametrize("width", [1440, 900, 390])
+def test_five_header_controls_fit_without_hiding_composer(
+    page, admin_base_url, tmp_path, code_control, width
+):
+    page.set_viewport_size({"width": width, "height": 900})
+    create_session(page, admin_base_url, tmp_path)
+    expect(page.locator("#codeMode")).to_be_enabled()
+    for control in (
+        "codeProvider",
+        "codeModel",
+        "codeReasoning",
+        "codeHarness",
+        "codeMode",
+    ):
+        expect(page.locator(f"#{control}")).to_be_visible()
+        box = page.locator(f"#{control}").bounding_box()
+        assert box["x"] >= 0 and box["x"] + box["width"] <= width
+    controls = page.locator(".session-controls").bounding_box()
+    composer = page.locator("#codeComposer").bounding_box()
+    assert composer["y"] >= controls["y"] + controls["height"]
+    assert composer["y"] + composer["height"] <= 900
+    page.screenshot(path=str(tmp_path / f"code-modes-{width}.png"))
+
+
+def test_header_provider_draft_and_mode_sync(
+    page, context, admin_base_url, tmp_path, code_control
+):
+    code_control.harness.configurations.update(
+        {"other/vendor/model": "other", "other/second": "second"}
+    )
+    url = create_session(page, admin_base_url, tmp_path)
+    expect(
+        page.locator(
+            ".session-controls .session-control > span, .session-controls .session-control > label"
+        )
+    ).to_have_text(["Provider", "Model", "Effort", "Harness", "Mode"])
+    expect(page.locator("#codeHarness")).to_have_value("codex")
+    expect(page.locator("#codeMode")).to_have_value("config")
+    second = context.new_page()
+    try:
+        second.goto(url)
+        page.locator("#codeComposer").fill("Keep this draft")
+        page.locator("#codeProvider").select_option("other")
+        expect(page.locator("#codeModel")).to_have_value("")
+        expect(page.locator("#codeSend")).to_be_disabled()
+        expect(second.locator("#codeProvider")).to_have_value("provider")
+        page.locator("#codeModel").fill("vendor/model")
+        page.get_by_role("option", name="vendor/model", exact=True).click()
+        expect(second.locator("#codeProvider")).to_have_value("other")
+        expect(second.locator("#codeModel")).to_have_value("vendor/model")
+        page.locator("#codeMode").select_option("auto_review")
+        expect(second.locator("#codeMode")).to_have_value("auto_review")
+        page.reload()
+        expect(page.locator("#codeMode")).to_have_value("auto_review")
+        expect(page.locator("#codeComposer")).to_have_value("Keep this draft")
+        send(page, "Use the selected mode")
+        connection = code_control.connection()
+        assert connection.modes == ["auto_review"]
+        assert connection.inputs[0][2] == "other/vendor/model"
+        for control in ("codeProvider", "codeModel", "codeReasoning", "codeMode"):
+            expect(page.locator(f"#{control}")).to_be_disabled()
+            expect(second.locator(f"#{control}")).to_be_disabled()
+    finally:
+        second.close()
+
+
+@pytest.mark.parametrize("reset", ["refresh", "conflict"])
+def test_unfinished_provider_selection_is_discarded_without_losing_message(
+    page, context, admin_base_url, tmp_path, code_control, reset
+):
+    code_control.harness.configurations["other/model"] = "other"
+    url = create_session(page, admin_base_url, tmp_path)
+    second = context.new_page()
+    try:
+        second.goto(url)
+        page.locator("#codeComposer").fill("Keep me")
+        page.locator("#codeProvider").select_option("other")
+        expect(page.locator("#codeSend")).to_be_disabled()
+        if reset == "refresh":
+            page.reload()
+        else:
+            second.locator("#codeMode").select_option("ask")
+        expect(page.locator("#codeProvider")).to_have_value("provider")
+        expect(page.locator("#codeModel")).to_have_value("model")
+        expect(page.locator("#codeSend")).to_be_enabled()
+        expect(page.locator("#codeComposer")).to_have_value("Keep me")
+    finally:
+        second.close()
+
+
+def test_provider_change_in_another_tab_closes_old_model_options(
+    page, context, admin_base_url, tmp_path, code_control
+):
+    code_control.harness.configurations["other/model"] = "other"
+    url = create_session(page, admin_base_url, tmp_path)
+    second = context.new_page()
+    try:
+        second.goto(url)
+        page.locator("#codeModel").fill("mod")
+        expect(page.get_by_role("option", name="model", exact=True)).to_be_visible()
+        second.locator("#codeProvider").select_option("other")
+        second.locator("#codeModel").fill("model")
+        second.get_by_role("option", name="model", exact=True).click()
+        expect(page.locator("#codeProvider")).to_have_value("other")
+        expect(page.get_by_role("listbox")).to_be_hidden()
+        expect(page.locator("#codeModel")).to_have_value("model")
+    finally:
+        second.close()
+
+
+def test_failed_mode_patch_restores_saved_controls_and_keeps_draft(
+    page, admin_base_url, tmp_path, code_control
+):
+    url = create_session(page, admin_base_url, tmp_path)
+    path = f"**/admin/api/code/sessions/{url.rsplit('/', 1)[1]}"
+    page.route(
+        path,
+        lambda route: (
+            route.fulfill(status=409, json={"detail": "Settings changed"})
+            if route.request.method == "PATCH"
+            else route.continue_()
+        ),
+    )
+    page.locator("#codeComposer").fill("Keep this message")
+    page.locator("#codeMode").select_option("full_access")
+    expect(page.locator("#codeNotice")).to_contain_text("Settings changed")
+    expect(page.locator("#codeMode")).to_have_value("config")
+    expect(page.locator("#codeMode")).to_be_enabled()
+    expect(page.locator("#codeComposer")).to_have_value("Keep this message")
+
+
+def test_review_updates_inline_and_unfinished_review_settles_after_restart_view(
+    page, context, admin_base_url, tmp_path, code_control
+):
+    url = create_session(page, admin_base_url, tmp_path)
+    send(page, "Review a command")
+    connection = code_control.connection()
+    protocol = CodexProtocol(connection.generation)
+    payload = {
+        "threadId": connection.thread_id,
+        "turnId": "turn-1",
+        "reviewId": "one",
+        "targetItemId": "tool",
+        "action": {
+            "type": "command",
+            "command": "echo harmless",
+            "cwd": str(tmp_path),
+            "source": "shell",
+        },
+        "review": {"status": "inProgress"},
+    }
+    second = context.new_page()
+    try:
+        second.goto(url)
+        code_control.run(
+            connection.sink(
+                protocol.notification("item/autoApprovalReview/started", payload)
+            )
+        )
+        review = page.locator('[data-kind="auto_review"]')
+        expect(review.locator("summary")).to_have_text("Auto-review: Reviewing")
+        review.locator("summary").click()
+        code_control.run(
+            connection.sink(
+                protocol.notification(
+                    "item/autoApprovalReview/completed",
+                    {
+                        **payload,
+                        "review": {
+                            "status": "approved",
+                            "rationale": "Harmless local action",
+                        },
+                    },
+                )
+            )
+        )
+        expect(review.locator("summary")).to_have_text("Auto-review: Approved")
+        expect(review.locator("details")).to_have_attribute("open", "")
+        expect(review).to_contain_text("Harmless local action")
+        expect(second.locator('[data-kind="auto_review"] summary')).to_have_text(
+            "Auto-review: Approved"
+        )
+        code_control.run(
+            connection.sink(
+                protocol.notification(
+                    "item/autoApprovalReview/started", {**payload, "reviewId": "two"}
+                )
+            )
+        )
+        code_control.run(connection.finish("turn-1", "interrupted"))
+        expect(page.locator('[data-kind="auto_review"] summary')).to_have_text(
+            ["Auto-review: Approved", "Auto-review: Result unavailable"]
+        )
+        page.reload()
+        expect(page.locator('[data-kind="auto_review"] summary')).to_have_text(
+            ["Auto-review: Approved", "Auto-review: Result unavailable"]
+        )
+    finally:
+        second.close()
 
 
 def create_session(page, base_url, directory):
@@ -971,7 +1173,7 @@ def test_off_clears_effort_when_reasoning_becomes_unavailable(
     try:
         second.goto(url)
         expect(second.locator("#codeReasoning")).to_have_value("off")
-        expect(second.locator("#codeModel")).to_have_value("provider/model")
+        expect(second.locator("#codeModel")).to_have_value("model")
         page.locator("#codeSend").click()
         connection = code_control.connection()
         assert connection.efforts == ["off"]
@@ -1218,11 +1420,9 @@ def test_model_effort_picker_syncs_tabs_and_keeps_missing_selection(
     second = context.new_page()
     try:
         second.goto(url)
-        page.get_by_role("combobox", name="Selected model", exact=True).fill(
-            "provider/other"
-        )
-        page.get_by_role("option", name="provider/other", exact=True).click()
-        expect(second.locator("#codeModel")).to_have_value("provider/other")
+        page.get_by_role("combobox", name="Selected model", exact=True).fill("other")
+        page.get_by_role("option", name="other", exact=True).click()
+        expect(second.locator("#codeModel")).to_have_value("other")
         page.locator("#codeReasoning").select_option("high")
         expect(second.locator("#codeReasoning")).to_have_value("high")
         send(page, "Use choice")
@@ -1241,7 +1441,7 @@ def test_model_effort_picker_syncs_tabs_and_keeps_missing_selection(
         else:
             page.locator("#codeSend").click()
             expect(page.locator("#codeNotice")).to_contain_text("unavailable")
-        expect(page.locator("#codeModel")).to_have_value("provider/other")
+        expect(page.locator("#codeModel")).to_have_value("other")
         expect(page.locator("#codeSend")).to_be_disabled()
         expect(page.locator("#codeComposer")).to_have_value("Preserve me")
         expect(page.locator("#codeComposerStatus")).to_contain_text("unavailable")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.1.4"
+version = "6.2.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -146,6 +146,27 @@ FCC_SMOKE_MODEL_NVIDIA_NIM_VISION=meta/llama-3.2-11b-vision-instruct \
 uv run pytest smoke/product/test_nvidia_nim_vision_product_live.py -n 0 -s --tb=short
 ```
 
+## Codex Code session modes
+
+Run the installed Codex against a local simulated provider, with disposable
+sessions and folders. This checks Ask, Auto-review, Full access, and returning
+to Use config without spending provider credits:
+
+```powershell
+$env:FCC_LIVE_SMOKE = "1"
+$env:FCC_SMOKE_TARGETS = "clients"
+uv run pytest smoke/product/test_codex_modes_product_live.py -n 0 -s -k local_e2e
+```
+
+For a real model smoke, set `FCC_SMOKE_CODEX_FREE_MODEL` to an explicitly chosen
+`open_router/<model>` reference and run the same file with
+`-k free_provider_e2e`. The test checks OpenRouter's current prompt and completion
+prices are zero and uses only that route; it never falls back to a paid model.
+The local cases do not need that setting or any provider credentials.
+
+Both runs print the installed Codex version. They require native sandbox support
+for restricted modes and never set up the sandbox or change your Codex config.
+
 ## Environment
 
 - Runtime settings use the isolated managed `~/.fcc/.env`; `FCC_ENV_FILE` is

--- a/smoke/capabilities.py
+++ b/smoke/capabilities.py
@@ -24,6 +24,21 @@ class CapabilityContract:
 
 CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
     CapabilityContract(
+        "persistence",
+        "code_session_settings_and_reviews",
+        "code_session_modes",
+        "free_claude_code.application.code_sessions.service.CodeService",
+        "Idle session settings updates and native Codex approval events",
+        "Per-turn mode selection, original permission settings, and ordered review history",
+        "Conflicting updates are rejected; native errors and interrupted reviews remain visible",
+        (
+            "tests/application/test_code_sessions.py",
+            "tests/runtime/test_code_sessions_sqlite.py",
+            "e2e/test_code_sessions.py",
+        ),
+        ("test_codex_modes_local_e2e", "test_codex_modes_free_provider_e2e"),
+    ),
+    CapabilityContract(
         "api_compatibility",
         "routes_and_probes",
         "anthropic_api_routes",

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -28,6 +28,25 @@ class FeatureCoverage:
 
 FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
     FeatureCoverage(
+        "code_session_modes",
+        "Code session permission choices reach native Codex and persist their review results",
+        (
+            "tests/application/test_code_sessions.py",
+            "tests/runtime/test_codex_app_server.py",
+            "tests/runtime/test_codex_protocol.py",
+            "tests/runtime/test_code_sessions_sqlite.py",
+            "e2e/test_code_sessions.py",
+        ),
+        (),
+        ("test_codex_modes_local_e2e", "test_codex_modes_free_provider_e2e"),
+        ("clients",),
+        (
+            "Codex executable",
+            "FCC_SMOKE_CODEX_FREE_MODEL and OpenRouter key for optional live inference",
+        ),
+        "local behavior must pass when Codex and native sandbox prerequisites are available; free inference is explicitly selected and pricing checked",
+    ),
+    FeatureCoverage(
         "zero_cost_provider_access",
         "Configured provider accepts real conversation turns",
         ("tests/api/test_dependencies.py", "tests/providers/"),

--- a/smoke/product/test_codex_modes_product_live.py
+++ b/smoke/product/test_codex_modes_product_live.py
@@ -1,0 +1,393 @@
+"""Installed Codex modes through FCC; local cases never use provider credentials."""
+
+import asyncio
+import json
+import os
+import shlex
+import shutil
+import sys
+import threading
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from free_claude_code.config.env_migrations import (
+    atomic_write_managed_config,
+    settings_env_keys,
+)
+from free_claude_code.config.provider_catalog import PROVIDER_CATALOG
+from smoke.lib.child_process import run_captured_text
+from smoke.lib.config import SmokeConfig
+from smoke.lib.e2e import SmokeServerDriver
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.clients,
+    pytest.mark.smoke_target("clients"),
+]
+
+
+def _environment(tmp_path: Path, model: str) -> tuple[dict[str, str], set[str]]:
+    binary = shutil.which("codex")
+    if not binary:
+        pytest.skip("missing_env: Codex is not installed")
+    version = run_captured_text([binary, "--version"], timeout=10, check=True)
+    print(version.stdout.strip())
+    atomic_write_managed_config(
+        {"ANTHROPIC_AUTH_TOKEN": "codex-mode-smoke", "PROXY_AUTH_ENABLED": "true"},
+        path=tmp_path / "home" / ".fcc" / ".env",
+    )
+    native_home = tmp_path / "codex-home"
+    native_home.mkdir()
+    (native_home / "config.toml").write_text(
+        'approval_policy = "on-request"\nsandbox_mode = "read-only"\n'
+        "[analytics]\nenabled = false\n",
+        encoding="utf-8",
+    )
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "USERPROFILE": str(tmp_path / "home"),
+        "CODEX_HOME": str(native_home),
+        "FCC_OPEN_BROWSER": "0",
+        "MODEL": model,
+        "MODEL_FABLE": model,
+        "MODEL_OPUS": model,
+        "MODEL_SONNET": model,
+        "MODEL_HAIKU": model,
+        "MODEL_FALLBACKS": "",
+        "MESSAGING_PLATFORM": "none",
+        "ANTHROPIC_AUTH_TOKEN": "codex-mode-smoke",
+        "PATH": os.pathsep.join(
+            [
+                str(Path(binary).parent),
+                str(Path(sys.executable).parent),
+                os.environ.get("PATH", ""),
+            ]
+        ),
+    }
+    # A fresh home excludes connected accounts and project configuration.
+    unset = set(settings_env_keys())
+    unset.update({"FCC_ENV_FILE", "OPENAI_API_KEY", "CODEX_API_KEY"})
+    return env, unset
+
+
+@contextmanager
+def _canned_provider() -> Iterator[tuple[str, dict[str, Any]]]:
+    state: dict[str, Any] = {"requests": [], "command": None, "reviews": 0}
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+        def do_GET(self) -> None:
+            body = json.dumps(
+                {"data": [{"id": "codex-mode-smoke", "object": "model"}]}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:
+            request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            state["requests"].append(request)
+            try:
+                assert self.path == "/v1/chat/completions"
+                assert request["model"] == "codex-mode-smoke"
+                schema = (
+                    request.get("response_format", {})
+                    .get("json_schema", {})
+                    .get("schema", {})
+                )
+                if "outcome" in schema.get("properties", {}):
+                    state["reviews"] += 1
+                    delta = {
+                        "content": json.dumps(
+                            {
+                                "outcome": "allow",
+                                "risk_level": "low",
+                                "user_authorization": "high",
+                                "rationale": "Disposable local smoke action",
+                            }
+                        )
+                    }
+                    reason = "stop"
+                elif state["command"]:
+                    names = [
+                        tool["function"]["name"]
+                        for tool in request["tools"]
+                        if tool["type"] == "function"
+                    ]
+                    assert "exec_command" in names, names
+                    arguments = {
+                        "cmd": state["command"],
+                        "max_output_tokens": 1000,
+                    }
+                    if state["mode"] != "full_access":
+                        arguments.update(
+                            sandbox_permissions="require_escalated",
+                            justification="Create the disposable smoke marker",
+                        )
+                    state["command"] = None
+                    delta = {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_" + uuid.uuid4().hex,
+                                "type": "function",
+                                "function": {
+                                    "name": "exec_command",
+                                    "arguments": json.dumps(arguments),
+                                },
+                            }
+                        ]
+                    }
+                    reason = "tool_calls"
+                else:
+                    delta = {"content": "FCC_MODE_SMOKE_DONE"}
+                    reason = "stop"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Connection", "close")
+                self.end_headers()
+                for payload, finish in ((delta, None), ({}, reason)):
+                    chunk = {
+                        "id": "chatcmpl-" + uuid.uuid4().hex,
+                        "object": "chat.completion.chunk",
+                        "created": 0,
+                        "model": "codex-mode-smoke",
+                        "choices": [
+                            {"index": 0, "delta": payload, "finish_reason": finish}
+                        ],
+                    }
+                    self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+                self.wfile.write(b"data: [DONE]\n\n")
+                self.wfile.flush()
+            except Exception as exc:
+                state["error"] = repr(exc)
+                self.send_error(500, "Local smoke fixture failed")
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1", state
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+async def _events(response: httpx.Response, queue: asyncio.Queue) -> None:
+    async for line in response.aiter_lines():
+        if line.startswith("data: "):
+            queue.put_nowait(json.loads(line[6:]))
+
+
+async def _exercise(
+    base_url: str,
+    workspace: Path,
+    modes: tuple[str, ...],
+    state: dict[str, Any] | None,
+    timeout_s: float,
+    session_id: str | None = None,
+) -> str:
+    workspace.mkdir(exist_ok=True)
+    async with httpx.AsyncClient(base_url=base_url, timeout=timeout_s) as client:
+        bootstrap = (await client.get("/admin/api/code/bootstrap")).json()
+        assert bootstrap["available"], bootstrap
+        path = f"/admin/api/code/sessions/{session_id or uuid.uuid4()}"
+        prepared = (
+            await client.get(path)
+            if session_id
+            else await client.post(
+                "/admin/api/code/sessions",
+                json={"session_id": path.rsplit("/", 1)[1], "cwd": str(workspace)},
+            )
+        )
+        prepared.raise_for_status()
+        session = prepared.json()["session"] if session_id else prepared.json()
+        queue = asyncio.Queue()
+        async with client.stream(
+            "GET", "/admin/api/code/events", timeout=None
+        ) as response:
+            response.raise_for_status()
+            reading = asyncio.create_task(_events(response, queue))
+            try:
+                await asyncio.wait_for(queue.get(), timeout_s)
+                for mode in modes:
+                    changed = await client.patch(
+                        path,
+                        json={"expected_revision": session["revision"], "mode": mode},
+                    )
+                    changed.raise_for_status()
+                    session = changed.json()
+                    marker = workspace.parent / f"marker-{uuid.uuid4().hex}.txt"
+                    command = (
+                        f"Set-Content -LiteralPath '{str(marker).replace(chr(39), chr(39) * 2)}' -Value smoke"
+                        if os.name == "nt"
+                        else f"printf smoke > {shlex.quote(str(marker))}"
+                    )
+                    if state is not None:
+                        state["command"] = command
+                        state["mode"] = mode
+                    escalation = (
+                        " with sandbox_permissions=require_escalated"
+                        if mode != "full_access"
+                        else ""
+                    )
+                    prompt = f"Run this exact harmless command once using exec_command{escalation}, then report its result: {command}"
+                    posted = await client.post(
+                        path + "/turns",
+                        json={
+                            "operation_id": str(uuid.uuid4()),
+                            "expected_revision": session["revision"],
+                            "expected_epoch": bootstrap["epoch"],
+                            "text": prompt,
+                        },
+                    )
+                    posted.raise_for_status()
+                    run_id = posted.json()["id"]
+                    approvals = 0
+                    async with asyncio.timeout(timeout_s):
+                        while True:
+                            event = await queue.get()
+                            if event.get("session_id") != session["id"]:
+                                continue
+                            pending = event.get("prompt")
+                            if pending and pending["status"] == "pending":
+                                assert mode in {"config", "ask"}, pending
+                                approvals += 1
+                                choices = pending["form"]["choices"]
+                                choice = next(
+                                    choice["id"]
+                                    for choice in choices
+                                    if choice["label"] in {"Allow once", "Allow"}
+                                )
+                                answer = await client.post(
+                                    path + f"/prompts/{pending['id']}/responses",
+                                    json={
+                                        "response_id": str(uuid.uuid4()),
+                                        "answer": {"choice": choice},
+                                    },
+                                )
+                                answer.raise_for_status()
+                            run = event.get("run")
+                            if (
+                                run
+                                and run["id"] == run_id
+                                and run["status"]
+                                in {"completed", "failed", "interrupted"}
+                            ):
+                                assert run["status"] == "completed", run
+                                break
+                    detail = (await client.get(path)).json()
+                    session = detail["session"]
+                    assert marker.exists(), detail
+                    assert approvals == (1 if mode in {"config", "ask"} else 0), detail
+                    reviews = [
+                        item
+                        for item in detail["items"]
+                        if item["run_id"] == run_id and item["kind"] == "auto_review"
+                    ]
+                    if mode == "auto_review":
+                        assert reviews and all(
+                            item["complete"]
+                            and item["title"] == "Auto-review: Approved"
+                            for item in reviews
+                        ), detail
+                    else:
+                        assert not reviews, detail
+                    print(
+                        f"{mode}: command completed; manual approvals={approvals}; reviews={len(reviews)}"
+                    )
+            finally:
+                reading.cancel()
+                await asyncio.gather(reading, return_exceptions=True)
+        return session["id"]
+
+
+def test_codex_modes_local_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> None:
+    env, unset = _environment(tmp_path, "lmstudio/codex-mode-smoke")
+    with _canned_provider() as (url, state):
+        env["LM_STUDIO_BASE_URL"] = url
+        driver = SmokeServerDriver(
+            smoke_config, name="codex-modes-local", env_overrides=env, env_unset=unset
+        )
+        try:
+            with driver.run() as server:
+                session_id = asyncio.run(
+                    _exercise(
+                        server.base_url,
+                        tmp_path / "workspace",
+                        ("ask", "auto_review", "full_access"),
+                        state,
+                        smoke_config.timeout_s,
+                    )
+                )
+            # A new FCC process must restore the original native settings when
+            # resuming the conversation that last ran with Full access.
+            with driver.run() as server:
+                asyncio.run(
+                    _exercise(
+                        server.base_url,
+                        tmp_path / "workspace",
+                        ("config",),
+                        state,
+                        smoke_config.timeout_s,
+                        session_id,
+                    )
+                )
+            assert "error" not in state, state.get("error")
+            assert state["reviews"] >= 1
+        finally:
+            (tmp_path / "local-requests.json").write_text(
+                json.dumps(state, indent=2), encoding="utf-8"
+            )
+
+
+def test_codex_modes_free_provider_e2e(
+    smoke_config: SmokeConfig, tmp_path: Path
+) -> None:
+    model = os.getenv("FCC_SMOKE_CODEX_FREE_MODEL")
+    if not model:
+        pytest.skip(
+            "missing_env: select FCC_SMOKE_CODEX_FREE_MODEL to run free live inference"
+        )
+    provider, name = model.split("/", 1)
+    assert provider == "open_router", (
+        "This live scenario verifies OpenRouter's published zero pricing."
+    )
+    catalog = httpx.get("https://openrouter.ai/api/v1/models", timeout=20)
+    catalog.raise_for_status()
+    entry = next(entry for entry in catalog.json()["data"] if entry["id"] == name)
+    assert all(float(entry["pricing"][key]) == 0 for key in ("prompt", "completion")), (
+        "Selected model is not free"
+    )
+    descriptor = PROVIDER_CATALOG[provider]
+    assert descriptor.credential_attr and descriptor.credential_env
+    key = getattr(smoke_config.settings, descriptor.credential_attr)
+    if not key:
+        pytest.skip("missing_env: OpenRouter key is unavailable")
+    env, unset = _environment(tmp_path, model)
+    env[descriptor.credential_env] = key
+    with SmokeServerDriver(
+        smoke_config, name="codex-modes-free", env_overrides=env, env_unset=unset
+    ).run() as server:
+        asyncio.run(
+            _exercise(
+                server.base_url,
+                tmp_path / "workspace",
+                ("auto_review",),
+                None,
+                max(smoke_config.timeout_s, 120),
+            )
+        )

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -4,6 +4,11 @@
   const modelComboboxes = new Set();
   let modelControl,
     reasoningControl,
+    providerControl,
+    harnessControl,
+    modeControl,
+    providerDraft = null,
+    harnesses = [],
     catalog = [],
     catalogLoaded = false,
     settingsPending = false;
@@ -269,6 +274,7 @@
       if (token !== syncToken || (epoch && data.epoch !== epoch)) return;
       available = data.available;
       catalog = data.models;
+      harnesses = data.harnesses;
       catalogLoaded = true;
       availabilityNotice = data.message || "";
     } catch (error) {
@@ -286,6 +292,7 @@
     if (epoch !== readyData.epoch) {
       epoch = readyData.epoch;
       records.clear();
+      providerDraft = null;
       deleted.clear();
       rendered = null;
     }
@@ -417,6 +424,7 @@
       ++viewToken;
       rendered = null;
       settingsPending = false;
+      providerDraft = null;
       notice = "";
       render();
       if (connected && epoch) {
@@ -675,6 +683,8 @@
     const id = selected,
       record = records.get(id);
     if (!ready(record) || settingsPending) return;
+    const revision = providerDraft?.revision ?? record.session.revision;
+    providerDraft = null;
     settingsPending = true;
     notice = "";
     renderControls();
@@ -682,7 +692,7 @@
       const session = await api(`${base}/sessions/${id}`, {
         method: "PATCH",
         body: JSON.stringify({
-          expected_revision: record.session.revision,
+          expected_revision: revision,
           ...changes,
         }),
       });
@@ -709,6 +719,7 @@
   }
   function selectionError(record) {
     if (!record?.session) return "";
+    if (providerDraft) return "Choose a model for the selected provider.";
     if (!catalogLoaded) return "Model list unavailable. Reconnecting…";
     const model = catalog.find((model) => model.id === record.session.model);
     if (!model) return "Selected model is unavailable. Choose another model.";
@@ -761,32 +772,105 @@
     dismissDialog();
     root.replaceChildren();
     modelComboboxes.clear();
-    modelControl = reasoningControl = null;
+    modelControl =
+      reasoningControl =
+      providerControl =
+      harnessControl =
+      modeControl =
+        null;
     const message = element("div", "", "session-notice");
     message.id = "codeNotice";
     message.setAttribute("role", "status");
     if (selected) {
       const id = selected,
         record = get(id);
-      const controls = element("div", undefined, "session-controls");
-      modelControl = UI.modelControl(
-        "codeModel",
-        record.session?.model || "",
-        () => catalog.map((model) => model.id),
-        modelComboboxes,
-        (model) => {
-          void updateSettings({ model });
+      const controls = element(
+        "div",
+        undefined,
+        "session-controls code-session-controls",
+      );
+      providerControl = UI.selectControl(
+        "codeProvider",
+        "Provider",
+        [],
+        "",
+        (provider) => {
+          const current = records.get(selected);
+          modelControl.combobox.close();
+          providerDraft =
+            provider === current.session.provider_id
+              ? null
+              : {
+                  id: selected,
+                  revision: current.session.revision,
+                  provider,
+                };
+          renderControls();
         },
       );
-      reasoningControl = UI.reasoningControl(
+      modelControl = UI.modelControl(
+        "codeModel",
+        record.session?.model_name || "",
+        () =>
+          catalog
+            .filter(
+              (model) =>
+                model.provider_id ===
+                (providerDraft?.provider ||
+                  records.get(selected)?.session?.provider_id),
+            )
+            .map((model) => model.model_name),
+        modelComboboxes,
+        (name) => {
+          const provider =
+            providerDraft?.provider ||
+            records.get(selected)?.session?.provider_id;
+          const model = catalog.find(
+            (model) =>
+              model.provider_id === provider && model.model_name === name,
+          );
+          if (model) void updateSettings({ model: model.id });
+        },
+      );
+      reasoningControl = UI.selectControl(
         "codeReasoning",
+        "Effort",
         [],
         "",
         (value) => {
           void updateSettings({ reasoning_effort: value });
         },
       );
-      controls.append(modelControl.group, reasoningControl.group);
+      harnessControl = UI.selectControl(
+        "codeHarness",
+        "Harness",
+        [],
+        "",
+        () => {},
+      );
+      modeControl = UI.selectControl(
+        "codeMode",
+        "Mode",
+        [
+          ["config", "Use config"],
+          ["ask", "Ask"],
+          ["auto_review", "Auto-review"],
+          ["full_access", "Full access"],
+        ],
+        record.session?.mode || "config",
+        (mode) => {
+          void updateSettings({ mode });
+        },
+      );
+      modeControl.select.title =
+        "Use config uses this session's original configured permission selection.";
+      controls.append(
+        providerControl.group,
+        modelControl.group,
+        reasoningControl.group,
+        harnessControl.group,
+        modeControl.group,
+      );
       const deletion = button("Delete", remove, "danger-button");
       deletion.id = "codeDelete";
       const header = UI.header(
@@ -973,7 +1057,7 @@
         );
         items.insertBefore(group, next || null);
       }
-      for (const item of source) renderItem(group.firstChild, item);
+      for (const item of source) renderItem(group.firstChild, item, run);
       const outcome = group.querySelector(".code-outcome");
       outcome.hidden = !["failed", "interrupted"].includes(run.status);
       const status = outcome.querySelector(".session-generation-status");
@@ -992,6 +1076,16 @@
     const record = records.get(selected),
       isBusy = busy(record),
       input = root.querySelector("#codeComposer");
+    if (
+      providerDraft &&
+      (providerDraft.id !== selected ||
+        providerDraft.revision !== record?.session?.revision ||
+        isBusy ||
+        pending(record))
+    ) {
+      providerDraft = null;
+      modelControl.combobox.close();
+    }
     const send = root.querySelector("#codeSend"),
       stop = root.querySelector("#codeStop");
     send.hidden = isBusy;
@@ -1026,10 +1120,36 @@
       pending(record) ||
       settingsPending ||
       !catalogLoaded;
-    modelControl.update(record?.session?.model || "", disabled);
+    const provider =
+      providerDraft?.provider || record?.session?.provider_id || "";
+    if (modelControl.group.dataset.provider !== provider) {
+      modelControl.combobox.close();
+      modelControl.group.dataset.provider = provider;
+    }
+    const providers = [...new Set(catalog.map((model) => model.provider_id))];
+    if (provider && !providers.includes(provider)) providers.push(provider);
+    providerControl.update(
+      providers.map((value) => [value, value]),
+      provider,
+    );
+    providerControl.select.disabled = disabled;
+    modelControl.update(
+      providerDraft ? "" : record?.session?.model_name || "",
+      disabled,
+    );
+    modelControl.input.placeholder = "Choose a model";
+    harnessControl.update(
+      harnesses.map((harness) => [harness.id, harness.name]),
+      record?.session?.harness || "codex",
+    );
+    harnessControl.select.disabled = true;
+    modeControl.select.value = record?.session?.mode || "config";
+    modeControl.select.disabled = disabled;
     const model = catalog.find((model) => model.id === record?.session?.model),
       effort =
-        record?.session?.reasoning_effort || model?.default_reasoning_effort || "off";
+        record?.session?.reasoning_effort ||
+        model?.default_reasoning_effort ||
+        "off";
     const options = ["off", "low", "medium", "high", "xhigh", "max"].map(
       (value) => [value, value],
     );
@@ -1061,7 +1181,7 @@
     UI.resizeComposer(input);
   }
 
-  function renderItem(parent, item) {
+  function renderItem(parent, item, run) {
     if (item.kind === "prompt") {
       const prompt = records.get(selected).prompts.get(item.id)?.value;
       if (prompt) renderPrompt(parent, prompt, item.sequence);
@@ -1095,6 +1215,14 @@
       );
       insertEntry(parent, node, item.sequence);
     }
+    const summary = node.querySelector(".code-tool > summary");
+    if (summary)
+      summary.textContent =
+        item.kind === "auto_review" &&
+        !item.complete &&
+        !activeStatuses.has(run.status)
+          ? "Auto-review: Result unavailable"
+          : item.title || "Tool";
     const content = node.querySelector(".code-prose"),
       value = item.html ?? item.text;
     if (node.codeText !== value) {

--- a/src/free_claude_code/api/admin_static/session_layout.css
+++ b/src/free_claude_code/api/admin_static/session_layout.css
@@ -268,6 +268,38 @@
   height: 38px;
 }
 
+.session-controls.code-session-controls {
+  display: grid;
+  grid-template-columns: minmax(110px, 1fr) minmax(180px, 2fr) minmax(
+      80px,
+      0.65fr
+    ) minmax(84px, 0.65fr) minmax(124px, 1fr);
+}
+.code-session-controls .session-control,
+.code-session-controls select {
+  min-width: 0;
+}
+.code-session-controls .session-model-control {
+  max-width: none;
+  grid-column: auto;
+}
+@media (max-width: 1100px) {
+  .session-controls.code-session-controls {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .code-session-controls .session-model-control {
+    grid-column: span 2;
+  }
+}
+@media (max-width: 700px) {
+  .session-controls.code-session-controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .code-session-controls .session-model-control {
+    grid-column: auto;
+  }
+}
+
 .session-notice {
   grid-area: notice;
   margin-top: 12px;

--- a/src/free_claude_code/api/admin_static/session_ui.js
+++ b/src/free_claude_code/api/admin_static/session_ui.js
@@ -117,7 +117,7 @@
       },
     };
   }
-  function reasoningControl(id, options, value, onChange) {
+  function selectControl(id, title, options, value, onChange) {
     const group = node("label", "session-control"),
       select = node("select");
     select.id = id;
@@ -133,7 +133,7 @@
     };
     update(options, value);
     select.addEventListener("change", () => onChange(select.value));
-    group.append(node("span", "", "Effort"), select);
+    group.append(node("span", "", title), select);
     return { group, select, update };
   }
   function composer(id, draft, placeholder, onInput, onSend, onStop) {
@@ -195,7 +195,7 @@
     shell,
     header,
     modelControl,
-    reasoningControl,
+    selectControl,
     composer,
     message,
     thinking,

--- a/src/free_claude_code/api/code_sessions_routes.py
+++ b/src/free_claude_code/api/code_sessions_routes.py
@@ -19,8 +19,10 @@ from free_claude_code.application.code_sessions import (
     CodeUnavailableError,
     CodeValidationError,
 )
+from free_claude_code.application.code_sessions.models import CodeMode
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.session_events import EventOverflowError
+from free_claude_code.config.model_refs import split_provider_model_ref
 from free_claude_code.core.json_types import JsonObject, JsonValue
 
 from .admin_routes import admin_page_response
@@ -51,6 +53,7 @@ class SettingsPayload(CommandPayload):
     title: str | None = Field(default=None, min_length=1, max_length=200)
     model: str | None = Field(default=None, min_length=1)
     reasoning_effort: str | None = None
+    mode: CodeMode = "config"
 
 
 class SendPayload(CommandPayload):
@@ -256,9 +259,20 @@ async def answer(
 
 
 def _session_payload(session: CodeSession) -> JsonObject:
-    return session.model_dump(
-        mode="json", exclude={"native_thread_id", "native_may_have_input", "auto_title"}
-    )
+    provider_id, model_name = split_provider_model_ref(session.model)
+    return {
+        **session.model_dump(
+            mode="json",
+            exclude={
+                "native_thread_id",
+                "native_may_have_input",
+                "native_permission_defaults",
+                "auto_title",
+            },
+        ),
+        "provider_id": provider_id,
+        "model_name": model_name,
+    }
 
 
 def _run_payload(run: CodeRun) -> JsonObject:

--- a/src/free_claude_code/application/code_sessions/models.py
+++ b/src/free_claude_code/application/code_sessions/models.py
@@ -12,6 +12,7 @@ type RunStatus = Literal[
     "preparing", "running", "stopping", "completed", "interrupted", "failed"
 ]
 ACTIVE_RUN_STATUSES = frozenset({"preparing", "running", "stopping"})
+type CodeMode = Literal["config", "ask", "auto_review", "full_access"]
 
 
 def now_ms() -> int:
@@ -27,10 +28,12 @@ class CodeSession(Record):
     cwd: str
     model: str
     reasoning_effort: str | None = None
+    mode: CodeMode = "config"
     harness: Literal["codex"] = "codex"
     title: str = "New code session"
     auto_title: bool = True
     native_thread_id: str | None = None
+    native_permission_defaults: JsonObject | None = None
     native_may_have_input: bool = False
     revision: int = 1
     status: Literal["ready", "deleting", "delete_uncertain"] = "ready"
@@ -45,6 +48,7 @@ class CodeRun(Record):
     text: str
     model: str
     reasoning_effort: str | None = None
+    mode: CodeMode = "config"
     ordinal: int = 0
     status: RunStatus = "preparing"
     submission_started: bool = False
@@ -112,6 +116,8 @@ class CodeItemPage:
 class CodeModel(Record):
     id: str
     display_name: str
+    provider_id: str
+    model_name: str
     reasoning_efforts: tuple[str, ...] = ()
     default_reasoning_effort: str | None = None
 
@@ -162,6 +168,7 @@ class HarnessEvent:
         "prompt",
         "resolved",
         "error",
+        "notice",
         "closed",
     ]
     turn_id: str | None = None
@@ -187,6 +194,7 @@ class NativeTurn:
 class NativeThread:
     id: str
     turns: tuple[NativeTurn, ...] = ()
+    permission_defaults: JsonObject | None = None
 
 
 class CodeError(Exception):

--- a/src/free_claude_code/application/code_sessions/ports.py
+++ b/src/free_claude_code/application/code_sessions/ports.py
@@ -11,6 +11,7 @@ from .models import (
     CodeDetail,
     CodeItem,
     CodeItemPage,
+    CodeMode,
     CodePage,
     CodePrompt,
     CodeRun,
@@ -35,7 +36,11 @@ class HarnessConnection(Protocol):
     async def read_thread(self, thread_id: str) -> NativeThread: ...
 
     async def start_turn(
-        self, text: str, selection: HarnessSelection, client_id: str
+        self,
+        text: str,
+        selection: HarnessSelection,
+        client_id: str,
+        permission_defaults: JsonObject,
     ) -> str: ...
 
     async def interrupt(self, turn_id: str) -> None: ...
@@ -53,6 +58,9 @@ class HarnessConnection(Protocol):
 
 class HarnessSelection(Protocol):
     @property
+    def mode(self) -> CodeMode: ...
+
+    @property
     def model(self) -> str: ...
 
     @property
@@ -69,7 +77,9 @@ class HarnessFactory(Protocol):
 
     def catalog(self) -> CodeCatalog: ...
 
-    def prepare(self, model: str, reasoning_effort: str | None) -> HarnessSelection: ...
+    def prepare(
+        self, model: str, reasoning_effort: str | None, mode: CodeMode
+    ) -> HarnessSelection: ...
 
     async def open_history(self, cwd: str, sink: EventSink) -> HarnessConnection: ...
 

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -5,6 +5,7 @@ import uuid
 from collections.abc import Coroutine, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import get_args
 
 from loguru import logger
 
@@ -20,6 +21,7 @@ from .models import (
     CodeConflictError,
     CodeDetail,
     CodeItem,
+    CodeMode,
     CodeNotFoundError,
     CodePage,
     CodePrompt,
@@ -333,9 +335,14 @@ class CodeService:
     async def _update_settings(
         self, session_id: str, revision: int, changes: JsonObject
     ) -> CodeSession:
-        if not changes or changes.keys() - {"title", "model", "reasoning_effort"}:
+        if not changes or changes.keys() - {
+            "title",
+            "model",
+            "reasoning_effort",
+            "mode",
+        }:
             raise CodeValidationError(
-                "Choose a title, model or reasoning effort to update."
+                "Choose a title, model, effort or mode to update."
             )
         owner = await self._owner(session_id)
         async with owner.lock:
@@ -348,11 +355,17 @@ class CodeService:
                         "Enter a title of at most 200 characters."
                     )
                 updates.update(title=title.strip(), auto_title=False)
+            if changes.keys() & {"model", "reasoning_effort", "mode"} and (
+                owner.busy or owner.pending
+            ):
+                raise CodeConflictError(
+                    "Finish this turn and its prompts before changing settings."
+                )
+            if "mode" in changes and changes["mode"] not in get_args(
+                CodeMode.__value__
+            ):
+                raise CodeValidationError("Choose an available permission mode.")
             if changes.keys() & {"model", "reasoning_effort"}:
-                if owner.busy or owner.pending:
-                    raise CodeConflictError(
-                        "Finish this turn and its prompts before changing settings."
-                    )
                 model = changes.get("model", owner.session.model)
                 entry = next(
                     (entry for entry in self.catalog().models if entry.id == model),
@@ -426,7 +439,7 @@ class CodeService:
                     "This session is busy. Your draft has been kept."
                 )
             selection = self._harness.prepare(
-                owner.session.model, owner.session.reasoning_effort
+                owner.session.model, owner.session.reasoning_effort, owner.session.mode
             )
             run = CodeRun(
                 id=operation_id,
@@ -434,6 +447,7 @@ class CodeService:
                 text=text,
                 model=selection.model,
                 reasoning_effort=selection.reasoning_effort,
+                mode=selection.mode,
             )
             title = (
                 " ".join(text.split())[:80]
@@ -601,7 +615,12 @@ class CodeService:
             async with owner.lock:
                 if native is not None:
                     session = owner.session.model_copy(
-                        update={"native_thread_id": native.id}
+                        update={
+                            "native_thread_id": native.id,
+                            "native_permission_defaults": owner.session.native_permission_defaults
+                            if owner.session.native_permission_defaults is not None
+                            else native.permission_defaults,
+                        }
                     )
                     await self._persist(owner, session)
                     owner.session = session
@@ -613,13 +632,18 @@ class CodeService:
                 if run.stop_requested or not self._accepting:
                     await self._finish_locked(owner, "interrupted")
                     return
+                defaults = owner.session.native_permission_defaults
+                if defaults is None:
+                    raise CodeUnavailableError(
+                        "The harness did not return its permission settings. Your input was not sent."
+                    )
                 run = run.model_copy(update={"submission_started": True})
                 session = owner.session.model_copy(
                     update={"native_may_have_input": True}
                 )
                 await self._persist(owner, session, run=run)
                 owner.session, owner.run = session, run
-            turn_id = await connection.start_turn(run.text, selection, run.id)
+            turn_id = await connection.start_turn(run.text, selection, run.id, defaults)
             async with owner.lock:
                 if owner.run is None or owner.run.id != run_id or not owner.busy:
                     return
@@ -935,6 +959,24 @@ class CodeService:
                         "run.notice",
                         message=event.message or "Codex reported an error.",
                         will_retry=event.will_retry,
+                    )
+                elif event.kind == "notice" and event.message and run is not None:
+                    await self._flush_locked(owner)
+                    item = CodeItem(
+                        id=str(uuid.uuid4()),
+                        session_id=owner.session.id,
+                        sequence=owner.sequence + 1,
+                        run_id=run.id,
+                        kind="notice",
+                        title="Notice",
+                        text=event.message,
+                        complete=True,
+                    )
+                    await self._persist(owner, owner.session, items=(item,))
+                    owner.items[item.id] = item
+                    owner.sequence = item.sequence
+                    self._publish(
+                        owner, "item.updated", item=item.model_dump(mode="json")
                     )
                 elif event.kind == "closed":
                     owner.connection = None

--- a/src/free_claude_code/runtime/code_sessions_sqlite.py
+++ b/src/free_claude_code/runtime/code_sessions_sqlite.py
@@ -25,7 +25,9 @@ from free_claude_code.application.code_sessions.models import (
 )
 from free_claude_code.core.interprocess_lock import InterprocessFileLock
 
-_JSON_FIELDS = frozenset({"raw", "form", "error_details", "request_id"})
+_JSON_FIELDS = frozenset(
+    {"raw", "form", "error_details", "request_id", "native_permission_defaults"}
+)
 _RUN_TRANSITIONS = {
     "preparing": {
         "preparing",
@@ -52,7 +54,8 @@ _PROMPT_TRANSITIONS = {
 def _values(record: Record) -> dict[str, object]:
     values = record.model_dump()
     for key in values.keys() & _JSON_FIELDS:
-        values[key] = json.dumps(values[key], sort_keys=True, separators=(",", ":"))
+        if values[key] is not None:
+            values[key] = json.dumps(values[key], sort_keys=True, separators=(",", ":"))
     if isinstance(record, CodeSession):
         values.update(
             title_search=record.title.casefold(), cwd_search=record.cwd.casefold()
@@ -63,7 +66,8 @@ def _values(record: Record) -> dict[str, object]:
 def _record[T: Record](model: type[T], row: sqlite3.Row) -> T:
     values = {key: row[key] for key in model.model_fields}
     for key in values.keys() & _JSON_FIELDS:
-        values[key] = json.loads(values[key])
+        if values[key] is not None:
+            values[key] = json.loads(values[key])
     return model.model_validate(values)
 
 
@@ -128,6 +132,12 @@ def _write_session(
         raise CodeConflictError(
             "This session changed. Refresh its state and try again."
         )
+    if (
+        not settings
+        and current.native_permission_defaults is not None
+        and session.native_permission_defaults != current.native_permission_defaults
+    ):
+        raise CodeConflictError("The original permission settings cannot be replaced.")
     fields = (
         {
             "title",
@@ -135,12 +145,14 @@ def _write_session(
             "auto_title",
             "model",
             "reasoning_effort",
+            "mode",
             "revision",
             "updated_at",
         }
         if settings
         else {
             "native_thread_id",
+            "native_permission_defaults",
             "native_may_have_input",
             "revision",
             "updated_at",
@@ -178,7 +190,7 @@ def _write_run(connection: sqlite3.Connection, run: CodeRun) -> None:
         or (previous.submission_started and not run.submission_started)
         or any(
             getattr(previous, key) != getattr(run, key)
-            for key in ("ordinal", "text", "model", "reasoning_effort")
+            for key in ("ordinal", "text", "model", "reasoning_effort", "mode")
         )
         or (
             previous.native_turn_id is not None
@@ -194,6 +206,7 @@ def _write_run(connection: sqlite3.Connection, run: CodeRun) -> None:
         "text",
         "model",
         "reasoning_effort",
+        "mode",
         "created_at",
     ):
         values.pop(key)
@@ -403,6 +416,18 @@ class SQLiteCodeStore:
         connection.execute("BEGIN IMMEDIATE")
         if connection.execute("PRAGMA user_version").fetchone()[0] == 0:
             _migrate_prompt_entries(connection)
+        if connection.execute("PRAGMA user_version").fetchone()[0] == 1:
+            for table in ("code_sessions", "code_runs"):
+                connection.execute(
+                    f"ALTER TABLE {table} ADD COLUMN mode TEXT NOT NULL DEFAULT 'config' "
+                    "CHECK(mode IN ('config','ask','auto_review','full_access'))"
+                )
+            connection.execute(
+                "ALTER TABLE code_sessions ADD COLUMN native_permission_defaults TEXT "
+                "CHECK(native_permission_defaults IS NULL OR "
+                "(json_valid(native_permission_defaults) AND json_type(native_permission_defaults) = 'object'))"
+            )
+            connection.execute("PRAGMA user_version = 2")
         connection.execute(
             "UPDATE code_runs SET status = 'interrupted', finished_at = ?, error = ? "
             "WHERE status IN ('preparing','running','stopping')",
@@ -581,9 +606,10 @@ class SQLiteCodeStore:
             previous = _session(connection, session.id)
             if previous.status != "ready":
                 raise CodeConflictError("This session is being deleted.")
-            if (previous.model, previous.reasoning_effort) != (
+            if (previous.model, previous.reasoning_effort, previous.mode) != (
                 session.model,
                 session.reasoning_effort,
+                session.mode,
             ):
                 _idle(connection, session.id)
             _write_session(connection, session, expected_revision, settings=True)
@@ -611,6 +637,7 @@ class SQLiteCodeStore:
             if (
                 previous.status != "ready"
                 or previous.model != run.model
+                or previous.mode != run.mode
                 or run.session_id != session.id
             ):
                 raise CodeConflictError(

--- a/src/free_claude_code/runtime/codex_app_server.py
+++ b/src/free_claude_code/runtime/codex_app_server.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, replace
 from free_claude_code.application.code_sessions.models import (
     CodeCatalog,
     CodeConflictError,
+    CodeMode,
     CodeModel,
     CodeUnavailableError,
     CodeValidationError,
@@ -29,6 +30,7 @@ from free_claude_code.cli.launchers.codex_model_catalog import build_codex_model
 from free_claude_code.cli.launchers.resources import LaunchResources
 from free_claude_code.cli.launchers.runner import LaunchContext
 from free_claude_code.cli.process_registry import register_pid, unregister_pid
+from free_claude_code.config.model_refs import split_provider_model_ref
 from free_claude_code.config.server_urls import local_proxy_root_url
 from free_claude_code.core.json_types import JsonObject
 from free_claude_code.core.version import package_version
@@ -135,7 +137,7 @@ class CodexAppServer:
         response = await self.rpc(
             "thread/start", {"cwd": self._cwd, "modelProvider": "fcc"}
         )
-        native = self._protocol.history(response)
+        native = self._thread_with_permissions(response)
         self.thread_id = native.id
         return native
 
@@ -144,7 +146,7 @@ class CodexAppServer:
             "thread/resume",
             {"threadId": thread_id, "cwd": self._cwd, "modelProvider": "fcc"},
         )
-        native = self._protocol.history(response)
+        native = self._thread_with_permissions(response)
         self.thread_id = native.id
         return native
 
@@ -153,8 +155,25 @@ class CodexAppServer:
             await self.rpc("thread/read", {"threadId": thread_id, "includeTurns": True})
         )
 
+    def _thread_with_permissions(self, response: JsonObject) -> NativeThread:
+        defaults = {
+            key: response.get(key)
+            for key in (
+                "approvalPolicy",
+                "approvalsReviewer",
+                "activePermissionProfile",
+                "sandbox",
+            )
+        }
+        _permission_settings("config", defaults)
+        return replace(self._protocol.history(response), permission_defaults=defaults)
+
     async def start_turn(
-        self, text: str, selection: HarnessSelection, client_id: str
+        self,
+        text: str,
+        selection: HarnessSelection,
+        client_id: str,
+        permission_defaults: JsonObject,
     ) -> str:
         model = self._model_slugs.get(selection.model)
         if not self.thread_id or model is None:
@@ -166,6 +185,7 @@ class CodexAppServer:
             "input": [{"type": "text", "text": text}],
             "clientUserMessageId": client_id,
             "model": model,
+            **_permission_settings(selection.mode, permission_defaults),
         }
         if self._reasoning.get(selection.model, True):
             off = selection.reasoning_effort == "off"
@@ -500,6 +520,7 @@ class _CodexSelection:
     configuration_key: str
     fingerprints: dict[str, str]
     reasoning_effort: str | None
+    mode: CodeMode
 
     async def open(self, cwd: str, sink: EventSink) -> CodexAppServer:
         resources = ExitStack()
@@ -565,7 +586,9 @@ class CodexHarnessFactory:
             ),
         )
 
-    def prepare(self, model: str, reasoning_effort: str | None) -> _CodexSelection:
+    def prepare(
+        self, model: str, reasoning_effort: str | None, mode: CodeMode
+    ) -> _CodexSelection:
         binary = self._binary or shutil.which("codex")
         if binary is None:
             raise CodeUnavailableError("Codex is not installed. " + SPEC.install_hint)
@@ -611,7 +634,7 @@ class CodexHarnessFactory:
             models,
         )
         return _CodexSelection(
-            context, model, fingerprints[model], fingerprints, effort
+            context, model, fingerprints[model], fingerprints, effort, mode
         )
 
     async def open_history(self, cwd: str, sink: EventSink) -> CodexAppServer:
@@ -632,6 +655,7 @@ class CodexHarnessFactory:
 
 
 def _model_option(model: str, entry: JsonObject) -> CodeModel:
+    provider_id, model_name = split_provider_model_ref(model)
     efforts = tuple(
         string_value(object_value(level).get("effort"))
         for level in array_value(entry.get("supported_reasoning_levels"))
@@ -639,6 +663,8 @@ def _model_option(model: str, entry: JsonObject) -> CodeModel:
     return CodeModel(
         id=model,
         display_name=string_value(entry.get("display_name")) or model,
+        provider_id=provider_id,
+        model_name=model_name,
         reasoning_efforts=tuple(
             "off" if effort == "none" else effort for effort in efforts
         )
@@ -646,6 +672,37 @@ def _model_option(model: str, entry: JsonObject) -> CodeModel:
         default_reasoning_effort=string_value(entry.get("default_reasoning_level"))
         or "off",
     )
+
+
+def _permission_settings(mode: CodeMode, defaults: JsonObject) -> JsonObject:
+    if mode != "config":
+        return {
+            "approvalPolicy": "never" if mode == "full_access" else "on-request",
+            "approvalsReviewer": "auto_review" if mode == "auto_review" else "user",
+            "permissions": ":danger-full-access"
+            if mode == "full_access"
+            else ":workspace",
+        }
+    policy = defaults.get("approvalPolicy")
+    reviewer = string_value(defaults.get("approvalsReviewer"))
+    profile = string_value(
+        object_value(defaults.get("activePermissionProfile")).get("id")
+    )
+    sandbox = object_value(defaults.get("sandbox"))
+    if (
+        not isinstance(policy, str | dict)
+        or not policy
+        or not reviewer
+        or (not profile and not sandbox.get("type"))
+    ):
+        raise CodeUnavailableError(
+            "Codex did not return complete native permission settings. Your input was not sent."
+        )
+    return {
+        "approvalPolicy": policy,
+        "approvalsReviewer": reviewer,
+        **({"permissions": profile} if profile else {"sandboxPolicy": sandbox}),
+    }
 
 
 def _fingerprint(entry: JsonObject) -> str:

--- a/src/free_claude_code/runtime/codex_protocol.py
+++ b/src/free_claude_code/runtime/codex_protocol.py
@@ -87,8 +87,47 @@ class CodexProtocol:
                     self.generation, thread_id, "resolved", request_id=request_id
                 )
             return None
+        if method == "guardianWarning" and thread_id:
+            return HarnessEvent(
+                self.generation,
+                thread_id,
+                "notice",
+                message=string_value(params.get("message")),
+            )
         if not thread_id or not turn_id:
             return None
+        if method in {
+            "item/autoApprovalReview/started",
+            "item/autoApprovalReview/completed",
+        }:
+            review_id = string_value(params.get("reviewId"))
+            if not review_id:
+                return None
+            review = object_value(params.get("review"))
+            status = string_value(review.get("status"))
+            label = {
+                "inProgress": "Reviewing",
+                "approved": "Approved",
+                "denied": "Denied",
+                "timedOut": "Timed out",
+                "aborted": "Aborted",
+            }.get(status, status)
+            return HarnessEvent(
+                self.generation,
+                thread_id,
+                "item",
+                turn_id=turn_id,
+                item=ItemUpdate(
+                    turn_id,
+                    f"auto-review:{review_id}",
+                    "auto_review",
+                    title=f"Auto-review: {label}",
+                    text=string_value(review.get("rationale")),
+                    detail=pretty({"action": params.get("action"), "review": review}),
+                    raw=dict(params),
+                    complete=method == "item/autoApprovalReview/completed",
+                ),
+            )
         raw = object_value(params.get("item"))
         item_id = string_value(params.get("itemId")) or string_value(raw.get("id"))
         if not item_id:

--- a/tests/api/test_code_sessions_routes.py
+++ b/tests/api/test_code_sessions_routes.py
@@ -41,6 +41,51 @@ async def create_session(code_api):
 
 
 @pytest.mark.asyncio
+async def test_mode_is_saved_but_native_defaults_stay_private(code_api):
+    client, code, harness, _, _ = code_api
+    harness.configurations["other/vendor/model"] = "other"
+    session = await create_session(code_api)
+    path = f"/admin/api/code/sessions/{session['id']}"
+    changed = await client.patch(
+        path,
+        json={
+            "expected_revision": session["revision"],
+            "mode": "auto_review",
+            "model": "other/vendor/model",
+        },
+    )
+    assert changed.status_code == 200
+    assert changed.json()["mode"] == "auto_review"
+    assert changed.json()["provider_id"] == "other"
+    assert changed.json()["model_name"] == "vendor/model"
+    for mode in (None, "plan", "never"):
+        rejected = await client.patch(
+            path, json={"expected_revision": changed.json()["revision"], "mode": mode}
+        )
+        assert rejected.status_code == 422
+    await code.send(
+        session["id"],
+        str(uuid.uuid4()),
+        changed.json()["revision"],
+        "hello",
+        expected_epoch=code.epoch,
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    detail = (await client.get(path)).json()
+    assert detail["run"]["mode"] == "auto_review"
+    assert "native_permission_defaults" not in detail["session"]
+    assert (await code.get_detail(session["id"])).session.native_permission_defaults
+    rejected = await client.patch(
+        path,
+        json={
+            "expected_revision": detail["session"]["revision"],
+            "native_permission_defaults": {},
+        },
+    )
+    assert rejected.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_code_library_has_one_harness_and_no_native_work_on_open(code_api):
     client, _, harness, _, _ = code_api
     bootstrap = await client.get("/admin/api/code/bootstrap")

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -13,6 +13,7 @@ from free_claude_code.application.code_sessions.models import (
     PromptRequest,
 )
 from free_claude_code.runtime.code_sessions_sqlite import SQLiteCodeStore
+from free_claude_code.runtime.codex_protocol import CodexProtocol
 from tests.code_sessions_support import FakeConnection, FakeHarness
 
 
@@ -35,6 +36,193 @@ async def code(tmp_path):
 async def session_for(code):
     service, _, directory = code
     return await service.create_session(new_id(), str(directory))
+
+
+@pytest.mark.asyncio
+async def test_mode_is_captured_per_turn_and_does_not_recreate_native_process(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    modes = ["full_access", "config", "ask", "auto_review"]
+    for ordinal, mode in enumerate(modes, 1):
+        session = await service.update_settings(
+            session.id, session.revision, {"mode": mode}
+        )
+        run = await service.send(
+            session.id,
+            new_id(),
+            session.revision,
+            "hello",
+            expected_epoch=service.epoch,
+        )
+        assert run.mode == mode
+        await asyncio.wait_for(harness.wait_inputs(ordinal), 3)
+        current = (await service.get_detail(session.id)).session
+        with pytest.raises(CodeConflictError):
+            await service.update_settings(current.id, current.revision, {"mode": "ask"})
+        await harness.connections[0].finish(f"turn-{ordinal}")
+        await service.wait_idle(session.id)
+        session = (await service.get_detail(session.id)).session
+    assert len(harness.connections) == 1
+    assert harness.connections[0].modes == modes
+    assert session.native_permission_defaults == harness.permission_defaults
+
+
+@pytest.mark.asyncio
+async def test_mode_change_and_send_compete_for_one_revision(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    results = await asyncio.gather(
+        service.update_settings(session.id, session.revision, {"mode": "full_access"}),
+        service.send(
+            session.id,
+            new_id(),
+            session.revision,
+            "hello",
+            expected_epoch=service.epoch,
+        ),
+        return_exceptions=True,
+    )
+    assert sum(isinstance(result, CodeConflictError) for result in results) == 1
+    detail = await service.get_detail(session.id)
+    if detail.run:
+        assert detail.run.mode == "config"
+        await asyncio.wait_for(harness.started.wait(), 3)
+        await harness.connections[0].finish("turn-1")
+    else:
+        assert detail.session.mode == "full_access"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", [None, "plan", "never", {}, 1])
+async def test_invalid_mode_is_rejected_without_changing_session(code, mode):
+    service, _, _ = code
+    session = await session_for(code)
+    with pytest.raises(CodeValidationError):
+        await service.update_settings(session.id, session.revision, {"mode": mode})
+    assert (await service.get_detail(session.id)).session == session
+
+
+@pytest.mark.asyncio
+async def test_native_defaults_are_saved_before_input_and_preserved_on_resume(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    original = {"policy": "configured-original"}
+    harness.permission_defaults = original
+    session = await service.update_settings(
+        session.id, session.revision, {"mode": "full_access"}
+    )
+    await service.send(
+        session.id, new_id(), session.revision, "first", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    saved = await service._store.get_session(session.id)
+    assert saved.native_permission_defaults == original
+    assert harness.connections[0].defaults == [original]
+    await harness.connections[0].finish("turn-1")
+    await service.wait_idle(session.id)
+    harness.permission_defaults = {"policy": "current-override"}
+    harness.configurations[harness.model] = "recreate-process"
+    session = (await service.get_detail(session.id)).session
+    session = await service.update_settings(
+        session.id, session.revision, {"mode": "config"}
+    )
+    await service.send(
+        session.id, new_id(), session.revision, "second", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.wait_inputs(2), 3)
+    assert len(harness.connections) == 2
+    assert harness.connections[1].defaults == [original]
+    await harness.connections[1].finish("turn-2")
+
+
+@pytest.mark.asyncio
+async def test_failure_saving_native_defaults_never_submits_input(code, monkeypatch):
+    service, harness, _ = code
+    session = await session_for(code)
+    save = service._store.save_progress
+
+    async def reject_defaults(session, *args, **kwargs):
+        if session.native_permission_defaults is not None:
+            raise CodeUnavailableError("Unable to save permission defaults")
+        await save(session, *args, **kwargs)
+
+    monkeypatch.setattr(service._store, "save_progress", reject_defaults)
+    await service.send(
+        session.id, new_id(), session.revision, "first", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(service.wait_idle(session.id), 3)
+    assert not any(connection.inputs for connection in harness.connections)
+    assert not (await service._store.latest_run(session.id)).submission_started
+
+
+@pytest.mark.asyncio
+async def test_native_reviews_and_notices_keep_identity_order_and_survive_restart(code):
+    service, harness, directory = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "hello", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    protocol = CodexProtocol(connection.generation)
+    payload = {
+        "threadId": connection.thread_id,
+        "turnId": "turn-1",
+        "targetItemId": "same-command",
+        "action": {"command": "echo test"},
+        "review": {"status": "inProgress"},
+    }
+    for review_id in ("one", "two"):
+        await connection.sink(
+            protocol.notification(
+                "item/autoApprovalReview/started", {**payload, "reviewId": review_id}
+            )
+        )
+    await connection.text("turn-1", "reply", "After reviews", complete=True)
+    before = await service.get_detail(session.id)
+    for review_id in ("two", "one"):
+        await connection.sink(
+            protocol.notification(
+                "item/autoApprovalReview/completed",
+                {
+                    **payload,
+                    "reviewId": review_id,
+                    "review": {"status": "denied", "rationale": "Native refusal"},
+                },
+            )
+        )
+    await connection.sink(
+        protocol.notification(
+            "guardianWarning",
+            {"threadId": connection.thread_id, "message": "Native warning"},
+        )
+    )
+    await connection.sink(
+        HarnessEvent("old-generation", connection.thread_id, "notice", message="stale")
+    )
+    await connection.finish("turn-1")
+    await service.wait_idle(session.id)
+    detail = await service.get_detail(session.id)
+    assert [item.id for item in detail.items[:4]] == [item.id for item in before.items]
+    assert [item.kind for item in detail.items] == [
+        "user",
+        "auto_review",
+        "auto_review",
+        "text",
+        "notice",
+    ]
+    assert all(item.title == "Auto-review: Denied" for item in detail.items[1:3])
+    assert detail.run.status == "completed"
+    assert detail.items[-1].text == "Native warning"
+    await service.close()
+    restarted = CodeService(
+        SQLiteCodeStore(directory / "code.db", directory / "code.lock"), harness
+    )
+    await restarted.start()
+    try:
+        assert (await restarted.get_detail(session.id)).items == detail.items
+    finally:
+        await restarted.close()
 
 
 @pytest.mark.asyncio

--- a/tests/code_sessions_support.py
+++ b/tests/code_sessions_support.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from free_claude_code.application.code_sessions.models import (
     CodeCatalog,
     CodeConflictError,
+    CodeMode,
     CodeModel,
     CodeUnavailableError,
     CodeValidationError,
@@ -19,6 +20,7 @@ from free_claude_code.application.code_sessions.models import (
     RunStatus,
 )
 from free_claude_code.application.code_sessions.ports import EventSink, HarnessSelection
+from free_claude_code.config.model_refs import split_provider_model_ref
 from free_claude_code.core.json_types import JsonObject
 
 
@@ -26,6 +28,12 @@ class FakeHarness:
     def __init__(self):
         self.connections: list[FakeConnection] = []
         self.model = "provider/model"
+        self.permission_defaults: JsonObject = {
+            "approvalPolicy": "on-request",
+            "approvalsReviewer": "user",
+            "sandbox": {"type": "workspaceWrite"},
+            "activePermissionProfile": {"id": ":workspace"},
+        }
         self.configurations = {self.model: "capabilities-1"}
         self.efforts = ("off", "low", "medium", "high", "xhigh", "max")
         self.default_effort = "medium"
@@ -62,6 +70,8 @@ class FakeHarness:
                 CodeModel(
                     id=model,
                     display_name=model,
+                    provider_id=split_provider_model_ref(model)[0],
+                    model_name=split_provider_model_ref(model)[1],
                     reasoning_efforts=self.efforts,
                     default_reasoning_effort=self.default_effort,
                 )
@@ -69,7 +79,7 @@ class FakeHarness:
             ),
         )
 
-    def prepare(self, model, reasoning_effort):
+    def prepare(self, model, reasoning_effort, mode):
         if model not in self.configurations:
             raise CodeValidationError("This model is unavailable.")
         if reasoning_effort is not None and reasoning_effort not in self.efforts:
@@ -80,10 +90,11 @@ class FakeHarness:
             self.configurations[model],
             dict(self.configurations),
             reasoning_effort or self.default_effort,
+            mode,
         )
 
     async def open_history(self, cwd: str, sink: EventSink):
-        return await self.prepare(self.model, None).open(cwd, sink)
+        return await self.prepare(self.model, None, "config").open(cwd, sink)
 
     async def wait_inputs(self, count: int):
         while sum(len(connection.inputs) for connection in self.connections) < count:
@@ -98,6 +109,7 @@ class FakeSelection:
     configuration_key: str
     catalog: dict[str, str]
     reasoning_effort: str | None
+    mode: CodeMode
 
     async def open(self, cwd: str, sink: EventSink):
         connection = FakeConnection(self.harness, sink, self.catalog)
@@ -114,6 +126,8 @@ class FakeConnection:
         self.thread_id: str | None = None
         self.inputs: list[tuple[str, str, str]] = []
         self.efforts: list[str | None] = []
+        self.modes: list[CodeMode] = []
+        self.defaults: list[JsonObject] = []
         self.interrupts: list[str] = []
         self.deleted: list[str] = []
         self.resumed: list[str] = []
@@ -134,7 +148,9 @@ class FakeConnection:
             raise CodeUnavailableError("Native process closed during creation.")
         self.thread_id = f"native-{len(self.harness.histories) + 1}"
         self.harness.histories[self.thread_id] = []
-        return NativeThread(self.thread_id)
+        return NativeThread(
+            self.thread_id, permission_defaults=self.harness.permission_defaults
+        )
 
     async def resume_thread(self, thread_id: str):
         self.resumed.append(thread_id)
@@ -152,11 +168,20 @@ class FakeConnection:
             tuple(
                 NativeTurn(turn_id, tuple(items)) for turn_id, items in groups.items()
             ),
+            self.harness.permission_defaults,
         )
 
-    async def start_turn(self, text: str, selection: HarnessSelection, client_id: str):
+    async def start_turn(
+        self,
+        text: str,
+        selection: HarnessSelection,
+        client_id: str,
+        permission_defaults: JsonObject,
+    ):
         self.inputs.append((client_id, text, selection.model))
         self.efforts.append(selection.reasoning_effort)
+        self.modes.append(selection.mode)
+        self.defaults.append(permission_defaults)
         self.harness.input_changed.set()
         self.harness.submitted.set()
         self.harness.turn_count += 1

--- a/tests/runtime/codex_fake_process.py
+++ b/tests/runtime/codex_fake_process.py
@@ -13,6 +13,12 @@ def emit(value):
 
 
 mode = sys.argv[1]
+defaults = {
+    "approvalPolicy": "on-request",
+    "approvalsReviewer": "user",
+    "sandbox": {"type": "workspaceWrite"},
+    "activePermissionProfile": {"id": ":workspace"},
+}
 creation_id = None
 turn = "turn-1"
 for line in sys.stdin.buffer:
@@ -30,13 +36,18 @@ for line in sys.stdin.buffer:
             emit(
                 {
                     "id": request_id,
-                    "result": {"thread": {"id": "native-1", "turns": []}},
+                    "result": {"thread": {"id": "native-1", "turns": []}, **defaults},
                 }
             )
     elif method == "test/barrier":
         emit({"id": request_id, "result": {}})
     elif method == "test/release-create":
-        emit({"id": creation_id, "result": {"thread": {"id": "native-1", "turns": []}}})
+        emit(
+            {
+                "id": creation_id,
+                "result": {"thread": {"id": "native-1", "turns": []}, **defaults},
+            }
+        )
         emit({"id": request_id, "result": {}})
     elif method == "turn/start":
         emit(

--- a/tests/runtime/test_code_sessions_sqlite.py
+++ b/tests/runtime/test_code_sessions_sqlite.py
@@ -136,6 +136,89 @@ async def _session(store):
 
 
 @pytest.mark.asyncio
+async def test_mode_and_original_defaults_survive_restart_and_cannot_be_rewritten(
+    store, tmp_path
+):
+    session = await _session(store)
+    with closing(sqlite3.connect(tmp_path / "code.db")) as connection:
+        assert connection.execute(
+            "SELECT native_permission_defaults FROM code_sessions"
+        ).fetchone() == (None,)
+    defaults = {
+        "approvalPolicy": "on-request",
+        "approvalsReviewer": "user",
+        "sandbox": {"type": "readOnly"},
+    }
+    session = session.model_copy(update={"native_permission_defaults": defaults})
+    await store.save_progress(session, session.revision)
+    for replacement in (None, {"different": True}):
+        with pytest.raises(CodeConflictError):
+            await store.save_progress(
+                session.model_copy(update={"native_permission_defaults": replacement}),
+                session.revision,
+            )
+    session = await store.update_settings(
+        session.model_copy(
+            update={"mode": "full_access", "revision": session.revision + 1}
+        ),
+        session.revision,
+    )
+    await store.close()
+    await store.start()
+    saved = await store.get_session(session.id)
+    assert saved.mode == "full_access"
+    assert saved.native_permission_defaults == defaults
+
+
+@pytest.mark.asyncio
+async def test_mode_is_guarded_by_sqlite_busy_and_run_immutability(store):
+    session, run = await _admit(store, await _session(store))
+    with pytest.raises(CodeConflictError):
+        await store.update_settings(
+            session.model_copy(
+                update={"mode": "full_access", "revision": session.revision + 1}
+            ),
+            session.revision,
+        )
+    with pytest.raises(CodeConflictError):
+        await store.save_progress(
+            session,
+            session.revision,
+            run=run.model_copy(update={"mode": "full_access"}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_version_one_database_gains_mode_without_losing_history(store, tmp_path):
+    session, run = await _admit(store, await _session(store))
+    items = await store.items(session.id, None, None)
+    await store.close()
+    with closing(sqlite3.connect(tmp_path / "code.db")) as connection, connection:
+        connection.execute("ALTER TABLE code_sessions DROP COLUMN mode")
+        connection.execute(
+            "ALTER TABLE code_sessions DROP COLUMN native_permission_defaults"
+        )
+        connection.execute("ALTER TABLE code_runs DROP COLUMN mode")
+        connection.execute("PRAGMA user_version = 1")
+    for _ in range(2):
+        await store.start()
+        saved = await store.get_session(session.id)
+        assert saved.mode == "config"
+        assert saved.native_permission_defaults is None
+        assert (await store.get_run(session.id, run.id)).mode == "config"
+        assert await store.items(session.id, None, None) == items
+        with closing(sqlite3.connect(tmp_path / "code.db")) as connection:
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute("UPDATE code_sessions SET mode = 'unknown'")
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "UPDATE code_sessions SET native_permission_defaults = '[]'"
+                )
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_admission_is_atomic_and_idempotent(store):
     session = await _session(store)
     results = await asyncio.gather(
@@ -417,6 +500,11 @@ async def _legacy_prompt_database(store, path):
     with closing(sqlite3.connect(path)) as connection, connection:
         connection.execute("DROP TABLE code_prompts")
         connection.execute(_LEGACY_PROMPTS)
+        connection.execute("ALTER TABLE code_sessions DROP COLUMN mode")
+        connection.execute(
+            "ALTER TABLE code_sessions DROP COLUMN native_permission_defaults"
+        )
+        connection.execute("ALTER TABLE code_runs DROP COLUMN mode")
         connection.execute("PRAGMA user_version = 0")
         for prompt in prompts:
             connection.execute(
@@ -475,7 +563,7 @@ async def test_legacy_prompts_migrate_once_to_run_ends_without_resequencing(
             )
             assert saved[prompt.id] == expected
         with closing(sqlite3.connect(path)) as connection:
-            assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
             assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
             assert any(
                 row[2] == "code_items"

--- a/tests/runtime/test_codex_app_server.py
+++ b/tests/runtime/test_codex_app_server.py
@@ -2,12 +2,95 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
 from free_claude_code.application.code_sessions.models import CodeUnavailableError
 from free_claude_code.runtime.codex_app_server import CodexAppServer
 from tests.code_sessions_support import FakeHarness
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("profile", [None, {"id": "custom"}])
+async def test_complete_mode_overrides_restore_native_defaults(
+    tmp_path, monkeypatch, profile
+):
+    defaults = {
+        "approvalPolicy": {"granular": {"sandbox_approval": True, "rules": False}},
+        "approvalsReviewer": "user",
+        "activePermissionProfile": profile,
+        "sandbox": {
+            "type": "workspaceWrite",
+            "writableRoots": [str(tmp_path / "extra")],
+            "networkAccess": True,
+            "excludeTmpdirEnvVar": True,
+            "excludeSlashTmp": True,
+        },
+    }
+    native = CodexAppServer(
+        [],
+        {},
+        str(tmp_path),
+        AsyncMock(),
+        model_slugs={"provider/model": "native-slug"},
+    )
+    rpc = AsyncMock(return_value={"thread": {"id": "native", "turns": []}, **defaults})
+    monkeypatch.setattr(native, "rpc", rpc)
+    thread = await native.create_thread()
+    assert thread.permission_defaults == defaults
+    assert rpc.call_args.args[1] == {"cwd": str(tmp_path), "modelProvider": "fcc"}
+    rpc.return_value = {"turn": {"id": "turn"}}
+    harness = FakeHarness()
+    expected = {
+        "ask": {
+            "approvalPolicy": "on-request",
+            "approvalsReviewer": "user",
+            "permissions": ":workspace",
+        },
+        "auto_review": {
+            "approvalPolicy": "on-request",
+            "approvalsReviewer": "auto_review",
+            "permissions": ":workspace",
+        },
+        "full_access": {
+            "approvalPolicy": "never",
+            "approvalsReviewer": "user",
+            "permissions": ":danger-full-access",
+        },
+        "config": {
+            "approvalPolicy": defaults["approvalPolicy"],
+            "approvalsReviewer": "user",
+            **(
+                {"permissions": "custom"}
+                if profile
+                else {"sandboxPolicy": defaults["sandbox"]}
+            ),
+        },
+    }
+    for mode in ("ask", "auto_review", "full_access", "config"):
+        selection = harness.prepare(harness.model, "high", mode)
+        await native.start_turn("hello", selection, "input", thread.permission_defaults)
+        params = rpc.call_args.args[1]
+        assert {
+            key: value
+            for key, value in params.items()
+            if key
+            in {"approvalPolicy", "approvalsReviewer", "permissions", "sandboxPolicy"}
+        } == expected[mode]
+        assert params["model"] == "native-slug" and params["effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_missing_native_permission_settings_rejects_thread_preparation(
+    tmp_path, monkeypatch
+):
+    native = CodexAppServer([], {}, str(tmp_path), AsyncMock())
+    monkeypatch.setattr(
+        native, "rpc", AsyncMock(return_value={"thread": {"id": "native", "turns": []}})
+    )
+    with pytest.raises(CodeUnavailableError, match="permission"):
+        await native.create_thread()
 
 
 async def connect(tmp_path, mode):
@@ -41,7 +124,10 @@ async def test_jsonl_large_unicode_events_can_precede_rpc_ack(tmp_path):
         assert (await native.create_thread()).id == "native-1"
         assert (
             await native.start_turn(
-                "hello", FakeHarness().prepare("provider/model", None), "input-1"
+                "hello",
+                FakeHarness().prepare("provider/model", None, "config"),
+                "input-1",
+                FakeHarness().permission_defaults,
             )
             == "turn-1"
         )
@@ -60,7 +146,10 @@ async def test_server_rpc_during_start_preserves_numeric_zero_id(tmp_path):
     try:
         await native.create_thread()
         await native.start_turn(
-            "hello", FakeHarness().prepare("provider/model", None), "input-1"
+            "hello",
+            FakeHarness().prepare("provider/model", None, "config"),
+            "input-1",
+            FakeHarness().permission_defaults,
         )
         await asyncio.wait_for(prompted.wait(), 3)
         response = native.prepare_answer(0, {"choice": "0"})
@@ -142,7 +231,10 @@ async def test_spawned_agent_prompt_is_visible_in_its_registered_root_session(tm
     try:
         await native.create_thread()
         await native.start_turn(
-            "delegate", FakeHarness().prepare("provider/model", None), "input-1"
+            "delegate",
+            FakeHarness().prepare("provider/model", None, "config"),
+            "input-1",
+            FakeHarness().permission_defaults,
         )
         await asyncio.wait_for(prompted.wait(), 3)
         event = next(event for event in events if event.kind == "prompt")
@@ -183,7 +275,10 @@ async def test_turn_start_resets_sticky_effort_and_preserves_client_identity(
     harness = FakeHarness()
     for effort in (None, "high", "off", "max", None):
         await native.start_turn(
-            "hello", harness.prepare("provider/model", effort), "operation"
+            "hello",
+            harness.prepare("provider/model", effort, "config"),
+            "operation",
+            harness.permission_defaults,
         )
     assert [request.get("effort") for request in requests] == (
         ["medium", "high", "none", "max", "medium"] if reasoning else [None] * 5

--- a/tests/runtime/test_codex_catalog.py
+++ b/tests/runtime/test_codex_catalog.py
@@ -112,16 +112,16 @@ def test_code_picker_and_native_selection_use_the_same_advertised_efforts():
     assert advertised.default_model == "nvidia_nim/configured"
     model = advertised.models[1]
     assert model.reasoning_efforts == ("off", "low", "medium", "high", "xhigh", "max")
-    selected = factory.prepare(model.id, None)
+    selected = factory.prepare(model.id, None, "config")
     assert selected.model == model.id
     assert selected.context.settings.model == model.id
     assert selected.reasoning_effort == model.default_reasoning_effort == "medium"
     for effort in model.reasoning_efforts:
-        assert factory.prepare(model.id, effort).reasoning_effort == effort
+        assert factory.prepare(model.id, effort, "config").reasoning_effort == effort
     with pytest.raises(CodeValidationError, match="effort"):
-        factory.prepare(model.id, "unsupported")
+        factory.prepare(model.id, "unsupported", "config")
     with pytest.raises(CodeValidationError, match="model"):
-        factory.prepare("missing/model", None)
+        factory.prepare("missing/model", None, "config")
 
 
 def test_non_reasoning_model_off_selection_is_available():
@@ -139,4 +139,4 @@ def test_non_reasoning_model_off_selection_is_available():
     )
     assert model.reasoning_efforts == ("off",)
     assert model.default_reasoning_effort == "off"
-    assert factory.prepare(model.id, "off").reasoning_effort == "off"
+    assert factory.prepare(model.id, "off", "config").reasoning_effort == "off"

--- a/tests/runtime/test_codex_protocol.py
+++ b/tests/runtime/test_codex_protocol.py
@@ -1,7 +1,74 @@
 import pytest
 
 from free_claude_code.application.code_sessions import CodeValidationError
+from free_claude_code.core.json_types import JsonObject
 from free_claude_code.runtime.codex_protocol import CodexProtocol, NativePrompt
+
+
+@pytest.mark.parametrize(
+    "status,label",
+    [
+        ("approved", "Approved"),
+        ("denied", "Denied"),
+        ("timedOut", "Timed out"),
+        ("aborted", "Aborted"),
+    ],
+)
+def test_auto_review_has_own_identity_and_preserves_native_action_and_rationale(
+    status, label
+):
+    protocol = CodexProtocol("generation")
+    payload: JsonObject = {
+        "threadId": "thread",
+        "turnId": "turn",
+        "reviewId": "review",
+        "targetItemId": None,
+        "action": {
+            "type": "networkAccess",
+            "host": "localhost",
+            "port": 8000,
+            "protocol": "http",
+            "target": "http://localhost:8000",
+        },
+        "review": {"status": "inProgress"},
+        "startedAtMs": 10,
+    }
+    started = protocol.notification("item/autoApprovalReview/started", payload)
+    assert started is not None and started.item is not None
+    assert started.item.item_id == "auto-review:review"
+    assert not started.item.complete
+    completed = protocol.notification(
+        "item/autoApprovalReview/completed",
+        {
+            **payload,
+            "review": {
+                "status": status,
+                "rationale": "Native explanation",
+                "riskLevel": "low",
+            },
+            "completedAtMs": 20,
+        },
+    )
+    assert completed is not None and completed.item is not None
+    assert completed.item.item_id == started.item.item_id
+    assert completed.item.title == f"Auto-review: {label}"
+    assert completed.item.complete
+    assert completed.item.text == "Native explanation"
+    assert "localhost" in completed.item.detail
+    assert completed.item.raw["review"] == {
+        "status": status,
+        "rationale": "Native explanation",
+        "riskLevel": "low",
+    }
+
+
+def test_native_guardian_warning_is_a_notice_without_a_turn_id():
+    event = CodexProtocol("generation").notification(
+        "guardianWarning", {"threadId": "thread", "message": "Review is unavailable"}
+    )
+    assert event is not None
+    assert event.kind == "notice" and event.turn_id is None
+    assert event.message == "Review is unavailable"
 
 
 def notification(protocol, method, **extra):

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.1.4"
+version = "6.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Code sessions combine provider and model selection and offer no way to choose Codex's permission mode. Native Auto-review decisions are also missing from the conversation.

## How

Show Provider, Model, Effort, Harness, and Mode in the session header. Choosing a provider filters the model list and requires an explicit model choice. Mode offers Use config, Ask, Auto-review, and Full access.

Save the mode with the session and capture it for each turn. Returning to Use config restores the session's original native permission settings, including after an FCC restart. Save native Auto-review actions, decisions, and explanations in their original transcript positions and synchronize them across tabs.

Add repeatable smoke coverage using installed Codex, plus an explicitly selected live scenario that verifies the model's prices are zero. Release as 6.2.0.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61891089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/alishahryar1/-/pull-requests/alishahryar1/free-claude-code/1726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No blocking issues were identified; the reviewed permission-mode behavior is ready to merge.

What we checked:
- Documented the before-state where no permission fields existed because modes were not implemented. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated the after-state showing three permission modes with their endpoints: ask maps to on-request/user/:workspace, auto_review maps to on-request/auto_review/:workspace, and full_access maps to never/user/:danger-full-access. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Noted that config restores capture granular policy, user, and custom profile as part of the updated permission setup. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- Adds provider-aware model selection and persisted permission modes for Code sessions.
- Preserves captured Codex permission defaults for configuration mode and applies the expected permissions for ask, auto-review, and full-access modes.
- Migrates existing SQLite session data to store session and run modes plus native permission defaults.

## Merge safety
No issues requiring changes were identified. The reviewed permission and persistence behavior is ready to merge.
</details>

<!-- /greptile_comment -->