### PR TITLE
Show Thinking in transcript during 500 ms output gaps

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -740,6 +740,194 @@ def test_existing_session_keeps_streaming_while_folder_picker_is_open(
         observer.close()
 
 
+@pytest.mark.parametrize("terminal", ["completed", "failed", "interrupted"])
+def test_thinking_fills_quiet_gaps_without_changing_transcript(
+    page, admin_base_url, tmp_path, code_control, terminal
+):
+    create_session(page, admin_base_url, tmp_path)
+    page.clock.install(time=1000)
+    page.clock.pause_at(1000)
+    send(page, "Inspect this project")
+    connection = code_control.connection()
+    expect(page.locator("#codeStop")).to_be_visible()
+    activity = page.locator("#codeActivity")
+    expect(activity).to_have_count(1)
+    expect(page.locator("#codeComposerStatus")).to_have_count(0)
+    page.clock.run_for(499)
+    expect(activity).to_be_hidden()
+    page.clock.run_for(1)
+    expect(activity).to_have_text("Thinking…")
+    expect(activity).to_be_visible()
+    for chunk in ("A", "AB", "ABC"):
+        code_control.run(connection.text("turn-1", "text", chunk))
+        expect(page.locator('.code-item[data-kind="text"] .code-prose')).to_have_text(
+            chunk
+        )
+        page.clock.run_for(400)
+        expect(activity).to_be_hidden()
+    for kind in ("text", "reasoning", "tool"):
+        for complete, text in ((False, "Streaming"), (True, "Finished")):
+            code_control.run(
+                connection.text("turn-1", kind, text, complete=complete, kind=kind)
+            )
+            item = page.locator(f'.code-item[data-kind="{kind}"]')
+            expect(item.locator(".code-prose")).to_have_text(text)
+            expect(activity).to_be_hidden()
+            page.clock.run_for(499)
+            expect(activity).to_be_hidden()
+            page.clock.run_for(1)
+            expect(activity).to_be_visible()
+    # A duplicate update and an unrelated composer render are not streaming.
+    code_control.run(
+        connection.text("turn-1", "tool", "Finished", complete=True, kind="tool")
+    )
+    page.locator("#codeComposer").fill("Next question")
+    expect(activity).to_be_visible()
+    assert page.locator(".code-items #codeActivity").count() == 0
+    assert (
+        activity.evaluate("node => node.previousElementSibling.className")
+        == "code-items"
+    )
+    code_control.run(connection.finish("turn-1", status=terminal))
+    expect(page.locator("#codeSend")).to_be_visible()
+    expect(activity).to_be_hidden()
+    page.clock.run_for(1000)
+    expect(activity).to_be_hidden()
+    expect(page.locator(".code-item")).to_have_count(4)
+
+
+def test_thinking_respects_prompts_refresh_navigation_and_stop(
+    page, admin_base_url, tmp_path, code_control
+):
+    control_feed(page)
+    url = create_session(page, admin_base_url, tmp_path)
+    page.clock.install(time=1000)
+    page.clock.pause_at(1000)
+    send(page, "Inspect")
+    connection = code_control.connection()
+    code_control.run(connection.prompt(0))
+    expect(page.get_by_role("button", name="Allow", exact=True)).to_be_visible()
+    page.clock.run_for(1000)
+    expect(page.locator("#codeActivity")).to_be_hidden()
+    page.get_by_role("button", name="Allow", exact=True).click()
+    expect(page.locator(".code-prompt-state")).to_have_text("Resolved")
+    page.clock.run_for(499)
+    expect(page.locator("#codeActivity")).to_be_hidden()
+    page.clock.run_for(1)
+    expect(page.locator("#codeActivity")).to_be_visible()
+    code_control.run(
+        connection.sink(
+            HarnessEvent(
+                connection.generation,
+                connection.thread_id,
+                "error",
+                turn_id="turn-1",
+                message="Upstream paused",
+                will_retry=True,
+            )
+        )
+    )
+    notice = page.locator('.code-item[data-kind="notice"] .code-prose')
+    expect(notice).to_have_text("Retrying… Upstream paused")
+    expect(page.locator("#codeActivity")).to_be_hidden()
+    page.reload()
+    expect(notice).to_have_text("Retrying… Upstream paused")
+    expect(page.locator(".code-prompt-state")).to_have_text("Resolved")
+    page.clock.run_for(500)
+    expect(page.locator("#codeActivity")).to_be_visible()
+    # Replaying the connection snapshot does not count as fresh output.
+    page.evaluate("window.replayCodeReady()")
+    expect(page.locator("#codeStop")).to_be_enabled()
+    expect(page.locator("#codeActivity")).to_be_visible()
+    page.get_by_role("button", name="Providers", exact=True).click()
+    page.clock.run_for(1000)
+    assert page.locator("#codeActivity").evaluate("node => node.hidden")
+    page.get_by_role("button", name="Code sessions", exact=True).click()
+    # Return through the library if the main tab opens the library route.
+    if page.url != url:
+        page.locator(".session-card").first.click()
+    expect(page.locator("#codeStop")).to_be_enabled()
+    page.clock.run_for(499)
+    expect(page.locator("#codeActivity")).to_be_hidden()
+    page.clock.run_for(1)
+    expect(page.locator("#codeActivity")).to_be_visible()
+    code_control.harness.interrupt_gate.clear()
+    page.locator("#codeStop").click()
+    expect(page.locator("#codeStop")).to_be_disabled()
+    page.clock.run_for(500)
+    expect(page.locator("#codeActivity")).to_be_visible()
+    code_control.run(release_interrupt(code_control))
+    expect(page.locator(".code-outcome")).to_contain_text("Turn stopped.")
+    page.clock.run_for(1000)
+    expect(page.locator("#codeActivity")).to_be_hidden()
+
+
+async def release_interrupt(code_control):
+    code_control.harness.interrupt_gate.set()
+
+
+def test_thinking_preserves_expanded_items_and_scroll_position(
+    page, admin_base_url, tmp_path, code_control
+):
+    create_session(page, admin_base_url, tmp_path)
+    page.clock.install(time=1000)
+    page.clock.pause_at(1000)
+    send(page, "Inspect")
+    connection = code_control.connection()
+    code_control.run(connection.text("turn-1", "reason", "Reading", kind="reasoning"))
+    reason = page.locator(".session-thinking")
+    expect(reason).to_have_count(1)
+    reason.locator("summary").click()
+    page.evaluate("window.savedReason = document.querySelector('.session-thinking')")
+    code_control.run(connection.text("turn-1", "text", "Paragraph\n\n" * 100))
+    expect(page.locator('.code-item[data-kind="text"] .code-prose')).to_contain_text(
+        "Paragraph"
+    )
+    transcript = page.locator("#codeTranscript")
+    transcript.evaluate("node => node.scrollTop = 0")
+    page.clock.run_for(500)
+    expect(page.locator("#codeActivity")).to_be_visible()
+    assert transcript.evaluate("node => node.scrollTop") == 0
+    assert reason.evaluate("node => node === window.savedReason && node.open")
+    transcript.evaluate("node => node.scrollTop = node.scrollHeight")
+    code_control.run(
+        connection.text("turn-1", "reason", "Reading more", kind="reasoning")
+    )
+    expect(reason.locator(".code-prose")).to_have_text("Reading more")
+    page.clock.run_for(500)
+    assert (
+        transcript.evaluate(
+            "node => node.scrollHeight - node.scrollTop - node.clientHeight"
+        )
+        < 2
+    )
+    assert reason.evaluate("node => node === window.savedReason && node.open")
+
+
+def test_deletion_error_stays_beside_delete_and_survives_refresh(
+    page, admin_base_url, tmp_path, code_control
+):
+    create_session(page, admin_base_url, tmp_path)
+    send(page, "Inspect")
+    connection = code_control.connection()
+    code_control.run(connection.finish("turn-1"))
+    code_control.harness.delete_error = RuntimeError("Delete failed")
+    page.locator("#codeDelete").click()
+    page.get_by_role("button", name="Delete session", exact=True).click()
+    error = page.locator("#codeDeletionError")
+    expect(error).to_contain_text("You can retry deletion")
+    page.reload()
+    expect(error).to_contain_text("You can retry deletion")
+    expect(page.locator("#codeDelete")).to_have_attribute(
+        "aria-describedby", "codeDeletionError"
+    )
+    expect(page.locator("#codeComposerStatus")).to_have_count(0)
+    code_control.harness.delete_error = None
+    page.locator("#codeDelete").click()
+    page.get_by_role("button", name="Delete session", exact=True).click()
+    expect(page).to_have_url(f"{admin_base_url}/admin/code")
+
+
 def test_code_streams_survive_refresh_and_all_viewers_leaving(
     page, context, admin_base_url, tmp_path, code_control
 ):
@@ -1369,7 +1557,7 @@ def test_off_clears_effort_when_reasoning_becomes_unavailable(
     code_control.harness.efforts = ("off",)
     code_control.harness.default_effort = "off"
     page.evaluate("window.CodeSessions.refresh()")
-    expect(page.locator("#codeComposerStatus")).to_contain_text("unavailable")
+    expect(page.locator("#codeSelectionError")).to_contain_text("unavailable")
     expect(effort).to_have_value("high")
     expect(effort.locator("option:checked")).to_have_text("high")
     expect(effort.locator("option:disabled")).to_have_text(
@@ -1394,7 +1582,7 @@ def test_off_clears_effort_when_reasoning_becomes_unavailable(
         effort.select_option("off")
     assert reset.value.json()["reasoning_effort"] == "off"
     assert len(patches) == 1 and patches[0]["reasoning_effort"] == "off"
-    expect(page.locator("#codeComposerStatus")).not_to_contain_text("unavailable")
+    expect(page.locator("#codeSelectionError")).to_be_hidden()
     expect(page.locator("#codeSend")).to_be_enabled()
     page.reload()
     expect(effort).to_have_value("off")
@@ -1628,7 +1816,7 @@ def test_failed_reply_stays_after_its_output_once_and_not_in_composer(
     expect(
         page.locator(".code-outcome").filter(has_text="Provider refused the request")
     ).to_have_count(1)
-    expect(page.locator("#codeComposerStatus")).not_to_contain_text("Provider refused")
+    expect(page.locator("#codeComposerStatus")).to_have_count(0)
     expect(page.locator("#codeNotice")).to_be_hidden()
     send(page, "Second")
     code_control.run(connection.finish("turn-2"))
@@ -1674,7 +1862,7 @@ def test_model_effort_picker_syncs_tabs_and_keeps_missing_selection(
         expect(page.locator("#codeModel")).to_have_value("other")
         expect(page.locator("#codeSend")).to_be_disabled()
         expect(page.locator("#codeComposer")).to_have_value("Preserve me")
-        expect(page.locator("#codeComposerStatus")).to_contain_text("unavailable")
+        expect(page.locator("#codeSelectionError")).to_contain_text("unavailable")
     finally:
         second.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.16"
+version = "6.2.17"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -41,6 +41,9 @@
     notice = "",
     available = false;
   let activeDialog = null;
+  let viewActive = false,
+    activityKey = null,
+    activityTimer = null;
 
   function element(tag, text, className) {
     const node = document.createElement(tag);
@@ -113,11 +116,6 @@
     if (version >= record.version) {
       if (!record.session || data.session.revision >= record.session.revision)
         record.session = data.session;
-      if (
-        record.run?.id !== data.run?.id ||
-        !activeStatuses.has(data.run?.status)
-      )
-        record.runNotice = "";
       record.run = data.run;
       if (data.active_review_ids)
         record.activeReviewIds = new Set(data.active_review_ids);
@@ -159,19 +157,24 @@
     const data = JSON.parse(event.data);
     if (data.epoch !== epoch) return;
     const previousRevision = records.get(data.session_id)?.session?.revision;
+    const previousItem = records.get(data.session_id)?.items.get(data.item?.id);
+    let outputChanged = false;
     if (type === "session.deleted") {
       removeDeletedSession(data.session_id, "Session deleted.");
     } else {
       merge(data);
       if (type === "session.notice" && data.session_id === selected)
         notice = data.message;
-      if (type === "run.notice") {
-        const record = records.get(data.session_id);
-        if (record && busy(record) && data.version >= record.version)
-          record.runNotice = data.will_retry
-            ? `Retrying… ${data.message}`
-            : data.message;
-      }
+      const record = records.get(data.session_id);
+      outputChanged =
+        type === "item.updated" &&
+        data.session_id === selected &&
+        data.item?.run_id === record?.run?.id &&
+        record?.items.get(data.item?.id)?.value === data.item &&
+        data.version > (previousItem?.version ?? -1) &&
+        ["kind", "title", "text", "html", "detail", "complete"].some(
+          (key) => previousItem?.value[key] !== data.item[key],
+        );
     }
     if (
       !selected &&
@@ -179,7 +182,41 @@
         data.session?.revision !== previousRevision)
     )
       void refreshLibrary();
-    render();
+    render(outputChanged);
+  }
+
+  function clearActivity() {
+    clearTimeout(activityTimer);
+    activityTimer = null;
+    activityKey = null;
+    const node = root?.querySelector("#codeActivity");
+    if (node) node.hidden = true;
+  }
+
+  function renderActivity(outputChanged) {
+    const record = records.get(selected),
+      node = root?.querySelector("#codeActivity");
+    if (!viewActive || !node || !busy(record) || pending(record)) {
+      clearActivity();
+      return;
+    }
+    const key = `${selected}:${record.run.id}`;
+    if (activityKey === key && !outputChanged) return;
+    clearActivity();
+    activityKey = key;
+    activityTimer = setTimeout(() => {
+      activityTimer = null;
+      if (activityKey !== key) return;
+      const current = records.get(selected);
+      if (!viewActive || !busy(current) || pending(current)) {
+        clearActivity();
+        return;
+      }
+      const transcript = root.querySelector("#codeTranscript"),
+        bottom = UI.nearBottom(transcript);
+      node.hidden = false;
+      if (bottom) transcript.scrollTop = transcript.scrollHeight;
+    }, 500);
   }
 
   async function list(cursor = null) {
@@ -316,7 +353,6 @@
       ) {
         // The run is no longer active; detail supplies its actual outcome.
         record.run = null;
-        record.runNotice = "";
         record.loaded = false;
         record.cursor = readyData.cursor;
       }
@@ -370,7 +406,6 @@
       "item.updated",
       "prompt.updated",
       "session.notice",
-      "run.notice",
     ])
       source.addEventListener(type, (event) => {
         if (feed === source) receive(type, event);
@@ -418,6 +453,7 @@
     activate(path);
   }
   function activate(path) {
+    viewActive = true;
     if (path !== desiredPath) dismissDialog();
     desiredPath = path;
     if (!api) return;
@@ -449,6 +485,7 @@
       render();
     }
     connect();
+    render();
   }
 
   function accepted(id, operationId) {
@@ -778,6 +815,7 @@
     return node;
   }
   function shell() {
+    clearActivity();
     dismissDialog();
     root.replaceChildren();
     modelComboboxes.clear();
@@ -880,8 +918,30 @@
         harnessControl.group,
         modeControl.group,
       );
+      const selectionMessage = element(
+        "div",
+        "",
+        "code-control-error code-selection-error",
+      );
+      selectionMessage.id = "codeSelectionError";
+      selectionMessage.setAttribute("role", "status");
+      selectionMessage.hidden = true;
+      controls.append(selectionMessage);
+      for (const control of [
+        providerControl.select,
+        modelControl.input,
+        reasoningControl.select,
+      ])
+        control.setAttribute("aria-describedby", selectionMessage.id);
       const deletion = button("Delete", remove, "danger-button");
       deletion.id = "codeDelete";
+      const deletionMessage = element("div", "", "code-control-error");
+      deletionMessage.id = "codeDeletionError";
+      deletionMessage.setAttribute("role", "status");
+      deletionMessage.hidden = true;
+      deletion.setAttribute("aria-describedby", deletionMessage.id);
+      const deletionGroup = element("div");
+      deletionGroup.append(deletion, deletionMessage);
       const header = UI.header(
         "← Code sessions",
         () => navigate(null),
@@ -894,7 +954,7 @@
           )
             void updateSettings({ title: title.value });
         },
-        [deletion],
+        [deletionGroup],
         controls,
       );
       header.append(element("p", "", "code-folder"));
@@ -920,7 +980,11 @@
         "secondary-button session-older",
       );
       older.id = "codeOlder";
-      transcript.append(older, element("div", undefined, "code-items"));
+      const activity = element("div", "Thinking…", "code-activity");
+      activity.id = "codeActivity";
+      activity.setAttribute("role", "status");
+      activity.hidden = true;
+      transcript.append(older, element("div", undefined, "code-items"), activity);
       const composer = UI.composer(
         "code",
         saved(id).draft || "",
@@ -977,7 +1041,7 @@
     rendered = selected || "library";
   }
 
-  function render() {
+  function render(outputChanged = false) {
     if (!root) return;
     if (rendered !== (selected || "library")) shell();
     const message = root.querySelector("#codeNotice");
@@ -1075,6 +1139,7 @@
         run.error ||
         (run.status === "interrupted" ? "Turn stopped." : "This turn failed.");
     }
+    renderActivity(outputChanged);
     if (bottom) transcript.scrollTop = transcript.scrollHeight;
     root.querySelector("#codeOlder").hidden = !record?.nextBefore;
     renderControls();
@@ -1116,7 +1181,9 @@
     deletion.textContent =
       record?.session?.status === "delete_uncertain"
         ? "Check deletion"
-        : "Delete";
+        : record?.session?.status === "deleting"
+          ? "Deleting…"
+          : "Delete";
     deletion.disabled =
       !synchronized ||
       !record?.loaded ||
@@ -1166,18 +1233,12 @@
     for (const option of reasoningControl.select.options)
       option.disabled = !model?.reasoning_efforts.includes(option.value);
     reasoningControl.select.disabled = disabled || !model;
-    root.querySelector("#codeComposerStatus").textContent =
-      record?.session?.error ||
-      selectionError(record) ||
-      (record?.session?.status !== "ready"
-        ? "Deleting…"
-        : record.run?.stop_requested && isBusy
-          ? "Stopping…"
-          : pending(record)
-            ? "Waiting for input"
-            : isBusy
-              ? record.runNotice || "Working…"
-              : "Codex");
+    const selectionMessage = root.querySelector("#codeSelectionError"),
+      deletionMessage = root.querySelector("#codeDeletionError");
+    selectionMessage.textContent = selectionError(record);
+    selectionMessage.hidden = !selectionMessage.textContent;
+    deletionMessage.textContent = record?.session?.error || "";
+    deletionMessage.hidden = !deletionMessage.textContent;
     for (const node of root.querySelectorAll(".code-prompt")) {
       const prompt = record?.prompts.get(node.dataset.id)?.value;
       for (const control of node.querySelectorAll("input, select, button"))
@@ -1516,7 +1577,12 @@
     }
     form.append(actions);
   }
-  window.addEventListener("pagehide", dismissDialog);
+  function deactivate() {
+    viewActive = false;
+    clearActivity();
+    dismissDialog();
+  }
+  window.addEventListener("pagehide", deactivate);
   window.CodeSessions = {
     initialize(client) {
       api = client;
@@ -1524,7 +1590,7 @@
       if (desiredPath) activate(desiredPath);
     },
     activate,
-    deactivate: dismissDialog,
+    deactivate,
     async refresh() {
       if (!api || !epoch) return;
       try {

--- a/src/free_claude_code/api/admin_static/session_layout.css
+++ b/src/free_claude_code/api/admin_static/session_layout.css
@@ -446,13 +446,25 @@
 }
 
 .session-composer-actions {
+  justify-content: flex-end;
   gap: 12px;
   margin-top: 4px;
 }
 
-.session-composer-status {
+.code-activity {
   color: var(--muted);
+  font-size: 14px;
+  padding: 12px 0;
+}
+
+.code-control-error {
+  color: var(--error);
   font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.code-selection-error {
+  grid-column: 1 / -1;
 }
 
 .session-older {

--- a/src/free_claude_code/api/admin_static/session_ui.js
+++ b/src/free_claude_code/api/admin_static/session_ui.js
@@ -144,10 +144,7 @@
     textarea.value = draft;
     textarea.placeholder = placeholder;
     textarea.setAttribute("aria-label", "Message");
-    const actions = node("div", "session-composer-actions"),
-      status = node("span", "session-composer-status");
-    status.id = `${id}ComposerStatus`;
-    status.setAttribute("aria-live", "polite");
+    const actions = node("div", "session-composer-actions");
     const send = button("Send", "primary-button", onSend),
       stop = button("Stop", "danger-button", onStop);
     send.id = `${id}Send`;
@@ -163,7 +160,7 @@
         if (!send.disabled && !send.hidden) onSend();
       }
     });
-    actions.append(status, send, stop);
+    actions.append(send, stop);
     element.append(textarea, actions);
     return element;
   }

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -1001,15 +1001,14 @@ class CodeService:
                             )
                             owner.prompts[prompt.id] = resolved
                             self._publish_prompt(owner, resolved)
-                elif event.kind == "error" and matches:
-                    self._publish(
-                        owner,
-                        "run.notice",
-                        message=event.message or "Codex reported an error.",
-                        will_retry=event.will_retry,
-                    )
-                elif event.kind == "notice" and event.message and run is not None:
+                elif run is not None and (
+                    (event.kind == "error" and matches)
+                    or (event.kind == "notice" and event.message)
+                ):
                     await self._flush_locked(owner)
+                    message = event.message or "Codex reported an error."
+                    if event.kind == "error" and event.will_retry:
+                        message = f"Retrying… {message}"
                     item = CodeItem(
                         id=str(uuid.uuid4()),
                         session_id=owner.session.id,
@@ -1017,7 +1016,7 @@ class CodeService:
                         run_id=run.id,
                         kind="notice",
                         title="Notice",
-                        text=event.message,
+                        text=message,
                         complete=True,
                         raw=event.raw,
                     )

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -693,13 +693,14 @@ async def test_failed_outcome_is_durable_once_after_partial_output_and_older_pag
 
 @pytest.mark.asyncio
 async def test_retry_notice_does_not_finish_run_and_stale_error_is_ignored(code):
-    service, harness, _ = code
+    service, harness, directory = code
     session = await session_for(code)
     await service.send(
         session.id, new_id(), session.revision, "hello", expected_epoch=service.epoch
     )
     await harness.started.wait()
     connection = harness.connections[0]
+    await connection.text("turn-1", "before", "Before retry", complete=True)
     await connection.sink(
         HarnessEvent(
             connection.generation,
@@ -710,7 +711,19 @@ async def test_retry_notice_does_not_finish_run_and_stale_error_is_ignored(code)
             will_retry=True,
         )
     )
-    assert (await service.get_detail(session.id)).run.status == "running"
+    detail = await service.get_detail(session.id)
+    assert detail.run.status == "running"
+    assert [item.kind for item in detail.items] == ["user", "text", "notice"]
+    assert detail.items[-1].text == "Retrying… retry"
+    assert detail.items[-1].sequence > detail.items[-2].sequence
+    await connection.sink(
+        HarnessEvent(
+            connection.generation, connection.thread_id, "error", turn_id="turn-1"
+        )
+    )
+    detail = await service.get_detail(session.id)
+    assert detail.run.status == "running"
+    assert detail.items[-1].text == "Codex reported an error."
     await connection.text("turn-1", "text", "success", complete=True)
     await connection.finish("turn-1")
     subscription, _ = await service.subscribe()
@@ -727,6 +740,16 @@ async def test_retry_notice_does_not_finish_run_and_stale_error_is_ignored(code)
     assert service.cursor == cursor
     await subscription.aclose()
     assert (await service.get_detail(session.id)).run.error is None
+    detail = await service.get_detail(session.id)
+    await service.close()
+    restarted = CodeService(
+        SQLiteCodeStore(directory / "code.db", directory / "code.lock"), harness
+    )
+    await restarted.start()
+    try:
+        assert (await restarted.get_detail(session.id)).items == detail.items
+    finally:
+        await restarted.close()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.16"
+version = "6.2.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Code sessions need feedback when a turn is running but no visible output is arriving. The composer footer mixes activity labels with retry warnings and control errors, while conversation feedback belongs in the ordered transcript.

## How

- Show one temporary `Thinking…` indicator at the transcript tail after 500 ms without output updates. Hide it immediately when text, reasoning, or tool output changes, while user input is pending, and when the turn ends. Static completed output does not suppress it.
- Keep the indicator outside saved history and preserve transcript ordering, inline questions and approvals, expanded items, and scroll position. Refresh uses the current run state and a fresh quiet interval.
- Save intermediate native errors and retry warnings through the existing sequenced notice-item path so they survive refresh. Intermediate errors leave the run active until a terminal event arrives.
- Remove composer status text. Display model/effort validation beside the selection controls and deletion errors beside Delete; keep Send and Stop aligned to the right.
- Bump the patch version to 6.2.17.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63524409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not safe to merge until reconnect synchronization restarts the transcript activity indicator.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcode-transcript-activity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcode-transcript-activity%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fapi%2Fadmin_static%2Fcode_sessions.js%3A203-204%0AAfter%20a%20reconnect%20synchronizes%20newly%20received%20output%20for%20the%20selected%20run%2C%20%60synchronize%28%29%60%20renders%20without%20marking%20that%20output%20as%20changed.%20Because%20the%20run%20key%20is%20unchanged%2C%20%60renderActivity%28%29%60%20returns%20early%20and%20preserves%20an%20existing%20%E2%80%9CThinking%E2%80%A6%E2%80%9D%20indicator%20or%20its%20previous%20timer.%20Users%20can%20therefore%20see%20%E2%80%9CThinking%E2%80%A6%E2%80%9D%20immediately%20after%20synchronized%20output%20rather%20than%20only%20after%20a%20new%20500%20ms%20quiet%20interval.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1777&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Restart Thinking After Reconnect** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1777#discussion_r3998190143">▶</a>

<details open><summary><h3>Summary</h3></summary>

- Reconnecting a session can leave the transcript’s “Thinking…” indicator visible after newly synchronized output instead of restarting its quiet-period timing.

## Merge safety

Do not merge until the reconnect path resets activity timing after synchronized output.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Show transcript thinking feedback during..."](https://github.com/alishahryar1/free-claude-code/commit/0022435267ad2962223946769822e745a1b61868)</sub>

<!-- /greptile_comment -->