### PR TITLE
Show Codex sub-agent Auto-review results in Code sessions

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -10,6 +10,7 @@ from free_claude_code.application.code_sessions.models import (
     PromptRequest,
 )
 from free_claude_code.runtime.codex_protocol import CodexProtocol
+from tests.code_sessions_support import CodexPackets
 
 
 @pytest.mark.parametrize("width", [1440, 900, 390])
@@ -211,6 +212,96 @@ def test_review_updates_inline_and_unfinished_review_settles_after_restart_view(
         )
     finally:
         second.close()
+
+
+def test_child_review_outlives_parent_and_updates_in_place_in_both_tabs(
+    page, context, admin_base_url, tmp_path, code_control
+):
+    url = create_session(page, admin_base_url, tmp_path)
+    send(page, "Delegate work")
+    connection = code_control.connection()
+    packets = CodexPackets(connection)
+    code_control.run(packets.spawn())
+    second = context.new_page()
+    try:
+        second.goto(url)
+        code_control.run(packets.review())
+        review = page.locator('[data-kind="subagent_auto_review"]')
+        expect(review.locator("summary")).to_have_text(
+            "Sub-agent Auto-review: Reviewing"
+        )
+        identity = review.get_attribute("data-id")
+        review.locator("summary").click()
+        code_control.run(connection.finish("turn-1"))
+        second.reload()
+        expect(
+            second.locator('[data-kind="subagent_auto_review"] summary')
+        ).to_have_text("Sub-agent Auto-review: Reviewing")
+        page.locator("#codeComposer").fill("Continue while reviewing")
+        expect(page.locator("#codeSend")).to_be_enabled()
+        page.locator("#codeSend").click()
+        code_control.run(code_control.harness.wait_inputs(2))
+        code_control.run(packets.review(status="approved"))
+        expect(review.locator("summary")).to_have_text(
+            "Sub-agent Auto-review: Approved"
+        )
+        expect(review).to_have_attribute("data-id", identity)
+        expect(review.locator("details")).to_have_attribute("open", "")
+        expect(
+            second.locator('[data-kind="subagent_auto_review"] summary')
+        ).to_have_text("Sub-agent Auto-review: Approved")
+        messages = page.locator(".code-item")
+        expect(messages).to_have_count(3)
+        expect(messages.nth(1)).to_have_attribute("data-id", identity)
+        expect(messages.nth(2)).to_contain_text("Continue while reviewing")
+        code_control.run(connection.finish("turn-2"))
+        code_control.run(packets.review(review_id="pending"))
+        code_control.run(packets.warning())
+        expect(page.locator('[data-kind="notice"]')).to_contain_text(
+            "Sub-agent: Native warning"
+        )
+        code_control.run(connection.close())
+        expected = [
+            "Sub-agent Auto-review: Approved",
+            "Sub-agent Auto-review: Result unavailable",
+        ]
+        expect(page.locator('[data-kind="subagent_auto_review"] summary')).to_have_text(
+            expected
+        )
+        expect(
+            second.locator('[data-kind="subagent_auto_review"] summary')
+        ).to_have_text(expected)
+        page.reload()
+        expect(page.locator('[data-kind="subagent_auto_review"] summary')).to_have_text(
+            expected
+        )
+    finally:
+        second.close()
+
+
+@pytest.mark.parametrize("change", ["start", "close"])
+def test_child_review_liveness_ignores_an_older_detail_snapshot(
+    page, admin_base_url, tmp_path, code_control, change
+):
+    url = create_session(page, admin_base_url, tmp_path)
+    send(page, "Delegate")
+    connection = code_control.connection()
+    packets = CodexPackets(connection)
+    code_control.run(packets.spawn())
+    code_control.run(connection.finish("turn-1"))
+    if change == "close":
+        code_control.run(packets.review())
+    path = f"{admin_base_url}/admin/api/code/sessions/{url.rsplit('/', 1)[1]}"
+    previous = page.request.get(path).json()
+    code_control.run(packets.review() if change == "start" else connection.close())
+    title = "Sub-agent Auto-review: " + (
+        "Reviewing" if change == "start" else "Result unavailable"
+    )
+    summary = page.locator('[data-kind="subagent_auto_review"] summary')
+    expect(summary).to_have_text(title)
+    page.route(path, lambda route: route.fulfill(json=previous))
+    page.evaluate("window.CodeSessions.refresh()")
+    expect(summary).to_have_text(title)
 
 
 def create_session(page, base_url, directory):

