### PR TITLE
Add Claude Code in JetBrains ACP preview card

### DIFF
--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -1,5 +1,6 @@
 import json
 import tomllib
+from itertools import pairwise
 
 import pytest
 from playwright.sync_api import expect
@@ -16,7 +17,14 @@ def test_codex_connect_disconnect_and_modal_paths(
     expect(page.locator("#openClaudeIntegration")).to_be_enabled()
     expect(page.locator("#messageArea")).to_have_text("")
     cards = page.locator("#view-integrations > article")
-    expect(cards).to_have_count(2)
+    expect(cards).to_have_count(3)
+    expect(cards.locator("h3")).to_have_text(
+        [
+            "Claude Code in VS Code",
+            "Codex in VS Code and App",
+            "Claude Code in JetBrains ACP",
+        ]
+    )
     expect(page.locator("#claudeIntegrationStatus")).not_to_be_visible()
     expect(page.locator("#openCodexIntegration")).to_be_enabled()
     expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
@@ -25,14 +33,17 @@ def test_codex_connect_disconnect_and_modal_paths(
     )
     bounds = [card.bounding_box() for card in cards.all()]
     if width >= 1200:
-        assert bounds[0]["y"] == bounds[1]["y"]
-        assert bounds[1]["x"] > bounds[0]["x"]
+        assert len({bound["y"] for bound in bounds}) == 1
+        assert all(right["x"] > left["x"] for left, right in pairwise(bounds))
         descriptions = [
             card.locator(".section-heading p").bounding_box() for card in cards.all()
         ]
-        assert descriptions[0]["y"] == descriptions[1]["y"]
+        assert len({description["y"] for description in descriptions}) == 1
     else:
-        assert bounds[1]["y"] > bounds[0]["y"]
+        assert all(right["y"] > left["y"] for left, right in pairwise(bounds))
+    assert page.locator("body").evaluate(
+        "element => element.scrollWidth <= window.innerWidth"
+    )
     opener = page.locator("#openCodexIntegration")
     dialog = page.get_by_role("dialog", name="Codex in VS Code and App", exact=True)
     opener.click()
@@ -72,8 +83,8 @@ def test_codex_connect_disconnect_and_modal_paths(
             button.bounding_box()
             for button in page.locator(".integration-card > button").all()
         ]
-        assert buttons[0]["y"] == buttons[1]["y"]
-        assert buttons[0]["height"] == buttons[1]["height"]
+        assert len({button["y"] for button in buttons}) == 1
+        assert len({button["height"] for button in buttons}) == 1
     expect(page.locator("#codexIntegrationMessage")).to_have_text(
         "Settings saved. Restart Codex and select an FCC model."
     )
@@ -96,6 +107,79 @@ def test_codex_connect_disconnect_and_modal_paths(
     assert tomllib.loads(path.read_text()) == {"model": "my-choice"}
     assert not (tmp_path / "vscode" / "settings.json").exists()
     assert not (tmp_path / ".claude.json").exists()
+
+
+@pytest.mark.parametrize("width", [1280, 390])
+def test_jetbrains_preview_connect_is_noop_and_modal_dismisses(
+    page, admin_base_url, tmp_path, width
+):
+    page.set_viewport_size({"width": width, "height": 900})
+    page.goto(f"{admin_base_url}/admin/integrations")
+    expect(page.locator("#messageArea")).to_have_text("")
+    expect(page.locator("#openClaudeIntegration")).to_be_enabled()
+    expect(page.locator("#openCodexIntegration")).to_be_enabled()
+    opener = page.locator("#openJetBrainsIntegration")
+    expect(opener).to_be_enabled()
+    expect(opener).to_have_text("Connect")
+    card = page.locator("#view-integrations > article").nth(2)
+    expect(card).to_contain_text(
+        "Use FCC's models in Claude Code through JetBrains ACP."
+    )
+    expect(card.get_by_role("status")).to_have_count(0)
+    page.screenshot(path=str(tmp_path / f"jetbrains-card-{width}.png"), full_page=True)
+    paths = [
+        tmp_path / ".fcc" / ".env",
+        tmp_path / "vscode" / "settings.json",
+        tmp_path / ".claude.json",
+        tmp_path / ".codex" / "config.toml",
+    ]
+    before = {path: path.read_bytes() if path.exists() else None for path in paths}
+    requests = []
+
+    def record_request(request):
+        requests.append((request.method, request.url))
+
+    page.on("request", record_request)
+    dialog = page.get_by_role("dialog", name="Claude Code in JetBrains ACP", exact=True)
+    for dismiss in ("close", "escape", "outside"):
+        opener.click()
+        expect(dialog).to_be_visible()
+        close = dialog.get_by_role("button", name="Close", exact=True)
+        expect(close).to_be_focused()
+        expect(dialog).to_have_accessible_description(
+            "Route Claude Code in JetBrains through your FCC server."
+        )
+        assert dialog.evaluate("element => element.scrollWidth <= element.clientWidth")
+        page.locator("#jetBrainsIntegrationDescription").click()
+        dialog.click(position={"x": 10, "y": 80})
+        expect(dialog).to_be_visible()
+        action = dialog.get_by_role("button", name="Connect", exact=True)
+        for _ in range(2):
+            expect(action).to_be_enabled()
+            action.click()
+            expect(dialog).to_be_visible()
+            expect(action).to_have_text("Connect")
+        if dismiss == "close":
+            page.screenshot(path=str(tmp_path / f"jetbrains-modal-{width}.png"))
+            close.click()
+        elif dismiss == "escape":
+            page.keyboard.press("Escape")
+        else:
+            page.mouse.click(1, 1)
+        expect(dialog).not_to_be_visible()
+        expect(opener).to_be_focused()
+        expect(opener).to_have_text("Connect")
+    assert requests == []
+    assert {
+        path: path.read_bytes() if path.exists() else None for path in paths
+    } == before
+    page.remove_listener("request", record_request)
+    page.reload()
+    expect(opener).to_be_enabled()
+    expect(opener).to_have_text("Connect")
+    expect(dialog).not_to_be_visible()
+    opener.click()
+    expect(dialog).to_be_visible()
 
 
 @pytest.mark.parametrize("width", [1280, 390])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.13"
+version = "6.2.14"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1435,6 +1435,17 @@ codexIntegrationDialog.addEventListener("click", (event) => {
   }
 });
 
+const jetBrainsIntegrationDialog = byId("jetBrainsIntegrationDialog");
+byId("openJetBrainsIntegration").addEventListener("click", () => jetBrainsIntegrationDialog.showModal());
+byId("closeJetBrainsIntegration").addEventListener("click", () => jetBrainsIntegrationDialog.close());
+jetBrainsIntegrationDialog.addEventListener("click", (event) => {
+  if (event.target !== jetBrainsIntegrationDialog) return;
+  const bounds = jetBrainsIntegrationDialog.getBoundingClientRect();
+  if (event.clientX < bounds.left || event.clientX > bounds.right || event.clientY < bounds.top || event.clientY > bounds.bottom) {
+    jetBrainsIntegrationDialog.close();
+  }
+});
+
 load().then(showRestartNotice).catch((error) => {
   showMessage(error.message, "error");
 });

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -131,6 +131,23 @@
               <button id="confirmCodexIntegration" class="primary-button" type="button">Connect</button>
               <p id="codexIntegrationDialogMessage" class="message-area error" role="alert" hidden></p>
             </dialog>
+            <article class="provider-strip integration-card">
+              <div class="section-heading">
+                <div>
+                  <h3>Claude Code in JetBrains ACP</h3>
+                  <p>Use FCC's models in Claude Code through JetBrains ACP.</p>
+                </div>
+              </div>
+              <button id="openJetBrainsIntegration" class="primary-button" type="button">Connect</button>
+            </article>
+            <dialog id="jetBrainsIntegrationDialog" class="integration-dialog" aria-labelledby="jetBrainsIntegrationTitle" aria-describedby="jetBrainsIntegrationDescription">
+              <div class="section-heading">
+                <h3 id="jetBrainsIntegrationTitle">Claude Code in JetBrains ACP</h3>
+                <button id="closeJetBrainsIntegration" class="ghost-button" type="button" aria-label="Close" autofocus>×</button>
+              </div>
+              <p id="jetBrainsIntegrationDescription">Route Claude Code in JetBrains through your FCC server.</p>
+              <button id="confirmJetBrainsIntegration" class="primary-button" type="button">Connect</button>
+            </dialog>
           </section>
 
           <section id="view-code" class="admin-view" data-view="code" hidden>

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.13"
+version = "6.2.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Add a preview of the documented Claude Code integration for JetBrains ACP to the Integrations page.

## How

Add a third card with a brief description and the existing native modal styling. The card's Connect button opens the modal. Close, Escape, and backdrop clicks dismiss it and return focus to the card. Extend the layout checks to cover alignment of all three cards on desktop and their order on mobile.

Accepted scope: the modal's Connect button stays enabled and intentionally does nothing, leaving the modal open. This step adds no connection state, configuration operations, or file-path list; functional setup is a later increment.

Bump the patch version once to 6.2.14.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63381464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; the new preview interaction works without changing user configuration or contacting external services.

What we checked:
- Verified the parent revision and confirmed that the JetBrains ACP preview card was not present. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated the JetBrains ACP preview in desktop and mobile by opening the modal, interacting with its inert Connect action, and dismissing it with Close, Escape, and a backdrop click, while confirming focus returned to the card's Connect button. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Verified that invoking the preview action kept the modal open, issued no network requests, and did not modify the checked configuration files. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details open><summary><h3>Summary</h3></summary>

- Adds a JetBrains ACP integration preview card and native modal to the admin Integrations page. The preview can be opened and dismissed with Close, Escape, or a backdrop click, returns focus to its Connect button, and intentionally makes no requests or configuration changes.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Add Claude Code JetBrains ACP integratio..."](https://github.com/alishahryar1/free-claude-code/commit/8386f0f24fb2bb0f8bb7070a7091e15c1b86385b)</sub>

<!-- /greptile_comment -->