### PR TITLE
Restart Thinking quiet interval after recovered output

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -797,6 +797,42 @@ def test_thinking_fills_quiet_gaps_without_changing_transcript(
     expect(page.locator(".code-item")).to_have_count(4)
 
 
+@pytest.mark.parametrize("quiet_elapsed", [200, 500])
+@pytest.mark.parametrize("recovered_item", ["reply", "new-reply"])
+def test_recovered_output_restarts_thinking_quiet_interval(
+    page, admin_base_url, tmp_path, code_control, quiet_elapsed, recovered_item
+):
+    control_feed(page)
+    create_session(page, admin_base_url, tmp_path)
+    page.clock.install(time=1000)
+    page.clock.pause_at(1000)
+    send(page, "Inspect")
+    connection = code_control.connection()
+    code_control.run(
+        connection.text("turn-1", "reply", "Before disconnect", complete=True)
+    )
+    expect(page.get_by_text("Before disconnect", exact=True)).to_be_visible()
+    page.clock.run_for(quiet_elapsed)
+    activity = page.locator("#codeActivity")
+    if quiet_elapsed == 500:
+        expect(activity).to_be_visible()
+    else:
+        expect(activity).to_be_hidden()
+
+    page.evaluate("window.dropCodeEvents = ['item.updated']")
+    code_control.run(
+        connection.text("turn-1", recovered_item, "Recovered output", complete=True)
+    )
+    expect(page.get_by_text("Recovered output", exact=True)).to_have_count(0)
+    page.evaluate("window.replayCodeReady()")
+    expect(page.get_by_text("Recovered output", exact=True)).to_be_visible()
+    expect(activity).to_be_hidden()
+    page.clock.run_for(499)
+    expect(activity).to_be_hidden()
+    page.clock.run_for(1)
+    expect(activity).to_be_visible()
+
+
 def test_thinking_respects_prompts_refresh_navigation_and_stop(
     page, admin_base_url, tmp_path, code_control
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.18"
+version = "6.2.19"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -128,7 +128,20 @@
       [...(data.runs || []), ...(data.run ? [data.run] : [])],
       version,
     );
-    mergeEntries(record.items, data.item ? [data.item] : data.items, version);
+    const items = data.item ? [data.item] : data.items || [],
+      outputChanged =
+        id === selected &&
+        items.some((item) => {
+          const previous = record.items.get(item.id);
+          return (
+            item.run_id === record.run?.id &&
+            version > (previous?.version ?? -1) &&
+            ["kind", "title", "text", "html", "detail", "complete"].some(
+              (key) => previous?.value[key] !== item[key],
+            )
+          );
+        });
+    mergeEntries(record.items, items, version);
     const prompts = data.prompt ? [data.prompt] : data.prompts || [];
     mergeEntries(record.prompts, prompts, version);
     for (const prompt of prompts) {
@@ -151,30 +164,20 @@
           });
       }
     }
+    return outputChanged;
   }
 
   function receive(type, event) {
     const data = JSON.parse(event.data);
     if (data.epoch !== epoch) return;
     const previousRevision = records.get(data.session_id)?.session?.revision;
-    const previousItem = records.get(data.session_id)?.items.get(data.item?.id);
     let outputChanged = false;
     if (type === "session.deleted") {
       removeDeletedSession(data.session_id, "Session deleted.");
     } else {
-      merge(data);
+      outputChanged = merge(data) && type === "item.updated";
       if (type === "session.notice" && data.session_id === selected)
         notice = data.message;
-      const record = records.get(data.session_id);
-      outputChanged =
-        type === "item.updated" &&
-        data.session_id === selected &&
-        data.item?.run_id === record?.run?.id &&
-        record?.items.get(data.item?.id)?.value === data.item &&
-        data.version > (previousItem?.version ?? -1) &&
-        ["kind", "title", "text", "html", "detail", "complete"].some(
-          (key) => previousItem?.value[key] !== data.item[key],
-        );
     }
     if (
       !selected &&
@@ -307,11 +310,11 @@
       deleted.has(id)
     )
       return;
-    merge(data);
+    const outputChanged = merge(data);
     const record = get(id);
     record.loaded = true;
     record.nextBefore = data.next_before;
-    render();
+    render(!before && outputChanged);
   }
   async function bootstrap() {
     const token = syncToken;

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.18"
+version = "6.2.19"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

After reconnecting, Code sessions can display recovered output while retaining “Thinking…” or its previous timer. Only live item events reported visible changes, so synchronization missed the fresh 500 ms quiet interval. This fixes Greptile's reconnect finding on #1777.

## How

Reuse the existing accepted-output comparison in the shared merge path and pass its result to rendering for live updates and current-session snapshots. Newly added or changed output restarts the quiet interval; unchanged snapshots, stale updates, and older-history pagination do not.

Bump the patch version to 6.2.19 so browsers fetch the updated JavaScript.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63531620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not safe to merge until the JetBrains ACP Connect action performs the advertised configuration or is removed.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fthinking-reconnect-fix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fthinking-reconnect-fix%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fapi%2Fadmin_static%2Findex.html%3A149%0AThe%20new%20JetBrains%20ACP%20dialog%20presents%20a%20Connect%20button%2C%20but%20clicking%20it%20leaves%20the%20dialog%20open%20and%20does%20not%20save%20configuration%20or%20send%20a%20connection%20request.%20Users%20are%20told%20they%20can%20connect%20Claude%20Code%20through%20JetBrains%20ACP%2C%20but%20cannot%20actually%20enable%20that%20integration.%20This%20must%20be%20fixed%20or%20the%20unavailable%20action%20must%20be%20removed%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1780&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**JetBrains connection is inert** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1780/files#diff-a483348957d317cdd4e82ed6bbc4381cddc7afc1ed21e8cc5a6be9eb5e4e3141R149">▶</a>

<details open><summary><h3>Summary</h3></summary>

- ## Summary
- The new JetBrains ACP integration advertises a Connect flow that does not configure anything. Clicking its confirmation button leaves the dialog open and sends no request, so users cannot enable the integration from the Admin UI.
- This must be fixed or the unavailable Connect action must be removed before merging.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Restart transcript quiet interval for re..."](https://github.com/alishahryar1/free-claude-code/commit/97b177474a62dca0a2912128b136121fa2a3f1eb)</sub>

<!-- /greptile_comment -->