--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -279,6 +279,59 @@ def test_child_review_outlives_parent_and_updates_in_place_in_both_tabs(
         second.close()
 
 
+def test_pending_child_review_outside_page_survives_refresh_in_both_tabs(
+    page, context, admin_base_url, tmp_path, code_control
+):
+    url = create_session(page, admin_base_url, tmp_path)
+    send(page, "Delegate")
+    connection = code_control.connection()
+    packets = CodexPackets(connection)
+    code_control.run(packets.spawn())
+    code_control.run(packets.review())
+    review = page.locator('[data-kind="subagent_auto_review"]')
+    expect(review).to_have_count(1)
+    identity = review.get_attribute("data-id")
+    code_control.run(connection.finish("turn-1"))
+    send(page, "Continue")
+    code_control.run(code_control.harness.wait_inputs(2))
+
+    async def more_output():
+        for index in range(55):
+            await connection.text(
+                "turn-2", str(index), f"Output {index}", complete=True
+            )
+        await connection.finish("turn-2")
+
+    code_control.run(more_output())
+    page.reload()
+    second = context.new_page()
+    try:
+        second.goto(url)
+        for tab in (page, second):
+            expect(
+                tab.locator('[data-kind="subagent_auto_review"] summary')
+            ).to_have_text("Sub-agent Auto-review: Reviewing")
+            expect(tab.locator(".code-item").first).to_have_attribute(
+                "data-id", identity
+            )
+        review.locator("summary").click()
+        code_control.run(packets.review(status="approved"))
+        for tab in (page, second):
+            expect(
+                tab.locator('[data-kind="subagent_auto_review"] summary')
+            ).to_have_text("Sub-agent Auto-review: Approved")
+            expect(tab.locator(".code-item").first).to_have_attribute(
+                "data-id", identity
+            )
+            expect(tab.locator('[data-kind="subagent_auto_review"]')).to_have_count(1)
+        expect(review.locator("details")).to_have_attribute("open", "")
+        page.get_by_role("button", name="Load older messages", exact=True).click()
+        expect(page.locator(".code-item")).to_have_count(58)
+        expect(page.locator('[data-kind="subagent_auto_review"]')).to_have_count(1)
+    finally:
+        second.close()
+
+
 @pytest.mark.parametrize("change", ["start", "close"])
 def test_child_review_liveness_ignores_an_older_detail_snapshot(
     page, admin_base_url, tmp_path, code_control, change

--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -279,9 +279,18 @@ def test_child_review_outlives_parent_and_updates_in_place_in_both_tabs(
         second.close()
 
 
+@pytest.mark.parametrize(
+    ("delivery", "status", "title"),
+    [
+        ("live", "approved", "Approved"),
+        ("reconnect", "denied", "Denied"),
+        ("stale_snapshot", "approved", "Approved"),
+    ],
+)
 def test_pending_child_review_outside_page_survives_refresh_in_both_tabs(
-    page, context, admin_base_url, tmp_path, code_control
+    page, context, admin_base_url, tmp_path, code_control, delivery, status, title
 ):
+    control_feed(page)
     url = create_session(page, admin_base_url, tmp_path)
     send(page, "Delegate")
     connection = code_control.connection()
@@ -315,19 +324,96 @@ def test_pending_child_review_outside_page_survives_refresh_in_both_tabs(
                 "data-id", identity
             )
         review.locator("summary").click()
-        code_control.run(packets.review(status="approved"))
+        page.locator("#codeComposer").fill("Keep draft")
+        if delivery == "reconnect":
+            page.evaluate("window.dropCodeEvents = ['item.updated']")
+        elif delivery == "stale_snapshot":
+            endpoint = url.replace(admin_base_url, "").replace(
+                "/admin/code/", "/admin/api/code/sessions/"
+            )
+            hold_code_reads(page, endpoint)
+            page.evaluate("void window.codeFeed.onerror(new Event('error'))")
+            page.wait_for_function(
+                "path => window.codeReadHolds.some(held => held.path === path)",
+                arg=endpoint,
+            )
+        code_control.run(packets.review(status=status))
+        if delivery == "reconnect":
+            page.evaluate(
+                "window.dropCodeEvents = []; void window.codeFeed.onerror(new Event('error'))"
+            )
+        elif delivery == "stale_snapshot":
+            expect(review.locator("summary")).to_have_text(
+                f"Sub-agent Auto-review: {title}"
+            )
+            page.evaluate("window.releaseCodeReads()")
+        expect(page.locator("#codeSend")).to_be_enabled()
         for tab in (page, second):
             expect(
                 tab.locator('[data-kind="subagent_auto_review"] summary')
-            ).to_have_text("Sub-agent Auto-review: Approved")
+            ).to_have_text(f"Sub-agent Auto-review: {title}")
             expect(tab.locator(".code-item").first).to_have_attribute(
                 "data-id", identity
             )
             expect(tab.locator('[data-kind="subagent_auto_review"]')).to_have_count(1)
         expect(review.locator("details")).to_have_attribute("open", "")
+        expect(page.locator("#codeComposer")).to_have_value("Keep draft")
         page.get_by_role("button", name="Load older messages", exact=True).click()
         expect(page.locator(".code-item")).to_have_count(58)
         expect(page.locator('[data-kind="subagent_auto_review"]')).to_have_count(1)
+    finally:
+        second.close()
+
+
+def test_reobserved_child_review_outside_page_appears_without_refresh(
+    page, context, admin_base_url, tmp_path, code_control
+):
+    url = create_session(page, admin_base_url, tmp_path)
+    send(page, "Delegate")
+    first = code_control.connection()
+    packets = CodexPackets(first)
+    code_control.run(packets.spawn())
+    code_control.run(packets.review())
+    review = page.locator('[data-kind="subagent_auto_review"]')
+    expect(review).to_have_count(1)
+    identity = review.get_attribute("data-id")
+    code_control.run(first.finish("turn-1"))
+    code_control.run(first.close())
+    send(page, "Continue")
+    code_control.run(code_control.harness.wait_inputs(2))
+    replacement = code_control.harness.connections[-1]
+
+    async def more_output():
+        for index in range(55):
+            await replacement.text(
+                "turn-2", str(index), f"Output {index}", complete=True
+            )
+        await replacement.finish("turn-2")
+
+    code_control.run(more_output())
+    page.reload()
+    second = context.new_page()
+    try:
+        second.goto(url)
+        for tab in (page, second):
+            expect(tab.locator("#codeOlder")).to_be_visible()
+            expect(tab.locator('[data-kind="subagent_auto_review"]')).to_have_count(0)
+        packets = CodexPackets(replacement)
+        code_control.run(packets.spawn())
+        code_control.run(packets.review())
+        for tab in (page, second):
+            expect(
+                tab.locator('[data-kind="subagent_auto_review"] summary')
+            ).to_have_text("Sub-agent Auto-review: Reviewing")
+            expect(tab.locator(".code-item").first).to_have_attribute(
+                "data-id", identity
+            )
+        code_control.run(packets.review(status="approved"))
+        for tab in (page, second):
+            expect(
+                tab.locator('[data-kind="subagent_auto_review"] summary')
+            ).to_have_text("Sub-agent Auto-review: Approved")
+            expect(tab.locator('[data-kind="subagent_auto_review"]')).to_have_count(1)
     finally:
         second.close()
 
@@ -751,7 +837,7 @@ def test_old_detail_cannot_replace_streamed_output(
       const original = window.fetch;
       window.fetch = async (...args) => {
         const result = await original(...args);
-        if (/\\/api\\/code\\/sessions\\/[0-9a-f-]+$/.test(String(args[0]))) {
+        if (/\\/api\\/code\\/sessions\\/[0-9a-f-]+$/.test(new URL(String(args[0]), location.origin).pathname)) {
           window.detailCaptured = true;
           await new Promise(resolve => { window.releaseDetail = resolve; });
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.0"
+version = "6.2.1"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -150,7 +150,8 @@ uv run pytest smoke/product/test_nvidia_nim_vision_product_live.py -n 0 -s --tb=
 
 Run the installed Codex against a local simulated provider, with disposable
 sessions and folders. This checks Ask, Auto-review, Full access, and returning
-to Use config without spending provider credits:
+to Use config without spending provider credits. It also checks a sub-agent's
+review completing after the parent reply and a subsequent message:
 
 ```powershell
 $env:FCC_LIVE_SMOKE = "1"

--- a/smoke/capabilities.py
+++ b/smoke/capabilities.py
@@ -36,7 +36,11 @@ CAPABILITY_CONTRACTS: tuple[CapabilityContract, ...] = (
             "tests/runtime/test_code_sessions_sqlite.py",
             "e2e/test_code_sessions.py",
         ),
-        ("test_codex_modes_local_e2e", "test_codex_modes_free_provider_e2e"),
+        (
+            "test_codex_modes_local_e2e",
+            "test_codex_child_review_local_e2e",
+            "test_codex_modes_free_provider_e2e",
+        ),
     ),
     CapabilityContract(
         "api_compatibility",

--- a/smoke/features.py
+++ b/smoke/features.py
@@ -38,7 +38,11 @@ FEATURE_INVENTORY: tuple[FeatureCoverage, ...] = (
             "e2e/test_code_sessions.py",
         ),
         (),
-        ("test_codex_modes_local_e2e", "test_codex_modes_free_provider_e2e"),
+        (
+            "test_codex_modes_local_e2e",
+            "test_codex_child_review_local_e2e",
+            "test_codex_modes_free_provider_e2e",
+        ),
         ("clients",),
         (
             "Codex executable",

--- a/smoke/product/test_codex_modes_product_live.py
+++ b/smoke/product/test_codex_modes_product_live.py
@@ -5,6 +5,7 @@ import json
 import os
 import shlex
 import shutil
+import sqlite3
 import sys
 import threading
 import uuid
@@ -77,8 +78,32 @@ def _environment(tmp_path: Path, model: str) -> tuple[dict[str, str], set[str]]:
     return env, unset
 
 
+def _tool_call(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tool_calls": [
+            {
+                "index": 0,
+                "id": "call_" + uuid.uuid4().hex,
+                "type": "function",
+                "function": {"name": name, "arguments": json.dumps(arguments)},
+            }
+        ]
+    }
+
+
+def _marker_command(marker: Path) -> str:
+    return (
+        f"Set-Content -LiteralPath '{str(marker).replace(chr(39), chr(39) * 2)}' -Value smoke"
+        if os.name == "nt"
+        else f"printf smoke > {shlex.quote(str(marker))}"
+    )
+
+
 @contextmanager
-def _canned_provider() -> Iterator[tuple[str, dict[str, Any]]]:
+def _canned_provider(
+    review_release: threading.Event | None = None,
+    child_finished: threading.Event | None = None,
+) -> Iterator[tuple[str, dict[str, Any]]]:
     state: dict[str, Any] = {"requests": [], "command": None, "reviews": 0}
 
     class Handler(BaseHTTPRequestHandler):
@@ -106,8 +131,19 @@ def _canned_provider() -> Iterator[tuple[str, dict[str, Any]]]:
                     .get("json_schema", {})
                     .get("schema", {})
                 )
+                # The child starts without the parent's history. Route the canned
+                # actor by that boundary, independently of task-message encoding.
+                child_request = child_finished is not None and not any(
+                    "FCC_PARENT_REVIEW_WORK" in json.dumps(message.get("content", ""))
+                    for message in request["messages"]
+                    if message["role"] == "user"
+                )
                 if "outcome" in schema.get("properties", {}):
                     state["reviews"] += 1
+                    if review_release is not None:
+                        assert review_release.wait(30), (
+                            "Local child reviewer was not released"
+                        )
                     delta = {
                         "content": json.dumps(
                             {
@@ -119,7 +155,35 @@ def _canned_provider() -> Iterator[tuple[str, dict[str, Any]]]:
                         )
                     }
                     reason = "stop"
-                elif state["command"]:
+                elif state.get("spawn"):
+                    functions = {
+                        tool["function"]["name"]: tool["function"]
+                        for tool in request["tools"]
+                        if tool["type"] == "function"
+                    }
+                    spawn_name = next(
+                        (
+                            name
+                            for name in functions
+                            if name.rsplit("__", 1)[-1] == "spawn_agent"
+                        ),
+                        None,
+                    )
+                    assert spawn_name is not None, list(functions)
+                    properties = functions[spawn_name]["parameters"]["properties"]
+                    arguments = {
+                        "message": "FCC_CHILD_REVIEW_WORK: Execute the disposable local smoke command, then finish."
+                    }
+                    if "task_name" in properties:
+                        arguments["task_name"] = "smoke_child"
+                    if "fork_turns" in properties:
+                        arguments["fork_turns"] = "none"
+                    elif "fork_context" in properties:
+                        arguments["fork_context"] = False
+                    state["spawn"] = False
+                    delta = _tool_call(spawn_name, arguments)
+                    reason = "tool_calls"
+                elif state["command"] and (child_finished is None or child_request):
                     names = [
                         tool["function"]["name"]
                         for tool in request["tools"]
@@ -136,21 +200,11 @@ def _canned_provider() -> Iterator[tuple[str, dict[str, Any]]]:
                             justification="Create the disposable smoke marker",
                         )
                     state["command"] = None
-                    delta = {
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": "call_" + uuid.uuid4().hex,
-                                "type": "function",
-                                "function": {
-                                    "name": "exec_command",
-                                    "arguments": json.dumps(arguments),
-                                },
-                            }
-                        ]
-                    }
+                    delta = _tool_call("exec_command", arguments)
                     reason = "tool_calls"
                 else:
+                    if child_request and child_finished is not None:
+                        child_finished.set()
                     delta = {"content": "FCC_MODE_SMOKE_DONE"}
                     reason = "stop"
                 self.send_response(200)
@@ -172,7 +226,7 @@ def _canned_provider() -> Iterator[tuple[str, dict[str, Any]]]:
                 self.wfile.flush()
             except Exception as exc:
                 state["error"] = repr(exc)
-                self.send_error(500, "Local smoke fixture failed")
+                self.send_error(400, "Local smoke fixture failed")
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
     server.daemon_threads = True
@@ -231,11 +285,7 @@ async def _exercise(
                     changed.raise_for_status()
                     session = changed.json()
                     marker = workspace.parent / f"marker-{uuid.uuid4().hex}.txt"
-                    command = (
-                        f"Set-Content -LiteralPath '{str(marker).replace(chr(39), chr(39) * 2)}' -Value smoke"
-                        if os.name == "nt"
-                        else f"printf smoke > {shlex.quote(str(marker))}"
-                    )
+                    command = _marker_command(marker)
                     if state is not None:
                         state["command"] = command
                         state["mode"] = mode
@@ -350,6 +400,178 @@ def test_codex_modes_local_e2e(smoke_config: SmokeConfig, tmp_path: Path) -> Non
             assert state["reviews"] >= 1
         finally:
             (tmp_path / "local-requests.json").write_text(
+                json.dumps(state, indent=2), encoding="utf-8"
+            )
+
+
+async def _exercise_child_review(
+    base_url: str,
+    workspace: Path,
+    release: threading.Event,
+    finished: threading.Event,
+    timeout_s: float,
+) -> str:
+    workspace.mkdir()
+    async with httpx.AsyncClient(base_url=base_url, timeout=timeout_s) as client:
+        bootstrap = (await client.get("/admin/api/code/bootstrap")).json()
+        assert bootstrap["available"], bootstrap
+        session_id = str(uuid.uuid4())
+        path = f"/admin/api/code/sessions/{session_id}"
+        created = await client.post(
+            "/admin/api/code/sessions",
+            json={"session_id": session_id, "cwd": str(workspace)},
+        )
+        created.raise_for_status()
+        changed = await client.patch(
+            path,
+            json={
+                "expected_revision": created.json()["revision"],
+                "mode": "auto_review",
+            },
+        )
+        changed.raise_for_status()
+        session = changed.json()
+        queue = asyncio.Queue()
+
+        async def send(text: str) -> str:
+            response = await client.post(
+                path + "/turns",
+                json={
+                    "operation_id": str(uuid.uuid4()),
+                    "expected_revision": session["revision"],
+                    "expected_epoch": bootstrap["epoch"],
+                    "text": text,
+                },
+            )
+            response.raise_for_status()
+            return response.json()["id"]
+
+        async def event() -> dict[str, Any]:
+            while True:
+                value = await queue.get()
+                if value.get("session_id") == session_id:
+                    assert value.get("prompt", {}).get("status") != "pending", value
+                    run = value.get("run") or {}
+                    assert run.get("status") not in {"failed", "interrupted"}, value
+                    return value
+
+        async with client.stream(
+            "GET", "/admin/api/code/events", timeout=None
+        ) as response:
+            response.raise_for_status()
+            reading = asyncio.create_task(_events(response, queue))
+            try:
+                async with asyncio.timeout(timeout_s):
+                    await queue.get()
+                    first = await send(
+                        "FCC_PARENT_REVIEW_WORK: Delegate a harmless local command to one child agent."
+                    )
+                    review = None
+                    parent_done = False
+                    while review is None or not parent_done:
+                        value = await event()
+                        item = value.get("item", {})
+                        if item.get("kind") == "subagent_auto_review":
+                            review = item
+                        parent_done |= (
+                            value.get("run", {}).get("id") == first
+                            and value["run"]["status"] == "completed"
+                        )
+                    detail = (await client.get(path)).json()
+                    assert (
+                        not review["complete"]
+                        and review["id"] in detail["active_review_ids"]
+                    ), detail
+                    session = detail["session"]
+                    second = await send("Reply while the child review is pending.")
+                    while True:
+                        value = await event()
+                        if (
+                            value.get("run", {}).get("id") == second
+                            and value["run"]["status"] == "completed"
+                        ):
+                            break
+                    release.set()
+                    while True:
+                        value = await event()
+                        item = value.get("item", {})
+                        if item.get("id") == review["id"] and item["complete"]:
+                            assert item["title"] == "Sub-agent Auto-review: Approved", (
+                                item
+                            )
+                            assert (
+                                item["run_id"] == first
+                                and item["sequence"] == review["sequence"]
+                            ), item
+                            assert (
+                                value["run"]["id"] == second
+                                and value["run"]["status"] == "completed"
+                            ), value
+                            break
+                    assert await asyncio.to_thread(finished.wait, timeout_s), (
+                        "Child did not finish its command"
+                    )
+                    detail = (await client.get(path)).json()
+                    assert detail["active_review_ids"] == [], detail
+                    print(
+                        "child Auto-review: parent finished; next message completed; original review approved"
+                    )
+            finally:
+                release.set()
+                reading.cancel()
+                await asyncio.gather(reading, return_exceptions=True)
+        return session_id
+
+
+def test_codex_child_review_local_e2e(
+    smoke_config: SmokeConfig, tmp_path: Path
+) -> None:
+    env, unset = _environment(tmp_path, "lmstudio/codex-mode-smoke")
+    with (tmp_path / "codex-home" / "config.toml").open(
+        "a", encoding="utf-8"
+    ) as config:
+        config.write("[features]\nmulti_agent = true\nmulti_agent_v2 = true\n")
+    release, finished = threading.Event(), threading.Event()
+    marker = tmp_path / "child-marker.txt"
+    with _canned_provider(release, finished) as (url, state):
+        env["LM_STUDIO_BASE_URL"] = url
+        state.update(spawn=True, mode="auto_review", command=_marker_command(marker))
+        try:
+            with SmokeServerDriver(
+                smoke_config,
+                name="codex-child-review-local",
+                env_overrides=env,
+                env_unset=unset,
+            ).run() as server:
+                session_id = asyncio.run(
+                    _exercise_child_review(
+                        server.base_url,
+                        tmp_path / "workspace",
+                        release,
+                        finished,
+                        smoke_config.timeout_s,
+                    )
+                )
+                assert marker.read_text().strip() == "smoke"
+                with sqlite3.connect(
+                    tmp_path / "home" / ".fcc" / "code" / "code.db"
+                ) as database:
+                    root = database.execute(
+                        "SELECT native_thread_id FROM code_sessions WHERE id = ?",
+                        (session_id,),
+                    ).fetchone()[0]
+                    rows = database.execute(
+                        "SELECT raw FROM code_items WHERE session_id = ? AND kind = 'subagent_auto_review'",
+                        (session_id,),
+                    ).fetchall()
+                    assert rows and all(
+                        json.loads(row[0])["threadId"] != root for row in rows
+                    )
+            assert "error" not in state, state.get("error")
+            assert state["reviews"] == 1
+        finally:
+            release.set()
+            (tmp_path / "child-requests.json").write_text(
                 json.dumps(state, indent=2), encoding="utf-8"
             )
 

--- a/smoke/product/test_codex_modes_product_live.py
+++ b/smoke/product/test_codex_modes_product_live.py
@@ -10,7 +10,7 @@ import sys
 import threading
 import uuid
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -553,8 +553,8 @@ def test_codex_child_review_local_e2e(
                     )
                 )
                 assert marker.read_text().strip() == "smoke"
-                with sqlite3.connect(
-                    tmp_path / "home" / ".fcc" / "code" / "code.db"
+                with closing(
+                    sqlite3.connect(tmp_path / "home" / ".fcc" / "code" / "code.db")
                 ) as database:
                     root = database.execute(
                         "SELECT native_thread_id FROM code_sessions WHERE id = ?",

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -78,6 +78,7 @@
         cursor: -1,
         items: new Map(),
         prompts: new Map(),
+        activeReviewIds: new Set(),
         activePrompts: new Map(),
         runs: new Map(),
         loaded: false,
@@ -118,6 +119,8 @@
       )
         record.runNotice = "";
       record.run = data.run;
+      if (data.active_review_ids)
+        record.activeReviewIds = new Set(data.active_review_ids);
       record.version = version;
       record.cursor = Math.max(record.cursor, data.cursor || 0);
       if (record.run) accepted(id, record.run.id);
@@ -1216,13 +1219,18 @@
       insertEntry(parent, node, item.sequence);
     }
     const summary = node.querySelector(".code-tool > summary");
-    if (summary)
+    if (summary) {
+      const childReview = item.kind === "subagent_auto_review";
+      const active = childReview
+        ? records.get(selected).activeReviewIds.has(item.id)
+        : activeStatuses.has(run.status);
       summary.textContent =
-        item.kind === "auto_review" &&
+        (childReview || item.kind === "auto_review") &&
         !item.complete &&
-        !activeStatuses.has(run.status)
-          ? "Auto-review: Result unavailable"
+        !active
+          ? `${childReview ? "Sub-agent " : ""}Auto-review: Result unavailable`
           : item.title || "Tool";
+    }
     const content = node.querySelector(".code-prose"),
       value = item.html ?? item.text;
     if (node.codeText !== value) {

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -240,10 +240,16 @@
     const requestEpoch = epoch,
       token = viewToken,
       connection = syncToken;
+    const params = new URLSearchParams();
+    if (before) params.set("before", before);
+    else
+      // Reconcile unfinished entries even after they fall outside the newest page.
+      for (const { value } of get(id).items.values())
+        if (!value.complete) params.append("include_item_ids", value.id);
     let data;
     try {
       data = await api(
-        `${base}/sessions/${id}${before ? `/items?before=${encodeURIComponent(before)}` : ""}`,
+        `${base}/sessions/${id}${before ? "/items" : ""}?${params}`,
       );
     } catch (error) {
       if (token !== viewToken || connection !== syncToken || selected !== id)

--- a/src/free_claude_code/api/code_sessions_routes.py
+++ b/src/free_claude_code/api/code_sessions_routes.py
@@ -303,6 +303,7 @@ def _detail_payload(detail: CodeDetail) -> JsonObject:
         "run": _run_payload(detail.run) if detail.run else None,
         "runs": [_run_payload(run) for run in detail.runs],
         "active_prompt_ids": list(detail.active_prompt_ids),
+        "active_review_ids": list(detail.active_review_ids),
         "items": [_item_payload(item) for item in detail.items],
         "prompts": [_prompt_payload(prompt) for prompt in detail.prompts],
         "epoch": detail.epoch,

--- a/src/free_claude_code/api/code_sessions_routes.py
+++ b/src/free_claude_code/api/code_sessions_routes.py
@@ -174,9 +174,13 @@ async def create(
 
 @router.get("/admin/api/code/sessions/{session_id}")
 async def detail(
-    session_id: str, services: ApiServices = Depends(get_services)
+    session_id: str,
+    include_item_ids: tuple[str, ...] = Query(default=()),
+    services: ApiServices = Depends(get_services),
 ) -> JsonObject:
-    return _detail_payload(await _code(services).get_detail(session_id))
+    return _detail_payload(
+        await _code(services).get_detail(session_id, include_item_ids=include_item_ids)
+    )
 
 
 @router.get("/admin/api/code/sessions/{session_id}/items")

--- a/src/free_claude_code/application/code_sessions/models.py
+++ b/src/free_claude_code/application/code_sessions/models.py
@@ -104,6 +104,7 @@ class CodeDetail:
     next_before: tuple[int, int] | None = None
     runs: tuple[CodeRun, ...] = ()
     active_prompt_ids: tuple[str, ...] = ()
+    active_review_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,6 +180,7 @@ class HarnessEvent:
     message: str | None = None
     will_retry: bool = False
     error_details: JsonObject = field(default_factory=dict)
+    raw: JsonObject = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/free_claude_code/application/code_sessions/ports.py
+++ b/src/free_claude_code/application/code_sessions/ports.py
@@ -160,7 +160,11 @@ class CodeApplicationPort(Protocol):
     ) -> CodePage: ...
 
     async def get_detail(
-        self, session_id: str, *, before: tuple[int, int] | None = None
+        self,
+        session_id: str,
+        *,
+        before: tuple[int, int] | None = None,
+        include_item_ids: Sequence[str] = (),
     ) -> CodeDetail: ...
 
     async def subscribe(self) -> tuple[EventSubscription, JsonObject]: ...

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -59,6 +59,7 @@ class _Owner:
     loaded_thread_id: str | None = None
     dirty: set[str] = field(default_factory=set)
     known_turns: set[str] = field(default_factory=set)
+    review_generations: dict[str, str] = field(default_factory=dict)
     dirty_characters: int = 0
     storage_failed: bool = False
     failure_task: asyncio.Task[None] | None = None
@@ -73,6 +74,14 @@ class _Owner:
         return any(
             prompt.status in {"pending", "answering"}
             for prompt in self.prompts.values()
+        )
+
+    @property
+    def active_review_ids(self) -> tuple[str, ...]:
+        return tuple(
+            item_id
+            for item_id, generation in self.review_generations.items()
+            if generation == self.generation
         )
 
 
@@ -212,7 +221,7 @@ class CodeService:
                     {run.id: run for run in runs},
                     sequence=max((item.sequence for item in items), default=0),
                     known_turns={
-                        item.native_turn_id for item in items if item.native_turn_id
+                        run.native_turn_id for run in runs if run.native_turn_id
                     },
                 )
                 if owner.run and owner.run.native_turn_id:
@@ -260,7 +269,12 @@ class CodeService:
             self._summary(owner)
             for owner in tuple(self._owners.values())
             if not owner.deleted
-            and (owner.busy or owner.pending or owner.session.status != "ready")
+            and (
+                owner.busy
+                or owner.pending
+                or owner.active_review_ids
+                or owner.session.status != "ready"
+            )
         ]
         return subscription, {
             "epoch": self.epoch,
@@ -325,6 +339,7 @@ class CodeService:
                     for prompt in owner.prompts.values()
                     if prompt.status in {"pending", "answering"}
                 ),
+                owner.active_review_ids,
             )
 
     async def update_settings(
@@ -733,7 +748,7 @@ class CodeService:
                 }
             )
             for item in turn.items:
-                self._update_item(owner, item, recovered_run=run)
+                self._update_item(owner, item, run, historical=True)
             items = tuple(owner.items[item_id] for item_id in owner.dirty)
             await self._persist(owner, owner.session, run=run, items=items)
             owner.dirty.clear()
@@ -787,9 +802,7 @@ class CodeService:
                 or not owner.busy
             ):
                 return
-            owner.connection = None
-            owner.generation = None
-            owner.loaded_thread_id = None
+            self._detach_connection_locked(owner)
         await connection.close()
         async with owner.lock:
             if owner.run and owner.run.id == run.id and owner.busy:
@@ -893,8 +906,39 @@ class CodeService:
                     else:
                         self._publish(owner, "run.updated")
                         self._schedule_interrupt(owner)
-                elif event.kind == "item" and event.item is not None and matches:
-                    self._update_item(owner, event.item)
+                elif (
+                    event.kind == "item"
+                    and event.item is not None
+                    and event.item.kind == "subagent_auto_review"
+                    and run is not None
+                ):
+                    existing = self._native_item(owner, event.item)
+                    if (
+                        existing is not None
+                        and existing.complete
+                        and not event.item.complete
+                    ):
+                        return
+                    target = owner.runs[existing.run_id] if existing else run
+                    item = self._update_item(owner, event.item, target)
+                    previous_generation = owner.review_generations.get(item.id)
+                    if item.complete:
+                        owner.review_generations.pop(item.id, None)
+                    else:
+                        owner.review_generations[item.id] = event.generation
+                    if (
+                        not owner.dirty
+                        and previous_generation != owner.review_generations.get(item.id)
+                    ):
+                        self._publish(owner, "session.updated")
+                    await self._flush_locked(owner)
+                elif (
+                    event.kind == "item"
+                    and event.item is not None
+                    and matches
+                    and run is not None
+                ):
+                    self._update_item(owner, event.item, run)
                     if event.item.complete or owner.dirty_characters >= 4096:
                         await self._flush_locked(owner)
                     elif owner.flush_task is None or owner.flush_task.done():
@@ -971,6 +1015,7 @@ class CodeService:
                         title="Notice",
                         text=event.message,
                         complete=True,
+                        raw=event.raw,
                     )
                     await self._persist(owner, owner.session, items=(item,))
                     owner.items[item.id] = item
@@ -979,9 +1024,7 @@ class CodeService:
                         owner, "item.updated", item=item.model_dump(mode="json")
                     )
                 elif event.kind == "closed":
-                    owner.connection = None
-                    owner.generation = None
-                    owner.loaded_thread_id = None
+                    self._detach_connection_locked(owner)
                     if owner.busy:
                         await self._finish_locked(
                             owner,
@@ -998,15 +1041,9 @@ class CodeService:
                     "Code event could not be saved: exc_type={}", type(exc).__name__
                 )
 
-    def _update_item(
-        self, owner: _Owner, update: ItemUpdate, *, recovered_run: CodeRun | None = None
-    ) -> None:
-        run = recovered_run or owner.run
-        if run is None:
-            raise CodeUnavailableError("Codex returned output without a saved turn.")
-        historical = recovered_run is not None
-        owner.known_turns.add(update.turn_id)
-        existing = next(
+    @staticmethod
+    def _native_item(owner: _Owner, update: ItemUpdate) -> CodeItem | None:
+        return next(
             (
                 item
                 for item in owner.items.values()
@@ -1015,6 +1052,18 @@ class CodeService:
             ),
             None,
         )
+
+    def _update_item(
+        self,
+        owner: _Owner,
+        update: ItemUpdate,
+        run: CodeRun,
+        *,
+        historical: bool = False,
+    ) -> CodeItem:
+        if update.kind != "subagent_auto_review":
+            owner.known_turns.add(update.turn_id)
+        existing = self._native_item(owner, update)
         if existing is None and update.kind == "user":
             if update.client_id is not None and update.client_id != run.id:
                 raise CodeUnavailableError(
@@ -1051,13 +1100,14 @@ class CodeService:
             complete=update.complete or bool(existing and existing.complete),
         )
         if item == existing:
-            return
+            return existing
         owner.items[item.id] = item
         owner.dirty.add(item.id)
         owner.dirty_characters += abs(
             len(item.text) - (len(existing.text) if existing else 0)
         ) + abs(len(item.detail) - (len(existing.detail) if existing else 0))
         owner.version += 1
+        return item
 
     async def _flush_later(self, owner: _Owner) -> None:
         await asyncio.sleep(0.25)
@@ -1077,7 +1127,12 @@ class CodeService:
         owner.dirty.clear()
         owner.dirty_characters = 0
         for item in sorted(items, key=lambda value: value.sequence):
-            self._publish(owner, "item.updated", item=item.model_dump(mode="json"))
+            self._publish(
+                owner,
+                "item.updated",
+                item=item.model_dump(mode="json"),
+                runs=[owner.runs[item.run_id].model_dump(mode="json")],
+            )
 
     async def _finish_locked(
         self,
@@ -1162,12 +1217,20 @@ class CodeService:
         await self._close_connection(owner)
         self._storage_failure(owner)
 
+    def _detach_connection_locked(self, owner: _Owner) -> HarnessConnection | None:
+        connection = owner.connection
+        owner.connection = None
+        owner.generation = None
+        owner.loaded_thread_id = None
+        if owner.review_generations:
+            owner.review_generations.clear()
+            if not owner.deleted:
+                self._publish(owner, "session.updated")
+        return connection
+
     async def _close_connection(self, owner: _Owner) -> None:
         async with owner.lock:
-            connection = owner.connection
-            owner.connection = None
-            owner.generation = None
-            owner.loaded_thread_id = None
+            connection = self._detach_connection_locked(owner)
         if connection is not None:
             await connection.close()
         async with owner.lock:
@@ -1293,6 +1356,7 @@ class CodeService:
             "session_id": owner.session.id,
             "session": owner.session.model_dump(mode="json"),
             "run": owner.run.model_dump(mode="json") if owner.run else None,
+            "active_review_ids": list(owner.active_review_ids),
             "version": owner.version,
             "epoch": self.epoch,
         }

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -298,10 +298,12 @@ class CodeService:
                 active_start = (owner.run.ordinal, 0)
                 page_before = min(before, active_start) if before else active_start
             page = await self._store.item_page(session_id, page_before, 50)
+            active_review_ids = set(owner.active_review_ids)
             active = [
                 item
                 for item in owner.items.values()
                 if (owner.busy and owner.run and item.run_id == owner.run.id)
+                or item.id in active_review_ids
                 or (
                     item.kind == "prompt"
                     and owner.prompts[item.id].status in {"pending", "answering"}

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -287,7 +287,11 @@ class CodeService:
         return self._events.cursor
 
     async def get_detail(
-        self, session_id: str, *, before: tuple[int, int] | None = None
+        self,
+        session_id: str,
+        *,
+        before: tuple[int, int] | None = None,
+        include_item_ids: Sequence[str] = (),
     ) -> CodeDetail:
         owner = await self._owner(session_id)
         async with owner.lock:
@@ -298,19 +302,19 @@ class CodeService:
                 active_start = (owner.run.ordinal, 0)
                 page_before = min(before, active_start) if before else active_start
             page = await self._store.item_page(session_id, page_before, 50)
-            active_review_ids = set(owner.active_review_ids)
-            active = [
+            included_ids = {*owner.active_review_ids, *include_item_ids}
+            extra = [
                 item
                 for item in owner.items.values()
                 if (owner.busy and owner.run and item.run_id == owner.run.id)
-                or item.id in active_review_ids
+                or item.id in included_ids
                 or (
                     item.kind == "prompt"
                     and owner.prompts[item.id].status in {"pending", "answering"}
                 )
             ]
             selected = sorted(
-                {item.id: item for item in [*page.items, *active]}.values(),
+                {item.id: item for item in [*page.items, *extra]}.values(),
                 key=lambda item: (owner.runs[item.run_id].ordinal, item.sequence),
             )
             prompt_ids = {item.id for item in selected if item.kind == "prompt"}
@@ -331,7 +335,7 @@ class CodeService:
                         run.id: run
                         for run in (
                             *page.runs,
-                            *(owner.runs[item.run_id] for item in active),
+                            *(owner.runs[item.run_id] for item in extra),
                             *((owner.run,) if owner.run else ()),
                         )
                     }.values()
@@ -928,11 +932,9 @@ class CodeService:
                         owner.review_generations.pop(item.id, None)
                     else:
                         owner.review_generations[item.id] = event.generation
-                    if (
-                        not owner.dirty
-                        and previous_generation != owner.review_generations.get(item.id)
-                    ):
-                        self._publish(owner, "session.updated")
+                    if previous_generation != owner.review_generations.get(item.id):
+                        # Reannounce the saved row when its liveness changes.
+                        owner.dirty.add(item.id)
                     await self._flush_locked(owner)
                 elif (
                     event.kind == "item"

--- a/src/free_claude_code/runtime/codex_app_server.py
+++ b/src/free_claude_code/runtime/codex_app_server.py
@@ -474,7 +474,12 @@ class CodexAppServer:
                 result = await self.rpc(
                     "thread/read", {"threadId": thread_id, "includeTurns": False}
                 )
-            except CodeConflictError, CodeUnavailableError, NativeHistoryMissing:
+            except (
+                CodeConflictError,
+                CodeUnavailableError,
+                NativeHistoryMissing,
+                OSError,
+            ):
                 return False
             thread = object_value(result.get("thread"))
             if thread.get("id") != thread_id:

--- a/src/free_claude_code/runtime/codex_app_server.py
+++ b/src/free_claude_code/runtime/codex_app_server.py
@@ -432,7 +432,62 @@ class CodexAppServer:
 
     async def _dispatch(self) -> None:
         while (event := await self._queue.get()) is not None:
+            review = event.item is not None and event.item.kind == "auto_review"
+            if (
+                event.thread_id is not None
+                and event.thread_id != self.thread_id
+                and (review or (event.kind == "notice" and event.message))
+                and await self._owns_thread(event.thread_id)
+            ):
+                if review and event.item is not None:
+                    identity = json.dumps(
+                        [event.thread_id, event.item.raw["reviewId"]],
+                        separators=(",", ":"),
+                    )
+                    event = replace(
+                        event,
+                        thread_id=self.thread_id,
+                        item=replace(
+                            event.item,
+                            item_id=f"subagent-auto-review:{identity}",
+                            kind="subagent_auto_review",
+                            title=f"Sub-agent {event.item.title}",
+                        ),
+                    )
+                else:
+                    event = replace(
+                        event,
+                        thread_id=self.thread_id,
+                        message=f"Sub-agent: {event.message}",
+                    )
             await self._sink(event)
+
+    async def _owns_thread(self, thread_id: str) -> bool:
+        # Native child listeners can deliver reviews without thread/started.
+        # Resolve ancestry from metadata, outside the reader that serves the RPC.
+        ancestors: set[str] = set()
+        while thread_id not in self._owned_threads:
+            if thread_id in ancestors:
+                return False
+            ancestors.add(thread_id)
+            try:
+                result = await self.rpc(
+                    "thread/read", {"threadId": thread_id, "includeTurns": False}
+                )
+            except CodeConflictError, CodeUnavailableError, NativeHistoryMissing:
+                return False
+            thread = object_value(result.get("thread"))
+            if thread.get("id") != thread_id:
+                return False
+            source = object_value(object_value(thread.get("source")).get("subAgent"))
+            parent = string_value(
+                object_value(source.get("thread_spawn")).get("parent_thread_id")
+            )
+            if not parent:
+                return False
+            thread_id = parent
+        self._owned_threads.update(ancestors)
+        return True
 
     async def _read_stderr(self) -> None:
         assert self.process.stderr is not None

--- a/src/free_claude_code/runtime/codex_protocol.py
+++ b/src/free_claude_code/runtime/codex_protocol.py
@@ -93,6 +93,7 @@ class CodexProtocol:
                 thread_id,
                 "notice",
                 message=string_value(params.get("message")),
+                raw=dict(params),
             )
         if not thread_id or not turn_id:
             return None

--- a/tests/api/test_code_sessions_routes.py
+++ b/tests/api/test_code_sessions_routes.py
@@ -9,7 +9,7 @@ from free_claude_code.application.code_sessions import CodeService
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.runtime.code_sessions_sqlite import SQLiteCodeStore
 from tests.api.support import create_test_app
-from tests.code_sessions_support import FakeHarness
+from tests.code_sessions_support import CodexPackets, FakeHarness
 
 
 @pytest_asyncio.fixture
@@ -38,6 +38,35 @@ async def create_session(code_api):
     )
     assert response.status_code == 201
     return response.json()
+
+
+@pytest.mark.asyncio
+async def test_detail_exposes_child_review_liveness_without_native_source(code_api):
+    client, code, harness, _, _ = code_api
+    session = await create_session(code_api)
+    path = f"/admin/api/code/sessions/{session['id']}"
+    await code.send(
+        session["id"],
+        str(uuid.uuid4()),
+        session["revision"],
+        "Delegate",
+        expected_epoch=code.epoch,
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    packets = CodexPackets(connection)
+    await packets.spawn()
+    await packets.review()
+    await connection.finish("turn-1")
+    detail = (await client.get(path)).json()
+    review = detail["items"][-1]
+    assert detail.get("active_review_ids") == [review["id"]]
+    assert review["kind"] == "subagent_auto_review"
+    assert not {"raw", "native_turn_id", "native_item_id", "generation"} & review.keys()
+    await connection.close()
+    closed = (await client.get(path)).json()
+    assert closed["active_review_ids"] == []
+    assert closed["items"] == detail["items"]
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -1,5 +1,6 @@
 import asyncio
 import uuid
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 import pytest_asyncio
@@ -36,6 +37,100 @@ async def code(tmp_path):
 async def session_for(code):
     service, _, directory = code
     return await service.create_session(new_id(), str(directory))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "finished", "status"),
+    [(BrokenPipeError, False, "failed"), (ConnectionResetError, True, "completed")],
+)
+async def test_child_lookup_pipe_failure_delivers_queued_close(
+    code, monkeypatch, failure, finished, status
+):
+    service, harness, _ = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "Delegate", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    packets = CodexPackets(connection)
+    await packets.spawn()
+    await packets.review()
+    if finished:
+        await connection.finish("turn-1")
+    native = packets.native
+    monkeypatch.delattr(native, "rpc")
+    native._alive = True
+    native._process = Mock(
+        stdin=Mock(drain=AsyncMock(side_effect=failure("Pipe closed")))
+    )
+    await native._packet(
+        {
+            "method": "guardianWarning",
+            "params": {"threadId": "unregistered-child", "message": "Child warning"},
+        }
+    )
+    native._queue.put_nowait(
+        HarnessEvent(
+            connection.generation,
+            connection.thread_id,
+            "closed",
+            message="Native process ended",
+        )
+    )
+    native._queue.put_nowait(None)
+    try:
+        await native._dispatch()
+        detail = await service.get_detail(session.id)
+        assert detail.active_review_ids == ()
+        assert detail.run.status == status
+        assert [item.kind for item in detail.items] == ["user", "subagent_auto_review"]
+        assert not detail.items[-1].complete
+    finally:
+        for _, future in native._pending.values():
+            future.cancel()
+
+
+@pytest.mark.asyncio
+async def test_pending_child_review_outside_page_keeps_its_run_and_history_cursor(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    first = await service.send(
+        session.id, new_id(), session.revision, "Delegate", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    packets = CodexPackets(connection)
+    await packets.spawn()
+    await packets.review()
+    review = (await service.get_detail(session.id)).items[-1]
+    await connection.finish("turn-1")
+    session = (await service.get_detail(session.id)).session
+    await service.send(
+        session.id, new_id(), session.revision, "Continue", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.wait_inputs(2), 3)
+    for index in range(55):
+        await connection.text("turn-2", str(index), f"Output {index}", complete=True)
+    await connection.finish("turn-2")
+    newest = await service.get_detail(session.id)
+    assert len(newest.items) == 51
+    assert newest.items[0].id == review.id and newest.items[0].run_id == first.id
+    assert first.id in {run.id for run in newest.runs}
+    assert newest.active_review_ids == (review.id,)
+    assert newest.next_before == (2, 9)
+    await packets.review(status="approved")
+    resolved = await service.get_detail(session.id)
+    assert resolved.active_review_ids == ()
+    assert review.id not in {item.id for item in resolved.items}
+    assert resolved.next_before == newest.next_before
+    older = await service.get_detail(session.id, before=newest.next_before)
+    saved = next(item for item in older.items if item.id == review.id)
+    assert saved.complete and saved.title == "Sub-agent Auto-review: Approved"
+    assert saved.sequence == review.sequence and saved.run_id == first.id
+    merged = {item.id: item for item in (*older.items, *resolved.items)}
+    assert sorted(item.sequence for item in merged.values()) == list(range(1, 59))
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -125,6 +125,13 @@ async def test_pending_child_review_outside_page_keeps_its_run_and_history_curso
     assert resolved.active_review_ids == ()
     assert review.id not in {item.id for item in resolved.items}
     assert resolved.next_before == newest.next_before
+    refreshed = await service.get_detail(
+        session.id, include_item_ids=(review.id, review.id, "missing")
+    )
+    assert len(refreshed.items) == 51
+    assert refreshed.items[0].id == review.id and refreshed.items[0].complete
+    assert first.id in {run.id for run in refreshed.runs}
+    assert refreshed.next_before == newest.next_before
     older = await service.get_detail(session.id, before=newest.next_before)
     saved = next(item for item in older.items if item.id == review.id)
     assert saved.complete and saved.title == "Sub-agent Auto-review: Approved"
@@ -338,8 +345,10 @@ async def test_mode_is_captured_per_turn_and_does_not_recreate_native_process(co
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("pending_output", [False, True])
 async def test_reobserved_child_review_publishes_liveness_on_new_native_connection(
     code,
+    pending_output,
 ):
     service, harness, _ = code
     session = await session_for(code)
@@ -360,18 +369,25 @@ async def test_reobserved_child_review_publishes_liveness_on_new_native_connecti
     )
     await asyncio.wait_for(harness.wait_inputs(2), 3)
     second = harness.connections[1]
-    await second.finish("turn-2")
+    if not pending_output:
+        await second.finish("turn-2")
     assert (await service.get_detail(session.id)).active_review_ids == ()
     packets = CodexPackets(second)
     await packets.spawn()
     subscription, _ = await service.subscribe()
     try:
+        if pending_output:
+            await second.text("turn-2", "reply", "In progress")
         await packets.review()
         event = await asyncio.wait_for(anext(aiter(subscription)), 3)
+        while event.data["active_review_ids"] != [review.id]:
+            event = await asyncio.wait_for(anext(aiter(subscription)), 3)
         assert event.data["active_review_ids"] == [review.id]
+        assert event.data.get("item", {}).get("id") == review.id
+        assert event.data["runs"][0]["id"] == review.run_id
         detail = await service.get_detail(session.id)
         assert next(item for item in detail.items if item.id == review.id) == review
-        assert detail.run.status == "completed"
+        assert detail.run.status == ("running" if pending_output else "completed")
     finally:
         await subscription.aclose()
 

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -14,7 +14,7 @@ from free_claude_code.application.code_sessions.models import (
 )
 from free_claude_code.runtime.code_sessions_sqlite import SQLiteCodeStore
 from free_claude_code.runtime.codex_protocol import CodexProtocol
-from tests.code_sessions_support import FakeConnection, FakeHarness
+from tests.code_sessions_support import CodexPackets, FakeConnection, FakeHarness
 
 
 def new_id():
@@ -36,6 +36,181 @@ async def code(tmp_path):
 async def session_for(code):
     service, _, directory = code
     return await service.create_session(new_id(), str(directory))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ownership", ["notification", "metadata"])
+async def test_owned_child_reviews_and_warnings_reach_saved_parent_transcript(
+    code, ownership
+):
+    service, harness, _ = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "Delegate", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    packets = CodexPackets(connection)
+    if ownership == "notification":
+        await packets.spawn()
+        await packets.spawn("grandchild", "child")
+        await packets.spawn("unrelated", "outside")
+    else:
+        packets.parents.update(
+            {
+                "child": connection.thread_id,
+                "grandchild": "child",
+                "unrelated": "outside",
+            }
+        )
+    for child in (connection.thread_id, "child", "grandchild", "unrelated"):
+        await packets.review(child, status="approved", turn="turn-1")
+        await packets.warning(child)
+    detail = await service.get_detail(session.id)
+    assert [item.kind for item in detail.items] == [
+        "user",
+        "auto_review",
+        "notice",
+        "subagent_auto_review",
+        "notice",
+        "subagent_auto_review",
+        "notice",
+    ]
+    reviews = [item for item in detail.items if item.kind == "subagent_auto_review"]
+    assert len({item.native_item_id for item in reviews}) == 2
+    assert [item.raw["threadId"] for item in reviews] == ["child", "grandchild"]
+    assert all(item.title == "Sub-agent Auto-review: Approved" for item in reviews)
+    assert detail.items[-1].text == "Sub-agent: Native warning"
+    assert detail.items[-1].raw == {
+        "threadId": "grandchild",
+        "message": "Native warning",
+    }
+    assert await service._store.items(session.id, None, None) == detail.items
+    assert detail.run.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_child_review_stays_with_first_entry_after_next_turn_begins(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    first = await service.send(
+        session.id, new_id(), session.revision, "Delegate", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    packets = CodexPackets(connection)
+    await packets.spawn()
+    await packets.review()
+    before = await service.get_detail(session.id)
+    assert len(before.items) == 2
+    review = before.items[-1]
+    assert before.active_review_ids == (review.id,)
+    await connection.finish("turn-1")
+    await packets.send(
+        "turn/completed",
+        {"threadId": "child", "turn": {"id": "child-turn", "status": "completed"}},
+    )
+    assert (await service.get_detail(session.id)).active_review_ids == (review.id,)
+    subscription, ready = await service.subscribe()
+    events = aiter(subscription)
+    try:
+        assert ready["sessions"][0]["active_review_ids"] == [review.id]
+        session = (await service.get_detail(session.id)).session
+        harness.start_gate.clear()
+        harness.started.clear()
+        second = await service.send(
+            session.id,
+            new_id(),
+            session.revision,
+            "Continue",
+            expected_epoch=service.epoch,
+        )
+        await asyncio.wait_for(harness.wait_inputs(2), 3)
+        await packets.review(status="denied")
+        await packets.review(status="denied")
+        await packets.review()
+        await packets.warning()
+        await packets.review(review_id="next", status="approved", turn="turn-2")
+        await packets.send(
+            "turn/started", {"threadId": "child", "turn": {"id": "turn-2"}}
+        )
+        await packets.send(
+            "turn/completed",
+            {"threadId": "child", "turn": {"id": "turn-2", "status": "completed"}},
+        )
+        detail = await service.get_detail(session.id)
+        saved = next(item for item in detail.items if item.id == review.id)
+        assert (saved.run_id, saved.sequence, saved.native_turn_id) == (
+            first.id,
+            review.sequence,
+            "child-turn",
+        )
+        assert saved.title == "Sub-agent Auto-review: Denied" and saved.complete
+        assert detail.active_review_ids == ()
+        assert detail.run.id == second.id and detail.run.native_turn_id is None
+        assert all(item.run_id == second.id for item in detail.items[-3:])
+        while (event := await asyncio.wait_for(anext(events), 3)).data.get(
+            "item", {}
+        ).get("id") != review.id:
+            pass
+        assert event.data["runs"][0]["id"] == first.id
+        assert event.data["run"]["id"] == second.id
+        harness.start_gate.set()
+        await asyncio.wait_for(harness.started.wait(), 3)
+        assert (await service.get_detail(session.id)).run.native_turn_id == "turn-2"
+        await connection.finish("turn-2")
+    finally:
+        harness.start_gate.set()
+        await subscription.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("closure", ["native", "service"])
+async def test_pending_child_review_becomes_unavailable_when_idle_connection_ends(
+    code, closure
+):
+    service, harness, directory = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "Delegate", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    packets = CodexPackets(connection)
+    await packets.spawn()
+    await connection.finish("turn-1")
+    await packets.review()
+    before = await service.get_detail(session.id)
+    assert len(before.items) == 2
+    review = before.items[-1]
+    assert before.active_review_ids == (review.id,)
+    subscription, _ = await service.subscribe()
+    events = aiter(subscription)
+    try:
+        if closure == "native":
+            await connection.close()
+        else:
+            await service._close_connection(await service._owner(session.id))
+        event = await asyncio.wait_for(anext(events), 3)
+        assert event.data["active_review_ids"] == []
+        await packets.review(status="approved")
+        detail = await service.get_detail(session.id)
+        assert detail.items == before.items
+        assert detail.active_review_ids == ()
+        assert detail.run.status == "completed"
+        await service.close()
+        restarted = CodeService(
+            SQLiteCodeStore(directory / "code.db", directory / "code.lock"), harness
+        )
+        await restarted.start()
+        try:
+            restored = await restarted.get_detail(session.id)
+            assert restored.items == before.items
+            assert restored.active_review_ids == ()
+        finally:
+            await restarted.close()
+    finally:
+        await subscription.aclose()
 
 
 @pytest.mark.asyncio
@@ -65,6 +240,71 @@ async def test_mode_is_captured_per_turn_and_does_not_recreate_native_process(co
     assert len(harness.connections) == 1
     assert harness.connections[0].modes == modes
     assert session.native_permission_defaults == harness.permission_defaults
+
+
+@pytest.mark.asyncio
+async def test_reobserved_child_review_publishes_liveness_on_new_native_connection(
+    code,
+):
+    service, harness, _ = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "Delegate", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    first = harness.connections[0]
+    packets = CodexPackets(first)
+    await packets.spawn()
+    await packets.review()
+    review = (await service.get_detail(session.id)).items[-1]
+    await first.finish("turn-1")
+    harness.configurations[harness.model] = "replacement"
+    session = (await service.get_detail(session.id)).session
+    await service.send(
+        session.id, new_id(), session.revision, "Continue", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.wait_inputs(2), 3)
+    second = harness.connections[1]
+    await second.finish("turn-2")
+    assert (await service.get_detail(session.id)).active_review_ids == ()
+    packets = CodexPackets(second)
+    await packets.spawn()
+    subscription, _ = await service.subscribe()
+    try:
+        await packets.review()
+        event = await asyncio.wait_for(anext(aiter(subscription)), 3)
+        assert event.data["active_review_ids"] == [review.id]
+        detail = await service.get_detail(session.id)
+        assert next(item for item in detail.items if item.id == review.id) == review
+        assert detail.run.status == "completed"
+    finally:
+        await subscription.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forced_interrupt_clears_pending_child_review_liveness(code, monkeypatch):
+    service, harness, _ = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "Delegate", expected_epoch=service.epoch
+    )
+    await asyncio.wait_for(harness.started.wait(), 3)
+    connection = harness.connections[0]
+    packets = CodexPackets(connection)
+    await packets.spawn()
+    await packets.review()
+    assert (await service.get_detail(session.id)).active_review_ids
+
+    async def unavailable(_turn_id):
+        raise CodeUnavailableError("Native interrupt transport failed")
+
+    monkeypatch.setattr(connection, "interrupt", unavailable)
+    await service.stop(session.id, (await service.get_detail(session.id)).run.id)
+    await asyncio.wait_for(service.wait_idle(session.id), 3)
+    detail = await service.get_detail(session.id)
+    assert detail.active_review_ids == ()
+    assert detail.run.status == "interrupted"
+    assert not detail.items[-1].complete
 
 
 @pytest.mark.asyncio

--- a/tests/code_sessions_support.py
+++ b/tests/code_sessions_support.py
@@ -3,6 +3,7 @@
 import asyncio
 import uuid
 from dataclasses import dataclass
+from unittest.mock import AsyncMock
 
 from free_claude_code.application.code_sessions.models import (
     CodeCatalog,
@@ -22,6 +23,96 @@ from free_claude_code.application.code_sessions.models import (
 from free_claude_code.application.code_sessions.ports import EventSink, HarnessSelection
 from free_claude_code.config.model_refs import split_provider_model_ref
 from free_claude_code.core.json_types import JsonObject
+from free_claude_code.runtime.codex_app_server import CodexAppServer
+from free_claude_code.runtime.codex_protocol import CodexProtocol
+
+
+class CodexPackets:
+    """Feed native packets through the real adapter without starting a process."""
+
+    def __init__(self, connection):
+        self.connection = connection
+        self.native = CodexAppServer([], {}, "", connection.sink)
+        self.native.generation = connection.generation
+        self.native._protocol = CodexProtocol(connection.generation)
+        self.parents: dict[str, str] = {}
+        self.native.rpc = AsyncMock(side_effect=self.metadata)
+
+    async def metadata(self, method: str, params: JsonObject) -> JsonObject:
+        assert method == "thread/read" and params["includeTurns"] is False
+        identity = params["threadId"]
+        assert isinstance(identity, str)
+        parent = self.parents.get(identity)
+        return {
+            "thread": {
+                "id": identity,
+                "source": {"subAgent": {"thread_spawn": {"parent_thread_id": parent}}}
+                if parent
+                else "vscode",
+            }
+        }
+
+    async def send(self, method, params):
+        if self.native.thread_id is None:
+            future = asyncio.get_running_loop().create_future()
+            self.native._pending["register"] = ("thread/resume", future)
+            await self.native._packet(
+                {
+                    "id": "register",
+                    "result": {"thread": {"id": self.connection.thread_id}},
+                }
+            )
+        await self.native._packet({"method": method, "params": params})
+        self.native._queue.put_nowait(None)
+        await self.native._dispatch()
+
+    async def spawn(self, child="child", parent=None):
+        self.parents[child] = parent or self.connection.thread_id
+        await self.send(
+            "thread/started",
+            {
+                "thread": {
+                    "id": child,
+                    "source": {
+                        "subAgent": {
+                            "thread_spawn": {
+                                "parent_thread_id": parent or self.connection.thread_id,
+                                "depth": 1 if parent is None else 2,
+                            }
+                        }
+                    },
+                }
+            },
+        )
+
+    async def review(
+        self, child="child", review_id="review", status="inProgress", turn="child-turn"
+    ):
+        payload = {
+            "threadId": child,
+            "turnId": turn,
+            "reviewId": review_id,
+            "targetItemId": "command",
+            "startedAtMs": 1000,
+            "action": {
+                "type": "command",
+                "command": "echo harmless",
+                "cwd": "/tmp",
+                "source": "shell",
+            },
+            "review": {"status": status, "rationale": f"Native {status}"},
+        }
+        if status != "inProgress":
+            payload.update(completedAtMs=2000, decisionSource="agent")
+        await self.send(
+            "item/autoApprovalReview/started"
+            if status == "inProgress"
+            else "item/autoApprovalReview/completed",
+            payload,
+        )
+
+    async def warning(self, child="child", message="Native warning"):
+        await self.send("guardianWarning", {"threadId": child, "message": message})
 
 
 class FakeHarness:

--- a/tests/runtime/codex_fake_process.py
+++ b/tests/runtime/codex_fake_process.py
@@ -2,6 +2,8 @@
 
 import json
 import sys
+import time
+from pathlib import Path
 
 
 def emit(value):
@@ -29,7 +31,7 @@ for line in sys.stdin.buffer:
         emit({"id": request_id, "result": {"userAgent": "codex/0.153.0"}})
     elif method == "initialized":
         pass
-    elif method == "thread/start":
+    elif method in {"thread/start", "thread/resume"}:
         if mode == "delayed-create":
             creation_id = request_id
         else:
@@ -50,6 +52,8 @@ for line in sys.stdin.buffer:
         )
         emit({"id": request_id, "result": {}})
     elif method == "turn/start":
+        if mode == "child-warning-on-close":
+            turn = request["params"]["clientUserMessageId"]
         emit(
             {
                 "method": "turn/started",
@@ -170,3 +174,14 @@ for line in sys.stdin.buffer:
         sys.stdout.buffer.flush()
     else:
         emit({"id": request_id, "result": {}})
+
+if mode == "child-warning-on-close":
+    emit(
+        {
+            "method": "guardianWarning",
+            "params": {"threadId": "child", "message": "Child is shutting down"},
+        }
+    )
+    # Keep stdout alive until the parent has processed this close-time event.
+    while not Path(sys.argv[2]).exists():
+        time.sleep(0.01)

--- a/tests/runtime/test_codex_app_server.py
+++ b/tests/runtime/test_codex_app_server.py
@@ -1,14 +1,107 @@
 import asyncio
 import os
 import sys
+import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
+from free_claude_code.application.code_sessions import CodeService
 from free_claude_code.application.code_sessions.models import CodeUnavailableError
+from free_claude_code.runtime.code_sessions_sqlite import SQLiteCodeStore
 from free_claude_code.runtime.codex_app_server import CodexAppServer
 from tests.code_sessions_support import FakeHarness
+
+
+@pytest.mark.asyncio
+async def test_child_warning_during_shutdown_allows_connection_replacement(
+    tmp_path, monkeypatch
+):
+    harness = FakeHarness()
+    prepare = harness.prepare
+    connections = []
+    releases = []
+    warning = asyncio.Event()
+
+    def selection_for(model, effort, mode):
+        selection = prepare(model, effort, mode)
+
+        async def open_native(cwd, sink):
+            release = tmp_path / f"release-{len(connections)}"
+            releases.append(release)
+
+            async def receive(event):
+                await sink(event)
+                if event.kind == "notice" and event.thread_id == "child":
+                    warning.set()
+
+            native = CodexAppServer(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("codex_fake_process.py")),
+                    "child-warning-on-close",
+                    str(release),
+                ],
+                dict(os.environ),
+                cwd,
+                receive,
+                model_slugs={model: model},
+                fingerprints=selection.catalog,
+            )
+            await native.start()
+            connections.append(native)
+            return native
+
+        monkeypatch.setattr(selection, "open", open_native)
+        return selection
+
+    monkeypatch.setattr(harness, "prepare", selection_for)
+    service = CodeService(
+        SQLiteCodeStore(tmp_path / "code.db", tmp_path / "code.lock"), harness
+    )
+    await service.start()
+    observing = asyncio.create_task(warning.wait())
+    try:
+        session = await service.create_session(str(uuid.uuid4()), str(tmp_path))
+        await service.send(
+            session.id,
+            str(uuid.uuid4()),
+            session.revision,
+            "First",
+            expected_epoch=service.epoch,
+        )
+        await asyncio.wait_for(service.wait_idle(session.id), 3)
+        first = await service.get_detail(session.id)
+        assert first.run is not None
+        assert first.run.status == "completed"
+        harness.configurations[harness.model] = "replacement"
+        await service.send(
+            session.id,
+            str(uuid.uuid4()),
+            first.session.revision,
+            "Next",
+            expected_epoch=service.epoch,
+        )
+        dispatcher = connections[0]._dispatcher
+        assert dispatcher is not None
+        processed, _ = await asyncio.wait(
+            (observing, dispatcher), timeout=3, return_when=asyncio.FIRST_COMPLETED
+        )
+        assert processed, "The close-time warning was never processed"
+        releases[0].touch()
+        await asyncio.wait_for(service.wait_idle(session.id), 3)
+        detail = await service.get_detail(session.id)
+        assert detail.run is not None
+        assert detail.run.status == "completed", detail.run.error
+        assert len(connections) == 2 and connections[0].process.returncode is not None
+        assert all(item.kind != "notice" for item in detail.items)
+    finally:
+        for release in releases:
+            release.touch()
+        observing.cancel()
+        await asyncio.gather(observing, return_exceptions=True)
+        await service.close()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.0"
+version = "6.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Code sessions hide Auto-review results and warnings from Codex sub-agents. A sub-agent's review can continue after the main reply and finish while the user is already sending another message.

## How

Use Codex's parent metadata to recognize the session's sub-agents and save their reviews and warnings in the transcript. Keep each review in its original position and include pending reviews after refresh even when more than 50 newer entries exist. When the native connection ends, stop showing unfinished reviews as active.

Reconnect refreshes unfinished cards from saved history, including older cards outside the newest page. When Codex reports a pending review again after connection replacement, send its saved card and original turn together so connected tabs can display it immediately.

Handle a closed pipe during the parent lookup so shutdown completes and the next message can open a replacement connection.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61923174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/alishahryar1/-/pull-requests/alishahryar1/free-claude-code/1728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<details><summary><h3>Summary</h3></summary>

- The PR persists and displays Codex sub-agent auto-review results and warnings in code-session transcripts. Active or requested review cards are included outside the newest transcript page, and saved review cards are reannounced when a replacement connection observes them.
</details>

<!-- /greptile_comment -->