### PR TITLE
Fix Windows Muse installation with empty PATH entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.1"
+version = "6.2.2"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/scripts/install-muse.ps1
+++ b/scripts/install-muse.ps1
@@ -222,7 +222,7 @@ function Read-MuseOwnershipRecord {
 }
 
 function Get-MuseCanonicalPath {
-    param([Parameter(Mandatory = $true)][string] $Path)
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string] $Path)
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
         return $null

--- a/scripts/uninstall-muse.ps1
+++ b/scripts/uninstall-muse.ps1
@@ -101,7 +101,7 @@ function Read-MuseOwnershipRecord {
 }
 
 function Get-MuseCanonicalPath {
-    param([Parameter(Mandatory = $true)][string] $Path)
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string] $Path)
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
         return $null

--- a/tests/scripts/test_muse_windows_lifecycle.py
+++ b/tests/scripts/test_muse_windows_lifecycle.py
@@ -352,6 +352,7 @@ def _run_installer_lifecycle(
     publish_failure: bool = False,
     dry_run: bool = False,
     install_root_is_file: bool = False,
+    empty_path_entries: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
     local_app_data = tmp_path / "local-app-data"
     if install_root_is_file:
@@ -370,6 +371,9 @@ def _run_installer_lifecycle(
     user_path = os.pathsep.join(
         (str(tmp_path / "user-one"), str(tmp_path / "user-two"))
     )
+    if empty_path_entries:
+        process_path = os.pathsep + process_path + os.pathsep
+        user_path = os.pathsep + user_path + os.pathsep
     script = f"""$ErrorActionPreference = 'Stop'
 $env:LOCALAPPDATA = {_ps_literal(local_app_data)}
 $env:Path = {_ps_literal(process_path)}
@@ -486,14 +490,16 @@ def test_muse_installer_rejects_file_at_managed_root_before_fetch(
 
 
 @pytest.mark.parametrize("powershell", POWERSHELLS)
+@pytest.mark.parametrize("empty_path_entries", [False, True])
 def test_muse_installer_publishes_verified_binary_record_and_path(
-    tmp_path: Path, powershell: str
+    tmp_path: Path, powershell: str, empty_path_entries: bool
 ) -> None:
     payload = b"fresh Muse payload"
     result, local_app_data, call_log = _run_installer_lifecycle(
         tmp_path,
         powershell,
         payload=payload,
+        empty_path_entries=empty_path_entries,
     )
     root, executable, record_path = _managed_paths(local_app_data)
 
@@ -503,8 +509,11 @@ def test_muse_installer_publishes_verified_binary_record_and_path(
         payload
     )
     state = json.loads(result.stdout.splitlines()[-1])
-    assert state["UserPath"].split(os.pathsep)[0] == str(root / "bin")
-    assert state["ProcessPath"].split(os.pathsep)[0] == str(root / "bin")
+    for field, prefix in (("UserPath", "user"), ("ProcessPath", "process")):
+        expected = [str(tmp_path / f"{prefix}-one"), str(tmp_path / f"{prefix}-two")]
+        if empty_path_entries:
+            expected = ["", *expected, ""]
+        assert state[field] == os.pathsep.join([str(root / "bin"), *expected])
     assert call_log.read_text(encoding="utf-8").splitlines() == [
         "metadata",
         "download",
@@ -799,8 +808,9 @@ def _create_managed_install(
 
 
 @pytest.mark.parametrize("powershell", POWERSHELLS)
+@pytest.mark.parametrize("empty_path_entries", [False, True])
 def test_muse_uninstaller_removes_only_managed_assets_and_exact_path_entries(
-    tmp_path: Path, powershell: str
+    tmp_path: Path, powershell: str, empty_path_entries: bool
 ) -> None:
     local_app_data = tmp_path / "local-app-data"
     root, executable, record_path = _create_managed_install(local_app_data)
@@ -808,7 +818,13 @@ def test_muse_uninstaller_removes_only_managed_assets_and_exact_path_entries(
     muse_state.parent.mkdir(parents=True)
     muse_state.write_text('{"native":true}', encoding="utf-8")
 
-    result, _ = _run_uninstaller_lifecycle(tmp_path, powershell)
+    path_entries = [str(tmp_path / "one"), str(tmp_path / "two")]
+    if empty_path_entries:
+        path_entries = ["", *path_entries, "", ""]
+    user_path = os.pathsep.join(
+        [str(root / "bin"), *path_entries, str(root / "bin") + os.sep]
+    )
+    result, _ = _run_uninstaller_lifecycle(tmp_path, powershell, user_path=user_path)
 
     assert result.returncode == 0, result.stderr
     assert not executable.exists()
@@ -816,7 +832,7 @@ def test_muse_uninstaller_removes_only_managed_assets_and_exact_path_entries(
     assert not root.exists()
     assert muse_state.read_text(encoding="utf-8") == '{"native":true}'
     state = json.loads(result.stdout.splitlines()[-1])
-    expected_path = os.pathsep.join((str(tmp_path / "one"), str(tmp_path / "two")))
+    expected_path = os.pathsep.join(path_entries)
     assert state == {
         "UserPath": expected_path,
         "ProcessPath": expected_path,

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.1"
+version = "6.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Windows Muse installation fails when PATH contains an empty entry, such as a trailing `;` or `;;`. PowerShell rejects the empty string before our existing check can handle it. The Muse uninstaller has the same bug.

Fixes #1727.

## How

Add `AllowEmptyString` to the path helper's parameter in both scripts. This lets the existing empty-value check run and preserves other PATH entries and their order. Bump FCC to `6.2.2`.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61966448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/alishahryar1/-/pull-requests/alishahryar1/free-claude-code/1729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No merge-blocking issue was identified; the focused PATH lifecycle check preserves empty and unrelated entries while removing only the managed Muse path.

What we checked:
- Ran the general-contract-validation-proof for path-empty-segments handling; the validation exited with code 0 and showed that prepending ';C:\\one;;C:\\two;' yields 'managed;;C:\\one;;C:\\two;' and that removing the managed-path returns to the original value. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Opened and reviewed the executable source and the observed test output to verify the implementation and its results. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- Muse installation and uninstallation now accept empty Windows PATH segments during canonicalization, preserving those entries while managing the Muse bin directory. Lifecycle coverage was extended for leading, interior, and trailing empty PATH values, and package metadata was updated to 6.2.2.
- ## T-Rex validation blocked Native Windows PowerShell execution could not run because neither `pwsh` nor `powershell` is available in this environment. The available executable validation inspected both updated helpers and modeled the PATH lifecycle successfully.
</details>

<!-- /greptile_comment -->