### PR TITLE
feat: add Integrations placeholder tab

### DIFF
--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -34,6 +34,13 @@ const VIEW_GROUPS = [
     containerId: "messagingSections",
   },
   {
+    id: "integrations",
+    label: "Integrations",
+    title: "Integrations",
+    sections: [],
+    containerId: "view-integrations",
+  },
+  {
     id: "code",
     label: "Code sessions",
     title: "Code sessions",
@@ -145,7 +152,7 @@ function setActiveView(viewId, { scroll = false } = {}) {
   document.querySelector(".app-shell").classList.toggle("session-active", sessionActive);
   document.querySelector(".main").classList.toggle("session-main", sessionActive);
   document.querySelector(".topbar").hidden = sessionActive;
-  document.querySelector(".action-bar").hidden = sessionActive;
+  document.querySelector(".action-bar").hidden = sessionActive || activeView.id === "integrations";
 
   document.querySelectorAll(".nav-link").forEach((link) => {
     const selected = link.dataset.view === activeView.id;

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -82,6 +82,10 @@
             ></div>
           </section>
 
+          <section id="view-integrations" class="admin-view" data-view="integrations" hidden>
+            <p>Work in progress</p>
+          </section>
+
           <section id="view-code" class="admin-view" data-view="code" hidden>
             <div id="codeRoot" class="code-root session-root" aria-live="off"></div>
           </section>


### PR DESCRIPTION
## Why

Add a starting point for integrations in the Admin UI.

## How

Add an Integrations tab that displays "Work in progress" and hides the configuration Apply bar while selected.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63237814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: no blocking product or security issues were identified.

What we checked:
- Authored a focused browser check for selecting Integrations, confirming its placeholder and hidden action bar, then returning to Providers and confirming the action bar is restored. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Attempted the rendered Admin flow, but browser startup stopped before a page loaded due to the required Chromium headless-shell executable being absent from the configured cache. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Checked the changed Admin JavaScript for valid syntax and confirmed it parses correctly. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Recorded the exact runtime blocker message indicating the missing executable at the expected Playwright path. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Noted the security status for this focused UI hypothesis: no security finding reported. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details open><summary><h3>Summary</h3></summary>

- Adds an Integrations placeholder to the Admin interface and hides configuration actions while that view is open.
- No product issues were identified in the changed code.
- ### T-Rex validation blocked The rendered Admin navigation check could not start because the configured browser cache does not contain the required Chromium headless-shell executable.
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat: add Integrations placeholder tab"](https://github.com/alishahryar1/free-claude-code/commit/ca0a80ab4a87ce08ebbe1e31ec2b48ab10236a94)</sub>

<!-- /greptile_comment -->