### PR TITLE
Use only the managed FCC proxy token

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -149,13 +149,18 @@ def admin_base_url(
     monkeypatch.setenv("VOICE_NOTE_ENABLED", "false")
     monkeypatch.setenv("FCC_OPEN_BROWSER", "false")
     monkeypatch.setenv("PROXY_AUTH_ENABLED", "false")
-    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "e2e-proxy-token")
     for key, value in getattr(request, "param", {}).items():
         monkeypatch.setenv(key, value)
     monkeypatch.setattr(paths, "config_dir_path", lambda: config_dir)
     monkeypatch.setattr(env_migrations, "legacy_env_paths", lambda: ())
     monkeypatch.setattr(env_migrations, "verified_checkout_env_path", lambda: None)
     clear_settings_cache()
+
+    store = ManagedConfigStore()
+    store.initialize({})
+    store.commit(
+        dict(store.read({}).managed) | {"ANTHROPIC_AUTH_TOKEN": "e2e-proxy-token"}
+    )
 
     provider_secret = "CREDENTIAL[unrecognized-format-987654321]"
     providers: dict[str, BaseProvider] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.9"
+version = "6.2.10"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/config/env_migrations.py
+++ b/src/free_claude_code/config/env_migrations.py
@@ -414,10 +414,7 @@ def _materialize_auth_state(
             "true" if values[ANTHROPIC_AUTH_TOKEN_ENV].strip() else "false"
         )
         return
-    process_token = process.get(ANTHROPIC_AUTH_TOKEN_ENV, "").strip()
-    if process_token:
-        values[PROXY_AUTH_ENABLED_ENV] = "true"
-    elif had_legacy_state:
+    if had_legacy_state:
         values[PROXY_AUTH_ENABLED_ENV] = "false"
 
 

