### PR TITLE
Tolerate NIM chunks after finish_reason (#1734)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.2"
+version = "6.2.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -101,7 +101,6 @@ MISTRAL_REASONING_SMOKE_DEFAULT_MODEL = "mistral/mistral-medium-3-5"
 NVIDIA_NIM_CLI_DEFAULT_MODELS: tuple[str, ...] = (
     "nvidia/nemotron-3.5-lightning-30b-a3b",
     "moonshotai/kimi-k3",
-    "minimaxai/minimax-m3",
     "nvidia/nemotron-3-super-120b-a12b",
 )
 

--- a/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
+++ b/src/free_claude_code/providers/nvidia_nim/native_tool_stream.py
@@ -200,16 +200,26 @@ def normalize_nim_native_tool_stream(
     stream: Any,
     body: Mapping[str, Any],
 ) -> AsyncIterator[Any]:
-    """Convert leaked MiniMax-M3 markup into ordinary OpenAI tool-call chunks."""
+    """Convert leaked MiniMax-M3 markup into ordinary OpenAI tool-call chunks.
+
+    NIM can emit additional deltas after the chunk that carries
+    ``finish_reason``, so the terminal marker is held back and re-emitted
+    once the raw stream ends.
+    """
     schemas = _openai_tool_schemas(body)
 
     async def _iter() -> AsyncIterator[Any]:
         content_framer = _MiniMaxM3ToolFramer()
         reasoning_framer = _MiniMaxM3ToolFramer()
         structured_tool_calls_seen = False
-        finalized = False
+        held_finish_reason: Any = None
+        held_usage: Any = None
 
         async for chunk in stream:
+            usage = getattr(chunk, "usage", None)
+            if usage is not None:
+                held_usage = usage
+
             choices = getattr(chunk, "choices", None)
             if not choices:
                 yield chunk
@@ -236,99 +246,73 @@ def normalize_nim_native_tool_stream(
                 else reasoning
             )
             finish_reason = getattr(choice, "finish_reason", None)
-            generated_calls: tuple[_NativeToolCall, ...] = ()
-            if finish_reason is not None:
-                safe_content, safe_reasoning, generated_calls = (
-                    _finish_native_tool_framers(
-                        content_framer,
-                        reasoning_framer,
-                        content=safe_content,
-                        reasoning_content=safe_reasoning,
-                        schemas=schemas,
-                        structured_tool_calls_seen=structured_tool_calls_seen,
-                    )
-                )
-                finalized = True
+            if finish_reason is not None and held_finish_reason is None:
+                held_finish_reason = finish_reason
 
             normalized = _normalized_chunks(
                 chunk,
-                choice,
                 delta,
                 content=safe_content,
                 reasoning_content=safe_reasoning,
-                generated_calls=generated_calls,
-                terminal=finish_reason is not None,
+                hold_terminal=finish_reason is not None,
             )
             for normalized_chunk in normalized:
                 yield normalized_chunk
 
-        if not finalized:
-            content, reasoning, generated_calls = _finish_native_tool_framers(
-                content_framer,
-                reasoning_framer,
-                content=None,
-                reasoning_content=None,
-                schemas=schemas,
-                structured_tool_calls_seen=structured_tool_calls_seen,
-            )
-            if content or reasoning or generated_calls:
-                for normalized_chunk in _synthetic_chunks(
-                    content=content,
-                    reasoning_content=reasoning,
-                    generated_calls=generated_calls,
-                ):
-                    yield normalized_chunk
+        content, reasoning, generated_calls = _finish_native_tool_framers(
+            content_framer,
+            reasoning_framer,
+            content=None,
+            reasoning_content=None,
+            schemas=schemas,
+            structured_tool_calls_seen=structured_tool_calls_seen,
+        )
+        for normalized_chunk in _synthetic_chunks(
+            content=content,
+            reasoning_content=reasoning,
+            generated_calls=generated_calls,
+        ):
+            yield normalized_chunk
+        if held_finish_reason is not None:
+            terminal = _chunk()
+            terminal.choices[0].finish_reason = held_finish_reason
+            terminal.usage = held_usage
+            yield terminal
 
     return _NormalizedNativeToolStream(_iter(), stream)
 
 
 def _normalized_chunks(
     source_chunk: Any,
-    source_choice: Any,
     source_delta: Any,
     *,
     content: Any,
     reasoning_content: Any,
-    generated_calls: tuple[_NativeToolCall, ...],
-    terminal: bool,
+    hold_terminal: bool,
 ) -> list[Any]:
     source_content = getattr(source_delta, "content", None)
     source_reasoning = getattr(source_delta, "reasoning_content", None)
     structured_calls = getattr(source_delta, "tool_calls", None)
-    source_finish_reason = getattr(source_choice, "finish_reason", None)
-    source_usage = getattr(source_chunk, "usage", None)
 
-    if (
-        not generated_calls
-        and content == source_content
-        and reasoning_content == source_reasoning
+    if not hold_terminal and (
+        content == source_content and reasoning_content == source_reasoning
     ):
         return [source_chunk]
 
-    chunks: list[Any] = []
-    has_source_payload = (
-        bool(content)
-        or bool(reasoning_content)
-        or _has_structured_tool_calls(structured_calls)
-    )
-    if has_source_payload or not generated_calls:
-        chunks.append(
-            _chunk(
-                content=content,
-                reasoning_content=reasoning_content,
-                tool_calls=structured_calls,
-            )
+    if hold_terminal and not (
+        content or reasoning_content or _has_structured_tool_calls(structured_calls)
+    ):
+        # The terminal marker is re-emitted after the raw stream ends, so a
+        # terminal chunk with no payload of its own contributes nothing.
+        return []
+
+    return [
+        _chunk(
+            content=content,
+            reasoning_content=reasoning_content,
+            tool_calls=structured_calls,
         )
-
-    chunks.extend(_tool_call_chunk(call) for call in generated_calls)
-
-    if not chunks:
-        chunks.append(_chunk())
-
-    if terminal:
-        chunks[-1].choices[0].finish_reason = source_finish_reason
-        chunks[-1].usage = source_usage
-    return chunks
+    ]
 
 
 def _synthetic_chunks(

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -979,7 +979,6 @@ def test_nvidia_nim_cli_default_models_are_normalized() -> None:
     assert tuple(refs) == (
         "nvidia_nim/nvidia/nemotron-3.5-lightning-30b-a3b",
         "nvidia_nim/moonshotai/kimi-k3",
-        "nvidia_nim/minimaxai/minimax-m3",
         "nvidia_nim/nvidia/nemotron-3-super-120b-a12b",
     )
     assert set(refs.values()) == {"nvidia_nim_cli_default"}

--- a/tests/providers/test_nvidia_nim_native_tool_stream.py
+++ b/tests/providers/test_nvidia_nim_native_tool_stream.py
@@ -163,8 +163,15 @@ async def test_normalizer_preserves_ordinary_stream_without_tool_schemas() -> No
 
     normalized = await _normalize([source], {})
 
-    assert normalized == [source]
-    assert normalized[0] is source
+    assert _content(normalized) == "Answer"
+    assert _reasoning(normalized) == "Thinking"
+    assert not _tool_calls(normalized)
+    assert [
+        chunk.choices[0].finish_reason
+        for chunk in normalized
+        if chunk.choices[0].finish_reason is not None
+    ] == ["stop"]
+    assert normalized[-1].choices[0].finish_reason == "stop"
 
 
 @pytest.mark.asyncio
@@ -609,3 +616,142 @@ async def test_normalizer_rejects_native_argument_nesting_above_limit(
             [_chunk(content=raw, finish_reason="tool_calls")],
             body,
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["content", "reasoning_content"])
+async def test_normalizer_tolerates_empty_deltas_after_finish_reason(
+    field: str,
+) -> None:
+    raw = _tool_block(_invoke("Read", _element("file_path", "README.md")))
+    body = _body(
+        _function(
+            "Read",
+            {"file_path": {"type": "string"}},
+            ["file_path"],
+        )
+    )
+
+    normalized = await _normalize(
+        [
+            _chunk(
+                content=raw if field == "content" else None,
+                reasoning_content=raw if field == "reasoning_content" else None,
+                finish_reason="tool_calls",
+            ),
+            _chunk(
+                content="" if field == "content" else None,
+                reasoning_content="" if field == "reasoning_content" else None,
+            ),
+        ],
+        body,
+    )
+
+    calls = _tool_calls(normalized)
+    assert len(calls) == 1
+    assert calls[0].function.name == "Read"
+    assert [
+        chunk.choices[0].finish_reason
+        for chunk in normalized
+        if chunk.choices[0].finish_reason is not None
+    ] == ["tool_calls"]
+
+
+@pytest.mark.asyncio
+async def test_normalizer_preserves_text_after_finish_reason() -> None:
+    normalized = await _normalize(
+        [
+            _chunk(content="Hello "),
+            _chunk(content="world", finish_reason="stop"),
+            _chunk(content=" and more"),
+        ],
+        {},
+    )
+
+    assert _content(normalized) == "Hello world and more"
+    assert [
+        chunk.choices[0].finish_reason
+        for chunk in normalized
+        if chunk.choices[0].finish_reason is not None
+    ] == ["stop"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["content", "reasoning_content"])
+async def test_normalizer_decodes_tool_block_streamed_after_finish_reason(
+    field: str,
+) -> None:
+    raw = "Preparing. " + _tool_block(
+        _invoke("Read", _element("file_path", "README.md"))
+    )
+    body = _body(
+        _function(
+            "Read",
+            {"file_path": {"type": "string"}},
+            ["file_path"],
+        )
+    )
+
+    normalized = await _normalize(
+        [
+            _chunk(finish_reason="tool_calls"),
+            _chunk(
+                content=raw if field == "content" else None,
+                reasoning_content=raw if field == "reasoning_content" else None,
+            ),
+        ],
+        body,
+    )
+
+    assert (_content(normalized) if field == "content" else _reasoning(normalized)) == (
+        "Preparing. "
+    )
+    calls = _tool_calls(normalized)
+    assert len(calls) == 1
+    assert calls[0].function.name == "Read"
+    assert json.loads(calls[0].function.arguments) == {"file_path": "README.md"}
+    assert normalized[-1].choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_normalizer_emits_single_finish_reason_for_duplicate_terminal_chunks() -> (
+    None
+):
+    raw = _tool_block(_invoke("Read", _element("file_path", "README.md")))
+    body = _body(
+        _function(
+            "Read",
+            {"file_path": {"type": "string"}},
+            ["file_path"],
+        )
+    )
+
+    normalized = await _normalize(
+        [
+            _chunk(content=raw, finish_reason="tool_calls"),
+            _chunk(finish_reason="tool_calls"),
+        ],
+        body,
+    )
+
+    assert len(_tool_calls(normalized)) == 1
+    assert [
+        chunk.choices[0].finish_reason
+        for chunk in normalized
+        if chunk.choices[0].finish_reason is not None
+    ] == ["tool_calls"]
+
+
+@pytest.mark.asyncio
+async def test_normalizer_carries_latest_usage_on_final_terminal_chunk() -> None:
+    usage_first = SimpleNamespace(prompt_tokens=1)
+    usage_last = SimpleNamespace(prompt_tokens=2)
+    text = _chunk(content="Answer", finish_reason="stop")
+    text.usage = usage_first
+    usage_only = SimpleNamespace(choices=[], usage=usage_last)
+
+    normalized = await _normalize([text, usage_only], {})
+
+    assert any(chunk is usage_only for chunk in normalized)
+    assert normalized[-1].choices[0].finish_reason == "stop"
+    assert normalized[-1].usage is usage_last

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.2"
+version = "6.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

Users on `nvidia_nim/minimaxai/minimax-m3` hit a hard **"API Error: MiniMax-M3 tool framer is already finished"** on every tool-use turn (every file edit), reported in #1734.

### Root cause

The MiniMax-M3 native-tool normalizer finalized its framers at the **first** chunk carrying `finish_reason`. NVIDIA NIM — now in MiniMax-M3 decommission (the model page serves `isDeprecated: true`, *"This API will be deprecated on 09/08/2026"*) — emits **additional deltas after the terminal chunk**. Any trailing delta, even an empty string, called `feed()` on a FINISHED framer and raised `RuntimeError`. Because a plain `RuntimeError` is not in the retryable stream-error class, it surfaced as a terminal API error instead of triggering the existing malformed-markup recovery path.

Two related defects:
1. The FINISHED guard fired before the empty-text early-return, so even `""` deltas crashed.
2. A duplicate `finish_reason` chunk re-ran finalization and re-parsed the retained tool block, **duplicating generated tool calls**.

## Changes

- **Hold-terminal + end-of-stream finalization** in `native_tool_stream.py`: framers are fed every string delta regardless of position; the terminal marker (first `finish_reason` wins) and latest `usage` are held back and re-emitted as one final chunk after the raw stream ends. Finalization runs exactly once → no framer crash, no duplicate parse, tool blocks streamed after the terminal chunk still decode, and trailing non-markup text passes through as visible content.
- 5 new regression tests: the #1734 repro (empty delta after finish), text after finish, tool block streamed after finish, duplicate terminal chunks (single finish_reason, single call), and latest-usage carriage.
- Dropped deprecated `minimaxai/minimax-m3` (NIM sunset 2026-09-08) from `NVIDIA_NIM_CLI_DEFAULT_MODELS` smoke defaults + contract test. Users who configured the model themselves are unaffected — the fix keeps their streams working for as long as NIM keeps serving it.
- Version 6.2.3.

The framer class itself is unchanged; its FINISHED guard remains as a defensive invariant. All 36 normalizer tests pass, including 7 new post-terminal regression items that fail on the pre-fix code with the exact user-reported error.

## Test plan

- [x] `uv run pytest tests/providers/test_nvidia_nim_native_tool_stream.py tests/providers/test_nvidia_nim.py tests/providers/test_streaming_errors.py tests/contracts/test_smoke_config.py -q` — 231 passed
- [x] Full local set: `ruff format --check`, `ruff check`, `ty check`, `pytest -q` (5175 passed, 144 skipped), `pytest e2e -q` (97 passed, 1 skipped)
- [x] Regression tests verified to fail on pre-fix normalizer with `RuntimeError: MiniMax-M3 tool framer is already finished`

Closes #1734

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62766489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; no blocking or non-blocking issues were found.

What we checked:
- Ran a deterministic asynchronous harness to exercise a completion marker, later text, a native tool block, and a usage-only chunk, and verified the decoded tool output, the final marker, and its latest usage. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Ran ordinary terminal-payload and incomplete-markup scenarios; terminal content and structured calls were preserved, while malformed native markup raised the expected protocol error. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Ran the NVIDIA NIM native-tool stream regression suite and confirmed 36 tests passed. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Executed the exact harness command and the exact regression command, both finishing with exit code 0, and reviewed the complete captured outputs; the harness source was uploaded. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- NVIDIA NIM native-tool stream handling now defers completion until the raw stream ends, preserving late text and native tool output.
- The final completion marker carries the most recent usage data, while duplicate terminal markers are collapsed.
- Default NVIDIA NIM CLI smoke coverage no longer includes the deprecated MiniMax-M3 model.
- Focused regression coverage passed for the affected stream-normalization behavior.

<sub>Reviews (1) · Last reviewed commit: ["Tolerate NIM chunks after finish\_reason ..."](https://github.com/alishahryar1/free-claude-code/commit/cfa42f8110a88e11b80cb8db9d1443a9a0e7c730)</sub>

<!-- /greptile_comment -->