### PR TITLE
feat: add Admin setup for local editor integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`,
 
 For installed editors and Codex App, open **Admin UI → Integrations**:
 
-1. Choose **Set up** on the client card.
+1. Choose **Apply FCC settings** on the client card.
 2. Save your work and close the affected clients. Review the file path and short
    setup summary, then click **Confirm**.
 3. Wait for FCC to finish before making other edits, then reload or restart the
@@ -358,32 +358,37 @@ manual guides below for WSL, remote environments, named profiles, and custom
 installation or configuration paths.
 
 After changing FCC's address or token, finish any required FCC restart, then
-return here and choose **Update** where offered. **Disconnect** restores settings
-saved before setup when those settings have not since been edited. For a
-recognized manual setup, it removes identifiable FCC values; previous settings
-are unknown, so the client may need its normal setup again. Conflicting later
-edits require manual correction before FCC can continue.
+choose **Apply FCC settings** again. Applying replaces the known FCC connection
+fields, including manual changes to those fields, and preserves unrelated
+settings. For Codex, an existing model choice is preserved when its current
+provider is FCC; switching to FCC or filling a missing model uses FCC's default.
 
 Keep affected clients closed during configuration changes. Codex App, VS Code,
 and normal Codex CLI sessions share the same Codex file. FCC checks for changes,
 but another program can still save between that check and FCC's save. FCC cannot
 guarantee preservation of that simultaneous save.
 
-<a id="integration-recovery"></a>
+If a change is interrupted, click **Refresh integrations** to inspect the current
+file before applying again. A failed request may have completed the file change.
 
-If a change was interrupted, choose **Recover** to finish FCC's saved setup
-history. Recovery leaves the client file as it is. If the earlier file change
-was not completed, you can retry it after recovery. If you already restored the
-original settings yourself, **Disconnect** releases FCC's saved history without
-rewriting that file.
+To disconnect, expand **How to disconnect** on the card and edit its displayed
+configuration file:
 
-If recovery is unavailable because the file changed again or the saved history
-cannot be read, inspect the client configuration using the manual guides below.
-Preserve a copy of the matching record in `~/.fcc/integrations/`
-(`%USERPROFILE%\.fcc\integrations\` on Windows) before removing it to abandon
-FCC's history. The records are `claude-vscode.json`, `codex.json`,
-`claude-jetbrains.json`, and `claude-login.json`. Removing a record does not change
-the client file, and it loses FCC's ability to restore the earlier settings.
+- **Claude Code in VS Code:** remove FCC's `ANTHROPIC_BASE_URL`,
+  `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` entries
+  from `claudeCode.environmentVariables`, preserving unrelated entries. Remove
+  `claudeCode.disableLoginPrompt` or set it to false, then reload VS Code. Other
+  optional setup flags can be removed if no longer wanted. Separate global or
+  project overrides still need manual correction if present.
+- **Codex:** remove `model_provider` only when it selects `fcc`, remove the FCC
+  entry under `model_providers` including its auth settings, and remove
+  `model_catalog_json` only when it points to FCC's catalog. Remove or replace
+  the FCC model selection with a model for your normal provider. This applies
+  to table-header and inline TOML layouts; preserve other providers and settings.
+  Restart affected App, VS Code, and CLI sessions and use normal authentication.
+- **JetBrains:** remove only `agent_servers["Claude Code (FCC)"]`, including any
+  custom fields inside that named agent. Preserve other agents, restart the IDE,
+  and select your normal agent.
 
 <details>
 <summary><strong>Claude Code in VS Code</strong></summary>
@@ -538,8 +543,8 @@ do not edit the installation inventory.
 If Claude Code asks you to log in after you configure the FCC URL and token, open
 **Admin UI → Integrations → Fix Claude Code login prompt → Fix**, review the
 change, and confirm. Restart Claude Code or the IDE afterward. This changes the
-shared first-run state for the current user; it does not sign in to an account,
-and Disconnect does not undo it. If onboarding is already complete, check the
+shared first-run state for the current user; it does not sign in to an account.
+If onboarding is already complete, check the
 client's connection settings for another cause.
 
 For the manual fallback, open its state file:

--- a/README.md
+++ b/README.md
@@ -338,12 +338,34 @@ For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`,
 `fcc-pi`, `fcc-opencode`, `fcc-cline`, `fcc-hermes`, `fcc-dsh`, `fcc-grok`,
 `fcc-muse`, or `fcc-aider`.
 
-Use the guides below for editor integrations.
+For installed editors and Codex App, open **Admin UI → Integrations**:
+
+1. Choose **Set up** on the client card.
+2. Review the file path and short setup summary, then click **Confirm**.
+3. Reload or restart the client as instructed.
+
+The three cards cover Claude Code in VS Code, Codex App and VS Code together,
+and Claude Code in JetBrains. A separate **Fix Claude Code login prompt** item
+applies the first-run workaround described below. Configured means the settings
+were saved; restart the client to use them.
+
+Setup supports standard local installations on Windows, macOS, and Linux, using
+the same user account as FCC and VS Code's default profile. Install missing
+clients or adapters yourself, then click **Refresh integrations**. Use the
+manual guides below for WSL, remote environments, named profiles, and custom
+installation or configuration paths.
+
+After changing FCC's address or token, finish any required FCC restart, then
+return here and choose **Update** where offered. **Disconnect** restores settings
+saved before setup when those settings have not since been edited. For a
+recognized manual setup, it removes identifiable FCC values; previous settings
+are unknown, so the client may need its normal setup again. Conflicting later
+edits require manual correction before FCC can continue.
 
 <details>
 <summary><strong>Claude Code in VS Code</strong></summary>
 
-Install the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code). Open VS Code's user settings as JSON and add:
+Install the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code), then use its card in **Integrations**. For manual setup, open VS Code's user settings as JSON and merge:
 
 ```json
 "claudeCode.disableLoginPrompt": true,
@@ -351,6 +373,7 @@ Install the [Claude Code extension](https://marketplace.visualstudio.com/items?i
   { "name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082" },
   { "name": "ANTHROPIC_AUTH_TOKEN", "value": "freecc" },
   { "name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1" },
+  { "name": "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "value": "" },
   { "name": "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "value": "190000" },
   { "name": "DISABLE_AUTOUPDATER", "value": "1" },
   { "name": "DISABLE_FEEDBACK_COMMAND", "value": "1" },
@@ -358,17 +381,24 @@ Install the [Claude Code extension](https://marketplace.visualstudio.com/items?i
 ]
 ```
 
-Match the port and authentication token to the Admin UI, then reload the extension.
+Match the port and authentication token to the Admin UI. Run **Developer: Reload
+Window**, then start a new Claude session. Conflicting environment settings in
+Claude's user or project configuration may also need manual correction.
 
 </details>
 
 <details>
 <summary><strong>Codex App</strong></summary>
 
-Start FCC, then edit your Codex configuration:
+Start FCC and use **Integrations → Codex App and VS Code**. This shared setup
+also affects normal Codex CLI use. Setup starts with FCC's current default model;
+later model choices remain yours. After changing FCC's token, the existing
+credential helper reads the new token without a settings Update.
+
+For manual setup, edit your Codex configuration:
 
 - Windows: `%USERPROFILE%\.codex\config.toml`
-- macOS: `~/.codex/config.toml`
+- macOS/Linux: `~/.codex/config.toml`
 
 Add the matching model-catalog path and replace `YOUR_USERNAME`.
 
@@ -409,7 +439,7 @@ then select an FCC model from its model picker.
 <details>
 <summary><strong>Codex in VS Code</strong></summary>
 
-Install the [Codex extension](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt). Create or edit `~/.codex/config.toml` (`%USERPROFILE%\.codex\config.toml` on Windows):
+Install the [Codex extension](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt), then use the shared Codex card in **Integrations**. For manual setup, create or edit `~/.codex/config.toml` (`%USERPROFILE%\.codex\config.toml` on Windows):
 
 ```toml
 model_provider = "fcc"
@@ -434,33 +464,58 @@ WSL-backed Codex, edit the file inside WSL.
 <details>
 <summary><strong>Claude Code in JetBrains ACP</strong></summary>
 
-Edit the installed Claude ACP configuration:
+Install a JetBrains IDE with ACP support, Node.js 22 or newer, and
+[`@agentclientprotocol/claude-agent-acp`](https://github.com/zed-industries/claude-agent-acp).
+For example, install the adapter with `npm install -g @agentclientprotocol/claude-agent-acp`.
+Then choose **Integrations → Claude Code in JetBrains → Set up**. FCC detects
+standard global npm installations; registry-only or custom cache locations may
+need manual setup.
 
-- Windows: `C:\Users\%USERNAME%\AppData\Roaming\JetBrains\acp-agents\installed.json`
-- Linux/macOS: `~/.jetbrains/acp.json`
-
-Set the environment for `acp.registry.claude-acp`:
+For manual setup, merge a custom agent into `~/.jetbrains/acp.json` on every OS
+(`%USERPROFILE%\.jetbrains\acp.json` on Windows). Replace the command and argument
+below with the absolute paths to your installed Node executable and the adapter's
+entrypoint, as declared in its `package.json`. Use forward slashes or escaped
+backslashes for Windows JSON paths. Preserve existing agents:
 
 ```json
-"env": {
-  "ANTHROPIC_BASE_URL": "http://localhost:8082",
-  "ANTHROPIC_AUTH_TOKEN": "freecc",
-  "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
-  "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000",
-  "DISABLE_AUTOUPDATER": "1",
-  "DISABLE_FEEDBACK_COMMAND": "1",
-  "DISABLE_ERROR_REPORTING": "1"
+{
+  "agent_servers": {
+    "Claude Code (FCC)": {
+      "command": "/absolute/path/to/node",
+      "args": ["/absolute/path/to/claude-agent-acp/dist/index.js"],
+      "env": {
+        "ANTHROPIC_BASE_URL": "http://localhost:8082",
+        "ANTHROPIC_AUTH_TOKEN": "freecc",
+        "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "190000",
+        "DISABLE_AUTOUPDATER": "1",
+        "DISABLE_FEEDBACK_COMMAND": "1",
+        "DISABLE_ERROR_REPORTING": "1"
+      }
+    }
+  }
 }
 ```
 
-Match the port and token to the Admin UI, then restart the IDE.
+Match the port and token to the Admin UI, restart the IDE, and select
+**Claude Code (FCC)** in a new chat. Use JetBrains's
+[custom-agent configuration](https://www.jetbrains.com/help/ai-assistant/acp.html);
+do not edit the installation inventory.
 
 </details>
 
 <details>
 <summary><strong>Claude Code still asks you to log in</strong></summary>
 
-If Claude Code asks you to log in after you configure the FCC URL and token, open its state file:
+If Claude Code asks you to log in after you configure the FCC URL and token, open
+**Admin UI → Integrations → Fix Claude Code login prompt → Fix**, review the
+change, and confirm. Restart Claude Code or the IDE afterward. This changes the
+shared first-run state for the current user; it does not sign in to an account,
+and Disconnect does not undo it. If onboarding is already complete, check the
+client's connection settings for another cause.
+
+For the manual fallback, open its state file:
 
 - Windows: `%USERPROFILE%\.claude.json`
 - macOS/Linux/WSL: `~/.claude.json`

--- a/README.md
+++ b/README.md
@@ -341,8 +341,10 @@ For terminal use, start `fcc-server`, then run `fcc-claude`, `fcc-codex`,
 For installed editors and Codex App, open **Admin UI → Integrations**:
 
 1. Choose **Set up** on the client card.
-2. Review the file path and short setup summary, then click **Confirm**.
-3. Reload or restart the client as instructed.
+2. Save your work and close the affected clients. Review the file path and short
+   setup summary, then click **Confirm**.
+3. Wait for FCC to finish before making other edits, then reload or restart the
+   client as instructed.
 
 The three cards cover Claude Code in VS Code, Codex App and VS Code together,
 and Claude Code in JetBrains. A separate **Fix Claude Code login prompt** item
@@ -361,6 +363,27 @@ saved before setup when those settings have not since been edited. For a
 recognized manual setup, it removes identifiable FCC values; previous settings
 are unknown, so the client may need its normal setup again. Conflicting later
 edits require manual correction before FCC can continue.
+
+Keep affected clients closed during configuration changes. Codex App, VS Code,
+and normal Codex CLI sessions share the same Codex file. FCC checks for changes,
+but another program can still save between that check and FCC's save. FCC cannot
+guarantee preservation of that simultaneous save.
+
+<a id="integration-recovery"></a>
+
+If a change was interrupted, choose **Recover** to finish FCC's saved setup
+history. Recovery leaves the client file as it is. If the earlier file change
+was not completed, you can retry it after recovery. If you already restored the
+original settings yourself, **Disconnect** releases FCC's saved history without
+rewriting that file.
+
+If recovery is unavailable because the file changed again or the saved history
+cannot be read, inspect the client configuration using the manual guides below.
+Preserve a copy of the matching record in `~/.fcc/integrations/`
+(`%USERPROFILE%\.fcc\integrations\` on Windows) before removing it to abandon
+FCC's history. The records are `claude-vscode.json`, `codex.json`,
+`claude-jetbrains.json`, and `claude-login.json`. Removing a record does not change
+the client file, and it loses FCC's ability to restore the earlier settings.
 
 <details>
 <summary><strong>Claude Code in VS Code</strong></summary>
@@ -470,6 +493,10 @@ For example, install the adapter with `npm install -g @agentclientprotocol/claud
 Then choose **Integrations → Claude Code in JetBrains → Set up**. FCC detects
 standard global npm installations; registry-only or custom cache locations may
 need manual setup.
+
+Automatic setup uses a short version query to verify a direct Node executable
+and checks the adapter's declared minimum version. Wrappers, unresolved runtime
+managers, and version requirements FCC cannot verify use the manual setup below.
 
 For manual setup, merge a custom agent into `~/.jetbrains/acp.json` on every OS
 (`%USERPROFILE%\.jetbrains\acp.json` on Windows). Replace the command and argument

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -30,9 +30,12 @@ from free_claude_code.providers.base import BaseProvider, ProviderConfig
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.asgi import RuntimeASGIApp
+from free_claude_code.runtime.codex_catalog import CodexModelCatalogPublisher
 from free_claude_code.runtime.configuration import ConfigurationService
 from free_claude_code.runtime.folder_picker import NativeFolderPicker
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
+from tests.integration_support import installed_clients
 
 
 class _ModelListingProvider(BaseProvider):
@@ -119,11 +122,17 @@ def code_control(tmp_path):
 
 
 @pytest.fixture
+def integration_installations(tmp_path):
+    return installed_clients(tmp_path)
+
+
+@pytest.fixture
 def admin_base_url(
     request: pytest.FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     code_control: CodeControl,
+    integration_installations,
 ) -> Iterator[str]:
     """Serve one fully isolated Admin application on an OS-assigned port."""
 
@@ -177,9 +186,11 @@ def admin_base_url(
     manager = ProviderRuntimeManager(
         get_settings(),
         runtime_factory=lambda snapshot: ProviderRuntime(snapshot, dict(providers)),
+        model_catalog_publisher=CodexModelCatalogPublisher(),
     )
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(integration_installations),
         configuration=ConfigurationService(ManagedConfigStore()),
         transcriber=None,
         code_service=code_control.service,

--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -7,7 +7,9 @@ import pytest
 from playwright.sync_api import expect
 
 from free_claude_code.application.integrations import IntegrationAction as Action
+from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.application.integrations import IntegrationId as Item
+from free_claude_code.runtime.integrations import service as service_module
 from free_claude_code.runtime.integrations.service import IntegrationService
 from tests.integration_support import connection, write_json
 
@@ -64,6 +66,7 @@ def test_setup_cancel_confirm_disconnect(
     expect(dialog).not_to_contain_text("e2e-proxy-token")
     expect(dialog).not_to_contain_text("ANTHROPIC_BASE_URL")
     expect(dialog).to_contain_text("Disconnect")
+    expect(dialog).to_contain_text("Save and close VS Code")
     expect(dialog.get_by_role("heading")).to_be_in_viewport()
     expect(dialog.get_by_role("button", name="Confirm", exact=True)).to_be_in_viewport()
     expect(dialog.get_by_role("button", name="Cancel", exact=True)).to_be_focused()
@@ -273,7 +276,65 @@ def test_preview_shows_only_the_file_and_a_short_summary(
     expect(dialog).not_to_contain_text("model_provider")
     expect(dialog).to_contain_text(str(path))
     expect(dialog).to_contain_text("Disconnect")
+    expect(dialog).to_contain_text("Save and close")
+    expect(dialog).to_contain_text("Codex App, VS Code, and the CLI")
     expect(dialog.locator("img")).to_have_count(0)
     assert page.evaluate("window.previewExecuted === undefined")
     dialog.get_by_role("button", name="Cancel", exact=True).click()
     assert tomllib.loads(path.read_text())["model"] == text
+
+
+@pytest.mark.parametrize(
+    "viewport", [{"width": 1280, "height": 900}, {"width": 390, "height": 844}]
+)
+def test_recover_confirmation_preserves_restored_settings_and_clears_history(
+    page, admin_base_url, integration_installations, monkeypatch, viewport
+):
+    locator = integration_installations
+    original = {"claudeCode.disableLoginPrompt": True, "editor.fontSize": 17}
+    write_json(locator.vscode_settings, original)
+    service = IntegrationService(locator)
+    ctx = connection(locator.home)
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    revision = preview["revision"]
+    assert isinstance(revision, str)
+    service.apply(Item.CLAUDE_VSCODE, Action.SETUP, revision, ctx)
+    actual_record = service_module.write_record
+
+    def fail_cleanup(path, record):
+        if record is None:
+            raise OSError("interrupted cleanup")
+        actual_record(path, record)
+
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.DISCONNECT, ctx)
+    revision = preview["revision"]
+    assert isinstance(revision, str)
+    with monkeypatch.context() as patch:
+        patch.setattr(service_module, "write_record", fail_cleanup)
+        with pytest.raises(IntegrationError):
+            service.apply(Item.CLAUDE_VSCODE, Action.DISCONNECT, revision, ctx)
+    before = locator.vscode_settings.read_bytes()
+    history = service.state_dir / "claude-vscode.json"
+    history_before = history.read_bytes()
+    page.set_viewport_size(viewport)
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-vscode")
+    expect(card.get_by_role("button", name="Disconnect", exact=True)).to_have_count(0)
+    card.get_by_role("button", name="Recover", exact=True).click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_contain_text(str(locator.vscode_settings))
+    expect(dialog).to_contain_text("setup history")
+    expect(dialog).not_to_contain_text("FCC will update this file")
+    expect(dialog).not_to_contain_text("Save and close")
+    expect(dialog.get_by_role("heading")).to_be_in_viewport()
+    expect(dialog.get_by_role("button", name="Confirm", exact=True)).to_be_in_viewport()
+    dialog.get_by_role("button", name="Cancel", exact=True).click()
+    assert locator.vscode_settings.read_bytes() == before
+    assert history.read_bytes() == history_before
+    confirm(page, card, "Recover")
+    expect(page.locator("#integrationMessage")).to_contain_text("Recovery finished")
+    expect(card.get_by_role("button", name="Recover", exact=True)).to_have_count(0)
+    expect(card.get_by_role("button", name="Set up", exact=True)).to_be_visible()
+    assert json.loads(locator.vscode_settings.read_bytes()) == original
+    assert locator.vscode_settings.read_bytes() == before
+    assert not history.exists()

--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -1,0 +1,279 @@
+"""Browser confirmation flows exercise only fixture client files."""
+
+import json
+import tomllib
+
+import pytest
+from playwright.sync_api import expect
+
+from free_claude_code.application.integrations import IntegrationAction as Action
+from free_claude_code.application.integrations import IntegrationId as Item
+from free_claude_code.runtime.integrations.service import IntegrationService
+from tests.integration_support import connection, write_json
+
+
+def open_integrations(page, base):
+    page.goto(f"{base}/admin")
+    expect(page.locator("#messageArea")).to_have_text("")
+    page.get_by_role("button", name="Integrations", exact=True).click()
+    expect(page.locator(".integration-card")).to_have_count(4)
+
+
+def item_card(page, item):
+    return page.locator(f'[data-integration="{item}"]')
+
+
+def confirm(page, card, action):
+    card.get_by_role("button", name=action, exact=True).click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+    dialog.get_by_role("button", name="Confirm", exact=True).click()
+    expect(dialog).to_have_count(0)
+
+
+def test_four_items_preserve_unsaved_admin_fields(page, admin_base_url):
+    page.goto(f"{admin_base_url}/admin")
+    expect(page.locator("#messageArea")).to_have_text("")
+    field = page.locator("#field-NVIDIA_NIM_API_KEY")
+    field.fill("unsaved-draft")
+    page.get_by_role("button", name="Integrations", exact=True).click()
+    expect(page.locator(".integration-card")).to_have_count(4)
+    expect(page.locator(".action-bar")).to_be_hidden()
+    expect(item_card(page, "codex")).to_contain_text("App installed")
+    expect(item_card(page, "codex")).to_contain_text("VS Code extension installed")
+    expect(item_card(page, "claude-login")).to_contain_text(
+        "Fix Claude Code login prompt"
+    )
+    page.get_by_role("button", name="Providers", exact=True).click()
+    expect(field).to_have_value("unsaved-draft")
+    expect(page.locator("#dirtyState")).to_have_text("1 unsaved change")
+
+
+def test_setup_cancel_confirm_disconnect(
+    page, admin_base_url, integration_installations
+):
+    locator = integration_installations
+    original = {"editor.fontSize": 16, "claudeCode.disableLoginPrompt": False}
+    write_json(locator.vscode_settings, original)
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-vscode")
+    setup = card.get_by_role("button", name="Set up", exact=True)
+    setup.click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_contain_text(str(locator.vscode_settings))
+    expect(dialog).not_to_contain_text("e2e-proxy-token")
+    expect(dialog).not_to_contain_text("ANTHROPIC_BASE_URL")
+    expect(dialog).to_contain_text("Disconnect")
+    expect(dialog.get_by_role("heading")).to_be_in_viewport()
+    expect(dialog.get_by_role("button", name="Confirm", exact=True)).to_be_in_viewport()
+    expect(dialog.get_by_role("button", name="Cancel", exact=True)).to_be_focused()
+    page.keyboard.press("Escape")
+    expect(dialog).to_have_count(0)
+    expect(setup).to_be_focused()
+    assert json.loads(locator.vscode_settings.read_bytes()) == original
+    confirm(page, card, "Set up")
+    expect(card).to_contain_text("Configured")
+    expect(page.locator("#integrationMessage")).to_contain_text("Reload Window")
+    confirm(page, card, "Disconnect")
+    assert json.loads(locator.vscode_settings.read_bytes()) == original
+
+
+def test_explicit_update_of_saved_connection_from_previous_server_settings(
+    page, admin_base_url, integration_installations
+):
+    locator = integration_installations
+    service = IntegrationService(locator)
+    # Model the client file and undo record left by an earlier FCC server.
+    old = connection(locator.home, port=8182, token="previous-fcc-token")
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, old)
+    revision = preview["revision"]
+    assert isinstance(revision, str)
+    service.apply(Item.CLAUDE_VSCODE, Action.SETUP, revision, old)
+    before = locator.vscode_settings.read_bytes()
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-vscode")
+    expect(card.get_by_role("button", name="Update", exact=True)).to_be_visible()
+    assert locator.vscode_settings.read_bytes() == before
+    confirm(page, card, "Update")
+    assert "8182" not in locator.vscode_settings.read_text()
+    assert "e2e-proxy-token" in locator.vscode_settings.read_text()
+    confirm(page, card, "Disconnect")
+    assert json.loads(locator.vscode_settings.read_bytes()) == {}
+
+
+@pytest.mark.parametrize(
+    "admin_base_url", [{"MODEL": "open_router/vendor/model-a"}], indirect=True
+)
+def test_shared_codex_config_and_restart_instructions(
+    page, admin_base_url, integration_installations
+):
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "codex")
+    confirm(page, card, "Set up")
+    expect(page.locator("#integrationMessage")).to_contain_text("normal Codex CLI")
+    path = integration_installations.home / ".codex/config.toml"
+    assert tomllib.loads(path.read_text())["model_provider"] == "fcc"
+    confirm(page, card, "Disconnect")
+    assert "model_provider" not in tomllib.loads(path.read_text())
+
+
+def test_stale_preview_and_later_edits_are_refused(
+    page, admin_base_url, integration_installations
+):
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-vscode")
+    card.get_by_role("button", name="Set up", exact=True).click()
+    expect(page.get_by_role("dialog")).to_be_visible()
+    write_json(integration_installations.vscode_settings, {"editor.fontSize": 18})
+    page.get_by_role("dialog").get_by_role("button", name="Confirm", exact=True).click()
+    expect(page.locator("#integrationMessage")).to_contain_text(
+        "changed since this preview"
+    )
+    assert json.loads(integration_installations.vscode_settings.read_bytes()) == {
+        "editor.fontSize": 18
+    }
+    confirm(page, card, "Set up")
+    data = json.loads(integration_installations.vscode_settings.read_bytes())
+    data["claudeCode.environmentVariables"][0]["value"] = "https://user.example"
+    write_json(integration_installations.vscode_settings, data)
+    card.get_by_role("button", name="Disconnect", exact=True).click()
+    expect(page.locator("#integrationMessage")).to_contain_text("edited after FCC")
+    expect(page.get_by_role("dialog")).to_have_count(0)
+    assert json.loads(integration_installations.vscode_settings.read_bytes()) == data
+
+
+@pytest.mark.parametrize(
+    "original", [None, {"hasCompletedOnboarding": False, "private": "do-not-show"}]
+)
+def test_separate_login_repair(
+    page, admin_base_url, integration_installations, original
+):
+    path = integration_installations.home / ".claude.json"
+    if original is not None:
+        write_json(path, original)
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-login")
+    confirm(page, card, "Fix")
+    expect(card).to_contain_text("Onboarding already completed")
+    expect(card.get_by_role("button", name="Fix", exact=True)).to_have_count(0)
+    expect(page.locator("#integrationMessage")).to_contain_text(
+        "Onboarding setting saved"
+    )
+    assert json.loads(path.read_bytes()) == {
+        **(original or {}),
+        "hasCompletedOnboarding": True,
+    }
+    assert "do-not-show" not in page.locator("#view-integrations").inner_text()
+    confirm(page, item_card(page, "claude-vscode"), "Set up")
+    confirm(page, item_card(page, "claude-vscode"), "Disconnect")
+    assert json.loads(path.read_bytes())["hasCompletedOnboarding"] is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [b'{"bad":', b'{"hasCompletedOnboarding":false,"hasCompletedOnboarding":true}'],
+)
+def test_invalid_repair_file_shows_attention_without_write(
+    page, admin_base_url, integration_installations, content
+):
+    path = integration_installations.home / ".claude.json"
+    path.write_bytes(content)
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-login")
+    expect(card).to_contain_text("Needs attention")
+    expect(card.get_by_role("button", name="Fix", exact=True)).to_have_count(0)
+    assert path.read_bytes() == content
+
+
+def test_missing_adapter_shows_manual_prerequisites(
+    page, admin_base_url, integration_installations
+):
+    (
+        integration_installations.home
+        / "lib/node_modules/@agentclientprotocol/claude-agent-acp/package.json"
+    ).unlink()
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-jetbrains")
+    expect(card).to_contain_text("Install the Claude ACP adapter")
+    expect(card.get_by_role("button", name="Set up", exact=True)).to_have_count(0)
+    expect(card.get_by_role("link", name="Manual setup", exact=True)).to_be_visible()
+
+
+def test_repair_cancel_and_stale_confirmation_preserve_shared_state(
+    page, admin_base_url, integration_installations
+):
+    path = integration_installations.home / ".claude.json"
+    write_json(path, {"hasCompletedOnboarding": False, "private": "do-not-show"})
+    before = path.read_bytes()
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-login")
+    card.get_by_role("button", name="Fix", exact=True).click()
+    page.get_by_role("dialog").get_by_role("button", name="Cancel", exact=True).click()
+    assert path.read_bytes() == before
+    card.get_by_role("button", name="Fix", exact=True).click()
+    expect(page.get_by_role("dialog")).to_be_visible()
+    write_json(path, {"hasCompletedOnboarding": False, "user": "new state"})
+    changed = path.read_bytes()
+    page.get_by_role("dialog").get_by_role("button", name="Confirm", exact=True).click()
+    expect(page.locator("#integrationMessage")).to_contain_text(
+        "changed since this preview"
+    )
+    assert path.read_bytes() == changed
+    confirm(page, card, "Fix")
+    assert json.loads(path.read_bytes()) == {
+        "hasCompletedOnboarding": True,
+        "user": "new state",
+    }
+
+
+def test_manual_disconnect_describes_unknown_history_and_keeps_other_settings(
+    page, admin_base_url, integration_installations
+):
+    path = integration_installations.vscode_settings
+    write_json(
+        path,
+        {
+            "editor.fontSize": 16,
+            "claudeCode.environmentVariables": [
+                {"name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082"},
+                {"name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1"},
+                {"name": "ANTHROPIC_AUTH_TOKEN", "value": "old-manual-secret"},
+            ],
+        },
+    )
+    open_integrations(page, admin_base_url)
+    card = item_card(page, "claude-vscode")
+    expect(card).to_contain_text("Manual FCC setup detected")
+    card.get_by_role("button", name="Disconnect", exact=True).click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_contain_text("Previous settings are unknown")
+    expect(dialog).not_to_contain_text("old-manual-secret")
+    dialog.get_by_role("button", name="Confirm", exact=True).click()
+    expect(dialog).to_have_count(0)
+    assert json.loads(path.read_bytes()) == {
+        "editor.fontSize": 16,
+        "claudeCode.environmentVariables": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "admin_base_url", [{"MODEL": "open_router/vendor/model-a"}], indirect=True
+)
+def test_preview_shows_only_the_file_and_a_short_summary(
+    page, admin_base_url, integration_installations
+):
+    path = integration_installations.home / ".codex/config.toml"
+    path.parent.mkdir()
+    text = '<img src=x onerror="window.previewExecuted=true">'
+    path.write_text(f"model='{text}'\n")
+    open_integrations(page, admin_base_url)
+    item_card(page, "codex").get_by_role("button", name="Set up", exact=True).click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).not_to_contain_text("onerror")
+    expect(dialog).not_to_contain_text("model_provider")
+    expect(dialog).to_contain_text(str(path))
+    expect(dialog).to_contain_text("Disconnect")
+    expect(dialog.locator("img")).to_have_count(0)
+    assert page.evaluate("window.previewExecuted === undefined")
+    dialog.get_by_role("button", name="Cancel", exact=True).click()
+    assert tomllib.loads(path.read_text())["model"] == text

--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -6,10 +6,7 @@ import tomllib
 import pytest
 from playwright.sync_api import expect
 
-from free_claude_code.application.integrations import IntegrationAction as Action
-from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.application.integrations import IntegrationId as Item
-from free_claude_code.runtime.integrations import service as service_module
 from free_claude_code.runtime.integrations.service import IntegrationService
 from tests.integration_support import connection, write_json
 
@@ -51,21 +48,19 @@ def test_four_items_preserve_unsaved_admin_fields(page, admin_base_url):
     expect(page.locator("#dirtyState")).to_have_text("1 unsaved change")
 
 
-def test_setup_cancel_confirm_disconnect(
-    page, admin_base_url, integration_installations
-):
+def test_apply_cancel_confirm_reapply(page, admin_base_url, integration_installations):
     locator = integration_installations
     original = {"editor.fontSize": 16, "claudeCode.disableLoginPrompt": False}
     write_json(locator.vscode_settings, original)
     open_integrations(page, admin_base_url)
     card = item_card(page, "claude-vscode")
-    setup = card.get_by_role("button", name="Set up", exact=True)
+    setup = card.get_by_role("button", name="Apply FCC settings", exact=True)
     setup.click()
     dialog = page.get_by_role("dialog")
     expect(dialog).to_contain_text(str(locator.vscode_settings))
     expect(dialog).not_to_contain_text("e2e-proxy-token")
     expect(dialog).not_to_contain_text("ANTHROPIC_BASE_URL")
-    expect(dialog).to_contain_text("Disconnect")
+    expect(dialog).to_contain_text("Manual disconnect instructions are on the card")
     expect(dialog).to_contain_text("Save and close VS Code")
     expect(dialog.get_by_role("heading")).to_be_in_viewport()
     expect(dialog.get_by_role("button", name="Confirm", exact=True)).to_be_in_viewport()
@@ -74,34 +69,39 @@ def test_setup_cancel_confirm_disconnect(
     expect(dialog).to_have_count(0)
     expect(setup).to_be_focused()
     assert json.loads(locator.vscode_settings.read_bytes()) == original
-    confirm(page, card, "Set up")
+    confirm(page, card, "Apply FCC settings")
     expect(card).to_contain_text("Configured")
     expect(page.locator("#integrationMessage")).to_contain_text("Reload Window")
-    confirm(page, card, "Disconnect")
-    assert json.loads(locator.vscode_settings.read_bytes()) == original
+    before = locator.vscode_settings.read_bytes()
+    confirm(page, card, "Apply FCC settings")
+    expect(page.locator("#integrationMessage")).to_contain_text(
+        "No client settings changed"
+    )
+    assert locator.vscode_settings.read_bytes() == before
 
 
-def test_explicit_update_of_saved_connection_from_previous_server_settings(
+def test_explicit_reapply_of_connection_from_previous_server_settings(
     page, admin_base_url, integration_installations
 ):
     locator = integration_installations
     service = IntegrationService(locator)
-    # Model the client file and undo record left by an earlier FCC server.
+    # Model a client file left by an earlier FCC server.
     old = connection(locator.home, port=8182, token="previous-fcc-token")
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, old)
+    preview = service.preview(Item.CLAUDE_VSCODE, old)
     revision = preview["revision"]
     assert isinstance(revision, str)
-    service.apply(Item.CLAUDE_VSCODE, Action.SETUP, revision, old)
+    service.apply(Item.CLAUDE_VSCODE, revision, old)
     before = locator.vscode_settings.read_bytes()
     open_integrations(page, admin_base_url)
     card = item_card(page, "claude-vscode")
-    expect(card.get_by_role("button", name="Update", exact=True)).to_be_visible()
+    expect(
+        card.get_by_role("button", name="Apply FCC settings", exact=True)
+    ).to_be_visible()
     assert locator.vscode_settings.read_bytes() == before
-    confirm(page, card, "Update")
+    confirm(page, card, "Apply FCC settings")
     assert "8182" not in locator.vscode_settings.read_text()
     assert "e2e-proxy-token" in locator.vscode_settings.read_text()
-    confirm(page, card, "Disconnect")
-    assert json.loads(locator.vscode_settings.read_bytes()) == {}
+    expect(card.get_by_role("button", name="Disconnect", exact=True)).to_have_count(0)
 
 
 @pytest.mark.parametrize(
@@ -112,20 +112,19 @@ def test_shared_codex_config_and_restart_instructions(
 ):
     open_integrations(page, admin_base_url)
     card = item_card(page, "codex")
-    confirm(page, card, "Set up")
+    confirm(page, card, "Apply FCC settings")
     expect(page.locator("#integrationMessage")).to_contain_text("normal Codex CLI")
     path = integration_installations.home / ".codex/config.toml"
     assert tomllib.loads(path.read_text())["model_provider"] == "fcc"
-    confirm(page, card, "Disconnect")
-    assert "model_provider" not in tomllib.loads(path.read_text())
+    expect(card.locator("summary")).to_have_text("How to disconnect")
 
 
-def test_stale_preview_and_later_edits_are_refused(
+def test_stale_preview_is_refused_and_fresh_apply_replaces_fcc_edits(
     page, admin_base_url, integration_installations
 ):
     open_integrations(page, admin_base_url)
     card = item_card(page, "claude-vscode")
-    card.get_by_role("button", name="Set up", exact=True).click()
+    card.get_by_role("button", name="Apply FCC settings", exact=True).click()
     expect(page.get_by_role("dialog")).to_be_visible()
     write_json(integration_installations.vscode_settings, {"editor.fontSize": 18})
     page.get_by_role("dialog").get_by_role("button", name="Confirm", exact=True).click()
@@ -135,14 +134,17 @@ def test_stale_preview_and_later_edits_are_refused(
     assert json.loads(integration_installations.vscode_settings.read_bytes()) == {
         "editor.fontSize": 18
     }
-    confirm(page, card, "Set up")
+    confirm(page, card, "Apply FCC settings")
     data = json.loads(integration_installations.vscode_settings.read_bytes())
     data["claudeCode.environmentVariables"][0]["value"] = "https://user.example"
     write_json(integration_installations.vscode_settings, data)
-    card.get_by_role("button", name="Disconnect", exact=True).click()
-    expect(page.locator("#integrationMessage")).to_contain_text("edited after FCC")
-    expect(page.get_by_role("dialog")).to_have_count(0)
-    assert json.loads(integration_installations.vscode_settings.read_bytes()) == data
+    confirm(page, card, "Apply FCC settings")
+    saved = json.loads(integration_installations.vscode_settings.read_bytes())
+    assert saved["editor.fontSize"] == 18
+    assert (
+        "https://user.example"
+        not in integration_installations.vscode_settings.read_text()
+    )
 
 
 @pytest.mark.parametrize(
@@ -158,7 +160,8 @@ def test_separate_login_repair(
     card = item_card(page, "claude-login")
     confirm(page, card, "Fix")
     expect(card).to_contain_text("Onboarding already completed")
-    expect(card.get_by_role("button", name="Fix", exact=True)).to_have_count(0)
+    expect(card.get_by_role("button", name="Fix", exact=True)).to_be_visible()
+    expect(card.locator("details")).to_have_count(0)
     expect(page.locator("#integrationMessage")).to_contain_text(
         "Onboarding setting saved"
     )
@@ -167,8 +170,7 @@ def test_separate_login_repair(
         "hasCompletedOnboarding": True,
     }
     assert "do-not-show" not in page.locator("#view-integrations").inner_text()
-    confirm(page, item_card(page, "claude-vscode"), "Set up")
-    confirm(page, item_card(page, "claude-vscode"), "Disconnect")
+    confirm(page, item_card(page, "claude-vscode"), "Apply FCC settings")
     assert json.loads(path.read_bytes())["hasCompletedOnboarding"] is True
 
 
@@ -198,7 +200,9 @@ def test_missing_adapter_shows_manual_prerequisites(
     open_integrations(page, admin_base_url)
     card = item_card(page, "claude-jetbrains")
     expect(card).to_contain_text("Install the Claude ACP adapter")
-    expect(card.get_by_role("button", name="Set up", exact=True)).to_have_count(0)
+    expect(
+        card.get_by_role("button", name="Apply FCC settings", exact=True)
+    ).to_have_count(0)
     expect(card.get_by_role("link", name="Manual setup", exact=True)).to_be_visible()
 
 
@@ -229,36 +233,6 @@ def test_repair_cancel_and_stale_confirmation_preserve_shared_state(
     }
 
 
-def test_manual_disconnect_describes_unknown_history_and_keeps_other_settings(
-    page, admin_base_url, integration_installations
-):
-    path = integration_installations.vscode_settings
-    write_json(
-        path,
-        {
-            "editor.fontSize": 16,
-            "claudeCode.environmentVariables": [
-                {"name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082"},
-                {"name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1"},
-                {"name": "ANTHROPIC_AUTH_TOKEN", "value": "old-manual-secret"},
-            ],
-        },
-    )
-    open_integrations(page, admin_base_url)
-    card = item_card(page, "claude-vscode")
-    expect(card).to_contain_text("Manual FCC setup detected")
-    card.get_by_role("button", name="Disconnect", exact=True).click()
-    dialog = page.get_by_role("dialog")
-    expect(dialog).to_contain_text("Previous settings are unknown")
-    expect(dialog).not_to_contain_text("old-manual-secret")
-    dialog.get_by_role("button", name="Confirm", exact=True).click()
-    expect(dialog).to_have_count(0)
-    assert json.loads(path.read_bytes()) == {
-        "editor.fontSize": 16,
-        "claudeCode.environmentVariables": [],
-    }
-
-
 @pytest.mark.parametrize(
     "admin_base_url", [{"MODEL": "open_router/vendor/model-a"}], indirect=True
 )
@@ -270,12 +244,14 @@ def test_preview_shows_only_the_file_and_a_short_summary(
     text = '<img src=x onerror="window.previewExecuted=true">'
     path.write_text(f"model='{text}'\n")
     open_integrations(page, admin_base_url)
-    item_card(page, "codex").get_by_role("button", name="Set up", exact=True).click()
+    item_card(page, "codex").get_by_role(
+        "button", name="Apply FCC settings", exact=True
+    ).click()
     dialog = page.get_by_role("dialog")
     expect(dialog).not_to_contain_text("onerror")
     expect(dialog).not_to_contain_text("model_provider")
     expect(dialog).to_contain_text(str(path))
-    expect(dialog).to_contain_text("Disconnect")
+    expect(dialog).to_contain_text("Manual disconnect instructions are on the card")
     expect(dialog).to_contain_text("Save and close")
     expect(dialog).to_contain_text("Codex App, VS Code, and the CLI")
     expect(dialog.locator("img")).to_have_count(0)
@@ -287,54 +263,67 @@ def test_preview_shows_only_the_file_and_a_short_summary(
 @pytest.mark.parametrize(
     "viewport", [{"width": 1280, "height": 900}, {"width": 390, "height": 844}]
 )
-def test_recover_confirmation_preserves_restored_settings_and_clears_history(
-    page, admin_base_url, integration_installations, monkeypatch, viewport
+def test_manual_disconnect_instructions_expand_without_requests_or_writes(
+    page, admin_base_url, integration_installations, viewport
 ):
     locator = integration_installations
-    original = {"claudeCode.disableLoginPrompt": True, "editor.fontSize": 17}
-    write_json(locator.vscode_settings, original)
-    service = IntegrationService(locator)
-    ctx = connection(locator.home)
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
-    revision = preview["revision"]
-    assert isinstance(revision, str)
-    service.apply(Item.CLAUDE_VSCODE, Action.SETUP, revision, ctx)
-    actual_record = service_module.write_record
-
-    def fail_cleanup(path, record):
-        if record is None:
-            raise OSError("interrupted cleanup")
-        actual_record(path, record)
-
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.DISCONNECT, ctx)
-    revision = preview["revision"]
-    assert isinstance(revision, str)
-    with monkeypatch.context() as patch:
-        patch.setattr(service_module, "write_record", fail_cleanup)
-        with pytest.raises(IntegrationError):
-            service.apply(Item.CLAUDE_VSCODE, Action.DISCONNECT, revision, ctx)
-    before = locator.vscode_settings.read_bytes()
-    history = service.state_dir / "claude-vscode.json"
-    history_before = history.read_bytes()
+    write_json(locator.vscode_settings, {"editor.fontSize": 16})
     page.set_viewport_size(viewport)
     open_integrations(page, admin_base_url)
+    paths = [
+        locator.vscode_settings,
+        locator.home / ".codex/config.toml",
+        locator.home / ".jetbrains/acp.json",
+        locator.home / ".claude.json",
+    ]
+    before = {path: path.read_bytes() if path.exists() else None for path in paths}
+    requests = []
+    page.on("request", lambda request: requests.append(request))
+    for item, expected in [
+        (
+            "claude-vscode",
+            [
+                "ANTHROPIC_BASE_URL",
+                "ANTHROPIC_AUTH_TOKEN",
+                "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY",
+                "disableLoginPrompt",
+                "global/project",
+            ],
+        ),
+        (
+            "codex",
+            [
+                "model_provider",
+                "model_providers",
+                "model_catalog_json",
+                "inline TOML",
+                "normal authentication",
+            ],
+        ),
+        (
+            "claude-jetbrains",
+            ['agent_servers["Claude Code (FCC)"]', "custom fields", "other agents"],
+        ),
+    ]:
+        card = item_card(page, item)
+        help = card.locator("details")
+        expect(help).not_to_have_attribute("open", "")
+        help.locator("summary").click()
+        expect(help).to_have_attribute("open", "")
+        for text in expected:
+            expect(help).to_contain_text(text)
+        expect(card.get_by_role("button", name="Disconnect", exact=True)).to_have_count(
+            0
+        )
+        assert card.evaluate("el => el.scrollWidth <= el.clientWidth")
+    assert requests == []
+    assert {
+        path: path.read_bytes() if path.exists() else None for path in paths
+    } == before
     card = item_card(page, "claude-vscode")
-    expect(card.get_by_role("button", name="Disconnect", exact=True)).to_have_count(0)
-    card.get_by_role("button", name="Recover", exact=True).click()
+    card.get_by_role("button", name="Apply FCC settings", exact=True).click()
     dialog = page.get_by_role("dialog")
-    expect(dialog).to_contain_text(str(locator.vscode_settings))
-    expect(dialog).to_contain_text("setup history")
-    expect(dialog).not_to_contain_text("FCC will update this file")
-    expect(dialog).not_to_contain_text("Save and close")
     expect(dialog.get_by_role("heading")).to_be_in_viewport()
     expect(dialog.get_by_role("button", name="Confirm", exact=True)).to_be_in_viewport()
+    expect(dialog.locator("details")).to_have_count(0)
     dialog.get_by_role("button", name="Cancel", exact=True).click()
-    assert locator.vscode_settings.read_bytes() == before
-    assert history.read_bytes() == history_before
-    confirm(page, card, "Recover")
-    expect(page.locator("#integrationMessage")).to_contain_text("Recovery finished")
-    expect(card.get_by_role("button", name="Recover", exact=True)).to_have_count(0)
-    expect(card.get_by_role("button", name="Set up", exact=True)).to_be_visible()
-    assert json.loads(locator.vscode_settings.read_bytes()) == original
-    assert locator.vscode_settings.read_bytes() == before
-    assert not history.exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.2"
+version = "6.3.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"
@@ -24,6 +24,9 @@ dependencies = [
     "loguru>=0.7.0",
     "aiohttp>=3.14.3",
     "jsonschema>=4.25.0",
+    "tomlkit>=0.15.1",
+    "tree-sitter>=0.26.0",
+    "tree-sitter-json>=0.24.8",
     "google-auth[requests]>=2.56.3",
     "requests[socks]>=2.34.2",
     "pystray>=0.19.5; sys_platform == 'win32' or sys_platform == 'darwin'",

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -48,6 +48,8 @@ _ADMIN_ASSET_FILENAMES = frozenset(
         "session_layout.css",
         "session_ui.js",
         "model_combobox.js",
+        "integrations.js",
+        "integrations.css",
     }
 )
 LOCAL_PROVIDER_PATHS = {

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -34,6 +34,13 @@ const VIEW_GROUPS = [
     containerId: "messagingSections",
   },
   {
+    id: "integrations",
+    label: "Integrations",
+    title: "Integrations",
+    sections: [],
+    containerId: "integrationsRoot",
+  },
+  {
     id: "code",
     label: "Code sessions",
     title: "Code sessions",
@@ -98,6 +105,7 @@ async function api(path, options = {}) {
 }
 
 async function load() {
+  window.Integrations.initialize(api);
   showMessage("Loading admin config");
   const config = await api("/admin/api/config");
   state.config = config;
@@ -145,7 +153,7 @@ function setActiveView(viewId, { scroll = false } = {}) {
   document.querySelector(".app-shell").classList.toggle("session-active", sessionActive);
   document.querySelector(".main").classList.toggle("session-main", sessionActive);
   document.querySelector(".topbar").hidden = sessionActive;
-  document.querySelector(".action-bar").hidden = sessionActive;
+  document.querySelector(".action-bar").hidden = sessionActive || activeView.id === "integrations";
 
   document.querySelectorAll(".nav-link").forEach((link) => {
     const selected = link.dataset.view === activeView.id;
@@ -168,6 +176,8 @@ function setActiveView(viewId, { scroll = false } = {}) {
   }
   if (activeView.id === "code") window.CodeSessions.activate(window.location.pathname);
   else window.CodeSessions.deactivate();
+  if (activeView.id === "integrations") window.Integrations.activate();
+  else window.Integrations.deactivate();
 }
 
 function navigateToView(viewId) {

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/admin/assets/__FCC_VERSION__/admin.css" />
     <link rel="stylesheet" href="/admin/assets/__FCC_VERSION__/code_sessions.css" />
     <link rel="stylesheet" href="/admin/assets/__FCC_VERSION__/session_layout.css" />
+    <link rel="stylesheet" href="/admin/assets/__FCC_VERSION__/integrations.css" />
   </head>
   <body>
     <div class="app-shell">
@@ -82,6 +83,20 @@
             ></div>
           </section>
 
+          <section id="view-integrations" class="admin-view" data-view="integrations" hidden>
+            <div class="integrations-intro">
+              <div>
+                <p>Connect installed clients to FCC. Review each change before saving, then restart the client.</p>
+                <p id="integrationScope">Standard local installations for this OS and user account; VS Code default profile.</p>
+                <p>Configured means settings are saved. It does not verify a live connection.</p>
+                <p id="integrationServerNotice" role="status"></p>
+              </div>
+              <button id="refreshIntegrations" class="secondary-button" type="button">Refresh integrations</button>
+            </div>
+            <p id="integrationMessage" class="integration-message" role="status" aria-live="polite"></p>
+            <div id="integrationsRoot" class="integration-grid"></div>
+          </section>
+
           <section id="view-code" class="admin-view" data-view="code" hidden>
             <div id="codeRoot" class="code-root session-root" aria-live="off"></div>
           </section>
@@ -102,6 +117,7 @@
     <script src="/admin/assets/__FCC_VERSION__/model_combobox.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/session_ui.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/code_sessions.js"></script>
+    <script src="/admin/assets/__FCC_VERSION__/integrations.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/admin.js"></script>
   </body>
 </html>

--- a/src/free_claude_code/api/admin_static/integrations.css
+++ b/src/free_claude_code/api/admin_static/integrations.css
@@ -8,13 +8,15 @@
 .integration-heading h3 { margin: 0; font-size: 17px; }
 .integration-status { font-size: 12px; border: 1px solid var(--line-strong); border-radius: var(--radius-full); padding: 4px 9px; white-space: nowrap; color: var(--muted); }
 .integration-status.configured { color: var(--ok); border-color: var(--ok-border); }
-.integration-status.update_available, .integration-status.needs_attention { color: var(--warn); border-color: var(--warn-border); }
+.integration-status.needs_attention { color: var(--warn); border-color: var(--warn-border); }
 .integration-badges { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; font-size: 12px; color: var(--accent); }
 .integration-card p, .integration-dialog p { font-size: 13px; color: var(--muted); line-height: 1.6; }
 .integration-path { overflow-wrap: anywhere; font-family: ui-monospace, monospace; }
 .integration-guidance { color: var(--text) !important; }
 .integration-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
 .integration-actions a { color: var(--muted); font-size: 13px; text-underline-offset: 3px; }
+.integration-disconnect { margin-top: 20px; border-top: 1px solid var(--line-strong); padding-top: 16px; overflow-wrap: anywhere; }
+.integration-disconnect summary { cursor: pointer; color: var(--muted); font-size: 13px; }
 .integration-message { white-space: pre-wrap; line-height: 1.6; color: var(--ok); margin: 16px 0; }
 .integration-message:empty { display: none; }
 .integration-message.error { color: var(--error); }

--- a/src/free_claude_code/api/admin_static/integrations.css
+++ b/src/free_claude_code/api/admin_static/integrations.css
@@ -1,0 +1,29 @@
+.integrations-intro { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 24px; }
+.integrations-intro p { margin: 0 0 10px; color: var(--muted); line-height: 1.6; }
+.integrations-intro button { flex-shrink: 0; }
+.integration-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 20px; }
+.integration-card { padding: 24px; background: var(--panel); border: 1px solid var(--line-strong); border-radius: var(--radius-lg); min-width: 0; }
+.integration-card[data-integration="claude-login"] { grid-column: 1 / -1; }
+.integration-heading { display: flex; justify-content: space-between; align-items: start; flex-wrap: wrap; gap: 12px; }
+.integration-heading h3 { margin: 0; font-size: 17px; }
+.integration-status { font-size: 12px; border: 1px solid var(--line-strong); border-radius: var(--radius-full); padding: 4px 9px; white-space: nowrap; color: var(--muted); }
+.integration-status.configured { color: var(--ok); border-color: var(--ok-border); }
+.integration-status.update_available, .integration-status.needs_attention { color: var(--warn); border-color: var(--warn-border); }
+.integration-badges { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; font-size: 12px; color: var(--accent); }
+.integration-card p, .integration-dialog p { font-size: 13px; color: var(--muted); line-height: 1.6; }
+.integration-path { overflow-wrap: anywhere; font-family: ui-monospace, monospace; }
+.integration-guidance { color: var(--text) !important; }
+.integration-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+.integration-actions a { color: var(--muted); font-size: 13px; text-underline-offset: 3px; }
+.integration-message { white-space: pre-wrap; line-height: 1.6; color: var(--ok); margin: 16px 0; }
+.integration-message:empty { display: none; }
+.integration-message.error { color: var(--error); }
+.integration-dialog { width: min(520px, calc(100vw - 32px)); max-height: calc(100vh - 48px); padding: 24px; background: var(--panel); color: var(--text); border: 1px solid var(--line-strong); border-radius: var(--radius-lg); overflow: hidden; }
+.integration-dialog[open] { display: flex; flex-direction: column; }
+.integration-dialog-content { overflow-y: auto; min-height: 0; padding-right: 12px; }
+.integration-dialog h3, .integration-dialog .integration-actions { flex: none; }
+.integration-dialog::backdrop { background: rgba(0, 0, 0, 0.72); }
+.integration-dialog h3 { margin-top: 0; }
+.integration-dialog .integration-path { padding: 12px; background: var(--panel-strong); border-radius: var(--radius-sm); }
+@media (max-width: 1200px) { .integration-grid { grid-template-columns: 1fr; } }
+@media (max-width: 600px) { .integrations-intro { flex-direction: column; gap: 10px; } .integration-card { padding: 18px; } }

--- a/src/free_claude_code/api/admin_static/integrations.js
+++ b/src/free_claude_code/api/admin_static/integrations.js
@@ -4,7 +4,7 @@
   const root = document.getElementById("integrationsRoot");
   const message = document.getElementById("integrationMessage");
   const refreshButton = document.getElementById("refreshIntegrations");
-  const labels = { setup: "Set up", update: "Update", disconnect: "Disconnect", repair: "Fix" };
+  const labels = { setup: "Set up", update: "Update", disconnect: "Disconnect", repair: "Fix", recover: "Recover" };
   const statuses = { not_configured: "Not configured", configured: "Configured", update_available: "Update available", needs_attention: "Needs attention" };
 
   function node(tag, text = "", className = "") {
@@ -96,7 +96,7 @@
     dialog.setAttribute("aria-labelledby", heading.id);
     const content = node("div", "", "integration-dialog-content");
     dialog.append(heading, content);
-    content.append(node("p", "FCC will update this file:"), node("p", preview.path, "integration-path"));
+    content.append(node("p", preview.writes_file ? "FCC will update this file:" : "Configuration file:"), node("p", preview.path, "integration-path"));
     content.append(node("p", preview.summary, "integration-guidance"));
     const actions = node("div", "", "integration-actions");
     let committing = false;

--- a/src/free_claude_code/api/admin_static/integrations.js
+++ b/src/free_claude_code/api/admin_static/integrations.js
@@ -1,0 +1,145 @@
+(() => {
+  "use strict";
+  let api, active = false, busy = false, generation = 0;
+  const root = document.getElementById("integrationsRoot");
+  const message = document.getElementById("integrationMessage");
+  const refreshButton = document.getElementById("refreshIntegrations");
+  const labels = { setup: "Set up", update: "Update", disconnect: "Disconnect", repair: "Fix" };
+  const statuses = { not_configured: "Not configured", configured: "Configured", update_available: "Update available", needs_attention: "Needs attention" };
+
+  function node(tag, text = "", className = "") {
+    const value = document.createElement(tag);
+    value.textContent = text;
+    value.className = className;
+    return value;
+  }
+  function button(label, action, className = "secondary-button") {
+    const value = node("button", label, className);
+    value.type = "button";
+    value.addEventListener("click", action);
+    return value;
+  }
+  function notice(text, error = false) {
+    message.textContent = text;
+    message.classList.toggle("error", error);
+  }
+  function setBusy(value) {
+    busy = value;
+    refreshButton.disabled = value;
+    for (const control of root.querySelectorAll("button")) control.disabled = value;
+  }
+  function render(item) {
+    const card = node("article", "", "integration-card");
+    card.dataset.integration = item.id;
+    const heading = node("div", "", "integration-heading");
+    heading.append(node("h3", item.title));
+    heading.append(node("span", statuses[item.status] || "Needs attention", `integration-status ${item.status}`));
+    card.append(heading);
+    const badges = node("div", "", "integration-badges");
+    for (const badge of item.badges) badges.append(node("span", badge));
+    if (item.manual) badges.append(node("span", "Manual FCC setup detected"));
+    card.append(badges, node("p", item.path, "integration-path"));
+    if (item.id === "codex") card.append(node("p", "One shared configuration for Codex App, the VS Code extension, and normal Codex CLI use."));
+    if (item.id === "claude-login") card.append(node("p", "Apply the shared Claude Code first-run setting when it still asks you to log in."));
+    if (item.message) card.append(node("p", item.message, "integration-guidance"));
+    for (const missing of item.missing) card.append(node("p", missing, "integration-guidance"));
+    if (item.status === "configured" && item.id !== "claude-login") card.append(node("p", "Configuration saved. Restart the client to use it."));
+    const actions = node("div", "", "integration-actions");
+    for (const action of item.actions) {
+      const control = button(labels[action], () => preview(item, action, control), action === "disconnect" ? "secondary-button" : "primary-button");
+      actions.append(control);
+    }
+    const manual = node("a", "Manual setup");
+    manual.href = item.documentation_url;
+    manual.target = "_blank";
+    manual.rel = "noopener noreferrer";
+    actions.append(manual);
+    card.append(actions);
+    return card;
+  }
+  async function refresh() {
+    if (!api || busy) return;
+    const request = ++generation;
+    refreshButton.disabled = true;
+    try {
+      const result = await api("/admin/api/integrations");
+      if (request !== generation) return;
+      root.replaceChildren(...result.items.map(render));
+      document.getElementById("integrationScope").textContent = result.scope;
+      document.getElementById("integrationServerNotice").textContent = result.notice || "";
+    } catch (error) {
+      if (request === generation) notice(`Could not inspect integrations. ${error.message}`, true);
+    } finally {
+      if (request === generation) refreshButton.disabled = false;
+    }
+  }
+  async function preview(item, action, source) {
+    if (busy) return;
+    ++generation;
+    setBusy(true);
+    notice("");
+    try {
+      const result = await api(`/admin/api/integrations/${item.id}/preview`, {
+        method: "POST", body: JSON.stringify({ action }),
+      });
+      if (active) showPreview(result, source);
+    } catch (error) {
+      notice(error.message, true);
+    } finally {
+      setBusy(false);
+    }
+  }
+  function showPreview(preview, source) {
+    const dialog = node("dialog", "", "integration-dialog");
+    const heading = node("h3", `${labels[preview.action]}: ${preview.title}`);
+    heading.id = "integrationDialogTitle";
+    dialog.setAttribute("aria-labelledby", heading.id);
+    const content = node("div", "", "integration-dialog-content");
+    dialog.append(heading, content);
+    content.append(node("p", "FCC will update this file:"), node("p", preview.path, "integration-path"));
+    content.append(node("p", preview.summary, "integration-guidance"));
+    const actions = node("div", "", "integration-actions");
+    let committing = false;
+    function close() {
+      if (committing) return;
+      dialog.close();
+      dialog.remove();
+      if (source.isConnected) source.focus();
+    }
+    const cancel = button("Cancel", close);
+    cancel.autofocus = true;
+    const confirm = button("Confirm", async () => {
+      if (committing) return;
+      committing = true;
+      setBusy(true);
+      cancel.disabled = confirm.disabled = true;
+      confirm.textContent = "Saving…";
+      try {
+        const result = await api(`/admin/api/integrations/${preview.id}/apply`, {
+          method: "POST", body: JSON.stringify({ action: preview.action, revision: preview.revision }),
+        });
+        notice(`${result.message || "No client settings changed."} ${result.instructions}`);
+      } catch (error) {
+        notice(`${error.message} Current files will be checked again before another confirmation.`, true);
+      } finally {
+        committing = false;
+        close();
+        setBusy(false);
+        await refresh();
+        if (active) refreshButton.focus();
+      }
+    }, "primary-button");
+    actions.append(cancel, confirm);
+    dialog.append(actions);
+    dialog.addEventListener("cancel", (event) => { event.preventDefault(); close(); });
+    document.body.append(dialog);
+    dialog.showModal();
+    cancel.focus();
+  }
+  refreshButton.addEventListener("click", refresh);
+  window.Integrations = {
+    initialize(request) { api = request; },
+    activate() { active = true; refresh(); },
+    deactivate() { active = false; ++generation; },
+  };
+})();

--- a/src/free_claude_code/api/admin_static/integrations.js
+++ b/src/free_claude_code/api/admin_static/integrations.js
@@ -4,8 +4,23 @@
   const root = document.getElementById("integrationsRoot");
   const message = document.getElementById("integrationMessage");
   const refreshButton = document.getElementById("refreshIntegrations");
-  const labels = { setup: "Set up", update: "Update", disconnect: "Disconnect", repair: "Fix", recover: "Recover" };
-  const statuses = { not_configured: "Not configured", configured: "Configured", update_available: "Update available", needs_attention: "Needs attention" };
+  const statuses = { not_configured: "Not configured", configured: "Configured", needs_attention: "Needs attention" };
+  const disconnectInstructions = {
+    "claude-vscode": [
+      "In the user settings file above, remove FCC's ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, and CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY entries from claudeCode.environmentVariables. Keep unrelated environment entries.",
+      "Remove claudeCode.disableLoginPrompt or set it to false to resume normal login. Other optional flags from the setup snippet can be removed if no longer wanted. Reload VS Code.",
+      "These steps remove this card's routing settings. Separate global/project overrides still need manual correction if present.",
+    ],
+    codex: [
+      "In the shared TOML file above, remove model_provider only when it selects fcc. Remove the FCC entry under model_providers, including its auth settings. Remove model_catalog_json only when it points to FCC's catalog.",
+      "Remove or replace the FCC model selection with a model for your normal provider. These steps apply to both table-header and inline TOML layouts. Preserve other providers and settings.",
+      "Restart affected Codex App, VS Code, and CLI sessions, then use the client's normal authentication.",
+    ],
+    "claude-jetbrains": [
+      'In the ACP file above, remove only agent_servers["Claude Code (FCC)"]. This removes the named agent, including any custom fields inside it. Preserve other agents.',
+      "Restart the IDE and select your normal agent.",
+    ],
+  };
 
   function node(tag, text = "", className = "") {
     const value = document.createElement(tag);
@@ -37,7 +52,6 @@
     card.append(heading);
     const badges = node("div", "", "integration-badges");
     for (const badge of item.badges) badges.append(node("span", badge));
-    if (item.manual) badges.append(node("span", "Manual FCC setup detected"));
     card.append(badges, node("p", item.path, "integration-path"));
     if (item.id === "codex") card.append(node("p", "One shared configuration for Codex App, the VS Code extension, and normal Codex CLI use."));
     if (item.id === "claude-login") card.append(node("p", "Apply the shared Claude Code first-run setting when it still asks you to log in."));
@@ -45,8 +59,8 @@
     for (const missing of item.missing) card.append(node("p", missing, "integration-guidance"));
     if (item.status === "configured" && item.id !== "claude-login") card.append(node("p", "Configuration saved. Restart the client to use it."));
     const actions = node("div", "", "integration-actions");
-    for (const action of item.actions) {
-      const control = button(labels[action], () => preview(item, action, control), action === "disconnect" ? "secondary-button" : "primary-button");
+    if (item.can_apply) {
+      const control = button(item.id === "claude-login" ? "Fix" : "Apply FCC settings", () => preview(item, control), "primary-button");
       actions.append(control);
     }
     const manual = node("a", "Manual setup");
@@ -55,6 +69,12 @@
     manual.rel = "noopener noreferrer";
     actions.append(manual);
     card.append(actions);
+    if (disconnectInstructions[item.id]) {
+      const help = node("details", "", "integration-disconnect");
+      help.append(node("summary", "How to disconnect"));
+      for (const instruction of disconnectInstructions[item.id]) help.append(node("p", instruction));
+      card.append(help);
+    }
     return card;
   }
   async function refresh() {
@@ -73,14 +93,14 @@
       if (request === generation) refreshButton.disabled = false;
     }
   }
-  async function preview(item, action, source) {
+  async function preview(item, source) {
     if (busy) return;
     ++generation;
     setBusy(true);
     notice("");
     try {
       const result = await api(`/admin/api/integrations/${item.id}/preview`, {
-        method: "POST", body: JSON.stringify({ action }),
+        method: "POST", body: JSON.stringify({}),
       });
       if (active) showPreview(result, source);
     } catch (error) {
@@ -91,7 +111,7 @@
   }
   function showPreview(preview, source) {
     const dialog = node("dialog", "", "integration-dialog");
-    const heading = node("h3", `${labels[preview.action]}: ${preview.title}`);
+    const heading = node("h3", `${preview.id === "claude-login" ? "Fix" : "Apply FCC settings"}: ${preview.title}`);
     heading.id = "integrationDialogTitle";
     dialog.setAttribute("aria-labelledby", heading.id);
     const content = node("div", "", "integration-dialog-content");
@@ -116,7 +136,7 @@
       confirm.textContent = "Saving…";
       try {
         const result = await api(`/admin/api/integrations/${preview.id}/apply`, {
-          method: "POST", body: JSON.stringify({ action: preview.action, revision: preview.revision }),
+          method: "POST", body: JSON.stringify({ revision: preview.revision }),
         });
         notice(`${result.message || "No client settings changed."} ${result.instructions}`);
       } catch (error) {

--- a/src/free_claude_code/api/app.py
+++ b/src/free_claude_code/api/app.py
@@ -14,6 +14,7 @@ from free_claude_code.application.code_sessions import (
     CodeValidationError,
 )
 from free_claude_code.application.errors import ApplicationError
+from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.core.anthropic import anthropic_error_payload
 from free_claude_code.core.diagnostics import (
     redacted_exception_traceback,
@@ -29,6 +30,7 @@ from free_claude_code.core.version import package_version
 from .admin_cache import AdminNoStoreMiddleware, attach_admin_no_store
 from .admin_routes import router as admin_router
 from .code_sessions_routes import router as code_router
+from .integrations_routes import router as integrations_router
 from .ports import ApiServices
 from .request_errors import ordinary_application_error_response
 from .request_ids import (
@@ -51,7 +53,16 @@ def create_app(services: ApiServices) -> FastAPI:
 
     app.include_router(admin_router)
     app.include_router(code_router)
+    app.include_router(integrations_router)
     app.include_router(router)
+
+    @app.exception_handler(IntegrationError)
+    async def integration_error_handler(request: Request, exc: IntegrationError):
+        response = JSONResponse(
+            status_code=exc.status_code, content={"detail": str(exc)}
+        )
+        attach_admin_no_store(response, path=request.url.path)
+        return response
 
     @app.exception_handler(CodeError)
     async def code_error_handler(request: Request, exc: CodeError):

--- a/src/free_claude_code/api/integrations_routes.py
+++ b/src/free_claude_code/api/integrations_routes.py
@@ -1,0 +1,54 @@
+"""Local Admin transport for fixed, confirmed integration operations."""
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, Field
+
+from free_claude_code.application.integrations import (
+    IntegrationAction,
+    IntegrationId,
+    validate_action,
+)
+
+from .admin_security import require_loopback_admin
+from .dependencies import get_services
+from .ports import ApiServices
+
+router = APIRouter(
+    prefix="/admin/api/integrations", dependencies=[Depends(require_loopback_admin)]
+)
+
+
+class PreviewPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    action: IntegrationAction
+
+
+class ApplyPayload(PreviewPayload):
+    revision: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+@router.get("")
+async def inspect_integrations(services: ApiServices = Depends(get_services)):
+    return await services.admin.inspect_integrations()
+
+
+@router.post("/{item}/preview")
+async def preview_integration(
+    item: IntegrationId,
+    payload: PreviewPayload,
+    services: ApiServices = Depends(get_services),
+):
+    validate_action(item, payload.action)
+    return await services.admin.preview_integration(item, payload.action)
+
+
+@router.post("/{item}/apply")
+async def apply_integration(
+    item: IntegrationId,
+    payload: ApplyPayload,
+    services: ApiServices = Depends(get_services),
+):
+    validate_action(item, payload.action)
+    return await services.admin.apply_integration(
+        item, payload.action, payload.revision
+    )

--- a/src/free_claude_code/api/integrations_routes.py
+++ b/src/free_claude_code/api/integrations_routes.py
@@ -4,9 +4,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict, Field
 
 from free_claude_code.application.integrations import (
-    IntegrationAction,
     IntegrationId,
-    validate_action,
 )
 
 from .admin_security import require_loopback_admin
@@ -20,7 +18,6 @@ router = APIRouter(
 
 class PreviewPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    action: IntegrationAction
 
 
 class ApplyPayload(PreviewPayload):
@@ -38,8 +35,7 @@ async def preview_integration(
     payload: PreviewPayload,
     services: ApiServices = Depends(get_services),
 ):
-    validate_action(item, payload.action)
-    return await services.admin.preview_integration(item, payload.action)
+    return await services.admin.preview_integration(item)
 
 
 @router.post("/{item}/apply")
@@ -48,7 +44,4 @@ async def apply_integration(
     payload: ApplyPayload,
     services: ApiServices = Depends(get_services),
 ):
-    validate_action(item, payload.action)
-    return await services.admin.apply_integration(
-        item, payload.action, payload.revision
-    )
+    return await services.admin.apply_integration(item, payload.revision)

--- a/src/free_claude_code/api/ports.py
+++ b/src/free_claude_code/api/ports.py
@@ -9,7 +9,7 @@ from free_claude_code.application.connected_accounts import (
     ConnectedAccountLoginMode,
     ConnectedAccountStatus,
 )
-from free_claude_code.application.integrations import IntegrationAction, IntegrationId
+from free_claude_code.application.integrations import IntegrationId
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
 from free_claude_code.application.ports import RequestRuntimePort, TaskController
 from free_claude_code.config.admin.state import ConfigInputValue, ValueState
@@ -31,12 +31,10 @@ class AdminRuntimePort(Protocol):
 
     async def inspect_integrations(self) -> JsonObject: ...
 
-    async def preview_integration(
-        self, item: IntegrationId, action: IntegrationAction
-    ) -> JsonObject: ...
+    async def preview_integration(self, item: IntegrationId) -> JsonObject: ...
 
     async def apply_integration(
-        self, item: IntegrationId, action: IntegrationAction, revision: str
+        self, item: IntegrationId, revision: str
     ) -> JsonObject: ...
 
     async def pick_folder(self, initial_path: str | None) -> str | None: ...

--- a/src/free_claude_code/api/ports.py
+++ b/src/free_claude_code/api/ports.py
@@ -9,6 +9,7 @@ from free_claude_code.application.connected_accounts import (
     ConnectedAccountLoginMode,
     ConnectedAccountStatus,
 )
+from free_claude_code.application.integrations import IntegrationAction, IntegrationId
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
 from free_claude_code.application.ports import RequestRuntimePort, TaskController
 from free_claude_code.config.admin.state import ConfigInputValue, ValueState
@@ -27,6 +28,16 @@ class AdminRuntimePort(Protocol):
     async def admin_values(self) -> ValueState: ...
 
     async def admin_status(self) -> JsonObject: ...
+
+    async def inspect_integrations(self) -> JsonObject: ...
+
+    async def preview_integration(
+        self, item: IntegrationId, action: IntegrationAction
+    ) -> JsonObject: ...
+
+    async def apply_integration(
+        self, item: IntegrationId, action: IntegrationAction, revision: str
+    ) -> JsonObject: ...
 
     async def pick_folder(self, initial_path: str | None) -> str | None: ...
 

--- a/src/free_claude_code/application/integrations.py
+++ b/src/free_claude_code/application/integrations.py
@@ -1,0 +1,30 @@
+"""Fixed local-client setup actions exposed by FCC Admin."""
+
+from enum import StrEnum
+
+
+class IntegrationId(StrEnum):
+    CLAUDE_VSCODE = "claude-vscode"
+    CODEX = "codex"
+    CLAUDE_JETBRAINS = "claude-jetbrains"
+    CLAUDE_LOGIN = "claude-login"
+
+
+class IntegrationAction(StrEnum):
+    SETUP = "setup"
+    UPDATE = "update"
+    DISCONNECT = "disconnect"
+    REPAIR = "repair"
+
+
+class IntegrationError(Exception):
+    """A safe, user-facing configuration error, without source-file contents."""
+
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def validate_action(target: IntegrationId, action: IntegrationAction) -> None:
+    if (target == IntegrationId.CLAUDE_LOGIN) != (action == IntegrationAction.REPAIR):
+        raise IntegrationError("This action is not available for this item.")

--- a/src/free_claude_code/application/integrations.py
+++ b/src/free_claude_code/application/integrations.py
@@ -10,24 +10,9 @@ class IntegrationId(StrEnum):
     CLAUDE_LOGIN = "claude-login"
 
 
-class IntegrationAction(StrEnum):
-    SETUP = "setup"
-    UPDATE = "update"
-    DISCONNECT = "disconnect"
-    REPAIR = "repair"
-    RECOVER = "recover"
-
-
 class IntegrationError(Exception):
     """A safe, user-facing configuration error, without source-file contents."""
 
     def __init__(self, message: str, *, status_code: int = 400) -> None:
         super().__init__(message)
         self.status_code = status_code
-
-
-def validate_action(target: IntegrationId, action: IntegrationAction) -> None:
-    if action == IntegrationAction.RECOVER:
-        return
-    if (target == IntegrationId.CLAUDE_LOGIN) != (action == IntegrationAction.REPAIR):
-        raise IntegrationError("This action is not available for this item.")

--- a/src/free_claude_code/application/integrations.py
+++ b/src/free_claude_code/application/integrations.py
@@ -15,6 +15,7 @@ class IntegrationAction(StrEnum):
     UPDATE = "update"
     DISCONNECT = "disconnect"
     REPAIR = "repair"
+    RECOVER = "recover"
 
 
 class IntegrationError(Exception):
@@ -26,5 +27,7 @@ class IntegrationError(Exception):
 
 
 def validate_action(target: IntegrationId, action: IntegrationAction) -> None:
+    if action == IntegrationAction.RECOVER:
+        return
     if (target == IntegrationId.CLAUDE_LOGIN) != (action == IntegrationAction.REPAIR):
         raise IntegrationError("This action is not available for this item.")

--- a/src/free_claude_code/cli/claude_env.py
+++ b/src/free_claude_code/cli/claude_env.py
@@ -8,6 +8,19 @@ CLAUDE_CODE_AUTO_COMPACT_WINDOW = "190000"
 CLAUDE_BINARY_NAME = "claude"
 
 
+def claude_proxy_values(*, proxy_root_url: str, auth_token: str) -> dict[str, str]:
+    """Explicit connection values shared by launchers and installed editors."""
+    return {
+        "ANTHROPIC_BASE_URL": proxy_root_url,
+        "ANTHROPIC_AUTH_TOKEN": auth_token,
+        "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW": CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+        "DISABLE_AUTOUPDATER": "1",
+        "DISABLE_FEEDBACK_COMMAND": "1",
+        "DISABLE_ERROR_REPORTING": "1",
+    }
+
+
 def build_claude_proxy_env(
     *,
     proxy_root_url: str,
@@ -22,13 +35,7 @@ def build_claude_proxy_env(
         proxy_root_url=proxy_root_url,
         remove_prefixes=("ANTHROPIC_",),
         remove_keys=("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",),
-        updates={
-            "ANTHROPIC_BASE_URL": proxy_root_url,
-            "ANTHROPIC_AUTH_TOKEN": auth_token,
-            "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
-            "CLAUDE_CODE_AUTO_COMPACT_WINDOW": CLAUDE_CODE_AUTO_COMPACT_WINDOW,
-            "DISABLE_AUTOUPDATER": "1",
-            "DISABLE_FEEDBACK_COMMAND": "1",
-            "DISABLE_ERROR_REPORTING": "1",
-        },
+        updates=claude_proxy_values(
+            proxy_root_url=proxy_root_url, auth_token=auth_token
+        ),
     )

--- a/src/free_claude_code/cli/launchers/codex.py
+++ b/src/free_claude_code/cli/launchers/codex.py
@@ -30,22 +30,29 @@ _STRIPPED_CODEX_ENV_KEYS = frozenset(
 )
 
 
-def codex_config_args(*, api_url: str, model: str | None = None) -> list[str]:
-    """Build native TOML overrides for the FCC Responses provider."""
+def codex_config_values(
+    *, api_url: str, model: str | None = None, auth_command: str = "fcc-codex"
+) -> dict[str, str | list[str]]:
+    """Structured FCC settings shared by launch overrides and editor setup."""
 
     values: dict[str, str | list[str]] = {
         "model_provider": "fcc",
         "model_providers.fcc.name": "Free Claude Code",
         "model_providers.fcc.base_url": proxy_v1_url(api_url),
-        "model_providers.fcc.auth.command": "fcc-codex",
+        "model_providers.fcc.auth.command": auth_command,
         "model_providers.fcc.auth.args": [_PRINT_PROXY_AUTH_TOKEN_FLAG],
         "model_providers.fcc.wire_api": "responses",
     }
     if model:
         values["model"] = model
+    return values
+
+
+def codex_config_args(*, api_url: str, model: str | None = None) -> list[str]:
+    """Build native TOML overrides for the FCC Responses provider."""
     return [
         arg
-        for key, value in values.items()
+        for key, value in codex_config_values(api_url=api_url, model=model).items()
         for arg in ("-c", f"{key}={json.dumps(value)}")
     ]
 

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -22,6 +22,11 @@ from free_claude_code.application.connected_accounts import (
     ConnectedAccountStatus,
 )
 from free_claude_code.application.errors import ApplicationUnavailableError
+from free_claude_code.application.integrations import (
+    IntegrationAction,
+    IntegrationError,
+    IntegrationId,
+)
 from free_claude_code.application.model_metadata import ProviderModelRefreshResult
 from free_claude_code.application.ports import StopResult
 from free_claude_code.config.admin.persistence import (
@@ -31,7 +36,10 @@ from free_claude_code.config.admin.state import ConfigInputValue, ValueState
 from free_claude_code.config.admin.status import provider_config_status
 from free_claude_code.config.loader import clear_settings_cache
 from free_claude_code.config.model_refs import parse_provider_type
-from free_claude_code.config.paths import messaging_state_dir_path
+from free_claude_code.config.paths import (
+    codex_model_catalog_path,
+    messaging_state_dir_path,
+)
 from free_claude_code.config.server_urls import local_admin_url, local_proxy_root_url
 from free_claude_code.config.settings import Settings
 from free_claude_code.core.json_types import JsonObject
@@ -47,8 +55,11 @@ from free_claude_code.providers.credential_validation import (
     check_credentials,
 )
 
+from .codex_catalog import current_codex_models
 from .configuration import ConfigurationService
 from .folder_picker import NativeFolderPicker
+from .integrations.service import IntegrationService
+from .integrations.targets import Connection
 from .provider_manager import ProviderRuntimeManager
 from .retired_chat import remove_retired_chat_history
 
@@ -141,6 +152,7 @@ class ApplicationRuntime:
         provider_manager: ProviderRuntimeManager,
         *,
         configuration: ConfigurationService,
+        integrations: IntegrationService,
         transcriber: Transcriber | None,
         code_service: CodeService | None = None,
         restart_callback: RestartCallback | None = None,
@@ -148,6 +160,7 @@ class ApplicationRuntime:
     ) -> None:
         self.provider_manager = provider_manager
         self._configuration = configuration
+        self._integrations = integrations
         self._code_service = code_service
         self._folder_picker = NativeFolderPicker()
         self._transcriber = transcriber
@@ -251,6 +264,69 @@ class ApplicationRuntime:
 
     async def pick_folder(self, initial_path: str | None) -> str | None:
         return await self._folder_picker.pick_folder(initial_path)
+
+    async def _integration_connection(self) -> Connection:
+        settings = self.settings
+        return Connection(
+            settings,
+            current_codex_models(self.provider_manager, settings),
+            codex_model_catalog_path(),
+            await self._configuration.saved_proxy_auth_token(),
+        )
+
+    def _require_integration_ready(self, action: IntegrationAction) -> None:
+        if self._draining:
+            raise IntegrationError(
+                "The server is shutting down. Reconnect after restart.", status_code=409
+            )
+        if self._pending_fields and action in {
+            IntegrationAction.SETUP,
+            IntegrationAction.UPDATE,
+        }:
+            raise IntegrationError(
+                "Restart FCC to activate its saved settings before configuring a client.",
+                status_code=409,
+            )
+
+    async def inspect_integrations(self) -> JsonObject:
+        async with self._config_lock:
+            connection = await self._integration_connection()
+            result = await to_thread.run_sync(self._integrations.inspect, connection)
+            result["notice"] = (
+                "Restart FCC to activate saved settings before configuring a client."
+                if self._pending_fields
+                else ""
+            )
+            return result
+
+    async def preview_integration(
+        self, item: IntegrationId, action: IntegrationAction
+    ) -> JsonObject:
+        async with self._config_lock:
+            self._require_integration_ready(action)
+            connection = await self._integration_connection()
+            return await to_thread.run_sync(
+                self._integrations.preview, item, action, connection
+            )
+
+    async def apply_integration(
+        self, item: IntegrationId, action: IntegrationAction, revision: str
+    ) -> JsonObject:
+        async with self._config_lock:
+            self._require_integration_ready(action)
+            connection = await self._integration_connection()
+            self._require_integration_ready(action)
+            return await _await_owned_task(
+                asyncio.create_task(
+                    to_thread.run_sync(
+                        self._integrations.apply,
+                        item,
+                        action,
+                        revision,
+                        connection,
+                    )
+                )
+            )
 
     async def apply_admin_config(
         self,

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -265,8 +265,12 @@ class ApplicationRuntime:
     async def pick_folder(self, initial_path: str | None) -> str | None:
         return await self._folder_picker.pick_folder(initial_path)
 
-    async def _integration_connection(self) -> Connection:
+    async def _integration_connection(
+        self, action: IntegrationAction | None = None
+    ) -> Connection:
         settings = self.settings
+        if action == IntegrationAction.RECOVER:
+            return Connection(settings, (), codex_model_catalog_path(), "")
         return Connection(
             settings,
             current_codex_models(self.provider_manager, settings),
@@ -304,7 +308,7 @@ class ApplicationRuntime:
     ) -> JsonObject:
         async with self._config_lock:
             self._require_integration_ready(action)
-            connection = await self._integration_connection()
+            connection = await self._integration_connection(action)
             return await to_thread.run_sync(
                 self._integrations.preview, item, action, connection
             )
@@ -314,7 +318,7 @@ class ApplicationRuntime:
     ) -> JsonObject:
         async with self._config_lock:
             self._require_integration_ready(action)
-            connection = await self._integration_connection()
+            connection = await self._integration_connection(action)
             self._require_integration_ready(action)
             return await _await_owned_task(
                 asyncio.create_task(

--- a/src/free_claude_code/runtime/application.py
+++ b/src/free_claude_code/runtime/application.py
@@ -23,7 +23,6 @@ from free_claude_code.application.connected_accounts import (
 )
 from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.application.integrations import (
-    IntegrationAction,
     IntegrationError,
     IntegrationId,
 )
@@ -265,12 +264,8 @@ class ApplicationRuntime:
     async def pick_folder(self, initial_path: str | None) -> str | None:
         return await self._folder_picker.pick_folder(initial_path)
 
-    async def _integration_connection(
-        self, action: IntegrationAction | None = None
-    ) -> Connection:
+    async def _integration_connection(self) -> Connection:
         settings = self.settings
-        if action == IntegrationAction.RECOVER:
-            return Connection(settings, (), codex_model_catalog_path(), "")
         return Connection(
             settings,
             current_codex_models(self.provider_manager, settings),
@@ -278,15 +273,12 @@ class ApplicationRuntime:
             await self._configuration.saved_proxy_auth_token(),
         )
 
-    def _require_integration_ready(self, action: IntegrationAction) -> None:
+    def _require_integration_ready(self, item: IntegrationId) -> None:
         if self._draining:
             raise IntegrationError(
                 "The server is shutting down. Reconnect after restart.", status_code=409
             )
-        if self._pending_fields and action in {
-            IntegrationAction.SETUP,
-            IntegrationAction.UPDATE,
-        }:
+        if self._pending_fields and item != IntegrationId.CLAUDE_LOGIN:
             raise IntegrationError(
                 "Restart FCC to activate its saved settings before configuring a client.",
                 status_code=409,
@@ -303,29 +295,24 @@ class ApplicationRuntime:
             )
             return result
 
-    async def preview_integration(
-        self, item: IntegrationId, action: IntegrationAction
-    ) -> JsonObject:
+    async def preview_integration(self, item: IntegrationId) -> JsonObject:
         async with self._config_lock:
-            self._require_integration_ready(action)
-            connection = await self._integration_connection(action)
+            self._require_integration_ready(item)
+            connection = await self._integration_connection()
             return await to_thread.run_sync(
-                self._integrations.preview, item, action, connection
+                self._integrations.preview, item, connection
             )
 
-    async def apply_integration(
-        self, item: IntegrationId, action: IntegrationAction, revision: str
-    ) -> JsonObject:
+    async def apply_integration(self, item: IntegrationId, revision: str) -> JsonObject:
         async with self._config_lock:
-            self._require_integration_ready(action)
-            connection = await self._integration_connection(action)
-            self._require_integration_ready(action)
+            self._require_integration_ready(item)
+            connection = await self._integration_connection()
+            self._require_integration_ready(item)
             return await _await_owned_task(
                 asyncio.create_task(
                     to_thread.run_sync(
                         self._integrations.apply,
                         item,
-                        action,
                         revision,
                         connection,
                     )

--- a/src/free_claude_code/runtime/bootstrap.py
+++ b/src/free_claude_code/runtime/bootstrap.py
@@ -28,6 +28,8 @@ from free_claude_code.providers.openai_codex import (
 )
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.providers.runtime.factory import create_provider
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 
 from .application import ApplicationRuntime, RestartCallback
 from .asgi import RuntimeASGIApp
@@ -79,6 +81,7 @@ def build_asgi_app(
     )
     runtime = ApplicationRuntime(
         provider_manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=ConfigurationService(ManagedConfigStore()),
         code_service=code_service,
         transcriber=_create_transcriber(settings),

--- a/src/free_claude_code/runtime/configuration.py
+++ b/src/free_claude_code/runtime/configuration.py
@@ -36,6 +36,13 @@ class ConfigurationService:
         )
         return load_value_state(snapshot)
 
+    async def saved_proxy_auth_token(self) -> str:
+        """Read credentials available to a separately launched desktop helper."""
+        snapshot = await to_thread.run_sync(
+            lambda: self._store.read(env={}), limiter=self._worker_limiter
+        )
+        return snapshot.settings.proxy_auth_token
+
     async def prepare(
         self, updates: Mapping[str, ConfigInputValue], active_settings: Settings
     ) -> PreparedAdminUpdate:

--- a/src/free_claude_code/runtime/integrations/__init__.py
+++ b/src/free_claude_code/runtime/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Local client configuration, behind the Admin runtime boundary."""

--- a/src/free_claude_code/runtime/integrations/discovery.py
+++ b/src/free_claude_code/runtime/integrations/discovery.py
@@ -1,12 +1,15 @@
-"""Read installed-client metadata without starting clients or installers."""
+"""Read installed-client metadata and probe Node without starting clients or installers."""
 
 import json
 import os
 import plistlib
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Timer
+from time import monotonic
 from xml.etree import ElementTree
 
 
@@ -54,6 +57,17 @@ def windows_codex_locations() -> tuple[Path, ...]:
         return ()
 
 
+type NodeVersion = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class AcpInstallation:
+    command: tuple[str, ...] = ()
+    manifest: Path | None = None
+    node_version: NodeVersion | None = None
+    issue: str = ""
+
+
 @dataclass(frozen=True)
 class InstalledClients:
     claude_vscode: bool
@@ -62,7 +76,7 @@ class InstalledClients:
     jetbrains: bool
     claude_command: Path | None
     fcc_command: Path | None
-    acp_command: tuple[str, ...]
+    acp: AcpInstallation
     scope_issue: str
 
 
@@ -104,7 +118,12 @@ class LocalInstallations:
         elif self.platform == "darwin":
             root = self.home / "Library/Application Support"
         else:
-            root = Path(self.environ.get("XDG_CONFIG_HOME", str(self.home / ".config")))
+            override = self.environ.get("XDG_CONFIG_HOME", "")
+            root = (
+                Path(override)
+                if override and Path(override).is_absolute()
+                else self.home / ".config"
+            )
         return root / "Code/User/settings.json"
 
     def command(self, name: str) -> Path | None:
@@ -231,13 +250,17 @@ class LocalInstallations:
         return self.command("chatgpt") is not None
 
     def _jetbrains(self) -> bool:
-        for root in self.app_roots:
-            for pattern in (
+        patterns = (
+            ("*.app/Contents/Resources/product-info.json",)
+            if self.platform == "darwin"
+            else (
                 "*/product-info.json",
                 "JetBrains/*/product-info.json",
                 "*/*/product-info.json",
-                "*.app/Contents/Resources/product-info.json",
-            ):
+            )
+        )
+        for root in self.app_roots:
+            for pattern in patterns:
                 for path in root.glob(pattern):
                     metadata = _json(path)
                     if not isinstance(metadata, dict) or metadata.get(
@@ -263,23 +286,115 @@ class LocalInstallations:
                             if isinstance(launch, dict) and isinstance(
                                 relative := launch.get("launcherPath"), str
                             ):
-                                base = (
+                                if (
+                                    Path(relative).is_absolute()
+                                    or Path(relative).anchor
+                                ):
+                                    continue
+                                boundary = (
                                     path.parent.parent
                                     if self.platform == "darwin"
                                     else path.parent
                                 )
-                                executable = (base / relative).resolve()
+                                executable = (path.parent / relative).resolve()
                                 if (
-                                    executable.is_relative_to(base.resolve())
+                                    executable.is_relative_to(boundary.resolve())
                                     and executable.is_file()
                                 ):
                                     return True
         return False
 
-    def _acp_command(self) -> tuple[str, ...]:
+    def _node_version(self, node: Path) -> NodeVersion | None:
+        try:
+            node = node.resolve(strict=True)
+            expected_name = "node.exe" if self.platform == "win32" else "node"
+            if node.name.lower() != expected_name or not node.is_file():
+                return None
+            parent = node.parent
+            if (
+                "shims" in {part.lower() for part in node.parts}
+                or parent.name.lower() in {"volta", ".volta"}
+                or (
+                    parent.name.lower() == "bin"
+                    and parent.parent.name.lower() in {"volta", ".volta"}
+                )
+            ):
+                return None
+            if (volta := self.environ.get("VOLTA_HOME")) and parent == (
+                Path(volta) / "bin"
+            ).resolve():
+                return None
+            with node.open("rb") as executable:
+                header = executable.read(4)
+            native = (
+                header.startswith(b"MZ")
+                if self.platform == "win32"
+                else header
+                in {
+                    b"\xfe\xed\xfa\xce",
+                    b"\xce\xfa\xed\xfe",
+                    b"\xfe\xed\xfa\xcf",
+                    b"\xcf\xfa\xed\xfe",
+                    b"\xca\xfe\xba\xbe",
+                    b"\xbe\xba\xfe\xca",
+                    b"\xca\xfe\xba\xbf",
+                    b"\xbf\xba\xfe\xca",
+                }
+                if self.platform == "darwin"
+                else header == b"\x7fELF"
+            )
+            if not native:
+                return None
+            environment = {"LC_ALL": "C", "LANG": "C"}
+            if self.platform == "win32":
+                environment.update(
+                    (key, value)
+                    for key, value in self.environ.items()
+                    if key.upper() in {"SYSTEMROOT", "WINDIR", "SYSTEMDRIVE"}
+                )
+            with subprocess.Popen(
+                [str(node), "--version"],
+                shell=False,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                bufsize=0,
+                cwd=self.home,
+                env=environment,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            ) as process:
+                deadline = monotonic() + 2
+                timer = Timer(2, process.kill)
+                timer.start()
+                try:
+                    assert process.stdout is not None
+                    output = bytearray()
+                    while len(output) <= 256:
+                        chunk = process.stdout.read(257 - len(output))
+                        if not chunk:
+                            break
+                        output.extend(chunk)
+                    if len(output) > 256:
+                        return None
+                    if process.wait() != 0 or monotonic() >= deadline:
+                        return None
+                finally:
+                    timer.cancel()
+                    process.kill()
+                    process.wait()
+                    timer.join()
+            match = re.fullmatch(rb"v([0-9]+)\.([0-9]+)\.([0-9]+)\r?\n", output)
+            if match is not None:
+                return int(match[1]), int(match[2]), int(match[3])
+        except OSError:
+            return None
+        return None
+
+    def _acp_installation(self) -> AcpInstallation:
+        missing = "Install the Claude ACP adapter and Node.js 22 or newer. A compatible installed adapter was not detected."
         node = self.command("node")
         if node is None or node.suffix.lower() == ".cmd":
-            return ()
+            return AcpInstallation(issue=missing)
         roots = [node.parent.parent / "lib/node_modules"]
         if self.platform == "win32":
             roots.append(
@@ -293,7 +408,7 @@ class LocalInstallations:
             candidates.append(
                 adapter.parent / "node_modules/@agentclientprotocol/claude-agent-acp"
             )
-        found: set[Path] = set()
+        found: dict[Path, tuple[Path, object]] = {}
         for package in candidates:
             metadata = _json(package / "package.json")
             if (
@@ -310,8 +425,44 @@ class LocalInstallations:
                     executable.is_relative_to(package.resolve())
                     and executable.is_file()
                 ):
-                    found.add(executable)
-        return (str(node), str(next(iter(found)))) if len(found) == 1 else ()
+                    engines = metadata.get("engines")
+                    found[executable] = (
+                        (package / "package.json").resolve(),
+                        engines.get("node") if isinstance(engines, dict) else None,
+                    )
+        if len(found) != 1:
+            return AcpInstallation(issue=missing)
+        executable, (manifest, requirement) = next(iter(found.items()))
+        minimum = (
+            re.fullmatch(
+                r">=\s*(0|[1-9][0-9]*)(?:\.(0|[1-9][0-9]*))?(?:\.(0|[1-9][0-9]*))?",
+                requirement.strip(),
+            )
+            if isinstance(requirement, str) and len(requirement.strip()) <= 64
+            else None
+        )
+        if minimum is None:
+            return AcpInstallation(
+                manifest=manifest,
+                issue="The installed ACP adapter has an unsupported Node requirement. Use manual setup.",
+            )
+        required = max(
+            (22, 0, 0),
+            (int(minimum[1]), int(minimum[2] or 0), int(minimum[3] or 0)),
+        )
+        version = self._node_version(node)
+        if version is None:
+            return AcpInstallation(
+                manifest=manifest,
+                issue="Could not verify a direct Node.js 22+ runtime. Use an installed Node executable or manual setup; wrappers and unresolved runtime managers are unsupported.",
+            )
+        if version < required:
+            return AcpInstallation(
+                manifest=manifest,
+                node_version=version,
+                issue=f"Detected Node.js {'.'.join(map(str, version))}; this ACP adapter needs {'.'.join(map(str, required))} or newer.",
+            )
+        return AcpInstallation((str(node), str(executable)), manifest, version)
 
     def scan(self) -> InstalledClients:
         scope = ""
@@ -325,6 +476,6 @@ class LocalInstallations:
             self._jetbrains(),
             self.command("claude"),
             self.command("fcc-codex"),
-            self._acp_command(),
+            AcpInstallation(issue=scope) if scope else self._acp_installation(),
             scope,
         )

--- a/src/free_claude_code/runtime/integrations/discovery.py
+++ b/src/free_claude_code/runtime/integrations/discovery.py
@@ -112,9 +112,18 @@ class LocalInstallations:
         return cls(home, sys.platform, env, Path(sys.executable).parent, tuple(roots))
 
     @property
+    def appdata(self) -> Path:
+        override = self.environ.get("APPDATA", "")
+        return (
+            Path(override)
+            if override and Path(override).is_absolute()
+            else self.home / "AppData/Roaming"
+        )
+
+    @property
     def vscode_settings(self) -> Path:
         if self.platform == "win32":
-            root = Path(self.environ.get("APPDATA", str(self.home / "AppData/Roaming")))
+            root = self.appdata
         elif self.platform == "darwin":
             root = self.home / "Library/Application Support"
         else:
@@ -234,6 +243,8 @@ class LocalInstallations:
                         metadata = plistlib.loads(
                             (bundle / "Contents/Info.plist").read_bytes()
                         )
+                        if not isinstance(metadata, dict):
+                            continue
                         executable = metadata.get("CFBundleExecutable")
                         if metadata.get(
                             "CFBundleIdentifier"
@@ -397,10 +408,7 @@ class LocalInstallations:
             return AcpInstallation(issue=missing)
         roots = [node.parent.parent / "lib/node_modules"]
         if self.platform == "win32":
-            roots.append(
-                Path(self.environ.get("APPDATA", str(self.home / "AppData/Roaming")))
-                / "npm/node_modules"
-            )
+            roots.append(self.appdata / "npm/node_modules")
         adapter = self.command("claude-agent-acp")
         candidates = [root / "@agentclientprotocol/claude-agent-acp" for root in roots]
         if adapter is not None:

--- a/src/free_claude_code/runtime/integrations/discovery.py
+++ b/src/free_claude_code/runtime/integrations/discovery.py
@@ -1,0 +1,330 @@
+"""Read installed-client metadata without starting clients or installers."""
+
+import json
+import os
+import plistlib
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+def _json(path: Path) -> object:
+    try:
+        return json.loads(path.read_bytes())
+    except OSError, ValueError:
+        return None
+
+
+def windows_codex_locations() -> tuple[Path, ...]:
+    """The package identity survives changes to the desktop executable's name."""
+    try:
+        result = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Get-AppxPackage -Name OpenAI.Codex | Select-Object -ExpandProperty InstallLocation | ConvertTo-Json -Compress",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        values = (
+            json.loads(result.stdout)
+            if result.returncode == 0 and result.stdout.strip()
+            else []
+        )
+        if isinstance(values, str):
+            values = [values]
+        return (
+            tuple(
+                Path(value)
+                for value in values
+                if isinstance(value, str) and Path(value).is_absolute()
+            )
+            if isinstance(values, list)
+            else ()
+        )
+    except OSError, ValueError, subprocess.TimeoutExpired:
+        return ()
+
+
+@dataclass(frozen=True)
+class InstalledClients:
+    claude_vscode: bool
+    codex_vscode: bool
+    codex_app: bool
+    jetbrains: bool
+    claude_command: Path | None
+    fcc_command: Path | None
+    acp_command: tuple[str, ...]
+    scope_issue: str
+
+
+@dataclass(frozen=True)
+class LocalInstallations:
+    home: Path
+    platform: str
+    environ: dict[str, str]
+    python_bin: Path
+    app_roots: tuple[Path, ...]
+
+    @classmethod
+    def current(cls) -> LocalInstallations:
+        home, env = Path.home(), dict(os.environ)
+        if sys.platform == "win32":
+            roots = [
+                Path(value)
+                for key in ("ProgramFiles", "ProgramFiles(x86)")
+                if (value := env.get(key))
+            ]
+            if local := env.get("LOCALAPPDATA"):
+                roots.extend(
+                    (Path(local) / "Programs", Path(local) / "JetBrains/Toolbox/apps")
+                )
+        elif sys.platform == "darwin":
+            roots = [home / "Applications", Path("/Applications")]
+        else:
+            roots = [
+                Path("/usr/share"),
+                Path("/opt"),
+                home / ".local/share/JetBrains/Toolbox/apps",
+            ]
+        return cls(home, sys.platform, env, Path(sys.executable).parent, tuple(roots))
+
+    @property
+    def vscode_settings(self) -> Path:
+        if self.platform == "win32":
+            root = Path(self.environ.get("APPDATA", str(self.home / "AppData/Roaming")))
+        elif self.platform == "darwin":
+            root = self.home / "Library/Application Support"
+        else:
+            root = Path(self.environ.get("XDG_CONFIG_HOME", str(self.home / ".config")))
+        return root / "Code/User/settings.json"
+
+    def command(self, name: str) -> Path | None:
+        directories = [
+            Path(value)
+            for value in self.environ.get("PATH", "").split(os.pathsep)
+            if value
+        ]
+        if name == "fcc-codex":
+            directories.insert(0, self.python_bin)
+        suffixes = (".exe", ".cmd", "") if self.platform == "win32" else ("",)
+        for directory in directories:
+            for suffix in suffixes:
+                candidate = directory / (name + suffix)
+                if candidate.is_file() and (
+                    self.platform == "win32" or os.access(candidate, os.X_OK)
+                ):
+                    return candidate.resolve()
+        return None
+
+    def _vscode_installed(self) -> bool:
+        for root in self.app_roots:
+            if self.platform == "win32":
+                app = root / "Microsoft VS Code"
+                product, executable = (
+                    app / "resources/app/product.json",
+                    app / "Code.exe",
+                )
+            elif self.platform == "darwin":
+                app = root / "Visual Studio Code.app/Contents"
+                product, executable = (
+                    app / "Resources/app/product.json",
+                    app / "MacOS/Electron",
+                )
+            else:
+                app = root / "code"
+                product, executable = app / "resources/app/product.json", app / "code"
+            metadata = _json(product)
+            if (
+                isinstance(metadata, dict)
+                and metadata.get("applicationName") == "code"
+                and executable.is_file()
+            ):
+                return True
+        return False
+
+    def _extensions(self) -> set[str]:
+        root = self.home / ".vscode/extensions"
+        index = _json(root / "extensions.json")
+        result: set[str] = set()
+        if not isinstance(index, list):
+            return result
+        for descriptor in index:
+            if not isinstance(descriptor, dict):
+                continue
+            identity, relative = (
+                descriptor.get("identifier"),
+                descriptor.get("relativeLocation"),
+            )
+            if not isinstance(identity, dict) or not isinstance(relative, str):
+                continue
+            identifier = identity.get("id")
+            if identifier not in {"anthropic.claude-code", "openai.chatgpt"}:
+                continue
+            package = (root / relative).resolve()
+            if not package.is_relative_to(root.resolve()):
+                continue
+            manifest = _json(package / "package.json")
+            if (
+                isinstance(manifest, dict)
+                and f"{manifest.get('publisher')}.{manifest.get('name')}" == identifier
+            ):
+                result.add(identifier)
+        return result
+
+    def _codex_app(self) -> bool:
+        if self.platform == "win32":
+            for root in windows_codex_locations():
+                try:
+                    manifest = ElementTree.parse(root / "AppxManifest.xml").getroot()
+                    identity = next(
+                        (
+                            node
+                            for node in manifest.iter()
+                            if node.tag.rsplit("}", 1)[-1] == "Identity"
+                        ),
+                        None,
+                    )
+                    if identity is None or identity.get("Name") != "OpenAI.Codex":
+                        continue
+                    for node in manifest.iter():
+                        if node.tag.rsplit("}", 1)[-1] == "Application" and (
+                            relative := node.get("Executable")
+                        ):
+                            executable = (root / relative).resolve()
+                            if (
+                                executable.is_relative_to(root.resolve())
+                                and executable.is_file()
+                            ):
+                                return True
+                except OSError, ElementTree.ParseError:
+                    continue
+            return False
+        if self.platform == "darwin":
+            for root in self.app_roots:
+                for bundle in root.glob("*.app"):
+                    try:
+                        metadata = plistlib.loads(
+                            (bundle / "Contents/Info.plist").read_bytes()
+                        )
+                        executable = metadata.get("CFBundleExecutable")
+                        if metadata.get(
+                            "CFBundleIdentifier"
+                        ) == "com.openai.codex" and isinstance(executable, str):
+                            path = bundle / "Contents/MacOS" / executable
+                            if (
+                                path.resolve().is_relative_to(bundle.resolve())
+                                and path.is_file()
+                            ):
+                                return True
+                    except OSError, ValueError, plistlib.InvalidFileException:
+                        continue
+            return False
+        return self.command("chatgpt") is not None
+
+    def _jetbrains(self) -> bool:
+        for root in self.app_roots:
+            for pattern in (
+                "*/product-info.json",
+                "JetBrains/*/product-info.json",
+                "*/*/product-info.json",
+                "*.app/Contents/Resources/product-info.json",
+            ):
+                for path in root.glob(pattern):
+                    metadata = _json(path)
+                    if not isinstance(metadata, dict) or metadata.get(
+                        "productCode"
+                    ) not in {
+                        "IU",
+                        "IC",
+                        "PY",
+                        "PC",
+                        "WS",
+                        "PS",
+                        "GO",
+                        "CL",
+                        "RD",
+                        "RM",
+                        "RR",
+                        "DB",
+                    }:
+                        continue
+                    launches = metadata.get("launch", [])
+                    if isinstance(launches, list):
+                        for launch in launches:
+                            if isinstance(launch, dict) and isinstance(
+                                relative := launch.get("launcherPath"), str
+                            ):
+                                base = (
+                                    path.parent.parent
+                                    if self.platform == "darwin"
+                                    else path.parent
+                                )
+                                executable = (base / relative).resolve()
+                                if (
+                                    executable.is_relative_to(base.resolve())
+                                    and executable.is_file()
+                                ):
+                                    return True
+        return False
+
+    def _acp_command(self) -> tuple[str, ...]:
+        node = self.command("node")
+        if node is None or node.suffix.lower() == ".cmd":
+            return ()
+        roots = [node.parent.parent / "lib/node_modules"]
+        if self.platform == "win32":
+            roots.append(
+                Path(self.environ.get("APPDATA", str(self.home / "AppData/Roaming")))
+                / "npm/node_modules"
+            )
+        adapter = self.command("claude-agent-acp")
+        candidates = [root / "@agentclientprotocol/claude-agent-acp" for root in roots]
+        if adapter is not None:
+            candidates.extend(adapter.resolve().parents[:3])
+            candidates.append(
+                adapter.parent / "node_modules/@agentclientprotocol/claude-agent-acp"
+            )
+        found: set[Path] = set()
+        for package in candidates:
+            metadata = _json(package / "package.json")
+            if (
+                not isinstance(metadata, dict)
+                or metadata.get("name") != "@agentclientprotocol/claude-agent-acp"
+            ):
+                continue
+            entry = metadata.get("bin")
+            if isinstance(entry, dict):
+                entry = entry.get("claude-agent-acp")
+            if isinstance(entry, str):
+                executable = (package / entry).resolve()
+                if (
+                    executable.is_relative_to(package.resolve())
+                    and executable.is_file()
+                ):
+                    found.add(executable)
+        return (str(node), str(next(iter(found)))) if len(found) == 1 else ()
+
+    def scan(self) -> InstalledClients:
+        scope = ""
+        if self.environ.get("WSL_DISTRO_NAME") or self.environ.get("WSL_INTEROP"):
+            scope = "WSL setup is manual. Use FCC and the client in the same supported native environment."
+        extensions = self._extensions() if self._vscode_installed() else set()
+        return InstalledClients(
+            "anthropic.claude-code" in extensions,
+            "openai.chatgpt" in extensions,
+            self._codex_app(),
+            self._jetbrains(),
+            self.command("claude"),
+            self.command("fcc-codex"),
+            self._acp_command(),
+            scope,
+        )

--- a/src/free_claude_code/runtime/integrations/documents.py
+++ b/src/free_claude_code/runtime/integrations/documents.py
@@ -1,0 +1,288 @@
+"""Source-preserving edits for the small set of supported client files."""
+
+import json
+import tomllib
+from collections.abc import Iterator, MutableMapping
+
+import tomlkit
+import tree_sitter_json
+from tree_sitter import Language, Node, Parser
+
+from free_claude_code.application.integrations import IntegrationError
+
+MISSING = object()
+type PathKey = str | int
+type SettingPath = tuple[PathKey, ...]
+
+
+def _invalid() -> IntegrationError:
+    return IntegrationError(
+        "The configuration file is malformed or has unsupported syntax. Fix it before continuing."
+    )
+
+
+def _constant(_value: str) -> None:
+    raise _invalid()
+
+
+def _tokens(node: Node) -> Iterator[Node]:
+    if node.is_missing:
+        return
+    if node.type in {"comment", "string"} or not node.children:
+        yield node
+    else:
+        for child in node.children:
+            yield from _tokens(child)
+
+
+class JsonDocument:
+    def __init__(self, source: bytes, *, jsonc: bool) -> None:
+        self._bom = b"\xef\xbb\xbf" if source.startswith(b"\xef\xbb\xbf") else b""
+        self._body = source[len(self._bom) :]
+        self._jsonc = jsonc
+        self._parser = Parser(Language(tree_sitter_json.language()))
+        self._parse()
+
+    def _parse(self) -> None:
+        try:
+            self._body.decode("utf-8")
+            original = self._parser.parse(self._body)
+            tokens = list(_tokens(original.root_node))
+            significant = [node for node in tokens if node.type != "comment"]
+            self._commas = [node.start_byte for node in significant if node.type == ","]
+            projection = bytearray(self._body)
+            if self._jsonc:
+                for index, node in enumerate(significant):
+                    if (
+                        node.type == ","
+                        and 0 < index < len(significant) - 1
+                        and significant[index + 1].type in {"}", "]"}
+                        and significant[index - 1].type not in {"{", "[", ":", ","}
+                    ):
+                        projection[node.start_byte : node.end_byte] = b" " * (
+                            node.end_byte - node.start_byte
+                        )
+                for node in tokens:
+                    if node.type == "comment":
+                        for index in range(node.start_byte, node.end_byte):
+                            if projection[index] not in (10, 13):
+                                projection[index] = 32
+            self._projection = bytes(projection)
+            self.data = json.loads(self._projection, parse_constant=_constant)
+            tree = self._parser.parse(self._projection)
+            if not isinstance(self.data, dict) or tree.root_node.has_error:
+                raise _invalid()
+            self._root = tree.root_node.named_children[0]
+        except UnicodeError, ValueError, IndexError:
+            raise _invalid() from None
+
+    def _child(self, parent: Node, key: PathKey) -> Node | None:
+        if isinstance(key, str) and parent.type == "object":
+            matches = []
+            for pair in parent.named_children:
+                key_node = pair.child_by_field_name("key")
+                if (
+                    key_node is not None
+                    and json.loads(
+                        self._projection[key_node.start_byte : key_node.end_byte]
+                    )
+                    == key
+                ):
+                    matches.append(pair.child_by_field_name("value"))
+            if len(matches) > 1:
+                raise IntegrationError(
+                    "A setting being changed has duplicate keys. Remove the duplicate before continuing."
+                )
+            return matches[0] if matches else None
+        if isinstance(key, int) and parent.type == "array" and key >= 0:
+            children = parent.named_children
+            return children[key] if key < len(children) else None
+        raise IntegrationError(
+            "A setting being changed has an incompatible object or array type."
+        )
+
+    def _find(self, path: SettingPath) -> Node | None:
+        node = self._root
+        for key in path:
+            child = self._child(node, key)
+            if child is None:
+                return None
+            node = child
+        return node
+
+    def get(self, path: SettingPath) -> object:
+        node = self._find(path)
+        if node is None:
+            return MISSING
+        return json.loads(self._projection[node.start_byte : node.end_byte])
+
+    def render(self) -> bytes:
+        return self._bom + self._body
+
+    def _edit(self, edits: list[tuple[int, int, bytes]]) -> None:
+        body = self._body
+        grouped: dict[tuple[int, int], bytes] = {}
+        for start, end, replacement in edits:
+            grouped[start, end] = grouped.get((start, end), b"") + replacement
+        for (start, end), replacement in sorted(grouped.items(), reverse=True):
+            body = body[:start] + replacement + body[end:]
+        # Validate before replacing this document, including all untouched bytes.
+        candidate = JsonDocument(self._bom + body, jsonc=self._jsonc)
+        self.__dict__.update(candidate.__dict__)
+
+    def _insert(self, parent: Node, value: bytes) -> None:
+        children = parent.named_children
+        close = parent.end_byte - 1
+        edits = []
+        if children:
+            last = children[-1]
+            if not any(last.end_byte <= comma < close for comma in self._commas):
+                edits.append((last.end_byte, last.end_byte, b","))
+        newline = b"\r\n" if b"\r\n" in self._body else b"\n"
+        line_start = self._body.rfind(b"\n", 0, close) + 1
+        closing_indent = self._body[line_start:close]
+        if line_start > parent.start_byte and not closing_indent.strip():
+            indent = closing_indent + b"  "
+            if children:
+                first = children[0].start_byte
+                first_line = self._body.rfind(b"\n", 0, first) + 1
+                existing = self._body[first_line:first]
+                if not existing.strip():
+                    indent = existing
+            edits.append((line_start, line_start, indent + value + newline))
+        else:
+            edits.append((close, close, (b" " if children else b"") + value))
+        self._edit(edits)
+
+    def set(self, path: SettingPath, value: object) -> None:
+        node = self._root
+        for index, key in enumerate(path):
+            child = self._child(node, key)
+            if child is None:
+                nested = value
+                for tail in reversed(path[index + 1 :]):
+                    if not isinstance(tail, str):
+                        raise IntegrationError(
+                            "A missing array must be created before adding entries."
+                        )
+                    nested = {tail: nested}
+                encoded = json.dumps(
+                    nested, ensure_ascii=False, allow_nan=False
+                ).encode()
+                if isinstance(key, str):
+                    encoded = (
+                        json.dumps(key, ensure_ascii=False).encode() + b": " + encoded
+                    )
+                elif key != len(node.named_children):
+                    raise IntegrationError(
+                        "An array entry no longer exists.", status_code=409
+                    )
+                self._insert(node, encoded)
+                return
+            node = child
+        if self.get(path) == value and type(self.get(path)) is type(value):
+            return
+        self._edit(
+            [
+                (
+                    node.start_byte,
+                    node.end_byte,
+                    json.dumps(value, ensure_ascii=False, allow_nan=False).encode(),
+                )
+            ]
+        )
+
+    def delete(self, path: SettingPath) -> None:
+        node = self._find(path)
+        if node is None:
+            return
+        parent = self._find(path[:-1])
+        assert parent is not None
+        if parent.type == "object":
+            node = node.parent
+            assert node is not None
+        siblings = parent.named_children
+        index = siblings.index(node)
+        after = (
+            siblings[index + 1].start_byte
+            if index + 1 < len(siblings)
+            else parent.end_byte - 1
+        )
+        commas = [comma for comma in self._commas if node.end_byte <= comma < after]
+        if not commas and index > 0:
+            commas = [
+                comma
+                for comma in self._commas
+                if siblings[index - 1].end_byte <= comma < node.start_byte
+            ]
+        edits = [(node.start_byte, node.end_byte, b"")]
+        if commas:
+            edits.append((commas[0], commas[0] + 1, b""))
+        self._edit(edits)
+
+
+class TomlDocument:
+    def __init__(self, source: bytes) -> None:
+        try:
+            self._text = source.decode("utf-8")
+            self.data = tomllib.loads(self._text)
+            self._document = tomlkit.parse(self._text)
+            if tomlkit.dumps(self._document) != self._text:
+                raise IntegrationError(
+                    "This TOML layout cannot be edited without reformatting other settings. Use manual setup."
+                )
+        except UnicodeError, ValueError:
+            raise _invalid() from None
+
+    def render(self) -> bytes:
+        return self._text.encode()
+
+    def get(self, path: SettingPath) -> object:
+        current: object = self.data
+        for key in path:
+            if not isinstance(key, str) or not isinstance(current, dict):
+                raise IntegrationError(
+                    "A setting being changed has an incompatible table type."
+                )
+            if key not in current:
+                return MISSING
+            current = current[key]
+        return current
+
+    def _change(self, path: SettingPath, value: object) -> None:
+        candidate = tomlkit.parse(self._text)
+        current: MutableMapping = candidate
+        for key in path[:-1]:
+            if not isinstance(key, str):
+                raise IntegrationError("Unsupported TOML setting path.")
+            if key not in current:
+                current[key] = tomlkit.table()
+            child = current[key]
+            if not isinstance(child, MutableMapping):
+                raise IntegrationError(
+                    "A setting being changed has an incompatible table type."
+                )
+            current = child
+        key = path[-1]
+        if not isinstance(key, str):
+            raise IntegrationError("Unsupported TOML setting path.")
+        if value is MISSING:
+            current.pop(key, None)
+        else:
+            current[key] = value
+        text = tomlkit.dumps(candidate)
+        try:
+            data = tomllib.loads(text)
+        except ValueError:
+            raise _invalid() from None
+        self._text, self._document, self.data = text, candidate, data
+
+    def set(self, path: SettingPath, value: object) -> None:
+        existing = self.get(path)
+        if existing == value and type(existing) is type(value):
+            return
+        self._change(path, value)
+
+    def delete(self, path: SettingPath) -> None:
+        if self.get(path) is not MISSING:
+            self._change(path, MISSING)

--- a/src/free_claude_code/runtime/integrations/documents.py
+++ b/src/free_claude_code/runtime/integrations/documents.py
@@ -3,9 +3,14 @@
 import json
 import tomllib
 from collections.abc import Iterator, MutableMapping
+from copy import deepcopy
+from datetime import datetime, time
+from decimal import Decimal
 
 import tomlkit
 import tree_sitter_json
+from tomlkit.exceptions import TOMLKitError
+from tomlkit.items import Table
 from tree_sitter import Language, Node, Parser
 
 from free_claude_code.application.integrations import IntegrationError
@@ -23,6 +28,84 @@ def _invalid() -> IntegrationError:
 
 def _constant(_value: str) -> None:
     raise _invalid()
+
+
+def _same_data(first: object, second: object) -> bool:
+    if type(first) is not type(second):
+        return False
+    if isinstance(first, dict) and isinstance(second, dict):
+        return first.keys() == second.keys() and all(
+            _same_data(value, second[key]) for key, value in first.items()
+        )
+    if isinstance(first, list) and isinstance(second, list):
+        return len(first) == len(second) and all(
+            _same_data(left, right) for left, right in zip(first, second, strict=True)
+        )
+    if isinstance(first, Decimal) and isinstance(second, Decimal):
+        if first.is_nan() or second.is_nan():
+            return (
+                first.is_nan()
+                and second.is_nan()
+                and first.is_signed() == second.is_signed()
+            )
+        return first == second and first.is_signed() == second.is_signed()
+    if isinstance(first, datetime | time) and isinstance(second, datetime | time):
+        return first.isoformat() == second.isoformat()
+    return first == second
+
+
+def _validation_value(value: object) -> object:
+    if isinstance(value, dict):
+        return {key: _validation_value(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_validation_value(child) for child in value]
+    return Decimal(repr(value)) if isinstance(value, float) else value
+
+
+def _expected_data(data: dict, path: SettingPath, value: object) -> dict:
+    expected = deepcopy(data)
+    current: object = expected
+    for key in path[:-1]:
+        if isinstance(current, dict) and isinstance(key, str):
+            if key not in current:
+                current[key] = {}
+            current = current[key]
+        elif (
+            isinstance(current, list)
+            and isinstance(key, int)
+            and 0 <= key < len(current)
+        ):
+            current = current[key]
+        else:
+            raise IntegrationError(
+                "A setting being changed has an incompatible parent."
+            )
+    key = path[-1]
+    if isinstance(current, dict) and isinstance(key, str):
+        if value is MISSING:
+            current.pop(key, None)
+        else:
+            current[key] = _validation_value(value)
+    elif (
+        isinstance(current, list) and isinstance(key, int) and 0 <= key <= len(current)
+    ):
+        if value is MISSING and key < len(current):
+            current.pop(key)
+        elif value is not MISSING:
+            if key == len(current):
+                current.append(_validation_value(value))
+            else:
+                current[key] = _validation_value(value)
+    else:
+        raise IntegrationError("A setting being changed has an incompatible parent.")
+    return expected
+
+
+def _require_expected(actual: dict, expected: dict) -> None:
+    if not _same_data(actual, expected):
+        raise IntegrationError(
+            "This configuration layout cannot be edited without changing other settings. Use manual setup."
+        )
 
 
 def _tokens(node: Node) -> Iterator[Node]:
@@ -69,6 +152,9 @@ class JsonDocument:
                                 projection[index] = 32
             self._projection = bytes(projection)
             self.data = json.loads(self._projection, parse_constant=_constant)
+            self._semantic = json.loads(
+                self._projection, parse_float=Decimal, parse_constant=_constant
+            )
             tree = self._parser.parse(self._projection)
             if not isinstance(self.data, dict) or tree.root_node.has_error:
                 raise _invalid()
@@ -119,7 +205,7 @@ class JsonDocument:
     def render(self) -> bytes:
         return self._bom + self._body
 
-    def _edit(self, edits: list[tuple[int, int, bytes]]) -> None:
+    def _edit(self, edits: list[tuple[int, int, bytes]], expected: dict) -> None:
         body = self._body
         grouped: dict[tuple[int, int], bytes] = {}
         for start, end, replacement in edits:
@@ -128,9 +214,10 @@ class JsonDocument:
             body = body[:start] + replacement + body[end:]
         # Validate before replacing this document, including all untouched bytes.
         candidate = JsonDocument(self._bom + body, jsonc=self._jsonc)
+        _require_expected(candidate._semantic, expected)
         self.__dict__.update(candidate.__dict__)
 
-    def _insert(self, parent: Node, value: bytes) -> None:
+    def _insert(self, parent: Node, value: bytes, expected: dict) -> None:
         children = parent.named_children
         close = parent.end_byte - 1
         edits = []
@@ -152,9 +239,10 @@ class JsonDocument:
             edits.append((line_start, line_start, indent + value + newline))
         else:
             edits.append((close, close, (b" " if children else b"") + value))
-        self._edit(edits)
+        self._edit(edits, expected)
 
     def set(self, path: SettingPath, value: object) -> None:
+        expected = _expected_data(self._semantic, path, value)
         node = self._root
         for index, key in enumerate(path):
             child = self._child(node, key)
@@ -177,10 +265,10 @@ class JsonDocument:
                     raise IntegrationError(
                         "An array entry no longer exists.", status_code=409
                     )
-                self._insert(node, encoded)
+                self._insert(node, encoded, expected)
                 return
             node = child
-        if self.get(path) == value and type(self.get(path)) is type(value):
+        if _same_data(self._semantic, expected):
             return
         self._edit(
             [
@@ -189,7 +277,8 @@ class JsonDocument:
                     node.end_byte,
                     json.dumps(value, ensure_ascii=False, allow_nan=False).encode(),
                 )
-            ]
+            ],
+            expected,
         )
 
     def delete(self, path: SettingPath) -> None:
@@ -218,7 +307,7 @@ class JsonDocument:
         edits = [(node.start_byte, node.end_byte, b"")]
         if commas:
             edits.append((commas[0], commas[0] + 1, b""))
-        self._edit(edits)
+        self._edit(edits, _expected_data(self._semantic, path, MISSING))
 
 
 class TomlDocument:
@@ -226,12 +315,13 @@ class TomlDocument:
         try:
             self._text = source.decode("utf-8")
             self.data = tomllib.loads(self._text)
+            self._semantic = tomllib.loads(self._text, parse_float=Decimal)
             self._document = tomlkit.parse(self._text)
             if tomlkit.dumps(self._document) != self._text:
                 raise IntegrationError(
                     "This TOML layout cannot be edited without reformatting other settings. Use manual setup."
                 )
-        except UnicodeError, ValueError:
+        except UnicodeError, ValueError, TOMLKitError:
             raise _invalid() from None
 
     def render(self) -> bytes:
@@ -250,37 +340,54 @@ class TomlDocument:
         return current
 
     def _change(self, path: SettingPath, value: object) -> None:
-        candidate = tomlkit.parse(self._text)
-        current: MutableMapping = candidate
-        for key in path[:-1]:
+        expected = _expected_data(self._semantic, path, value)
+        if _same_data(self._semantic, expected):
+            return
+        try:
+            candidate = tomlkit.parse(self._text)
+            current: MutableMapping = candidate
+            ancestors: list[tuple[MutableMapping, str]] = []
+            for key in path[:-1]:
+                if not isinstance(key, str):
+                    raise IntegrationError("Unsupported TOML setting path.")
+                if key not in current:
+                    current[key] = tomlkit.inline_table()
+                child = current[key]
+                if not isinstance(child, MutableMapping):
+                    raise IntegrationError(
+                        "A setting being changed has an incompatible table type."
+                    )
+                ancestors.append((current, key))
+                current = child
+            key = path[-1]
             if not isinstance(key, str):
                 raise IntegrationError("Unsupported TOML setting path.")
-            if key not in current:
-                current[key] = tomlkit.table()
-            child = current[key]
-            if not isinstance(child, MutableMapping):
-                raise IntegrationError(
-                    "A setting being changed has an incompatible table type."
-                )
-            current = child
-        key = path[-1]
-        if not isinstance(key, str):
-            raise IntegrationError("Unsupported TOML setting path.")
-        if value is MISSING:
-            current.pop(key, None)
-        else:
-            current[key] = value
-        text = tomlkit.dumps(candidate)
-        try:
+            if value is MISSING:
+                current.pop(key, None)
+                for parent, name in reversed(ancestors):
+                    child = parent[name]
+                    if (
+                        isinstance(child, Table)
+                        and child.is_super_table()
+                        and not child
+                    ):
+                        parent[name] = tomlkit.inline_table()
+            else:
+                current[key] = value
+            text = tomlkit.dumps(candidate)
             data = tomllib.loads(text)
-        except ValueError:
+            semantic = tomllib.loads(text, parse_float=Decimal)
+            _require_expected(semantic, expected)
+        except ValueError, TOMLKitError:
             raise _invalid() from None
-        self._text, self._document, self.data = text, candidate, data
+        self._text, self._document, self.data, self._semantic = (
+            text,
+            candidate,
+            data,
+            semantic,
+        )
 
     def set(self, path: SettingPath, value: object) -> None:
-        existing = self.get(path)
-        if existing == value and type(existing) is type(value):
-            return
         self._change(path, value)
 
     def delete(self, path: SettingPath) -> None:

--- a/src/free_claude_code/runtime/integrations/documents.py
+++ b/src/free_claude_code/runtime/integrations/documents.py
@@ -89,9 +89,7 @@ def _expected_data(data: dict, path: SettingPath, value: object) -> dict:
     elif (
         isinstance(current, list) and isinstance(key, int) and 0 <= key <= len(current)
     ):
-        if value is MISSING and key < len(current):
-            current.pop(key)
-        elif value is not MISSING:
+        if value is not MISSING:
             if key == len(current):
                 current.append(_validation_value(value))
             else:
@@ -280,34 +278,6 @@ class JsonDocument:
             ],
             expected,
         )
-
-    def delete(self, path: SettingPath) -> None:
-        node = self._find(path)
-        if node is None:
-            return
-        parent = self._find(path[:-1])
-        assert parent is not None
-        if parent.type == "object":
-            node = node.parent
-            assert node is not None
-        siblings = parent.named_children
-        index = siblings.index(node)
-        after = (
-            siblings[index + 1].start_byte
-            if index + 1 < len(siblings)
-            else parent.end_byte - 1
-        )
-        commas = [comma for comma in self._commas if node.end_byte <= comma < after]
-        if not commas and index > 0:
-            commas = [
-                comma
-                for comma in self._commas
-                if siblings[index - 1].end_byte <= comma < node.start_byte
-            ]
-        edits = [(node.start_byte, node.end_byte, b"")]
-        if commas:
-            edits.append((commas[0], commas[0] + 1, b""))
-        self._edit(edits, _expected_data(self._semantic, path, MISSING))
 
 
 class TomlDocument:

--- a/src/free_claude_code/runtime/integrations/service.py
+++ b/src/free_claude_code/runtime/integrations/service.py
@@ -1,0 +1,675 @@
+"""Inspect, preview, and confirm one local integration change at a time."""
+
+import hashlib
+import hmac
+import json
+import secrets
+from dataclasses import asdict, dataclass
+
+from pydantic import ValidationError
+
+from free_claude_code.application.integrations import IntegrationAction as Action
+from free_claude_code.application.integrations import IntegrationError, validate_action
+from free_claude_code.application.integrations import IntegrationId as Item
+from free_claude_code.core.interprocess_lock import InterprocessFileLock
+from free_claude_code.core.json_types import JsonObject
+
+from .discovery import InstalledClients, LocalInstallations
+from .documents import MISSING, JsonDocument
+from .storage import (
+    FieldHistory,
+    FileSnapshot,
+    Ownership,
+    PendingWrite,
+    SavedValue,
+    atomic_write,
+    check_path,
+    content_hash,
+    write_record,
+)
+from .targets import AGENT_PATH, ENV_SETTING, Connection, Target, make_targets, same_url
+
+
+@dataclass
+class Capture:
+    target: Target
+    source: FileSnapshot
+    record_file: FileSnapshot
+    record: Ownership | None
+    dependencies: tuple[FileSnapshot, ...]
+    installed: InstalledClients
+    pending: PendingWrite | None
+
+    @property
+    def completed_action(self) -> Action | None:
+        if self.pending is not None and self.source.digest == self.pending.after:
+            return self.pending.action
+        return None
+
+
+@dataclass
+class Prepared:
+    capture: Capture
+    output: bytes
+    following: Ownership | None
+    preview: JsonObject
+
+
+def _codex_extension_in_wsl(capture: Capture) -> bool:
+    vscode = capture.dependencies[1]
+    return (
+        vscode.data is not None
+        and JsonDocument(vscode.data, jsonc=True).get(
+            ("chatgpt.runCodexInWindowsSubsystemForLinux",)
+        )
+        is True
+    )
+
+
+def _display(key: str, value: object) -> str:
+    if value is MISSING:
+        return "Not set"
+    if any(part in key.lower() for part in ("auth", "token", "env_key")):
+        return "********"
+    if (
+        "base_url" in key.lower()
+        and isinstance(value, str)
+        and ("@" in value or "?" in value)
+    ):
+        return "********"
+    return json.dumps(value, ensure_ascii=False)
+
+
+class IntegrationService:
+    def __init__(self, installations: LocalInstallations) -> None:
+        self.installations = installations
+        self.state_dir = installations.home / ".fcc/integrations"
+        self._revision_key = secrets.token_bytes(32)
+
+    def _capture(
+        self, target: Target, installed: InstalledClients, connection: Connection
+    ) -> Capture:
+        source = FileSnapshot.read(target.path)
+        record_file = FileSnapshot.read(self.state_dir / f"{target.id}.json")
+        record = None
+        pending = None
+        if record_file.data is not None:
+            try:
+                payload = json.loads(record_file.data)
+                if isinstance(payload, dict) and payload.get("phase") == "pending":
+                    pending = PendingWrite.model_validate(payload)
+                    validate_action(target.id, pending.action)
+                    if pending.item != target.id or pending.path != str(target.path):
+                        raise ValueError("target")
+                    if source.digest == pending.before:
+                        record = pending.previous
+                    elif source.digest == pending.after:
+                        record = pending.following
+                    else:
+                        raise IntegrationError(
+                            "An interrupted write needs attention because the file has changed. Use manual cleanup; FCC will not overwrite the uncertain file.",
+                            status_code=409,
+                        )
+                else:
+                    record = Ownership.model_validate(payload)
+                if record is not None and (
+                    record.item != target.id
+                    or record.path != str(target.path)
+                    or not set(record.fields) <= target.recipe.keys()
+                    or any(
+                        tuple(path) not in target.containers()
+                        for path in record.created_containers
+                    )
+                ):
+                    raise ValueError("target")
+            except ValueError, ValidationError:
+                raise IntegrationError(
+                    "The saved undo record cannot be read. Previous settings cannot be restored; use manual cleanup."
+                ) from None
+        dependencies = []
+        if target.id in {Item.CLAUDE_VSCODE, Item.CLAUDE_JETBRAINS}:
+            dependencies.append(
+                FileSnapshot.read(self.installations.home / ".claude/settings.json")
+            )
+        if target.id == Item.CODEX:
+            dependencies.append(FileSnapshot.read(connection.catalog_path))
+            dependencies.append(FileSnapshot.read(self.installations.vscode_settings))
+            if installed.fcc_command is not None:
+                dependencies.append(FileSnapshot.read(installed.fcc_command))
+        if target.id == Item.CLAUDE_JETBRAINS:
+            dependencies.extend(
+                FileSnapshot.read(self.installations.home / path)
+                for path in installed.acp_command
+            )
+        return Capture(
+            target, source, record_file, record, tuple(dependencies), installed, pending
+        )
+
+    def _revision(
+        self, capture: Capture, action: Action, connection: Connection
+    ) -> str:
+        context = (
+            {}
+            if capture.target.id == Item.CLAUDE_LOGIN
+            else {
+                "url": connection.url,
+                "token": connection.settings.proxy_auth_token,
+                "auth_enabled": connection.settings.proxy_auth_enabled,
+                "saved_auth_token": connection.saved_auth_token,
+                "model": connection.model,
+                "models": [model.wire_slug for model in connection.models],
+                "catalog": str(connection.catalog_path),
+            }
+        )
+        payload = {
+            "id": capture.target.id,
+            "action": action,
+            "context": context,
+            "installed": asdict(capture.installed),
+            "files": [
+                (str(file.path), file.digest, file.identity)
+                for file in (capture.source, capture.record_file, *capture.dependencies)
+            ],
+        }
+        return hmac.new(
+            self._revision_key,
+            json.dumps(payload, sort_keys=True, default=str).encode(),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def _claude_conflicts(self, capture: Capture, connection: Connection) -> None:
+        target = capture.target
+        document = target.document(capture.source.data)
+        environments: list[dict[str, object]] = []
+        if target.id == Item.CLAUDE_VSCODE:
+            entries = document.get((ENV_SETTING,))
+            if isinstance(entries, list):
+                extra = {
+                    entry["name"]: entry.get("value")
+                    for entry in entries
+                    if isinstance(entry, dict)
+                    and isinstance(entry.get("name"), str)
+                    and f"env.{entry['name']}" not in target.recipe
+                }
+                environments.append(extra)
+        else:
+            entries = document.get((*AGENT_PATH, "env"))
+            if isinstance(entries, dict):
+                environments.append(
+                    {
+                        key: value
+                        for key, value in entries.items()
+                        if f"env.{key}" not in target.recipe
+                    }
+                )
+        global_settings = capture.dependencies[0]
+        if global_settings.data is not None:
+            global_env = JsonDocument(global_settings.data, jsonc=True).get(("env",))
+            if global_env is not MISSING and not isinstance(global_env, dict):
+                raise IntegrationError(
+                    "The user-level Claude env setting must be an object. Correct .claude/settings.json first."
+                )
+            if isinstance(global_env, dict):
+                environments.append(global_env)
+        for environment in environments:
+            for key, value in environment.items():
+                if not (
+                    key.startswith("ANTHROPIC_")
+                    or key.startswith("CLAUDE_CODE_USE_")
+                    or key
+                    in {
+                        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+                        "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY",
+                    }
+                ):
+                    continue
+                expected = target.recipe.get(f"env.{key}", MISSING)
+                matches = (
+                    same_url(value, connection.url)
+                    if key == "ANTHROPIC_BASE_URL"
+                    else value == expected
+                )
+                if value not in (None, "") and not matches:
+                    raise IntegrationError(
+                        f"Conflicting {key} in Claude environment settings. Correct the editor environment or .claude/settings.json manually before setup."
+                    )
+
+    def _require_ready(
+        self, capture: Capture, action: Action, connection: Connection
+    ) -> None:
+        target = capture.target
+        if capture.installed.scope_issue:
+            raise IntegrationError(capture.installed.scope_issue)
+        if action == Action.DISCONNECT or action == capture.completed_action:
+            return
+        if target.missing:
+            raise IntegrationError(" ".join(target.missing))
+        if target.id == Item.CODEX:
+            if (
+                connection.settings.proxy_auth_enabled
+                and connection.saved_auth_token != connection.settings.proxy_auth_token
+            ):
+                raise IntegrationError(
+                    "Save the FCC authentication token in its user configuration before setup; a desktop helper cannot inherit server-only credentials."
+                )
+            catalog = capture.dependencies[0]
+            try:
+                data = json.loads(catalog.data) if catalog.data is not None else None
+                models = data.get("models", []) if isinstance(data, dict) else []
+                slugs = {
+                    model["slug"]
+                    for model in models
+                    if isinstance(model, dict) and isinstance(model.get("slug"), str)
+                }
+            except ValueError:
+                slugs = set()
+            if (
+                not connection.models
+                or not slugs
+                or (action == Action.SETUP and connection.model not in slugs)
+            ):
+                raise IntegrationError(
+                    "FCC's model catalog/default is not ready. Select an available FCC model before setup."
+                )
+            if not capture.installed.codex_app and _codex_extension_in_wsl(capture):
+                raise IntegrationError(
+                    "This Codex extension runs in WSL and needs manual setup. Its WSL mode will not be changed."
+                )
+
+    def _prepare(
+        self, capture: Capture, action: Action, connection: Connection
+    ) -> Prepared:
+        target = capture.target
+        validate_action(target.id, action)
+        document = target.document(capture.source.data)
+        values = target.values(document)
+        recognized = target.recognized(values, connection)
+        self._require_ready(capture, action, connection)
+        record = capture.record
+        if action == Action.SETUP and record is not None:
+            raise IntegrationError(
+                "This setup is already managed. Use Update or Disconnect; later edits will be preserved.",
+                status_code=409,
+            )
+        if (
+            action in {Action.UPDATE, Action.DISCONNECT}
+            and record is None
+            and not recognized
+            and capture.completed_action != action
+        ):
+            raise IntegrationError(
+                "An FCC connection could not be identified. Use Set up or follow the manual cleanup instructions."
+            )
+        if action != Action.DISCONNECT and target.id in {
+            Item.CLAUDE_VSCODE,
+            Item.CLAUDE_JETBRAINS,
+        }:
+            self._claude_conflicts(capture, connection)
+            if (
+                target.id == Item.CLAUDE_JETBRAINS
+                and record is None
+                and not recognized
+                and document.get(AGENT_PATH) is not MISSING
+            ):
+                raise IntegrationError(
+                    "A different agent already uses the name Claude Code (FCC). Rename that entry manually before setup."
+                )
+        desired = dict(target.recipe)
+        if target.id == Item.CODEX:
+            if action == Action.UPDATE:
+                desired.pop("model", None)
+            key = "model_providers.fcc.requires_openai_auth"
+            if values[key] is False:
+                desired[key] = False
+        notes = [
+            "Only the default local user profile is configured. Other profiles and remote environments use manual setup."
+        ]
+        fields = (
+            {}
+            if record is None
+            else {
+                key: value.model_copy(deep=True) for key, value in record.fields.items()
+            }
+        )
+        containers = (
+            [
+                list(path)
+                for path in target.containers()
+                if document.get(path) is MISSING
+            ]
+            if record is None
+            else record.created_containers
+        )
+        if action == Action.DISCONNECT:
+            if record is None:
+                notes.append(
+                    "Previous settings are unknown. Remove only identifiable FCC values; the client may need its normal setup again."
+                )
+                desired = {
+                    key: MISSING
+                    for key, value in values.items()
+                    if target.manual_owned(key, value, connection)
+                }
+            else:
+                notes.append(
+                    "Restore saved previous settings and remove values introduced by FCC. Later user edits stop the whole action."
+                )
+                desired = {
+                    key: field.prior.unpack() if field.prior is not None else MISSING
+                    for key, field in fields.items()
+                }
+            if (
+                record is not None
+                and target.id == Item.CLAUDE_JETBRAINS
+                and list(AGENT_PATH) in record.created_containers
+            ):
+                expected: dict[str, object] = {"env": {}}
+                env = expected["env"]
+                assert isinstance(env, dict)
+                for key, field in fields.items():
+                    if field.last.present:
+                        if key.startswith("env."):
+                            env[key[4:]] = field.last.value
+                        else:
+                            expected[key] = field.last.value
+                if document.get(AGENT_PATH) != expected:
+                    raise IntegrationError(
+                        "The Claude Code (FCC) agent was edited or has added fields. Preserve those changes and remove it manually.",
+                        status_code=409,
+                    )
+        elif recognized and record is None and action == Action.UPDATE:
+            notes.append(
+                "Adopt this manual FCC connection for future updates. Previous non-FCC settings are unknown for its existing FCC values."
+            )
+            for key, value in values.items():
+                if target.manual_owned(key, value, connection):
+                    fields[key] = FieldHistory(
+                        prior=None, last=SavedValue.capture(value)
+                    )
+        elif action == Action.REPAIR:
+            notes.append(
+                "Change only shared Claude first-run state. This does not authenticate an account, and Disconnect will not reset it."
+            )
+        else:
+            notes.append(
+                "Save previous values so Disconnect can restore them when they have not been edited afterward."
+            )
+        changes: list[JsonObject] = []
+        for key, value in desired.items():
+            current = values[key]
+            if current == value and type(current) is type(value):
+                continue
+            if (
+                record is not None
+                and key in fields
+                and SavedValue.capture(current) != fields[key].last
+            ):
+                raise IntegrationError(
+                    f"The setting {key} was edited after FCC setup. No settings will change; correct or remove it manually.",
+                    status_code=409,
+                )
+            changes.append(
+                {
+                    "setting": key,
+                    "before": _display(key, current),
+                    "after": _display(key, value),
+                }
+            )
+            if action not in {Action.DISCONNECT, Action.REPAIR}:
+                if key not in fields:
+                    prior = (
+                        None
+                        if recognized and target.manual_owned(key, current, connection)
+                        else SavedValue.capture(current)
+                    )
+                    fields[key] = FieldHistory(
+                        prior=prior, last=SavedValue.capture(value)
+                    )
+                else:
+                    fields[key].last = SavedValue.capture(value)
+            target.write(document, key, value)
+        if action == Action.DISCONNECT:
+            if record is None and target.id == Item.CLAUDE_JETBRAINS:
+                if document.get(AGENT_PATH) in ({}, {"env": {}}):
+                    document.delete(AGENT_PATH)
+                    notes.append("Remove the empty Claude Code (FCC) agent entry.")
+                else:
+                    notes.append(
+                        "Keep remaining custom agent fields; finish any further cleanup manually."
+                    )
+            for path in reversed(containers):
+                remaining = document.get(tuple(path))
+                if remaining == {} or remaining == []:
+                    document.delete(tuple(path))
+        output = document.render()
+        if changes:
+            capture.source.require_writable()
+        following = (
+            None
+            if action in {Action.DISCONNECT, Action.REPAIR}
+            else Ownership(
+                item=target.id,
+                path=str(target.path),
+                fields=fields,
+                created_containers=containers,
+            )
+        )
+        if not changes:
+            following = record
+            output = capture.source.data if capture.source.data is not None else output
+        if target.id == Item.CODEX:
+            notes.append(
+                "The App, VS Code extension, and normal Codex CLI share this file and provider selection."
+            )
+        unknown_history = (recognized and record is None) or any(
+            field.prior is None for field in fields.values()
+        )
+        if action == Action.REPAIR:
+            summary = "Apply the Claude Code first-run fix for this user. This one-time repair has no Disconnect action."
+        elif action == Action.DISCONNECT:
+            summary = (
+                "Remove the recognized FCC settings. Previous settings are unknown."
+                if unknown_history
+                else "Restore the settings saved before FCC setup."
+            )
+        else:
+            summary = (
+                "You can Disconnect later to remove FCC settings. Previous settings are unknown."
+                if unknown_history
+                else "You can Disconnect later to restore the settings saved before setup."
+            )
+        if target.id == Item.CODEX:
+            summary = (
+                "This file is shared by Codex App, VS Code, and the CLI. " + summary
+            )
+        preview: JsonObject = {
+            "id": target.id,
+            "action": action,
+            "title": target.title,
+            "path": str(target.path),
+            "summary": summary,
+            "changes": changes,
+            "notes": notes,
+            "instructions": target.instructions,
+            "revision": self._revision(capture, action, connection),
+            "endpoint": connection.url if target.id != Item.CLAUDE_LOGIN else None,
+            "helper_path": str(capture.installed.fcc_command)
+            if target.id == Item.CODEX and capture.installed.fcc_command
+            else None,
+        }
+        return Prepared(capture, output, following, preview)
+
+    def _one(self, item: Item, action: Action, connection: Connection) -> Prepared:
+        installed = self.installations.scan()
+        target = next(
+            target
+            for target in make_targets(self.installations, installed, connection)
+            if target.id == item
+        )
+        return self._prepare(
+            self._capture(target, installed, connection), action, connection
+        )
+
+    def preview(self, item: Item, action: Action, connection: Connection) -> JsonObject:
+        return self._one(item, action, connection).preview
+
+    def inspect(self, connection: Connection) -> JsonObject:
+        installed = self.installations.scan()
+        items: list[JsonObject] = []
+        for target in make_targets(self.installations, installed, connection):
+            entry: JsonObject = {
+                "id": target.id,
+                "title": target.title,
+                "path": str(target.path),
+                "badges": list(target.badges),
+                "missing": list(target.missing),
+                "documentation_url": target.documentation_url,
+                "instructions": target.instructions,
+                "actions": [],
+                "status": "not_configured",
+                "message": "",
+                "manual": False,
+            }
+            try:
+                capture = self._capture(target, installed, connection)
+                if (
+                    target.id == Item.CODEX
+                    and installed.codex_vscode
+                    and _codex_extension_in_wsl(capture)
+                ):
+                    entry["badges"] = [*target.badges, "VS Code uses WSL: manual setup"]
+                values = target.values(target.document(capture.source.data))
+                recognized = target.recognized(values, connection)
+                entry["manual"] = (
+                    recognized
+                    and capture.record is None
+                    and target.id != Item.CLAUDE_LOGIN
+                )
+                actions = []
+                if target.id == Item.CLAUDE_LOGIN:
+                    if recognized:
+                        entry["status"], entry["message"] = (
+                            "configured",
+                            "Onboarding already completed. Remaining login failures require checking the connection.",
+                        )
+                    elif not target.missing:
+                        actions.append(Action.REPAIR.value)
+                elif capture.record is not None or recognized:
+                    entry["status"] = "configured"
+                    actions.append(Action.DISCONNECT.value)
+                    try:
+                        prepared = self._prepare(capture, Action.UPDATE, connection)
+                        if prepared.preview["changes"]:
+                            entry["status"] = "update_available"
+                            actions.insert(0, Action.UPDATE.value)
+                    except IntegrationError as error:
+                        entry["status"], entry["message"] = (
+                            "needs_attention",
+                            str(error),
+                        )
+                elif not target.missing:
+                    self._require_ready(capture, Action.SETUP, connection)
+                    actions.append(Action.SETUP.value)
+                entry["actions"] = actions
+                if capture.pending is not None:
+                    entry["status"] = "needs_attention"
+                    entry["message"] = (
+                        "A previous write was interrupted. Confirm the action to finish its saved record."
+                    )
+                    recovery_action = (
+                        capture.completed_action
+                        if capture.record is None
+                        and capture.completed_action is not None
+                        else Action.UPDATE
+                        if capture.record is not None
+                        else capture.pending.action
+                    )
+                    entry["actions"] = [recovery_action.value]
+            except IntegrationError as error:
+                entry["status"], entry["message"] = "needs_attention", str(error)
+            items.append(entry)
+        return {
+            "items": items,
+            "scope": "Standard local installations for this OS and user account; VS Code default profile.",
+        }
+
+    def apply(
+        self, item: Item, action: Action, revision: str, connection: Connection
+    ) -> JsonObject:
+        lock = InterprocessFileLock(self.state_dir / "write.lock")
+        try:
+            check_path(self.state_dir)
+            self.state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            if not lock.acquire(wait=True, timeout=5):
+                raise IntegrationError(
+                    "Another integration change is in progress. Refresh and try again.",
+                    status_code=409,
+                )
+            prepared = self._one(item, action, connection)
+            current_revision = prepared.preview["revision"]
+            assert isinstance(current_revision, str)
+            if not hmac.compare_digest(revision, current_revision):
+                raise IntegrationError(
+                    "Settings changed since this preview. Refresh and confirm the new changes.",
+                    status_code=409,
+                )
+            capture = prepared.capture
+            if not prepared.preview["changes"]:
+                if capture.pending is not None:
+                    capture.source.require_unchanged()
+                    capture.record_file.require_unchanged()
+                    write_record(capture.record_file.path, capture.record)
+                return {"applied": False, "instructions": capture.target.instructions}
+            for snapshot in (
+                capture.source,
+                capture.record_file,
+                *capture.dependencies,
+            ):
+                snapshot.require_unchanged()
+            pending = PendingWrite(
+                item=item,
+                action=action,
+                path=str(capture.target.path),
+                before=capture.source.digest,
+                after=content_hash(prepared.output),
+                previous=capture.record,
+                following=prepared.following,
+            )
+            write_record(capture.record_file.path, pending)
+            try:
+                capture.source.require_unchanged()
+                atomic_write(
+                    capture.target.path,
+                    prepared.output,
+                    mode=capture.source.identity[3]
+                    if capture.source.identity
+                    else 0o600,
+                    expected=capture.source,
+                )
+            except OSError, IntegrationError:
+                if capture.record_file.data is None:
+                    write_record(capture.record_file.path, None)
+                else:
+                    atomic_write(capture.record_file.path, capture.record_file.data)
+                raise
+            actual = FileSnapshot.read(capture.target.path)
+            if actual.data != prepared.output:
+                raise IntegrationError(
+                    "The file changed during verification. No further changes were made; inspect it before retrying.",
+                    status_code=409,
+                )
+            capture.target.document(actual.data)
+            write_record(capture.record_file.path, prepared.following)
+            return {
+                "applied": True,
+                "instructions": capture.target.instructions,
+                "message": "Onboarding setting saved."
+                if item == Item.CLAUDE_LOGIN
+                else "Configuration saved.",
+            }
+        except OSError:
+            raise IntegrationError(
+                "Could not save configuration. Check file permissions and refresh before retrying."
+            ) from None
+        finally:
+            lock.release()

--- a/src/free_claude_code/runtime/integrations/service.py
+++ b/src/free_claude_code/runtime/integrations/service.py
@@ -6,158 +6,59 @@ import json
 import secrets
 from dataclasses import asdict, dataclass
 
-from pydantic import ValidationError
-
-from free_claude_code.application.integrations import IntegrationAction as Action
-from free_claude_code.application.integrations import IntegrationError, validate_action
+from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.application.integrations import IntegrationId as Item
 from free_claude_code.core.interprocess_lock import InterprocessFileLock
 from free_claude_code.core.json_types import JsonObject
 
-from .discovery import AcpInstallation, InstalledClients, LocalInstallations
+from .discovery import InstalledClients, LocalInstallations
 from .documents import MISSING, JsonDocument
-from .storage import (
-    FieldHistory,
-    FileSnapshot,
-    Ownership,
-    PendingWrite,
-    SavedValue,
-    atomic_write,
-    check_path,
-    content_hash,
-    write_record,
-)
+from .storage import FileSnapshot, atomic_write, check_path
 from .targets import AGENT_PATH, ENV_SETTING, Connection, Target, make_targets, same_url
-
-_RECOVERY_GUIDE = (
-    "https://github.com/Alishahryar1/free-claude-code#integration-recovery"
-)
-
-
-@dataclass(frozen=True)
-class Recovery:
-    action: Action
-    completed: bool
-    ownership: Ownership | None
 
 
 @dataclass
 class Capture:
     target: Target
     source: FileSnapshot
-    record_file: FileSnapshot
-    record: Ownership | None
     dependencies: tuple[FileSnapshot, ...]
     installed: InstalledClients
-    recovery: Recovery | None
 
 
 @dataclass
 class Prepared:
     capture: Capture
     output: bytes | None
-    following: Ownership | None
-    record_changed: bool
     preview: JsonObject
 
 
-def _validate_ownership(target: Target, record: Ownership | None) -> None:
-    if record is None:
-        return
-    if (
-        record.item != target.id
-        or record.path != str(target.path)
-        or not set(record.fields) <= target.recipe.keys()
-        or any(
-            tuple(path) not in target.containers() for path in record.created_containers
-        )
-    ):
-        raise ValueError("target")
-    target.validate_values(
-        {key: field.last.unpack() for key, field in record.fields.items()}
-    )
-    target.validate_values(
-        {
-            key: field.prior.unpack()
-            for key, field in record.fields.items()
-            if field.prior is not None
-        }
-    )
-
-
-def _codex_extension_in_wsl(capture: Capture) -> bool:
-    vscode = capture.dependencies[1]
-    return (
-        vscode.data is not None
-        and JsonDocument(vscode.data, jsonc=True).get(
+def _codex_extension_in_wsl(vscode: FileSnapshot) -> bool:
+    value = (
+        JsonDocument(vscode.data, jsonc=True).get(
             ("chatgpt.runCodexInWindowsSubsystemForLinux",)
         )
-        is True
+        if vscode.data is not None
+        else MISSING
     )
-
-
-def _display(key: str, value: object) -> str:
     if value is MISSING:
-        return "Not set"
-    if any(part in key.lower() for part in ("auth", "token", "env_key")):
-        return "********"
-    if (
-        "base_url" in key.lower()
-        and isinstance(value, str)
-        and ("@" in value or "?" in value)
-    ):
-        return "********"
-    return json.dumps(value, ensure_ascii=False)
+        return False
+    if type(value) is not bool:
+        raise IntegrationError(
+            "The Codex extension's WSL setting must be a boolean. Correct the VS Code settings before continuing."
+        )
+    return value
 
 
 class IntegrationService:
     def __init__(self, installations: LocalInstallations) -> None:
         self.installations = installations
-        self.state_dir = installations.home / ".fcc/integrations"
+        self._lock_path = installations.home / ".fcc/integrations/write.lock"
         self._revision_key = secrets.token_bytes(32)
 
     def _capture(
         self, target: Target, installed: InstalledClients, connection: Connection
     ) -> Capture:
         source = FileSnapshot.read(target.path)
-        record_file = FileSnapshot.read(self.state_dir / f"{target.id}.json")
-        record = None
-        recovery = None
-        if record_file.data is not None:
-            try:
-                payload = json.loads(record_file.data)
-                if isinstance(payload, dict) and payload.get("phase") == "pending":
-                    pending = PendingWrite.model_validate(payload)
-                    validate_action(target.id, pending.action)
-                    if (
-                        pending.item != target.id
-                        or pending.path != str(target.path)
-                        or pending.action == Action.RECOVER
-                        or pending.before == pending.after
-                    ):
-                        raise ValueError("target")
-                    _validate_ownership(target, pending.previous)
-                    _validate_ownership(target, pending.following)
-                    if source.digest not in {pending.before, pending.after}:
-                        raise IntegrationError(
-                            "An interrupted write needs attention because the file has changed. Use manual cleanup; FCC will not overwrite the uncertain file.",
-                            status_code=409,
-                        )
-                    completed = source.digest == pending.after
-                    recovery = Recovery(
-                        pending.action,
-                        completed,
-                        pending.following if completed else pending.previous,
-                    )
-                else:
-                    record = Ownership.model_validate(payload)
-                    _validate_ownership(target, record)
-            except ValueError, ValidationError:
-                raise IntegrationError(
-                    "The saved undo record cannot be read. Previous settings cannot be restored; use manual cleanup."
-                ) from None
-        if recovery is not None:
-            return Capture(target, source, record_file, None, (), installed, recovery)
         dependencies = []
         if target.id in {Item.CLAUDE_VSCODE, Item.CLAUDE_JETBRAINS}:
             dependencies.append(
@@ -165,7 +66,13 @@ class IntegrationService:
             )
         if target.id == Item.CODEX:
             dependencies.append(FileSnapshot.read(connection.catalog_path))
-            dependencies.append(FileSnapshot.read(self.installations.vscode_settings))
+            if not installed.codex_app and installed.codex_vscode:
+                vscode = FileSnapshot.read(self.installations.vscode_settings)
+                if _codex_extension_in_wsl(vscode):
+                    raise IntegrationError(
+                        "This Codex extension runs in WSL and needs manual setup. Its WSL mode will not be changed."
+                    )
+                dependencies.append(vscode)
             if installed.fcc_command is not None:
                 dependencies.append(FileSnapshot.read(installed.fcc_command))
         if target.id == Item.CLAUDE_JETBRAINS:
@@ -175,16 +82,12 @@ class IntegrationService:
             )
             if installed.acp.manifest is not None:
                 dependencies.append(FileSnapshot.read(installed.acp.manifest))
-        return Capture(
-            target, source, record_file, record, tuple(dependencies), installed, None
-        )
+        return Capture(target, source, tuple(dependencies), installed)
 
-    def _revision(
-        self, capture: Capture, action: Action, connection: Connection
-    ) -> str:
+    def _revision(self, capture: Capture, connection: Connection) -> str:
         context = (
             {}
-            if capture.target.id == Item.CLAUDE_LOGIN or action == Action.RECOVER
+            if capture.target.id == Item.CLAUDE_LOGIN
             else {
                 "url": connection.url,
                 "token": connection.settings.proxy_auth_token,
@@ -197,12 +100,11 @@ class IntegrationService:
         )
         payload = {
             "id": capture.target.id,
-            "action": action,
             "context": context,
-            "installed": {} if action == Action.RECOVER else asdict(capture.installed),
+            "installed": asdict(capture.installed),
             "files": [
                 (str(file.path), file.digest, file.identity)
-                for file in (capture.source, capture.record_file, *capture.dependencies)
+                for file in (capture.source, *capture.dependencies)
             ],
         }
         return hmac.new(
@@ -269,13 +171,9 @@ class IntegrationService:
                     )
 
     def _require_ready(
-        self, capture: Capture, action: Action, connection: Connection
+        self, capture: Capture, connection: Connection, *, needs_default: bool
     ) -> None:
         target = capture.target
-        if capture.installed.scope_issue:
-            raise IntegrationError(capture.installed.scope_issue)
-        if action == Action.DISCONNECT:
-            return
         if target.missing:
             raise IntegrationError(" ".join(target.missing))
         if target.id == Item.CODEX:
@@ -300,255 +198,46 @@ class IntegrationService:
             if (
                 not connection.models
                 or not slugs
-                or (action == Action.SETUP and connection.model not in slugs)
+                or (needs_default and connection.model not in slugs)
             ):
                 raise IntegrationError(
                     "FCC's model catalog/default is not ready. Select an available FCC model before setup."
                 )
-            if not capture.installed.codex_app and _codex_extension_in_wsl(capture):
-                raise IntegrationError(
-                    "This Codex extension runs in WSL and needs manual setup. Its WSL mode will not be changed."
-                )
 
-    def _prepare_recovery(self, capture: Capture, connection: Connection) -> Prepared:
-        recovery = capture.recovery
-        if recovery is None:
-            raise IntegrationError(
-                "There is no interrupted action to recover.", status_code=409
-            )
-        summary = (
-            f"The file already matches the saved {recovery.action} result. Finish recovering FCC's setup history."
-            if recovery.completed
-            else "The file matches its earlier state. Recover FCC's setup history so you can retry the action."
-        )
-        preview: JsonObject = {
-            "id": capture.target.id,
-            "action": Action.RECOVER,
-            "title": capture.target.title,
-            "path": str(capture.target.path),
-            "summary": summary,
-            "writes_file": False,
-            "changes": [],
-            "notes": [],
-            "instructions": capture.target.instructions if recovery.completed else "",
-            "revision": self._revision(capture, Action.RECOVER, connection),
-            "endpoint": None,
-            "helper_path": None,
-        }
-        return Prepared(capture, None, recovery.ownership, True, preview)
-
-    def _prepare(
-        self, capture: Capture, action: Action, connection: Connection
-    ) -> Prepared:
+    def _prepare(self, capture: Capture, connection: Connection) -> Prepared:
         target = capture.target
-        validate_action(target.id, action)
-        if action == Action.RECOVER:
-            return self._prepare_recovery(capture, connection)
-        if capture.recovery is not None:
-            raise IntegrationError(
-                "Recover the interrupted action before starting another change.",
-                status_code=409,
-            )
         document = target.document(capture.source.data)
         original = document.render()
         values = target.values(document)
-        recognized = target.recognized(values, connection)
-        self._require_ready(capture, action, connection)
-        record = capture.record
-        if action == Action.SETUP and (record is not None or recognized):
-            raise IntegrationError(
-                "An FCC setup already exists. Use Update or Disconnect; later edits will be preserved.",
-                status_code=409,
-            )
-        if (
-            action in {Action.UPDATE, Action.DISCONNECT}
-            and record is None
-            and not recognized
-        ):
-            raise IntegrationError(
-                "An FCC connection could not be identified. Use Set up or follow the manual cleanup instructions."
-            )
-        if action != Action.DISCONNECT and target.id in {
-            Item.CLAUDE_VSCODE,
-            Item.CLAUDE_JETBRAINS,
-        }:
-            self._claude_conflicts(capture, connection)
-            if (
-                target.id == Item.CLAUDE_JETBRAINS
-                and record is None
-                and not recognized
-                and document.get(AGENT_PATH) is not MISSING
-            ):
-                raise IntegrationError(
-                    "A different agent already uses the name Claude Code (FCC). Rename that entry manually before setup."
-                )
         desired = dict(target.recipe)
+        needs_default = True
         if target.id == Item.CODEX:
-            if action == Action.UPDATE:
-                desired.pop("model", None)
+            model = values["model"]
+            if (
+                values["model_provider"] == "fcc"
+                and isinstance(model, str)
+                and model.strip()
+            ):
+                desired["model"] = model
+                needs_default = False
             key = "model_providers.fcc.requires_openai_auth"
             if values[key] is False:
                 desired[key] = False
-        notes = [
-            "Only the default local user profile is configured. Other profiles and remote environments use manual setup."
-        ]
-        fields = (
-            {}
-            if record is None
-            else {
-                key: value.model_copy(deep=True) for key, value in record.fields.items()
-            }
-        )
-        containers = (
-            [
-                list(path)
-                for path in target.containers()
-                if document.get(path) is MISSING
-            ]
-            if record is None
-            else record.created_containers
-        )
-        if action == Action.DISCONNECT:
-            if record is None:
-                notes.append(
-                    "Previous settings are unknown. Remove only identifiable FCC values; the client may need its normal setup again."
-                )
-                desired = {
-                    key: MISSING
-                    for key, value in values.items()
-                    if target.manual_owned(key, value, connection)
-                }
-            else:
-                notes.append(
-                    "Restore saved previous settings and remove values introduced by FCC. Later user edits stop the whole action."
-                )
-                desired = {
-                    key: field.prior.unpack() if field.prior is not None else MISSING
-                    for key, field in fields.items()
-                }
-            if (
-                record is not None
-                and target.id == Item.CLAUDE_JETBRAINS
-                and list(AGENT_PATH) in record.created_containers
-            ):
-                agent = document.get(AGENT_PATH)
-                expected: dict[str, object] = {}
-                env: dict[str, object] = {}
-                if isinstance(agent, dict) and "env" in agent:
-                    expected["env"] = env
-                for key in fields:
-                    value = values[key]
-                    if value is not MISSING:
-                        if key.startswith("env."):
-                            env[key[4:]] = value
-                            expected["env"] = env
-                        else:
-                            expected[key] = value
-                if agent is not MISSING and agent != expected:
-                    raise IntegrationError(
-                        "The Claude Code (FCC) agent was edited or has added fields. Preserve those changes and remove it manually.",
-                        status_code=409,
-                    )
-        elif recognized and record is None and action == Action.UPDATE:
-            notes.append(
-                "Adopt this manual FCC connection for future updates. Previous non-FCC settings are unknown for its existing FCC values."
-            )
-            for key, value in values.items():
-                if target.manual_owned(key, value, connection):
-                    fields[key] = FieldHistory(
-                        prior=None, last=SavedValue.capture(value)
-                    )
-        elif action == Action.REPAIR:
-            notes.append(
-                "Change only shared Claude first-run state. This does not authenticate an account, and Disconnect will not reset it."
-            )
-        else:
-            notes.append(
-                "Save previous values so Disconnect can restore them when they have not been edited afterward."
-            )
-        changes: list[JsonObject] = []
+        self._require_ready(capture, connection, needs_default=needs_default)
+        if target.id in {Item.CLAUDE_VSCODE, Item.CLAUDE_JETBRAINS}:
+            self._claude_conflicts(capture, connection)
         for key, value in desired.items():
-            current = values[key]
-            if current == value and type(current) is type(value):
-                continue
-            if (
-                record is not None
-                and key in fields
-                and SavedValue.capture(current) != fields[key].last
-            ):
-                raise IntegrationError(
-                    f"The setting {key} was edited after FCC setup. No settings will change; correct or remove it manually.",
-                    status_code=409,
-                )
-            changes.append(
-                {
-                    "setting": key,
-                    "before": _display(key, current),
-                    "after": _display(key, value),
-                }
-            )
-            if action not in {Action.DISCONNECT, Action.REPAIR}:
-                if key not in fields:
-                    prior = (
-                        None
-                        if recognized and target.manual_owned(key, current, connection)
-                        else SavedValue.capture(current)
-                    )
-                    fields[key] = FieldHistory(
-                        prior=prior, last=SavedValue.capture(value)
-                    )
-                else:
-                    fields[key].last = SavedValue.capture(value)
             target.write(document, key, value)
-        if action == Action.DISCONNECT:
-            if record is None and target.id == Item.CLAUDE_JETBRAINS:
-                if document.get(AGENT_PATH) in ({}, {"env": {}}):
-                    document.delete(AGENT_PATH)
-                    notes.append("Remove the empty Claude Code (FCC) agent entry.")
-                else:
-                    notes.append(
-                        "Keep remaining custom agent fields; finish any further cleanup manually."
-                    )
-            for path in reversed(containers):
-                remaining = document.get(tuple(path))
-                if remaining == {} or remaining == []:
-                    document.delete(tuple(path))
+        target.validate_values(target.values(document))
         rendered = document.render()
         output = rendered if rendered != original else None
         if output is not None:
             capture.source.require_writable()
-        following = (
-            None
-            if action in {Action.DISCONNECT, Action.REPAIR}
-            else Ownership(
-                item=target.id,
-                path=str(target.path),
-                fields=fields,
-                created_containers=containers,
-            )
+        summary = (
+            "Apply the Claude Code first-run fix for this user."
+            if target.id == Item.CLAUDE_LOGIN
+            else "Apply replaces FCC connection settings, including manual changes to those fields. Manual disconnect instructions are on the card."
         )
-        record_changed = following != record
-        if target.id == Item.CODEX:
-            notes.append(
-                "The App, VS Code extension, and normal Codex CLI share this file and provider selection."
-            )
-        unknown_history = (recognized and record is None) or any(
-            field.prior is None for field in fields.values()
-        )
-        if action == Action.REPAIR:
-            summary = "Apply the Claude Code first-run fix for this user. This one-time repair has no Disconnect action."
-        elif action == Action.DISCONNECT:
-            summary = (
-                "Remove the recognized FCC settings. Previous settings are unknown."
-                if unknown_history
-                else "Restore the settings saved before FCC setup."
-            )
-        else:
-            summary = (
-                "You can Disconnect later to remove FCC settings. Previous settings are unknown."
-                if unknown_history
-                else "You can Disconnect later to restore the settings saved before setup."
-            )
         if output is not None:
             clients = {
                 Item.CLAUDE_VSCODE: "VS Code",
@@ -566,48 +255,26 @@ class IntegrationService:
             )
         preview: JsonObject = {
             "id": target.id,
-            "action": action,
             "title": target.title,
             "path": str(target.path),
             "summary": summary,
             "writes_file": output is not None,
-            "changes": changes,
-            "notes": notes,
             "instructions": target.instructions,
-            "revision": self._revision(capture, action, connection),
-            "endpoint": connection.url if target.id != Item.CLAUDE_LOGIN else None,
-            "helper_path": str(capture.installed.fcc_command)
-            if target.id == Item.CODEX and capture.installed.fcc_command
-            else None,
+            "revision": self._revision(capture, connection),
         }
-        return Prepared(capture, output, following, record_changed, preview)
+        return Prepared(capture, output, preview)
 
-    def _one(self, item: Item, action: Action, connection: Connection) -> Prepared:
-        installed = (
-            InstalledClients(
-                claude_vscode=False,
-                codex_vscode=False,
-                codex_app=False,
-                jetbrains=False,
-                claude_command=None,
-                fcc_command=None,
-                acp=AcpInstallation(),
-                scope_issue="",
-            )
-            if action == Action.RECOVER
-            else self.installations.scan()
-        )
+    def _one(self, item: Item, connection: Connection) -> Prepared:
+        installed = self.installations.scan()
         target = next(
             target
             for target in make_targets(self.installations, installed, connection)
             if target.id == item
         )
-        return self._prepare(
-            self._capture(target, installed, connection), action, connection
-        )
+        return self._prepare(self._capture(target, installed, connection), connection)
 
-    def preview(self, item: Item, action: Action, connection: Connection) -> JsonObject:
-        return self._one(item, action, connection).preview
+    def preview(self, item: Item, connection: Connection) -> JsonObject:
+        return self._one(item, connection).preview
 
     def inspect(self, connection: Connection) -> JsonObject:
         installed = self.installations.scan()
@@ -621,88 +288,52 @@ class IntegrationService:
                 "missing": list(target.missing),
                 "documentation_url": target.documentation_url,
                 "instructions": target.instructions,
-                "actions": [],
+                "can_apply": False,
                 "status": "not_configured",
                 "message": "",
-                "manual": False,
             }
             try:
-                capture = self._capture(target, installed, connection)
-                if capture.recovery is not None:
-                    entry["status"] = "needs_attention"
-                    entry["message"] = (
-                        "A previous change was interrupted. Recover its saved setup history before continuing."
-                    )
-                    entry["missing"] = []
-                    entry["documentation_url"] = _RECOVERY_GUIDE
-                    entry["actions"] = [Action.RECOVER.value]
-                    items.append(entry)
-                    continue
-                if (
-                    target.id == Item.CODEX
-                    and installed.codex_vscode
-                    and _codex_extension_in_wsl(capture)
-                ):
-                    entry["badges"] = [*target.badges, "VS Code uses WSL: manual setup"]
-                values = target.values(target.document(capture.source.data))
-                recognized = target.recognized(values, connection)
-                entry["manual"] = (
-                    recognized
-                    and capture.record is None
-                    and target.id != Item.CLAUDE_LOGIN
+                prepared = self._prepare(
+                    self._capture(target, installed, connection), connection
                 )
-                actions = []
-                if target.id == Item.CLAUDE_LOGIN:
-                    if recognized:
-                        entry["status"], entry["message"] = (
-                            "configured",
-                            "Onboarding already completed. Remaining login failures require checking the connection.",
-                        )
-                    elif not target.missing:
-                        actions.append(Action.REPAIR.value)
-                elif capture.record is not None or recognized:
+                entry["can_apply"] = True
+                if prepared.output is None:
                     entry["status"] = "configured"
-                    actions.append(Action.DISCONNECT.value)
-                    try:
-                        prepared = self._prepare(capture, Action.UPDATE, connection)
-                        if prepared.output is not None or prepared.record_changed:
-                            entry["status"] = "update_available"
-                            actions.insert(0, Action.UPDATE.value)
-                    except IntegrationError as error:
-                        entry["status"], entry["message"] = (
-                            "needs_attention",
-                            str(error),
+                    if target.id == Item.CLAUDE_LOGIN:
+                        entry["message"] = (
+                            "Onboarding already completed. Remaining login failures require checking the connection."
                         )
-                elif not target.missing:
-                    self._require_ready(capture, Action.SETUP, connection)
-                    actions.append(Action.SETUP.value)
-                entry["actions"] = actions
             except IntegrationError as error:
                 entry["status"], entry["message"] = "needs_attention", str(error)
-            if (
-                entry["status"] == "needs_attention"
-                and (self.state_dir / f"{target.id}.json").is_file()
-            ):
-                entry["documentation_url"] = _RECOVERY_GUIDE
+            if target.id == Item.CODEX and installed.codex_vscode:
+                vscode_path = self.installations.vscode_settings
+                try:
+                    if _codex_extension_in_wsl(FileSnapshot.read(vscode_path)):
+                        entry["badges"] = [
+                            *target.badges,
+                            "VS Code uses WSL: manual setup",
+                        ]
+                except IntegrationError as error:
+                    entry["message"] = (
+                        f"VS Code extension information unavailable ({vscode_path}): {error}"
+                    )
             items.append(entry)
         return {
             "items": items,
             "scope": "Standard local installations for this OS and user account; VS Code default profile.",
         }
 
-    def apply(
-        self, item: Item, action: Action, revision: str, connection: Connection
-    ) -> JsonObject:
-        lock = InterprocessFileLock(self.state_dir / "write.lock")
+    def apply(self, item: Item, revision: str, connection: Connection) -> JsonObject:
+        lock = InterprocessFileLock(self._lock_path)
         try:
-            check_path(self.state_dir)
-            self.state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            check_path(self._lock_path.parent)
+            self._lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
             if not lock.acquire(wait=True, timeout=5):
                 raise IntegrationError(
                     "Another integration change is in progress. Refresh and try again.",
                     status_code=409,
                 )
-            prepared = self._one(item, action, connection)
+            prepared = self._one(item, connection)
             current_revision = prepared.preview["revision"]
             assert isinstance(current_revision, str)
             if not hmac.compare_digest(revision, current_revision):
@@ -711,38 +342,15 @@ class IntegrationService:
                     status_code=409,
                 )
             capture = prepared.capture
-            for snapshot in (
-                capture.source,
-                capture.record_file,
-                *capture.dependencies,
-            ):
+            for snapshot in (capture.source, *capture.dependencies):
                 snapshot.require_unchanged()
             output = prepared.output
             if output is None:
-                if prepared.record_changed:
-                    write_record(capture.record_file.path, prepared.following)
                 return {
-                    "applied": prepared.record_changed,
+                    "applied": False,
                     "instructions": prepared.preview["instructions"],
-                    "message": "Recovery finished."
-                    if action == Action.RECOVER
-                    else "Disconnected. The client settings were already restored."
-                    if action == Action.DISCONNECT and prepared.record_changed
-                    else "FCC setup history saved."
-                    if prepared.record_changed
-                    else "No client settings changed.",
+                    "message": "No client settings changed.",
                 }
-            pending = PendingWrite(
-                item=item,
-                action=action,
-                path=str(capture.target.path),
-                before=capture.source.digest,
-                after=content_hash(output),
-                previous=capture.record,
-                following=prepared.following,
-            )
-            write_record(capture.record_file.path, pending)
-            capture.source.require_unchanged()
             atomic_write(
                 capture.target.path,
                 output,
@@ -756,7 +364,6 @@ class IntegrationService:
                     status_code=409,
                 )
             capture.target.document(actual.data)
-            write_record(capture.record_file.path, prepared.following)
             return {
                 "applied": True,
                 "instructions": capture.target.instructions,

--- a/src/free_claude_code/runtime/integrations/service.py
+++ b/src/free_claude_code/runtime/integrations/service.py
@@ -14,7 +14,7 @@ from free_claude_code.application.integrations import IntegrationId as Item
 from free_claude_code.core.interprocess_lock import InterprocessFileLock
 from free_claude_code.core.json_types import JsonObject
 
-from .discovery import InstalledClients, LocalInstallations
+from .discovery import AcpInstallation, InstalledClients, LocalInstallations
 from .documents import MISSING, JsonDocument
 from .storage import (
     FieldHistory,
@@ -29,6 +29,17 @@ from .storage import (
 )
 from .targets import AGENT_PATH, ENV_SETTING, Connection, Target, make_targets, same_url
 
+_RECOVERY_GUIDE = (
+    "https://github.com/Alishahryar1/free-claude-code#integration-recovery"
+)
+
+
+@dataclass(frozen=True)
+class Recovery:
+    action: Action
+    completed: bool
+    ownership: Ownership | None
+
 
 @dataclass
 class Capture:
@@ -38,21 +49,40 @@ class Capture:
     record: Ownership | None
     dependencies: tuple[FileSnapshot, ...]
     installed: InstalledClients
-    pending: PendingWrite | None
-
-    @property
-    def completed_action(self) -> Action | None:
-        if self.pending is not None and self.source.digest == self.pending.after:
-            return self.pending.action
-        return None
+    recovery: Recovery | None
 
 
 @dataclass
 class Prepared:
     capture: Capture
-    output: bytes
+    output: bytes | None
     following: Ownership | None
+    record_changed: bool
     preview: JsonObject
+
+
+def _validate_ownership(target: Target, record: Ownership | None) -> None:
+    if record is None:
+        return
+    if (
+        record.item != target.id
+        or record.path != str(target.path)
+        or not set(record.fields) <= target.recipe.keys()
+        or any(
+            tuple(path) not in target.containers() for path in record.created_containers
+        )
+    ):
+        raise ValueError("target")
+    target.validate_values(
+        {key: field.last.unpack() for key, field in record.fields.items()}
+    )
+    target.validate_values(
+        {
+            key: field.prior.unpack()
+            for key, field in record.fields.items()
+            if field.prior is not None
+        }
+    )
 
 
 def _codex_extension_in_wsl(capture: Capture) -> bool:
@@ -92,40 +122,42 @@ class IntegrationService:
         source = FileSnapshot.read(target.path)
         record_file = FileSnapshot.read(self.state_dir / f"{target.id}.json")
         record = None
-        pending = None
+        recovery = None
         if record_file.data is not None:
             try:
                 payload = json.loads(record_file.data)
                 if isinstance(payload, dict) and payload.get("phase") == "pending":
                     pending = PendingWrite.model_validate(payload)
                     validate_action(target.id, pending.action)
-                    if pending.item != target.id or pending.path != str(target.path):
+                    if (
+                        pending.item != target.id
+                        or pending.path != str(target.path)
+                        or pending.action == Action.RECOVER
+                        or pending.before == pending.after
+                    ):
                         raise ValueError("target")
-                    if source.digest == pending.before:
-                        record = pending.previous
-                    elif source.digest == pending.after:
-                        record = pending.following
-                    else:
+                    _validate_ownership(target, pending.previous)
+                    _validate_ownership(target, pending.following)
+                    if source.digest not in {pending.before, pending.after}:
                         raise IntegrationError(
                             "An interrupted write needs attention because the file has changed. Use manual cleanup; FCC will not overwrite the uncertain file.",
                             status_code=409,
                         )
+                    completed = source.digest == pending.after
+                    recovery = Recovery(
+                        pending.action,
+                        completed,
+                        pending.following if completed else pending.previous,
+                    )
                 else:
                     record = Ownership.model_validate(payload)
-                if record is not None and (
-                    record.item != target.id
-                    or record.path != str(target.path)
-                    or not set(record.fields) <= target.recipe.keys()
-                    or any(
-                        tuple(path) not in target.containers()
-                        for path in record.created_containers
-                    )
-                ):
-                    raise ValueError("target")
+                    _validate_ownership(target, record)
             except ValueError, ValidationError:
                 raise IntegrationError(
                     "The saved undo record cannot be read. Previous settings cannot be restored; use manual cleanup."
                 ) from None
+        if recovery is not None:
+            return Capture(target, source, record_file, None, (), installed, recovery)
         dependencies = []
         if target.id in {Item.CLAUDE_VSCODE, Item.CLAUDE_JETBRAINS}:
             dependencies.append(
@@ -139,10 +171,12 @@ class IntegrationService:
         if target.id == Item.CLAUDE_JETBRAINS:
             dependencies.extend(
                 FileSnapshot.read(self.installations.home / path)
-                for path in installed.acp_command
+                for path in installed.acp.command
             )
+            if installed.acp.manifest is not None:
+                dependencies.append(FileSnapshot.read(installed.acp.manifest))
         return Capture(
-            target, source, record_file, record, tuple(dependencies), installed, pending
+            target, source, record_file, record, tuple(dependencies), installed, None
         )
 
     def _revision(
@@ -150,7 +184,7 @@ class IntegrationService:
     ) -> str:
         context = (
             {}
-            if capture.target.id == Item.CLAUDE_LOGIN
+            if capture.target.id == Item.CLAUDE_LOGIN or action == Action.RECOVER
             else {
                 "url": connection.url,
                 "token": connection.settings.proxy_auth_token,
@@ -165,7 +199,7 @@ class IntegrationService:
             "id": capture.target.id,
             "action": action,
             "context": context,
-            "installed": asdict(capture.installed),
+            "installed": {} if action == Action.RECOVER else asdict(capture.installed),
             "files": [
                 (str(file.path), file.digest, file.identity)
                 for file in (capture.source, capture.record_file, *capture.dependencies)
@@ -240,7 +274,7 @@ class IntegrationService:
         target = capture.target
         if capture.installed.scope_issue:
             raise IntegrationError(capture.installed.scope_issue)
-        if action == Action.DISCONNECT or action == capture.completed_action:
+        if action == Action.DISCONNECT:
             return
         if target.missing:
             raise IntegrationError(" ".join(target.missing))
@@ -276,26 +310,60 @@ class IntegrationService:
                     "This Codex extension runs in WSL and needs manual setup. Its WSL mode will not be changed."
                 )
 
+    def _prepare_recovery(self, capture: Capture, connection: Connection) -> Prepared:
+        recovery = capture.recovery
+        if recovery is None:
+            raise IntegrationError(
+                "There is no interrupted action to recover.", status_code=409
+            )
+        summary = (
+            f"The file already matches the saved {recovery.action} result. Finish recovering FCC's setup history."
+            if recovery.completed
+            else "The file matches its earlier state. Recover FCC's setup history so you can retry the action."
+        )
+        preview: JsonObject = {
+            "id": capture.target.id,
+            "action": Action.RECOVER,
+            "title": capture.target.title,
+            "path": str(capture.target.path),
+            "summary": summary,
+            "writes_file": False,
+            "changes": [],
+            "notes": [],
+            "instructions": capture.target.instructions if recovery.completed else "",
+            "revision": self._revision(capture, Action.RECOVER, connection),
+            "endpoint": None,
+            "helper_path": None,
+        }
+        return Prepared(capture, None, recovery.ownership, True, preview)
+
     def _prepare(
         self, capture: Capture, action: Action, connection: Connection
     ) -> Prepared:
         target = capture.target
         validate_action(target.id, action)
+        if action == Action.RECOVER:
+            return self._prepare_recovery(capture, connection)
+        if capture.recovery is not None:
+            raise IntegrationError(
+                "Recover the interrupted action before starting another change.",
+                status_code=409,
+            )
         document = target.document(capture.source.data)
+        original = document.render()
         values = target.values(document)
         recognized = target.recognized(values, connection)
         self._require_ready(capture, action, connection)
         record = capture.record
-        if action == Action.SETUP and record is not None:
+        if action == Action.SETUP and (record is not None or recognized):
             raise IntegrationError(
-                "This setup is already managed. Use Update or Disconnect; later edits will be preserved.",
+                "An FCC setup already exists. Use Update or Disconnect; later edits will be preserved.",
                 status_code=409,
             )
         if (
             action in {Action.UPDATE, Action.DISCONNECT}
             and record is None
             and not recognized
-            and capture.completed_action != action
         ):
             raise IntegrationError(
                 "An FCC connection could not be identified. Use Set up or follow the manual cleanup instructions."
@@ -363,16 +431,20 @@ class IntegrationService:
                 and target.id == Item.CLAUDE_JETBRAINS
                 and list(AGENT_PATH) in record.created_containers
             ):
-                expected: dict[str, object] = {"env": {}}
-                env = expected["env"]
-                assert isinstance(env, dict)
-                for key, field in fields.items():
-                    if field.last.present:
+                agent = document.get(AGENT_PATH)
+                expected: dict[str, object] = {}
+                env: dict[str, object] = {}
+                if isinstance(agent, dict) and "env" in agent:
+                    expected["env"] = env
+                for key in fields:
+                    value = values[key]
+                    if value is not MISSING:
                         if key.startswith("env."):
-                            env[key[4:]] = field.last.value
+                            env[key[4:]] = value
+                            expected["env"] = env
                         else:
-                            expected[key] = field.last.value
-                if document.get(AGENT_PATH) != expected:
+                            expected[key] = value
+                if agent is not MISSING and agent != expected:
                     raise IntegrationError(
                         "The Claude Code (FCC) agent was edited or has added fields. Preserve those changes and remove it manually.",
                         status_code=409,
@@ -441,8 +513,9 @@ class IntegrationService:
                 remaining = document.get(tuple(path))
                 if remaining == {} or remaining == []:
                     document.delete(tuple(path))
-        output = document.render()
-        if changes:
+        rendered = document.render()
+        output = rendered if rendered != original else None
+        if output is not None:
             capture.source.require_writable()
         following = (
             None
@@ -454,9 +527,7 @@ class IntegrationService:
                 created_containers=containers,
             )
         )
-        if not changes:
-            following = record
-            output = capture.source.data if capture.source.data is not None else output
+        record_changed = following != record
         if target.id == Item.CODEX:
             notes.append(
                 "The App, VS Code extension, and normal Codex CLI share this file and provider selection."
@@ -478,6 +549,17 @@ class IntegrationService:
                 if unknown_history
                 else "You can Disconnect later to restore the settings saved before setup."
             )
+        if output is not None:
+            clients = {
+                Item.CLAUDE_VSCODE: "VS Code",
+                Item.CODEX: "these clients",
+                Item.CLAUDE_JETBRAINS: "your JetBrains IDEs",
+                Item.CLAUDE_LOGIN: "Claude Code and IDE sessions using it",
+            }[target.id]
+            summary = (
+                f"Save and close {clients} before confirming; avoid other edits until FCC finishes. "
+                + summary
+            )
         if target.id == Item.CODEX:
             summary = (
                 "This file is shared by Codex App, VS Code, and the CLI. " + summary
@@ -488,6 +570,7 @@ class IntegrationService:
             "title": target.title,
             "path": str(target.path),
             "summary": summary,
+            "writes_file": output is not None,
             "changes": changes,
             "notes": notes,
             "instructions": target.instructions,
@@ -497,10 +580,23 @@ class IntegrationService:
             if target.id == Item.CODEX and capture.installed.fcc_command
             else None,
         }
-        return Prepared(capture, output, following, preview)
+        return Prepared(capture, output, following, record_changed, preview)
 
     def _one(self, item: Item, action: Action, connection: Connection) -> Prepared:
-        installed = self.installations.scan()
+        installed = (
+            InstalledClients(
+                claude_vscode=False,
+                codex_vscode=False,
+                codex_app=False,
+                jetbrains=False,
+                claude_command=None,
+                fcc_command=None,
+                acp=AcpInstallation(),
+                scope_issue="",
+            )
+            if action == Action.RECOVER
+            else self.installations.scan()
+        )
         target = next(
             target
             for target in make_targets(self.installations, installed, connection)
@@ -532,6 +628,16 @@ class IntegrationService:
             }
             try:
                 capture = self._capture(target, installed, connection)
+                if capture.recovery is not None:
+                    entry["status"] = "needs_attention"
+                    entry["message"] = (
+                        "A previous change was interrupted. Recover its saved setup history before continuing."
+                    )
+                    entry["missing"] = []
+                    entry["documentation_url"] = _RECOVERY_GUIDE
+                    entry["actions"] = [Action.RECOVER.value]
+                    items.append(entry)
+                    continue
                 if (
                     target.id == Item.CODEX
                     and installed.codex_vscode
@@ -559,7 +665,7 @@ class IntegrationService:
                     actions.append(Action.DISCONNECT.value)
                     try:
                         prepared = self._prepare(capture, Action.UPDATE, connection)
-                        if prepared.preview["changes"]:
+                        if prepared.output is not None or prepared.record_changed:
                             entry["status"] = "update_available"
                             actions.insert(0, Action.UPDATE.value)
                     except IntegrationError as error:
@@ -571,22 +677,13 @@ class IntegrationService:
                     self._require_ready(capture, Action.SETUP, connection)
                     actions.append(Action.SETUP.value)
                 entry["actions"] = actions
-                if capture.pending is not None:
-                    entry["status"] = "needs_attention"
-                    entry["message"] = (
-                        "A previous write was interrupted. Confirm the action to finish its saved record."
-                    )
-                    recovery_action = (
-                        capture.completed_action
-                        if capture.record is None
-                        and capture.completed_action is not None
-                        else Action.UPDATE
-                        if capture.record is not None
-                        else capture.pending.action
-                    )
-                    entry["actions"] = [recovery_action.value]
             except IntegrationError as error:
                 entry["status"], entry["message"] = "needs_attention", str(error)
+            if (
+                entry["status"] == "needs_attention"
+                and (self.state_dir / f"{target.id}.json").is_file()
+            ):
+                entry["documentation_url"] = _RECOVERY_GUIDE
             items.append(entry)
         return {
             "items": items,
@@ -614,46 +711,46 @@ class IntegrationService:
                     status_code=409,
                 )
             capture = prepared.capture
-            if not prepared.preview["changes"]:
-                if capture.pending is not None:
-                    capture.source.require_unchanged()
-                    capture.record_file.require_unchanged()
-                    write_record(capture.record_file.path, capture.record)
-                return {"applied": False, "instructions": capture.target.instructions}
             for snapshot in (
                 capture.source,
                 capture.record_file,
                 *capture.dependencies,
             ):
                 snapshot.require_unchanged()
+            output = prepared.output
+            if output is None:
+                if prepared.record_changed:
+                    write_record(capture.record_file.path, prepared.following)
+                return {
+                    "applied": prepared.record_changed,
+                    "instructions": prepared.preview["instructions"],
+                    "message": "Recovery finished."
+                    if action == Action.RECOVER
+                    else "Disconnected. The client settings were already restored."
+                    if action == Action.DISCONNECT and prepared.record_changed
+                    else "FCC setup history saved."
+                    if prepared.record_changed
+                    else "No client settings changed.",
+                }
             pending = PendingWrite(
                 item=item,
                 action=action,
                 path=str(capture.target.path),
                 before=capture.source.digest,
-                after=content_hash(prepared.output),
+                after=content_hash(output),
                 previous=capture.record,
                 following=prepared.following,
             )
             write_record(capture.record_file.path, pending)
-            try:
-                capture.source.require_unchanged()
-                atomic_write(
-                    capture.target.path,
-                    prepared.output,
-                    mode=capture.source.identity[3]
-                    if capture.source.identity
-                    else 0o600,
-                    expected=capture.source,
-                )
-            except OSError, IntegrationError:
-                if capture.record_file.data is None:
-                    write_record(capture.record_file.path, None)
-                else:
-                    atomic_write(capture.record_file.path, capture.record_file.data)
-                raise
+            capture.source.require_unchanged()
+            atomic_write(
+                capture.target.path,
+                output,
+                mode=capture.source.identity[3] if capture.source.identity else 0o600,
+                expected=capture.source,
+            )
             actual = FileSnapshot.read(capture.target.path)
-            if actual.data != prepared.output:
+            if actual.data != output:
                 raise IntegrationError(
                     "The file changed during verification. No further changes were made; inspect it before retrying.",
                     status_code=409,

--- a/src/free_claude_code/runtime/integrations/storage.py
+++ b/src/free_claude_code/runtime/integrations/storage.py
@@ -1,4 +1,4 @@
-"""Atomic client writes and minimal, private undo records."""
+"""Snapshots and atomic client configuration writes."""
 
 import hashlib
 import os
@@ -6,17 +6,8 @@ import stat
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, JsonValue
-
-from free_claude_code.application.integrations import (
-    IntegrationAction,
-    IntegrationError,
-    IntegrationId,
-)
-
-from .documents import MISSING
+from free_claude_code.application.integrations import IntegrationError
 
 
 def content_hash(data: bytes | None) -> str:
@@ -26,6 +17,10 @@ def content_hash(data: bytes | None) -> str:
 
 
 def check_path(path: Path) -> None:
+    if not path.is_absolute():
+        raise IntegrationError(
+            "Configuration paths must be absolute. Use manual setup."
+        )
     for part in (path, *path.parents):
         if part.is_symlink() or part.is_junction():
             raise IntegrationError(
@@ -85,52 +80,6 @@ class FileSnapshot:
             )
 
 
-class SavedValue(BaseModel):
-    model_config = ConfigDict(extra="forbid", strict=True)
-    present: bool
-    value: JsonValue = None
-
-    @classmethod
-    def capture(cls, value: object) -> SavedValue:
-        return cls.model_validate(
-            {
-                "present": value is not MISSING,
-                "value": None if value is MISSING else value,
-            }
-        )
-
-    def unpack(self) -> object:
-        return self.value if self.present else MISSING
-
-
-class FieldHistory(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    prior: SavedValue | None
-    last: SavedValue
-
-
-class Ownership(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    version: Literal[1] = 1
-    item: IntegrationId
-    path: str
-    fields: dict[str, FieldHistory]
-    created_containers: list[list[str]] = []
-
-
-class PendingWrite(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    version: Literal[1] = 1
-    phase: Literal["pending"] = "pending"
-    item: IntegrationId
-    action: IntegrationAction
-    path: str
-    before: str
-    after: str
-    previous: Ownership | None
-    following: Ownership | None
-
-
 def atomic_write(
     path: Path, data: bytes, *, mode: int = 0o600, expected: FileSnapshot | None = None
 ) -> None:
@@ -152,10 +101,3 @@ def atomic_write(
     finally:
         if temporary is not None:
             temporary.unlink(missing_ok=True)
-
-
-def write_record(path: Path, record: Ownership | PendingWrite | None) -> None:
-    if record is None:
-        path.unlink(missing_ok=True)
-    else:
-        atomic_write(path, record.model_dump_json().encode())

--- a/src/free_claude_code/runtime/integrations/storage.py
+++ b/src/free_claude_code/runtime/integrations/storage.py
@@ -1,0 +1,161 @@
+"""Atomic client writes and minimal, private undo records."""
+
+import hashlib
+import os
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, JsonValue
+
+from free_claude_code.application.integrations import (
+    IntegrationAction,
+    IntegrationError,
+    IntegrationId,
+)
+
+from .documents import MISSING
+
+
+def content_hash(data: bytes | None) -> str:
+    return hashlib.sha256(
+        b"missing" if data is None else b"present\0" + data
+    ).hexdigest()
+
+
+def check_path(path: Path) -> None:
+    for part in (path, *path.parents):
+        if part.is_symlink() or part.is_junction():
+            raise IntegrationError(
+                "This configuration uses a symlink or junction. Use manual setup for this location."
+            )
+
+
+@dataclass(frozen=True)
+class FileSnapshot:
+    path: Path
+    data: bytes | None
+    identity: tuple[int, int, int, int] | None
+
+    @classmethod
+    def read(cls, path: Path) -> FileSnapshot:
+        check_path(path)
+        try:
+            before = path.stat()
+            if not stat.S_ISREG(before.st_mode):
+                raise IntegrationError("A configuration path is not a regular file.")
+            data = path.read_bytes()
+            after = path.stat()
+            identity = (after.st_ino, after.st_mtime_ns, after.st_size, after.st_mode)
+            if identity != (
+                before.st_ino,
+                before.st_mtime_ns,
+                before.st_size,
+                before.st_mode,
+            ):
+                raise IntegrationError(
+                    "A configuration file changed while being read. Refresh and try again.",
+                    status_code=409,
+                )
+            return cls(path, data, identity)
+        except FileNotFoundError:
+            return cls(path, None, None)
+        except OSError:
+            raise IntegrationError(
+                "Could not read a configuration file. Check the displayed path and its permissions."
+            ) from None
+
+    @property
+    def digest(self) -> str:
+        return content_hash(self.data)
+
+    def require_unchanged(self) -> None:
+        if FileSnapshot.read(self.path) != self:
+            raise IntegrationError(
+                "Settings changed since this preview. Refresh and confirm the new changes.",
+                status_code=409,
+            )
+
+    def require_writable(self) -> None:
+        if self.identity is not None and not self.identity[3] & 0o222:
+            raise IntegrationError(
+                "The configuration file is read-only. Change its permissions before continuing."
+            )
+
+
+class SavedValue(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+    present: bool
+    value: JsonValue = None
+
+    @classmethod
+    def capture(cls, value: object) -> SavedValue:
+        return cls.model_validate(
+            {
+                "present": value is not MISSING,
+                "value": None if value is MISSING else value,
+            }
+        )
+
+    def unpack(self) -> object:
+        return self.value if self.present else MISSING
+
+
+class FieldHistory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    prior: SavedValue | None
+    last: SavedValue
+
+
+class Ownership(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    version: Literal[1] = 1
+    item: IntegrationId
+    path: str
+    fields: dict[str, FieldHistory]
+    created_containers: list[list[str]] = []
+
+
+class PendingWrite(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    version: Literal[1] = 1
+    phase: Literal["pending"] = "pending"
+    item: IntegrationId
+    action: IntegrationAction
+    path: str
+    before: str
+    after: str
+    previous: Ownership | None
+    following: Ownership | None
+
+
+def atomic_write(
+    path: Path, data: bytes, *, mode: int = 0o600, expected: FileSnapshot | None = None
+) -> None:
+    check_path(path)
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent, prefix=".fcc-", suffix=".tmp", delete=False
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.chmod(stat.S_IMODE(mode))
+        if expected is not None:
+            expected.require_unchanged()
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def write_record(path: Path, record: Ownership | PendingWrite | None) -> None:
+    if record is None:
+        path.unlink(missing_ok=True)
+    else:
+        atomic_write(path, record.model_dump_json().encode())

--- a/src/free_claude_code/runtime/integrations/targets.py
+++ b/src/free_claude_code/runtime/integrations/targets.py
@@ -77,19 +77,6 @@ class Target:
             jsonc=self.id == IntegrationId.CLAUDE_VSCODE,
         )
 
-    def containers(self) -> tuple[tuple[str, ...], ...]:
-        if self.id == IntegrationId.CODEX:
-            return (
-                ("model_providers",),
-                ("model_providers", "fcc"),
-                ("model_providers", "fcc", "auth"),
-            )
-        if self.id == IntegrationId.CLAUDE_VSCODE:
-            return ((ENV_SETTING,),)
-        if self.id == IntegrationId.CLAUDE_JETBRAINS:
-            return (("agent_servers",), AGENT_PATH, (*AGENT_PATH, "env"))
-        return ()
-
     def _env_index(self, document: Document, name: str) -> int | None:
         entries = document.get((ENV_SETTING,))
         if entries is MISSING:
@@ -136,8 +123,6 @@ class Target:
             name = key[4:]
             index = self._env_index(document, name)
             if index is None:
-                if value is MISSING:
-                    return
                 if document.get((ENV_SETTING,)) is MISSING:
                     document.set((ENV_SETTING,), [])
                 entries = document.get((ENV_SETTING,))
@@ -145,19 +130,17 @@ class Target:
                 document.set(
                     (ENV_SETTING, len(entries)), {"name": name, "value": value}
                 )
-            elif value is MISSING:
-                document.delete((ENV_SETTING, index))
             else:
                 document.set((ENV_SETTING, index, "value"), value)
             return
         if value is MISSING:
+            assert isinstance(document, TomlDocument)
             document.delete(self.path_for(key))
         else:
             document.set(self.path_for(key), value)
 
     def values(self, document: Document) -> dict[str, object]:
         values = {key: self.read(document, key) for key in self.recipe}
-        self.validate_values(values)
         return values
 
     def validate_values(self, values: dict[str, object]) -> None:
@@ -180,42 +163,6 @@ class Target:
                 raise IntegrationError(
                     f"The setting {key} has an unsupported value type."
                 )
-
-    def recognized(self, values: dict[str, object], connection: Connection) -> bool:
-        if self.id == IntegrationId.CODEX:
-            command = values.get("model_providers.fcc.auth.command")
-            helper = (
-                isinstance(command, str)
-                and Path(command).name in {"fcc-codex", "fcc-codex.exe"}
-                and values.get("model_providers.fcc.auth.args")
-                == ["--print-proxy-auth-token"]
-            )
-            return values.get("model_provider") == "fcc" and (
-                values.get("model_providers.fcc.name") == "Free Claude Code" or helper
-            )
-        if self.id == IntegrationId.CLAUDE_LOGIN:
-            return values.get("hasCompletedOnboarding") is True
-        return (
-            same_url(values.get("env.ANTHROPIC_BASE_URL"), connection.url)
-            and values.get("env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY") == "1"
-        )
-
-    def manual_owned(self, key: str, value: object, connection: Connection) -> bool:
-        if value is MISSING:
-            return False
-        if self.id == IntegrationId.CODEX:
-            if key == "model":
-                return value in {model.wire_slug for model in connection.models}
-            if key == "model_catalog_json":
-                return isinstance(value, str) and Path(value) == connection.catalog_path
-            return key.startswith("model_providers.fcc.") or (
-                key == "model_provider" and value == "fcc"
-            )
-        if key == "env.ANTHROPIC_AUTH_TOKEN":
-            return True
-        if key == "env.ANTHROPIC_BASE_URL":
-            return same_url(value, connection.url)
-        return value == self.recipe[key]
 
 
 def make_targets(

--- a/src/free_claude_code/runtime/integrations/targets.py
+++ b/src/free_claude_code/runtime/integrations/targets.py
@@ -1,0 +1,325 @@
+"""Explicit settings for the four supported Admin integration items."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from free_claude_code.application.integrations import IntegrationError, IntegrationId
+from free_claude_code.cli.claude_env import claude_proxy_values
+from free_claude_code.cli.launchers.codex import codex_config_values
+from free_claude_code.cli.launchers.model_catalog import (
+    ClientModel,
+    catalog_wire_slug_for_ref,
+)
+from free_claude_code.config.server_urls import local_proxy_root_url
+from free_claude_code.config.settings import Settings
+
+from .discovery import InstalledClients, LocalInstallations
+from .documents import MISSING, JsonDocument, SettingPath, TomlDocument
+
+ENV_SETTING = "claudeCode.environmentVariables"
+AGENT_PATH = ("agent_servers", "Claude Code (FCC)")
+type Document = JsonDocument | TomlDocument
+
+
+@dataclass(frozen=True)
+class Connection:
+    settings: Settings
+    models: tuple[ClientModel, ...]
+    catalog_path: Path
+    saved_auth_token: str
+
+    @property
+    def url(self) -> str:
+        return local_proxy_root_url(self.settings)
+
+    @property
+    def model(self) -> str | None:
+        return catalog_wire_slug_for_ref(self.models, self.settings.model)
+
+
+def same_url(value: object, expected: str) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        first, second = urlsplit(value), urlsplit(expected)
+        local = {"localhost", "127.0.0.1", "::1"}
+        return (
+            first.scheme == second.scheme
+            and first.port == second.port
+            and first.path.rstrip("/") == second.path.rstrip("/")
+            and not (first.username or first.password or first.query or first.fragment)
+            and (
+                first.hostname == second.hostname
+                or {first.hostname, second.hostname} <= local
+            )
+        )
+    except ValueError:
+        return False
+
+
+@dataclass(frozen=True)
+class Target:
+    id: IntegrationId
+    path: Path
+    title: str
+    recipe: dict[str, object]
+    missing: tuple[str, ...]
+    badges: tuple[str, ...]
+    instructions: str
+    documentation_url: str
+
+    def document(self, source: bytes | None) -> Document:
+        if self.id == IntegrationId.CODEX:
+            return TomlDocument(source if source is not None else b"")
+        return JsonDocument(
+            source if source is not None else b"{}\n",
+            jsonc=self.id == IntegrationId.CLAUDE_VSCODE,
+        )
+
+    def containers(self) -> tuple[tuple[str, ...], ...]:
+        if self.id == IntegrationId.CODEX:
+            return (
+                ("model_providers",),
+                ("model_providers", "fcc"),
+                ("model_providers", "fcc", "auth"),
+            )
+        if self.id == IntegrationId.CLAUDE_VSCODE:
+            return ((ENV_SETTING,),)
+        if self.id == IntegrationId.CLAUDE_JETBRAINS:
+            return (("agent_servers",), AGENT_PATH, (*AGENT_PATH, "env"))
+        return ()
+
+    def _env_index(self, document: Document, name: str) -> int | None:
+        entries = document.get((ENV_SETTING,))
+        if entries is MISSING:
+            return None
+        if not isinstance(entries, list):
+            raise IntegrationError(
+                "Claude's environmentVariables setting must be an array."
+            )
+        matches = []
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict) or not isinstance(
+                document.get((ENV_SETTING, index, "name")), str
+            ):
+                raise IntegrationError(
+                    "Claude's environmentVariables entries must have a string name."
+                )
+            if document.get((ENV_SETTING, index, "name")) == name:
+                matches.append(index)
+        if len(matches) > 1:
+            raise IntegrationError(
+                f"Remove duplicate environment entries for {name} before continuing."
+            )
+        return matches[0] if matches else None
+
+    def path_for(self, key: str) -> SettingPath:
+        if self.id == IntegrationId.CLAUDE_VSCODE:
+            return (key,)
+        if self.id == IntegrationId.CLAUDE_JETBRAINS:
+            return (*AGENT_PATH, *key.split("."))
+        return tuple(key.split("."))
+
+    def read(self, document: Document, key: str) -> object:
+        if self.id == IntegrationId.CLAUDE_VSCODE and key.startswith("env."):
+            index = self._env_index(document, key[4:])
+            return (
+                MISSING
+                if index is None
+                else document.get((ENV_SETTING, index, "value"))
+            )
+        return document.get(self.path_for(key))
+
+    def write(self, document: Document, key: str, value: object) -> None:
+        if self.id == IntegrationId.CLAUDE_VSCODE and key.startswith("env."):
+            name = key[4:]
+            index = self._env_index(document, name)
+            if index is None:
+                if value is MISSING:
+                    return
+                if document.get((ENV_SETTING,)) is MISSING:
+                    document.set((ENV_SETTING,), [])
+                entries = document.get((ENV_SETTING,))
+                assert isinstance(entries, list)
+                document.set(
+                    (ENV_SETTING, len(entries)), {"name": name, "value": value}
+                )
+            elif value is MISSING:
+                document.delete((ENV_SETTING, index))
+            else:
+                document.set((ENV_SETTING, index, "value"), value)
+            return
+        if value is MISSING:
+            document.delete(self.path_for(key))
+        else:
+            document.set(self.path_for(key), value)
+
+    def values(self, document: Document) -> dict[str, object]:
+        values = {key: self.read(document, key) for key in self.recipe}
+        for key, value in values.items():
+            if value is MISSING:
+                continue
+            if key in {
+                "hasCompletedOnboarding",
+                "claudeCode.disableLoginPrompt",
+                "model_providers.fcc.requires_openai_auth",
+            }:
+                valid = type(value) is bool
+            elif key.endswith("args"):
+                valid = isinstance(value, list) and all(
+                    isinstance(arg, str) for arg in value
+                )
+            else:
+                valid = isinstance(value, str)
+            if not valid:
+                raise IntegrationError(
+                    f"The setting {key} has an unsupported value type."
+                )
+        return values
+
+    def recognized(self, values: dict[str, object], connection: Connection) -> bool:
+        if self.id == IntegrationId.CODEX:
+            command = values.get("model_providers.fcc.auth.command")
+            helper = (
+                isinstance(command, str)
+                and Path(command).name in {"fcc-codex", "fcc-codex.exe"}
+                and values.get("model_providers.fcc.auth.args")
+                == ["--print-proxy-auth-token"]
+            )
+            return values.get("model_provider") == "fcc" and (
+                values.get("model_providers.fcc.name") == "Free Claude Code" or helper
+            )
+        if self.id == IntegrationId.CLAUDE_LOGIN:
+            return values.get("hasCompletedOnboarding") is True
+        return (
+            same_url(values.get("env.ANTHROPIC_BASE_URL"), connection.url)
+            and values.get("env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY") == "1"
+        )
+
+    def manual_owned(self, key: str, value: object, connection: Connection) -> bool:
+        if value is MISSING:
+            return False
+        if self.id == IntegrationId.CODEX:
+            if key == "model":
+                return value in {model.wire_slug for model in connection.models}
+            if key == "model_catalog_json":
+                return isinstance(value, str) and Path(value) == connection.catalog_path
+            return key.startswith("model_providers.fcc.") or (
+                key == "model_provider" and value == "fcc"
+            )
+        if key == "env.ANTHROPIC_AUTH_TOKEN":
+            return True
+        if key == "env.ANTHROPIC_BASE_URL":
+            return same_url(value, connection.url)
+        return value == self.recipe[key]
+
+
+def make_targets(
+    locator: LocalInstallations, installed: InstalledClients, connection: Connection
+) -> tuple[Target, ...]:
+    claude = {
+        f"env.{key}": value
+        for key, value in claude_proxy_values(
+            proxy_root_url=connection.url,
+            auth_token=connection.settings.proxy_auth_token,
+        ).items()
+    }
+    claude["env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = ""
+    codex: dict[str, object] = dict(
+        codex_config_values(
+            api_url=connection.url,
+            model=connection.model,
+            auth_command=str(installed.fcc_command or "fcc-codex"),
+        )
+    )
+    codex["model"] = connection.model
+    codex["model_catalog_json"] = str(connection.catalog_path)
+    for name in ("env_key", "experimental_bearer_token", "requires_openai_auth"):
+        codex[f"model_providers.fcc.{name}"] = MISSING
+    codex_missing = []
+    if not installed.codex_app and not installed.codex_vscode:
+        codex_missing.append(
+            "Install Codex App or the Codex extension in VS Code's default local profile."
+        )
+    if installed.fcc_command is None:
+        codex_missing.append(
+            "The installed fcc-codex credential helper was not found. Reinstall FCC using its normal installer."
+        )
+    jetbrains_missing = []
+    if not installed.jetbrains:
+        jetbrains_missing.append(
+            "A supported JetBrains IDE was not detected in the standard installation locations."
+        )
+    if not installed.acp_command:
+        jetbrains_missing.append(
+            "Install the Claude ACP adapter and its required Node runtime. A usable installed adapter was not detected."
+        )
+    shared = (installed.scope_issue,) if installed.scope_issue else ()
+    return (
+        Target(
+            IntegrationId.CLAUDE_VSCODE,
+            locator.vscode_settings,
+            "Claude Code in VS Code",
+            {"claudeCode.disableLoginPrompt": True, **claude},
+            shared
+            + (
+                ()
+                if installed.claude_vscode
+                else (
+                    "Install the Claude Code extension in VS Code's default local profile.",
+                )
+            ),
+            ("VS Code extension installed",) if installed.claude_vscode else (),
+            "Run Developer: Reload Window in VS Code, then start a new Claude session.",
+            "https://code.claude.com/docs/en/vs-code",
+        ),
+        Target(
+            IntegrationId.CODEX,
+            locator.home / ".codex/config.toml",
+            "Codex App and VS Code",
+            codex,
+            shared + tuple(codex_missing),
+            tuple(
+                label
+                for found, label in (
+                    (installed.codex_app, "App installed"),
+                    (installed.codex_vscode, "VS Code extension installed"),
+                )
+                if found
+            ),
+            "Restart Codex App and reload VS Code. This shared configuration also affects normal Codex CLI use.",
+            "https://learn.chatgpt.com/docs/developer-settings",
+        ),
+        Target(
+            IntegrationId.CLAUDE_JETBRAINS,
+            locator.home / ".jetbrains/acp.json",
+            "Claude Code in JetBrains",
+            {
+                "command": installed.acp_command[0] if installed.acp_command else "",
+                "args": list(installed.acp_command[1:]),
+                **claude,
+            },
+            shared + tuple(jetbrains_missing),
+            ("JetBrains IDE installed",) if installed.jetbrains else (),
+            "Restart the IDE and select Claude Code (FCC) in a new chat. The existing registry agent is unchanged.",
+            "https://www.jetbrains.com/help/ai-assistant/acp.html",
+        ),
+        Target(
+            IntegrationId.CLAUDE_LOGIN,
+            locator.home / ".claude.json",
+            "Fix Claude Code login prompt",
+            {"hasCompletedOnboarding": True},
+            shared
+            + (
+                ()
+                if installed.claude_command
+                or installed.claude_vscode
+                or (installed.jetbrains and installed.acp_command)
+                else ("An installed Claude Code client was not detected.",)
+            ),
+            (),
+            "Restart Claude Code or your IDE. This changes shared first-run state for this user; it does not sign in to an account.",
+            "https://github.com/Alishahryar1/free-claude-code#connect-your-client",
+        ),
+    )

--- a/src/free_claude_code/runtime/integrations/targets.py
+++ b/src/free_claude_code/runtime/integrations/targets.py
@@ -157,6 +157,10 @@ class Target:
 
     def values(self, document: Document) -> dict[str, object]:
         values = {key: self.read(document, key) for key in self.recipe}
+        self.validate_values(values)
+        return values
+
+    def validate_values(self, values: dict[str, object]) -> None:
         for key, value in values.items():
             if value is MISSING:
                 continue
@@ -176,7 +180,6 @@ class Target:
                 raise IntegrationError(
                     f"The setting {key} has an unsupported value type."
                 )
-        return values
 
     def recognized(self, values: dict[str, object], connection: Connection) -> bool:
         if self.id == IntegrationId.CODEX:
@@ -251,9 +254,10 @@ def make_targets(
         jetbrains_missing.append(
             "A supported JetBrains IDE was not detected in the standard installation locations."
         )
-    if not installed.acp_command:
+    if not installed.acp.command:
         jetbrains_missing.append(
-            "Install the Claude ACP adapter and its required Node runtime. A usable installed adapter was not detected."
+            installed.acp.issue
+            or "Install the Claude ACP adapter and Node.js 22 or newer. A compatible installed adapter was not detected."
         )
     shared = (installed.scope_issue,) if installed.scope_issue else ()
     return (
@@ -296,8 +300,8 @@ def make_targets(
             locator.home / ".jetbrains/acp.json",
             "Claude Code in JetBrains",
             {
-                "command": installed.acp_command[0] if installed.acp_command else "",
-                "args": list(installed.acp_command[1:]),
+                "command": installed.acp.command[0] if installed.acp.command else "",
+                "args": list(installed.acp.command[1:]),
                 **claude,
             },
             shared + tuple(jetbrains_missing),
@@ -315,7 +319,7 @@ def make_targets(
                 ()
                 if installed.claude_command
                 or installed.claude_vscode
-                or (installed.jetbrains and installed.acp_command)
+                or (installed.jetbrains and installed.acp.command)
                 else ("An installed Claude Code client was not detected.",)
             ),
             (),

--- a/tests/api/support.py
+++ b/tests/api/support.py
@@ -14,6 +14,8 @@ from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime, RestartCallback
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 
 
@@ -54,6 +56,7 @@ def create_test_app(
         )
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=ConfigurationService(store),
         transcriber=None,
         restart_callback=restart_callback,

--- a/tests/api/test_admin_integrations.py
+++ b/tests/api/test_admin_integrations.py
@@ -5,16 +5,10 @@ import threading
 import httpx
 import pytest
 
-from free_claude_code.application.integrations import IntegrationAction as Action
 from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.application.integrations import IntegrationId as Item
 from free_claude_code.runtime.integrations.discovery import LocalInstallations
 from free_claude_code.runtime.integrations.service import IntegrationService
-from free_claude_code.runtime.integrations.storage import (
-    PendingWrite,
-    content_hash,
-    write_record,
-)
 from tests.api.support import create_test_app, runtime_for_app
 from tests.integration_support import connection, installed_clients
 
@@ -38,12 +32,12 @@ async def test_inspect_preview_apply_and_conflict_are_local_no_store(integration
         assert "no-store" in response.headers["cache-control"]
         assert len(response.json()["items"]) == 4
         preview = await client.post(
-            "/admin/api/integrations/claude-vscode/preview", json={"action": "setup"}
+            "/admin/api/integrations/claude-vscode/preview", json={}
         )
         assert preview.status_code == 200
         assert "fixture-proxy-token" not in preview.text
         assert not locator.vscode_settings.exists()
-        payload = {"action": "setup", "revision": preview.json()["revision"]}
+        payload = {"revision": preview.json()["revision"]}
         applied = await client.post(
             "/admin/api/integrations/claude-vscode/apply", json=payload
         )
@@ -81,8 +75,8 @@ async def test_integration_endpoints_enforce_loopback(
     ) as client:
         for method, path, payload in [
             ("GET", "", None),
-            ("POST", "/claude-login/preview", {"action": "repair"}),
-            ("POST", "/claude-login/apply", {"action": "repair", "revision": "a" * 64}),
+            ("POST", "/claude-login/preview", {}),
+            ("POST", "/claude-login/apply", {"revision": "a" * 64}),
         ]:
             response = await client.request(
                 method, "/admin/api/integrations" + path, json=payload
@@ -96,10 +90,12 @@ async def test_integration_endpoints_enforce_loopback(
 @pytest.mark.parametrize(
     "item,payload,status",
     [
-        ("anything", {"action": "setup"}, 422),
+        ("anything", {}, 422),
+        ("codex", {"action": "disconnect"}, 422),
+        ("codex", {"action": "recover"}, 422),
         ("codex", {"action": "execute"}, 422),
-        ("claude-login", {"action": "setup"}, 400),
-        ("codex", {"action": "repair"}, 400),
+        ("claude-login", {"action": "setup"}, 422),
+        ("codex", {"action": "repair"}, 422),
         ("claude-login", {"action": "repair", "path": "arbitrary.json"}, 422),
     ],
 )
@@ -117,6 +113,31 @@ async def test_fixed_items_actions_and_payloads(integration_app, item, payload, 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extra",
+    [{"action": "disconnect"}, {"action": "recover"}, {"path": "arbitrary.json"}],
+)
+async def test_apply_rejects_retired_actions_even_with_a_valid_revision(
+    integration_app, extra
+):
+    app, locator = integration_app
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        preview = await client.post(
+            "/admin/api/integrations/claude-login/preview", json={}
+        )
+        assert preview.status_code == 200
+        response = await client.post(
+            "/admin/api/integrations/claude-login/apply",
+            json={"revision": preview.json()["revision"], **extra},
+        )
+        assert response.status_code == 422
+        assert "no-store" in response.headers["cache-control"]
+    assert not (locator.home / ".claude.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_pending_settings_block_connection_setup_but_allow_onboarding_repair(
     integration_app,
 ):
@@ -124,12 +145,12 @@ async def test_pending_settings_block_connection_setup_but_allow_onboarding_repa
     runtime = runtime_for_app(app)
     runtime._pending_fields = ["PORT"]
     with pytest.raises(IntegrationError, match="Restart"):
-        await runtime.preview_integration(Item.CLAUDE_VSCODE, Action.SETUP)
-    preview = await runtime.preview_integration(Item.CLAUDE_LOGIN, Action.REPAIR)
-    assert preview["changes"]
+        await runtime.preview_integration(Item.CLAUDE_VSCODE)
+    preview = await runtime.preview_integration(Item.CLAUDE_LOGIN)
+    assert preview["writes_file"]
     runtime.begin_shutdown()
     with pytest.raises(IntegrationError, match="shutting down"):
-        await runtime.preview_integration(Item.CLAUDE_LOGIN, Action.REPAIR)
+        await runtime.preview_integration(Item.CLAUDE_LOGIN)
 
 
 @pytest.mark.asyncio
@@ -138,7 +159,7 @@ async def test_cancelled_integration_write_settles_under_configuration_lock(
 ):
     app, locator = integration_app
     runtime = runtime_for_app(app)
-    preview = await runtime.preview_integration(Item.CLAUDE_LOGIN, Action.REPAIR)
+    preview = await runtime.preview_integration(Item.CLAUDE_LOGIN)
     entered, release = threading.Event(), threading.Event()
     actual = IntegrationService.apply
 
@@ -150,9 +171,7 @@ async def test_cancelled_integration_write_settles_under_configuration_lock(
     monkeypatch.setattr(IntegrationService, "apply", wait_then_apply)
     revision = preview["revision"]
     assert isinstance(revision, str)
-    task = asyncio.create_task(
-        runtime.apply_integration(Item.CLAUDE_LOGIN, Action.REPAIR, revision)
-    )
+    task = asyncio.create_task(runtime.apply_integration(Item.CLAUDE_LOGIN, revision))
     try:
         assert await asyncio.to_thread(entered.wait, 3)
         task.cancel()
@@ -170,51 +189,3 @@ async def test_cancelled_integration_write_settles_under_configuration_lock(
         is True
     )
     assert not runtime._config_lock.locked()
-
-
-@pytest.mark.asyncio
-async def test_recovery_does_not_require_current_connection_credentials(
-    integration_app, monkeypatch
-):
-    app, locator = integration_app
-    path = locator.home / ".claude.json"
-    path.write_bytes(b'{"hasCompletedOnboarding":true}')
-    write_record(
-        locator.home / ".fcc/integrations/claude-login.json",
-        PendingWrite(
-            item=Item.CLAUDE_LOGIN,
-            action=Action.REPAIR,
-            path=str(path),
-            before=content_hash(None),
-            after=content_hash(path.read_bytes()),
-            previous=None,
-            following=None,
-        ),
-    )
-    runtime = runtime_for_app(app)
-    runtime._pending_fields = ["PORT"]
-
-    async def unreadable_credentials(_self):
-        raise OSError("unavailable current credential file")
-
-    monkeypatch.setattr(
-        type(runtime._configuration), "saved_proxy_auth_token", unreadable_credentials
-    )
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app), base_url="http://localhost"
-    ) as client:
-        response = await client.post(
-            "/admin/api/integrations/claude-login/preview", json={"action": "recover"}
-        )
-        assert response.status_code == 200
-        preview = response.json()
-        assert preview["writes_file"] is False
-        before = path.read_bytes()
-        response = await client.post(
-            "/admin/api/integrations/claude-login/apply",
-            json={"action": "recover", "revision": preview["revision"]},
-        )
-        assert response.status_code == 200
-        assert response.json()["applied"] is True
-        assert path.read_bytes() == before
-        assert not (locator.home / ".fcc/integrations/claude-login.json").exists()

--- a/tests/api/test_admin_integrations.py
+++ b/tests/api/test_admin_integrations.py
@@ -1,0 +1,167 @@
+import asyncio
+import json
+import threading
+
+import httpx
+import pytest
+
+from free_claude_code.application.integrations import IntegrationAction as Action
+from free_claude_code.application.integrations import IntegrationError
+from free_claude_code.application.integrations import IntegrationId as Item
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
+from tests.api.support import create_test_app, runtime_for_app
+from tests.integration_support import connection, installed_clients
+
+
+@pytest.fixture
+def integration_app(tmp_path, monkeypatch):
+    locator = installed_clients(tmp_path)
+    monkeypatch.setattr(LocalInstallations, "current", classmethod(lambda cls: locator))
+    app = create_test_app(connection(tmp_path).settings)
+    return app, locator
+
+
+@pytest.mark.asyncio
+async def test_inspect_preview_apply_and_conflict_are_local_no_store(integration_app):
+    app, locator = integration_app
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.get("/admin/api/integrations")
+        assert response.status_code == 200
+        assert "no-store" in response.headers["cache-control"]
+        assert len(response.json()["items"]) == 4
+        preview = await client.post(
+            "/admin/api/integrations/claude-vscode/preview", json={"action": "setup"}
+        )
+        assert preview.status_code == 200
+        assert "fixture-proxy-token" not in preview.text
+        assert not locator.vscode_settings.exists()
+        payload = {"action": "setup", "revision": preview.json()["revision"]}
+        applied = await client.post(
+            "/admin/api/integrations/claude-vscode/apply", json=payload
+        )
+        assert applied.status_code == 200
+        assert applied.json()["applied"] is True
+        assert (
+            json.loads(locator.vscode_settings.read_bytes())[
+                "claudeCode.disableLoginPrompt"
+            ]
+            is True
+        )
+        repeated = await client.post(
+            "/admin/api/integrations/claude-vscode/apply", json=payload
+        )
+        assert repeated.status_code == 409
+        assert "no-store" in repeated.headers["cache-control"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "client_host,headers",
+    [
+        ("192.0.2.10", {}),
+        ("127.0.0.1", {"host": "evil.example"}),
+        ("127.0.0.1", {"origin": "https://evil.example"}),
+    ],
+)
+async def test_integration_endpoints_enforce_loopback(
+    integration_app, client_host, headers
+):
+    app, locator = integration_app
+    transport = httpx.ASGITransport(app=app, client=(client_host, 1234))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://localhost", headers=headers
+    ) as client:
+        for method, path, payload in [
+            ("GET", "", None),
+            ("POST", "/claude-login/preview", {"action": "repair"}),
+            ("POST", "/claude-login/apply", {"action": "repair", "revision": "a" * 64}),
+        ]:
+            response = await client.request(
+                method, "/admin/api/integrations" + path, json=payload
+            )
+            assert response.status_code == 403
+            assert "no-store" in response.headers["cache-control"]
+    assert not (locator.home / ".claude.json").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "item,payload,status",
+    [
+        ("anything", {"action": "setup"}, 422),
+        ("codex", {"action": "execute"}, 422),
+        ("claude-login", {"action": "setup"}, 400),
+        ("codex", {"action": "repair"}, 400),
+        ("claude-login", {"action": "repair", "path": "arbitrary.json"}, 422),
+    ],
+)
+async def test_fixed_items_actions_and_payloads(integration_app, item, payload, status):
+    app, locator = integration_app
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.post(
+            f"/admin/api/integrations/{item}/preview", json=payload
+        )
+        assert response.status_code == status
+        assert "no-store" in response.headers["cache-control"]
+    assert not (locator.home / ".claude.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_pending_settings_block_connection_setup_but_allow_onboarding_repair(
+    integration_app,
+):
+    app, _locator = integration_app
+    runtime = runtime_for_app(app)
+    runtime._pending_fields = ["PORT"]
+    with pytest.raises(IntegrationError, match="Restart"):
+        await runtime.preview_integration(Item.CLAUDE_VSCODE, Action.SETUP)
+    preview = await runtime.preview_integration(Item.CLAUDE_LOGIN, Action.REPAIR)
+    assert preview["changes"]
+    runtime.begin_shutdown()
+    with pytest.raises(IntegrationError, match="shutting down"):
+        await runtime.preview_integration(Item.CLAUDE_LOGIN, Action.REPAIR)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_integration_write_settles_under_configuration_lock(
+    integration_app, monkeypatch
+):
+    app, locator = integration_app
+    runtime = runtime_for_app(app)
+    preview = await runtime.preview_integration(Item.CLAUDE_LOGIN, Action.REPAIR)
+    entered, release = threading.Event(), threading.Event()
+    actual = IntegrationService.apply
+
+    def wait_then_apply(self, *args):
+        entered.set()
+        assert release.wait(timeout=5)
+        return actual(self, *args)
+
+    monkeypatch.setattr(IntegrationService, "apply", wait_then_apply)
+    revision = preview["revision"]
+    assert isinstance(revision, str)
+    task = asyncio.create_task(
+        runtime.apply_integration(Item.CLAUDE_LOGIN, Action.REPAIR, revision)
+    )
+    try:
+        assert await asyncio.to_thread(entered.wait, 3)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        assert runtime._config_lock.locked()
+    finally:
+        release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert (
+        json.loads((locator.home / ".claude.json").read_bytes())[
+            "hasCompletedOnboarding"
+        ]
+        is True
+    )
+    assert not runtime._config_lock.locked()

--- a/tests/api/test_admin_integrations.py
+++ b/tests/api/test_admin_integrations.py
@@ -10,6 +10,11 @@ from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.application.integrations import IntegrationId as Item
 from free_claude_code.runtime.integrations.discovery import LocalInstallations
 from free_claude_code.runtime.integrations.service import IntegrationService
+from free_claude_code.runtime.integrations.storage import (
+    PendingWrite,
+    content_hash,
+    write_record,
+)
 from tests.api.support import create_test_app, runtime_for_app
 from tests.integration_support import connection, installed_clients
 
@@ -165,3 +170,51 @@ async def test_cancelled_integration_write_settles_under_configuration_lock(
         is True
     )
     assert not runtime._config_lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_recovery_does_not_require_current_connection_credentials(
+    integration_app, monkeypatch
+):
+    app, locator = integration_app
+    path = locator.home / ".claude.json"
+    path.write_bytes(b'{"hasCompletedOnboarding":true}')
+    write_record(
+        locator.home / ".fcc/integrations/claude-login.json",
+        PendingWrite(
+            item=Item.CLAUDE_LOGIN,
+            action=Action.REPAIR,
+            path=str(path),
+            before=content_hash(None),
+            after=content_hash(path.read_bytes()),
+            previous=None,
+            following=None,
+        ),
+    )
+    runtime = runtime_for_app(app)
+    runtime._pending_fields = ["PORT"]
+
+    async def unreadable_credentials(_self):
+        raise OSError("unavailable current credential file")
+
+    monkeypatch.setattr(
+        type(runtime._configuration), "saved_proxy_auth_token", unreadable_credentials
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.post(
+            "/admin/api/integrations/claude-login/preview", json={"action": "recover"}
+        )
+        assert response.status_code == 200
+        preview = response.json()
+        assert preview["writes_file"] is False
+        before = path.read_bytes()
+        response = await client.post(
+            "/admin/api/integrations/claude-login/apply",
+            json={"action": "recover", "revision": preview["revision"]},
+        )
+        assert response.status_code == 200
+        assert response.json()["applied"] is True
+        assert path.read_bytes() == before
+        assert not (locator.home / ".fcc/integrations/claude-login.json").exists()

--- a/tests/api/test_app_lifespan_and_errors.py
+++ b/tests/api/test_app_lifespan_and_errors.py
@@ -23,6 +23,8 @@ from free_claude_code.runtime.application import (
 from free_claude_code.runtime.asgi import RuntimeASGIApp
 from free_claude_code.runtime.bootstrap import _create_transcriber, build_asgi_app
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 from tests.api.support import create_test_app
 
@@ -47,7 +49,10 @@ async def test_runtime_startup_logs_admin_url_without_printed_server_banner():
     )
     manager = ProviderRuntimeManager(settings)
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     uvicorn_logger = MagicMock()
 
@@ -155,7 +160,10 @@ async def test_runtime_startup_warms_catalog_before_background_refresh():
     settings = _settings(messaging_platform="none")
     manager = ProviderRuntimeManager(settings)
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     events: list[str] = []
 

--- a/tests/api/test_runtime_safe_logging.py
+++ b/tests/api/test_runtime_safe_logging.py
@@ -8,6 +8,8 @@ import pytest
 from free_claude_code.config.settings import Settings
 from free_claude_code.runtime.application import ApplicationRuntime, best_effort
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 
 
@@ -23,6 +25,7 @@ async def test_messaging_start_failure_default_logs_exclude_traceback(caplog):
     )
     runtime = ApplicationRuntime(
         ProviderRuntimeManager(settings),
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=None,
     )

--- a/tests/cli/test_config_restart_lifecycle.py
+++ b/tests/cli/test_config_restart_lifecycle.py
@@ -17,6 +17,8 @@ from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.asgi import RuntimeASGIApp
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 
 
@@ -42,6 +44,7 @@ def test_supervised_http_apply_finishes_and_reconnects(monkeypatch, stop_during_
         monkeypatch.setattr(manager, "_refresh_generation_in_background", AsyncMock())
         runtime = ApplicationRuntime(
             manager,
+            integrations=IntegrationService(LocalInstallations.current()),
             configuration=ConfigurationService(ManagedConfigStore()),
             transcriber=None,
             restart_callback=restart_callback,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 from free_claude_code.config import env_migrations, paths
 from free_claude_code.config.loader import clear_settings_cache
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
 from tests.providers.support import (
     immediate_admission,
     make_provider_config,
@@ -30,6 +31,15 @@ def _isolate_managed_config(monkeypatch, tmp_path):
     monkeypatch.setattr(paths, "config_dir_path", lambda: config_dir)
     monkeypatch.setattr(env_migrations, "legacy_env_paths", lambda: ())
     monkeypatch.setattr(env_migrations, "verified_checkout_env_path", lambda: None)
+    monkeypatch.setattr(
+        LocalInstallations,
+        "current",
+        classmethod(
+            lambda cls: LocalInstallations(
+                tmp_path, "linux", {}, tmp_path / "python", ()
+            )
+        ),
+    )
     clear_settings_cache()
     yield
     clear_settings_cache()

--- a/tests/integration_support.py
+++ b/tests/integration_support.py
@@ -21,10 +21,15 @@ def write_json(path: Path, value: object) -> None:
     path.write_text(json.dumps(value), encoding="utf-8")
 
 
+class FixtureInstallations(LocalInstallations):
+    def _node_version(self, node: Path) -> tuple[int, int, int] | None:
+        return (22, 0, 0) if node.is_file() else None
+
+
 def installed_clients(home: Path) -> LocalInstallations:
     bins, apps = home / "bin", home / "apps"
     env = {"PATH": str(bins), "XDG_CONFIG_HOME": str(home / ".config")}
-    locator = LocalInstallations(home, "linux", env, bins, (apps,))
+    locator = FixtureInstallations(home, "linux", env, bins, (apps,))
     for name in ("fcc-codex", "claude", "node", "chatgpt"):
         executable(bins / name)
     write_json(apps / "code/resources/app/product.json", {"applicationName": "code"})
@@ -56,6 +61,7 @@ def installed_clients(home: Path) -> LocalInstallations:
         {
             "name": "@agentclientprotocol/claude-agent-acp",
             "bin": {"claude-agent-acp": "dist/index.js"},
+            "engines": {"node": ">=22"},
         },
     )
     executable(package / "dist/index.js")

--- a/tests/integration_support.py
+++ b/tests/integration_support.py
@@ -1,0 +1,90 @@
+"""Synthetic installed clients and configuration homes for integration tests."""
+
+import json
+from pathlib import Path
+
+from free_claude_code.cli.launchers.model_catalog import ClientModel
+from free_claude_code.config.settings import Settings
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.targets import Connection
+
+
+def executable(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("fixture", encoding="utf-8")
+    path.chmod(0o700)
+    return path
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def installed_clients(home: Path) -> LocalInstallations:
+    bins, apps = home / "bin", home / "apps"
+    env = {"PATH": str(bins), "XDG_CONFIG_HOME": str(home / ".config")}
+    locator = LocalInstallations(home, "linux", env, bins, (apps,))
+    for name in ("fcc-codex", "claude", "node", "chatgpt"):
+        executable(bins / name)
+    write_json(apps / "code/resources/app/product.json", {"applicationName": "code"})
+    executable(apps / "code/code")
+    descriptors = []
+    for extension_id in ("anthropic.claude-code", "openai.chatgpt"):
+        publisher, name = extension_id.split(".", 1)
+        extension = home / ".vscode/extensions" / f"{extension_id}-1.0.0"
+        write_json(
+            extension / "package.json",
+            {"publisher": publisher, "name": name, "version": "1.0.0"},
+        )
+        descriptors.append(
+            {
+                "identifier": {"id": extension_id},
+                "relativeLocation": extension.name,
+                "version": "1.0.0",
+            }
+        )
+    write_json(home / ".vscode/extensions/extensions.json", descriptors)
+    executable(apps / "idea/bin/idea.sh")
+    write_json(
+        apps / "idea/product-info.json",
+        {"productCode": "IU", "launch": [{"launcherPath": "bin/idea.sh"}]},
+    )
+    package = home / "lib/node_modules/@agentclientprotocol/claude-agent-acp"
+    write_json(
+        package / "package.json",
+        {
+            "name": "@agentclientprotocol/claude-agent-acp",
+            "bin": {"claude-agent-acp": "dist/index.js"},
+        },
+    )
+    executable(package / "dist/index.js")
+    return locator
+
+
+def connection(
+    home: Path, *, port: int = 8082, token: str = "fixture-proxy-token"
+) -> Connection:
+    catalog = home / ".fcc/codex-model-catalog.json"
+    write_json(catalog, {"models": [{"slug": "test/model"}]})
+    return Connection(
+        Settings(
+            MODEL="open_router/test-model",
+            PORT=port,
+            ANTHROPIC_AUTH_TOKEN=token,
+            MESSAGING_PLATFORM="none",
+        ),
+        (
+            ClientModel(
+                "test/model",
+                "open_router/test-model",
+                "Test model",
+                True,
+                None,
+                100_000,
+                10_000,
+            ),
+        ),
+        catalog,
+        token,
+    )

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -35,6 +35,8 @@ from free_claude_code.providers.credential_validation import (
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 from tests.providers.support import make_provider_config
 
@@ -258,7 +260,10 @@ def _runtime_with_admin_provider(
         ),
     )
     return ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     ), manager
 
 
@@ -343,7 +348,10 @@ async def test_provider_check_never_returns_unrecognized_credentials(
 async def test_stop_all_maps_messaging_outcome_to_application_count() -> None:
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     workflow = MagicMock()
     workflow.stop_all_tasks = AsyncMock(
@@ -371,7 +379,10 @@ async def test_provider_apply_constructs_before_commit_then_publishes(tmp_path) 
         runtime_factory=factory,
     )
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     prepared = _prepared(_settings("nvidia_nim/new"), tmp_path)
     factory.events.clear()
@@ -415,7 +426,10 @@ async def test_candidate_failure_never_commits_and_preserves_current(tmp_path) -
         runtime_factory=factory,
     )
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     prepared = _prepared(_settings("nvidia_nim/new"), tmp_path)
     factory.fail = True
@@ -447,7 +461,10 @@ async def test_persistence_failure_closes_candidate_and_preserves_current(
         runtime_factory=factory,
     )
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     prepared = _prepared(_settings("nvidia_nim/new"), tmp_path)
 
@@ -482,6 +499,7 @@ async def test_restart_required_apply_commits_without_hot_publication(tmp_path) 
     restart = MagicMock(return_value=None)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=None,
         restart_callback=restart,
@@ -533,7 +551,10 @@ async def test_credential_checks_gate_both_apply_paths(tmp_path, pending, status
         _settings("nvidia_nim/old"), runtime_factory=factory
     )
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     prepared = replace(
         _prepared(_settings("nvidia_nim/new"), tmp_path, pending_fields=pending),
@@ -580,7 +601,10 @@ async def test_credential_checks_gate_both_apply_paths(tmp_path, pending, status
 async def test_cancelled_credential_check_never_commits(tmp_path):
     manager = ProviderRuntimeManager(_settings("nvidia_nim/old"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     prepared = replace(
         _prepared(_settings("nvidia_nim/new"), tmp_path), changed_keys=("GROQ_API_KEY",)
@@ -611,6 +635,7 @@ async def test_close_drains_messaging_before_transcriber_and_is_idempotent() -> 
     transcriber = TrackingTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -644,6 +669,7 @@ async def test_close_retains_transcriber_ownership_when_close_fails() -> None:
     transcriber = FailingTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -669,6 +695,7 @@ async def test_close_retries_runtime_before_closing_later_resources() -> None:
     transcriber = TrackingTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -708,6 +735,7 @@ async def test_close_retries_connected_account_without_reclosing_providers() -> 
     account.close = AsyncMock(side_effect=[RuntimeError("auth cleanup failed"), None])
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=None,
         connected_accounts={"openai": account},
@@ -748,6 +776,7 @@ async def test_connected_account_status_reports_cached_model_count() -> None:
     )
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=None,
         connected_accounts={"openai": account},
@@ -766,7 +795,10 @@ async def test_close_retries_workflow_close_before_closing_delivery() -> None:
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     messaging = TrackingMessagingRuntime(events)
     workflow = MagicMock()
@@ -806,7 +838,10 @@ async def test_close_does_not_drain_workflow_until_ingress_is_quiescent() -> Non
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     messaging = TrackingMessagingRuntime(events, fail_quiesce_once=True)
     workflow = MagicMock()
@@ -836,7 +871,10 @@ async def test_close_retries_failed_persistence_before_closing_delivery() -> Non
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     messaging = TrackingMessagingRuntime(events)
     workflow = MagicMock()
@@ -877,7 +915,10 @@ async def test_close_retries_real_workflow_persistence_without_losing_latest_sta
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     messaging = TrackingMessagingRuntime(events)
     cli_manager = MagicMock()
@@ -963,6 +1004,7 @@ async def test_cancelled_transcriber_close_retains_ownership() -> None:
     transcriber = CancelledTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -982,6 +1024,7 @@ async def test_cancelled_application_close_remains_retryable() -> None:
     transcriber = CancellingOnceTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -1006,6 +1049,7 @@ async def test_startup_failure_closes_owned_transcriber() -> None:
     transcriber = TrackingTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -1030,6 +1074,7 @@ async def test_startup_cancellation_cleans_partial_messaging_and_reraises() -> N
     transcriber = TrackingTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -1067,7 +1112,10 @@ async def test_public_start_retries_transient_partial_messaging_cleanup() -> Non
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     messaging = TrackingMessagingRuntime(events, fail_quiesce_once=True)
     workflow = MagicMock()
@@ -1132,6 +1180,7 @@ async def test_public_start_retains_persistently_unclean_partial_messaging_graph
     transcriber = TrackingTranscriber(events)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=AsyncMock(spec=ConfigurationService),
         transcriber=transcriber,
     )
@@ -1204,7 +1253,10 @@ async def test_public_start_retains_persistently_unclean_partial_messaging_graph
 async def test_messaging_start_failure_is_nonfatal_after_complete_cleanup() -> None:
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
 
     with (
@@ -1225,7 +1277,10 @@ async def test_messaging_start_failure_fails_closed_when_cleanup_is_incomplete()
 ):
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
 
     with (
@@ -1247,7 +1302,10 @@ async def test_composition_records_runtime_before_workspace_setup() -> None:
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     messaging = TrackingMessagingRuntime(events)
     components = MessagingPlatformComponents(
@@ -1278,7 +1336,10 @@ async def test_composition_publishes_startup_notice_after_runtime_and_repair() -
     events: list[str] = []
     manager = ProviderRuntimeManager(_settings("nvidia_nim/model"))
     runtime = ApplicationRuntime(
-        manager, configuration=AsyncMock(spec=ConfigurationService), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=AsyncMock(spec=ConfigurationService),
+        transcriber=None,
     )
     messaging = TrackingMessagingRuntime(events)
     notice = MessagingStartupNotice(

--- a/tests/runtime/test_config_startup.py
+++ b/tests/runtime/test_config_startup.py
@@ -11,6 +11,8 @@ from free_claude_code.config.paths import config_lock_path
 from free_claude_code.core.interprocess_lock import InterprocessFileLock
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 from tests.runtime.test_application_runtime import _settings
 
@@ -27,7 +29,10 @@ async def test_shutdown_drains_initialization_worker(cancel, fail):
     store = ManagedConfigStore()
     manager = ProviderRuntimeManager(_settings("nvidia_nim/old"))
     runtime = ApplicationRuntime(
-        manager, configuration=ConfigurationService(store), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=ConfigurationService(store),
+        transcriber=None,
     )
     consolidate = loader.consolidate_managed_config
 
@@ -99,6 +104,7 @@ async def test_closed_runtime_cannot_start_another_configuration_writer():
     store = ManagedConfigStore()
     runtime = ApplicationRuntime(
         ProviderRuntimeManager(_settings("nvidia_nim/old")),
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=ConfigurationService(store),
         transcriber=None,
     )

--- a/tests/runtime/test_config_transactions.py
+++ b/tests/runtime/test_config_transactions.py
@@ -8,6 +8,8 @@ from free_claude_code.application.errors import ApplicationUnavailableError
 from free_claude_code.config.loader import ManagedConfigStore
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 from tests.runtime.test_application_runtime import TrackingFactory, _prepared, _settings
 
@@ -31,6 +33,7 @@ async def test_awaitable_restart_callback_is_not_executed_under_apply_lock(tmp_p
     callback = MagicMock(side_effect=close_on_restart)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=configuration,
         transcriber=None,
         restart_callback=callback,
@@ -82,7 +85,11 @@ async def test_cancelled_commit_settles_before_shutdown(tmp_path, pending, fail)
     configuration.commit.side_effect = commit
     restart = MagicMock(return_value=None)
     runtime = ApplicationRuntime(
-        manager, configuration=configuration, transcriber=None, restart_callback=restart
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=configuration,
+        transcriber=None,
+        restart_callback=restart,
     )
     with patch(
         "free_claude_code.runtime.application.check_credentials",
@@ -129,6 +136,7 @@ async def test_cancellation_at_finalization_handoff_prevents_persistence(
     restart = MagicMock(return_value=None)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=ConfigurationService(store),
         transcriber=None,
         restart_callback=restart,
@@ -186,7 +194,12 @@ async def test_cancellation_waiting_for_replacement_does_not_persist(tmp_path):
     configuration.prepare.return_value = _prepared(
         _settings("nvidia_nim/new"), tmp_path
     )
-    runtime = ApplicationRuntime(manager, configuration=configuration, transcriber=None)
+    runtime = ApplicationRuntime(
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=configuration,
+        transcriber=None,
+    )
     with patch(
         "free_claude_code.runtime.application.check_credentials",
         AsyncMock(return_value=()),
@@ -215,6 +228,7 @@ async def test_worker_commit_retains_ownership_against_queued_apply(
     restart = MagicMock(return_value=None)
     runtime = ApplicationRuntime(
         manager,
+        integrations=IntegrationService(LocalInstallations.current()),
         configuration=ConfigurationService(store),
         transcriber=None,
         restart_callback=restart,

--- a/tests/runtime/test_integration_discovery.py
+++ b/tests/runtime/test_integration_discovery.py
@@ -15,7 +15,7 @@ def test_discovery_reads_installed_metadata_without_running_clients(
     )
     snapshot = locator.scan()
     assert snapshot.claude_vscode and snapshot.codex_vscode and snapshot.codex_app
-    assert snapshot.jetbrains and snapshot.acp_command
+    assert snapshot.jetbrains and snapshot.acp.command
     assert snapshot.fcc_command == tmp_path / "bin/fcc-codex"
 
 
@@ -38,7 +38,7 @@ def test_index_requires_matching_package_identity_and_existing_entrypoint(tmp_pa
     ).unlink()
     snapshot = locator.scan()
     assert not snapshot.claude_vscode
-    assert not snapshot.acp_command
+    assert not snapshot.acp.command
 
 
 @pytest.mark.parametrize(
@@ -117,3 +117,176 @@ def test_installed_helper_symlink_resolves_to_its_executable(tmp_path):
     except OSError:
         pytest.skip("Symlink creation is not permitted on this host")
     assert locator.scan().fcc_command == actual
+
+
+@pytest.mark.parametrize("override", [None, "", "relative/config", "~/.config"])
+def test_invalid_xdg_override_uses_default_absolute_target(tmp_path, override):
+    locator = installed_clients(tmp_path)
+    if override is None:
+        locator.environ.pop("XDG_CONFIG_HOME")
+    else:
+        locator.environ["XDG_CONFIG_HOME"] = override
+    assert locator.vscode_settings == tmp_path / ".config/Code/User/settings.json"
+    assert locator.vscode_settings.is_absolute()
+
+
+def test_macos_jetbrains_launcher_is_relative_to_its_manifest(tmp_path):
+    contents = tmp_path / "apps/IntelliJ IDEA.app/Contents"
+    executable(contents / "MacOS/idea")
+    write_json(
+        contents / "Resources/product-info.json",
+        {"productCode": "IU", "launch": [{"launcherPath": "../MacOS/idea"}]},
+    )
+    locator = LocalInstallations(
+        tmp_path, "darwin", {}, tmp_path / "bin", (tmp_path / "apps",)
+    )
+    assert locator.scan().jetbrains
+
+
+@pytest.mark.parametrize("version", [(20, 19, 0), (21, 7, 3)])
+def test_acp_rejects_node_below_its_runtime_requirement(tmp_path, monkeypatch, version):
+    locator = installed_clients(tmp_path)
+    package = tmp_path / "lib/node_modules/@agentclientprotocol/claude-agent-acp"
+    write_json(
+        package / "package.json",
+        {
+            "name": "@agentclientprotocol/claude-agent-acp",
+            "bin": {"claude-agent-acp": "dist/index.js"},
+            "engines": {"node": ">=22"},
+        },
+    )
+    monkeypatch.setattr(
+        type(locator), "_node_version", lambda _self, _node: version, raising=False
+    )
+    assert not locator.scan().acp.command
+
+
+def test_absolute_xdg_override_is_used_without_changing_location(tmp_path):
+    locator = installed_clients(tmp_path)
+    locator.environ["XDG_CONFIG_HOME"] = str(tmp_path / "custom-config")
+    assert locator.vscode_settings == tmp_path / "custom-config/Code/User/settings.json"
+
+
+@pytest.mark.parametrize("platform", ["win32", "darwin", "linux"])
+def test_jetbrains_rejects_absolute_launcher_declarations(tmp_path, platform):
+    base = tmp_path / "apps/idea"
+    if platform == "darwin":
+        base = tmp_path / "apps/IDEA.app/Contents/Resources"
+    launcher = executable(base / "bin/idea")
+    write_json(
+        base / "product-info.json",
+        {"productCode": "IU", "launch": [{"launcherPath": str(launcher)}]},
+    )
+    locator = LocalInstallations(
+        tmp_path, platform, {}, tmp_path / "bin", (tmp_path / "apps",)
+    )
+    assert not locator._jetbrains()
+
+
+@pytest.mark.parametrize("symlink", [False, True])
+def test_jetbrains_launcher_cannot_escape_its_installation(tmp_path, symlink):
+    outside = executable(tmp_path / "outside/idea")
+    base = tmp_path / "apps/IDEA.app/Contents"
+    launcher = base / "MacOS/idea"
+    launcher.parent.mkdir(parents=True)
+    if symlink:
+        try:
+            launcher.symlink_to(outside)
+        except OSError:
+            pytest.skip("Symlink creation is not permitted on this host")
+        relative = "../MacOS/idea"
+    else:
+        relative = "../../../../outside/idea"
+    write_json(
+        base / "Resources/product-info.json",
+        {"productCode": "IU", "launch": [{"launcherPath": relative}]},
+    )
+    locator = LocalInstallations(
+        tmp_path, "darwin", {}, tmp_path / "bin", (tmp_path / "apps",)
+    )
+    assert not locator._jetbrains()
+
+
+def test_macos_manifest_outside_bundle_does_not_expand_launcher_boundary(tmp_path):
+    executable(tmp_path / "apps/other/idea")
+    write_json(
+        tmp_path / "apps/idea/product-info.json",
+        {"productCode": "IU", "launch": [{"launcherPath": "../other/idea"}]},
+    )
+    locator = LocalInstallations(
+        tmp_path, "darwin", {}, tmp_path / "bin", (tmp_path / "apps",)
+    )
+    assert not locator._jetbrains()
+
+
+@pytest.mark.parametrize(
+    "version,requirement,compatible",
+    [
+        ((22, 0, 0), ">=22", True),
+        ((24, 2, 1), ">=22", True),
+        ((22, 0, 0), ">=24", False),
+        ((24, 1, 0), ">=24.1", True),
+        ((24, 0, 9), ">=24.1", False),
+        ((24, 1, 2), ">=24.1.2", True),
+        ((24, 1, 1), ">=24.1.2", False),
+        ((21, 0, 0), ">=20", False),
+        ((22, 0, 0), None, False),
+        ((22, 0, 0), "^22 || ^24", False),
+        ((22, 0, 0), ">=22 <25", False),
+        (None, ">=22", False),
+        pytest.param((22, 0, 0), ">=" + "9" * 5000, False, id="oversized-minimum"),
+    ],
+)
+def test_acp_honors_supported_package_engine_minimums(
+    tmp_path, monkeypatch, version, requirement, compatible
+):
+    locator = installed_clients(tmp_path)
+    package = tmp_path / "lib/node_modules/@agentclientprotocol/claude-agent-acp"
+    write_json(
+        package / "package.json",
+        {
+            "name": "@agentclientprotocol/claude-agent-acp",
+            "bin": {"claude-agent-acp": "dist/index.js"},
+            "engines": {"node": requirement},
+        },
+    )
+    monkeypatch.setattr(
+        type(locator), "_node_version", lambda _self, _node: version, raising=False
+    )
+    assert bool(locator.scan().acp.command) is compatible
+
+
+@pytest.mark.parametrize("ineligible", ["missing_package", "wsl", "ambiguous_package"])
+def test_ineligible_acp_installation_does_not_probe_node(
+    tmp_path, monkeypatch, ineligible
+):
+    locator = installed_clients(tmp_path)
+    if ineligible == "missing_package":
+        (
+            tmp_path
+            / "lib/node_modules/@agentclientprotocol/claude-agent-acp/package.json"
+        ).unlink()
+    elif ineligible == "wsl":
+        locator.environ["WSL_DISTRO_NAME"] = "fixture"
+    else:
+        executable(tmp_path / "bin/claude-agent-acp")
+        write_json(
+            tmp_path
+            / "bin/node_modules/@agentclientprotocol/claude-agent-acp/package.json",
+            {
+                "name": "@agentclientprotocol/claude-agent-acp",
+                "bin": {"claude-agent-acp": "dist/index.js"},
+                "engines": {"node": ">=22"},
+            },
+        )
+        executable(
+            tmp_path
+            / "bin/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js"
+        )
+    monkeypatch.setattr(
+        type(locator),
+        "_node_version",
+        lambda *_a: pytest.fail("must not probe"),
+        raising=False,
+    )
+    assert not locator.scan().acp.command

--- a/tests/runtime/test_integration_discovery.py
+++ b/tests/runtime/test_integration_discovery.py
@@ -1,9 +1,19 @@
+import json
+import os
 import plistlib
+from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
 from free_claude_code.runtime.integrations.discovery import LocalInstallations
-from tests.integration_support import executable, installed_clients, write_json
+from free_claude_code.runtime.integrations.service import IntegrationService
+from tests.integration_support import (
+    connection,
+    executable,
+    installed_clients,
+    write_json,
+)
 
 
 def test_discovery_reads_installed_metadata_without_running_clients(
@@ -58,6 +68,72 @@ def test_standard_settings_paths(tmp_path, platform, suffix):
         (tmp_path / "apps",),
     )
     assert locator.vscode_settings == tmp_path / suffix
+
+
+@pytest.mark.parametrize(
+    "override", [None, "", "relative-data", r"C:relative-data", r"\relative-data"]
+)
+def test_invalid_appdata_uses_absolute_user_roaming_target(tmp_path, override):
+    locator = replace(installed_clients(tmp_path), platform="win32")
+    if override is not None:
+        locator.environ["APPDATA"] = override
+    assert (
+        locator.vscode_settings == tmp_path / "AppData/Roaming/Code/User/settings.json"
+    )
+
+
+def test_absolute_appdata_preserves_relocated_profile(tmp_path):
+    locator = replace(installed_clients(tmp_path), platform="win32")
+    locator.environ["APPDATA"] = str(tmp_path / "relocated")
+    assert locator.vscode_settings == tmp_path / "relocated/Code/User/settings.json"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Native Windows path classification")
+def test_absolute_unc_appdata_is_not_rebased_to_local_home(tmp_path):
+    locator = replace(installed_clients(tmp_path), platform="win32")
+    locator.environ["APPDATA"] = r"\\server\profile\Roaming"
+    assert locator.vscode_settings == Path(
+        r"\\server\profile\Roaming\Code\User\settings.json"
+    )
+
+
+def test_windows_acp_uses_same_roaming_fallback(tmp_path, monkeypatch):
+    locator = replace(installed_clients(tmp_path), platform="win32")
+    locator.environ["APPDATA"] = ""
+    old = (
+        tmp_path / "lib/node_modules/@agentclientprotocol/claude-agent-acp/package.json"
+    )
+    metadata = json.loads(old.read_bytes())
+    old.unlink()
+    package = (
+        tmp_path
+        / "AppData/Roaming/npm/node_modules/@agentclientprotocol/claude-agent-acp"
+    )
+    write_json(package / "package.json", metadata)
+    entry = executable(package / "dist/index.js")
+    monkeypatch.setattr(
+        "free_claude_code.runtime.integrations.discovery.windows_codex_locations",
+        lambda: (),
+    )
+    assert locator.scan().acp.command == (str(tmp_path / "bin/node"), str(entry))
+
+
+@pytest.mark.parametrize("metadata", [[], ["unrelated app"], "unsupported root"])
+def test_unsupported_macos_metadata_does_not_hide_other_client_actions(
+    tmp_path, metadata
+):
+    locator = replace(installed_clients(tmp_path), platform="darwin")
+    contents = tmp_path / "apps/Unrelated.app/Contents"
+    contents.mkdir(parents=True)
+    (contents / "Info.plist").write_bytes(plistlib.dumps(metadata))
+    items = IntegrationService(locator).inspect(connection(tmp_path))["items"]
+    assert isinstance(items, list)
+    repair = next(
+        item
+        for item in items
+        if isinstance(item, dict) and item["id"] == "claude-login"
+    )
+    assert repair["can_apply"] is True
 
 
 def test_macos_app_uses_bundle_identity_and_declared_executable(tmp_path):

--- a/tests/runtime/test_integration_discovery.py
+++ b/tests/runtime/test_integration_discovery.py
@@ -1,0 +1,119 @@
+import plistlib
+
+import pytest
+
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from tests.integration_support import executable, installed_clients, write_json
+
+
+def test_discovery_reads_installed_metadata_without_running_clients(
+    tmp_path, monkeypatch
+):
+    locator = installed_clients(tmp_path)
+    monkeypatch.setattr(
+        "subprocess.run", lambda *_a, **_kw: pytest.fail("must not launch a client")
+    )
+    snapshot = locator.scan()
+    assert snapshot.claude_vscode and snapshot.codex_vscode and snapshot.codex_app
+    assert snapshot.jetbrains and snapshot.acp_command
+    assert snapshot.fcc_command == tmp_path / "bin/fcc-codex"
+
+
+def test_stray_extension_directory_does_not_count_as_profile_installation(tmp_path):
+    locator = installed_clients(tmp_path)
+    (tmp_path / ".vscode/extensions/extensions.json").unlink()
+    snapshot = locator.scan()
+    assert not snapshot.claude_vscode and not snapshot.codex_vscode
+
+
+def test_index_requires_matching_package_identity_and_existing_entrypoint(tmp_path):
+    locator = installed_clients(tmp_path)
+    write_json(
+        tmp_path / ".vscode/extensions/anthropic.claude-code-1.0.0/package.json",
+        {"publisher": "wrong", "name": "claude-code"},
+    )
+    (
+        tmp_path
+        / "lib/node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js"
+    ).unlink()
+    snapshot = locator.scan()
+    assert not snapshot.claude_vscode
+    assert not snapshot.acp_command
+
+
+@pytest.mark.parametrize(
+    "platform,suffix",
+    [
+        ("win32", "AppData/Roaming/Code/User/settings.json"),
+        ("darwin", "Library/Application Support/Code/User/settings.json"),
+        ("linux", ".config/Code/User/settings.json"),
+    ],
+)
+def test_standard_settings_paths(tmp_path, platform, suffix):
+    locator = LocalInstallations(
+        tmp_path,
+        platform,
+        {"APPDATA": str(tmp_path / "AppData/Roaming")},
+        tmp_path / "bin",
+        (tmp_path / "apps",),
+    )
+    assert locator.vscode_settings == tmp_path / suffix
+
+
+def test_macos_app_uses_bundle_identity_and_declared_executable(tmp_path):
+    bundle = tmp_path / "apps/ChatGPT.app/Contents"
+    executable(bundle / "MacOS/ChatGPT")
+    (bundle / "Info.plist").write_bytes(
+        plistlib.dumps(
+            {"CFBundleIdentifier": "com.openai.codex", "CFBundleExecutable": "ChatGPT"}
+        )
+    )
+    locator = LocalInstallations(
+        tmp_path, "darwin", {}, tmp_path / "bin", (tmp_path / "apps",)
+    )
+    assert locator.scan().codex_app
+    (bundle / "MacOS/ChatGPT").unlink()
+    assert not locator.scan().codex_app
+
+
+def test_windows_app_uses_package_declared_executable(tmp_path, monkeypatch):
+    package = tmp_path / "WindowsApps/OpenAI.Codex"
+    executable(package / "app/ChatGPT.exe")
+    (package / "AppxManifest.xml").write_text(
+        '<Package><Identity Name="OpenAI.Codex"/><Applications><Application Executable="app/ChatGPT.exe"/></Applications></Package>'
+    )
+    monkeypatch.setattr(
+        "free_claude_code.runtime.integrations.discovery.windows_codex_locations",
+        lambda: (package,),
+    )
+    locator = LocalInstallations(
+        tmp_path, "win32", {}, tmp_path / "bin", (tmp_path / "apps",)
+    )
+    assert locator.scan().codex_app
+
+
+def test_wsl_scope_is_reported_without_configuring_another_environment(tmp_path):
+    locator = installed_clients(tmp_path)
+    locator.environ["WSL_DISTRO_NAME"] = "Ubuntu"
+    assert "WSL" in locator.scan().scope_issue
+
+
+def test_discovery_does_not_create_missing_settings_or_state(tmp_path):
+    locator = LocalInstallations(
+        tmp_path, "linux", {}, tmp_path / "bin", (tmp_path / "apps",)
+    )
+    assert not locator.scan().claude_vscode
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_installed_helper_symlink_resolves_to_its_executable(tmp_path):
+    locator = installed_clients(tmp_path)
+    helper = tmp_path / "bin/fcc-codex"
+    helper.unlink()
+    actual = tmp_path / "tool/bin/fcc-codex"
+    executable(actual)
+    try:
+        helper.symlink_to(actual)
+    except OSError:
+        pytest.skip("Symlink creation is not permitted on this host")
+    assert locator.scan().fcc_command == actual

--- a/tests/runtime/test_integration_documents.py
+++ b/tests/runtime/test_integration_documents.py
@@ -1,0 +1,189 @@
+"""Edits to client configuration preserve text outside the requested settings."""
+
+import pytest
+
+from free_claude_code.application.integrations import IntegrationError
+from free_claude_code.runtime.integrations.documents import (
+    MISSING,
+    JsonDocument,
+    TomlDocument,
+)
+
+
+def test_jsonc_value_change_preserves_bom_unicode_crlf_and_comments():
+    source = '\ufeff{\r\n  // keep\r\n  "unrelated": "é",\r\n  "owned": "old", /* keep */\r\n}\r\n'.encode()
+    document = JsonDocument(source, jsonc=True)
+    document.set(("owned",), "new")
+    assert document.render() == source.replace(b'"old"', b'"new"')
+    assert document.get(("unrelated",)) == "é"
+
+
+@pytest.mark.parametrize("trailing", ["", ","])
+def test_insertion_keeps_line_comment_attached_to_existing_value(trailing):
+    source = f'{{\n  "keep": 1{trailing} // keep this comment\n}}'.encode()
+    document = JsonDocument(source, jsonc=True)
+    document.set(("owned",), True)
+    result = document.render()
+    assert b'"keep": 1, // keep this comment' in result
+    assert document.get(("owned",)) is True
+    assert result.endswith(b"}")
+
+
+@pytest.mark.parametrize("source", [b"{}", b"{ /* keep */ }", b"{\n// keep\n}"])
+def test_add_nested_property_to_empty_or_comment_only_object(source):
+    document = JsonDocument(source, jsonc=True)
+    document.set(("agent_servers", "Claude Code (FCC)", "env", "TOKEN"), "test")
+    assert (
+        document.get(("agent_servers", "Claude Code (FCC)", "env", "TOKEN")) == "test"
+    )
+    assert source.strip(b"{} \n") in document.render()
+
+
+@pytest.mark.parametrize("index", [0, 1, 2])
+@pytest.mark.parametrize("trailing", ["", ","])
+def test_array_removal_keeps_other_entries_and_comments(index, trailing):
+    source = (
+        '{"env": [ {"name":"A","value":"a"}, /* keep */ '
+        '{"name":"B","value":"b"}, {"name":"C","value":"c"}' + trailing + " ]}"
+    ).encode()
+    document = JsonDocument(source, jsonc=True)
+    document.delete(("env", index))
+    expected = [{"name": name, "value": name.lower()} for name in "ABC"]
+    expected.pop(index)
+    assert document.get(("env",)) == expected
+    assert b"/* keep */" in document.render()
+    for entry in expected:
+        assert (
+            f'{{"name":"{entry["name"]}","value":"{entry["value"]}"}}'.encode()
+            in document.render()
+        )
+
+
+@pytest.mark.parametrize(
+    "source", [b'{"owned":true}', b'{"owned":true,}', b'{"owned":true, // keep\n}']
+)
+def test_delete_only_property_leaves_valid_object(source):
+    document = JsonDocument(source, jsonc=True)
+    document.delete(("owned",))
+    assert document.data == {}
+    if b"// keep" in source:
+        assert b"// keep" in document.render()
+
+
+def test_array_append_and_nested_value_edit_preserve_other_values():
+    document = JsonDocument(
+        '{"env":[{"name":"KEEP", "value":"é"},]}'.encode(), jsonc=True
+    )
+    document.set(("env", 1), {"name": "FCC", "value": "old"})
+    document.set(("env", 1, "value"), "new")
+    assert document.get(("env", 1, "value")) == "new"
+    assert b'{"name":"KEEP", "value":"\xc3\xa9"}' in document.render()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        b"{,}",
+        b"[1,,]",
+        b'{"a":01}',
+        b"{} {}",
+        b'{"a":NaN}',
+        b'{"a":}',
+        b'{"a": /* unclosed',
+        b"{a:1}",
+    ],
+)
+def test_jsonc_rejects_invalid_syntax(source):
+    with pytest.raises(IntegrationError):
+        JsonDocument(source, jsonc=True)
+
+
+@pytest.mark.parametrize("source", [b'{"a":1,}', b'{/* comment */"a":1}'])
+def test_strict_json_does_not_accept_jsonc_extensions(source):
+    with pytest.raises(IntegrationError):
+        JsonDocument(source, jsonc=False)
+
+
+def test_duplicate_owned_key_is_rejected_without_exposing_values():
+    document = JsonDocument(
+        b'{"owned":"secret-a","owned":"secret-b","keep":1}', jsonc=True
+    )
+    with pytest.raises(IntegrationError) as error:
+        document.set(("owned",), "new")
+    assert "secret" not in str(error.value)
+    assert document.render() == b'{"owned":"secret-a","owned":"secret-b","keep":1}'
+
+
+def test_unrelated_duplicate_keys_are_preserved_but_owned_parent_is_ambiguous():
+    document = JsonDocument(b'{"keep":1,"keep":2,"owned":false}', jsonc=True)
+    document.set(("owned",), True)
+    assert document.render() == b'{"keep":1,"keep":2,"owned":true}'
+    document = JsonDocument(b'{"env":{},"env":{}}', jsonc=True)
+    with pytest.raises(IntegrationError):
+        document.set(("env", "key"), "value")
+
+
+def test_noop_json_edit_is_byte_identical_and_missing_delete_is_safe():
+    source = b'{ "owned": true, "keep": "slash\\/value" }'
+    document = JsonDocument(source, jsonc=True)
+    document.set(("owned",), True)
+    document.delete(("absent",))
+    assert document.get(("absent",)) is MISSING
+    assert document.render() == source
+
+
+def test_append_at_immediate_closing_delimiter_orders_separator_before_entry():
+    document = JsonDocument(b'{"one":true}', jsonc=True)
+    document.set(("two",), [])
+    document.set(("two", 0), "first")
+    document.set(("two", 1), "second")
+    assert document.data == {"one": True, "two": ["first", "second"]}
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_toml_changes_one_value_without_reformatting_other_tables(newline):
+    source = newline.join(
+        [
+            "# keep",
+            'model = "old" # model',
+            "[model_providers.other]",
+            'name = "Other"',
+            "",
+        ]
+    ).encode()
+    document = TomlDocument(source)
+    document.set(("model",), "new")
+    assert document.render() == source.replace(b'"old"', b'"new"')
+    document.set(
+        ("model_providers", "fcc", "auth", "args"), ["--print-proxy-auth-token"]
+    )
+    assert document.get(("model_providers", "other", "name")) == "Other"
+
+
+def test_toml_inline_tables_and_deletion_preserve_other_provider():
+    document = TomlDocument(
+        b'[model_providers]\nfcc = { name = "Old", auth = {command="old"} }\nother = {name="Keep"}\n'
+    )
+    document.set(("model_providers", "fcc", "auth", "command"), "fcc-codex")
+    document.delete(("model_providers", "fcc", "name"))
+    assert document.get(("model_providers", "fcc", "auth", "command")) == "fcc-codex"
+    assert b'other = {name="Keep"}' in document.render()
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        JsonDocument(b'{"env": "wrong"}', jsonc=True),
+        TomlDocument(b'model_providers = "wrong"\n'),
+    ],
+)
+def test_incompatible_container_cannot_be_replaced_as_a_side_effect(document):
+    path = (
+        ("env", "key")
+        if isinstance(document, JsonDocument)
+        else ("model_providers", "fcc", "name")
+    )
+    before = document.render()
+    with pytest.raises(IntegrationError):
+        document.set(path, "new")
+    assert document.render() == before

--- a/tests/runtime/test_integration_documents.py
+++ b/tests/runtime/test_integration_documents.py
@@ -1,6 +1,8 @@
 """Edits to client configuration preserve text outside the requested settings."""
 
 import pytest
+import tomlkit
+from tomlkit.exceptions import TOMLKitError
 
 from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.runtime.integrations.documents import (
@@ -171,6 +173,40 @@ def test_toml_inline_tables_and_deletion_preserve_other_provider():
 
 
 @pytest.mark.parametrize(
+    "source",
+    [
+        b'model_providers.fcc.name="Old"\nmodel_providers.other.name="Keep"\n',
+        b'[model_providers]\nfcc={name="Old"}\nother={name="Keep"}\n',
+        b'model_providers={fcc.name="Old", other.name="Keep"}\n',
+    ],
+)
+def test_missing_auth_preserves_dotted_and_inline_provider_scope(source):
+    document = TomlDocument(source)
+    document.set(("model_providers", "fcc", "auth", "command"), "fcc-codex")
+    document.set(("model_provider",), "fcc")
+    assert document.data == {
+        "model_providers": {
+            "fcc": {"name": "Old", "auth": {"command": "fcc-codex"}},
+            "other": {"name": "Keep"},
+        },
+        "model_provider": "fcc",
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        b'model_providers.fcc.name="Old"\nmodel_providers.other.name="Keep"\n',
+        b'model_providers={fcc.name="Old", other.name="Keep"}\n',
+    ],
+)
+def test_deleting_final_dotted_leaf_preserves_its_empty_parent(source):
+    document = TomlDocument(source)
+    document.delete(("model_providers", "fcc", "name"))
+    assert document.data == {"model_providers": {"fcc": {}, "other": {"name": "Keep"}}}
+
+
+@pytest.mark.parametrize(
     "document",
     [
         JsonDocument(b'{"env": "wrong"}', jsonc=True),
@@ -187,3 +223,83 @@ def test_incompatible_container_cannot_be_replaced_as_a_side_effect(document):
     with pytest.raises(IntegrationError):
         document.set(path, "new")
     assert document.render() == before
+
+
+@pytest.mark.parametrize(
+    "original,corrupted",
+    [
+        ("keep=true", "keep=1"),
+        ("keep=1.00000000000000001", "keep=1.00000000000000002"),
+        ("keep=1979-05-27T07:32:00Z", "keep=1979-05-27T00:32:00-07:00"),
+        ('keep={nested=[true, "same"]}', 'keep={nested=[1, "same"]}'),
+    ],
+)
+def test_toml_rejects_parseable_unrelated_semantic_changes(
+    monkeypatch, original, corrupted
+):
+    source = f'owned="old"\n{original}\n'.encode()
+    document = TomlDocument(source)
+    actual_dumps = tomlkit.dumps
+    monkeypatch.setattr(
+        tomlkit,
+        "dumps",
+        lambda candidate: actual_dumps(candidate).replace(original, corrupted),
+    )
+    with pytest.raises(IntegrationError):
+        document.set(("owned",), "new")
+    assert document.render() == source
+    assert document.get(("owned",)) == "old"
+
+
+def test_json_rejects_serializer_changes_to_unrelated_values(monkeypatch):
+    source = b'{"keep":1,"owned":"old"}'
+    document = JsonDocument(source, jsonc=False)
+    monkeypatch.setattr(
+        "free_claude_code.runtime.integrations.documents.json.dumps",
+        lambda *_args, **_kwargs: '"new", "keep": 2',
+    )
+    with pytest.raises(IntegrationError):
+        document.set(("owned",), "new")
+    assert document.render() == source
+    assert document.data == {"keep": 1, "owned": "old"}
+
+
+@pytest.mark.parametrize("kind", ["json", "toml"])
+def test_nested_boolean_to_integer_is_not_treated_as_a_noop(kind):
+    document = (
+        JsonDocument(b'{"owned":{"inner":true}}', jsonc=False)
+        if kind == "json"
+        else TomlDocument(b"owned={inner=true}\n")
+    )
+    document.set(("owned",), {"inner": 1})
+    assert type(document.get(("owned", "inner"))) is int
+
+
+@pytest.mark.parametrize("error_type", [ValueError, TOMLKitError])
+def test_toml_dump_errors_are_sanitized_without_adopting_changes(
+    monkeypatch, error_type
+):
+    source = b'owned="old"\n'
+    document = TomlDocument(source)
+
+    def fail_dump(_candidate):
+        raise error_type("private contents")
+
+    monkeypatch.setattr(tomlkit, "dumps", fail_dump)
+    with pytest.raises(IntegrationError) as caught:
+        document.set(("owned",), "new")
+    assert "private contents" not in str(caught.value)
+    assert document.render() == source
+
+
+def test_toml_preserves_unrelated_nonfinite_exact_numbers_dates_and_arrays():
+    source = (
+        'owned="old"\r\n'
+        "numbers=[nan,-nan,+inf,-inf,1.00000000000000001]\r\n"
+        "day=1979-05-27\r\nclock=07:32:00.123\r\n"
+        "stamp=1979-05-27T07:32:00-07:00\r\n"
+        'mixed=[true,1,"é",{name="keep"}] # untouched\r\n'
+    ).encode()
+    document = TomlDocument(source)
+    document.set(("owned",), "new")
+    assert document.render() == source.replace(b'"old"', b'"new"')

--- a/tests/runtime/test_integration_documents.py
+++ b/tests/runtime/test_integration_documents.py
@@ -41,37 +41,6 @@ def test_add_nested_property_to_empty_or_comment_only_object(source):
     assert source.strip(b"{} \n") in document.render()
 
 
-@pytest.mark.parametrize("index", [0, 1, 2])
-@pytest.mark.parametrize("trailing", ["", ","])
-def test_array_removal_keeps_other_entries_and_comments(index, trailing):
-    source = (
-        '{"env": [ {"name":"A","value":"a"}, /* keep */ '
-        '{"name":"B","value":"b"}, {"name":"C","value":"c"}' + trailing + " ]}"
-    ).encode()
-    document = JsonDocument(source, jsonc=True)
-    document.delete(("env", index))
-    expected = [{"name": name, "value": name.lower()} for name in "ABC"]
-    expected.pop(index)
-    assert document.get(("env",)) == expected
-    assert b"/* keep */" in document.render()
-    for entry in expected:
-        assert (
-            f'{{"name":"{entry["name"]}","value":"{entry["value"]}"}}'.encode()
-            in document.render()
-        )
-
-
-@pytest.mark.parametrize(
-    "source", [b'{"owned":true}', b'{"owned":true,}', b'{"owned":true, // keep\n}']
-)
-def test_delete_only_property_leaves_valid_object(source):
-    document = JsonDocument(source, jsonc=True)
-    document.delete(("owned",))
-    assert document.data == {}
-    if b"// keep" in source:
-        assert b"// keep" in document.render()
-
-
 def test_array_append_and_nested_value_edit_preserve_other_values():
     document = JsonDocument(
         '{"env":[{"name":"KEEP", "value":"é"},]}'.encode(), jsonc=True
@@ -125,11 +94,10 @@ def test_unrelated_duplicate_keys_are_preserved_but_owned_parent_is_ambiguous():
         document.set(("env", "key"), "value")
 
 
-def test_noop_json_edit_is_byte_identical_and_missing_delete_is_safe():
+def test_noop_json_edit_is_byte_identical():
     source = b'{ "owned": true, "keep": "slash\\/value" }'
     document = JsonDocument(source, jsonc=True)
     document.set(("owned",), True)
-    document.delete(("absent",))
     assert document.get(("absent",)) is MISSING
     assert document.render() == source
 

--- a/tests/runtime/test_integration_node.py
+++ b/tests/runtime/test_integration_node.py
@@ -1,0 +1,159 @@
+"""The Node version probe runs controlled fixture processes, never installed clients."""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from tests.integration_support import executable
+
+
+@pytest.fixture
+def version_probe(tmp_path, monkeypatch):
+    node = executable(tmp_path / ("node.exe" if sys.platform == "win32" else "node"))
+    node.write_bytes(
+        b"MZ\x00\x00"
+        if sys.platform == "win32"
+        else b"\xcf\xfa\xed\xfe"
+        if sys.platform == "darwin"
+        else b"\x7fELF"
+    )
+    locator = LocalInstallations(
+        tmp_path,
+        sys.platform,
+        {
+            **os.environ,
+            "NODE_OPTIONS": "--require private-module",
+            "NODE_REPL_HISTORY": "private-path",
+            "LD_PRELOAD": "private-library",
+            "DYLD_INSERT_LIBRARIES": "private-library",
+            "PATH": "private-path",
+        },
+        tmp_path,
+        (),
+    )
+    actual_popen = subprocess.Popen
+    children = []
+
+    def probe(script):
+        def spawn(argv, **kwargs):
+            assert argv == [str(node), "--version"]
+            assert kwargs["shell"] is False
+            assert kwargs["stdin"] == subprocess.DEVNULL
+            assert kwargs["stderr"] == subprocess.DEVNULL
+            assert kwargs["cwd"] == tmp_path
+            assert {key.upper() for key in kwargs["env"]} <= {
+                "SYSTEMROOT",
+                "WINDIR",
+                "SYSTEMDRIVE",
+                "LANG",
+                "LC_ALL",
+            }
+            if sys.platform == "win32":
+                assert kwargs["creationflags"] & subprocess.CREATE_NO_WINDOW
+                assert any(key.upper() == "SYSTEMROOT" for key in kwargs["env"])
+            child = actual_popen([sys.executable, "-c", script], **kwargs)
+            children.append(child)
+            return child
+
+        monkeypatch.setattr(subprocess, "Popen", spawn)
+        result = locator._node_version(node)
+        assert len(children) == 1
+        assert children[0].poll() is not None
+        return result
+
+    yield probe
+    for child in children:
+        if child.poll() is None:
+            child.kill()
+        child.wait(timeout=5)
+
+
+@pytest.mark.parametrize(
+    "output,exit_code,expected",
+    [
+        (b"v22.20.0\n", 0, (22, 20, 0)),
+        (b"v24.1.2\r\n", 0, (24, 1, 2)),
+        (b"v22.20.0\n", 1, None),
+        (b"v22.20.0", 0, None),
+        (b"v22.20.0\nv24.0.0\n", 0, None),
+        (b"v22.20.0-nightly\n", 0, None),
+        (b"Version 22\n", 0, None),
+        (b"\xff\n", 0, None),
+    ],
+)
+def test_node_probe_accepts_only_one_successful_complete_version(
+    version_probe, output, exit_code, expected
+):
+    assert (
+        version_probe(
+            f"import sys; sys.stdout.buffer.write({output!r}); sys.exit({exit_code})"
+        )
+        == expected
+    )
+
+
+def test_node_probe_reads_a_version_split_across_pipe_writes(version_probe):
+    assert version_probe(
+        "import sys,time; sys.stdout.write('v22.'); sys.stdout.flush(); "
+        "time.sleep(0.05); sys.stdout.write('20.0\\n')"
+    ) == (22, 20, 0)
+
+
+def test_node_probe_terminates_and_reaps_an_unresponsive_process(version_probe):
+    started = time.monotonic()
+    assert version_probe("import time; time.sleep(15)") is None
+    assert time.monotonic() - started < 5
+
+
+def test_node_probe_stops_after_excess_output_instead_of_buffering_it(version_probe):
+    started = time.monotonic()
+    assert (
+        version_probe(
+            "import sys,time; sys.stdout.buffer.write(b'x'*1000000); "
+            "sys.stdout.flush(); time.sleep(15)"
+        )
+        is None
+    )
+    assert time.monotonic() - started < 5
+
+
+@pytest.mark.parametrize(
+    "platform,header",
+    [("win32", b"MZ00"), ("linux", b"\x7fELF"), ("darwin", b"\xcf\xfa\xed\xfe")],
+)
+@pytest.mark.parametrize("location", ["script", "shims", "volta", "custom_volta"])
+def test_node_wrappers_and_manager_shims_are_rejected_without_execution(
+    tmp_path, monkeypatch, platform, header, location
+):
+    name = "node.exe" if platform == "win32" else "node"
+    directories = {
+        "script": tmp_path,
+        "shims": tmp_path / "shims",
+        "volta": tmp_path / ".volta/bin",
+        "custom_volta": tmp_path / "custom-tools/bin",
+    }
+    node = executable(directories[location] / name)
+    node.write_bytes(b"#!/bin/sh\n" if location == "script" else header)
+    locator = LocalInstallations(
+        tmp_path, platform, {"VOLTA_HOME": str(tmp_path / "custom-tools")}, tmp_path, ()
+    )
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda *_a, **_kw: pytest.fail("wrapper must not execute")
+    )
+    assert locator._node_version(node) is None
+
+
+def test_node_probe_execution_error_is_an_unknown_version(tmp_path, monkeypatch):
+    node = executable(tmp_path / "node")
+    node.write_bytes(b"\x7fELF")
+    locator = LocalInstallations(tmp_path, "linux", {}, tmp_path, ())
+
+    def unavailable(*_args, **_kwargs):
+        raise OSError("private process error")
+
+    monkeypatch.setattr(subprocess, "Popen", unavailable)
+    assert locator._node_version(node) is None

--- a/tests/runtime/test_integrations.py
+++ b/tests/runtime/test_integrations.py
@@ -4,13 +4,13 @@ import json
 import tomllib
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
+from pathlib import Path
 from threading import Barrier
 
 import pytest
 import tomlkit
 from tomlkit.exceptions import TOMLKitError
 
-from free_claude_code.application.integrations import IntegrationAction as Action
 from free_claude_code.application.integrations import IntegrationError
 from free_claude_code.application.integrations import IntegrationId as Item
 from free_claude_code.runtime.integrations import service as service_module
@@ -26,103 +26,323 @@ def setup(tmp_path):
     return IntegrationService(locator), locator, connection(tmp_path)
 
 
-def perform(service, ctx, item, action):
-    preview = service.preview(item, action, ctx)
-    return service.apply(item, action, preview["revision"], ctx)
+def perform(service, ctx, item):
+    preview = service.preview(item, ctx)
+    return service.apply(item, preview["revision"], ctx)
 
 
 def card(service, ctx, item):
     return next(entry for entry in service.inspect(ctx)["items"] if entry["id"] == item)
 
 
+def test_reapply_overwrites_edited_connection_leaves_and_keeps_other_settings(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CLAUDE_VSCODE)
+    document = JsonDocument(locator.vscode_settings.read_bytes(), jsonc=True)
+    document.set(("claudeCode.disableLoginPrompt",), "wrong-type")
+    document.set(("editor.fontSize",), 19)
+    locator.vscode_settings.write_bytes(
+        document.render().replace(b"fixture-proxy-token", b"manual-token")
+    )
+    changed = connection(locator.home, port=8182, token="new-token")
+    perform(service, changed, Item.CLAUDE_VSCODE)
+    data = json.loads(locator.vscode_settings.read_bytes())
+    assert data["editor.fontSize"] == 19
+    assert data["claudeCode.disableLoginPrompt"] is True
+    environment = {
+        entry["name"]: entry["value"]
+        for entry in data["claudeCode.environmentVariables"]
+    }
+    assert environment["ANTHROPIC_AUTH_TOKEN"] == "new-token"
+    assert environment["ANTHROPIC_BASE_URL"] == changed.url
+
+
+def test_apply_ignores_old_journal_and_never_writes_history(setup):
+    service, locator, ctx = setup
+    journal = locator.home / ".fcc/integrations/claude-vscode.json"
+    write_json(journal, {"unreadable": "old development history"})
+    original = journal.read_bytes()
+    perform(service, ctx, Item.CLAUDE_VSCODE)
+    assert journal.read_bytes() == original
+    perform(service, ctx, Item.CODEX)
+    assert not (journal.parent / "codex.json").exists()
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ('model_provider="fcc"\nmodel="chosen/model"\n', "chosen/model"),
+        ('model_provider="fcc"\n', "test/model"),
+        ('model_provider="fcc"\nmodel=""\n', "test/model"),
+        ('model_provider="fcc"\nmodel=123\n', "test/model"),
+        ('model_provider="other"\nmodel="old/model"\n', "test/model"),
+    ],
+)
+def test_apply_uses_current_provider_to_choose_model(setup, source, expected):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(source)
+    perform(service, ctx, Item.CODEX)
+    assert tomllib.loads(path.read_text())["model"] == expected
+
+
+@pytest.mark.parametrize(
+    "source", [b"{broken", b'{"chatgpt.runCodexInWindowsSubsystemForLinux":"false"}']
+)
+def test_unknown_extension_mode_blocks_extension_only_apply(setup, source):
+    service, locator, ctx = setup
+    (locator.home / "bin/chatgpt").unlink()
+    locator.vscode_settings.parent.mkdir(parents=True)
+    locator.vscode_settings.write_bytes(source)
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CODEX, ctx)
+
+
+def test_independent_codex_app_does_not_read_optional_vscode_settings(
+    setup, monkeypatch
+):
+    service, locator, ctx = setup
+    installed = replace(locator.scan(), codex_app=True)
+    monkeypatch.setattr(type(locator), "scan", lambda _self: installed)
+    actual_read = service_module.FileSnapshot.read
+
+    def required_read(path):
+        if path == locator.vscode_settings:
+            raise IntegrationError("Optional VS Code settings are unreadable")
+        return actual_read(path)
+
+    monkeypatch.setattr(service_module.FileSnapshot, "read", required_read)
+    perform(service, ctx, Item.CODEX)
+    entry = card(service, ctx, Item.CODEX)
+    assert entry["can_apply"] is True
+    assert entry["status"] == "configured"
+    assert str(locator.vscode_settings) in entry["message"]
+    assert "unavailable" in entry["message"]
+
+
+@pytest.mark.parametrize("item", list(Item))
+def test_matching_file_is_a_noop_without_atomic_replacement(setup, monkeypatch, item):
+    service, locator, ctx = setup
+    perform(service, ctx, item)
+    preview = service.preview(item, ctx)
+    path = Path(preview["path"])
+    before = storage_module.FileSnapshot.read(path)
+    assert preview["writes_file"] is False
+    assert card(service, ctx, item)["status"] == "configured"
+    assert card(service, ctx, item)["can_apply"] is True
+    monkeypatch.setattr(
+        service_module,
+        "atomic_write",
+        lambda *_args, **_kwargs: pytest.fail("No-op replaced a file"),
+    )
+    assert perform(service, ctx, item)["applied"] is False
+    assert storage_module.FileSnapshot.read(path) == before
+    assert not (locator.home / f".fcc/integrations/{item}.json").exists()
+
+
+@pytest.mark.parametrize("has_app", [True, False])
+def test_only_required_vscode_changes_stale_codex_confirmation(setup, has_app):
+    service, locator, ctx = setup
+    if not has_app:
+        (locator.home / "bin/chatgpt").unlink()
+    write_json(locator.vscode_settings, {"editor.fontSize": 16})
+    preview = service.preview(Item.CODEX, ctx)
+    write_json(locator.vscode_settings, {"editor.fontSize": 20})
+    if has_app:
+        assert service.apply(Item.CODEX, preview["revision"], ctx)["applied"] is True
+    else:
+        with pytest.raises(IntegrationError, match="changed since this preview"):
+            service.apply(Item.CODEX, preview["revision"], ctx)
+        assert not (locator.home / ".codex/config.toml").exists()
+
+
+@pytest.mark.parametrize(
+    "source", [None, b"{}", b'{"chatgpt.runCodexInWindowsSubsystemForLinux":false}']
+)
+def test_extension_only_native_evidence_allows_apply(setup, source):
+    service, locator, ctx = setup
+    (locator.home / "bin/chatgpt").unlink()
+    if source is not None:
+        locator.vscode_settings.parent.mkdir(parents=True)
+        locator.vscode_settings.write_bytes(source)
+    assert perform(service, ctx, Item.CODEX)["applied"] is True
+
+
+def test_extension_only_unreadable_settings_never_imply_native_support(
+    setup, monkeypatch
+):
+    service, locator, ctx = setup
+    (locator.home / "bin/chatgpt").unlink()
+    actual_read = service_module.FileSnapshot.read
+
+    def unreadable_settings(path):
+        if path == locator.vscode_settings:
+            raise IntegrationError("Could not read settings")
+        return actual_read(path)
+
+    monkeypatch.setattr(service_module.FileSnapshot, "read", unreadable_settings)
+    entry = card(service, ctx, Item.CODEX)
+    assert entry["can_apply"] is False
+    assert str(locator.vscode_settings) in entry["message"]
+    with pytest.raises(IntegrationError, match="Could not read"):
+        service.preview(Item.CODEX, ctx)
+
+
+def test_app_with_malformed_optional_settings_can_reapply(setup):
+    service, locator, ctx = setup
+    assert locator.scan().codex_app is True
+    locator.vscode_settings.parent.mkdir(parents=True)
+    locator.vscode_settings.write_bytes(b'{"editor.fontSize":}')
+    preview = service.preview(Item.CODEX, ctx)
+    locator.vscode_settings.write_bytes(b'{"different-malformed":}')
+    assert service.apply(Item.CODEX, preview["revision"], ctx)["applied"] is True
+    assert card(service, ctx, Item.CODEX)["can_apply"] is True
+
+
+def test_jetbrains_apply_merges_existing_named_agent_without_ownership_gate(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".jetbrains/acp.json"
+    write_json(
+        path,
+        {
+            "agent_servers": {
+                "Other": {"command": "keep"},
+                "Claude Code (FCC)": {
+                    "command": 3,
+                    "args": False,
+                    "custom": "keep",
+                    "env": {"EXTRA": "keep", "ANTHROPIC_AUTH_TOKEN": 123},
+                },
+            }
+        },
+    )
+    perform(service, ctx, Item.CLAUDE_JETBRAINS)
+    agents = json.loads(path.read_bytes())["agent_servers"]
+    assert agents["Other"] == {"command": "keep"}
+    assert agents["Claude Code (FCC)"]["custom"] == "keep"
+    assert agents["Claude Code (FCC)"]["env"]["EXTRA"] == "keep"
+    assert (
+        agents["Claude Code (FCC)"]["env"]["ANTHROPIC_AUTH_TOKEN"]
+        == ctx.settings.proxy_auth_token
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'model_providers = {fcc={name="Original", env_key="OLD", experimental_bearer_token="SECRET"}, other={name="Keep"}}\n',
+        'model_provider="other"\nmodel_providers = {fcc.name="Original", fcc.auth.command="original-helper", fcc.env_key="OLD", fcc.experimental_bearer_token="SECRET", other.name="Keep"}\n',
+        'model_providers.fcc.auth.command="old"\nmodel_providers.fcc.env_key="OLD"\nmodel_providers.fcc.experimental_bearer_token="SECRET"\nmodel_providers.other.name="Keep"\n',
+        '[model_providers.fcc.auth]\nargs=["old"]\n[model_providers.fcc]\nname="Original"\nenv_key="OLD"\nexperimental_bearer_token="SECRET"\n[model_providers.other]\nname="Keep"\n',
+        '[model_providers]\nother.name="Keep"\nfcc.name="Original"\nfcc.auth={command="old",args=["old"]}\nfcc.env_key="OLD"\nfcc.experimental_bearer_token="SECRET"\n',
+    ],
+)
+def test_codex_apply_and_reapply_preserve_other_provider_across_layouts(setup, source):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(source)
+    for current in (ctx, connection(locator.home, port=8182)):
+        perform(service, current, Item.CODEX)
+        data = tomllib.loads(path.read_text())
+        assert data["model_providers"]["other"] == {"name": "Keep"}
+        fcc = data["model_providers"]["fcc"]
+        assert fcc["base_url"] == current.url + "/v1"
+        assert "env_key" not in fcc and "experimental_bearer_token" not in fcc
+        assert fcc["auth"]["args"] == ["--print-proxy-auth-token"]
+
+
+@pytest.mark.parametrize("value", ["false", "true", '"incorrect"'])
+def test_codex_only_preserves_explicit_false_openai_auth(setup, value):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(f"[model_providers.fcc]\nrequires_openai_auth={value}\n")
+    perform(service, ctx, Item.CODEX)
+    fcc = tomllib.loads(path.read_text())["model_providers"]["fcc"]
+    if value == "false":
+        assert fcc["requires_openai_auth"] is False
+    else:
+        assert "requires_openai_auth" not in fcc
+
+
+def test_atomic_write_rejects_relative_target_without_creating_a_file(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(IntegrationError, match="absolute"):
+        storage_module.atomic_write(Path("wrong/config.json"), b"{}")
+    assert not (tmp_path / "wrong").exists()
+
+
 def test_inspection_and_preview_do_not_write_configuration_or_ownership(setup):
     service, locator, ctx = setup
     before = set(locator.home.rglob("*"))
     assert len(service.inspect(ctx)["items"]) == 4
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
-    assert preview["changes"]
+    preview = service.preview(Item.CLAUDE_VSCODE, ctx)
+    assert preview["writes_file"]
     assert set(locator.home.rglob("*")) == before
     assert ctx.settings.proxy_auth_token not in json.dumps(preview)
 
 
-def test_vscode_setup_update_disconnect_restore_originals_and_unrelated_edits(setup):
+def test_vscode_apply_reapply_preserves_unrelated_edits(setup):
     service, locator, ctx = setup
     original = b'{\n // keep\n "editor.fontSize":15,\n "claudeCode.disableLoginPrompt":false,\n "claudeCode.environmentVariables":[{"name":"KEEP","value":"mine"},{"name":"ANTHROPIC_BASE_URL","value":"https://previous.example"}]\n}'
     locator.vscode_settings.parent.mkdir(parents=True)
     locator.vscode_settings.write_bytes(original)
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    perform(service, ctx, Item.CLAUDE_VSCODE)
     document = JsonDocument(locator.vscode_settings.read_bytes(), jsonc=True)
     assert document.get(("claudeCode.disableLoginPrompt",)) is True
     document.set(("editor.fontSize",), 20)
     locator.vscode_settings.write_bytes(document.render())
     changed = connection(locator.home, port=8182, token="new-token")
-    assert card(service, changed, Item.CLAUDE_VSCODE)["status"] == "update_available"
-    perform(service, changed, Item.CLAUDE_VSCODE, Action.UPDATE)
-    result = perform(service, changed, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    assert card(service, changed, Item.CLAUDE_VSCODE)["status"] == "not_configured"
+    perform(service, changed, Item.CLAUDE_VSCODE)
     restored = JsonDocument(locator.vscode_settings.read_bytes(), jsonc=True)
-    assert restored.get(("claudeCode.environmentVariables",)) == [
-        {"name": "KEEP", "value": "mine"},
-        {"name": "ANTHROPIC_BASE_URL", "value": "https://previous.example"},
-    ]
-    assert restored.get(("claudeCode.disableLoginPrompt",)) is False
+    entries = restored.get(("claudeCode.environmentVariables",))
+    assert isinstance(entries, list)
+    assert {"name": "KEEP", "value": "mine"} in entries
+    assert b"new-token" in locator.vscode_settings.read_bytes()
+    assert restored.get(("claudeCode.disableLoginPrompt",)) is True
     assert restored.get(("editor.fontSize",)) == 20
     assert b"// keep" in locator.vscode_settings.read_bytes()
-    assert result["applied"]
 
 
-def test_codex_shared_setup_and_restore_existing_provider_model_catalog(setup):
+def test_codex_apply_preserves_other_provider_and_uses_fcc_catalog(setup):
     service, locator, ctx = setup
     path = locator.home / ".codex/config.toml"
     path.parent.mkdir()
     original = b'# user\nmodel="old"\nmodel_provider="other"\nmodel_catalog_json="custom.json"\n[model_providers.other]\nname="Keep"\n'
     path.write_bytes(original)
-    perform(service, ctx, Item.CODEX, Action.SETUP)
+    perform(service, ctx, Item.CODEX)
     data = tomllib.loads(path.read_text())
     assert data["model"] == "test/model"
     assert data["model_providers"]["fcc"]["auth"]["command"] == str(
         locator.home / "bin/fcc-codex"
     )
     assert data["model_providers"]["other"]["name"] == "Keep"
-    perform(service, connection(locator.home, port=8182), Item.CODEX, Action.UPDATE)
-    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
+    perform(service, connection(locator.home, port=8182), Item.CODEX)
     data = tomllib.loads(path.read_text())
-    assert data["model"] == "old" and data["model_provider"] == "other"
-    assert data["model_catalog_json"] == "custom.json"
+    assert data["model"] == "test/model" and data["model_provider"] == "fcc"
+    assert data["model_catalog_json"] == str(ctx.catalog_path)
     assert b"# user" in path.read_bytes()
 
 
-def test_codex_update_keeps_user_model_and_disconnect_stops_on_that_edit(setup):
+def test_codex_reapply_keeps_user_model(setup):
     service, locator, ctx = setup
-    perform(service, ctx, Item.CODEX, Action.SETUP)
+    perform(service, ctx, Item.CODEX)
     path = locator.home / ".codex/config.toml"
     path.write_bytes(path.read_bytes().replace(b'"test/model"', b'"user/model"'))
     next_ctx = connection(locator.home, port=8182)
-    perform(service, next_ctx, Item.CODEX, Action.UPDATE)
+    perform(service, next_ctx, Item.CODEX)
     assert tomllib.loads(path.read_text())["model"] == "user/model"
-    before = path.read_bytes()
-    with pytest.raises(IntegrationError, match="model"):
-        service.preview(Item.CODEX, Action.DISCONNECT, next_ctx)
-    assert path.read_bytes() == before
-
-
-def test_later_edit_blocks_whole_update_and_setup_cannot_bypass_it(setup):
-    service, locator, ctx = setup
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    path = locator.vscode_settings
-    path.write_bytes(path.read_bytes().replace(b"fixture-proxy-token", b"user-token"))
-    before = path.read_bytes()
-    changed = connection(locator.home, port=8182, token="new-token")
-    assert card(service, changed, Item.CLAUDE_VSCODE)["status"] == "needs_attention"
-    for action in (Action.UPDATE, Action.DISCONNECT, Action.SETUP):
-        with pytest.raises(IntegrationError):
-            service.preview(Item.CLAUDE_VSCODE, action, changed)
-    assert path.read_bytes() == before
 
 
 @pytest.mark.parametrize("change", ["file", "connection", "dependency"])
 def test_stale_preview_cannot_write(setup, change):
     service, locator, ctx = setup
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    preview = service.preview(Item.CLAUDE_VSCODE, ctx)
     if change == "file":
         write_json(locator.vscode_settings, {"keep": "latest"})
     elif change == "connection":
@@ -135,7 +355,7 @@ def test_stale_preview_cannot_write(setup, change):
         else None
     )
     with pytest.raises(IntegrationError):
-        service.apply(Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx)
+        service.apply(Item.CLAUDE_VSCODE, preview["revision"], ctx)
     assert (
         locator.vscode_settings.read_bytes()
         if locator.vscode_settings.exists()
@@ -143,64 +363,23 @@ def test_stale_preview_cannot_write(setup, change):
     ) == before
 
 
-def test_duplicate_confirmation_keeps_original_undo_baseline(setup):
+def test_duplicate_confirmation_is_stale(setup):
     service, locator, ctx = setup
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
-    service.apply(Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx)
+    preview = service.preview(Item.CLAUDE_VSCODE, ctx)
+    service.apply(Item.CLAUDE_VSCODE, preview["revision"], ctx)
     before = locator.vscode_settings.read_bytes()
     with pytest.raises(IntegrationError):
-        service.apply(Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx)
+        service.apply(Item.CLAUDE_VSCODE, preview["revision"], ctx)
     assert locator.vscode_settings.read_bytes() == before
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
-    assert JsonDocument(locator.vscode_settings.read_bytes(), jsonc=True).data == {}
 
 
-def test_manual_connection_removal_does_not_invent_prior_settings(setup):
-    service, locator, ctx = setup
-    write_json(
-        locator.vscode_settings,
-        {
-            "keep": 1,
-            "claudeCode.disableLoginPrompt": True,
-            "claudeCode.environmentVariables": [
-                {"name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082"},
-                {"name": "ANTHROPIC_AUTH_TOKEN", "value": "old-token"},
-                {"name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1"},
-                {"name": "KEEP", "value": "mine"},
-            ],
-        },
-    )
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.DISCONNECT, ctx)
-    assert "previous" in " ".join(preview["notes"]).lower()
-    service.apply(Item.CLAUDE_VSCODE, Action.DISCONNECT, preview["revision"], ctx)
-    data = json.loads(locator.vscode_settings.read_bytes())
-    assert data["keep"] == 1
-    assert data["claudeCode.environmentVariables"] == [
-        {"name": "KEEP", "value": "mine"}
-    ]
-
-
-def test_manual_update_adoption_disconnects_instead_of_restoring_old_fcc_url(setup):
-    service, locator, ctx = setup
-    path = locator.home / ".codex/config.toml"
-    path.parent.mkdir()
-    path.write_text(
-        'model_provider="fcc"\n[model_providers.fcc]\nname="Free Claude Code"\nbase_url="http://localhost:7777/v1"\n'
-    )
-    perform(service, ctx, Item.CODEX, Action.UPDATE)
-    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
-    data = tomllib.loads(path.read_text())
-    assert "model_provider" not in data
-    assert "7777" not in path.read_text()
-
-
-def test_jetbrains_custom_agent_preserves_other_agents_and_added_fields_block_removal(
+def test_jetbrains_reapply_preserves_other_agents_and_added_fields(
     setup,
 ):
     service, locator, ctx = setup
     path = locator.home / ".jetbrains/acp.json"
     write_json(path, {"agent_servers": {"Other": {"command": "keep"}}})
-    perform(service, ctx, Item.CLAUDE_JETBRAINS, Action.SETUP)
+    perform(service, ctx, Item.CLAUDE_JETBRAINS)
     data = json.loads(path.read_bytes())
     assert data["agent_servers"]["Other"] == {"command": "keep"}
     data["agent_servers"]["Claude Code (FCC)"]["custom"] = True
@@ -209,10 +388,7 @@ def test_jetbrains_custom_agent_preserves_other_agents_and_added_fields_block_re
         service,
         connection(locator.home, port=8182),
         Item.CLAUDE_JETBRAINS,
-        Action.UPDATE,
     )
-    with pytest.raises(IntegrationError):
-        service.preview(Item.CLAUDE_JETBRAINS, Action.DISCONNECT, ctx)
     assert (
         json.loads(path.read_bytes())["agent_servers"]["Claude Code (FCC)"]["custom"]
         is True
@@ -228,26 +404,31 @@ def test_separate_onboarding_repair_changes_only_its_flag(setup, original):
     path = locator.home / ".claude.json"
     if original is not None:
         write_json(path, original)
-    preview = service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+    preview = service.preview(Item.CLAUDE_LOGIN, ctx)
     assert "do-not-return" not in json.dumps(preview)
-    service.apply(Item.CLAUDE_LOGIN, Action.REPAIR, preview["revision"], ctx)
+    service.apply(Item.CLAUDE_LOGIN, preview["revision"], ctx)
     assert json.loads(path.read_bytes()) == {
         **(original or {}),
         "hasCompletedOnboarding": True,
     }
     before = path.read_bytes()
-    assert service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)["changes"] == []
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    assert service.preview(Item.CLAUDE_LOGIN, ctx)["writes_file"] is False
+    perform(service, ctx, Item.CLAUDE_VSCODE)
     assert path.read_bytes() == before
 
 
-def test_onboarding_does_not_repair_other_login_failures_or_invalid_flags(setup):
+def test_onboarding_replaces_incorrect_leaf_type(setup):
     service, locator, ctx = setup
     for flag in ("false", 1):
-        write_json(locator.home / ".claude.json", {"hasCompletedOnboarding": flag})
-        with pytest.raises(IntegrationError):
-            service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+        write_json(
+            locator.home / ".claude.json",
+            {"hasCompletedOnboarding": flag, "keep": "private"},
+        )
+        perform(service, ctx, Item.CLAUDE_LOGIN)
+        assert json.loads((locator.home / ".claude.json").read_bytes()) == {
+            "hasCompletedOnboarding": True,
+            "keep": "private",
+        }
 
 
 def test_missing_client_and_catalog_do_not_trigger_installation_or_fallback_model(
@@ -256,11 +437,10 @@ def test_missing_client_and_catalog_do_not_trigger_installation_or_fallback_mode
     service, locator, ctx = setup
     (locator.home / "bin/fcc-codex").unlink()
     with pytest.raises(IntegrationError):
-        service.preview(Item.CODEX, Action.SETUP, ctx)
+        service.preview(Item.CODEX, ctx)
     with pytest.raises(IntegrationError):
         service.preview(
             Item.CODEX,
-            Action.SETUP,
             replace(ctx, models=()),
         )
 
@@ -272,27 +452,23 @@ def test_codex_auth_cleanup_is_masked_and_does_not_touch_other_providers(setup):
     path.write_text(
         '[model_providers.fcc]\nname="Old"\nenv_key="PRIVATE_ENV"\nexperimental_bearer_token="SECRET_BEARER"\nrequires_openai_auth=true\n[model_providers.other]\nname="Keep"\n'
     )
-    preview = service.preview(Item.CODEX, Action.SETUP, ctx)
+    preview = service.preview(Item.CODEX, ctx)
     assert "SECRET_BEARER" not in json.dumps(preview)
-    service.apply(Item.CODEX, Action.SETUP, preview["revision"], ctx)
+    service.apply(Item.CODEX, preview["revision"], ctx)
     assert (
         "experimental_bearer_token"
         not in tomllib.loads(path.read_text())["model_providers"]["fcc"]
     )
-    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
-    assert (
-        tomllib.loads(path.read_text())["model_providers"]["fcc"][
-            "experimental_bearer_token"
-        ]
-        == "SECRET_BEARER"
-    )
+    assert tomllib.loads(path.read_text())["model_providers"]["other"] == {
+        "name": "Keep"
+    }
 
 
 def test_codex_token_rotation_does_not_offer_update_but_known_auth_mismatch_blocks_setup(
     setup,
 ):
     service, locator, ctx = setup
-    perform(service, ctx, Item.CODEX, Action.SETUP)
+    perform(service, ctx, Item.CODEX)
     assert (
         card(service, connection(locator.home, token="changed"), Item.CODEX)["status"]
         == "configured"
@@ -305,7 +481,7 @@ def test_codex_token_rotation_does_not_offer_update_but_known_auth_mismatch_bloc
         saved_auth_token="different",
     )
     with pytest.raises(IntegrationError):
-        other.preview(Item.CODEX, Action.SETUP, bad)
+        other.preview(Item.CODEX, bad)
 
 
 def test_known_conflicting_claude_settings_are_reported_without_modification(setup):
@@ -314,20 +490,8 @@ def test_known_conflicting_claude_settings_are_reported_without_modification(set
     write_json(path, {"env": {"ANTHROPIC_BASE_URL": "https://other.example"}})
     before = path.read_bytes()
     with pytest.raises(IntegrationError):
-        service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+        service.preview(Item.CLAUDE_VSCODE, ctx)
     assert path.read_bytes() == before
-
-
-def test_disconnect_works_after_app_and_helper_are_removed(setup):
-    service, locator, ctx = setup
-    perform(service, ctx, Item.CODEX, Action.SETUP)
-    (locator.home / "bin/fcc-codex").unlink()
-    (locator.home / "bin/chatgpt").unlink()
-    (locator.home / ".vscode/extensions/extensions.json").unlink()
-    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
-    assert "model_provider" not in tomllib.loads(
-        (locator.home / ".codex/config.toml").read_text()
-    )
 
 
 def test_read_only_or_malformed_file_is_never_overwritten(setup):
@@ -335,12 +499,12 @@ def test_read_only_or_malformed_file_is_never_overwritten(setup):
     path = locator.home / ".claude.json"
     path.write_bytes(b'{"broken":')
     with pytest.raises(IntegrationError):
-        service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+        service.preview(Item.CLAUDE_LOGIN, ctx)
     path.write_bytes(b"{}")
     path.chmod(0o400)
     try:
         with pytest.raises(IntegrationError):
-            perform(service, ctx, Item.CLAUDE_LOGIN, Action.REPAIR)
+            perform(service, ctx, Item.CLAUDE_LOGIN)
         assert path.read_bytes() == b"{}"
     finally:
         path.chmod(0o600)
@@ -355,77 +519,39 @@ def test_symlink_configuration_requires_manual_setup(setup):
     except OSError:
         pytest.skip("Symlink creation is not permitted on this host")
     with pytest.raises(IntegrationError):
-        service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+        service.preview(Item.CLAUDE_LOGIN, ctx)
     assert target.read_bytes() == b"{}"
 
 
-@pytest.mark.parametrize("stage", ["pending", "external", "committed"])
-def test_failed_write_keeps_original_settings_recoverable(setup, monkeypatch, stage):
+@pytest.mark.parametrize("stage", ["before_replace", "after_replace"])
+def test_failed_write_can_be_retried_from_actual_file(setup, monkeypatch, stage):
     service, locator, ctx = setup
     original = {"claudeCode.disableLoginPrompt": False, "editor.fontSize": 16}
     write_json(locator.vscode_settings, original)
-    actual_record = service_module.write_record
     actual_write = service_module.atomic_write
 
-    def fail_record(path, record):
-        pending = isinstance(record, service_module.PendingWrite)
-        if (stage == "pending" and pending) or (stage == "committed" and not pending):
-            raise OSError("private error must not escape")
-        actual_record(path, record)
-
-    def fail_external(path, data, **kwargs):
-        if stage == "external" and path == locator.vscode_settings:
+    def fail_write(path, data, **kwargs):
+        if stage == "before_replace":
             raise OSError("private error must not escape")
         actual_write(path, data, **kwargs)
+        raise OSError("private error must not escape")
 
     with monkeypatch.context() as patch:
-        patch.setattr(service_module, "write_record", fail_record)
-        patch.setattr(service_module, "atomic_write", fail_external)
+        patch.setattr(service_module, "atomic_write", fail_write)
         with pytest.raises(IntegrationError, match="Could not save"):
-            perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    if stage != "committed":
-        assert json.loads(locator.vscode_settings.read_bytes()) == original
-    if stage != "pending":
-        assert card(service, ctx, Item.CLAUDE_VSCODE)["status"] == "needs_attention"
-        assert card(service, ctx, Item.CLAUDE_VSCODE)["actions"] == ["recover"]
-        perform(service, ctx, Item.CLAUDE_VSCODE, Action("recover"))
-    if stage != "committed":
-        perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
-    assert json.loads(locator.vscode_settings.read_bytes()) == original
-    assert not (service.state_dir / "claude-vscode.json").exists()
+            perform(service, ctx, Item.CLAUDE_VSCODE)
+    data = json.loads(locator.vscode_settings.read_bytes())
+    if stage == "before_replace":
+        assert data == original
+    else:
+        assert data["claudeCode.disableLoginPrompt"] is True
+        assert data["editor.fontSize"] == 16
+    result = perform(service, ctx, Item.CLAUDE_VSCODE)
+    assert result["applied"] is (stage == "before_replace")
+    assert not (locator.home / ".fcc/integrations/claude-vscode.json").exists()
 
 
-@pytest.mark.parametrize(
-    "item,action",
-    [(Item.CLAUDE_LOGIN, Action.REPAIR), (Item.CLAUDE_VSCODE, Action.DISCONNECT)],
-)
-def test_completed_write_with_failed_record_cleanup_can_be_finished(
-    setup, monkeypatch, item, action
-):
-    service, _locator, ctx = setup
-    if action == Action.DISCONNECT:
-        perform(service, ctx, item, Action.SETUP)
-    actual_record = service_module.write_record
-
-    def fail_cleanup(path, record):
-        if record is None:
-            raise OSError("cleanup failure")
-        actual_record(path, record)
-
-    with monkeypatch.context() as patch:
-        patch.setattr(service_module, "write_record", fail_cleanup)
-        with pytest.raises(IntegrationError):
-            perform(service, ctx, item, action)
-    assert card(service, ctx, item)["actions"] == ["recover"]
-    result = perform(service, ctx, item, Action("recover"))
-    assert result["applied"] is True
-    assert not (service.state_dir / f"{item}.json").exists()
-
-
-def test_interference_after_replace_retains_pending_record_and_refuses_more_writes(
-    setup, monkeypatch
-):
+def test_interference_after_replace_is_reported_and_preserved(setup, monkeypatch):
     service, locator, ctx = setup
     actual_write = service_module.atomic_write
 
@@ -437,12 +563,10 @@ def test_interference_after_replace_retains_pending_record_and_refuses_more_writ
     with monkeypatch.context() as patch:
         patch.setattr(service_module, "atomic_write", interfere)
         with pytest.raises(IntegrationError, match="verification"):
-            perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    assert card(service, ctx, Item.CLAUDE_VSCODE)["status"] == "needs_attention"
-    with pytest.raises(IntegrationError, match="interrupted write"):
-        service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+            perform(service, ctx, Item.CLAUDE_VSCODE)
+    assert card(service, ctx, Item.CLAUDE_VSCODE)["can_apply"] is True
     assert json.loads(locator.vscode_settings.read_bytes()) == {"user": "later edit"}
-    assert (service.state_dir / "claude-vscode.json").exists()
+    assert not (locator.home / ".fcc/integrations/claude-vscode.json").exists()
 
 
 def test_concurrent_confirmations_across_services_have_one_winner(setup):
@@ -451,30 +575,22 @@ def test_concurrent_confirmations_across_services_have_one_winner(setup):
     barrier = Barrier(2)
 
     def confirm(owner):
-        preview = owner.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+        preview = owner.preview(Item.CLAUDE_VSCODE, ctx)
         barrier.wait(timeout=5)
         try:
-            return owner.apply(
-                Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx
-            )["applied"]
+            return owner.apply(Item.CLAUDE_VSCODE, preview["revision"], ctx)["applied"]
         except IntegrationError as error:
             assert error.status_code == 409
             return False
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         assert sorted(pool.map(confirm, [service, other])) == [False, True]
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
-    assert json.loads(locator.vscode_settings.read_bytes()) == {}
-
-
-def test_manual_jetbrains_disconnect_removes_exact_recipe_entry(setup):
-    service, locator, ctx = setup
-    perform(service, ctx, Item.CLAUDE_JETBRAINS, Action.SETUP)
-    (service.state_dir / "claude-jetbrains.json").unlink()
-    perform(service, ctx, Item.CLAUDE_JETBRAINS, Action.DISCONNECT)
-    assert "Claude Code (FCC)" not in json.loads(
-        (locator.home / ".jetbrains/acp.json").read_bytes()
-    ).get("agent_servers", {})
+    assert (
+        json.loads(locator.vscode_settings.read_bytes())[
+            "claudeCode.disableLoginPrompt"
+        ]
+        is True
+    )
 
 
 def test_missing_codex_default_is_explained_on_the_card(setup):
@@ -483,7 +599,7 @@ def test_missing_codex_default_is_explained_on_the_card(setup):
     entry = card(service, missing_default, Item.CODEX)
     assert entry["status"] == "needs_attention"
     assert "catalog/default" in entry["message"]
-    assert "setup" not in entry["actions"]
+    assert entry["can_apply"] is False
 
 
 def test_codex_wsl_extension_badge_explains_manual_scope_and_native_app_can_setup(
@@ -495,7 +611,7 @@ def test_codex_wsl_extension_badge_explains_manual_scope_and_native_app_can_setu
     )
     entry = card(service, ctx, Item.CODEX)
     assert any("WSL" in badge for badge in entry["badges"])
-    perform(service, ctx, Item.CODEX, Action.SETUP)
+    perform(service, ctx, Item.CODEX)
     assert (
         json.loads(locator.vscode_settings.read_bytes())[
             "chatgpt.runCodexInWindowsSubsystemForLinux"
@@ -509,11 +625,11 @@ def test_symlink_state_directory_does_not_even_create_a_lock_in_another_location
     other = locator.home / "other-state"
     other.mkdir()
     try:
-        service.state_dir.symlink_to(other, target_is_directory=True)
+        (locator.home / ".fcc/integrations").symlink_to(other, target_is_directory=True)
     except OSError:
         pytest.skip("Symlink creation is not permitted on this host")
     with pytest.raises(IntegrationError):
-        service.apply(Item.CLAUDE_LOGIN, Action.REPAIR, "a" * 64, ctx)
+        service.apply(Item.CLAUDE_LOGIN, "a" * 64, ctx)
     assert list(other.iterdir()) == []
 
 
@@ -537,7 +653,7 @@ def test_editor_write_during_temporary_file_flush_is_preserved(setup, monkeypatc
 
     monkeypatch.setattr(service_module, "atomic_write", interfere_during_write)
     with pytest.raises(IntegrationError, match="changed since this preview"):
-        perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+        perform(service, ctx, Item.CLAUDE_VSCODE)
     assert json.loads(locator.vscode_settings.read_bytes()) == later
 
 
@@ -548,62 +664,11 @@ def test_codex_setup_preserves_unrelated_dotted_provider(setup):
     path.write_text(
         'model_providers.fcc.name="Old"\nmodel_providers.other.name="Other"\n'
     )
-    perform(service, ctx, Item.CODEX, Action.SETUP)
+    perform(service, ctx, Item.CODEX)
     actual = tomllib.loads(path.read_text())
     assert actual["model_providers"].get("other") == {"name": "Other"}
     assert actual.get("model_provider") == "fcc"
     assert actual["model_providers"]["fcc"]["base_url"] == "http://127.0.0.1:8082/v1"
-
-
-def test_completed_disconnect_recovery_preserves_preexisting_flag(setup, monkeypatch):
-    service, locator, ctx = setup
-    original = {"claudeCode.disableLoginPrompt": True, "editor.fontSize": 17}
-    write_json(locator.vscode_settings, original)
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    actual_record = service_module.write_record
-
-    def fail_cleanup(path, record):
-        if record is None:
-            raise OSError("simulated cleanup failure")
-        actual_record(path, record)
-
-    with monkeypatch.context() as patch:
-        patch.setattr(service_module, "write_record", fail_cleanup)
-        with pytest.raises(IntegrationError):
-            perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
-    assert json.loads(locator.vscode_settings.read_bytes()) == original
-    assert card(service, ctx, Item.CLAUDE_VSCODE)["actions"] == ["recover"]
-    before = locator.vscode_settings.read_bytes()
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action("recover"))
-    assert locator.vscode_settings.read_bytes() == before
-    assert not (service.state_dir / "claude-vscode.json").exists()
-
-
-@pytest.mark.parametrize(
-    "item,relative,restored",
-    [
-        (Item.CLAUDE_VSCODE, ".config/Code/User/settings.json", b"{}"),
-        (Item.CODEX, ".codex/config.toml", b""),
-        (Item.CLAUDE_JETBRAINS, ".jetbrains/acp.json", b"{}"),
-    ],
-)
-@pytest.mark.parametrize("absent", [False, True])
-def test_managed_disconnect_releases_history_when_file_is_already_restored(
-    setup, item, relative, restored, absent
-):
-    service, locator, ctx = setup
-    perform(service, ctx, item, Action.SETUP)
-    path = locator.home / relative
-    if absent:
-        path.unlink()
-    else:
-        path.write_bytes(restored)
-    before = storage_module.FileSnapshot.read(path)
-    result = perform(service, ctx, item, Action.DISCONNECT)
-    assert not (service.state_dir / f"{item}.json").exists()
-    assert result["applied"] is True
-    assert storage_module.FileSnapshot.read(path) == before
-    assert service.preview(item, Action.SETUP, ctx)["changes"]
 
 
 def test_inline_fcc_provider_without_auth_keeps_all_cards_available(setup):
@@ -617,281 +682,7 @@ def test_inline_fcc_provider_without_auth_keeps_all_cards_available(setup):
     )
     result = service.inspect(ctx)
     assert len(result["items"]) == 4
-    assert card(service, ctx, Item.CODEX)["status"] == "update_available"
-
-
-@pytest.mark.parametrize(
-    "item,action",
-    [
-        (Item.CLAUDE_VSCODE, Action.SETUP),
-        (Item.CLAUDE_VSCODE, Action.UPDATE),
-        (Item.CLAUDE_VSCODE, Action.DISCONNECT),
-        (Item.CODEX, Action.DISCONNECT),
-        (Item.CLAUDE_LOGIN, Action.REPAIR),
-    ],
-)
-@pytest.mark.parametrize("stage", ["before_replace", "after_replace", "finalize"])
-def test_interrupted_operations_recover_without_replaying_client_write(
-    setup, monkeypatch, item, action, stage
-):
-    service, locator, ctx = setup
-    if item == Item.CODEX:
-        path = locator.home / ".codex/config.toml"
-        path.parent.mkdir()
-        path.write_text(
-            'model_provider="other"\n[model_providers.fcc]\nname="Original"\n'
-            'base_url="https://old.example/v1"\nexperimental_bearer_token="original-token"\n'
-        )
-        original = tomllib.loads(path.read_text())
-    else:
-        path = (
-            locator.home / ".claude.json"
-            if item == Item.CLAUDE_LOGIN
-            else locator.vscode_settings
-        )
-        original = (
-            {"hasCompletedOnboarding": False, "keep": "mine"}
-            if item == Item.CLAUDE_LOGIN
-            else {"claudeCode.disableLoginPrompt": True, "editor.fontSize": 17}
-        )
-        write_json(path, original)
-    if action in {Action.UPDATE, Action.DISCONNECT}:
-        perform(service, ctx, item, Action.SETUP)
-    if action == Action.UPDATE:
-        ctx = connection(locator.home, port=8182)
-    before = storage_module.FileSnapshot.read(path)
-    history = service.state_dir / f"{item}.json"
-    previous = json.loads(history.read_bytes()) if history.exists() else None
-    actual_write, actual_record = (
-        service_module.atomic_write,
-        service_module.write_record,
-    )
-
-    def fail_external(destination, data, **kwargs):
-        if destination == path and stage == "before_replace":
-            raise OSError("interrupted before replace")
-        actual_write(destination, data, **kwargs)
-        if destination == path and stage == "after_replace":
-            raise OSError("interrupted after replace")
-
-    def fail_record(destination, record):
-        if stage == "finalize" and not isinstance(record, service_module.PendingWrite):
-            raise OSError("interrupted finalization")
-        actual_record(destination, record)
-
-    with monkeypatch.context() as patch:
-        patch.setattr(service_module, "atomic_write", fail_external)
-        patch.setattr(service_module, "write_record", fail_record)
-        with pytest.raises(IntegrationError):
-            perform(service, ctx, item, action)
-    assert history.exists()
-    assert json.loads(history.read_bytes())["phase"] == "pending"
-    saved = storage_module.FileSnapshot.read(path)
-    if stage == "before_replace":
-        assert saved == before
-    assert card(service, ctx, item)["actions"] == ["recover"]
-    for other_action in (
-        [Action.REPAIR]
-        if item == Item.CLAUDE_LOGIN
-        else [Action.SETUP, Action.UPDATE, Action.DISCONNECT]
-    ):
-        with pytest.raises(IntegrationError):
-            service.preview(item, other_action, ctx)
-    recovery = service.preview(item, Action("recover"), ctx)
-    # Recovery must not depend on a new connection or newly unreadable prerequisites.
-    write_json(locator.home / ".claude/settings.json", {"env": "wrong"})
-    changed = replace(connection(locator.home, port=9192), models=())
-    result = service.apply(item, Action("recover"), recovery["revision"], changed)
-    assert result["applied"] is True
-    assert storage_module.FileSnapshot.read(path) == saved
-    if stage == "before_replace":
-        assert (
-            json.loads(history.read_bytes()) if history.exists() else None
-        ) == previous
-    elif action in {Action.DISCONNECT, Action.REPAIR}:
-        assert not history.exists()
-    else:
-        assert json.loads(history.read_bytes())["fields"]["env.ANTHROPIC_BASE_URL"][
-            "last"
-        ]["value"] == (
-            "http://127.0.0.1:8182"
-            if action == Action.UPDATE
-            else "http://127.0.0.1:8082"
-        )
-    if stage != "before_replace" and action == Action.DISCONNECT:
-        assert (
-            tomllib.loads(path.read_text())
-            if item == Item.CODEX
-            else json.loads(path.read_bytes())
-        ) == original
-    with pytest.raises(IntegrationError):
-        service.apply(item, Action("recover"), recovery["revision"], changed)
-    assert storage_module.FileSnapshot.read(path) == saved
-
-
-def test_disconnect_persists_container_cleanup_without_leaf_changes(setup):
-    service, locator, ctx = setup
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    write_json(locator.vscode_settings, {"claudeCode.environmentVariables": []})
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.DISCONNECT, ctx)
-    assert preview["changes"] == []
-    result = service.apply(
-        Item.CLAUDE_VSCODE, Action.DISCONNECT, preview["revision"], ctx
-    )
-    assert result["applied"] is True
-    assert json.loads(locator.vscode_settings.read_bytes()) == {}
-    assert not (service.state_dir / "claude-vscode.json").exists()
-
-
-def test_current_manual_configuration_can_be_adopted_without_rewriting_it(setup):
-    service, locator, ctx = setup
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    history = service.state_dir / "claude-vscode.json"
-    history.unlink()
-    before = storage_module.FileSnapshot.read(locator.vscode_settings)
-    assert "update" in card(service, ctx, Item.CLAUDE_VSCODE)["actions"]
-    result = perform(service, ctx, Item.CLAUDE_VSCODE, Action.UPDATE)
-    assert result["applied"] is True
-    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
-    assert history.exists()
-    assert all(
-        field["prior"] is None
-        for field in json.loads(history.read_bytes())["fields"].values()
-    )
-    assert "update" not in card(service, ctx, Item.CLAUDE_VSCODE)["actions"]
-
-
-def test_setup_cannot_bypass_manual_adoption_history(setup):
-    service, locator, ctx = setup
-    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    history = service.state_dir / "claude-vscode.json"
-    history.unlink()
-    before = storage_module.FileSnapshot.read(locator.vscode_settings)
-    with pytest.raises(IntegrationError):
-        service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
-    assert not history.exists()
-    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
-
-
-@pytest.fixture
-def pending_setup(setup):
-    service, locator, ctx = setup
-    write_json(locator.vscode_settings, {"claudeCode.disableLoginPrompt": True})
-    following = storage_module.Ownership(
-        item=Item.CLAUDE_VSCODE,
-        path=str(locator.vscode_settings),
-        fields={
-            "claudeCode.disableLoginPrompt": storage_module.FieldHistory(
-                prior=storage_module.SavedValue(present=False),
-                last=storage_module.SavedValue(present=True, value=True),
-            )
-        },
-    )
-    storage_module.write_record(
-        service.state_dir / "claude-vscode.json",
-        storage_module.PendingWrite(
-            item=Item.CLAUDE_VSCODE,
-            action=Action.SETUP,
-            path=str(locator.vscode_settings),
-            before=storage_module.content_hash(None),
-            after=storage_module.content_hash(locator.vscode_settings.read_bytes()),
-            previous=None,
-            following=following,
-        ),
-    )
-    return service, locator, ctx
-
-
-@pytest.mark.parametrize(
-    "corruption",
-    [
-        "previous_path",
-        "following_key",
-        "following_value",
-        "prior_value",
-        "equal_hashes",
-        "action",
-        "unrelated_edit",
-    ],
-)
-def test_invalid_pending_evidence_keeps_file_and_history_for_manual_resolution(
-    pending_setup, corruption
-):
-    service, locator, ctx = pending_setup
-    history = service.state_dir / "claude-vscode.json"
-    pending = json.loads(history.read_bytes())
-    if corruption == "previous_path":
-        pending["previous"] = {**pending["following"], "path": "wrong.json"}
-    elif corruption == "following_key":
-        # Validate the following record even when recovery would select previous.
-        locator.vscode_settings.unlink()
-        pending["following"]["fields"]["arbitrary.setting"] = pending["following"][
-            "fields"
-        ]["claudeCode.disableLoginPrompt"]
-    elif corruption in {"following_value", "prior_value"}:
-        field = pending["following"]["fields"]["claudeCode.disableLoginPrompt"]
-        field["last" if corruption == "following_value" else "prior"] = {
-            "present": True,
-            "value": {"wrong": "private contents"},
-        }
-    elif corruption == "equal_hashes":
-        pending["before"] = pending["after"]
-    elif corruption == "action":
-        pending["action"] = "recover"
-    else:
-        write_json(locator.vscode_settings, {"user": "changed"})
-    write_json(history, pending)
-    before = storage_module.FileSnapshot.read(locator.vscode_settings)
-    history_before = history.read_bytes()
-    entry = card(service, ctx, Item.CLAUDE_VSCODE)
-    assert entry["status"] == "needs_attention"
-    assert entry["actions"] == []
-    assert "private contents" not in json.dumps(entry)
-    with pytest.raises(IntegrationError):
-        service.preview(Item.CLAUDE_VSCODE, Action.RECOVER, ctx)
-    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
-    assert history.read_bytes() == history_before
-
-
-@pytest.mark.parametrize("changed", ["file", "history"])
-def test_stale_recovery_confirmation_keeps_current_evidence(pending_setup, changed):
-    service, locator, ctx = pending_setup
-    history = service.state_dir / "claude-vscode.json"
-    preview = service.preview(Item.CLAUDE_VSCODE, Action.RECOVER, ctx)
-    if changed == "file":
-        write_json(locator.vscode_settings, {"keep": "later"})
-    else:
-        history.write_bytes(history.read_bytes() + b"\n")
-    before = storage_module.FileSnapshot.read(locator.vscode_settings)
-    history_before = history.read_bytes()
-    with pytest.raises(IntegrationError) as caught:
-        service.apply(Item.CLAUDE_VSCODE, Action.RECOVER, preview["revision"], ctx)
-    assert caught.value.status_code == 409
-    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
-    assert history.read_bytes() == history_before
-
-
-def test_unstarted_recovery_preserves_absent_client_file(pending_setup):
-    service, locator, ctx = pending_setup
-    locator.vscode_settings.unlink()
-    result = perform(service, ctx, Item.CLAUDE_VSCODE, Action.RECOVER)
-    assert result["applied"] is True
-    assert not locator.vscode_settings.exists()
-    assert not (service.state_dir / "claude-vscode.json").exists()
-
-
-def test_recovery_does_not_rediscover_or_probe_installed_clients(
-    pending_setup, monkeypatch
-):
-    service, locator, ctx = pending_setup
-    monkeypatch.setattr(
-        type(locator),
-        "scan",
-        lambda _self: pytest.fail("recovery does not need discovery"),
-    )
-    before = storage_module.FileSnapshot.read(locator.vscode_settings)
-    assert perform(service, ctx, Item.CLAUDE_VSCODE, Action.RECOVER)["applied"] is True
-    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
+    assert card(service, ctx, Item.CODEX)["status"] == "not_configured"
 
 
 @pytest.mark.parametrize(
@@ -901,7 +692,7 @@ def test_acp_dependency_changes_reject_the_old_confirmation(
     setup, monkeypatch, changed
 ):
     service, locator, ctx = setup
-    preview = service.preview(Item.CLAUDE_JETBRAINS, Action.SETUP, ctx)
+    preview = service.preview(Item.CLAUDE_JETBRAINS, ctx)
     package = locator.home / "lib/node_modules/@agentclientprotocol/claude-agent-acp"
     if changed in {"requirement", "manifest"}:
         manifest = json.loads((package / "package.json").read_bytes())
@@ -922,9 +713,9 @@ def test_acp_dependency_changes_reject_the_old_confirmation(
         )
         path.write_text("replaced dependency")
     with pytest.raises(IntegrationError):
-        service.apply(Item.CLAUDE_JETBRAINS, Action.SETUP, preview["revision"], ctx)
+        service.apply(Item.CLAUDE_JETBRAINS, preview["revision"], ctx)
     assert not (locator.home / ".jetbrains/acp.json").exists()
-    assert not (service.state_dir / "claude-jetbrains.json").exists()
+    assert not ((locator.home / ".fcc/integrations") / "claude-jetbrains.json").exists()
 
 
 @pytest.mark.parametrize("failure", ["semantic", "value_error", "toml_error"])
@@ -956,6 +747,6 @@ def test_document_failure_is_isolated_before_client_or_history_writes(
     assert card(service, ctx, Item.CODEX)["status"] == "needs_attention"
     assert "private source contents" not in json.dumps(inspected)
     with pytest.raises(IntegrationError):
-        service.preview(Item.CODEX, Action.UPDATE, ctx)
+        service.preview(Item.CODEX, ctx)
     assert storage_module.FileSnapshot.read(path) == before
-    assert not (service.state_dir / "codex.json").exists()
+    assert not ((locator.home / ".fcc/integrations") / "codex.json").exists()

--- a/tests/runtime/test_integrations.py
+++ b/tests/runtime/test_integrations.py
@@ -7,6 +7,8 @@ from dataclasses import replace
 from threading import Barrier
 
 import pytest
+import tomlkit
+from tomlkit.exceptions import TOMLKitError
 
 from free_claude_code.application.integrations import IntegrationAction as Action
 from free_claude_code.application.integrations import IntegrationError
@@ -383,11 +385,12 @@ def test_failed_write_keeps_original_settings_recoverable(setup, monkeypatch, st
             perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
     if stage != "committed":
         assert json.loads(locator.vscode_settings.read_bytes()) == original
-        perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
-    else:
+    if stage != "pending":
         assert card(service, ctx, Item.CLAUDE_VSCODE)["status"] == "needs_attention"
-        assert card(service, ctx, Item.CLAUDE_VSCODE)["actions"] == ["update"]
-        perform(service, ctx, Item.CLAUDE_VSCODE, Action.UPDATE)
+        assert card(service, ctx, Item.CLAUDE_VSCODE)["actions"] == ["recover"]
+        perform(service, ctx, Item.CLAUDE_VSCODE, Action("recover"))
+    if stage != "committed":
+        perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
     perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
     assert json.loads(locator.vscode_settings.read_bytes()) == original
     assert not (service.state_dir / "claude-vscode.json").exists()
@@ -414,9 +417,9 @@ def test_completed_write_with_failed_record_cleanup_can_be_finished(
         patch.setattr(service_module, "write_record", fail_cleanup)
         with pytest.raises(IntegrationError):
             perform(service, ctx, item, action)
-    assert action in card(service, ctx, item)["actions"]
-    result = perform(service, ctx, item, action)
-    assert result["applied"] is False
+    assert card(service, ctx, item)["actions"] == ["recover"]
+    result = perform(service, ctx, item, Action("recover"))
+    assert result["applied"] is True
     assert not (service.state_dir / f"{item}.json").exists()
 
 
@@ -536,3 +539,423 @@ def test_editor_write_during_temporary_file_flush_is_preserved(setup, monkeypatc
     with pytest.raises(IntegrationError, match="changed since this preview"):
         perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
     assert json.loads(locator.vscode_settings.read_bytes()) == later
+
+
+def test_codex_setup_preserves_unrelated_dotted_provider(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(
+        'model_providers.fcc.name="Old"\nmodel_providers.other.name="Other"\n'
+    )
+    perform(service, ctx, Item.CODEX, Action.SETUP)
+    actual = tomllib.loads(path.read_text())
+    assert actual["model_providers"].get("other") == {"name": "Other"}
+    assert actual.get("model_provider") == "fcc"
+    assert actual["model_providers"]["fcc"]["base_url"] == "http://127.0.0.1:8082/v1"
+
+
+def test_completed_disconnect_recovery_preserves_preexisting_flag(setup, monkeypatch):
+    service, locator, ctx = setup
+    original = {"claudeCode.disableLoginPrompt": True, "editor.fontSize": 17}
+    write_json(locator.vscode_settings, original)
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    actual_record = service_module.write_record
+
+    def fail_cleanup(path, record):
+        if record is None:
+            raise OSError("simulated cleanup failure")
+        actual_record(path, record)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(service_module, "write_record", fail_cleanup)
+        with pytest.raises(IntegrationError):
+            perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    assert json.loads(locator.vscode_settings.read_bytes()) == original
+    assert card(service, ctx, Item.CLAUDE_VSCODE)["actions"] == ["recover"]
+    before = locator.vscode_settings.read_bytes()
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action("recover"))
+    assert locator.vscode_settings.read_bytes() == before
+    assert not (service.state_dir / "claude-vscode.json").exists()
+
+
+@pytest.mark.parametrize(
+    "item,relative,restored",
+    [
+        (Item.CLAUDE_VSCODE, ".config/Code/User/settings.json", b"{}"),
+        (Item.CODEX, ".codex/config.toml", b""),
+        (Item.CLAUDE_JETBRAINS, ".jetbrains/acp.json", b"{}"),
+    ],
+)
+@pytest.mark.parametrize("absent", [False, True])
+def test_managed_disconnect_releases_history_when_file_is_already_restored(
+    setup, item, relative, restored, absent
+):
+    service, locator, ctx = setup
+    perform(service, ctx, item, Action.SETUP)
+    path = locator.home / relative
+    if absent:
+        path.unlink()
+    else:
+        path.write_bytes(restored)
+    before = storage_module.FileSnapshot.read(path)
+    result = perform(service, ctx, item, Action.DISCONNECT)
+    assert not (service.state_dir / f"{item}.json").exists()
+    assert result["applied"] is True
+    assert storage_module.FileSnapshot.read(path) == before
+    assert service.preview(item, Action.SETUP, ctx)["changes"]
+
+
+def test_inline_fcc_provider_without_auth_keeps_all_cards_available(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(
+        'model_provider="fcc"\n[model_providers]\n'
+        'fcc={name="Free Claude Code",base_url="http://localhost:8082/v1"}\n'
+        'other={name="Other"}\n'
+    )
+    result = service.inspect(ctx)
+    assert len(result["items"]) == 4
+    assert card(service, ctx, Item.CODEX)["status"] == "update_available"
+
+
+@pytest.mark.parametrize(
+    "item,action",
+    [
+        (Item.CLAUDE_VSCODE, Action.SETUP),
+        (Item.CLAUDE_VSCODE, Action.UPDATE),
+        (Item.CLAUDE_VSCODE, Action.DISCONNECT),
+        (Item.CODEX, Action.DISCONNECT),
+        (Item.CLAUDE_LOGIN, Action.REPAIR),
+    ],
+)
+@pytest.mark.parametrize("stage", ["before_replace", "after_replace", "finalize"])
+def test_interrupted_operations_recover_without_replaying_client_write(
+    setup, monkeypatch, item, action, stage
+):
+    service, locator, ctx = setup
+    if item == Item.CODEX:
+        path = locator.home / ".codex/config.toml"
+        path.parent.mkdir()
+        path.write_text(
+            'model_provider="other"\n[model_providers.fcc]\nname="Original"\n'
+            'base_url="https://old.example/v1"\nexperimental_bearer_token="original-token"\n'
+        )
+        original = tomllib.loads(path.read_text())
+    else:
+        path = (
+            locator.home / ".claude.json"
+            if item == Item.CLAUDE_LOGIN
+            else locator.vscode_settings
+        )
+        original = (
+            {"hasCompletedOnboarding": False, "keep": "mine"}
+            if item == Item.CLAUDE_LOGIN
+            else {"claudeCode.disableLoginPrompt": True, "editor.fontSize": 17}
+        )
+        write_json(path, original)
+    if action in {Action.UPDATE, Action.DISCONNECT}:
+        perform(service, ctx, item, Action.SETUP)
+    if action == Action.UPDATE:
+        ctx = connection(locator.home, port=8182)
+    before = storage_module.FileSnapshot.read(path)
+    history = service.state_dir / f"{item}.json"
+    previous = json.loads(history.read_bytes()) if history.exists() else None
+    actual_write, actual_record = (
+        service_module.atomic_write,
+        service_module.write_record,
+    )
+
+    def fail_external(destination, data, **kwargs):
+        if destination == path and stage == "before_replace":
+            raise OSError("interrupted before replace")
+        actual_write(destination, data, **kwargs)
+        if destination == path and stage == "after_replace":
+            raise OSError("interrupted after replace")
+
+    def fail_record(destination, record):
+        if stage == "finalize" and not isinstance(record, service_module.PendingWrite):
+            raise OSError("interrupted finalization")
+        actual_record(destination, record)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(service_module, "atomic_write", fail_external)
+        patch.setattr(service_module, "write_record", fail_record)
+        with pytest.raises(IntegrationError):
+            perform(service, ctx, item, action)
+    assert history.exists()
+    assert json.loads(history.read_bytes())["phase"] == "pending"
+    saved = storage_module.FileSnapshot.read(path)
+    if stage == "before_replace":
+        assert saved == before
+    assert card(service, ctx, item)["actions"] == ["recover"]
+    for other_action in (
+        [Action.REPAIR]
+        if item == Item.CLAUDE_LOGIN
+        else [Action.SETUP, Action.UPDATE, Action.DISCONNECT]
+    ):
+        with pytest.raises(IntegrationError):
+            service.preview(item, other_action, ctx)
+    recovery = service.preview(item, Action("recover"), ctx)
+    # Recovery must not depend on a new connection or newly unreadable prerequisites.
+    write_json(locator.home / ".claude/settings.json", {"env": "wrong"})
+    changed = replace(connection(locator.home, port=9192), models=())
+    result = service.apply(item, Action("recover"), recovery["revision"], changed)
+    assert result["applied"] is True
+    assert storage_module.FileSnapshot.read(path) == saved
+    if stage == "before_replace":
+        assert (
+            json.loads(history.read_bytes()) if history.exists() else None
+        ) == previous
+    elif action in {Action.DISCONNECT, Action.REPAIR}:
+        assert not history.exists()
+    else:
+        assert json.loads(history.read_bytes())["fields"]["env.ANTHROPIC_BASE_URL"][
+            "last"
+        ]["value"] == (
+            "http://127.0.0.1:8182"
+            if action == Action.UPDATE
+            else "http://127.0.0.1:8082"
+        )
+    if stage != "before_replace" and action == Action.DISCONNECT:
+        assert (
+            tomllib.loads(path.read_text())
+            if item == Item.CODEX
+            else json.loads(path.read_bytes())
+        ) == original
+    with pytest.raises(IntegrationError):
+        service.apply(item, Action("recover"), recovery["revision"], changed)
+    assert storage_module.FileSnapshot.read(path) == saved
+
+
+def test_disconnect_persists_container_cleanup_without_leaf_changes(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    write_json(locator.vscode_settings, {"claudeCode.environmentVariables": []})
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.DISCONNECT, ctx)
+    assert preview["changes"] == []
+    result = service.apply(
+        Item.CLAUDE_VSCODE, Action.DISCONNECT, preview["revision"], ctx
+    )
+    assert result["applied"] is True
+    assert json.loads(locator.vscode_settings.read_bytes()) == {}
+    assert not (service.state_dir / "claude-vscode.json").exists()
+
+
+def test_current_manual_configuration_can_be_adopted_without_rewriting_it(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    history = service.state_dir / "claude-vscode.json"
+    history.unlink()
+    before = storage_module.FileSnapshot.read(locator.vscode_settings)
+    assert "update" in card(service, ctx, Item.CLAUDE_VSCODE)["actions"]
+    result = perform(service, ctx, Item.CLAUDE_VSCODE, Action.UPDATE)
+    assert result["applied"] is True
+    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
+    assert history.exists()
+    assert all(
+        field["prior"] is None
+        for field in json.loads(history.read_bytes())["fields"].values()
+    )
+    assert "update" not in card(service, ctx, Item.CLAUDE_VSCODE)["actions"]
+
+
+def test_setup_cannot_bypass_manual_adoption_history(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    history = service.state_dir / "claude-vscode.json"
+    history.unlink()
+    before = storage_module.FileSnapshot.read(locator.vscode_settings)
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    assert not history.exists()
+    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
+
+
+@pytest.fixture
+def pending_setup(setup):
+    service, locator, ctx = setup
+    write_json(locator.vscode_settings, {"claudeCode.disableLoginPrompt": True})
+    following = storage_module.Ownership(
+        item=Item.CLAUDE_VSCODE,
+        path=str(locator.vscode_settings),
+        fields={
+            "claudeCode.disableLoginPrompt": storage_module.FieldHistory(
+                prior=storage_module.SavedValue(present=False),
+                last=storage_module.SavedValue(present=True, value=True),
+            )
+        },
+    )
+    storage_module.write_record(
+        service.state_dir / "claude-vscode.json",
+        storage_module.PendingWrite(
+            item=Item.CLAUDE_VSCODE,
+            action=Action.SETUP,
+            path=str(locator.vscode_settings),
+            before=storage_module.content_hash(None),
+            after=storage_module.content_hash(locator.vscode_settings.read_bytes()),
+            previous=None,
+            following=following,
+        ),
+    )
+    return service, locator, ctx
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    [
+        "previous_path",
+        "following_key",
+        "following_value",
+        "prior_value",
+        "equal_hashes",
+        "action",
+        "unrelated_edit",
+    ],
+)
+def test_invalid_pending_evidence_keeps_file_and_history_for_manual_resolution(
+    pending_setup, corruption
+):
+    service, locator, ctx = pending_setup
+    history = service.state_dir / "claude-vscode.json"
+    pending = json.loads(history.read_bytes())
+    if corruption == "previous_path":
+        pending["previous"] = {**pending["following"], "path": "wrong.json"}
+    elif corruption == "following_key":
+        # Validate the following record even when recovery would select previous.
+        locator.vscode_settings.unlink()
+        pending["following"]["fields"]["arbitrary.setting"] = pending["following"][
+            "fields"
+        ]["claudeCode.disableLoginPrompt"]
+    elif corruption in {"following_value", "prior_value"}:
+        field = pending["following"]["fields"]["claudeCode.disableLoginPrompt"]
+        field["last" if corruption == "following_value" else "prior"] = {
+            "present": True,
+            "value": {"wrong": "private contents"},
+        }
+    elif corruption == "equal_hashes":
+        pending["before"] = pending["after"]
+    elif corruption == "action":
+        pending["action"] = "recover"
+    else:
+        write_json(locator.vscode_settings, {"user": "changed"})
+    write_json(history, pending)
+    before = storage_module.FileSnapshot.read(locator.vscode_settings)
+    history_before = history.read_bytes()
+    entry = card(service, ctx, Item.CLAUDE_VSCODE)
+    assert entry["status"] == "needs_attention"
+    assert entry["actions"] == []
+    assert "private contents" not in json.dumps(entry)
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CLAUDE_VSCODE, Action.RECOVER, ctx)
+    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
+    assert history.read_bytes() == history_before
+
+
+@pytest.mark.parametrize("changed", ["file", "history"])
+def test_stale_recovery_confirmation_keeps_current_evidence(pending_setup, changed):
+    service, locator, ctx = pending_setup
+    history = service.state_dir / "claude-vscode.json"
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.RECOVER, ctx)
+    if changed == "file":
+        write_json(locator.vscode_settings, {"keep": "later"})
+    else:
+        history.write_bytes(history.read_bytes() + b"\n")
+    before = storage_module.FileSnapshot.read(locator.vscode_settings)
+    history_before = history.read_bytes()
+    with pytest.raises(IntegrationError) as caught:
+        service.apply(Item.CLAUDE_VSCODE, Action.RECOVER, preview["revision"], ctx)
+    assert caught.value.status_code == 409
+    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
+    assert history.read_bytes() == history_before
+
+
+def test_unstarted_recovery_preserves_absent_client_file(pending_setup):
+    service, locator, ctx = pending_setup
+    locator.vscode_settings.unlink()
+    result = perform(service, ctx, Item.CLAUDE_VSCODE, Action.RECOVER)
+    assert result["applied"] is True
+    assert not locator.vscode_settings.exists()
+    assert not (service.state_dir / "claude-vscode.json").exists()
+
+
+def test_recovery_does_not_rediscover_or_probe_installed_clients(
+    pending_setup, monkeypatch
+):
+    service, locator, ctx = pending_setup
+    monkeypatch.setattr(
+        type(locator),
+        "scan",
+        lambda _self: pytest.fail("recovery does not need discovery"),
+    )
+    before = storage_module.FileSnapshot.read(locator.vscode_settings)
+    assert perform(service, ctx, Item.CLAUDE_VSCODE, Action.RECOVER)["applied"] is True
+    assert storage_module.FileSnapshot.read(locator.vscode_settings) == before
+
+
+@pytest.mark.parametrize(
+    "changed", ["requirement", "manifest", "version", "entrypoint", "runtime"]
+)
+def test_acp_dependency_changes_reject_the_old_confirmation(
+    setup, monkeypatch, changed
+):
+    service, locator, ctx = setup
+    preview = service.preview(Item.CLAUDE_JETBRAINS, Action.SETUP, ctx)
+    package = locator.home / "lib/node_modules/@agentclientprotocol/claude-agent-acp"
+    if changed in {"requirement", "manifest"}:
+        manifest = json.loads((package / "package.json").read_bytes())
+        if changed == "requirement":
+            manifest["engines"]["node"] = ">=24"
+        else:
+            manifest["version"] = "next-fixture-version"
+        write_json(package / "package.json", manifest)
+    elif changed == "version":
+        monkeypatch.setattr(
+            type(locator), "_node_version", lambda _self, _node: (24, 0, 0)
+        )
+    else:
+        path = (
+            package / "dist/index.js"
+            if changed == "entrypoint"
+            else locator.home / "bin/node"
+        )
+        path.write_text("replaced dependency")
+    with pytest.raises(IntegrationError):
+        service.apply(Item.CLAUDE_JETBRAINS, Action.SETUP, preview["revision"], ctx)
+    assert not (locator.home / ".jetbrains/acp.json").exists()
+    assert not (service.state_dir / "claude-jetbrains.json").exists()
+
+
+@pytest.mark.parametrize("failure", ["semantic", "value_error", "toml_error"])
+def test_document_failure_is_isolated_before_client_or_history_writes(
+    setup, monkeypatch, failure
+):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(
+        'keep=true\nmodel_provider="fcc"\n[model_providers.fcc]\nname="Free Claude Code"\n'
+    )
+    before = storage_module.FileSnapshot.read(path)
+    actual_dumps = tomlkit.dumps
+
+    def fail_mutated_candidate(candidate):
+        text = actual_dumps(candidate)
+        if "auth" in candidate["model_providers"]["fcc"]:
+            if failure == "value_error":
+                raise ValueError("private source contents")
+            if failure == "toml_error":
+                raise TOMLKitError("private source contents")
+            return text.replace("keep=true", "keep=1")
+        return text
+
+    monkeypatch.setattr(tomlkit, "dumps", fail_mutated_candidate)
+    inspected = service.inspect(ctx)
+    assert len(inspected["items"]) == 4
+    assert card(service, ctx, Item.CODEX)["status"] == "needs_attention"
+    assert "private source contents" not in json.dumps(inspected)
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CODEX, Action.UPDATE, ctx)
+    assert storage_module.FileSnapshot.read(path) == before
+    assert not (service.state_dir / "codex.json").exists()

--- a/tests/runtime/test_integrations.py
+++ b/tests/runtime/test_integrations.py
@@ -1,0 +1,538 @@
+"""Lifecycle tests use real files, synthetic installations, and no live clients."""
+
+import json
+import tomllib
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from threading import Barrier
+
+import pytest
+
+from free_claude_code.application.integrations import IntegrationAction as Action
+from free_claude_code.application.integrations import IntegrationError
+from free_claude_code.application.integrations import IntegrationId as Item
+from free_claude_code.runtime.integrations import service as service_module
+from free_claude_code.runtime.integrations import storage as storage_module
+from free_claude_code.runtime.integrations.documents import JsonDocument
+from free_claude_code.runtime.integrations.service import IntegrationService
+from tests.integration_support import connection, installed_clients, write_json
+
+
+@pytest.fixture
+def setup(tmp_path):
+    locator = installed_clients(tmp_path)
+    return IntegrationService(locator), locator, connection(tmp_path)
+
+
+def perform(service, ctx, item, action):
+    preview = service.preview(item, action, ctx)
+    return service.apply(item, action, preview["revision"], ctx)
+
+
+def card(service, ctx, item):
+    return next(entry for entry in service.inspect(ctx)["items"] if entry["id"] == item)
+
+
+def test_inspection_and_preview_do_not_write_configuration_or_ownership(setup):
+    service, locator, ctx = setup
+    before = set(locator.home.rglob("*"))
+    assert len(service.inspect(ctx)["items"]) == 4
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    assert preview["changes"]
+    assert set(locator.home.rglob("*")) == before
+    assert ctx.settings.proxy_auth_token not in json.dumps(preview)
+
+
+def test_vscode_setup_update_disconnect_restore_originals_and_unrelated_edits(setup):
+    service, locator, ctx = setup
+    original = b'{\n // keep\n "editor.fontSize":15,\n "claudeCode.disableLoginPrompt":false,\n "claudeCode.environmentVariables":[{"name":"KEEP","value":"mine"},{"name":"ANTHROPIC_BASE_URL","value":"https://previous.example"}]\n}'
+    locator.vscode_settings.parent.mkdir(parents=True)
+    locator.vscode_settings.write_bytes(original)
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    document = JsonDocument(locator.vscode_settings.read_bytes(), jsonc=True)
+    assert document.get(("claudeCode.disableLoginPrompt",)) is True
+    document.set(("editor.fontSize",), 20)
+    locator.vscode_settings.write_bytes(document.render())
+    changed = connection(locator.home, port=8182, token="new-token")
+    assert card(service, changed, Item.CLAUDE_VSCODE)["status"] == "update_available"
+    perform(service, changed, Item.CLAUDE_VSCODE, Action.UPDATE)
+    result = perform(service, changed, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    restored = JsonDocument(locator.vscode_settings.read_bytes(), jsonc=True)
+    assert restored.get(("claudeCode.environmentVariables",)) == [
+        {"name": "KEEP", "value": "mine"},
+        {"name": "ANTHROPIC_BASE_URL", "value": "https://previous.example"},
+    ]
+    assert restored.get(("claudeCode.disableLoginPrompt",)) is False
+    assert restored.get(("editor.fontSize",)) == 20
+    assert b"// keep" in locator.vscode_settings.read_bytes()
+    assert result["applied"]
+
+
+def test_codex_shared_setup_and_restore_existing_provider_model_catalog(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    original = b'# user\nmodel="old"\nmodel_provider="other"\nmodel_catalog_json="custom.json"\n[model_providers.other]\nname="Keep"\n'
+    path.write_bytes(original)
+    perform(service, ctx, Item.CODEX, Action.SETUP)
+    data = tomllib.loads(path.read_text())
+    assert data["model"] == "test/model"
+    assert data["model_providers"]["fcc"]["auth"]["command"] == str(
+        locator.home / "bin/fcc-codex"
+    )
+    assert data["model_providers"]["other"]["name"] == "Keep"
+    perform(service, connection(locator.home, port=8182), Item.CODEX, Action.UPDATE)
+    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
+    data = tomllib.loads(path.read_text())
+    assert data["model"] == "old" and data["model_provider"] == "other"
+    assert data["model_catalog_json"] == "custom.json"
+    assert b"# user" in path.read_bytes()
+
+
+def test_codex_update_keeps_user_model_and_disconnect_stops_on_that_edit(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CODEX, Action.SETUP)
+    path = locator.home / ".codex/config.toml"
+    path.write_bytes(path.read_bytes().replace(b'"test/model"', b'"user/model"'))
+    next_ctx = connection(locator.home, port=8182)
+    perform(service, next_ctx, Item.CODEX, Action.UPDATE)
+    assert tomllib.loads(path.read_text())["model"] == "user/model"
+    before = path.read_bytes()
+    with pytest.raises(IntegrationError, match="model"):
+        service.preview(Item.CODEX, Action.DISCONNECT, next_ctx)
+    assert path.read_bytes() == before
+
+
+def test_later_edit_blocks_whole_update_and_setup_cannot_bypass_it(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    path = locator.vscode_settings
+    path.write_bytes(path.read_bytes().replace(b"fixture-proxy-token", b"user-token"))
+    before = path.read_bytes()
+    changed = connection(locator.home, port=8182, token="new-token")
+    assert card(service, changed, Item.CLAUDE_VSCODE)["status"] == "needs_attention"
+    for action in (Action.UPDATE, Action.DISCONNECT, Action.SETUP):
+        with pytest.raises(IntegrationError):
+            service.preview(Item.CLAUDE_VSCODE, action, changed)
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("change", ["file", "connection", "dependency"])
+def test_stale_preview_cannot_write(setup, change):
+    service, locator, ctx = setup
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    if change == "file":
+        write_json(locator.vscode_settings, {"keep": "latest"})
+    elif change == "connection":
+        ctx = connection(locator.home, port=9090)
+    else:
+        (locator.home / ".vscode/extensions/extensions.json").unlink()
+    before = (
+        locator.vscode_settings.read_bytes()
+        if locator.vscode_settings.exists()
+        else None
+    )
+    with pytest.raises(IntegrationError):
+        service.apply(Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx)
+    assert (
+        locator.vscode_settings.read_bytes()
+        if locator.vscode_settings.exists()
+        else None
+    ) == before
+
+
+def test_duplicate_confirmation_keeps_original_undo_baseline(setup):
+    service, locator, ctx = setup
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    service.apply(Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx)
+    before = locator.vscode_settings.read_bytes()
+    with pytest.raises(IntegrationError):
+        service.apply(Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx)
+    assert locator.vscode_settings.read_bytes() == before
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    assert JsonDocument(locator.vscode_settings.read_bytes(), jsonc=True).data == {}
+
+
+def test_manual_connection_removal_does_not_invent_prior_settings(setup):
+    service, locator, ctx = setup
+    write_json(
+        locator.vscode_settings,
+        {
+            "keep": 1,
+            "claudeCode.disableLoginPrompt": True,
+            "claudeCode.environmentVariables": [
+                {"name": "ANTHROPIC_BASE_URL", "value": "http://localhost:8082"},
+                {"name": "ANTHROPIC_AUTH_TOKEN", "value": "old-token"},
+                {"name": "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "value": "1"},
+                {"name": "KEEP", "value": "mine"},
+            ],
+        },
+    )
+    preview = service.preview(Item.CLAUDE_VSCODE, Action.DISCONNECT, ctx)
+    assert "previous" in " ".join(preview["notes"]).lower()
+    service.apply(Item.CLAUDE_VSCODE, Action.DISCONNECT, preview["revision"], ctx)
+    data = json.loads(locator.vscode_settings.read_bytes())
+    assert data["keep"] == 1
+    assert data["claudeCode.environmentVariables"] == [
+        {"name": "KEEP", "value": "mine"}
+    ]
+
+
+def test_manual_update_adoption_disconnects_instead_of_restoring_old_fcc_url(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(
+        'model_provider="fcc"\n[model_providers.fcc]\nname="Free Claude Code"\nbase_url="http://localhost:7777/v1"\n'
+    )
+    perform(service, ctx, Item.CODEX, Action.UPDATE)
+    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
+    data = tomllib.loads(path.read_text())
+    assert "model_provider" not in data
+    assert "7777" not in path.read_text()
+
+
+def test_jetbrains_custom_agent_preserves_other_agents_and_added_fields_block_removal(
+    setup,
+):
+    service, locator, ctx = setup
+    path = locator.home / ".jetbrains/acp.json"
+    write_json(path, {"agent_servers": {"Other": {"command": "keep"}}})
+    perform(service, ctx, Item.CLAUDE_JETBRAINS, Action.SETUP)
+    data = json.loads(path.read_bytes())
+    assert data["agent_servers"]["Other"] == {"command": "keep"}
+    data["agent_servers"]["Claude Code (FCC)"]["custom"] = True
+    write_json(path, data)
+    perform(
+        service,
+        connection(locator.home, port=8182),
+        Item.CLAUDE_JETBRAINS,
+        Action.UPDATE,
+    )
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CLAUDE_JETBRAINS, Action.DISCONNECT, ctx)
+    assert (
+        json.loads(path.read_bytes())["agent_servers"]["Claude Code (FCC)"]["custom"]
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "original",
+    [None, {}, {"hasCompletedOnboarding": False, "private": "do-not-return"}],
+)
+def test_separate_onboarding_repair_changes_only_its_flag(setup, original):
+    service, locator, ctx = setup
+    path = locator.home / ".claude.json"
+    if original is not None:
+        write_json(path, original)
+    preview = service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+    assert "do-not-return" not in json.dumps(preview)
+    service.apply(Item.CLAUDE_LOGIN, Action.REPAIR, preview["revision"], ctx)
+    assert json.loads(path.read_bytes()) == {
+        **(original or {}),
+        "hasCompletedOnboarding": True,
+    }
+    before = path.read_bytes()
+    assert service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)["changes"] == []
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    assert path.read_bytes() == before
+
+
+def test_onboarding_does_not_repair_other_login_failures_or_invalid_flags(setup):
+    service, locator, ctx = setup
+    for flag in ("false", 1):
+        write_json(locator.home / ".claude.json", {"hasCompletedOnboarding": flag})
+        with pytest.raises(IntegrationError):
+            service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+
+
+def test_missing_client_and_catalog_do_not_trigger_installation_or_fallback_model(
+    setup,
+):
+    service, locator, ctx = setup
+    (locator.home / "bin/fcc-codex").unlink()
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CODEX, Action.SETUP, ctx)
+    with pytest.raises(IntegrationError):
+        service.preview(
+            Item.CODEX,
+            Action.SETUP,
+            replace(ctx, models=()),
+        )
+
+
+def test_codex_auth_cleanup_is_masked_and_does_not_touch_other_providers(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".codex/config.toml"
+    path.parent.mkdir()
+    path.write_text(
+        '[model_providers.fcc]\nname="Old"\nenv_key="PRIVATE_ENV"\nexperimental_bearer_token="SECRET_BEARER"\nrequires_openai_auth=true\n[model_providers.other]\nname="Keep"\n'
+    )
+    preview = service.preview(Item.CODEX, Action.SETUP, ctx)
+    assert "SECRET_BEARER" not in json.dumps(preview)
+    service.apply(Item.CODEX, Action.SETUP, preview["revision"], ctx)
+    assert (
+        "experimental_bearer_token"
+        not in tomllib.loads(path.read_text())["model_providers"]["fcc"]
+    )
+    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
+    assert (
+        tomllib.loads(path.read_text())["model_providers"]["fcc"][
+            "experimental_bearer_token"
+        ]
+        == "SECRET_BEARER"
+    )
+
+
+def test_codex_token_rotation_does_not_offer_update_but_known_auth_mismatch_blocks_setup(
+    setup,
+):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CODEX, Action.SETUP)
+    assert (
+        card(service, connection(locator.home, token="changed"), Item.CODEX)["status"]
+        == "configured"
+    )
+    other = IntegrationService(installed_clients(locator.home / "other"))
+    bad = connection(locator.home / "other")
+    bad = replace(
+        bad,
+        settings=bad.settings.model_copy(update={"proxy_auth_enabled": True}),
+        saved_auth_token="different",
+    )
+    with pytest.raises(IntegrationError):
+        other.preview(Item.CODEX, Action.SETUP, bad)
+
+
+def test_known_conflicting_claude_settings_are_reported_without_modification(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".claude/settings.json"
+    write_json(path, {"env": {"ANTHROPIC_BASE_URL": "https://other.example"}})
+    before = path.read_bytes()
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    assert path.read_bytes() == before
+
+
+def test_disconnect_works_after_app_and_helper_are_removed(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CODEX, Action.SETUP)
+    (locator.home / "bin/fcc-codex").unlink()
+    (locator.home / "bin/chatgpt").unlink()
+    (locator.home / ".vscode/extensions/extensions.json").unlink()
+    perform(service, ctx, Item.CODEX, Action.DISCONNECT)
+    assert "model_provider" not in tomllib.loads(
+        (locator.home / ".codex/config.toml").read_text()
+    )
+
+
+def test_read_only_or_malformed_file_is_never_overwritten(setup):
+    service, locator, ctx = setup
+    path = locator.home / ".claude.json"
+    path.write_bytes(b'{"broken":')
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+    path.write_bytes(b"{}")
+    path.chmod(0o400)
+    try:
+        with pytest.raises(IntegrationError):
+            perform(service, ctx, Item.CLAUDE_LOGIN, Action.REPAIR)
+        assert path.read_bytes() == b"{}"
+    finally:
+        path.chmod(0o600)
+
+
+def test_symlink_configuration_requires_manual_setup(setup):
+    service, locator, ctx = setup
+    target = locator.home / "other.json"
+    target.write_bytes(b"{}")
+    try:
+        (locator.home / ".claude.json").symlink_to(target)
+    except OSError:
+        pytest.skip("Symlink creation is not permitted on this host")
+    with pytest.raises(IntegrationError):
+        service.preview(Item.CLAUDE_LOGIN, Action.REPAIR, ctx)
+    assert target.read_bytes() == b"{}"
+
+
+@pytest.mark.parametrize("stage", ["pending", "external", "committed"])
+def test_failed_write_keeps_original_settings_recoverable(setup, monkeypatch, stage):
+    service, locator, ctx = setup
+    original = {"claudeCode.disableLoginPrompt": False, "editor.fontSize": 16}
+    write_json(locator.vscode_settings, original)
+    actual_record = service_module.write_record
+    actual_write = service_module.atomic_write
+
+    def fail_record(path, record):
+        pending = isinstance(record, service_module.PendingWrite)
+        if (stage == "pending" and pending) or (stage == "committed" and not pending):
+            raise OSError("private error must not escape")
+        actual_record(path, record)
+
+    def fail_external(path, data, **kwargs):
+        if stage == "external" and path == locator.vscode_settings:
+            raise OSError("private error must not escape")
+        actual_write(path, data, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(service_module, "write_record", fail_record)
+        patch.setattr(service_module, "atomic_write", fail_external)
+        with pytest.raises(IntegrationError, match="Could not save"):
+            perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    if stage != "committed":
+        assert json.loads(locator.vscode_settings.read_bytes()) == original
+        perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    else:
+        assert card(service, ctx, Item.CLAUDE_VSCODE)["status"] == "needs_attention"
+        assert card(service, ctx, Item.CLAUDE_VSCODE)["actions"] == ["update"]
+        perform(service, ctx, Item.CLAUDE_VSCODE, Action.UPDATE)
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    assert json.loads(locator.vscode_settings.read_bytes()) == original
+    assert not (service.state_dir / "claude-vscode.json").exists()
+
+
+@pytest.mark.parametrize(
+    "item,action",
+    [(Item.CLAUDE_LOGIN, Action.REPAIR), (Item.CLAUDE_VSCODE, Action.DISCONNECT)],
+)
+def test_completed_write_with_failed_record_cleanup_can_be_finished(
+    setup, monkeypatch, item, action
+):
+    service, _locator, ctx = setup
+    if action == Action.DISCONNECT:
+        perform(service, ctx, item, Action.SETUP)
+    actual_record = service_module.write_record
+
+    def fail_cleanup(path, record):
+        if record is None:
+            raise OSError("cleanup failure")
+        actual_record(path, record)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(service_module, "write_record", fail_cleanup)
+        with pytest.raises(IntegrationError):
+            perform(service, ctx, item, action)
+    assert action in card(service, ctx, item)["actions"]
+    result = perform(service, ctx, item, action)
+    assert result["applied"] is False
+    assert not (service.state_dir / f"{item}.json").exists()
+
+
+def test_interference_after_replace_retains_pending_record_and_refuses_more_writes(
+    setup, monkeypatch
+):
+    service, locator, ctx = setup
+    actual_write = service_module.atomic_write
+
+    def interfere(path, data, **kwargs):
+        actual_write(path, data, **kwargs)
+        if path == locator.vscode_settings:
+            write_json(path, {"user": "later edit"})
+
+    with monkeypatch.context() as patch:
+        patch.setattr(service_module, "atomic_write", interfere)
+        with pytest.raises(IntegrationError, match="verification"):
+            perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    assert card(service, ctx, Item.CLAUDE_VSCODE)["status"] == "needs_attention"
+    with pytest.raises(IntegrationError, match="interrupted write"):
+        service.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+    assert json.loads(locator.vscode_settings.read_bytes()) == {"user": "later edit"}
+    assert (service.state_dir / "claude-vscode.json").exists()
+
+
+def test_concurrent_confirmations_across_services_have_one_winner(setup):
+    service, locator, ctx = setup
+    other = IntegrationService(locator)
+    barrier = Barrier(2)
+
+    def confirm(owner):
+        preview = owner.preview(Item.CLAUDE_VSCODE, Action.SETUP, ctx)
+        barrier.wait(timeout=5)
+        try:
+            return owner.apply(
+                Item.CLAUDE_VSCODE, Action.SETUP, preview["revision"], ctx
+            )["applied"]
+        except IntegrationError as error:
+            assert error.status_code == 409
+            return False
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        assert sorted(pool.map(confirm, [service, other])) == [False, True]
+    perform(service, ctx, Item.CLAUDE_VSCODE, Action.DISCONNECT)
+    assert json.loads(locator.vscode_settings.read_bytes()) == {}
+
+
+def test_manual_jetbrains_disconnect_removes_exact_recipe_entry(setup):
+    service, locator, ctx = setup
+    perform(service, ctx, Item.CLAUDE_JETBRAINS, Action.SETUP)
+    (service.state_dir / "claude-jetbrains.json").unlink()
+    perform(service, ctx, Item.CLAUDE_JETBRAINS, Action.DISCONNECT)
+    assert "Claude Code (FCC)" not in json.loads(
+        (locator.home / ".jetbrains/acp.json").read_bytes()
+    ).get("agent_servers", {})
+
+
+def test_missing_codex_default_is_explained_on_the_card(setup):
+    service, _locator, ctx = setup
+    missing_default = replace(ctx, models=())
+    entry = card(service, missing_default, Item.CODEX)
+    assert entry["status"] == "needs_attention"
+    assert "catalog/default" in entry["message"]
+    assert "setup" not in entry["actions"]
+
+
+def test_codex_wsl_extension_badge_explains_manual_scope_and_native_app_can_setup(
+    setup,
+):
+    service, locator, ctx = setup
+    write_json(
+        locator.vscode_settings, {"chatgpt.runCodexInWindowsSubsystemForLinux": True}
+    )
+    entry = card(service, ctx, Item.CODEX)
+    assert any("WSL" in badge for badge in entry["badges"])
+    perform(service, ctx, Item.CODEX, Action.SETUP)
+    assert (
+        json.loads(locator.vscode_settings.read_bytes())[
+            "chatgpt.runCodexInWindowsSubsystemForLinux"
+        ]
+        is True
+    )
+
+
+def test_symlink_state_directory_does_not_even_create_a_lock_in_another_location(setup):
+    service, locator, ctx = setup
+    other = locator.home / "other-state"
+    other.mkdir()
+    try:
+        service.state_dir.symlink_to(other, target_is_directory=True)
+    except OSError:
+        pytest.skip("Symlink creation is not permitted on this host")
+    with pytest.raises(IntegrationError):
+        service.apply(Item.CLAUDE_LOGIN, Action.REPAIR, "a" * 64, ctx)
+    assert list(other.iterdir()) == []
+
+
+def test_editor_write_during_temporary_file_flush_is_preserved(setup, monkeypatch):
+    service, locator, ctx = setup
+    actual_write = service_module.atomic_write
+    actual_fsync = storage_module.os.fsync
+    later = {"editor.fontSize": 24}
+
+    def interfere_during_write(path, data, **kwargs):
+        if path != locator.vscode_settings:
+            return actual_write(path, data, **kwargs)
+
+        def fsync_then_edit(descriptor):
+            actual_fsync(descriptor)
+            write_json(path, later)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(storage_module.os, "fsync", fsync_then_edit)
+            return actual_write(path, data, **kwargs)
+
+    monkeypatch.setattr(service_module, "atomic_write", interfere_during_write)
+    with pytest.raises(IntegrationError, match="changed since this preview"):
+        perform(service, ctx, Item.CLAUDE_VSCODE, Action.SETUP)
+    assert json.loads(locator.vscode_settings.read_bytes()) == later

--- a/tests/runtime/test_retired_chat.py
+++ b/tests/runtime/test_retired_chat.py
@@ -15,6 +15,8 @@ from free_claude_code.core.interprocess_lock import InterprocessFileLock
 from free_claude_code.providers.runtime import ProviderRuntime
 from free_claude_code.runtime.application import ApplicationRuntime
 from free_claude_code.runtime.configuration import ConfigurationService
+from free_claude_code.runtime.integrations.discovery import LocalInstallations
+from free_claude_code.runtime.integrations.service import IntegrationService
 from free_claude_code.runtime.provider_manager import ProviderRuntimeManager
 from free_claude_code.runtime.retired_chat import remove_retired_chat_history
 
@@ -47,7 +49,10 @@ def _runtime():
         runtime_factory=lambda snapshot: ProviderRuntime(snapshot, {}),
     )
     return ApplicationRuntime(
-        manager, configuration=ConfigurationService(store), transcriber=None
+        manager,
+        integrations=IntegrationService(LocalInstallations.current()),
+        configuration=ConfigurationService(store),
+        transcriber=None,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.2"
+version = "6.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -620,6 +620,9 @@ dependencies = [
     { name = "python-telegram-bot" },
     { name = "requests", extra = ["socks"] },
     { name = "tiktoken" },
+    { name = "tomlkit" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-json" },
     { name = "uvicorn" },
 ]
 
@@ -673,8 +676,11 @@ requires-dist = [
     { name = "python-telegram-bot", specifier = ">=22.8" },
     { name = "requests", extras = ["socks"], specifier = ">=2.34.2" },
     { name = "tiktoken", specifier = ">=0.13.0" },
+    { name = "tomlkit", specifier = ">=0.15.1" },
     { name = "torch", marker = "extra == 'voice-local'", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "transformers", marker = "extra == 'voice-local'", specifier = ">=5.15.0" },
+    { name = "tree-sitter", specifier = ">=0.26.0" },
+    { name = "tree-sitter-json", specifier = ">=0.24.8" },
     { name = "uvicorn", specifier = ">=0.52.1" },
 ]
 provides-extras = ["voice", "voice-local"]
@@ -2598,6 +2604,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.13.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
@@ -2660,6 +2675,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/92/c50c61da7046bbb59a4d011291aeadcfb4d7980ab36fdb31e93823a3fb93/transformers-5.15.1.tar.gz", hash = "sha256:27c996bd9075ddc82d40f8590dfdc81ea45f611bfca477e0db5d7fd257a482f7", size = 9378434, upload-time = "2026-08-19T11:28:20.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/c4/a12e1d9b387fb0c40a57116db82b457e8c771cb419163cda29204d74a595/transformers-5.15.1-py3-none-any.whl", hash = "sha256:b7cdf238ff583e3a58dbc7fa34da1aaf091ce063141f65a30538160bd5afe93f", size = 11749582, upload-time = "2026-08-19T11:28:16.726Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/03/5600b84aff2e6c4fe80cfebb4063fe2f50299521befe5f6092ab8c082f4a/tree_sitter-0.26.0.tar.gz", hash = "sha256:b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245", size = 191423, upload-time = "2026-06-30T12:14:27.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7a/4d84e6f6ae2c3e757490dd84de251712c31e293dfe31f28da1ec019cefa2/tree_sitter-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5a3c93a352b7e6f70f73e121bbfa2d0117ba7478bd51114ed35c91b0b78814fa", size = 148901, upload-time = "2026-06-30T12:14:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/efe62ec65dc9d096e834d27b8c058127e2146e42ff3380b822a233f016a6/tree_sitter-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5fc2f41bf246ff2f70a9cc3690be35ec7580a4923151873d898c8bcb1a4503d3", size = 140805, upload-time = "2026-06-30T12:14:20.478Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2c/c82326b7b97e3c485c18679883b16f89e5e913c639d3b219d3da70c9e67e/tree_sitter-0.26.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8ea92a255c91671a7ec4625aba3ab7bb5220c423630ffbf83c45d7312abe084", size = 640586, upload-time = "2026-06-30T12:14:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7a/f56e7d8282859452611024c7cbc623bfba5b24b8cb9b8f8bc88c5219fe9a/tree_sitter-0.26.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f665510f0fcf4636fb9696f1f7853bed7a3bd764b7bb0cb8494e619c14ed5a0c", size = 668300, upload-time = "2026-06-30T12:14:22.728Z" },
+    { url = "https://files.pythonhosted.org/packages/91/51/240ee81b9d5e9ca0a6cb1528e8605ffa70ab58c89ce126631be96d3e4bae/tree_sitter-0.26.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:253df7ab82cc0a9d311cd65f06e9f99fb3eac55996ae9fc94da22f123a861b90", size = 649627, upload-time = "2026-06-30T12:14:23.819Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/54/760035cefedf9eb44f0f84c4ac22f1322e73155853e272576ee876336312/tree_sitter-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ff80d4833d330a73184a3ac5132abe93c575d2dea31975c6f15c0d21fef238aa", size = 664885, upload-time = "2026-06-30T12:14:25.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1b/0b36fe2a984ecedc4ce6aefd5d56447a6626a8e9b595c4e48658510ce8f8/tree_sitter-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:a4033fecc8f606c7f2e8b8014d0057b74668a7f0152763606f7bc25c5f9ec64c", size = 132688, upload-time = "2026-06-30T12:14:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/74/ebc041a13fbf40144afdb0d4b447e48e0b4012ca866c63de8b48f801f0c1/tree_sitter-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:823251c4b6725a7c03ed497a339135ede7ae4bdde75bb8be7ef5e305aeb4ff52", size = 120287, upload-time = "2026-06-30T12:14:26.991Z" },
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/29/e92df6dca3a6b2ab1c179978be398059817e1173fbacd47e832aaff3446b/tree_sitter_json-0.24.8.tar.gz", hash = "sha256:ca8486e52e2d261819311d35cf98656123d59008c3b7dcf91e61d2c0c6f3120e", size = 8155, upload-time = "2024-11-11T06:05:00.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/41/84866232980fb3cf0cff46f5af2dbb9bfa3324b32614c6a9af3d08926b72/tree_sitter_json-0.24.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:59ac06c6db1877d0e2076bce54a5fddcdd2fc38ca778905662e80fa9ffcea2ab", size = 8718, upload-time = "2024-11-11T06:04:49.779Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/31/102c15948d97b135611d6a995c97a3933c0e9745f25737723977f58e142c/tree_sitter_json-0.24.8-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:62b4c45b561db31436a81a3f037f71ec29049f4fc9bf5269b6ec3ebaaa35a1cd", size = 9163, upload-time = "2024-11-11T06:04:51.275Z" },
+    { url = "https://files.pythonhosted.org/packages/28/64/aa44ea2f3d2e76ec086ce83902eb26b2ed0a92d3fd5e2714c9cb007e90d1/tree_sitter_json-0.24.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8627f7d375fda9fc193ebee368c453f374f65c2f25c58b6fea4e6b49a7fccbc", size = 17726, upload-time = "2024-11-11T06:04:52.732Z" },
+    { url = "https://files.pythonhosted.org/packages/77/08/10001992526670e0d6f24c571b179f0ece90e5e014a4b98a3ce076884f32/tree_sitter_json-0.24.8-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85cca779872f7278f3a74eb38533d34b9c4de4fd548615e3361fa64fe350ad0a", size = 17236, upload-time = "2024-11-11T06:04:54.189Z" },
+    { url = "https://files.pythonhosted.org/packages/92/64/908e9e0bd84fe3c81c564115d3bbe0e49b0e152784bbaf153d749d00bbe6/tree_sitter_json-0.24.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:deeb45850dcc52990fbb52c80196492a099e3fa3512d928a390a91cf061068cc", size = 16071, upload-time = "2024-11-11T06:04:55.628Z" },
+    { url = "https://files.pythonhosted.org/packages/53/df/31daab1eedb445bef208a04fc35428de3afe2b37075fec84d7737e1c69de/tree_sitter_json-0.24.8-cp39-abi3-win_amd64.whl", hash = "sha256:e4849a03cd7197267b2688a4506a90a13568a8e0e8588080bd0212fcb38974e3", size = 11457, upload-time = "2024-11-11T06:04:57.698Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/3d/902d2f3125b6b90cebf404b63ca775bc6d82071ccc76c0d10fabfeb2febe/tree_sitter_json-0.24.8-cp39-abi3-win_arm64.whl", hash = "sha256:591e0096c882d12668b88f30d3ca6f85b9db3406910eaaab6afb6b17d65367dd", size = 10174, upload-time = "2024-11-11T06:04:59.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Connecting installed editors to FCC requires editing configuration files, and users need a clear way to apply new connection settings later. The JetBrains guide also needs the supported custom-agent configuration. Closes #1745.

## How

Add an Integrations tab for Claude Code in VS Code, shared Codex App/VS Code setup, JetBrains ACP, and the separate Claude login-prompt repair. Each client has one Apply FCC settings operation with a compact file-and-summary confirmation and expandable manual disconnect instructions.

Merge the current FCC connection fields into the current file, preserve unrelated settings, and retain an existing Codex model choice when its provider is FCC. Verify standard local installations and prerequisites, validate the edited document, reject stale confirmations, and perform one atomic file replacement. Refresh inspects the actual file after an interrupted request.

Ask users to save and close affected clients before confirming and keep them closed until FCC finishes. Document setup, reapply, manual disconnect, and the remaining limitation for simultaneous external saves. Clients are restarted manually.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62970141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

Not safe to merge until interrupted writes are protected and concurrent editor saves cannot be silently replaced.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fadmin-integrations%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fadmin-integrations%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fruntime%2Fintegrations%2Fservice.py%3A58-85%0AAn%20interrupted%20setup%20leaves%20a%20pending%20journal%2C%20but%20this%20capture%20path%20no%20longer%20reads%20or%20validates%20it.%20A%20later%20Apply%20therefore%20treats%20the%20client%20file%20as%20safe%20and%20overwrites%20it%20despite%20the%20unresolved%20earlier%20write.%20The%20original%20values%20and%20ownership%20data%20are%20also%20no%20longer%20retained%2C%20so%20users%20cannot%20recover%20the%20interrupted%20operation%20or%20restore%20settings%20through%20Disconnect.%0A%0A%23%23%23%20Issue%202%0Asrc%2Ffree_claude_code%2Fruntime%2Fintegrations%2Fstorage.py%3A98-100%0AThe%20unchanged-file%20check%20completes%20before%20%60os.replace%28%29%60.%20If%20an%20editor%20saves%20the%20configuration%20after%20that%20check%20but%20before%20replacement%2C%20this%20write%20replaces%20the%20editor's%20newer%20file%20without%20a%20conflict.%20The%20subsequent%20verification%20observes%20this%20replacement%2C%20so%20the%20concurrent%20edit-including%20unrelated%20user%20settings-is%20silently%20lost%20despite%20the%20conflicting-edit%20protection.%20This%20must%20be%20fixed%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1746&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Preserve recovery state** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1746#discussion_r3992850350">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Protect concurrent editor saves** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1746#discussion_r3986764267">▶</a>

<details open><summary><h3>Summary</h3></summary>

- Apply can overwrite a client configuration even when a pending journal records an unresolved earlier write.
- Restore pending-write validation and saved ownership history before merging so interrupted changes and later disconnects remain recoverable.

## Merge safety

Not safe to merge. The reproduced recovery regression can replace an uncertain client configuration, and the outstanding concurrent editor-save issue can still discard a newer user edit.
</details>

<sub>Reviews (4) · Last reviewed commit: ["refactor: simplify integrations to one c..."](https://github.com/alishahryar1/free-claude-code/commit/ef053543db3114c6b1a5a4a58b7fd972d637230d)</sub>

<!-- /greptile_comment -->