### PR TITLE
Finish Admin loading without waiting for local providers

### DIFF
--- a/e2e/test_admin_apply.py
+++ b/e2e/test_admin_apply.py
@@ -95,6 +95,10 @@ def test_key_rejection_retains_edits_and_restores_focus(
 def test_unverified_warning_survives_apply(
     page: Page, admin_base_url: str, restart: bool
 ):
+    availability: list[Route] = []
+    page.route(
+        "**/admin/api/providers/local-status", lambda route: availability.append(route)
+    )
     page.route(
         "**/admin/api/config/apply",
         lambda route: route.fulfill(
@@ -131,6 +135,31 @@ def test_unverified_warning_survives_apply(
     expect(page.locator("#field-NVIDIA_NIM_API_KEY")).to_be_editable()
     expect(page.locator("#applyButton")).to_have_text("Apply")
     expect(page.locator("#messageArea")).to_contain_text("Verification unavailable.")
+
+    current = page.locator('[data-provider-check-result="lmstudio"]')
+    with page.expect_response("**/admin/api/providers/local-status") as response:
+        old = availability.pop(0)
+        if restart:
+            old.fulfill(status=503, json={"detail": "Old check failed"})
+        else:
+            payload = old.fetch().json()
+            for provider in payload["providers"]:
+                provider.update(
+                    status="offline", label="Offline", message="Old availability result"
+                )
+            old.fulfill(json=payload)
+    response.value.finished()
+    page.evaluate("() => new Promise(requestAnimationFrame)")
+    expect(current).to_be_hidden()
+
+    if restart:
+        availability.pop().fulfill(status=503, json={"detail": "New check failed"})
+        expect(current).to_have_text("Availability check failed. Use Test to retry.")
+    else:
+        availability.pop().continue_()
+        expect(current).to_have_text("Reachable: http://localhost:1234/v1")
+    expect(page.locator("#messageArea")).to_contain_text("Verification unavailable.")
+    expect(page.locator("#field-NVIDIA_NIM_API_KEY")).to_be_editable()
 
 
 def test_apply_network_error_unlocks_form_and_keeps_edits(

--- a/e2e/test_admin_providers.py
+++ b/e2e/test_admin_providers.py
@@ -1,7 +1,7 @@
 """Rendered provider-setup regressions for the local Admin UI."""
 
 import pytest
-from playwright.sync_api import ConsoleMessage, Page, ViewportSize, expect
+from playwright.sync_api import ConsoleMessage, Page, Route, ViewportSize, expect
 
 
 @pytest.mark.parametrize(
@@ -170,3 +170,121 @@ def test_multi_field_provider_targets_first_missing_configuration(
 
     expect(account_input).to_be_in_viewport()
     expect(account_input).to_be_focused()
+
+
+def test_admin_loading_finishes_before_local_availability_checks(
+    page: Page, admin_base_url: str
+) -> None:
+    pending: list[Route] = []
+    page.route(
+        "**/admin/api/providers/local-status", lambda route: pending.append(route)
+    )
+    _open_admin(page, admin_base_url, {"width": 1280, "height": 720})
+    key = page.locator("#field-NVIDIA_NIM_API_KEY")
+    key.fill("unsaved-key")
+    expect(page.locator("#dirtyState")).to_have_text("1 unsaved change")
+    expect(page.locator("#applyButton")).to_be_enabled()
+
+    route = pending.pop()
+    payload = route.fetch().json()
+    providers = {provider["provider_id"]: provider for provider in payload["providers"]}
+    providers["llamacpp"].update(status="offline", label="Offline", status_code=503)
+    providers["ollama"].update(status="missing_url", label="Missing URL", base_url="")
+    route.fulfill(json=payload)
+    expect(page.locator('[data-provider-check-result="lmstudio"]')).to_have_text(
+        "Reachable: http://localhost:1234/v1"
+    )
+    expect(page.locator('[data-provider-check-result="llamacpp"]')).to_have_text(
+        "Unavailable: http://localhost:8080/v1 returned HTTP 503"
+    )
+    expect(page.locator('[data-provider-check-result="ollama"]')).to_be_hidden()
+    expect(page.locator('[data-provider="lmstudio"] .status-pill')).to_have_text(
+        "Configured"
+    )
+    expect(key).to_have_value("unsaved-key")
+    expect(page.locator("#dirtyState")).to_have_text("1 unsaved change")
+    expect(page.locator("#messageArea")).to_have_text("")
+
+
+@pytest.mark.parametrize("failure", ["http", "network"])
+def test_local_availability_failure_does_not_fail_admin_loading(
+    page: Page, admin_base_url: str, failure: str
+) -> None:
+    pending: list[Route] = []
+    errors: list[str] = []
+    page.on("pageerror", lambda error: errors.append(str(error)))
+    page.route(
+        "**/admin/api/providers/local-status", lambda route: pending.append(route)
+    )
+    with page.expect_request("**/admin/api/providers/local-status"):
+        page.goto(f"{admin_base_url}/admin")
+    expect(page.locator("#field-NVIDIA_NIM_API_KEY")).to_be_editable()
+    if failure == "http":
+        pending.pop().fulfill(status=503, json={"detail": "private-diagnostic-marker"})
+    else:
+        pending.pop().abort()
+
+    for provider_id in ("lmstudio", "llamacpp", "ollama"):
+        card = page.locator(f'[data-provider="{provider_id}"]')
+        expect(card.locator(".provider-check-result")).to_have_text(
+            "Availability check failed. Use Test to retry."
+        )
+        expect(card.locator(".status-pill")).to_have_text("Configured")
+        expect(card.get_by_role("button", name="Test", exact=True)).to_be_enabled()
+    expect(page.locator('[data-provider-check-result="open_router"]')).to_be_hidden()
+    expect(page.locator("#messageArea")).to_have_text("")
+    assert "private-diagnostic-marker" not in page.locator("body").inner_text()
+    assert errors == []
+
+
+@pytest.mark.parametrize("manual_finished", [False, True])
+def test_manual_provider_test_takes_precedence_over_automatic_availability(
+    page: Page, admin_base_url: str, manual_finished: bool
+) -> None:
+    availability: list[Route] = []
+    manual: list[Route] = []
+    page.route(
+        "**/admin/api/providers/local-status", lambda route: availability.append(route)
+    )
+    page.route(
+        "**/admin/api/providers/lmstudio/test", lambda route: manual.append(route)
+    )
+    _open_admin(page, admin_base_url, {"width": 1280, "height": 720})
+    card = page.locator('[data-provider="lmstudio"]')
+    with page.expect_request("**/admin/api/providers/lmstudio/test"):
+        card.get_by_role("button", name="Test", exact=True).click()
+    result = card.locator(".provider-check-result")
+    expect(result).to_have_text("Checking...")
+    if manual_finished:
+        manual.pop().fulfill(
+            json={
+                "provider_id": "lmstudio",
+                "ok": False,
+                "message": "Could not refresh this provider's models.",
+            }
+        )
+        expect(result).to_have_text(
+            "Unavailable: Could not refresh this provider's models."
+        )
+
+    with page.expect_response("**/admin/api/providers/local-status") as response:
+        if manual_finished:
+            availability.pop().fulfill(status=503, json={"detail": "Check failed"})
+        else:
+            availability.pop().continue_()
+    response.value.finished()
+    page.evaluate("() => new Promise(requestAnimationFrame)")
+    other = page.locator('[data-provider-check-result="ollama"]')
+    if manual_finished:
+        expect(result).to_have_text(
+            "Unavailable: Could not refresh this provider's models."
+        )
+        expect(other).to_have_text("Availability check failed. Use Test to retry.")
+    else:
+        expect(result).to_have_text("Checking...")
+        expect(other).to_have_text("Reachable: http://localhost:11434")
+        manual.pop().fulfill(
+            json={"provider_id": "lmstudio", "ok": True, "models": ["local-model"]}
+        )
+        expect(result).to_have_text("1 models available")
+    expect(card.get_by_role("button", name="Test", exact=True)).to_be_enabled()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.14"
+version = "6.2.15"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -6,6 +6,7 @@ const state = {
   modelOptions: [],
   modelComboboxes: new Set(),
   authPollers: new Map(),
+  localStatusRequest: null,
   activeView: viewFromLocation(),
 };
 
@@ -105,6 +106,7 @@ async function api(path, options = {}) {
 }
 
 async function load() {
+  state.localStatusRequest = null;
   showMessage("Loading admin config");
   const config = await api("/admin/api/config");
   state.config = config;
@@ -113,10 +115,10 @@ async function load() {
   renderProviders(config.provider_status);
   renderSections(config.sections, config.fields);
   byId("configPath").textContent = config.paths.managed;
+  void refreshLocalStatus(config);
   await Promise.all([
     refreshConnectedAccounts(),
     hydrateModelOptions(),
-    refreshLocalStatus(),
     window.CodeSessions.initialize(api),
   ]);
   updateDirtyState();
@@ -1100,32 +1102,53 @@ async function apply() {
   }
 }
 
-async function refreshLocalStatus() {
-  const result = await api("/admin/api/providers/local-status");
-  result.providers.forEach((provider) => {
-    if (provider.status === "missing_url") return;
-    if (provider.status === "reachable") {
+async function refreshLocalStatus(config) {
+  const request = {
+    providerIds: new Set(config.provider_status.filter((provider) =>
+      provider.kind === "local" && provider.status === "configured",
+    ).map((provider) => provider.provider_id)),
+  };
+  state.localStatusRequest = request;
+  try {
+    const result = await api("/admin/api/providers/local-status");
+    if (state.localStatusRequest !== request) return;
+    result.providers.forEach((provider) => {
+      if (!request.providerIds.has(provider.provider_id) || provider.status === "missing_url") return;
+      if (provider.status === "reachable") {
+        updateProviderCheckResult(
+          provider.provider_id,
+          "ok",
+          `Reachable: ${provider.base_url}`,
+        );
+        return;
+      }
+      const detail = provider.message
+        ? provider.message
+        : provider.status_code
+          ? `${provider.base_url} returned HTTP ${provider.status_code}`
+          : "The local provider did not respond.";
       updateProviderCheckResult(
         provider.provider_id,
-        "ok",
-        `Reachable: ${provider.base_url}`,
+        "error",
+        `Unavailable: ${detail}`,
       );
-      return;
-    }
-    const detail = provider.message
-      ? provider.message
-      : provider.status_code
-        ? `${provider.base_url} returned HTTP ${provider.status_code}`
-        : "The local provider did not respond.";
-    updateProviderCheckResult(
-      provider.provider_id,
-      "error",
-      `Unavailable: ${detail}`,
-    );
-  });
+    });
+  } catch {
+    if (state.localStatusRequest !== request) return;
+    request.providerIds.forEach((providerId) => {
+      updateProviderCheckResult(
+        providerId,
+        "error",
+        "Availability check failed. Use Test to retry.",
+      );
+    });
+  } finally {
+    if (state.localStatusRequest === request) state.localStatusRequest = null;
+  }
 }
 
 async function testProvider(providerId, button) {
+  state.localStatusRequest?.providerIds.delete(providerId);
   const original = button.textContent;
   button.disabled = true;
   button.textContent = "Checking...";

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.14"
+version = "6.2.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Admin keeps its loading message open and delays completing Apply/reconnect while local provider availability checks finish. Offline local services can add about 1.5 seconds to this wait.

## How

- Run automatic availability checks independently of Admin initialization and report request failures in the existing local card result areas with generic retry guidance.
- Discard an automatic batch after a new configuration load, and give manual Test actions precedence for their own cards.
- Bump the package and lockfile to 6.2.15.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63385970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the updated Admin loading and provider-status behavior was exercised in rendered browser flows without failures.

What we checked:
- The admin local status script was authored and executed during the general contract validation. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- A focused test run was executed, and the focused-output log shows 7 passed, 13 deselected in 5.83 seconds with exit code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Before and after renderings and command outputs were attached for review, and no repository changes were made. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validation artifacts, including the Python script, the focused-output log, and accompanying media, were prepared to support inspection. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details open><summary><h3>Summary</h3></summary>

- Admin configuration now completes without waiting for automatic local-provider availability checks.
- Automatic availability failures provide retry guidance while keeping the Admin page usable.
- Stale automatic responses are ignored, and manual provider tests retain control of their displayed result.

No issues found that require changes before merging.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Finish Admin loading without waiting for..."](https://github.com/alishahryar1/free-claude-code/commit/6945067a2ecfb6280158199d6f2a9f621e61e592)</sub>

<!-- /greptile_comment -->