### PR TITLE
Align integration cards and clarify Disconnect actions

### DIFF
--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -18,10 +18,16 @@ def test_codex_connect_disconnect_and_modal_paths(
     cards = page.locator("#view-integrations > article")
     expect(cards).to_have_count(2)
     expect(cards.nth(1)).to_contain_text(
-        "Use FCC's models in the Codex CLI, VS Code extension, and desktop app."
+        "Use FCC's models in the Codex VS Code extension and desktop app."
     )
+    bounds = [card.bounding_box() for card in cards.all()]
+    if width == 1280:
+        assert bounds[0]["y"] == bounds[1]["y"]
+        assert bounds[1]["x"] > bounds[0]["x"]
+    else:
+        assert bounds[1]["y"] > bounds[0]["y"]
     opener = page.locator("#openCodexIntegration")
-    dialog = page.get_by_role("dialog", name="Codex", exact=True)
+    dialog = page.get_by_role("dialog", name="Codex in VS Code and App", exact=True)
     opener.click()
     expect(dialog).to_be_visible()
     expect(page.locator("#claudeIntegrationDialog")).not_to_be_visible()
@@ -52,7 +58,15 @@ def test_codex_connect_disconnect_and_modal_paths(
     page.locator("#confirmCodexIntegration").click()
     expect(dialog).not_to_be_visible()
     expect(opener).to_have_text("Disconnect")
-    expect(page.locator("#codexIntegrationStatus")).to_have_text("Connected")
+    expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
+    expect(opener).to_have_css("color", "rgb(239, 68, 68)")
+    if width == 1280:
+        buttons = [
+            button.bounding_box()
+            for button in page.locator(".integration-card > button").all()
+        ]
+        assert buttons[0]["y"] == buttons[1]["y"]
+        assert buttons[0]["height"] == buttons[1]["height"]
     expect(page.locator("#codexIntegrationMessage")).to_have_text(
         "Settings saved. Restart Codex and select an FCC model."
     )
@@ -62,11 +76,15 @@ def test_codex_connect_disconnect_and_modal_paths(
     expect(opener).to_have_text("Disconnect")
     opener.click()
     expect(page.locator("#confirmCodexIntegration")).to_have_text("Disconnect")
+    expect(page.locator("#confirmCodexIntegration")).to_have_css(
+        "color", "rgb(239, 68, 68)"
+    )
     expect(dialog.locator("#codexIntegrationFiles li")).to_have_text(
         [str(path.resolve())]
     )
     page.locator("#confirmCodexIntegration").click()
     expect(opener).to_have_text("Connect")
+    expect(opener).to_have_css("color", "rgb(6, 16, 11)")
     assert tomllib.loads(path.read_text()) == {"model": "my-choice"}
     assert not (tmp_path / "vscode" / "settings.json").exists()
     assert not (tmp_path / ".claude.json").exists()
@@ -119,7 +137,8 @@ def test_connect_disconnect_and_modal_dismissal(page, admin_base_url, tmp_path):
     action.click()
     expect(dialog).not_to_be_visible()
     expect(card_button).to_have_text("Disconnect")
-    expect(page.locator("#claudeIntegrationStatus")).to_have_text("Connected")
+    expect(page.locator("#claudeIntegrationStatus")).not_to_be_visible()
+    expect(card_button).to_have_css("color", "rgb(239, 68, 68)")
     expect(page.locator("#claudeIntegrationMessage")).to_contain_text("Reload VS Code")
     assert json.loads(path.read_text())["claudeCode.disableLoginPrompt"] is True
     state_path = tmp_path / ".claude.json"
@@ -128,12 +147,14 @@ def test_connect_disconnect_and_modal_dismissal(page, admin_base_url, tmp_path):
     expect(card_button).to_have_text("Disconnect")
     card_button.click()
     expect(action).to_have_text("Disconnect")
+    expect(action).to_have_css("color", "rgb(239, 68, 68)")
     expect(page.locator("#claudeIntegrationDescription")).to_contain_text("Remove")
     page.keyboard.press("Escape")
     assert json.loads(path.read_text())["claudeCode.disableLoginPrompt"] is True
     card_button.click()
     action.click()
     expect(card_button).to_have_text("Connect")
+    expect(card_button).to_have_css("color", "rgb(6, 16, 11)")
     assert json.loads(path.read_text()) == {}
     assert json.loads(state_path.read_text())["hasCompletedOnboarding"] is True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.10"
+version = "6.2.11"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -259,7 +259,18 @@ textarea:focus-visible,
   margin: 4px 0 0 0;
 }
 
-.integration-card { max-width: 400px; }
+.integration-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 0;
+}
+.integration-card > button {
+  margin-top: auto;
+  min-height: 38px;
+  padding: 6px 14px;
+  font-size: 13px;
+}
 .integration-dialog {
   width: min(480px, calc(100vw - 32px));
   max-height: calc(100vh - 32px);

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1265,7 +1265,10 @@ function renderClaudeIntegration() {
   byId("openClaudeIntegration").disabled = busy;
   byId("confirmClaudeIntegration").textContent = busy ? "Saving…" : action;
   byId("confirmClaudeIntegration").disabled = busy || connected === null;
+  byId("openClaudeIntegration").className = connected ? "danger-button" : "primary-button";
+  byId("confirmClaudeIntegration").className = connected ? "danger-button" : "primary-button";
   const status = byId("claudeIntegrationStatus");
+  status.hidden = connected === true;
   status.textContent = connected === null
     ? (busy ? "Checking settings…" : "Could not check settings")
     : (connected ? "Connected" : "Not connected");
@@ -1355,7 +1358,10 @@ function renderCodexIntegration() {
   byId("openCodexIntegration").disabled = busy;
   byId("confirmCodexIntegration").textContent = busy ? "Saving…" : action;
   byId("confirmCodexIntegration").disabled = busy || connected === null;
+  byId("openCodexIntegration").className = connected ? "danger-button" : "primary-button";
+  byId("confirmCodexIntegration").className = connected ? "danger-button" : "primary-button";
   const status = byId("codexIntegrationStatus");
+  status.hidden = connected === true;
   status.textContent = connected === null
     ? (busy ? "Checking settings…" : "Could not check settings")
     : (connected ? "Connected" : "Not connected");

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -82,7 +82,7 @@
             ></div>
           </section>
 
-          <section id="view-integrations" class="admin-view" data-view="integrations" hidden>
+          <section id="view-integrations" class="admin-view provider-grid" data-view="integrations" hidden>
             <article class="provider-strip integration-card">
               <div class="section-heading">
                 <div>
@@ -91,8 +91,8 @@
                   <span id="claudeIntegrationStatus" class="status-pill neutral" role="status">Checking settings…</span>
                 </div>
               </div>
-              <button id="openClaudeIntegration" class="primary-button" type="button" disabled>Connect</button>
               <p id="claudeIntegrationMessage" class="message-area" role="status" hidden></p>
+              <button id="openClaudeIntegration" class="primary-button" type="button" disabled>Connect</button>
             </article>
             <dialog id="claudeIntegrationDialog" class="integration-dialog" aria-labelledby="claudeIntegrationTitle" aria-describedby="claudeIntegrationDescription">
               <div class="section-heading">
@@ -110,17 +110,17 @@
             <article class="provider-strip integration-card">
               <div class="section-heading">
                 <div>
-                  <h3>Codex</h3>
-                  <p>Use FCC's models in the Codex CLI, VS Code extension, and desktop app.</p>
+                  <h3>Codex in VS Code and App</h3>
+                  <p>Use FCC's models in the Codex VS Code extension and desktop app.</p>
                   <span id="codexIntegrationStatus" class="status-pill neutral" role="status">Checking settings…</span>
                 </div>
               </div>
-              <button id="openCodexIntegration" class="primary-button" type="button" disabled>Connect</button>
               <p id="codexIntegrationMessage" class="message-area" role="status" hidden></p>
+              <button id="openCodexIntegration" class="primary-button" type="button" disabled>Connect</button>
             </article>
             <dialog id="codexIntegrationDialog" class="integration-dialog" aria-labelledby="codexIntegrationTitle" aria-describedby="codexIntegrationDescription">
               <div class="section-heading">
-                <h3 id="codexIntegrationTitle">Codex</h3>
+                <h3 id="codexIntegrationTitle">Codex in VS Code and App</h3>
                 <button id="closeCodexIntegration" class="ghost-button" type="button" aria-label="Close" autofocus>×</button>
               </div>
               <p id="codexIntegrationDescription">Configure Codex to use FCC. Your selected model stays unchanged.</p>

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.10"
+version = "6.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Make Integrations match the horizontal card layout used elsewhere in Admin and make the connected state clear from the Disconnect action. Name the Codex integration consistently with the clients it describes.

## How

- Reuse the responsive provider grid so cards sit side by side on desktop and stack on mobile. Anchor equally sized action buttons at the bottom of each card so they align despite different text lengths and status messages.
- Hide the Connected badge and use the existing red danger-button style for Disconnect on both cards and their confirmation modals.
- Rename the Codex card/modal to "Codex in VS Code and App" and remove the CLI mention from its description.
- Update the browser checks for layout, labels, and connected styling. Bump the patch version once to 6.2.11.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63340893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Safe to merge: the reproduced concerns affect accessibility feedback and disabled-action clarity, but do not prevent the integration flows from functioning.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fintegration-card-layout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fintegration-card-layout%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fapi%2Fadmin_static%2Fadmin.js%3A1271-1275%0AWhen%20the%20initial%20integration%20check%20finds%20an%20existing%20Claude%20connection%2C%20this%20hides%20the%20%60role%3D%22status%22%60%20element%20as%20its%20text%20changes%20to%20%E2%80%9CConnected.%E2%80%9D%20The%20card%E2%80%99s%20other%20message%20region%20remains%20empty%2C%20so%20the%20completed%20connected%20state%20is%20absent%20from%20the%20accessibility%20tree.%20The%20Codex%20status%20follows%20the%20same%20pattern%20at%20lines%201364%E2%80%931368.%20Keep%20an%20exposed%20live%20status%20or%20publish%20an%20equivalent%20completion%20message.%20This%20is%20a%20non-blocking%20accessibility%20concern%3A%20screen-reader%20users%20otherwise%20need%20to%20navigate%20to%20the%20Disconnect%20control%20to%20discover%20that%20the%20integration%20is%20connected.%0A%0A%23%23%23%20Issue%202%0Asrc%2Ffree_claude_code%2Fapi%2Fadmin_static%2Fadmin.js%3A1268-1269%0AWhile%20a%20connected%20integration%E2%80%99s%20disconnect%20request%20is%20pending%2C%20these%20controls%20are%20disabled%20but%20retain%20%60danger-button%60.%20They%20therefore%20display%20an%20active%20red%20treatment%20and%20a%20pointer%20cursor%20even%20though%20clicks%20are%20ignored.%20The%20Codex%20controls%20have%20the%20same%20behavior%20at%20lines%201361%E2%80%931362.%20Add%20disabled%20styling%20for%20danger%20actions%2C%20including%20a%20%60not-allowed%60%20cursor%2C%20so%20the%20pending%20state%20is%20clear.%20This%20is%20a%20non-blocking%20usability%20concern%20that%20makes%20unavailable%20actions%20look%20actionable.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1763&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Keep connected status available** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1763/files#diff-909643d854668ecf7391d0b1cba9fcca13aba9f6cf618710c1f220544bd915a2R1275">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Show pending disconnect is disabled** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1763#discussion_r3994724517">▶</a>

<details open><summary><h3>Summary</h3></summary>

- The integrations view now uses the provider-card layout, updated connected-state actions, renamed Codex content, expanded browser coverage, and version 6.2.11. Two non-blocking interface concerns remain: connected refresh completion is removed from assistive technology, and pending disconnect actions look clickable while unavailable. The change is safe to merge, with these improvements recommended.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix: align integration cards and clarify..."](https://github.com/alishahryar1/free-claude-code/commit/f54c66901429f02277ebfef50c7dcff96dbbaefc)</sub>

<!-- /greptile_comment -->