### PR TITLE
Add Codex integration preview card

### DIFF
--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -7,6 +7,52 @@ from free_claude_code.cli import vscode
 
 
 @pytest.mark.parametrize("width", [1280, 390])
+def test_codex_preview_modal_is_noop_and_dismissible(
+    page, admin_base_url, tmp_path, width
+):
+    page.set_viewport_size({"width": width, "height": 900})
+    page.goto(f"{admin_base_url}/admin/integrations")
+    expect(page.locator("#openClaudeIntegration")).to_be_enabled()
+    expect(page.locator("#messageArea")).to_have_text("")
+    cards = page.locator("#view-integrations > article")
+    expect(cards).to_have_count(2)
+    expect(cards.nth(1)).to_contain_text(
+        "Use FCC's models in the Codex CLI, VS Code extension, and desktop app."
+    )
+    requests = []
+    page.on("request", lambda request: requests.append(request.url))
+    opener = page.locator("#openCodexIntegration")
+    dialog = page.get_by_role("dialog", name="Codex", exact=True)
+    opener.click()
+    expect(dialog).to_be_visible()
+    expect(page.locator("#claudeIntegrationDialog")).not_to_be_visible()
+    expect(dialog.get_by_role("button", name="Close", exact=True)).to_be_focused()
+    expect(dialog).to_contain_text(
+        "Will configure Codex to use FCC's models through its shared config.toml."
+    )
+    assert dialog.evaluate("element => element.scrollWidth <= element.clientWidth")
+    action = dialog.get_by_role("button", name="Connect", exact=True)
+    for _ in range(3):
+        action.click()
+        expect(action).to_be_enabled()
+        expect(dialog).to_be_visible()
+    page.locator("#codexIntegrationDescription").click()
+    expect(dialog).to_be_visible()
+    dialog.get_by_role("button", name="Close", exact=True).click()
+    expect(dialog).not_to_be_visible()
+    expect(opener).to_be_focused()
+    opener.click()
+    page.keyboard.press("Escape")
+    expect(dialog).not_to_be_visible()
+    opener.click()
+    page.mouse.click(1, 1)
+    expect(dialog).not_to_be_visible()
+    assert requests == []
+    assert not (tmp_path / "vscode" / "settings.json").exists()
+    assert not (tmp_path / ".claude.json").exists()
+
+
+@pytest.mark.parametrize("width", [1280, 390])
 def test_modal_shows_files_for_the_selected_action(
     page, admin_base_url, tmp_path, width
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.7"
+version = "6.2.8"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1341,6 +1341,17 @@ claudeIntegrationDialog.addEventListener("click", (event) => {
   }
 });
 
+const codexIntegrationDialog = byId("codexIntegrationDialog");
+byId("openCodexIntegration").addEventListener("click", () => codexIntegrationDialog.showModal());
+byId("closeCodexIntegration").addEventListener("click", () => codexIntegrationDialog.close());
+codexIntegrationDialog.addEventListener("click", (event) => {
+  if (event.target !== codexIntegrationDialog) return;
+  const bounds = codexIntegrationDialog.getBoundingClientRect();
+  if (event.clientX < bounds.left || event.clientX > bounds.right || event.clientY < bounds.top || event.clientY > bounds.bottom) {
+    codexIntegrationDialog.close();
+  }
+});
+
 load().then(showRestartNotice).catch((error) => {
   showMessage(error.message, "error");
 });

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -107,6 +107,23 @@
               <button id="confirmClaudeIntegration" class="primary-button" type="button">Connect</button>
               <p id="claudeIntegrationDialogMessage" class="message-area error" role="alert" hidden></p>
             </dialog>
+            <article class="provider-strip integration-card">
+              <div class="section-heading">
+                <div>
+                  <h3>Codex</h3>
+                  <p>Use FCC's models in the Codex CLI, VS Code extension, and desktop app.</p>
+                </div>
+              </div>
+              <button id="openCodexIntegration" class="primary-button" type="button">Connect</button>
+            </article>
+            <dialog id="codexIntegrationDialog" class="integration-dialog" aria-labelledby="codexIntegrationTitle" aria-describedby="codexIntegrationDescription">
+              <div class="section-heading">
+                <h3 id="codexIntegrationTitle">Codex</h3>
+                <button id="closeCodexIntegration" class="ghost-button" type="button" aria-label="Close" autofocus>×</button>
+              </div>
+              <p id="codexIntegrationDescription">Will configure Codex to use FCC's models through its shared config.toml.</p>
+              <button class="primary-button" type="button">Connect</button>
+            </dialog>
           </section>
 
           <section id="view-code" class="admin-view" data-view="code" hidden>

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.7"
+version = "6.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Add the next integration card in the agreed incremental UI rollout: one Codex card representing the terminal CLI, VS Code extension, and desktop app.

## How

Place Codex below the existing Claude card with a brief description. Connect opens a native dialog using the existing integration styling. Close it with ×, Escape, or an outside click. Bump the patch version once to **6.2.8**.

**Accepted scope for review:** the modal's enabled Connect button is intentionally a no-op. Clicking it leaves the dialog open, sends no request, and changes no state. Real configuration access, connection detection, and Disconnect are deferred to a separate piece. This PR is only the preview card and modal.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63310486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; the validated Codex preview flow behaves as an inert informational interaction.

What we checked:
- Viewed the pre-capture state and confirmed the parent revision shows no Codex card. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Executed the Codex modal validation script trex-artifacts/pr1759_codex_modal_validation.py to verify the modal behavior. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Observed that after capture the Codex preview modal appeared and the head run passed all required no-op and dismissal checks. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details open><summary><h3>Summary</h3></summary>

- Adds a preview-only Codex integration card and native modal to the Admin integrations view.
- The preview opens accessibly, supports Close, Escape, and outside-click dismissal, and does not make requests or modify local integration settings.

## Merge safety
Safe to merge.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Add Codex integration preview card and n..."](https://github.com/alishahryar1/free-claude-code/commit/cc0282298c86cde33780e2328688c10a0dc0410f)</sub>

<!-- /greptile_comment -->