### PR TITLE
Add Alibaba Model Studio provider (OpenAI-compatible DashScope API)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,11 @@ TOKENROUTER_BASE_URL="https://api.tokenrouter.com/v1"
 NARAROUTE_BASE_URL="https://router.bynara.id/v1"
 
 
+# xKiro Config (OpenAI-compatible multi-vendor Chat Completions gateway at api.xkiro.com/v1)
+# XKIRO_API_KEY=<your-token>
+XKIRO_BASE_URL="https://api.xkiro.com/v1"
+
+
 # Poolside AI (OpenAI-compatible Chat Completions at inference.poolside.ai/v1)
 # POOLSIDE_API_KEY=<your-token>
 
@@ -192,7 +197,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # Default model and optional Claude tier overrides
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "poolside" | "llm7"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "xkiro" | "poolside" | "llm7"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -308,6 +313,7 @@ REASONING_HAIKU=inherit
 # ZAI_API_PROXY=<http-or-socks-url>
 # TOKENROUTER_PROXY=<http-or-socks-url>
 # NARAROUTE_PROXY=<http-or-socks-url>
+# XKIRO_PROXY=<http-or-socks-url>
 # POOLSIDE_PROXY=<http-or-socks-url>
 # LLM7_PROXY=<http-or-socks-url>
 # FIREWORKS_PROXY=<http-or-socks-url>

--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,17 @@ NARAROUTE_BASE_URL="https://router.bynara.id/v1"
 XKIRO_BASE_URL="https://api.xkiro.com/v1"
 
 
+# Alibaba Cloud Model Studio (pay-as-you-go OpenAI-compatible API; keys and models
+# are region-bound: https://www.alibabacloud.com/help/en/model-studio/get-api-key)
+# Default below is the Singapore (international) endpoint. Beijing, US and Hong Kong
+# users must point this at their region (dashscope.aliyuncs.com, dashscope-us.aliyuncs.com,
+# cn-hongkong.dashscope.aliyuncs.com). Workspace-dedicated endpoints follow
+# https://{WorkspaceId}.{region}.maas.aliyuncs.com/compatible-mode/v1
+# (e.g. ws-xxxxxxxx.ap-southeast-1.maas.aliyuncs.com).
+# ALIBABA_MODELSTUDIO_API_KEY=<your-token>
+ALIBABA_MODELSTUDIO_BASE_URL="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
+
 # Poolside AI (OpenAI-compatible Chat Completions at inference.poolside.ai/v1)
 # POOLSIDE_API_KEY=<your-token>
 
@@ -197,7 +208,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # Default model and optional Claude tier overrides
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "xkiro" | "poolside" | "llm7"
+# Valid providers: "nvidia_nim" | "openai" | "azure_openai" | "open_router" | "gemini" | "vertex" | "deepseek" | "mistral" | "mistral_codestral" | "opencode_zen" | "opencode_go" | "vercel" | "bedrock" | "huggingface" | "cohere" | "wafer" | "kimi" | "kimi_code" | "minimax" | "cerebras" | "groq" | "cline_pass" | "xai" | "qwencloud" | "qwencloud_coding" | "together" | "deepinfra" | "siliconflow" | "nebius" | "chutes" | "featherless" | "agnes" | "zenmux" | "wandb" | "sambanova" | "kilo" | "fireworks" | "novita" | "cloudflare" | "zai" | "ollama_cloud" | "lmstudio" | "llamacpp" | "ollama" | "tokenrouter" | "nararoute" | "xkiro" | "alibaba_modelstudio" | "poolside" | "llm7"
 # MODEL_FABLE=<provider/model-id>
 # MODEL_OPUS=<provider/model-id>
 # MODEL_SONNET=<provider/model-id>
@@ -314,6 +325,7 @@ REASONING_HAIKU=inherit
 # TOKENROUTER_PROXY=<http-or-socks-url>
 # NARAROUTE_PROXY=<http-or-socks-url>
 # XKIRO_PROXY=<http-or-socks-url>
