### PR TITLE
feat: add first integration card and explanation modal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.2"
+version = "6.2.3"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -271,6 +271,8 @@ textarea:focus-visible,
   box-shadow: var(--shadow);
 }
 .integration-dialog::backdrop { background: rgba(0, 0, 0, 0.7); }
+.integration-card .section-heading,
+.integration-dialog .section-heading { border-bottom: 0; padding-bottom: 0; }
 .integration-dialog .section-heading { align-items: center; }
 .integration-dialog p { color: var(--muted); line-height: 1.6; margin: 0 0 24px; }
 

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -259,6 +259,21 @@ textarea:focus-visible,
   margin: 4px 0 0 0;
 }
 
+.integration-card { max-width: 400px; }
+.integration-dialog {
+  width: min(480px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  padding: 24px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: var(--shadow);
+}
+.integration-dialog::backdrop { background: rgba(0, 0, 0, 0.7); }
+.integration-dialog .section-heading { align-items: center; }
+.integration-dialog p { color: var(--muted); line-height: 1.6; margin: 0 0 24px; }
+
 /* Provider Status Cards */
 .provider-grid {
   display: grid;

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1246,6 +1246,17 @@ try {
   console.warn("Chat draft cleanup deferred until the next page load: storage unavailable");
 }
 
+const claudeIntegrationDialog = byId("claudeIntegrationDialog");
+byId("openClaudeIntegration").addEventListener("click", () => claudeIntegrationDialog.showModal());
+byId("closeClaudeIntegration").addEventListener("click", () => claudeIntegrationDialog.close());
+claudeIntegrationDialog.addEventListener("click", (event) => {
+  if (event.target !== claudeIntegrationDialog) return;
+  const bounds = claudeIntegrationDialog.getBoundingClientRect();
+  if (event.clientX < bounds.left || event.clientX > bounds.right || event.clientY < bounds.top || event.clientY > bounds.bottom) {
+    claudeIntegrationDialog.close();
+  }
+});
+
 load().then(showRestartNotice).catch((error) => {
   showMessage(error.message, "error");
 });

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -84,7 +84,12 @@
 
           <section id="view-integrations" class="admin-view" data-view="integrations" hidden>
             <article class="provider-strip integration-card">
-              <div class="section-heading"><h3>Claude Code in VS Code</h3></div>
+              <div class="section-heading">
+                <div>
+                  <h3>Claude Code in VS Code</h3>
+                  <p>Use FCC's models in the Claude Code extension for VS Code.</p>
+                </div>
+              </div>
               <button id="openClaudeIntegration" class="primary-button" type="button">Connect</button>
             </article>
             <dialog id="claudeIntegrationDialog" class="integration-dialog" aria-labelledby="claudeIntegrationTitle" aria-describedby="claudeIntegrationDescription">

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -97,7 +97,7 @@
                 <h3 id="claudeIntegrationTitle">Claude Code in VS Code</h3>
                 <button id="closeClaudeIntegration" class="ghost-button" type="button" aria-label="Close" autofocus>×</button>
               </div>
-              <p id="claudeIntegrationDescription">This integration lets you use the Claude Code extension in VS Code with FCC as its API provider.</p>
+              <p id="claudeIntegrationDescription">Will set FCC's URL and token in VS Code settings, enable model discovery, and skip the login prompt.</p>
               <button class="primary-button" type="button">Connect</button>
             </dialog>
           </section>

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -83,7 +83,18 @@
           </section>
 
           <section id="view-integrations" class="admin-view" data-view="integrations" hidden>
-            <p>Work in progress</p>
+            <article class="provider-strip integration-card">
+              <div class="section-heading"><h3>Claude Code in VS Code</h3></div>
+              <button id="openClaudeIntegration" class="primary-button" type="button">Connect</button>
+            </article>
+            <dialog id="claudeIntegrationDialog" class="integration-dialog" aria-labelledby="claudeIntegrationTitle" aria-describedby="claudeIntegrationDescription">
+              <div class="section-heading">
+                <h3 id="claudeIntegrationTitle">Claude Code in VS Code</h3>
+                <button id="closeClaudeIntegration" class="ghost-button" type="button" aria-label="Close" autofocus>×</button>
+              </div>
+              <p id="claudeIntegrationDescription">This integration lets you use the Claude Code extension in VS Code with FCC as its API provider.</p>
+              <button class="primary-button" type="button">Connect</button>
+            </dialog>
           </section>
 
           <section id="view-code" class="admin-view" data-view="code" hidden>

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.2"
+version = "6.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Introduce the first integration card so users can see what connecting Claude Code in VS Code to FCC will do.

## How

Add a Claude Code in VS Code card whose Connect button opens a native explanation dialog. The dialog has a no-op Connect button and closes through the × button or a click outside it. Bump the package version and lockfile to 6.2.3.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63242778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No outstanding issues require changes before merging.

<details open><summary><h3>Summary</h3></summary>

- Adds an Integrations-page card and native explanation dialog for connecting Claude Code in VS Code.
- Adds dialog styling and close behavior, including backdrop dismissal.
- Updates package metadata and lockfile version to 6.2.3.
</details>

<sub>Reviews (3) · Last reviewed commit: ["docs: summarize integration settings in ..."](https://github.com/alishahryar1/free-claude-code/commit/43000b543be3ee8282bf7fa02b8d30ec3bcfefac)</sub>

<!-- /greptile_comment -->