### PR TITLE
Align integration titles and remove redundant status badges

### DIFF
--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -7,7 +7,7 @@ from playwright.sync_api import expect
 from free_claude_code.cli import vscode
 
 
-@pytest.mark.parametrize("width", [1280, 390])
+@pytest.mark.parametrize("width", [1280, 1200, 390])
 def test_codex_connect_disconnect_and_modal_paths(
     page, admin_base_url, tmp_path, width
 ):
@@ -17,13 +17,20 @@ def test_codex_connect_disconnect_and_modal_paths(
     expect(page.locator("#messageArea")).to_have_text("")
     cards = page.locator("#view-integrations > article")
     expect(cards).to_have_count(2)
+    expect(page.locator("#claudeIntegrationStatus")).not_to_be_visible()
+    expect(page.locator("#openCodexIntegration")).to_be_enabled()
+    expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
     expect(cards.nth(1)).to_contain_text(
         "Use FCC's models in the Codex VS Code extension and desktop app."
     )
     bounds = [card.bounding_box() for card in cards.all()]
-    if width == 1280:
+    if width >= 1200:
         assert bounds[0]["y"] == bounds[1]["y"]
         assert bounds[1]["x"] > bounds[0]["x"]
+        descriptions = [
+            card.locator(".section-heading p").bounding_box() for card in cards.all()
+        ]
+        assert descriptions[0]["y"] == descriptions[1]["y"]
     else:
         assert bounds[1]["y"] > bounds[0]["y"]
     opener = page.locator("#openCodexIntegration")
@@ -60,7 +67,7 @@ def test_codex_connect_disconnect_and_modal_paths(
     expect(opener).to_have_text("Disconnect")
     expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
     expect(opener).to_have_css("color", "rgb(239, 68, 68)")
-    if width == 1280:
+    if width >= 1200:
         buttons = [
             button.bounding_box()
             for button in page.locator(".integration-card > button").all()
@@ -85,6 +92,7 @@ def test_codex_connect_disconnect_and_modal_paths(
     page.locator("#confirmCodexIntegration").click()
     expect(opener).to_have_text("Connect")
     expect(opener).to_have_css("color", "rgb(6, 16, 11)")
+    expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
     assert tomllib.loads(path.read_text()) == {"model": "my-choice"}
     assert not (tmp_path / "vscode" / "settings.json").exists()
     assert not (tmp_path / ".claude.json").exists()
@@ -155,6 +163,7 @@ def test_connect_disconnect_and_modal_dismissal(page, admin_base_url, tmp_path):
     action.click()
     expect(card_button).to_have_text("Connect")
     expect(card_button).to_have_css("color", "rgb(6, 16, 11)")
+    expect(page.locator("#claudeIntegrationStatus")).not_to_be_visible()
     assert json.loads(path.read_text()) == {}
     assert json.loads(state_path.read_text())["hasCompletedOnboarding"] is True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.11"
+version = "6.2.12"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -271,6 +271,7 @@ textarea:focus-visible,
   padding: 6px 14px;
   font-size: 13px;
 }
+.integration-card h3 { min-height: 2lh; }
 .integration-dialog {
   width: min(480px, calc(100vw - 32px));
   max-height: calc(100vh - 32px);

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1268,11 +1268,8 @@ function renderClaudeIntegration() {
   byId("openClaudeIntegration").className = connected ? "danger-button" : "primary-button";
   byId("confirmClaudeIntegration").className = connected ? "danger-button" : "primary-button";
   const status = byId("claudeIntegrationStatus");
-  status.hidden = connected === true;
-  status.textContent = connected === null
-    ? (busy ? "Checking settings…" : "Could not check settings")
-    : (connected ? "Connected" : "Not connected");
-  status.className = `status-pill ${connected ? "ok" : "neutral"}`;
+  status.hidden = connected !== null;
+  status.textContent = busy ? "Checking settings…" : "Could not check settings";
   byId("claudeIntegrationDescription").textContent = connected
     ? "Remove FCC's VS Code settings. Claude onboarding stays completed."
     : "Will set FCC's URL and token, enable model discovery, skip VS Code login, and complete Claude onboarding.";
@@ -1361,11 +1358,8 @@ function renderCodexIntegration() {
   byId("openCodexIntegration").className = connected ? "danger-button" : "primary-button";
   byId("confirmCodexIntegration").className = connected ? "danger-button" : "primary-button";
   const status = byId("codexIntegrationStatus");
-  status.hidden = connected === true;
-  status.textContent = connected === null
-    ? (busy ? "Checking settings…" : "Could not check settings")
-    : (connected ? "Connected" : "Not connected");
-  status.className = `status-pill ${connected ? "ok" : "neutral"}`;
+  status.hidden = connected !== null;
+  status.textContent = busy ? "Checking settings…" : "Could not check settings";
   byId("codexIntegrationDescription").textContent = connected
     ? "Remove FCC's Codex configuration. Other settings stay unchanged."
     : "Configure Codex to use FCC. Your selected model stays unchanged.";

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.11"
+version = "6.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Remove redundant connection badges: the Connect and Disconnect buttons already indicate the state. At narrower desktop widths, the Codex card title wraps onto two lines while the Claude title stays on one, pushing the Codex description below its neighbor.

## How

Hide normal connection status badges while retaining checking and error messages. Reserve two lines of height for integration card titles so descriptions begin at the same vertical position. Extend the browser check to cover the width that reproduces the mismatch and verify description and button alignment. Bump once to 6.2.12.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63342178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Safe to merge from a user-impact perspective, with a non-blocking test coverage gap that should be addressed to protect status feedback.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fintegration-title-alignment%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fintegration-title-alignment%22.%0A%0A%23%23%23%20Issue%201%0Ae2e%2Ftest_admin_integrations.py%3A20-22%0AThe%20new%20assertions%20verify%20only%20the%20normal%20resolved%20state%20after%20both%20settings%20checks%20complete.%20Neither%20card%20is%20tested%20while%20its%20check%20is%20pending%20or%20after%20its%20status%20request%20fails%2C%20even%20though%20both%20user-visible%20badge%20states%20remain%20in%20the%20changed%20rendering%20path.%20Add%20route-controlled%20delayed%20and%20failed-response%20coverage%20for%20Claude%20and%20Codex%20so%20these%20messages%20and%20their%20retry%20behavior%20do%20not%20regress%20unnoticed.%20This%20is%20non-blocking%2C%20but%20a%20regression%20would%20leave%20administrators%20without%20reliable%20status%20feedback.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1764&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Cover retained status states** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1764#discussion_r3994750789">▶</a>

<details open><summary><h3>Summary</h3></summary>

- The integration-card update hides resolved status badges and expands desktop layout coverage, but the browser tests do not cover the retained pending and failed settings-check messages for either integration card.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix: align integration titles and remove..."](https://github.com/alishahryar1/free-claude-code/commit/d81695e28fa663abe1c38cdf9609bba840e7abbb)</sub>

<!-- /greptile_comment -->