--- a/src/free_claude_code/config/loader.py
+++ b/src/free_claude_code/config/loader.py
@@ -152,18 +152,13 @@ def compose_settings_snapshot(
         if name := aliases.get(key):
             sources[name] = ConfigSource.MANAGED
 
-    managed_owns_token = bool(values.get(ANTHROPIC_AUTH_TOKEN_ENV, "").strip())
     for key in recognized:
         if key not in process:
             continue
-        if key == ANTHROPIC_AUTH_TOKEN_ENV and managed_owns_token:
+        # Servers and independently opened clients share the managed token/default.
+        if key == ANTHROPIC_AUTH_TOKEN_ENV:
             continue
-        value = process[key]
-        if key == ANTHROPIC_AUTH_TOKEN_ENV and not value.strip():
-            values.pop(key, None)
-            sources[aliases[key]] = ConfigSource.DEFAULT
-            continue
-        values[key] = value
+        values[key] = process[key]
         if name := aliases.get(key):
             sources[name] = ConfigSource.PROCESS
 

--- a/tests/api/test_managed_proxy_token.py
+++ b/tests/api/test_managed_proxy_token.py
@@ -1,0 +1,56 @@
+"""Independent Codex credential commands agree with the server's managed token."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+from free_claude_code.config.loader import ManagedConfigStore
+from tests.api.support import create_test_app
+
+
+@pytest.mark.parametrize("managed_token", [None, "admin-token"])
+@pytest.mark.parametrize("client_token", [None, "different-terminal-token"])
+def test_independent_codex_token_authenticates_with_server(
+    monkeypatch, managed_token, client_token
+):
+    store = ManagedConfigStore()
+    store.initialize({})
+    values = dict(store.read({}).managed)
+    values["PROXY_AUTH_ENABLED"] = "true"
+    if managed_token is not None:
+        values["ANTHROPIC_AUTH_TOKEN"] = managed_token
+    store.commit(values)
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "server-terminal-token")
+    settings = store.read().settings
+    child_env = dict(os.environ)
+    child_env.pop("ANTHROPIC_AUTH_TOKEN", None)
+    if client_token is not None:
+        child_env["ANTHROPIC_AUTH_TOKEN"] = client_token
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from pathlib import Path; "
+            "from free_claude_code.config import paths; "
+            "paths.config_dir_path = lambda: Path(sys.argv[1]); "
+            "from free_claude_code.cli.launchers.codex import launch; "
+            "launch(['--print-proxy-auth-token'])",
+            str(store.path.parent),
+        ],
+        env=child_env,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=15,
+    )
+    with TestClient(create_test_app(settings)) as client:
+        assert client.get("/v1/models").status_code == 401
+        response = client.get(
+            "/v1/models", headers={"Authorization": f"Bearer {result.stdout.strip()}"}
+        )
+        assert response.status_code == 200
+    assert result.stdout == (managed_token or "freecc") + "\n"
+    assert settings.proxy_auth_token == (managed_token or "freecc")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -11,6 +11,7 @@ from urllib.request import Request
 import pytest
 
 from free_claude_code.cli import local_http
+from free_claude_code.config.loader import ManagedConfigStore
 from free_claude_code.core.json_types import JsonObject
 
 
@@ -102,7 +103,11 @@ def launch_capture(monkeypatch: pytest.MonkeyPatch) -> LaunchCapture:
     from free_claude_code.cli.launchers import common
 
     capture = LaunchCapture()
-    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "launcher-test-token")
+    store = ManagedConfigStore()
+    store.initialize({})
+    store.commit(
+        dict(store.read({}).managed) | {"ANTHROPIC_AUTH_TOKEN": "launcher-test-token"}
+    )
     monkeypatch.setenv("HOST", "127.0.0.1")
     monkeypatch.setenv("PORT", "8182")
     monkeypatch.setenv("MODEL", "nvidia_nim/catalog-model:variant")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -244,11 +244,24 @@ def test_blank_required_process_value_is_rejected() -> None:
         compose_settings_snapshot({}, {"MODEL": " "})
 
 
-def test_blank_process_auth_token_uses_retained_default() -> None:
-    snapshot = compose_settings_snapshot({}, {"ANTHROPIC_AUTH_TOKEN": ""})
+@pytest.mark.parametrize("process_token", ["", "  ", "terminal-token"])
+def test_process_auth_token_cannot_override_retained_default(
+    process_token: str,
+) -> None:
+    snapshot = compose_settings_snapshot({}, {"ANTHROPIC_AUTH_TOKEN": process_token})
 
     assert snapshot.settings.proxy_auth_token == "freecc"
     assert snapshot.sources["proxy_auth_token"] is ConfigSource.DEFAULT
+
+
+@pytest.mark.parametrize("enabled", ["true", "false"])
+def test_auth_checkbox_does_not_change_retained_token(enabled: str) -> None:
+    snapshot = compose_settings_snapshot(
+        {"PROXY_AUTH_ENABLED": enabled, "ANTHROPIC_AUTH_TOKEN": "managed-token"},
+        {"ANTHROPIC_AUTH_TOKEN": "terminal-token"},
+    )
+    assert snapshot.settings.proxy_auth_enabled is (enabled == "true")
+    assert snapshot.settings.proxy_auth_token == "managed-token"
 
 
 def test_process_precedence_and_managed_token_exception() -> None:

--- a/tests/config/test_env_migrations.py
+++ b/tests/config/test_env_migrations.py
@@ -271,7 +271,7 @@ def test_explicit_managed_path_is_deduplicated(
     [
         ("ANTHROPIC_AUTH_TOKEN=secret\n", {}, "true", "secret"),
         ("ANTHROPIC_AUTH_TOKEN=\n", {}, "false", None),
-        ("", {"ANTHROPIC_AUTH_TOKEN": "process-secret"}, "true", None),
+        ("", {"ANTHROPIC_AUTH_TOKEN": "process-secret"}, "false", None),
         ("", {}, "false", None),
         (
             "PROXY_AUTH_ENABLED=false\nANTHROPIC_AUTH_TOKEN=secret\n",
@@ -308,6 +308,18 @@ def test_process_auth_flag_is_not_persisted(
     consolidate_managed_config({"PROXY_AUTH_ENABLED": "true"})
 
     assert "PROXY_AUTH_ENABLED" not in dotenv_values_from_file(managed)
+
+
+def test_fresh_install_ignores_process_token(monkeypatch, tmp_path):
+    managed, _ = _paths(monkeypatch, tmp_path)
+    process = {"ANTHROPIC_AUTH_TOKEN": "process-secret"}
+    consolidate_managed_config(process)
+    values = dotenv_values_from_file(managed)
+    assert "ANTHROPIC_AUTH_TOKEN" not in values
+    assert "PROXY_AUTH_ENABLED" not in values
+    settings = ManagedConfigStore().read(process).settings
+    assert settings.proxy_auth_token == "freecc"
+    assert settings.proxy_auth_enabled is False
 
 
 def test_only_managed_schema_marker_is_trusted(

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.9"
+version = "6.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

FCC and independently opened Codex clients could select different tokens when ANTHROPIC_AUTH_TOKEN existed only in one process environment. The token command could then return a credential rejected by FCC with HTTP 401, as Greptile identified in #1760. FCC supports managing this token through Admin.

## How

- Select the saved managed token, falling back to freecc. Ignore process-environment ANTHROPIC_AUTH_TOKEN even when no managed token has been saved.
- Stop inferring enabled authentication from that ignored process token during configuration migration. Preserve the authentication checkbox, retained non-empty token, and existing saved/legacy authentication choices. Explicit PROXY_AUTH_ENABLED and unrelated environment settings retain their existing behavior.
- Keep fcc-codex --print-proxy-auth-token and Codex's command-based authentication unchanged. This preserves the signed-in subscription authentication fix from #1366 without adding credential files or changing the integration modal.
- Add regression coverage that runs the actual token command in a separate process with a different environment and authenticates an API request against the server settings. Cover saved and default tokens, first-run migration, and checkbox behavior. Update launcher/browser fixtures to use managed tokens.
- Bump once from 6.2.9 to 6.2.10.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63331448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 1/5</h2>

Unsafe to merge until the process-token authentication and migration regressions are fixed.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fmanaged-proxy-token-only%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fmanaged-proxy-token-only%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fconfig%2Floader.py%3A158-160%0AWhen%20%60PROXY_AUTH_ENABLED%3Dtrue%60%20and%20only%20%60ANTHROPIC_AUTH_TOKEN%60%20is%20supplied%20through%20the%20process%20environment%2C%20this%20code%20ignores%20that%20secret%20without%20disabling%20authentication%20or%20requiring%20a%20managed%20token.%20The%20proxy%20instead%20uses%20the%20default%20%60freecc%60%20credential%3A%20requests%20using%20the%20intended%20process%20token%20are%20rejected%2C%20while%20requests%20using%20%60Bearer%20freecc%60%20succeed.%20Because%20the%20default%20bind%20address%20is%20%600.0.0.0%60%2C%20this%20can%20expose%20an%20enabled%20proxy%20to%20remote%20callers%20with%20a%20publicly%20known%20credential.%0A%0A**How%20this%20was%20verified%3A**%20An%20enabled%20process-token-only%20configuration%20rejected%20its%20process%20token%20and%20accepted%20%60Bearer%20freecc%60%20on%20%60%2Fv1%2Fmodels%60.%0A%0A%23%23%23%20Issue%202%0Asrc%2Ffree_claude_code%2Fconfig%2Fenv_migrations.py%3A417-418%0AFor%20an%20existing%20installation%20protected%20only%20by%20process%20%60ANTHROPIC_AUTH_TOKEN%60%2C%20first-time%20configuration%20consolidation%20writes%20%60PROXY_AUTH_ENABLED%3Dfalse%60%20when%20no%20explicit%20flag%20is%20present.%20The%20resulting%20proxy%20accepts%20requests%20with%20no%20credentials%20or%20an%20incorrect%20bearer%20token%2C%20removing%20the%20authentication%20protection%20that%20existed%20before%20the%20migration.%0A%0A**How%20this%20was%20verified%3A**%20Consolidating%20a%20process-token-only%20legacy%20configuration%20wrote%20%60false%60%2C%20after%20which%20protected%20routes%20returned%20200%20for%20unauthenticated%20and%20incorrect-token%20requests.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1762&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Predictable Proxy Credential** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1762#discussion_r3994533363">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Migration Disables Authentication** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1762#discussion_r3994533365">▶</a>

<details open><summary><h3>Summary</h3></summary>

- This change removes process-supplied proxy tokens from configuration composition and changes authentication migration behavior. Two verified regressions affect deployments that previously relied on `ANTHROPIC_AUTH_TOKEN`: one falls back to a predictable credential while authentication remains enabled, and the other disables authentication during first-time configuration consolidation.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix: use only managed proxy tokens"](https://github.com/alishahryar1/free-claude-code/commit/707eabe67332e88c41b9b58be3f970fef80eb503)</sub>

<!-- /greptile_comment -->