### PR TITLE
Forward images to DeepSeek-V4.1-Flash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.23"
+version = "6.2.24"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/providers/deepseek/compat.py
+++ b/src/free_claude_code/providers/deepseek/compat.py
@@ -42,17 +42,25 @@ _OMITTED_ATTACHMENT_TEXT = (
 )
 _OMITTED_ATTACHMENT_BLOCK = {"type": "text", "text": _OMITTED_ATTACHMENT_TEXT}
 
+# DeepSeek-V4.1-Flash moved vision into the primary API, so the ``vision`` name
+# heuristic below no longer catches it. Only the first-party GA id is listed:
+# legacy ``deepseek-v4-flash`` is deliberately excluded because gateways still
+# serve the older, text-only model under that name.
+_VISION_CAPABLE_MODEL_IDS = frozenset({"deepseek-flash"})
+
 
 def _is_vision_capable_model(model: str | None) -> bool:
     """True when the DeepSeek model accepts OpenAI image parts.
 
     DeepSeek's vision models (e.g. ``deepseek-v4-flash-vision-exp``) support
-    image inputs natively. Document blocks are still stripped because the
-    shared OpenAI conversion path has no document parts.
+    image inputs natively, as does DeepSeek-V4.1-Flash (``deepseek-flash``).
+    Document blocks are still stripped because the shared OpenAI conversion
+    path has no document parts.
     """
     if not model:
         return False
-    return "vision" in str(model).rsplit("/", 1)[-1].lower()
+    name = str(model).rsplit("/", 1)[-1].lower()
+    return "vision" in name or name in _VISION_CAPABLE_MODEL_IDS
 
 
 def build_deepseek_request_body(
@@ -204,7 +212,8 @@ def _strip_unsupported_attachment_blocks(
         logger.warning(
             "DEEPSEEK_REQUEST: stripped unsupported attachment blocks "
             "(top_level={} nested_in_tool_result={} placeholder_tool_results={}). "
-            "DeepSeek has no vision/document support; the model will not see this content.",
+            "This model does not accept these attachment types; it will not see "
+            "this content.",
             dict(top_level_dropped),
             dict(nested_dropped),
             placeholder_replacements,

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -925,6 +925,103 @@ def test_vision_model_strips_user_document():
     assert "image or document inputs" in lowered
 
 
+def _image_request(model: str) -> MessagesRequest:
+    return MessagesRequest(
+        model=model,
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockImage(
+                        type="image",
+                        source={
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "YQ==",
+                        },
+                    ),
+                    {"type": "text", "text": "Describe this image"},
+                ],
+            )
+        ],
+    )
+
+
+def test_v4_1_flash_forwards_user_image(deepseek_provider):
+    """``deepseek-flash`` has vision under the primary id, with no ``vision`` in it."""
+    request = _image_request("deepseek-flash")
+    deepseek_provider.stream_messages(request, reasoning=REASONING_ON)
+    body = deepseek_provider._chat._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+    content = body["messages"][0]["content"]
+    assert isinstance(content, list)
+    image_parts = [
+        part
+        for part in content
+        if isinstance(part, dict) and part.get("type") == "image_url"
+    ]
+    assert len(image_parts) == 1
+    assert image_parts[0]["image_url"]["url"] == "data:image/png;base64,YQ=="
+
+
+def test_v4_1_flash_strips_user_document(deepseek_provider):
+    """Vision does not imply document support; PDFs are still omitted."""
+    request = MessagesRequest(
+        model="deepseek-flash",
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    ContentBlockDocument(
+                        type="document",
+                        source={
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": "YQ==",
+                        },
+                    ),
+                ],
+            )
+        ],
+    )
+    deepseek_provider.stream_messages(request, reasoning=REASONING_ON)
+    body = deepseek_provider._chat._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+    content = body["messages"][0]["content"]
+    lowered = content.lower() if isinstance(content, str) else str(content).lower()
+    assert "attachment omitted" in lowered
+    assert not any(
+        isinstance(part, dict) and part.get("type") == "image_url"
+        for part in (content if isinstance(content, list) else ())
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "cline-pass/deepseek-v4-flash",
+        "novita/deepseek/deepseek-v4-flash-0731",
+    ],
+)
+def test_text_only_deepseek_models_still_strip_images(deepseek_provider, model):
+    """Legacy and gateway ids keep the old text-only behaviour."""
+    request = _image_request(model)
+    deepseek_provider.stream_messages(request, reasoning=REASONING_ON)
+    body = deepseek_provider._chat._build_request_body(
+        request, reasoning=reasoning_for(request)
+    )
+    content = body["messages"][0]["content"]
+    parts = content if isinstance(content, list) else ()
+    assert not any(
+        isinstance(part, dict) and part.get("type") == "image_url" for part in parts
+    )
+    assert "attachment omitted" not in str(content).lower()
+
+
 def test_startup_rejects_mcp_servers():
     request = MessagesRequest(
         model="m",

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.23"
+version = "6.2.24"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
DeepSeek-V4.1-Flash went GA as `deepseek-flash` and moved vision into the primary API, retiring the `-vision-exp` variant. FCC's vision check is `"vision" in model_name`, so `deepseek-flash` fails it and images get silently replaced with `[attachment omitted: DeepSeek does not support image or document inputs]`. The request still succeeds, so the caller never learns the image was dropped.

## What

- Match the GA id explicitly in `_is_vision_capable_model`, keeping the name heuristic for `-vision-exp`-style ids.
- Reword the log line, which said "DeepSeek has no vision/document support" and now fires for vision models receiving documents.
- `tests/providers/test_deepseek.py`: image forwarding for `deepseek-flash`, documents still stripped, and a parametrized guard that legacy/gateway ids keep stripping. `test_v4_1_flash_forwards_user_image` fails against the unpatched source.
- Bump 6.2.23 -> 6.2.24 (+ `uv lock`) per CONTRIBUTING.

## Tests

`uv run pytest tests/providers/test_deepseek.py` — 62 passed. `ruff format --check`, `ruff check`, and `ty check` clean.

The full suite on macOS has pre-existing `PermissionError` failures in the installer tests on `shutil.chflags`; they reproduce on unmodified `main` and aren't in the touched area.

I left `deepseek-v4-flash` out on purpose. The docs say the legacy name is still accepted and is now served by V4.1-Flash, but the id is prefix-stripped before matching, so a gateway serving the older text-only model under that exact name (`cline-pass/deepseek-v4-flash`) would get images forwarded to a model that can't take them. Happy to widen it if you'd rather track the routing.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63532188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<h3>Summary</h3>

- This update forwards image content to the explicitly supported DeepSeek Flash model while retaining attachment removal for incompatible DeepSeek models. It also updates focused compatibility tests and package metadata.

<sub>Reviews (3) · Last reviewed commit: ["Forward images to DeepSeek-V4.1-Flash"](https://github.com/alishahryar1/free-claude-code/commit/335b91da05e086da173d74afd751a848d51068ca)</sub>

<!-- /greptile_comment -->