### PR TITLE
fix: preserve selected Admin tab on refresh

### DIFF
--- a/e2e/test_admin_assets.py
+++ b/e2e/test_admin_assets.py
@@ -7,6 +7,23 @@ from playwright.sync_api import Error, Page, Request, expect
 from free_claude_code.core.version import package_version
 
 
+def test_selected_admin_tab_survives_refresh_and_browser_navigation(
+    page, admin_base_url
+):
+    page.goto(f"{admin_base_url}/admin")
+    for title in ("Model Config", "Messaging", "Integrations", "Providers"):
+        page.get_by_role("button", name=title, exact=True).click()
+        page.reload()
+        expect(page.locator("#pageTitle")).to_have_text(title)
+        expect(page.get_by_role("button", name=title, exact=True)).to_have_attribute(
+            "aria-current", "page"
+        )
+    page.go_back()
+    expect(page.locator("#pageTitle")).to_have_text("Integrations")
+    page.go_forward()
+    expect(page.locator("#pageTitle")).to_have_text("Providers")
+
+
 def test_admin_removes_chat_drafts_and_preserves_other_storage(page, admin_base_url):
     page.add_init_script("""(() => {
       for (let index = 0; index < 16; index++) {

--- a/e2e/test_admin_assets.py
+++ b/e2e/test_admin_assets.py
@@ -11,8 +11,14 @@ def test_selected_admin_tab_survives_refresh_and_browser_navigation(
     page, admin_base_url
 ):
     page.goto(f"{admin_base_url}/admin")
-    for title in ("Model Config", "Messaging", "Integrations", "Providers"):
+    for title, path in (
+        ("Model Config", "/admin/model_config"),
+        ("Messaging", "/admin/messaging"),
+        ("Integrations", "/admin/integrations"),
+        ("Providers", "/admin"),
+    ):
         page.get_by_role("button", name=title, exact=True).click()
+        expect(page).to_have_url(f"{admin_base_url}{path}")
         page.reload()
         expect(page.locator("#pageTitle")).to_have_text(title)
         expect(page.get_by_role("button", name=title, exact=True)).to_have_attribute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.3"
+version = "6.2.4"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -92,6 +92,9 @@ def admin_page_response() -> HTMLResponse:
 
 
 @router.get("/admin", include_in_schema=False)
+@router.get("/admin/model_config", include_in_schema=False)
+@router.get("/admin/messaging", include_in_schema=False)
+@router.get("/admin/integrations", include_in_schema=False)
 def admin_page(request: Request):
     require_loopback_admin(request)
     return admin_page_response()

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -50,8 +50,7 @@ const VIEW_GROUPS = [
 ];
 
 function viewFromLocation() {
-  if (window.location.pathname.startsWith("/admin/code")) return "code";
-  return new URLSearchParams(window.location.search).get("view") || "providers";
+  return window.location.pathname.split("/")[2] || "providers";
 }
 
 const byId = (id) => document.getElementById(id);
@@ -179,8 +178,7 @@ function setActiveView(viewId, { scroll = false } = {}) {
 }
 
 function navigateToView(viewId) {
-  const target = viewId === "code" ? "/admin/code"
-    : viewId === "providers" ? "/admin" : `/admin?view=${encodeURIComponent(viewId)}`;
+  const target = viewId === "providers" ? "/admin" : `/admin/${viewId}`;
   if (window.location.pathname + window.location.search !== target) {
     window.history.pushState({}, "", target);
   }

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -6,7 +6,7 @@ const state = {
   modelOptions: [],
   modelComboboxes: new Set(),
   authPollers: new Map(),
-  activeView: sessionViewFromPath(),
+  activeView: viewFromLocation(),
 };
 
 const MASKED_SECRET = "********";
@@ -49,8 +49,9 @@ const VIEW_GROUPS = [
   },
 ];
 
-function sessionViewFromPath() {
-  return window.location.pathname.startsWith("/admin/code") ? "code" : "providers";
+function viewFromLocation() {
+  if (window.location.pathname.startsWith("/admin/code")) return "code";
+  return new URLSearchParams(window.location.search).get("view") || "providers";
 }
 
 const byId = (id) => document.getElementById(id);
@@ -178,12 +179,10 @@ function setActiveView(viewId, { scroll = false } = {}) {
 }
 
 function navigateToView(viewId) {
-  if (viewId === "code") {
-    if (window.location.pathname !== `/admin/${viewId}`) {
-      window.history.pushState({}, "", `/admin/${viewId}`);
-    }
-  } else if (sessionViewFromPath() !== "providers") {
-    window.history.pushState({}, "", "/admin");
+  const target = viewId === "code" ? "/admin/code"
+    : viewId === "providers" ? "/admin" : `/admin?view=${encodeURIComponent(viewId)}`;
+  if (window.location.pathname + window.location.search !== target) {
+    window.history.pushState({}, "", target);
   }
   setActiveView(viewId, { scroll: true });
 }
@@ -1234,7 +1233,7 @@ document.addEventListener("pointerdown", (event) => {
 });
 
 window.addEventListener("popstate", () => {
-  const viewId = sessionViewFromPath();
+  const viewId = viewFromLocation();
   setActiveView(viewId, { scroll: false });
 });
 

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -162,13 +162,16 @@ def _catalog_proxy_env_keys() -> tuple[str, ...]:
     return tuple(keys)
 
 
-def test_admin_page_is_loopback_only(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "path", ["/admin", "/admin/model_config", "/admin/messaging", "/admin/integrations"]
+)
+def test_admin_page_is_loopback_only(monkeypatch, tmp_path, path):
     _set_home(monkeypatch, tmp_path)
     app = create_test_app()
 
-    assert _local_client(app).get("/admin").status_code == 200
+    assert _local_client(app).get(path).status_code == 200
     remote_client = TestClient(app, client=("203.0.113.10", 50000))
-    assert remote_client.get("/admin").status_code == 403
+    assert remote_client.get(path).status_code == 403
 
 
 def test_admin_page_uses_installed_version(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.3"
+version = "6.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Refreshing an Admin tab returns users to Providers and loses their place.

## How

Give Model Config, Messaging, and Integrations their own Admin paths and restore the selected tab on page load and browser Back/Forward navigation. Providers uses /admin and Code sessions retains its session paths. Bump the package version and lockfile to 6.2.4.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63264144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the dedicated paths preserve the selected Admin view while retaining existing route security and Code-session behavior.

<details open><summary><h3>Summary</h3></summary>

- Adds loopback-protected server routes for the new Admin paths.
- Derives the active view from the current pathname and updates history when tabs change.
- Adds API and browser coverage for direct loads, refreshes, and Back/Forward navigation.
- Bumps the package and lockfile project version to 6.2.4.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open or navigate within Admin] --> B[Read current pathname]
    B --> C{Path segment}
    C -->|empty| D[Providers]
    C -->|model_config| E[Model Config]
    C -->|messaging| F[Messaging]
    C -->|integrations| G[Integrations]
    C -->|code| H[Code sessions]
    I[Tab click] --> J[Push dedicated Admin path]
    J --> B
    K[Browser Back or Forward] --> L[popstate]
    L --> B
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["refactor: use dedicated paths for Admin ..."](https://github.com/alishahryar1/free-claude-code/commit/697adc836e59c72511af5f7c8b3431674a9f02e8)</sub>

<!-- /greptile_comment -->