+# ALIBABA_MODELSTUDIO_PROXY=<http-or-socks-url>
 # POOLSIDE_PROXY=<http-or-socks-url>
 # LLM7_PROXY=<http-or-socks-url>
 # FIREWORKS_PROXY=<http-or-socks-url>

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ from more than one provider before succeeding.
 | [Z.ai API (pay as you go)](https://z.ai/manage-apikey/apikey-list) | `ZAI_API_KEY` | `zai_api/glm-4.7-flash` |
 | [TokenRouter](https://www.tokenrouter.com/) | `TOKENROUTER_API_KEY` | `tokenrouter/moonshotai/kimi-k3-free` |
 | [NaraRoute](https://router.bynara.id/) | `NARAROUTE_API_KEY` | `nararoute/kimi-k3-free` |
+| [xKiro](https://xkiro.com/dashboard/api/keys) | `XKIRO_API_KEY` | `xkiro/deepseek/deepseek-v4-flash` |
 | [Poolside AI](https://platform.poolside.ai/) | `POOLSIDE_API_KEY` | `poolside/poolside/laguna-s-2.1` |
 | [LLM7.io](https://dash.llm7.io/) | `LLM7_API_KEY` | `llm7/default` |
 | [Ollama Cloud](https://ollama.com/settings/keys) | `OLLAMA_API_KEY` | `ollama_cloud/qwen3-coder:480b` |

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ from more than one provider before succeeding.
 | [TokenRouter](https://www.tokenrouter.com/) | `TOKENROUTER_API_KEY` | `tokenrouter/moonshotai/kimi-k3-free` |
 | [NaraRoute](https://router.bynara.id/) | `NARAROUTE_API_KEY` | `nararoute/kimi-k3-free` |
 | [xKiro](https://xkiro.com/dashboard/api/keys) | `XKIRO_API_KEY` | `xkiro/deepseek/deepseek-v4-flash` |
+| [Alibaba Model Studio](https://www.alibabacloud.com/help/en/model-studio/get-api-key) | `ALIBABA_MODELSTUDIO_API_KEY` | `alibaba_modelstudio/qwen3-max` |
 | [Poolside AI](https://platform.poolside.ai/) | `POOLSIDE_API_KEY` | `poolside/poolside/laguna-s-2.1` |
 | [LLM7.io](https://dash.llm7.io/) | `LLM7_API_KEY` | `llm7/default` |
 | [Ollama Cloud](https://ollama.com/settings/keys) | `OLLAMA_API_KEY` | `ollama_cloud/qwen3-coder:480b` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.15"
+version = "6.3.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.3.0"
+version = "6.4.0"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -90,6 +90,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "cloudflare": "cloudflare/@cf/moonshotai/kimi-k2.6",
     "tokenrouter": "tokenrouter/moonshotai/kimi-k3-free",
     "nararoute": "nararoute/kimi-k3-free",
+    "xkiro": "xkiro/deepseek/deepseek-v4-flash",
     "poolside": "poolside/poolside/laguna-s-2.1",
     "llm7": "llm7/default",
     "agnes": "agnes/agnes-2.0-flash",

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -91,6 +91,7 @@ PROVIDER_SMOKE_DEFAULT_MODELS: dict[str, str] = {
     "tokenrouter": "tokenrouter/moonshotai/kimi-k3-free",
     "nararoute": "nararoute/kimi-k3-free",
     "xkiro": "xkiro/deepseek/deepseek-v4-flash",
+    "alibaba_modelstudio": "alibaba_modelstudio/qwen3-max",
     "poolside": "poolside/poolside/laguna-s-2.1",
     "llm7": "llm7/default",
     "agnes": "agnes/agnes-2.0-flash",

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -263,6 +263,19 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, ProviderFieldOverride] = {
             "Defaults to https://router.bynara.id/v1."
         ),
     },
+    "XKIRO_API_KEY": {
+        "label": "xKiro API Key",
+        "description": (
+            "xKiro OpenAI-compatible multi-vendor gateway API key for api.xkiro.com/v1. "
+            "Keys begin with sk-xt-; create one at xkiro.com/dashboard/api/keys."
+        ),
+    },
+    "XKIRO_BASE_URL": {
+        "description": (
+            "xKiro OpenAI-compatible Chat Completions base URL. "
+            "Defaults to https://api.xkiro.com/v1."
+        ),
+    },
     "AGNES_API_KEY": {
         "label": "Agnes AI API Key",
         "description": (

--- a/src/free_claude_code/config/admin/provider_manifest.py
+++ b/src/free_claude_code/config/admin/provider_manifest.py
@@ -276,6 +276,24 @@ _PROVIDER_FIELD_OVERRIDES: dict[str, ProviderFieldOverride] = {
             "Defaults to https://api.xkiro.com/v1."
         ),
     },
+    "ALIBABA_MODELSTUDIO_API_KEY": {
+        "label": "Alibaba Model Studio API Key",
+        "description": (
+            "Alibaba Cloud Model Studio pay-as-you-go API key for the "
+            "OpenAI-compatible endpoint at dashscope-intl.aliyuncs.com/compatible-mode/v1. "
+            "Keys begin with sk-; create one in the Model Studio console "
+            "(modelstudio.console.alibabacloud.com)."
+        ),
+    },
+    "ALIBABA_MODELSTUDIO_BASE_URL": {
+        "description": (
+            "Alibaba Model Studio OpenAI-compatible Chat Completions base URL. "
+            "Defaults to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 "
+            "(Singapore). Beijing, US and Hong Kong users must point this at "
+            "their region; workspace-dedicated endpoints follow "
+            "https://{WorkspaceId}.{region}.maas.aliyuncs.com/compatible-mode/v1."
+        ),
+    },
     "AGNES_API_KEY": {
         "label": "Agnes AI API Key",
         "description": (

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -76,6 +76,8 @@ FEATHERLESS_DEFAULT_BASE = "https://api.featherless.ai/v1"
 TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 # NaraRoute OpenAI-compatible Chat Completions gateway.
 NARAROUTE_DEFAULT_BASE = "https://router.bynara.id/v1"
+# xKiro OpenAI-compatible multi-vendor Chat Completions gateway.
+XKIRO_DEFAULT_BASE = "https://api.xkiro.com/v1"
 # Poolside AI OpenAI-compatible Chat Completions API.
 POOLSIDE_DEFAULT_BASE = "https://inference.poolside.ai/v1"
 # LLM7.io OpenAI-compatible Chat Completions API.
@@ -526,6 +528,16 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=NARAROUTE_DEFAULT_BASE,
         base_url_attr="nararoute_base_url",
         proxy_attr="nararoute_proxy",
+    ),
+    "xkiro": ProviderDescriptor(
+        provider_id="xkiro",
+        display_name="xKiro",
+        credential_env="XKIRO_API_KEY",
+        credential_url="https://xkiro.com/dashboard/api/keys",
+        credential_attr="xkiro_api_key",
+        default_base_url=XKIRO_DEFAULT_BASE,
+        base_url_attr="xkiro_base_url",
+        proxy_attr="xkiro_proxy",
     ),
     "poolside": ProviderDescriptor(
         provider_id="poolside",

--- a/src/free_claude_code/config/provider_catalog.py
+++ b/src/free_claude_code/config/provider_catalog.py
@@ -78,6 +78,10 @@ TOKENROUTER_DEFAULT_BASE = "https://api.tokenrouter.com/v1"
 NARAROUTE_DEFAULT_BASE = "https://router.bynara.id/v1"
 # xKiro OpenAI-compatible multi-vendor Chat Completions gateway.
 XKIRO_DEFAULT_BASE = "https://api.xkiro.com/v1"
+# Alibaba Cloud Model Studio pay-as-you-go OpenAI-compatible API.
+ALIBABA_MODELSTUDIO_DEFAULT_BASE = (
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+)
 # Poolside AI OpenAI-compatible Chat Completions API.
 POOLSIDE_DEFAULT_BASE = "https://inference.poolside.ai/v1"
 # LLM7.io OpenAI-compatible Chat Completions API.
@@ -538,6 +542,16 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         default_base_url=XKIRO_DEFAULT_BASE,
         base_url_attr="xkiro_base_url",
         proxy_attr="xkiro_proxy",
+    ),
+    "alibaba_modelstudio": ProviderDescriptor(
+        provider_id="alibaba_modelstudio",
+        display_name="Alibaba Model Studio",
+        credential_env="ALIBABA_MODELSTUDIO_API_KEY",
+        credential_url="https://www.alibabacloud.com/help/en/model-studio/get-api-key",
+        credential_attr="alibaba_modelstudio_api_key",
+        default_base_url=ALIBABA_MODELSTUDIO_DEFAULT_BASE,
+        base_url_attr="alibaba_modelstudio_base_url",
+        proxy_attr="alibaba_modelstudio_proxy",
     ),
     "poolside": ProviderDescriptor(
         provider_id="poolside",

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -20,6 +20,7 @@ from .provider_catalog import (
     NARAROUTE_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
     TOKENROUTER_DEFAULT_BASE,
+    XKIRO_DEFAULT_BASE,
 )
 from .reasoning import ReasoningPreference
 
@@ -178,6 +179,15 @@ class Settings(BaseModel):
     nararoute_base_url: NonEmptyString = Field(
         default=NARAROUTE_DEFAULT_BASE,
         validation_alias="NARAROUTE_BASE_URL",
+    )
+
+    # ==================== xKiro Config ====================
+    xkiro_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="XKIRO_API_KEY"
+    )
+    xkiro_base_url: NonEmptyString = Field(
+        default=XKIRO_DEFAULT_BASE,
+        validation_alias="XKIRO_BASE_URL",
     )
 
     # ==================== Poolside AI (OpenAI-compatible) ====================
@@ -472,6 +482,9 @@ class Settings(BaseModel):
     )
     nararoute_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="NARAROUTE_PROXY"
+    )
+    xkiro_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="XKIRO_PROXY"
     )
     poolside_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="POOLSIDE_PROXY"

--- a/src/free_claude_code/config/settings.py
+++ b/src/free_claude_code/config/settings.py
@@ -16,6 +16,7 @@ from .constants import DEFAULT_MODEL, HTTP_CONNECT_TIMEOUT_DEFAULT
 from .model_refs import parse_model_fallbacks
 from .nim import NimSettings
 from .provider_catalog import (
+    ALIBABA_MODELSTUDIO_DEFAULT_BASE,
     BEDROCK_DEFAULT_BASE,
     NARAROUTE_DEFAULT_BASE,
     SUPPORTED_PROVIDER_IDS,
@@ -188,6 +189,15 @@ class Settings(BaseModel):
     xkiro_base_url: NonEmptyString = Field(
         default=XKIRO_DEFAULT_BASE,
         validation_alias="XKIRO_BASE_URL",
+    )
+
+    # ==================== Alibaba Cloud Model Studio (pay-as-you-go) ====================
+    alibaba_modelstudio_api_key: OptionalNonEmptyString = Field(
+        default=None, validation_alias="ALIBABA_MODELSTUDIO_API_KEY"
+    )
+    alibaba_modelstudio_base_url: NonEmptyString = Field(
+        default=ALIBABA_MODELSTUDIO_DEFAULT_BASE,
+        validation_alias="ALIBABA_MODELSTUDIO_BASE_URL",
     )
 
     # ==================== Poolside AI (OpenAI-compatible) ====================
@@ -485,6 +495,9 @@ class Settings(BaseModel):
     )
     xkiro_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="XKIRO_PROXY"
+    )
+    alibaba_modelstudio_proxy: OptionalNonEmptyString = Field(
+        default=None, validation_alias="ALIBABA_MODELSTUDIO_PROXY"
     )
     poolside_proxy: OptionalNonEmptyString = Field(
         default=None, validation_alias="POOLSIDE_PROXY"

--- a/src/free_claude_code/providers/credential_validation.py
+++ b/src/free_claude_code/providers/credential_validation.py
@@ -73,6 +73,7 @@ _MODELS = _list_field("data")
 # https://docs.wafer.ai/serverless/usage-api
 # https://platform.kimi.ai/docs/api/errors
 # https://router.bynara.id/id/docs
+# https://www.alibabacloud.com/help/en/model-studio/error-code (invalid_api_key → 401)
 _PROBES = (
     _Probe(
         "open_router",
@@ -141,6 +142,7 @@ _PROBES = (
         _AUTH_401,
     ),
     _Probe("nararoute", "/models", _MODELS, _AUTH_401),
+    _Probe("alibaba_modelstudio", "/models", _MODELS, _AUTH_401),
     # Positive evidence only: these errors can also reflect permissions, budget,
     # token type, or an undocumented response contract. Never reject on failure.
     # https://docs.deepinfra.com/api-reference/account/me

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -681,6 +681,28 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             enabled_value="high",
         ),
     ),
+    "alibaba_modelstudio": OpenAIChatProfile(
+        _policy(
+            "ALIBABA_MODELSTUDIO",
+            ReasoningReplayMode.REASONING_CONTENT,
+            include_extra_body=True,
+            extra_body_validator=validate_extra_body_does_not_override_reasoning_fields,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        # Qwen models in Model Studio are hybrid reasoners and their default
+        # varies per model (qwen3-max ships without reasoning while
+        # qwen3.8-max-0902 reasons out of the box), so the DashScope
+        # `enable_thinking` boolean — verified to switch thinking in both
+        # directions on both model kinds — forwards the client's resolved
+        # intent instead of leaving the per-model default in place.
+        NamedEffortReasoning(
+            (),
+            disabled_value=False,
+            enabled_value=True,
+            field="enable_thinking",
+            use_extra_body=True,
+        ),
+    ),
     "poolside": OpenAIChatProfile(
         _policy(
             "POOLSIDE",

--- a/src/free_claude_code/providers/openai_chat/profiles.py
+++ b/src/free_claude_code/providers/openai_chat/profiles.py
@@ -664,6 +664,23 @@ OPENAI_CHAT_PROFILES: dict[str, OpenAIChatProfile] = {
             thinking_boolean_path=("reasoning",),
         ),
     ),
+    "xkiro": OpenAIChatProfile(
+        _policy(
+            "XKIRO",
+            ReasoningReplayMode.REASONING_CONTENT,
+            default_max_tokens=ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        # xKiro translates reasoning_effort per vendor: every model declares the
+        # levels it accepts (reasoning_efforts in GET /v1/models) and unsupported
+        # values are adjusted downward, never rejected. Omitting the field is
+        # not disabling — most models default to reasoning on — so explicit
+        # effort keeps client intent and cost control intact.
+        NamedEffortReasoning(
+            _ALL_EFFORTS,
+            disabled_value="none",
+            enabled_value="high",
+        ),
+    ),
     "poolside": OpenAIChatProfile(
         _policy(
             "POOLSIDE",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -50,6 +50,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "zai_api",
     "tokenrouter",
     "nararoute",
+    "xkiro",
     "poolside",
     "llm7",
     "ollama_cloud",

--- a/tests/contracts/test_provider_catalog_order.py
+++ b/tests/contracts/test_provider_catalog_order.py
@@ -51,6 +51,7 @@ _EXPECTED_PROVIDER_ORDER: tuple[str, ...] = (
     "tokenrouter",
     "nararoute",
     "xkiro",
+    "alibaba_modelstudio",
     "poolside",
     "llm7",
     "ollama_cloud",

--- a/tests/providers/test_alibaba_modelstudio.py
+++ b/tests/providers/test_alibaba_modelstudio.py
@@ -1,0 +1,294 @@
+"""Tests for the Alibaba Model Studio OpenAI-chat provider profile."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.constants import ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+from free_claude_code.config.provider_catalog import ALIBABA_MODELSTUDIO_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import Message, MessagesRequest
+from free_claude_code.core.json_types import JsonObject, JsonValue
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_DEFAULT,
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+    reasoning_for,
+)
+
+_MODEL = "qwen3-max"
+
+
+@pytest.fixture
+def modelstudio_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "alibaba_modelstudio",
+        make_provider_config(
+            api_key="test-modelstudio-key",
+            base_url=ALIBABA_MODELSTUDIO_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(
+            provider_name="alibaba_modelstudio", max_attempts=1
+        ),
+    )
+
+
+def _request(**overrides: JsonValue) -> MessagesRequest:
+    payload: JsonObject = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "Inspect the file."}],
+        "tools": [
+            {
+                "name": "read_file",
+                "description": "Read a file",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }
+        ],
+    }
+    payload.update(overrides)
+    return MessagesRequest.model_validate(payload)
+
+
+def test_constructs_standard_openai_chat_provider(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    assert isinstance(modelstudio_provider, OpenAIChatProvider)
+    assert modelstudio_provider._provider_name == "ALIBABA_MODELSTUDIO"
+    assert modelstudio_provider._api_key == "test-modelstudio-key"
+    assert modelstudio_provider._base_url == ALIBABA_MODELSTUDIO_DEFAULT_BASE
+
+
+def test_base_url_constant() -> None:
+    assert (
+        ALIBABA_MODELSTUDIO_DEFAULT_BASE
+        == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    )
+
+
+def test_build_request_body_openai_chat_shape(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest(
+        model=_MODEL,
+        max_tokens=100,
+        messages=[Message(role="user", content="Hello")],
+        system="System prompt",
+    )
+
+    body = modelstudio_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assert body["model"] == _MODEL
+    assert body["max_tokens"] == 100
+    assert body["messages"] == [
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "Hello"},
+    ]
+
+
+def test_build_request_body_default_max_tokens(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest(
+        model=_MODEL,
+        messages=[Message(role="user", content="x")],
+    )
+
+    body = modelstudio_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assert body["max_tokens"] == ANTHROPIC_DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_build_request_body_preserves_validated_extra_body(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    """DashScope accepts extra parameters (top_k, etc.) via extra_body."""
+
+    request = MessagesRequest.model_validate(
+        {
+            "model": _MODEL,
+            "messages": [{"role": "user", "content": "x"}],
+            "extra_body": {"top_k": 50},
+        }
+    )
+
+    body = modelstudio_provider._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+
+    assert body["extra_body"]["top_k"] == 50
+
+
+def test_build_request_body_rejects_reserved_reasoning_extra_body_keys(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    request = MessagesRequest.model_validate(
+        {
+            "model": _MODEL,
+            "messages": [{"role": "user", "content": "x"}],
+            "extra_body": {"enable_thinking": True},
+        }
+    )
+
+    with pytest.raises(InvalidRequestError, match="extra_body must not override"):
+        modelstudio_provider._build_request_body(
+            request, reasoning=reasoning_for(request)
+        )
+
+
+def test_build_request_body_disables_thinking_when_reasoning_off(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    """Thinking models bill for reasoning, so OFF must disable it explicitly."""
+
+    body = modelstudio_provider._build_request_body(_request(), reasoning=REASONING_OFF)
+
+    assert body["extra_body"]["enable_thinking"] is False
+
+
+def test_build_request_body_enables_thinking_when_reasoning_on(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    """Non-thinking Qwen models default to answering directly, so ON must opt in."""
+
+    body = modelstudio_provider._build_request_body(_request(), reasoning=REASONING_ON)
+
+    assert body["extra_body"]["enable_thinking"] is True
+
+
+def test_build_request_body_omits_thinking_field_by_default(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    """Each Qwen model ships its own default, so FCC leaves it untouched."""
+
+    body = modelstudio_provider._build_request_body(
+        _request(), reasoning=REASONING_DEFAULT
+    )
+
+    assert "enable_thinking" not in body.get("extra_body", {})
+
+
+def test_replays_reasoning_content_with_tool_history(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(
+        messages=[
+            {"role": "user", "content": "Inspect the file."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Read it first."},
+                    {"type": "text", "text": "I will inspect it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "read_file",
+                        "input": {"path": "example.py"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "print('hello')",
+                    }
+                ],
+            },
+        ]
+    )
+
+    body = modelstudio_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "I will inspect it.",
+        "reasoning_content": "Read it first.",
+        "tool_calls": [
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": '{"path": "example.py"}',
+                },
+            }
+        ],
+    }
+    assert body["messages"][2] == {
+        "role": "tool",
+        "tool_call_id": "toolu_1",
+        "content": "print('hello')",
+    }
+
+
+def test_dashscope_model_ids_pass_through_untouched(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    """Model Studio ids are bare names (qwen3.8-max-0902), never aliases."""
+
+    body = modelstudio_provider._build_request_body(
+        _request(model="qwen3.8-max-0902"),
+        reasoning=REASONING_OFF,
+    )
+
+    assert body["model"] == "qwen3.8-max-0902"
+    assert body["extra_body"]["enable_thinking"] is False
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_default_listing_shape(
+    modelstudio_provider: OpenAIChatProvider,
+) -> None:
+    """The default listing reads GET /models with collection 'data', id 'id'."""
+
+    modelstudio_provider._client.models.list = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "qwen3-max",
+                    "object": "model",
+                    "owned_by": "system",
+                },
+                {
+                    "id": "qwen3.8-max-0902",
+                    "object": "model",
+                    "owned_by": "system",
+                },
+                {
+                    "id": "deepseek-v4",
+                    "object": "model",
+                    "owned_by": "system",
+                },
+            ]
+        }
+    )
+
+    model_infos = await modelstudio_provider.list_model_infos()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("qwen3-max"),
+            ProviderModelInfo("qwen3.8-max-0902"),
+            ProviderModelInfo("deepseek-v4"),
+        }
+    )

--- a/tests/providers/test_credential_validation.py
+++ b/tests/providers/test_credential_validation.py
@@ -196,11 +196,11 @@ async def test_unsupported_shared_credentials_never_send_http(monkeypatch):
     supported = {PROVIDER_CATALOG[row[0]].credential_env for row in CASES}
     all_keys = {d.credential_env for d in PROVIDER_CATALOG.values() if d.credential_env}
     keys = tuple(all_keys - supported)
-    assert len(keys) == 20
+    assert len(keys) == 21
     result = await validation.check_credentials(
         Settings.model_construct(), (*keys, "OPENCODE_API_KEY", "MODEL")
     )
-    assert len(result) == 20
+    assert len(result) == 21
     assert all(
         check.status == validation.CredentialStatus.UNVERIFIED for check in result
     )

--- a/tests/providers/test_credential_validation.py
+++ b/tests/providers/test_credential_validation.py
@@ -61,6 +61,12 @@ CASES = [
     ),
     ("nararoute", "https://router.bynara.id/v1/models", {"data": []}, 401),
     (
+        "alibaba_modelstudio",
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models",
+        {"data": []},
+        401,
+    ),
+    (
         "deepinfra",
         "https://api.deepinfra.com/v1/me",
         {"uid": "id", "email": None},

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -36,6 +36,7 @@ from free_claude_code.config.provider_catalog import (
     VERCEL_AI_GATEWAY_DEFAULT_BASE,
     WANDB_INFERENCE_DEFAULT_BASE,
     XAI_DEFAULT_BASE,
+    XKIRO_DEFAULT_BASE,
     ZAI_API_DEFAULT_BASE,
     ZAI_CODING_DEFAULT_BASE,
     ZENMUX_DEFAULT_BASE,
@@ -101,6 +102,8 @@ def _make_settings(**overrides):
     mock.tokenrouter_base_url = TOKENROUTER_DEFAULT_BASE
     mock.nararoute_api_key = "test_nararoute_key"
     mock.nararoute_base_url = NARAROUTE_DEFAULT_BASE
+    mock.xkiro_api_key = "test_xkiro_key"
+    mock.xkiro_base_url = XKIRO_DEFAULT_BASE
     mock.agnes_api_key = "test_agnes_key"
     mock.zenmux_api_key = "test_zenmux_key"
     mock.wandb_api_key = "test_wandb_key"
@@ -132,6 +135,7 @@ def _make_settings(**overrides):
     mock.zai_api_proxy = None
     mock.tokenrouter_proxy = None
     mock.nararoute_proxy = None
+    mock.xkiro_proxy = None
     mock.agnes_proxy = None
     mock.zenmux_proxy = None
     mock.wandb_proxy = None
@@ -887,6 +891,7 @@ def test_create_provider_instantiates_each_builtin():
         "zai_api": OpenAIChatProvider,
         "tokenrouter": OpenAIChatProvider,
         "nararoute": OpenAIChatProvider,
+        "xkiro": OpenAIChatProvider,
         "agnes": OpenAIChatProvider,
         "zenmux": OpenAIChatProvider,
         "wandb": OpenAIChatProvider,

--- a/tests/providers/test_provider_runtime.py
+++ b/tests/providers/test_provider_runtime.py
@@ -12,6 +12,7 @@ from free_claude_code.application.errors import (
 from free_claude_code.config.nim import NimSettings
 from free_claude_code.config.provider_catalog import (
     AGNES_DEFAULT_BASE,
+    ALIBABA_MODELSTUDIO_DEFAULT_BASE,
     BEDROCK_DEFAULT_BASE,
     CHUTES_DEFAULT_BASE,
     CLINE_DEFAULT_BASE,
@@ -104,6 +105,8 @@ def _make_settings(**overrides):
     mock.nararoute_base_url = NARAROUTE_DEFAULT_BASE
     mock.xkiro_api_key = "test_xkiro_key"
     mock.xkiro_base_url = XKIRO_DEFAULT_BASE
+    mock.alibaba_modelstudio_api_key = "test_modelstudio_key"
+    mock.alibaba_modelstudio_base_url = ALIBABA_MODELSTUDIO_DEFAULT_BASE
     mock.agnes_api_key = "test_agnes_key"
     mock.zenmux_api_key = "test_zenmux_key"
     mock.wandb_api_key = "test_wandb_key"
@@ -136,6 +139,7 @@ def _make_settings(**overrides):
     mock.tokenrouter_proxy = None
     mock.nararoute_proxy = None
     mock.xkiro_proxy = None
+    mock.alibaba_modelstudio_proxy = None
     mock.agnes_proxy = None
     mock.zenmux_proxy = None
     mock.wandb_proxy = None
@@ -892,6 +896,7 @@ def test_create_provider_instantiates_each_builtin():
         "tokenrouter": OpenAIChatProvider,
         "nararoute": OpenAIChatProvider,
         "xkiro": OpenAIChatProvider,
+        "alibaba_modelstudio": OpenAIChatProvider,
         "agnes": OpenAIChatProvider,
         "zenmux": OpenAIChatProvider,
         "wandb": OpenAIChatProvider,

--- a/tests/providers/test_xkiro.py
+++ b/tests/providers/test_xkiro.py
@@ -1,0 +1,204 @@
+"""Tests for the xKiro OpenAI-chat provider profile."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from free_claude_code.application.model_metadata import ProviderModelInfo
+from free_claude_code.config.provider_catalog import XKIRO_DEFAULT_BASE
+from free_claude_code.core.anthropic.models import MessagesRequest
+from free_claude_code.core.json_types import JsonObject, JsonValue
+from free_claude_code.core.reasoning import ReasoningPolicy
+from free_claude_code.providers.openai_chat import OpenAIChatProvider
+from tests.providers.support import (
+    REASONING_DEFAULT,
+    REASONING_OFF,
+    REASONING_ON,
+    immediate_admission,
+    make_provider_config,
+    profiled_provider,
+    reasoning_for,
+)
+
+_MODEL = "z-ai/glm-5.3"
+
+
+@pytest.fixture
+def xkiro_provider() -> OpenAIChatProvider:
+    return profiled_provider(
+        "xkiro",
+        make_provider_config(
+            api_key="test-xkiro-key",
+            base_url=XKIRO_DEFAULT_BASE,
+            rate_limit=10,
+            rate_window=60,
+        ),
+        admission=immediate_admission(provider_name="xkiro", max_attempts=1),
+    )
+
+
+def _request(**overrides: JsonValue) -> MessagesRequest:
+    payload: JsonObject = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "Inspect the file."}],
+        "tools": [
+            {
+                "name": "read_file",
+                "description": "Read a file",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }
+        ],
+    }
+    payload.update(overrides)
+    return MessagesRequest.model_validate(payload)
+
+
+def test_constructs_standard_openai_chat_provider(
+    xkiro_provider: OpenAIChatProvider,
+) -> None:
+    assert isinstance(xkiro_provider, OpenAIChatProvider)
+    assert xkiro_provider._provider_name == "XKIRO"
+    assert xkiro_provider._api_key == "test-xkiro-key"
+    assert xkiro_provider._base_url == XKIRO_DEFAULT_BASE
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "expected_effort"),
+    [
+        (REASONING_DEFAULT, None),
+        (REASONING_ON, "high"),
+        (REASONING_OFF, "none"),
+    ],
+)
+def test_encodes_client_reasoning_intent_for_the_gateway(
+    xkiro_provider: OpenAIChatProvider,
+    reasoning: ReasoningPolicy,
+    expected_effort: str | None,
+) -> None:
+    """The gateway translates effort per model, so FCC always states its intent.
+
+    xKiro's documented rule is that omitting the field is not disabling: most
+    models default to reasoning on and bill for it. Sending a level the target
+    model lacks is adjusted downward, never rejected, so FCC forwards the
+    client's intent verbatim.
+    """
+
+    body = xkiro_provider._build_request_body(_request(), reasoning=reasoning)
+
+    assert body["model"] == _MODEL
+    assert body["tools"][0]["function"]["name"] == "read_file"
+    assert body.get("reasoning_effort") == expected_effort
+    assert "thinking" not in body
+    assert "extra_body" not in body
+
+
+def test_replays_reasoning_content_with_tool_history(
+    xkiro_provider: OpenAIChatProvider,
+) -> None:
+    request = _request(
+        messages=[
+            {"role": "user", "content": "Inspect the file."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Read it first."},
+                    {"type": "text", "text": "I will inspect it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "read_file",
+                        "input": {"path": "example.py"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "print('hello')",
+                    }
+                ],
+            },
+        ]
+    )
+
+    body = xkiro_provider._build_request_body(
+        request,
+        reasoning=reasoning_for(request),
+    )
+
+    assert body["messages"][1] == {
+        "role": "assistant",
+        "content": "I will inspect it.",
+        "reasoning_content": "Read it first.",
+        "tool_calls": [
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": '{"path": "example.py"}',
+                },
+            }
+        ],
+    }
+    assert body["messages"][2] == {
+        "role": "tool",
+        "tool_call_id": "toolu_1",
+        "content": "print('hello')",
+    }
+
+
+def test_slash_separated_model_ids_pass_through_untouched(
+    xkiro_provider: OpenAIChatProvider,
+) -> None:
+    """xKiro model ids are vendor-prefixed (vendor/model), not aliases."""
+
+    body = xkiro_provider._build_request_body(
+        _request(model="openai/gpt-5.3-codex-spark"),
+        reasoning=REASONING_OFF,
+    )
+
+    assert body["model"] == "openai/gpt-5.3-codex-spark"
+    assert body["reasoning_effort"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_uses_default_listing_shape(
+    xkiro_provider: OpenAIChatProvider,
+) -> None:
+    """The default listing reads GET /models with collection 'data', id 'id'."""
+
+    xkiro_provider._client.models.list = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "z-ai/glm-5.3",
+                    "object": "model",
+                    "display_name": "GLM 5.3",
+                    "access_tier": "paid",
+                },
+                {
+                    "id": "openai/gpt-5.3-codex-spark",
+                    "object": "model",
+                    "display_name": "GPT 5.3 Codex Spark",
+                    "access_tier": "free",
+                },
+            ]
+        }
+    )
+
+    model_infos = await xkiro_provider.list_model_infos()
+
+    assert model_infos == frozenset(
+        {
+            ProviderModelInfo("z-ai/glm-5.3"),
+            ProviderModelInfo("openai/gpt-5.3-codex-spark"),
+        }
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.15"
+version = "6.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.3.0"
+version = "6.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Adds [Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/get-api-key) as an OpenAI-chat provider. Stacked on #1694: the branch is based on `add-xkiro-provider`, so this PR shows one new commit on top of it and collapses to a provider-only diff once #1694 lands.

## Why

Model Studio is Alibaba Cloud's pay-as-you-go model platform with an OpenAI-compatible endpoint (`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`). Its live catalog serves 165 chat models — the qwen3.5–3.8 series, deepseek-v4, glm-5.2, kimi-k3, qwen3.8-max-0902 — first-party Qwen hosting that the existing `qwencloud` / `qwencloud_coding` providers (subscription-bound) don't cover, which makes it useful as a direct alternative to multi-vendor gateways.

## How

- Register `alibaba_modelstudio` through the standard provider catalog: descriptor, Settings fields (`ALIBABA_MODELSTUDIO_API_KEY` / `ALIBABA_MODELSTUDIO_BASE_URL` / `ALIBABA_MODELSTUDIO_PROXY`), OpenAI-chat profile, admin manifest entries, `.env.example`, README table row, and a smoke default model (`alibaba_modelstudio/qwen3-max`).
- The default base URL is the international (Singapore) endpoint; `ALIBABA_MODELSTUDIO_BASE_URL` also accepts the regional hosts (Beijing, US, Hong Kong) and the dedicated workspace form `https://{WorkspaceId}.{region}.maas.aliyuncs.com/compatible-mode/v1` — all serve the same catalog.
- The reasoning profile follows DashScope's hybrid-reasoner semantics: Qwen models vary in their default (qwen3-max answers directly while qwen3.8-max-0902 reasons out of the box), so the `enable_thinking` boolean forwards the client's resolved intent through `extra_body` — verified to switch thinking in both directions on both model kinds — and `reasoning_content` deltas are replayed as thinking history (`ReasoningReplayMode.REASONING_CONTENT`).
- Credential validation probes `GET /models`: unlike xKiro's public catalog, it is auth-gated (invalid key → 401 `invalid_api_key`).
- Dedicated provider test file (`tests/providers/test_alibaba_modelstudio.py`) plus the contract/test-runtime synchronization every provider addition requires: catalog order, probe case, instantiation table, runtime settings mock.
- Version bump (minor, `uv lock` in the same commit), per the provider-addition precedent.

## Validation

Local `scripts/ci.ps1` (suppressions, ruff format/check, ty, pytest): 5,352 passed, 149 skipped, 0 failed. Live checks against the compatible-mode endpoint confirmed: identical 165-model catalogs on the international and workspace hosts, chat completions on qwen3-max and qwen3.8-max-0902, `enable_thinking` honored in both directions (thinking model → no reasoning; hybrid model → reasoning), reasoning deltas streamed on `reasoning_content`, and 401 `invalid_api_key` for a malformed key.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63525913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

What we checked:
- We verified that the provider's chat requests use deterministic mocked responses and that default reasoning omits enable_thinking, with false and true values sent for disabled and enabled reasoning, while the follow-up request history preserves assistant reasoning content, tool calls, and matching tool results. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- We confirmed that credential validation requests target the configured Model Studio /models endpoint with bearer authentication. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- We ran the focused provider, credential-validation, runtime, and catalog test suites and observed 107 tests passed. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Before this PR, the Alibaba-specific catalog constant could not be imported in the before-change worktree, establishing that the provider did not exist prior to the change. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Adds Alibaba Cloud Model Studio as an OpenAI-compatible chat provider, including configuration, runtime registration, credential validation, reasoning controls, model discovery, documentation, smoke defaults, and focused tests.
- The provider sends the intended DashScope thinking setting for enabled and disabled reasoning, preserves the default model behavior when reasoning is unspecified, and retains reasoning and tool-call history in follow-up requests.

<sub>Reviews (1) · Last reviewed commit: ["Add Alibaba Model Studio provider (OpenA..."](https://github.com/alishahryar1/free-claude-code/commit/e2936f241c401b8f29aae0c425bc8a73e1a24212)</sub>

<!-- /greptile_comment -->