### PR TITLE
Balance Admin spacing and stop treating API keys as passwords

### DIFF
--- a/e2e/form_support.py
+++ b/e2e/form_support.py
@@ -1,0 +1,12 @@
+"""Browser contracts for FCC's advisory autofill opt-outs."""
+
+
+def assert_autofill_opt_out(page):
+    failures = page.locator(
+        'form, textarea, input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"])'
+    ).evaluate_all("""nodes => nodes.flatMap(node => {
+      const valid = node.autocomplete === 'off' && node.hasAttribute('data-1p-ignore') &&
+        node.hasAttribute('data-bwignore') && node.getAttribute('data-form-type') === 'other';
+      return valid ? [] : [{id: node.id, tag: node.tagName, type: node.type}];
+    })""")
+    assert failures == [], failures

--- a/e2e/test_admin_assets.py
+++ b/e2e/test_admin_assets.py
@@ -2,9 +2,97 @@
 
 from urllib.parse import urlsplit
 
+import pytest
 from playwright.sync_api import Error, Page, Request, expect
 
+from e2e.form_support import assert_autofill_opt_out
 from free_claude_code.core.version import package_version
+
+
+@pytest.mark.parametrize("width", [1280, 900, 390])
+def test_admin_page_spacing_matches_visible_action_bar(page, admin_base_url, width):
+    page.set_viewport_size({"width": width, "height": 720})
+    page.goto(f"{admin_base_url}/admin")
+    expect(page.locator("#messageArea")).to_have_text("")
+
+    def assert_spacing():
+        page.wait_for_function("""() => !document.querySelector('.action-bar')
+          .getAnimations({subtree: true}).some(animation => animation.playState === 'running')""")
+        # Wait for layout/ResizeObserver delivery, then inspect rendered geometry.
+        page.evaluate(
+            "() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))"
+        )
+        measurements = page.evaluate("""() => {
+          const main = document.querySelector('.main');
+          const style = getComputedStyle(main);
+          const bar = document.querySelector('.action-bar');
+          const last = document.querySelector('.admin-view:not([hidden]) .form-sections > :last-child');
+          const heading = document.querySelector('#pageTitle');
+          const range = document.createRange();
+          range.selectNodeContents(heading);
+          const text = range.getBoundingClientRect();
+          const context = document.createElement('canvas').getContext('2d');
+          context.font = getComputedStyle(heading).font;
+          const metrics = context.measureText(heading.textContent);
+          const inkTop = text.top + (text.height - metrics.fontBoundingBoxAscent - metrics.fontBoundingBoxDescent) / 2
+            + metrics.fontBoundingBoxAscent - metrics.actualBoundingBoxAscent;
+          return {
+            top: parseFloat(style.paddingTop),
+            bottom: parseFloat(style.paddingBottom),
+            bar: bar.getBoundingClientRect().height,
+            endGap: last ? main.getBoundingClientRect().bottom - last.getBoundingClientRect().bottom : null,
+            headingGap: inkTop - main.getBoundingClientRect().top,
+          };
+        }""")
+        assert measurements["bottom"] - measurements["bar"] == pytest.approx(
+            measurements["top"], abs=1
+        )
+        # Ink can overshoot the font's cap metric; allow pixel rounding as well.
+        assert measurements["headingGap"] == pytest.approx(measurements["top"], abs=2)
+        if measurements["endGap"] is not None:
+            assert measurements["endGap"] - measurements["bar"] == pytest.approx(
+                measurements["top"], abs=1
+            )
+
+    for title in ("Providers", "Model Config", "Messaging"):
+        page.get_by_role("button", name=title, exact=True).click()
+        expect(page.locator("#pageTitle")).to_have_text(title)
+        assert_spacing()
+
+    original_height = page.locator(".action-bar").bounding_box()["height"]
+    page.locator("#messageArea").evaluate(
+        "node => node.textContent = 'A longer validation message that wraps onto multiple lines. '.repeat(20)"
+    )
+    assert_spacing()
+    assert page.locator(".action-bar").bounding_box()["height"] > original_height
+    page.set_viewport_size({"width": 700 if width > 900 else 1200, "height": 720})
+    assert_spacing()
+
+    page.get_by_role("button", name="Integrations", exact=True).click()
+    expect(page.locator(".action-bar")).to_be_hidden()
+    assert_spacing()
+    page.get_by_role("button", name="Providers", exact=True).click()
+    expect(page.locator(".action-bar")).to_be_visible()
+    assert_spacing()
+
+
+def test_settings_text_fields_opt_out_of_autofill(page, admin_base_url):
+    page.goto(f"{admin_base_url}/admin")
+    expect(page.locator("#messageArea")).to_have_text("")
+    for title in ("Providers", "Model Config", "Messaging", "Integrations"):
+        page.get_by_role("button", name=title, exact=True).click()
+        assert_autofill_opt_out(page)
+    page.get_by_role("button", name="Providers", exact=True).click()
+    key = page.locator("#field-NVIDIA_NIM_API_KEY")
+    expect(key).to_have_value("")
+    expect(key).to_have_attribute("type", "text")
+    expect(key).to_have_attribute("autocapitalize", "none")
+    expect(key).to_have_attribute("spellcheck", "false")
+    expect(key).to_have_attribute("autocorrect", "off")
+    expect(page.locator('.field input[type="password"]')).to_have_count(0)
+    key.fill("manually-entered-api-key")
+    expect(key).to_have_value("manually-entered-api-key")
+    expect(page.locator("#applyButton")).to_be_enabled()
 
 
 def test_selected_admin_tab_survives_refresh_and_browser_navigation(
@@ -117,6 +205,7 @@ def test_admin_loads_current_release_assets_before_rendering_dynamic_content(
     assert f"{versioned_root}/admin.css" in requested_paths
     assert f"{versioned_root}/code_sessions.css" in requested_paths
     assert f"{versioned_root}/model_combobox.js" in requested_paths
+    assert f"{versioned_root}/form_controls.js" in requested_paths
     assert f"{versioned_root}/code_sessions.js" in requested_paths
     assert f"{versioned_root}/admin.js" in requested_paths
     assert "/admin/assets/admin.css" not in requested_paths

--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 from playwright.sync_api import expect
 
+from e2e.form_support import assert_autofill_opt_out
 from free_claude_code.application.code_sessions.models import (
     HarnessEvent,
     PromptRequest,
@@ -1226,6 +1227,7 @@ def test_question_input_survives_streaming_and_secret_answer_is_not_stored(
     create_session(page, admin_base_url, tmp_path)
     send(page, "Ask me a question")
     connection = code_control.connection()
+    assert_autofill_opt_out(page)
     prompt = PromptRequest(
         7,
         "questions",
@@ -1267,6 +1269,7 @@ def test_question_input_survives_streaming_and_secret_answer_is_not_stored(
     secret = page.get_by_label("Your answer", exact=True)
     secret.fill("private-answer")
     expect(secret).to_have_attribute("type", "password")
+    assert_autofill_opt_out(page)
     secret.focus()
     secret.evaluate(
         "input => { window.savedPromptInput = input; input.setSelectionRange(2, 6); }"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.17"
+version = "6.2.18"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_routes.py
+++ b/src/free_claude_code/api/admin_routes.py
@@ -43,6 +43,7 @@ _ADMIN_ASSET_FILENAMES = frozenset(
     {
         "admin.css",
         "admin.js",
+        "form_controls.js",
         "app-icon.svg",
         "code_sessions.css",
         "code_sessions.js",

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -205,7 +205,7 @@ textarea:focus-visible,
 .main {
   min-width: 0;
   padding: 40px 48px;
-  padding-bottom: calc(40px + 96px); /* Fixed action bar clearance */
+  padding-bottom: calc(40px + var(--action-bar-height, 0px));
 }
 
 .topbar {
@@ -215,9 +215,10 @@ textarea:focus-visible,
 .topbar h2 {
   font-size: 30px;
   font-weight: 800;
+  line-height: 1;
   letter-spacing: -0.02em;
   color: var(--text-strong);
-  margin: 0;
+  margin: calc((1cap - 1em) / 2) 0 0;
 }
 
 /* Provider Strip & Panels */
@@ -481,6 +482,10 @@ textarea:focus-visible,
 .form-sections {
   display: grid;
   gap: 24px;
+}
+
+.form-sections > .settings-section:last-child {
+  margin-bottom: 0;
 }
 
 .settings-section {
@@ -852,7 +857,7 @@ textarea:focus-visible,
 
   .main {
     padding: 24px 20px;
-    padding-bottom: calc(24px + 180px); /* Stacked action bar clearance */
+    padding-bottom: calc(24px + var(--action-bar-height, 0px));
   }
 
   .action-bar {

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -637,7 +637,7 @@ function renderField(field) {
     label.appendChild(sourceEl);
   }
 
-  const input = inputForField(field);
+  const input = window.FccFormControls.configure(inputForField(field));
   input.id = `field-${field.key}`;
   input.dataset.key = field.key;
   input.dataset.original = comparableValue(field.value);
@@ -737,7 +737,9 @@ function inputForField(field) {
   const input = document.createElement("input");
   input.type = field.type === "number" ? "number" : "text";
   if (field.type === "secret") {
-    input.type = "password";
+    input.setAttribute("autocapitalize", "none");
+    input.spellcheck = false;
+    input.setAttribute("autocorrect", "off");
     input.placeholder = field.configured
       ? "Configured - enter a new value to replace"
       : "Not configured";
@@ -779,7 +781,7 @@ class ModelListEditor {
 
     const addRow = document.createElement("div");
     addRow.className = "model-list-add";
-    this.addInput = document.createElement("input");
+    this.addInput = window.FccFormControls.configure(document.createElement("input"));
     this.addInput.id = this.inputId;
     this.addInput.type = "text";
     this.addInput.autocomplete = "off";
@@ -1468,6 +1470,14 @@ jetBrainsIntegrationDialog.addEventListener("click", (event) => {
     jetBrainsIntegrationDialog.close();
   }
 });
+
+// Keep footer clearance exact when messages wrap or a view hides the bar.
+new ResizeObserver(([entry]) => {
+  document.documentElement.style.setProperty(
+    "--action-bar-height",
+    `${entry.target.getBoundingClientRect().height}px`,
+  );
+}).observe(document.querySelector(".action-bar"), { box: "border-box" });
 
 load().then(showRestartNotice).catch((error) => {
   showMessage(error.message, "error");

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -49,7 +49,7 @@
     const node = document.createElement(tag);
     if (text !== undefined) node.textContent = text;
     if (className) node.className = className;
-    return node;
+    return window.FccFormControls.configure(node);
   }
   function button(text, action, className = "secondary-button") {
     const node = element("button", text, className);

--- a/src/free_claude_code/api/admin_static/form_controls.js
+++ b/src/free_claude_code/api/admin_static/form_controls.js
@@ -1,0 +1,15 @@
+(() => {
+  "use strict";
+  window.FccFormControls = {
+    configure(node) {
+      if (node.matches('input:not([type="hidden"]), textarea, form')) {
+        node.autocomplete = "off";
+        // Advisory opt-outs for 1Password, Bitwarden, and Dashlane.
+        node.setAttribute("data-1p-ignore", "");
+        node.setAttribute("data-bwignore", "");
+        node.setAttribute("data-form-type", "other");
+      }
+      return node;
+    },
+  };
+})();

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -167,6 +167,7 @@
         </div>
       </footer>
     </div>
+    <script src="/admin/assets/__FCC_VERSION__/form_controls.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/model_combobox.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/session_ui.js"></script>
     <script src="/admin/assets/__FCC_VERSION__/code_sessions.js"></script>

--- a/src/free_claude_code/api/admin_static/session_ui.js
+++ b/src/free_claude_code/api/admin_static/session_ui.js
@@ -4,7 +4,7 @@
     const element = document.createElement(tag);
     if (className) element.className = className;
     element.textContent = text;
-    return element;
+    return window.FccFormControls.configure(element);
   }
   function button(label, className, action) {
     const element = node("button", className, label);

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -193,6 +193,7 @@ def test_admin_page_uses_installed_version(monkeypatch, tmp_path):
     assert 'href="/admin/assets/9.8.7/admin.css"' in response.text
     assert 'href="/admin/assets/9.8.7/code_sessions.css"' in response.text
     assert 'src="/admin/assets/9.8.7/model_combobox.js"' in response.text
+    assert 'src="/admin/assets/9.8.7/form_controls.js"' in response.text
     assert 'src="/admin/assets/9.8.7/code_sessions.js"' in response.text
     assert 'src="/admin/assets/9.8.7/admin.js"' in response.text
     assert 'href="/admin/assets/admin.css"' not in response.text
@@ -206,6 +207,7 @@ def test_admin_page_uses_installed_version(monkeypatch, tmp_path):
     (
         ("admin.css", "text/css"),
         ("admin.js", "text/javascript"),
+        ("form_controls.js", "text/javascript"),
         ("code_sessions.css", "text/css"),
         ("code_sessions.js", "text/javascript"),
         ("session_ui.js", "text/javascript"),

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.17"
+version = "6.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Long Admin pages have uneven visible top and bottom spacing. Fixed footer allowances and the final section's margin add excess bottom space. The page heading's font also adds space above its visible letters, so equal container padding alone still looks uneven. Integrations reserves footer space while its Apply bar is hidden.

Firefox treats API-key fields as login passwords and opens saved-password suggestions. Other Admin text boxes also lack consistent autofill opt-outs.

## How

Measure the Apply bar with `ResizeObserver` and reserve its exact height in addition to the normal page padding. The reservation follows message wrapping, viewport changes, and the bar being hidden. Remove the final settings section's bottom margin so the remaining gap matches the top padding.

Give page headings an explicit line height and a font-relative cap-height margin so their visible letters align with the top spacing in Chromium, Firefox, and WebKit.

Render settings credentials as ordinary text inputs, with capitalization, autocorrection, and spellchecking disabled. Newly entered keys are visible; stored credentials are not populated into the form. Native secret questions inside Code sessions retain masking.

Apply `autocomplete="off"` and the documented 1Password, Bitwarden, and Dashlane ignore hints through a shared helper used by settings and session input builders. This covers dynamically created fields and forms without interfering with typing, pasting, or FCC's own model suggestions. These are advisory hints; browsers and extensions can override them.

Bump the patch version to 6.2.18.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63529947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

Not safe to merge until newly entered Admin credentials are visually masked.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fadmin-page-spacing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fadmin-page-spacing%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fapi%2Fadmin_static%2Fadmin.js%3A739-748%0ASecret%20settings%20fields%20hold%20reusable%20provider%20API%20keys%2C%20bot%20tokens%2C%20and%20authentication%20tokens%2C%20but%20this%20code%20creates%20them%20as%20ordinary%20text%20inputs.%20Typed%20credentials%20are%20therefore%20exposed%20to%20nearby%20observers%2C%20screen%20sharing%2C%20and%20screen%20recordings%3B%20retain%20the%20autofill%20opt-outs%20while%20setting%20secret%20fields%20to%20use%20password%20masking.%0A%0A**How%20this%20was%20verified%3A**%20A%20rendered%20Admin%20secret%20field%20displayed%20a%20safely%20entered%20credential%20marker%20in%20clear%20text.%0A%0A%60%60%60suggestion%0A%20%20if%20%28field.type%20%3D%3D%3D%20%22secret%22%29%20%7B%0A%20%20%20%20input.type%20%3D%20%22password%22%3B%0A%20%20%20%20input.setAttribute%28%22autocapitalize%22%2C%20%22none%22%29%3B%0A%20%20%20%20input.spellcheck%20%3D%20false%3B%0A%20%20%20%20input.setAttribute%28%22autocorrect%22%2C%20%22off%22%29%3B%0A%20%20%20%20input.placeholder%20%3D%20field.configured%0A%20%20%20%20%20%20%3F%20%22Configured%20-%20enter%20a%20new%20value%20to%20replace%22%0A%20%20%20%20%20%20%3A%20%22Not%20configured%22%3B%0A%20%20%20%20input.value%20%3D%20%22%22%3B%0A%20%20%20%20input.autocomplete%20%3D%20%22off%22%3B%0A%20%20%7D%20else%20%7B%0A%60%60%60%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%202%0Asrc%2Ffree_claude_code%2Fapi%2Fadmin_static%2Fadmin.js%3A738%0A-%20**Bug**%0A%20%20-%20A%20focused%20rendered%20Admin%20browser%20test%20opened%20the%20Providers%20settings%20UI%20and%20targeted%20field-NVIDIANIMAPIKEY.%0A%20%20-%20Before%20entry%2C%20the%20control%20reported%20inputtype%3A%20'text'%20and%20ispasswordmasked%3A%20False.%0A%20%20-%20After%20entering%20the%20safe%20marker%20PR1779-visible-credential%2C%20the%20field%20retained%20the%20visible%20value%20with%20inputtype%3A%20'text'%20and%20ispasswordmasked%3A%20False.%0A%20%20-%20The%20test%20completed%20successfully%2C%20confirming%20that%20secret%20values%20are%20displayed%20rather%20than%20password-masked.%0A-%20**Cause**%0A%20%20-%20T-Rex%20reproduced%20this%20while%20running%20the%20changed%20behavior%2C%20but%20it%20did%20not%20return%20a%20separate%20root-cause%20sentence.%0A-%20**Fix**%0A%20%20-%20Update%20the%20changed%20code%20so%20this%20failing%20path%20is%20handled%2C%20then%20rerun%20the%20same%20T-Rex%20check%20to%20confirm%20it%20passes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Mask settings credentials** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1779/files#diff-909643d854668ecf7391d0b1cba9fcca13aba9f6cf618710c1f220544bd915a2R748">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**A focused rendered Admin browser test opened the Providers settings UI and targeted fie\.\.\.** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1779#discussion_r3998275722">▶</a>

<details open><summary><h3>Summary</h3></summary>

- This change makes newly entered Admin settings credentials visible while they are typed. Merge should wait until secret fields are masked again.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Balance Admin spacing and opt out of cre..."](https://github.com/alishahryar1/free-claude-code/commit/d68376abee7ea947458b0198f8fb6f85f549d7d7)</sub>

<!-- /greptile_comment -->