### PR TITLE
Show file paths in the Claude integration modal

### DIFF
--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -1,8 +1,33 @@
 import json
 
+import pytest
 from playwright.sync_api import expect
 
 from free_claude_code.cli import vscode
+
+
+@pytest.mark.parametrize("width", [1280, 390])
+def test_modal_shows_files_for_the_selected_action(
+    page, admin_base_url, tmp_path, width
+):
+    page.set_viewport_size({"width": width, "height": 900})
+    page.goto(f"{admin_base_url}/admin/integrations")
+    page.locator("#openClaudeIntegration").click()
+    dialog = page.locator("#claudeIntegrationDialog")
+    paths = dialog.locator("#claudeIntegrationFiles li")
+    expect(paths).to_have_text(
+        [
+            str((tmp_path / "vscode" / "settings.json").resolve()),
+            str((tmp_path / ".claude.json").resolve()),
+        ]
+    )
+    assert dialog.evaluate("element => element.scrollWidth <= element.clientWidth")
+    page.locator("#confirmClaudeIntegration").click()
+    expect(dialog).not_to_be_visible()
+    page.locator("#openClaudeIntegration").click()
+    expect(paths).to_have_text([str((tmp_path / "vscode" / "settings.json").resolve())])
+    page.keyboard.press("Escape")
+    expect(dialog).not_to_be_visible()
 
 
 def test_connect_disconnect_and_modal_dismissal(page, admin_base_url, tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.6"
+version = "6.2.7"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -275,6 +275,9 @@ textarea:focus-visible,
 .integration-dialog .section-heading { border-bottom: 0; padding-bottom: 0; }
 .integration-dialog .section-heading { align-items: center; }
 .integration-dialog p { color: var(--muted); line-height: 1.6; margin: 0 0 24px; }
+.integration-files { margin-bottom: 24px; font-size: 12px; color: var(--muted); }
+.integration-files ul { margin: 8px 0 0; padding-left: 20px; }
+.integration-files code { overflow-wrap: anywhere; }
 
 /* Provider Status Cards */
 .provider-grid {

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1245,7 +1245,7 @@ try {
 }
 
 const claudeIntegrationDialog = byId("claudeIntegrationDialog");
-const claudeIntegration = { connected: null, busy: false };
+const claudeIntegration = { connected: null, busy: false, paths: null };
 const claudeIntegrationPath = "/admin/api/integrations/claude-vscode";
 
 function integrationMessage(id, message, error = false) {
@@ -1256,7 +1256,7 @@ function integrationMessage(id, message, error = false) {
 }
 
 function renderClaudeIntegration() {
-  const { connected, busy } = claudeIntegration;
+  const { connected, busy, paths } = claudeIntegration;
   const action = connected ? "Disconnect" : "Connect";
   byId("openClaudeIntegration").textContent = connected === null && !busy ? "Retry" : action;
   byId("openClaudeIntegration").disabled = busy;
@@ -1270,6 +1270,18 @@ function renderClaudeIntegration() {
   byId("claudeIntegrationDescription").textContent = connected
     ? "Remove FCC's VS Code settings. Claude onboarding stays completed."
     : "Will set FCC's URL and token, enable model discovery, skip VS Code login, and complete Claude onboarding.";
+  const files = byId("claudeIntegrationFiles");
+  files.replaceChildren();
+  if (paths) {
+    const targets = connected ? [paths.vscode_settings] : [paths.vscode_settings, paths.claude_state];
+    targets.forEach((path) => {
+      const item = document.createElement("li");
+      const code = document.createElement("code");
+      code.textContent = path;
+      item.appendChild(code);
+      files.appendChild(item);
+    });
+  }
 }
 
 async function refreshClaudeIntegration() {
@@ -1280,6 +1292,7 @@ async function refreshClaudeIntegration() {
   try {
     const result = await api(claudeIntegrationPath);
     claudeIntegration.connected = result.connected;
+    claudeIntegration.paths = result.paths;
   } catch (error) {
     claudeIntegration.connected = null;
     integrationMessage("claudeIntegrationMessage", error.message, true);

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -100,6 +100,10 @@
                 <button id="closeClaudeIntegration" class="ghost-button" type="button" aria-label="Close" autofocus>×</button>
               </div>
               <p id="claudeIntegrationDescription">Will set FCC's URL and token, enable model discovery, skip VS Code login, and complete Claude onboarding.</p>
+              <div class="integration-files">
+                <strong>Files to modify</strong>
+                <ul id="claudeIntegrationFiles"></ul>
+              </div>
               <button id="confirmClaudeIntegration" class="primary-button" type="button">Connect</button>
               <p id="claudeIntegrationDialogMessage" class="message-area error" role="alert" hidden></p>
             </dialog>

--- a/src/free_claude_code/cli/vscode.py
+++ b/src/free_claude_code/cli/vscode.py
@@ -176,7 +176,13 @@ def configure(
         document, entries = _read(path, set(values))
         if connected:
             onboarding = _read_object(state_path)
-    return {
+    result: JsonObject = {
         "connected": _connected(document, entries, values)
         and onboarding.get(_ONBOARDING) is True,
     }
+    if connected is None:
+        result["paths"] = {
+            "vscode_settings": str(path),
+            "claude_state": str(state_path),
+        }
+    return result

--- a/tests/api/test_vscode_integration.py
+++ b/tests/api/test_vscode_integration.py
@@ -26,7 +26,7 @@ def integration(tmp_path, monkeypatch):
 
 def test_routes_read_actual_file_connect_and_disconnect(integration):
     client, path, _ = integration
-    assert client.get(ROOT).json() == {"connected": False}
+    assert client.get(ROOT).json()["connected"] is False
     response = client.post(f"{ROOT}/connect")
     assert response.status_code == 200
     assert response.json() == {"connected": True}
@@ -39,16 +39,40 @@ def test_routes_read_actual_file_connect_and_disconnect(integration):
     assert environment["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4321"
     assert environment["ANTHROPIC_AUTH_TOKEN"] == "integration-secret"
     assert "integration-secret" not in response.text
-    assert client.get(ROOT).json() == {"connected": True}
+    assert client.get(ROOT).json()["connected"] is True
     state_path = path.parent / ".claude.json"
     assert json.loads(state_path.read_text())["hasCompletedOnboarding"] is True
     state_path.write_text('{"hasCompletedOnboarding":false}')
-    assert client.get(ROOT).json() == {"connected": False}
+    assert client.get(ROOT).json()["connected"] is False
     assert client.post(f"{ROOT}/connect").json() == {"connected": True}
     path.write_text("{}")
-    assert client.get(ROOT).json() == {"connected": False}
+    assert client.get(ROOT).json()["connected"] is False
     assert client.post(f"{ROOT}/disconnect").json() == {"connected": False}
     assert json.loads(state_path.read_text())["hasCompletedOnboarding"] is True
+
+
+@pytest.mark.parametrize("field", ["vscode_settings", "claude_state"])
+def test_status_reports_resolved_file_paths_without_creating_files(integration, field):
+    client, path, _ = integration
+    state_path = path.parent / ".claude.json"
+    result = client.get(ROOT)
+    assert result.json()["paths"] == {
+        "vscode_settings": str(path.resolve()),
+        "claude_state": str(state_path.resolve()),
+    }
+    assert result.headers["cache-control"] == "no-store"
+    assert not path.exists()
+    assert not state_path.exists()
+    link = path if field == "vscode_settings" else state_path
+    target = path.parent / "actual-settings.json"
+    target.write_text("{}")
+    try:
+        link.symlink_to(target.name)
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314:
+            pytest.skip("Windows symlink creation requires Developer Mode or privilege")
+        raise
+    assert client.get(ROOT).json()["paths"][field] == str(target.resolve())
 
 
 @pytest.mark.parametrize("action", ["", "/connect", "/disconnect"])

--- a/tests/cli/test_vscode.py
+++ b/tests/cli/test_vscode.py
@@ -12,7 +12,8 @@ LOGIN = "claudeCode.disableLoginPrompt"
 
 
 def operate(path, connected=None):
-    return vscode.configure(path, path.parent / ".claude.json", URL, TOKEN, connected)
+    result = vscode.configure(path, path.parent / ".claude.json", URL, TOKEN, connected)
+    return {"connected": result["connected"]}
 
 
 def test_connect_completes_onboarding_and_disconnect_preserves_state(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.6"
+version = "6.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

The Claude integration modal describes the changes but does not show which files Connect or Disconnect will modify. Users should see those paths before confirming.

## How

Add a compact **Files to modify** list to the existing modal. Connect lists VS Code's global `settings.json` and the user's `.claude.json`; Disconnect lists only VS Code's settings because completed onboarding is retained.

The local status response supplies absolute paths from the same resolved targets used by the file operations, including symbolic-link targets. Render paths as text and wrap long paths within the modal. Bump the patch version once to **6.2.7**.

Accepted scope: display the target files for the selected action, preserving the existing behavior that skips unchanged files. The paused Codex card is separate work.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63305507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge. The updated API contract and responsive modal behavior completed successfully.

What we checked:
- Verified the HTTP path contract behavior before and after changes, confirming that the pre-change response returned only {"connected": false} with no path contract, while the post-change response now reveals both resolved paths (including symlink targets) and leaves absent configured files absent, with local-admin protections returning 403 and all responses carrying Cache-Control: no-store. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated the updated Connect modal UI at desktop and 390px widths, which now displays two Connect paths and one Disconnect path without horizontal overflow. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Captured and reviewed the final command run, including the after-command output that records the exact resolved paths, overflow results, the command used, its working directory, and the exit code. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details open><summary><h3>Summary</h3></summary>

- The Claude VS Code integration now shows the resolved local files it will update before confirmation. Connect shows the VS Code settings and Claude state files, while Disconnect shows only the VS Code settings file.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Show target file paths in the Claude int..."](https://github.com/alishahryar1/free-claude-code/commit/6a55f2daec8e110f462860340c4718c1b19cb3d3)</sub>

<!-- /greptile_comment -->