### PR TITLE
Convert provider requests once at stream startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.20"
+version = "6.2.21"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/application/execution.py
+++ b/src/free_claude_code/application/execution.py
@@ -167,20 +167,11 @@ class ProviderExecutor:
         raw_log_payload: object,
         request_id: str,
     ) -> AsyncIterator[str]:
-        """Preflight and execute one Anthropic Messages request."""
+        """Execute one Anthropic Messages request."""
 
         primary = routed.resolved.primary
         primary_provider = self._provider_resolver(primary.provider_id)
         primary_request = routed.request.model_copy(deep=True)
-        primary_failure: ExecutionFailure | None = None
-        try:
-            primary_provider.preflight_messages(
-                primary_request,
-                reasoning=routed.reasoning,
-                model_info=self._model_infos.get(primary.provider_model_ref),
-            )
-        except ExecutionFailure as failure:
-            primary_failure = failure
         input_tokens = self._token_counter(
             routed.request.messages,
             routed.request.system,
@@ -204,14 +195,6 @@ class ProviderExecutor:
                     deep=True,
                 )
             )
-            if index == 0 and primary_failure is not None:
-                raise primary_failure
-            if index > 0:
-                provider.preflight_messages(
-                    request,
-                    reasoning=routed.reasoning,
-                    model_info=self._model_infos.get(target.provider_model_ref),
-                )
             return provider.stream_messages(
                 request,
                 input_tokens=input_tokens,
@@ -242,19 +225,11 @@ class ProviderExecutor:
         raw_log_payload: object,
         request_id: str,
     ) -> AsyncIterator[str]:
-        """Preflight and execute one native OpenAI Responses request."""
+        """Execute one native OpenAI Responses request."""
 
         primary = routed.resolved.primary
         primary_provider = self._provider_resolver(primary.provider_id)
         primary_request = routed.request.model_copy(deep=True)
-        primary_failure: ExecutionFailure | None = None
-        try:
-            primary_provider.preflight_responses(
-                primary_request,
-                reasoning=routed.reasoning,
-            )
-        except ExecutionFailure as failure:
-            primary_failure = failure
         input_tokens = self._responses_token_counter(routed.request)
 
         def open_candidate(
@@ -274,10 +249,6 @@ class ProviderExecutor:
                     deep=True,
                 )
             )
-            if index == 0 and primary_failure is not None:
-                raise primary_failure
-            if index > 0:
-                provider.preflight_responses(request, reasoning=routed.reasoning)
             return provider.stream_responses(
                 request,
                 input_tokens=input_tokens,
@@ -324,7 +295,7 @@ class ProviderExecutor:
         request_id: str,
         open_candidate: CandidateStreamOpener,
     ) -> AsyncIterator[str]:
-        """Run one protocol-blind candidate lifecycle after eager preflight."""
+        """Start and consume candidates through one protocol-blind lifecycle."""
 
         primary = resolved.primary
         candidates = (primary, *resolved.fallbacks)

--- a/src/free_claude_code/application/ports.py
+++ b/src/free_claude_code/application/ports.py
@@ -15,14 +15,6 @@ from .model_metadata import ProviderModelInfo
 class ProviderPort(Protocol):
     """Minimal provider capability required to execute one request."""
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None: ...
-
     def stream_messages(
         self,
         request: MessagesRequest,
@@ -34,13 +26,6 @@ class ProviderPort(Protocol):
         request_headers: Mapping[str, str] | None = None,
         model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]: ...
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None: ...
 
     def stream_responses(
         self,

--- a/src/free_claude_code/providers/anthropic_messages/transport.py
+++ b/src/free_claude_code/providers/anthropic_messages/transport.py
@@ -146,23 +146,6 @@ class AnthropicMessagesTransport:
         except (NativeMessagesError, ResponsesConversionError, ValueError) as error:
             raise InvalidRequestError(str(error)) from error
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        self._messages_body(request, reasoning, model_info)
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        self._responses_body(request, reasoning)
-
     def stream_messages(
         self,
         request: MessagesRequest,

--- a/src/free_claude_code/providers/base.py
+++ b/src/free_claude_code/providers/base.py
@@ -38,25 +38,6 @@ class BaseProvider(ABC):
         self._config = config
 
     @abstractmethod
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        """Validate a Messages request before opening its SSE stream."""
-
-    @abstractmethod
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        """Validate a Responses request before opening its SSE stream."""
-
-    @abstractmethod
     async def cleanup(self) -> None:
         """Release any resources held by this provider."""
 
@@ -76,7 +57,7 @@ class BaseProvider(ABC):
         request_headers: Mapping[str, str] | None = None,
         model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
-        """Stream response in Anthropic SSE format."""
+        """Validate the request before yielding a response in Anthropic SSE format."""
 
     @abstractmethod
     def stream_responses(
@@ -89,4 +70,4 @@ class BaseProvider(ABC):
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
-        """Stream response in OpenAI Responses SSE format."""
+        """Validate the request before yielding OpenAI Responses SSE events."""

--- a/src/free_claude_code/providers/github_copilot/provider.py
+++ b/src/free_claude_code/providers/github_copilot/provider.py
@@ -118,25 +118,6 @@ class GitHubCopilotProvider(BaseProvider):
                 "Choose a concrete model from the connected Copilot account."
             )
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        # Endpoint family and capabilities belong to the current account lease.
-        # Conversion runs after acquisition and before opening the physical stream.
-        self._check_model(request.model)
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        self._check_model(request.model)
-
     async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
         if self._closing:
             raise ExecutionFailure(
@@ -157,7 +138,7 @@ class GitHubCopilotProvider(BaseProvider):
         request_headers: Mapping[str, str] | None = None,
         model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
-        self.preflight_messages(request, reasoning=reasoning)
+        self._check_model(request.model)
         return self._dispatch(
             request,
             input_tokens,
@@ -176,7 +157,7 @@ class GitHubCopilotProvider(BaseProvider):
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         request_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
-        self.preflight_responses(request, reasoning=reasoning)
+        self._check_model(request.model)
         return self._dispatch(
             request,
             input_tokens,

--- a/src/free_claude_code/providers/lmstudio/client.py
+++ b/src/free_claude_code/providers/lmstudio/client.py
@@ -12,6 +12,7 @@ heuristic recovery on top.
 """
 
 import time
+from collections.abc import AsyncIterator, Mapping
 
 import httpx
 from loguru import logger
@@ -30,6 +31,7 @@ from free_claude_code.core.reasoning import (
 )
 from free_claude_code.providers.admission import ProviderAdmissionController
 from free_claude_code.providers.base import ProviderConfig
+from free_claude_code.providers.endpoint import EndpointContext
 from free_claude_code.providers.failure_policy import (
     context_window_exceeded_provider_failure,
 )
@@ -81,28 +83,57 @@ class LMStudioProvider(OpenAIChatProvider):
         )
         self._loaded_context_cache: tuple[float, int | None] = (0.0, None)
 
-    def preflight_messages(
+    def stream_messages(
         self,
         request: MessagesRequest,
+        input_tokens: int = 0,
         *,
+        request_id: str | None = None,
+        response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
         model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        super().preflight_messages(request, reasoning=reasoning, model_info=model_info)
-        self._preflight_context_budget(
+        endpoint_context: EndpointContext | None = None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> AsyncIterator[str]:
+        stream = super().stream_messages(
+            request,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            response_model=response_model,
+            reasoning=reasoning,
+            model_info=model_info,
+            endpoint_context=endpoint_context,
+            request_headers=request_headers,
+        )
+        self._validate_context_budget(
             get_token_count(request.messages, request.system, request.tools)
         )
+        return stream
 
-    def preflight_responses(
+    def stream_responses(
         self,
         request: OpenAIResponsesRequest,
+        input_tokens: int = 0,
         *,
+        request_id: str | None = None,
+        response_model: str | None = None,
         reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        super().preflight_responses(request, reasoning=reasoning)
-        self._preflight_context_budget(estimate_responses_input_tokens(request))
+        endpoint_context: EndpointContext | None = None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> AsyncIterator[str]:
+        stream = super().stream_responses(
+            request,
+            input_tokens=input_tokens,
+            request_id=request_id,
+            response_model=response_model,
+            reasoning=reasoning,
+            endpoint_context=endpoint_context,
+            request_headers=request_headers,
+        )
+        self._validate_context_budget(estimate_responses_input_tokens(request))
+        return stream
 
-    def _preflight_context_budget(self, estimate: int) -> None:
+    def _validate_context_budget(self, estimate: int) -> None:
         loaded_context = self._loaded_context_length()
         if loaded_context is None:
             return
@@ -141,7 +172,7 @@ class LMStudioProvider(OpenAIChatProvider):
             value = max(loaded) if loaded else None
         except Exception as error:  # backstop only — never block the request
             logger.debug(
-                "LMSTUDIO context preflight unavailable: {}", type(error).__name__
+                "LMSTUDIO context validation unavailable: {}", type(error).__name__
             )
             value = None
         self._loaded_context_cache = (time.monotonic(), value)

--- a/src/free_claude_code/providers/openai_chat/provider.py
+++ b/src/free_claude_code/providers/openai_chat/provider.py
@@ -201,25 +201,6 @@ class OpenAIChatProvider(BaseProvider):
             collection_field=listing.collection_field,
         )
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        self._chat.preflight_messages(
-            request, reasoning=reasoning, model_info=model_info
-        )
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        self._chat.preflight_responses(request, reasoning=reasoning)
-
     def stream_messages(
         self,
         request: MessagesRequest,

--- a/src/free_claude_code/providers/openai_chat/transport.py
+++ b/src/free_claude_code/providers/openai_chat/transport.py
@@ -639,25 +639,6 @@ class OpenAIChatTransport:
             tool_adapter=translated.tool_adapter,
         )
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        """Validate OpenAI-chat request conversion before streaming."""
-        self._build_request_body(request, reasoning=reasoning, model_info=model_info)
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        """Validate direct Responses-to-Chat conversion before streaming."""
-        self._build_responses_request_body(request, reasoning=reasoning)
-
     async def _create_stream(
         self,
         body: dict,

--- a/src/free_claude_code/providers/openai_codex/provider.py
+++ b/src/free_claude_code/providers/openai_codex/provider.py
@@ -92,25 +92,6 @@ class OpenAICodexProvider(BaseProvider):
             session_id=session_id,
         )
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        self._responses.preflight_messages(
-            request, reasoning=reasoning, model_info=model_info
-        )
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        self._responses.preflight_responses(request, reasoning=reasoning)
-
     async def cleanup(self) -> None:
         await self._client.close()
 

--- a/src/free_claude_code/providers/openai_responses/transport.py
+++ b/src/free_claude_code/providers/openai_responses/transport.py
@@ -123,21 +123,6 @@ class OpenAIResponsesTransport:
         self._read_timeout_s = read_timeout_s
         self._log_raw_sse_events = log_raw_sse_events
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-        can_disable_reasoning: bool = True,
-    ) -> None:
-        self._build_messages_body(
-            request,
-            reasoning=reasoning,
-            model_info=model_info,
-            can_disable_reasoning=can_disable_reasoning,
-        )
-
     def stream_messages(
         self,
         request: MessagesRequest,
@@ -184,14 +169,6 @@ class OpenAIResponsesTransport:
                 )
             ),
         )
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None:
-        self._build_native_body(request, reasoning=reasoning)
 
     def stream_responses(
         self,

--- a/src/free_claude_code/providers/opencode/provider.py
+++ b/src/free_claude_code/providers/opencode/provider.py
@@ -162,45 +162,6 @@ class OpenCodeProvider(BaseProvider):
                 return {"x-opencode-session": session_id}
         return {}
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        """Validate synchronously when a route snapshot is already warm."""
-        snapshot = self._catalog.current_snapshot
-        if snapshot is None:
-            return
-        route = self._require_route(snapshot, request.model)
-        routed = _routed_messages_request(request, route)
-        if route.transport is OpenCodeUpstreamTransport.RESPONSES:
-            self._responses.preflight_messages(
-                routed, reasoning=reasoning, model_info=route.model_info
-            )
-            return
-        self._chat.preflight_messages(
-            routed, reasoning=reasoning, model_info=route.model_info
-        )
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        """Validate native Responses ingress against a warm catalog route."""
-        snapshot = self._catalog.current_snapshot
-        if snapshot is None:
-            return
-        route = self._require_route(snapshot, request.model)
-        routed = _routed_responses_request(request, route)
-        if route.transport is OpenCodeUpstreamTransport.RESPONSES:
-            self._responses.preflight_responses(routed, reasoning=reasoning)
-            return
-        self._chat.preflight_responses(routed, reasoning=reasoning)
-
     def stream_messages(
         self,
         request: MessagesRequest,
@@ -240,9 +201,6 @@ class OpenCodeProvider(BaseProvider):
         selected_stream: AsyncIterator[str] | None = None
         try:
             if route.transport is OpenCodeUpstreamTransport.RESPONSES:
-                self._responses.preflight_messages(
-                    routed, reasoning=reasoning, model_info=route.model_info
-                )
                 selected_stream = self._responses.stream_messages(
                     routed,
                     input_tokens=input_tokens,
@@ -254,9 +212,6 @@ class OpenCodeProvider(BaseProvider):
                     model_info=route.model_info,
                 )
             else:
-                self._chat.preflight_messages(
-                    routed, reasoning=reasoning, model_info=route.model_info
-                )
                 selected_stream = self._chat.stream_messages(
                     routed,
                     input_tokens=input_tokens,
@@ -316,7 +271,6 @@ class OpenCodeProvider(BaseProvider):
         selected_stream: AsyncIterator[str] | None = None
         try:
             if route.transport is OpenCodeUpstreamTransport.RESPONSES:
-                self._responses.preflight_responses(routed, reasoning=reasoning)
                 selected_stream = self._responses.stream_responses(
                     routed,
                     input_tokens=input_tokens,
@@ -327,7 +281,6 @@ class OpenCodeProvider(BaseProvider):
                     extra_headers=self._upstream_headers(request_headers or {}),
                 )
             else:
-                self._chat.preflight_responses(routed, reasoning=reasoning)
                 selected_stream = self._chat.stream_responses(
                     routed,
                     input_tokens=input_tokens,

--- a/tests/api/model_fallback_support.py
+++ b/tests/api/model_fallback_support.py
@@ -190,29 +190,16 @@ class ControlledFallbackProvider:
         chunks_before_failure: tuple[str, ...] = (),
         responses_chunks_before_failure: tuple[str, ...] = (),
         text: str | None = None,
-        preflight_error: InvalidRequestError | None = None,
+        validation_error: InvalidRequestError | None = None,
     ) -> None:
         self._failure = failure
         self._chunks_before_failure = chunks_before_failure
         self._responses_chunks_before_failure = responses_chunks_before_failure
         self._text = text
-        self._preflight_error = preflight_error
-        self.preflight_models: list[str] = []
+        self._validation_error = validation_error
         self.stream_models: list[str] = []
         self.response_models: list[str] = []
         self.close_calls = 0
-
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        del reasoning
-        self.preflight_models.append(request.model)
-        if self._preflight_error is not None:
-            raise self._preflight_error
 
     async def stream_messages(
         self,
@@ -226,6 +213,8 @@ class ControlledFallbackProvider:
         model_info: ProviderModelInfo | None = None,
     ) -> AsyncIterator[str]:
         del input_tokens, request_id, reasoning
+        if self._validation_error is not None:
+            raise self._validation_error
         self.stream_models.append(request.model)
         public_model = response_model or request.model
         self.response_models.append(public_model)
@@ -240,17 +229,6 @@ class ControlledFallbackProvider:
         finally:
             self.close_calls += 1
 
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None:
-        del reasoning
-        self.preflight_models.append(request.model)
-        if self._preflight_error is not None:
-            raise self._preflight_error
-
     async def stream_responses(
         self,
         request: OpenAIResponsesRequest,
@@ -262,6 +240,8 @@ class ControlledFallbackProvider:
         request_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
         del input_tokens, request_id, reasoning
+        if self._validation_error is not None:
+            raise self._validation_error
         self.stream_models.append(request.model)
         public_model = response_model or request.model
         self.response_models.append(public_model)

--- a/tests/api/test_api_handlers.py
+++ b/tests/api/test_api_handlers.py
@@ -39,10 +39,6 @@ _CLASSIFIER_USER = (
 
 class FakeProvider:
     def __init__(self, events: list[str] | None = None) -> None:
-        self.preflight_calls: list[tuple[MessagesRequest, ReasoningPolicy]] = []
-        self.responses_preflight_calls: list[
-            tuple[OpenAIResponsesRequest, ReasoningPolicy]
-        ] = []
         self.requests: list[MessagesRequest] = []
         self.responses_requests: list[OpenAIResponsesRequest] = []
         self.stream_kwargs: list[dict[str, Any]] = []
@@ -50,20 +46,6 @@ class FakeProvider:
             'event: message_start\ndata: {"type":"message_start"}\n\n',
             'event: message_stop\ndata: {"type":"message_stop"}\n\n',
         ]
-
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        self.preflight_calls.append((request, reasoning))
-
-    def preflight_responses(
-        self, request: OpenAIResponsesRequest, *, reasoning: ReasoningPolicy
-    ) -> None:
-        self.responses_preflight_calls.append((request, reasoning))
 
     async def cleanup(self) -> None:
         return None
@@ -161,25 +143,27 @@ async def test_messages_handler_passes_routed_request_and_stream_metadata() -> N
     assert provider.stream_kwargs[0]["request_id"].startswith("req_")
     assert provider.stream_kwargs[0]["response_model"] == "nvidia_nim/test-model"
     assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.provider_default()
-    assert len(provider.preflight_calls) == 1
+    assert len(provider.requests) == 1
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stream", [True, False])
-async def test_messages_handler_preflight_invalid_request_stays_http_error(
+async def test_messages_handler_startup_invalid_request_stays_http_error(
     stream: bool,
 ) -> None:
-    class RejectPreflightProvider(FakeProvider):
-        def preflight_messages(
+    class RejectStartupProvider(FakeProvider):
+        def stream_messages(
             self,
             request: MessagesRequest,
+            input_tokens: int = 0,
             *,
             reasoning: ReasoningPolicy,
             model_info: ProviderModelInfo | None = None,
-        ) -> None:
+            **kwargs: object,
+        ) -> AsyncIterator[str]:
             raise InvalidRequestError("bad tool shape")
 
-    provider = RejectPreflightProvider()
+    provider = RejectStartupProvider()
     handler = MessagesHandler(Settings(), provider_resolver=lambda _: provider)
     request = MessagesRequest(
         model="nvidia_nim/test-model",
@@ -188,8 +172,14 @@ async def test_messages_handler_preflight_invalid_request_stays_http_error(
         stream=stream,
     )
 
-    with pytest.raises(InvalidRequestError):
-        await handler.create(request)
+    if stream:
+        response = await handler.create(request)
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+        assert json.loads(bytes(response.body))["error"]["message"] == "bad tool shape"
+    else:
+        with pytest.raises(InvalidRequestError, match="bad tool shape"):
+            await handler.create(request)
 
 
 @pytest.mark.asyncio
@@ -453,11 +443,11 @@ async def test_messages_handler_normalizes_safety_classifier_policy(
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
     assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
     assert provider.requests[0].model == "test-model"
     assert provider.requests[0].system == system
-    assert provider.preflight_calls[0][0].stop_sequences is None
+    assert provider.requests[0].stop_sequences is None
     assert provider.requests[0].stop_sequences is None
     assert request.stop_sequences == [classifier_stop_sequence]
     assert _trace_events(
@@ -501,7 +491,7 @@ async def test_messages_handler_preserves_thinking_for_non_classifier() -> None:
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.provider_default()
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.provider_default()
     assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.provider_default()
     assert provider.requests[0].stop_sequences == ["</severity>"]
     assert (
@@ -531,7 +521,7 @@ async def test_messages_handler_tolerates_required_thinking_for_classifier() -> 
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
     assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
     assert provider.requests[0].stop_sequences is None
     assert request.stop_sequences == ["</block>"]
@@ -569,7 +559,7 @@ async def test_messages_handler_prefers_no_thinking_without_classifier_stop_hint
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
     assert provider.requests[0].stop_sequences is None
     assert _trace_events(
         trace_mock, "free_claude_code.api.route.safety_classifier_policy"
@@ -604,8 +594,8 @@ async def test_messages_handler_preserves_unowned_classifier_stop_sequences() ->
     assert isinstance(response, StreamingResponse)
     await _streaming_body_text(response)
 
-    assert provider.preflight_calls[0][1] == ReasoningPolicy.prefer_off()
-    assert provider.preflight_calls[0][0].stop_sequences == [
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.prefer_off()
+    assert provider.requests[0].stop_sequences == [
         "custom",
         "custom",
         "tail",
@@ -675,9 +665,7 @@ async def test_responses_handler_does_not_apply_safety_classifier_policy() -> No
         assert isinstance(response, StreamingResponse)
         await _streaming_body_text(response)
 
-    assert (
-        provider.responses_preflight_calls[0][1] == ReasoningPolicy.provider_default()
-    )
+    assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.provider_default()
     assert provider.stream_kwargs[0]["reasoning"] == ReasoningPolicy.provider_default()
     assert (
         _trace_events(

--- a/tests/api/test_execution_failure_contract.py
+++ b/tests/api/test_execution_failure_contract.py
@@ -45,8 +45,6 @@ class CanonicalFailureProvider:
         self._message = message
         self._retryable = retryable
         self._grouped = grouped
-        self.preflight_messages = MagicMock()
-        self.preflight_responses = MagicMock()
         self.stream_kwargs: list[dict[str, Any]] = []
 
     async def stream_messages(
@@ -101,23 +99,6 @@ class StalledProvider:
     def __init__(self, *, responses_chunks: tuple[str, ...] = ()) -> None:
         self._responses_chunks = responses_chunks
         self.close_calls = 0
-
-    def preflight_messages(
-        self,
-        _request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        del reasoning
-
-    def preflight_responses(
-        self,
-        _request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None:
-        del reasoning
 
     async def stream_messages(
         self,

--- a/tests/api/test_model_fallback.py
+++ b/tests/api/test_model_fallback.py
@@ -144,7 +144,7 @@ def test_final_failure_uses_last_candidate_typed_error(
         ("/v1/responses", responses_payload()),
     ),
 )
-def test_lazy_fallback_preflight_error_remains_ordinary(
+def test_lazy_fallback_validation_error_remains_ordinary(
     path: str,
     payload: dict[str, object],
 ) -> None:
@@ -152,7 +152,7 @@ def test_lazy_fallback_preflight_error_remains_ordinary(
         failure=execution_failure("primary overloaded")
     )
     fallback = ControlledFallbackProvider(
-        preflight_error=InvalidRequestError("fallback configuration is invalid")
+        validation_error=InvalidRequestError("fallback configuration is invalid")
     )
 
     with fallback_client(primary, fallback) as client:
@@ -183,7 +183,6 @@ def test_postframe_failure_never_opens_fallback_for_streaming_messages() -> None
     assert response.status_code == 200
     events = parse_sse_text(response.text)
     assert [event.event for event in events] == ["message_start", "error"]
-    assert fallback.preflight_models == []
     assert fallback.stream_models == []
 
 
@@ -204,7 +203,6 @@ def test_postframe_failure_never_opens_fallback_for_responses() -> None:
         "response.created",
         "response.failed",
     ]
-    assert fallback.preflight_models == []
     assert fallback.stream_models == []
 
 

--- a/tests/api/test_openai_responses.py
+++ b/tests/api/test_openai_responses.py
@@ -35,7 +35,7 @@ _RESPONSE_ID = "resp_test"
 class FakeProvider:
     def __init__(self, chunks: list[str]) -> None:
         self.chunks = chunks
-        self.preflight_responses = MagicMock()
+        self.startup_error: InvalidRequestError | None = None
         self.requests: list[OpenAIResponsesRequest] = []
         self.stream_kwargs: list[dict[str, object]] = []
 
@@ -44,6 +44,8 @@ class FakeProvider:
         request_data: OpenAIResponsesRequest,
         **kwargs: object,
     ) -> AsyncIterator[str]:
+        if self.startup_error is not None:
+            raise self.startup_error
         self.requests.append(request_data)
         self.stream_kwargs.append(kwargs)
         for chunk in self.chunks:
@@ -129,7 +131,7 @@ def test_create_response_stream_routes_native_request_through_provider(
     assert events[-1].data["response"]["output"][0]["content"][0]["text"] == (
         "Hello from provider"
     )
-    assert provider.preflight_responses.called
+    assert len(provider.requests) == 1
     routed = provider.requests[0]
     assert routed.model == _UPSTREAM_MODEL
     assert routed.input == "Hello"
@@ -163,9 +165,9 @@ def test_create_response_stream_preserves_output_limit_as_incomplete() -> None:
     assert incomplete["output"][0]["content"][0]["text"] == "partial output"
 
 
-def test_create_response_preflight_rejection_stays_an_ordinary_http_error() -> None:
+def test_create_response_startup_rejection_stays_an_ordinary_http_error() -> None:
     provider = FakeProvider(_responses_text_stream("unused"))
-    provider.preflight_responses.side_effect = InvalidRequestError("bad tool shape")
+    provider.startup_error = InvalidRequestError("bad tool shape")
     app = create_test_app()
 
     with (
@@ -540,7 +542,7 @@ def test_create_response_preserves_muse_code_request_shape() -> None:
         effort=ReasoningEffort.HIGH,
     )
     assert provider.stream_kwargs[0]["reasoning"] == expected_policy
-    assert provider.preflight_responses.call_args.kwargs["reasoning"] == expected_policy
+    assert provider.stream_kwargs[0]["reasoning"] == expected_policy
 
 
 def test_create_response_preserves_custom_tool_request() -> None:
@@ -700,7 +702,7 @@ def test_create_response_preserves_and_resolves_reasoning_effort(
     assert response.status_code == 200
     assert provider.requests[0].reasoning == reasoning
     assert provider.stream_kwargs[0]["reasoning"] == expected_policy
-    assert provider.preflight_responses.call_args.kwargs["reasoning"] == expected_policy
+    assert provider.stream_kwargs[0]["reasoning"] == expected_policy
 
 
 def test_create_response_relays_encrypted_reasoning() -> None:
@@ -732,7 +734,7 @@ def test_create_response_provider_rejects_unsupported_tool(
     responses_client: tuple[TestClient, FakeProvider],
 ) -> None:
     client, provider = responses_client
-    provider.preflight_responses.side_effect = InvalidRequestError(
+    provider.startup_error = InvalidRequestError(
         "Unsupported Responses tool type: 'web_search_preview'"
     )
 

--- a/tests/api/test_ordinary_error_phases.py
+++ b/tests/api/test_ordinary_error_phases.py
@@ -1,4 +1,4 @@
-"""Ordinary ingress, routing, readiness, and preflight error contracts."""
+"""Ordinary ingress, routing, readiness, and validation error contracts."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,7 +13,9 @@ from free_claude_code.application.errors import (
     UnknownProviderError,
 )
 from free_claude_code.config.settings import Settings
+from free_claude_code.providers.open_router import OpenRouterProvider
 from tests.api.support import create_test_app
+from tests.providers.support import immediate_admission, make_provider_config
 
 _PRODUCT_REQUESTS = (
     (
@@ -44,6 +46,48 @@ def _settings(**updates: object) -> Settings:
             **updates,
         }
     )
+
+
+@pytest.mark.parametrize("mode", ["messages_stream", "messages_nonstream", "responses"])
+def test_conversion_error_returns_http_400_without_generation(mode):
+    payload = {"model": "open_router/test-model"}
+    if mode == "responses":
+        payload["input"] = [
+            {"type": "reasoning", "encrypted_content": "fcc:history:v2:unsupported"}
+        ]
+        path = "/v1/responses"
+    else:
+        payload["stream"] = mode == "messages_stream"
+        payload["messages"] = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "redacted_thinking", "data": "fcc:history:v2:unsupported"}
+                ],
+            }
+        ]
+        path = "/v1/messages"
+    sdk = MagicMock()
+    with patch(
+        "free_claude_code.providers.openai_chat.client.AsyncOpenAI", return_value=sdk
+    ):
+        provider = OpenRouterProvider(
+            make_provider_config(
+                api_key="test", base_url="https://provider.invalid/v1"
+            ),
+            admission=immediate_admission(),
+        )
+    with (
+        patch("free_claude_code.api.routes.resolve_provider", return_value=provider),
+        TestClient(create_test_app(_settings())) as client,
+    ):
+        response = client.post(path, json=payload)
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert "replay" in response.json()["error"]["message"]
+    assert "x-should-retry" not in response.headers
+    sdk.chat.completions.create.assert_not_called()
 
 
 def _assert_ordinary_protocol_error(
@@ -189,19 +233,19 @@ def test_unknown_provider_is_protocol_specific_400_without_terminal_header(
     _PRODUCT_REQUESTS,
     ids=("messages", "responses"),
 )
-def test_preflight_rejection_is_protocol_specific_400_without_terminal_header(
+def test_startup_rejection_is_protocol_specific_400_without_terminal_header(
     wire_api: str,
     path: str,
     payload: dict[str, object],
 ) -> None:
     message = "bad tool shape"
     provider = MagicMock()
-    preflight = (
-        provider.preflight_responses
+    stream = (
+        provider.stream_responses
         if wire_api == "responses"
-        else provider.preflight_messages
+        else provider.stream_messages
     )
-    preflight.side_effect = InvalidRequestError(message)
+    stream.side_effect = InvalidRequestError(message)
     app = create_test_app(_settings())
 
     with (
@@ -218,7 +262,7 @@ def test_preflight_rejection_is_protocol_specific_400_without_terminal_header(
         if wire_api == "responses"
         else provider.stream_messages
     )
-    stream.assert_not_called()
+    stream.assert_called_once()
     _assert_ordinary_protocol_error(
         response,
         wire_api=wire_api,

--- a/tests/api/test_request_lifetime.py
+++ b/tests/api/test_request_lifetime.py
@@ -399,23 +399,6 @@ class _ControlledProvider:
         self.closed = asyncio.Event()
         self.request_ids: list[str] = []
 
-    def preflight_messages(
-        self,
-        _request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        del reasoning
-
-    def preflight_responses(
-        self,
-        _request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None:
-        del reasoning
-
     async def stream_messages(
         self,
         _request: MessagesRequest,

--- a/tests/api/test_web_server_tools.py
+++ b/tests/api/test_web_server_tools.py
@@ -128,23 +128,6 @@ class ScriptedSelectionProvider:
         self.stream_kwargs: list[dict[str, object]] = []
         self.close_count = 0
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        return None
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None:
-        raise AssertionError("Web-search selection received a Responses request")
-
     async def stream_responses(
         self,
         request: OpenAIResponsesRequest,

--- a/tests/application/test_execution.py
+++ b/tests/application/test_execution.py
@@ -25,26 +25,8 @@ from free_claude_code.core.reasoning import ReasoningCapability, ReasoningPolicy
 
 class FakeProvider:
     def __init__(self) -> None:
-        self.preflight_calls: list[tuple[MessagesRequest, ReasoningPolicy]] = []
         self.stream_calls: list[dict[str, object]] = []
         self.stream_close_calls = 0
-
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        self.preflight_calls.append((request, reasoning))
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None:
-        raise AssertionError("Messages test provider received a Responses request")
 
     async def stream_messages(
         self,
@@ -104,26 +86,8 @@ class FakeProvider:
 
 class ResponsesFakeProvider:
     def __init__(self) -> None:
-        self.preflight_calls: list[tuple[OpenAIResponsesRequest, ReasoningPolicy]] = []
         self.stream_calls: list[dict[str, object]] = []
         self.stream_close_calls = 0
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-    ) -> None:
-        self.preflight_calls.append((request, reasoning))
-
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        raise AssertionError("Responses test provider received a Messages request")
 
     async def stream_messages(
         self,
@@ -226,46 +190,34 @@ class ControlledProvider(FakeProvider):
             self.stream_close_calls += 1
 
 
-class FailingPreflightProvider(FakeProvider):
-    def preflight_messages(
+class FailingValidationProvider(FakeProvider):
+    def stream_messages(
         self,
         request: MessagesRequest,
+        input_tokens: int = 0,
         *,
         reasoning: ReasoningPolicy,
         model_info: ProviderModelInfo | None = None,
-    ) -> None:
+        **kwargs: object,
+    ) -> AsyncIterator[str]:
         raise ValueError("invalid provider request")
 
 
-class ApplicationErrorPreflightProvider(FakeProvider):
+class ApplicationErrorValidationProvider(FakeProvider):
     def __init__(self, error: InvalidRequestError) -> None:
         super().__init__()
         self._error = error
 
-    def preflight_messages(
+    def stream_messages(
         self,
         request: MessagesRequest,
+        input_tokens: int = 0,
         *,
         reasoning: ReasoningPolicy,
         model_info: ProviderModelInfo | None = None,
-    ) -> None:
+        **kwargs: object,
+    ) -> AsyncIterator[str]:
         raise self._error
-
-
-class ExecutionFailurePreflightProvider(FakeProvider):
-    def __init__(self, failure: ExecutionFailure) -> None:
-        super().__init__()
-        self._failure = failure
-
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        super().preflight_messages(request, reasoning=reasoning)
-        raise self._failure
 
 
 class FailingStreamConstructionProvider(FakeProvider):
@@ -382,13 +334,10 @@ def _routed_request(
 
 
 @pytest.mark.asyncio
-async def test_fallback_receives_its_own_cached_capability_in_preflight_and_stream():
+async def test_fallback_receives_its_own_cached_capability_in_stream():
     seen = []
 
     class MetadataProvider(ControlledProvider):
-        def preflight_messages(self, request, **kwargs):
-            seen.append(("preflight", request.model, kwargs["model_info"]))
-
         async def stream_messages(self, request, input_tokens=0, **kwargs):
             seen.append(("stream", request.model, kwargs["model_info"]))
             async for event in super().stream_messages(request, input_tokens, **kwargs):
@@ -420,9 +369,7 @@ async def test_fallback_receives_its_own_cached_capability_in_preflight_and_stre
     ]
     assert output == ["verdict"]
     assert seen == [
-        ("preflight", "provider-model", primary_info),
         ("stream", "provider-model", primary_info),
-        ("preflight", "fallback-model", fallback_info),
         ("stream", "fallback-model", fallback_info),
     ]
 
@@ -482,7 +429,7 @@ async def test_executor_routes_native_responses_without_messages_conversion() ->
         request_id="req_responses_application",
     )
 
-    assert provider.preflight_calls == [(request, ReasoningPolicy.on())]
+    assert provider.stream_calls == []
     assert [chunk async for chunk in stream] == [
         "event: response.completed\ndata: {}\n\n"
     ]
@@ -499,7 +446,9 @@ async def test_executor_routes_native_responses_without_messages_conversion() ->
 
 
 @pytest.mark.asyncio
-async def test_executor_uses_structural_provider_port_and_preflights_eagerly() -> None:
+async def test_executor_uses_structural_provider_port_and_defers_stream_startup() -> (
+    None
+):
     provider = FakeProvider()
     routed = _routed_request()
     request = routed.request
@@ -515,7 +464,7 @@ async def test_executor_uses_structural_provider_port_and_preflights_eagerly() -
         request_id="req_application",
     )
 
-    assert provider.preflight_calls == [(request, ReasoningPolicy.on())]
+    assert provider.stream_calls == []
     assert [chunk async for chunk in stream] == ["event: message_stop\ndata: {}\n\n"]
     assert provider.stream_calls == [
         {
@@ -561,7 +510,6 @@ async def test_primary_success_never_resolves_fallback() -> None:
 
     assert [chunk async for chunk in stream] == ["event: message_stop\ndata: {}\n\n"]
     assert resolved_ids == ["provider"]
-    assert fallback.preflight_calls == []
     assert fallback.stream_calls == []
 
 
@@ -601,9 +549,11 @@ async def test_retryable_preframe_failure_selects_fallback_after_closing_primary
     assert order == ["fallback-resolved"]
     assert primary.stream_close_calls == 1
     assert fallback.stream_close_calls == 1
-    assert fallback.preflight_calls[0][0].model == "fallback-model"
+    fallback_request = fallback.stream_calls[0]["request"]
+    assert isinstance(fallback_request, MessagesRequest)
+    assert fallback_request.model == "fallback-model"
     assert fallback.stream_calls[0] == {
-        "request": fallback.preflight_calls[0][0],
+        "request": fallback_request,
         "input_tokens": 17,
         "request_id": "req_fallback",
         "response_model": "gateway-model",
@@ -803,14 +753,14 @@ async def test_nonretryable_provider_failure_selects_fallback_before_first_frame
 
 
 @pytest.mark.asyncio
-async def test_primary_canonical_preflight_failure_selects_fallback() -> None:
+async def test_primary_canonical_startup_failure_selects_fallback() -> None:
     primary_failure = ExecutionFailure(
         kind=FailureKind.CONTEXT_WINDOW_EXCEEDED,
         status_code=400,
         message="primary context exceeded",
         retryable=False,
     )
-    primary = ExecutionFailurePreflightProvider(primary_failure)
+    primary = ExecutionFailureStreamConstructionProvider(primary_failure)
     fallback = ControlledProvider(["fallback-frame"])
     providers = {"provider": primary, "fallback": fallback}
     executor = ProviderExecutor(
@@ -821,12 +771,14 @@ async def test_primary_canonical_preflight_failure_selects_fallback() -> None:
     stream = executor.stream_messages(
         _routed_request(_target("fallback", "fallback-model")),
         raw_log_payload={},
-        request_id="req_preflight_fallback",
+        request_id="req_startup_fallback",
     )
 
     assert [chunk async for chunk in stream] == ["fallback-frame"]
     assert primary.stream_calls == []
-    assert fallback.preflight_calls[0][0].model == "fallback-model"
+    fallback_request = fallback.stream_calls[0]["request"]
+    assert isinstance(fallback_request, MessagesRequest)
+    assert fallback_request.model == "fallback-model"
 
 
 @pytest.mark.asyncio
@@ -881,10 +833,10 @@ async def test_failure_after_first_frame_never_selects_fallback() -> None:
 
 
 @pytest.mark.asyncio
-async def test_lazy_fallback_preflight_application_error_stops_unchanged() -> None:
+async def test_lazy_fallback_startup_application_error_stops_unchanged() -> None:
     primary = ControlledProvider([_execution_failure("primary")])
-    preflight_error = InvalidRequestError("fallback is misconfigured")
-    fallback = ApplicationErrorPreflightProvider(preflight_error)
+    startup_error = InvalidRequestError("fallback is misconfigured")
+    fallback = ApplicationErrorValidationProvider(startup_error)
     providers = {"provider": primary, "fallback": fallback}
     executor = ProviderExecutor(
         providers.__getitem__,
@@ -893,13 +845,13 @@ async def test_lazy_fallback_preflight_application_error_stops_unchanged() -> No
     stream = executor.stream_messages(
         _routed_request(_target("fallback", "model")),
         raw_log_payload={},
-        request_id="req_preflight",
+        request_id="req_startup",
     )
 
     with pytest.raises(InvalidRequestError) as exc_info:
         await anext(stream)
 
-    assert exc_info.value is preflight_error
+    assert exc_info.value is startup_error
     assert primary.stream_close_calls == 1
     assert fallback.stream_calls == []
 
@@ -1001,8 +953,9 @@ async def test_stream_construction_failure_remains_deferred_to_iteration() -> No
     assert resolved_ids == ["provider"]
 
 
-def test_executor_preflight_failure_stays_before_token_count_and_stream() -> None:
-    provider = FailingPreflightProvider()
+@pytest.mark.asyncio
+async def test_executor_validation_is_deferred_until_iteration() -> None:
+    provider = FailingValidationProvider()
     token_counter = MagicMock(return_value=17)
     executor = ProviderExecutor(
         lambda _provider_id: provider,
@@ -1010,14 +963,14 @@ def test_executor_preflight_failure_stays_before_token_count_and_stream() -> Non
         token_counter=token_counter,
     )
 
+    stream = executor.stream_messages(
+        _routed_request(),
+        raw_log_payload={},
+        request_id="req_application",
+    )
+    token_counter.assert_called_once()
     with pytest.raises(ValueError, match="invalid provider request"):
-        executor.stream_messages(
-            _routed_request(),
-            raw_log_payload={},
-            request_id="req_application",
-        )
-
-    token_counter.assert_not_called()
+        await anext(stream)
     assert provider.stream_calls == []
 
 

--- a/tests/application/test_request_conversion.py
+++ b/tests/application/test_request_conversion.py
@@ -1,0 +1,148 @@
+"""Request startup retains the conversion it validates before generation."""
+
+from dataclasses import replace
+from unittest.mock import patch
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+
+from free_claude_code.application.execution import ProviderExecutor
+from free_claude_code.core.anthropic import ReasoningReplayMode
+from free_claude_code.providers.openai_chat import (
+    NO_REASONING,
+    OpenAIChatProfile,
+    OpenAIChatProvider,
+    OpenAIChatRequestPolicy,
+)
+from tests.application.test_execution import _routed_request, _routed_responses_request
+from tests.providers.support import immediate_admission, make_provider_config
+from tests.providers.test_openai_chat_transport import _success
+from tests.providers.test_openai_codex_provider import (
+    OpenAICodexProvider,
+    _complete_stream,
+    _config,
+    _FakeAuth,
+)
+from tests.providers.test_opencode import (
+    _catalog_payload,
+    _provider_with_wire_transports,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wire", ["messages", "responses"])
+async def test_executor_converts_chat_request_once(wire):
+    generation_calls = []
+
+    def reply(request):
+        generation_calls.append(request)
+        return _success()
+
+    async with AsyncOpenAI(
+        api_key="test",
+        base_url="https://provider.invalid/v1",
+        max_retries=0,
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(reply)),
+    ) as client:
+        provider = OpenAIChatProvider(
+            make_provider_config(
+                api_key="test", base_url="https://provider.invalid/v1"
+            ),
+            profile=OpenAIChatProfile(
+                OpenAIChatRequestPolicy("TEST", ReasoningReplayMode.DISABLED),
+                NO_REASONING,
+            ),
+            admission=immediate_admission(),
+            client=client,
+        )
+        executor = ProviderExecutor(lambda _: provider, progress_timeout_seconds=60)
+        builder_name = (
+            "_build_request_body"
+            if wire == "messages"
+            else "_build_responses_request_body"
+        )
+        routed = (
+            _routed_request() if wire == "messages" else _routed_responses_request()
+        )
+        with patch.object(
+            provider._chat, builder_name, wraps=getattr(provider._chat, builder_name)
+        ) as build:
+            stream = getattr(executor, f"stream_{wire}")(
+                routed, raw_log_payload={}, request_id="conversion-once"
+            )
+            output = "".join([event async for event in stream])
+        assert "hello" in output
+        assert len(generation_calls) == 1
+        assert build.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wire", ["messages", "responses"])
+@pytest.mark.parametrize("egress", ["chat", "responses"])
+@pytest.mark.parametrize("warm", [False, True])
+async def test_executor_converts_selected_opencode_route_once(wire, egress, warm):
+    provider, generation, catalog = _provider_with_wire_transports(_catalog_payload())
+    transport = provider._chat if egress == "chat" else provider._responses
+    builders = {
+        ("chat", "messages"): "_build_request_body",
+        ("chat", "responses"): "_build_responses_request_body",
+        ("responses", "messages"): "_build_messages_body",
+        ("responses", "responses"): "_build_native_body",
+    }
+    name = builders[egress, wire]
+    routed = _routed_request() if wire == "messages" else _routed_responses_request()
+    routed = replace(
+        routed,
+        request=routed.request.model_copy(update={"model": f"{egress}-selector"}),
+    )
+    try:
+        if warm:
+            await provider.list_model_infos()
+        with patch.object(transport, name, wraps=getattr(transport, name)) as build:
+            executor = ProviderExecutor(lambda _: provider, progress_timeout_seconds=60)
+            stream = getattr(executor, f"stream_{wire}")(
+                routed, raw_log_payload={}, request_id="opencode-conversion-once"
+            )
+            assert f"{egress}-ok" in "".join([event async for event in stream])
+        assert build.call_count == 1
+        assert len(generation) == len(catalog) == 1
+    finally:
+        await provider.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wire", ["messages", "responses"])
+async def test_executor_converts_subscription_request_once(wire):
+    generation = []
+
+    def reply(request):
+        generation.append(request)
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=_complete_stream("hello"),
+        )
+
+    auth = _FakeAuth()
+    provider = OpenAICodexProvider(
+        _config(),
+        auth=auth,
+        admission=immediate_admission(),
+        transport=httpx2.MockTransport(reply),
+    )
+    name = "_build_messages_body" if wire == "messages" else "_build_native_body"
+    routed = _routed_request() if wire == "messages" else _routed_responses_request()
+    try:
+        with patch.object(
+            provider._responses, name, wraps=getattr(provider._responses, name)
+        ) as build:
+            executor = ProviderExecutor(lambda _: provider, progress_timeout_seconds=60)
+            stream = getattr(executor, f"stream_{wire}")(
+                routed, raw_log_payload={}, request_id="subscription-conversion-once"
+            )
+            assert auth.access_calls == 0
+            assert "hello" in "".join([event async for event in stream])
+        assert build.call_count == len(generation) == auth.access_calls == 1
+    finally:
+        await provider.cleanup()

--- a/tests/core/test_history_switching.py
+++ b/tests/core/test_history_switching.py
@@ -377,7 +377,7 @@ def test_completed_native_hosted_tools_become_readable_chat_history():
 
 
 @pytest.mark.parametrize("wire", ["messages", "responses"])
-def test_malformed_carrier_fails_preflight_before_inference(wire):
+def test_malformed_carrier_fails_startup_before_inference(wire):
     from free_claude_code.application.errors import InvalidRequestError
 
     provider = OpenRouterProvider(
@@ -386,7 +386,7 @@ def test_malformed_carrier_fails_preflight_before_inference(wire):
     )
     with pytest.raises(InvalidRequestError, match="replay"):
         if wire == "messages":
-            provider.preflight_messages(
+            provider.stream_messages(
                 MessagesRequest.model_validate(
                     {
                         "model": "m",
@@ -405,7 +405,7 @@ def test_malformed_carrier_fails_preflight_before_inference(wire):
                 )
             )
         else:
-            provider.preflight_responses(
+            provider.stream_responses(
                 OpenAIResponsesRequest(
                     model="m",
                     input=[

--- a/tests/providers/test_anthropic_messages_transport.py
+++ b/tests/providers/test_anthropic_messages_transport.py
@@ -595,12 +595,13 @@ async def test_auth_refresh_cannot_exceed_single_attempt_budget() -> None:
 
 
 @pytest.mark.asyncio
-async def test_preflight_rejects_invalid_conversion_without_request_io() -> None:
+async def test_startup_rejects_invalid_conversion_without_request_io() -> None:
     async with httpx.AsyncClient() as client:
         transport = _transport(client)
         with pytest.raises(InvalidRequestError):
-            transport.preflight_responses(
+            transport.stream_responses(
                 OpenAIResponsesRequest(
                     model="native", input=[{"type": "input_file", "file_id": "remote"}]
-                )
+                ),
+                endpoint_context=Endpoint(),
             )

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -788,7 +788,7 @@ def test_passthrough_tool_use_and_result(deepseek_provider):
     assert body["messages"][1]["role"] == "tool"
 
 
-def test_preflight_strips_user_image():
+def test_startup_strips_user_image():
     """Image blocks are silently stripped (DeepSeek lacks vision); request must not fail."""
     request = MessagesRequest(
         model="m",
@@ -818,7 +818,7 @@ def test_preflight_strips_user_image():
         admission=immediate_admission(),
     )
     # Should not raise; image is stripped.
-    provider.preflight_messages(request, reasoning=REASONING_ON)
+    provider.stream_messages(request, reasoning=REASONING_ON)
     body = provider._chat._build_request_body(request, reasoning=reasoning_for(request))
     content = body["messages"][0]["content"]
     assert "attachment omitted" in content.lower()
@@ -855,8 +855,8 @@ def test_vision_model_forwards_user_image():
         ),
         admission=immediate_admission(),
     )
-    # Must not raise on preflight (no InvalidRequestError for image blocks).
-    provider.preflight_messages(request, reasoning=REASONING_ON)
+    # Must not raise on validation (no InvalidRequestError for image blocks).
+    provider.stream_messages(request, reasoning=REASONING_ON)
     body = provider._chat._build_request_body(request, reasoning=reasoning_for(request))
     content = body["messages"][0]["content"]
     assert isinstance(content, list)
@@ -904,7 +904,7 @@ def test_vision_model_strips_user_document():
         ),
         admission=immediate_admission(),
     )
-    provider.preflight_messages(request, reasoning=REASONING_ON)
+    provider.stream_messages(request, reasoning=REASONING_ON)
     body = provider._chat._build_request_body(request, reasoning=reasoning_for(request))
     content = body["messages"][0]["content"]
     assert content
@@ -925,7 +925,7 @@ def test_vision_model_strips_user_document():
     assert "image or document inputs" in lowered
 
 
-def test_preflight_rejects_mcp_servers():
+def test_startup_rejects_mcp_servers():
     request = MessagesRequest(
         model="m",
         messages=[Message(role="user", content="x")],
@@ -941,10 +941,10 @@ def test_preflight_rejects_mcp_servers():
         admission=immediate_admission(),
     )
     with pytest.raises(InvalidRequestError, match="mcp_servers"):
-        provider.preflight_messages(request)
+        provider.stream_messages(request)
 
 
-def test_preflight_rejects_listed_server_tools_in_tools_list():
+def test_startup_rejects_listed_server_tools_in_tools_list():
     request = MessagesRequest(
         model="m",
         messages=[Message(role="user", content="x")],
@@ -960,10 +960,10 @@ def test_preflight_rejects_listed_server_tools_in_tools_list():
         admission=immediate_admission(),
     )
     with pytest.raises(InvalidRequestError, match="web_search"):
-        provider.preflight_messages(request)
+        provider.stream_messages(request)
 
 
-def test_preflight_preserves_completed_server_tool_history():
+def test_startup_preserves_completed_server_tool_history():
     request = MessagesRequest.model_validate(
         {
             "model": "m",
@@ -996,7 +996,7 @@ def test_preflight_preserves_completed_server_tool_history():
         ),
         admission=immediate_admission(),
     )
-    provider.preflight_messages(request)
+    provider.stream_messages(request)
     body = provider._chat._build_request_body(request)
     assert "[Earlier tool record]" in body["messages"][0]["content"]
 

--- a/tests/providers/test_github_copilot_provider.py
+++ b/tests/providers/test_github_copilot_provider.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import httpx2
@@ -37,6 +38,9 @@ from free_claude_code.core.reasoning import (
 from free_claude_code.providers.anthropic_messages.request_policy import (
     MessagesModelCapabilities,
 )
+from free_claude_code.providers.anthropic_messages.transport import (
+    AnthropicMessagesTransport,
+)
 from free_claude_code.providers.endpoint import HttpEndpoint
 from free_claude_code.providers.github_copilot.auth import CopilotAuthManager
 from free_claude_code.providers.github_copilot.provider import GitHubCopilotProvider
@@ -44,6 +48,10 @@ from free_claude_code.providers.github_copilot.types import (
     CopilotEgress,
     CopilotEndpoint,
     CopilotModel,
+)
+from free_claude_code.providers.openai_chat import OpenAIChatTransport
+from free_claude_code.providers.openai_responses.transport import (
+    OpenAIResponsesTransport,
 )
 from tests.providers.copilot_support import FakeRuntime, FakeSession
 from tests.providers.support import immediate_admission, make_provider_config
@@ -56,6 +64,48 @@ from tests.providers.test_openai_responses_transport import (
 from tests.providers.test_openai_responses_transport import (
     _sse as responses_sse,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("egress", list(CopilotEgress))
+@pytest.mark.parametrize("responses", [False, True])
+async def test_conversion_runs_once_under_current_account_lease(
+    tmp_path, egress, responses
+):
+    harness = Harness(tmp_path, egress)
+    cls, name = {
+        (CopilotEgress.CHAT, False): (OpenAIChatTransport, "_build_request_body"),
+        (CopilotEgress.CHAT, True): (
+            OpenAIChatTransport,
+            "_build_responses_request_body",
+        ),
+        (CopilotEgress.RESPONSES, False): (
+            OpenAIResponsesTransport,
+            "_build_messages_body",
+        ),
+        (CopilotEgress.RESPONSES, True): (
+            OpenAIResponsesTransport,
+            "_build_native_body",
+        ),
+        (CopilotEgress.MESSAGES, False): (AnthropicMessagesTransport, "_messages_body"),
+        (CopilotEgress.MESSAGES, True): (AnthropicMessagesTransport, "_responses_body"),
+    }[egress, responses]
+    original = getattr(cls, name)
+
+    def build(transport, *args, **kwargs):
+        assert harness.runtime.session_calls == 1
+        assert not harness.runtime.sessions[0].closed
+        assert harness.provider._active == 1
+        assert harness.seen == []
+        return original(transport, *args, **kwargs)
+
+    try:
+        with patch.object(cls, name, autospec=True, side_effect=build) as conversion:
+            assert "ok" in await collect(harness.stream(responses))
+        assert conversion.call_count == len(harness.seen) == 1
+        assert harness.provider._active == 0
+    finally:
+        await harness.close()
 
 
 class Wire(httpx.AsyncByteStream, httpx2.AsyncByteStream):

--- a/tests/providers/test_lmstudio.py
+++ b/tests/providers/test_lmstudio.py
@@ -1,16 +1,23 @@
 """Tests for LM Studio (OpenAI-compatible chat completions) provider."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from free_claude_code.application.errors import InvalidRequestError
+from free_claude_code.application.execution import ProviderExecutor
 from free_claude_code.config.provider_catalog import LMSTUDIO_DEFAULT_BASE
-from free_claude_code.core.anthropic import get_token_count
+from free_claude_code.core.anthropic import MessagesRequest, get_token_count
 from free_claude_code.core.failures import ExecutionFailure, FailureKind
+from free_claude_code.core.openai_responses import (
+    OpenAIResponsesRequest,
+    estimate_responses_input_tokens,
+)
 from free_claude_code.core.reasoning import ReasoningEffort, ReasoningPolicy
 from free_claude_code.providers.lmstudio import LMStudioProvider
+from tests.application.test_execution import _routed_request, _routed_responses_request
 from tests.providers.request_factory import make_messages_request
 from tests.providers.support import (
     REASONING_OFF,
@@ -36,7 +43,12 @@ def lmstudio_config():
 
 @pytest.fixture
 def lmstudio_provider(lmstudio_config):
-    return LMStudioProvider(lmstudio_config, admission=immediate_admission())
+    provider = LMStudioProvider(lmstudio_config, admission=immediate_admission())
+    with patch(
+        "free_claude_code.providers.lmstudio.client.httpx.get",
+        side_effect=httpx.ConnectError("offline test"),
+    ):
+        yield provider
 
 
 def test_init(lmstudio_config):
@@ -113,53 +125,133 @@ def test_build_request_body_never_replays_prior_thinking(lmstudio_provider):
     assert "prior reasoning" in str(body)
 
 
-def test_preflight_builds_before_context_budget_and_preserves_policy(
-    lmstudio_provider,
+@pytest.mark.parametrize("wire", ["messages", "responses"])
+def test_startup_builds_before_context_budget_and_preserves_policy(
+    lmstudio_provider, wire
 ):
-    request = make_request()
-    calls: list[tuple[str, object]] = []
+    request = (
+        make_request()
+        if wire == "messages"
+        else OpenAIResponsesRequest(model="model", input="hello")
+    )
+    calls = []
+    name = (
+        "_build_request_body" if wire == "messages" else "_build_responses_request_body"
+    )
+    original = getattr(lmstudio_provider._chat, name)
 
-    def build(request_arg, *, reasoning, model_info):
+    def build(request_arg, *, reasoning):
         assert request_arg is request
-        assert model_info is None
         calls.append(("build", reasoning))
-        return {}
+        return original(request_arg, reasoning=reasoning)
 
-    def check_context(estimate: int):
+    def check_context(estimate):
         calls.append(("context", estimate))
 
     with (
-        patch.object(lmstudio_provider._chat, "_build_request_body", side_effect=build),
+        patch.object(lmstudio_provider._chat, name, side_effect=build),
         patch.object(
-            lmstudio_provider,
-            "_preflight_context_budget",
-            side_effect=check_context,
+            lmstudio_provider, "_validate_context_budget", side_effect=check_context
         ),
+        patch.object(
+            lmstudio_provider._chat._admission, "start_execution"
+        ) as admission,
     ):
-        lmstudio_provider.preflight_messages(request, reasoning=REASONING_OFF)
+        getattr(lmstudio_provider, f"stream_{wire}")(request, reasoning=REASONING_OFF)
+    estimate = (
+        get_token_count(request.messages, request.system, request.tools)
+        if isinstance(request, MessagesRequest)
+        else estimate_responses_input_tokens(request)
+    )
+    assert calls == [("build", REASONING_OFF), ("context", estimate)]
+    admission.assert_not_called()
 
-    assert calls == [
-        ("build", REASONING_OFF),
-        ("context", get_token_count(request.messages, request.system, request.tools)),
-    ]
 
-
-def test_preflight_conversion_failure_skips_context_budget(lmstudio_provider):
-    request = make_request()
+@pytest.mark.parametrize("wire", ["messages", "responses"])
+def test_startup_conversion_failure_skips_context_budget(lmstudio_provider, wire):
+    request = (
+        make_request()
+        if wire == "messages"
+        else OpenAIResponsesRequest(model="model", input="hello")
+    )
     conversion_error = InvalidRequestError("invalid request conversion")
 
     with (
         patch.object(
             lmstudio_provider._chat,
-            "_build_request_body",
+            "_build_request_body"
+            if wire == "messages"
+            else "_build_responses_request_body",
             side_effect=conversion_error,
         ),
-        patch.object(lmstudio_provider, "_preflight_context_budget") as context,
+        patch.object(lmstudio_provider, "_validate_context_budget") as context,
         pytest.raises(InvalidRequestError, match="invalid request conversion"),
     ):
-        lmstudio_provider.preflight_messages(request, reasoning=REASONING_ON)
+        getattr(lmstudio_provider, f"stream_{wire}")(request, reasoning=REASONING_ON)
 
     context.assert_not_called()
+
+
+@pytest.mark.parametrize("wire", ["messages", "responses"])
+def test_context_rejection_never_starts_admission_or_generation(
+    lmstudio_provider, wire
+):
+    request = (
+        make_request()
+        if wire == "messages"
+        else OpenAIResponsesRequest(model="model", input="hello")
+    )
+    with (
+        patch.object(lmstudio_provider, "_loaded_context_length", return_value=1),
+        patch.object(
+            lmstudio_provider._chat._admission, "start_execution"
+        ) as admission,
+        patch.object(
+            lmstudio_provider._client.chat.completions, "create"
+        ) as generation,
+        pytest.raises(ExecutionFailure) as error,
+    ):
+        getattr(lmstudio_provider, f"stream_{wire}")(request)
+    assert error.value.kind is FailureKind.CONTEXT_WINDOW_EXCEEDED
+    admission.assert_not_called()
+    generation.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wire", ["messages", "responses"])
+async def test_primary_context_validation_counts_toward_progress_timeout(
+    lmstudio_provider, wire
+):
+    loop = asyncio.get_running_loop()
+    now = loop.time()
+
+    def slow_lookup():
+        nonlocal now
+        now += 2
+        return 100_000
+
+    executor = ProviderExecutor(lambda _: lmstudio_provider, progress_timeout_seconds=1)
+    routed = _routed_request() if wire == "messages" else _routed_responses_request()
+    with (
+        patch.object(loop, "time", side_effect=lambda: now),
+        patch.object(
+            lmstudio_provider, "_loaded_context_length", side_effect=slow_lookup
+        ),
+        patch.object(
+            lmstudio_provider._chat._admission, "start_execution"
+        ) as admission,
+        patch.object(
+            lmstudio_provider._client.chat.completions, "create"
+        ) as generation,
+    ):
+        stream = getattr(executor, f"stream_{wire}")(
+            routed, raw_log_payload={}, request_id="context-timeout"
+        )
+        with pytest.raises(ExecutionFailure) as error:
+            await anext(stream)
+    assert error.value.kind is FailureKind.TIMEOUT
+    admission.assert_not_called()
+    generation.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -242,29 +334,29 @@ async def test_cleanup(lmstudio_provider):
     await lmstudio_provider.cleanup()
 
 
-# --- Context-budget preflight (new: guards against LM Studio's silent
+# --- Context-budget validation (new: guards against LM Studio's silent
 # mid-stream truncation when a prompt exceeds the loaded model's context) ---
 
 
-def test_preflight_context_budget_noop_when_context_length_unknown(lmstudio_provider):
-    """No LM Studio /api/v0/models data available -> preflight is a no-op (fail open)."""
+def test_validate_context_budget_noop_when_context_length_unknown(lmstudio_provider):
+    """No LM Studio /api/v0/models data available -> validation is a no-op (fail open)."""
     with patch.object(lmstudio_provider, "_loaded_context_length", return_value=None):
-        lmstudio_provider._preflight_context_budget(1)  # must not raise
+        lmstudio_provider._validate_context_budget(1)  # must not raise
 
 
-def test_preflight_context_budget_allows_request_under_budget(lmstudio_provider):
+def test_validate_context_budget_allows_request_under_budget(lmstudio_provider):
     with patch.object(
         lmstudio_provider, "_loaded_context_length", return_value=100_000
     ):
-        lmstudio_provider._preflight_context_budget(1)  # must not raise
+        lmstudio_provider._validate_context_budget(1)  # must not raise
 
 
-def test_preflight_context_budget_rejects_request_over_90_percent(lmstudio_provider):
+def test_validate_context_budget_rejects_request_over_90_percent(lmstudio_provider):
     with (
         patch.object(lmstudio_provider, "_loaded_context_length", return_value=1000),
         pytest.raises(ExecutionFailure) as exc_info,
     ):
-        lmstudio_provider._preflight_context_budget(901)
+        lmstudio_provider._validate_context_budget(901)
 
     failure = exc_info.value
     assert failure.kind is FailureKind.CONTEXT_WINDOW_EXCEEDED

--- a/tests/providers/test_model_discovery.py
+++ b/tests/providers/test_model_discovery.py
@@ -354,23 +354,6 @@ class FakeProvider(BaseProvider):
         self.cleaned = False
         self.model_list_calls = 0
 
-    def preflight_messages(
-        self,
-        request: Any,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        return None
-
-    def preflight_responses(
-        self,
-        request: Any,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        return None
-
     async def cleanup(self) -> None:
         self.cleaned = True
 

--- a/tests/providers/test_nvidia_nim.py
+++ b/tests/providers/test_nvidia_nim.py
@@ -497,7 +497,7 @@ async def test_build_request_body_omits_reasoning_when_request_disables_thinking
     assert "reasoning_budget" not in extra
 
 
-def test_preflight_and_build_request_issue_206_post_tool_text(nim_provider):
+def test_startup_and_build_request_issue_206_post_tool_text(nim_provider):
     """Regression: assistant message with tool_use then text plus tool results (GitHub #206)."""
     tool_id = "toolu_issue_206"
     req = make_request(
@@ -527,7 +527,7 @@ def test_preflight_and_build_request_issue_206_post_tool_text(nim_provider):
             ),
         ],
     )
-    nim_provider.preflight_messages(req, reasoning=REASONING_OFF)
+    nim_provider.stream_messages(req, reasoning=REASONING_OFF)
     body = nim_provider._chat._build_request_body(req, reasoning=REASONING_OFF)
     assert "messages" in body
     assert any(m.get("role") == "tool" for m in body["messages"])

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -440,17 +440,14 @@ async def test_provider_accepts_claude_client_controls_before_upstream_io() -> N
     original_request = request.model_dump()
     reasoning = ReasoningPolicy.on(effort=ReasoningEffort.HIGH)
 
-    provider.preflight_messages(request, reasoning=reasoning)
-    assert requests == []
-
-    body = await _collect(
-        provider.stream_messages(
-            request,
-            request_id="req_client_controls",
-            response_model="claude-opus-4",
-            reasoning=reasoning,
-        )
+    stream = provider.stream_messages(
+        request,
+        request_id="req_client_controls",
+        response_model="claude-opus-4",
+        reasoning=reasoning,
     )
+    assert requests == []
+    body = await _collect(stream)
 
     assert len(requests) == 1
     upstream = requests[0]
@@ -487,15 +484,13 @@ async def test_provider_relays_native_responses_with_private_field_policy() -> N
     request = _responses_request()
     original = request.model_dump()
 
-    provider.preflight_responses(request)
-    assert requests == []
-    body = await _collect(
-        provider.stream_responses(
-            request,
-            request_id="req_native_responses",
-            response_model="openai/gpt-test",
-        )
+    stream = provider.stream_responses(
+        request,
+        request_id="req_native_responses",
+        response_model="openai/gpt-test",
     )
+    assert requests == []
+    body = await _collect(stream)
 
     assert len(requests) == 1
     upstream = json.loads(requests[0].content)
@@ -545,7 +540,7 @@ async def test_provider_relays_native_responses_with_private_field_policy() -> N
         ),
     ],
 )
-async def test_provider_preflight_rejects_unrepresentable_client_controls(
+async def test_provider_validation_rejects_unrepresentable_client_controls(
     field: str,
     value: object,
     error_path: str,
@@ -567,7 +562,7 @@ async def test_provider_preflight_rejects_unrepresentable_client_controls(
     }
 
     with pytest.raises(InvalidRequestError, match=error_path):
-        provider.preflight_messages(MessagesRequest.model_validate(payload))
+        provider.stream_messages(MessagesRequest.model_validate(payload))
 
     assert requests == []
     await provider.cleanup()

--- a/tests/providers/test_openai_responses_transport.py
+++ b/tests/providers/test_openai_responses_transport.py
@@ -1141,14 +1141,20 @@ async def test_cancellation_closes_the_sdk_stream() -> None:
 
 
 @pytest.mark.asyncio
-async def test_preflight_rejects_fields_responses_cannot_represent() -> None:
+async def test_startup_rejects_fields_responses_cannot_represent() -> None:
     client = _client(lambda _request: httpx2.Response(500))
     transport = _transport(client)
     request = _request(stop_sequences=["done"])
 
     try:
         with pytest.raises(InvalidRequestError, match="stop_sequences"):
-            transport.preflight_messages(request, reasoning=REASONING_ON)
+            transport.stream_messages(
+                request,
+                input_tokens=0,
+                request_id=None,
+                response_model=request.model,
+                reasoning=REASONING_ON,
+            )
     finally:
         await client.close()
 

--- a/tests/providers/test_opencode.py
+++ b/tests/providers/test_opencode.py
@@ -722,7 +722,6 @@ async def test_responses_tool_search_accepts_optional_codex_arguments() -> None:
     )
     try:
         await provider.list_model_infos()
-        provider.preflight_responses(request)
         body = "".join([chunk async for chunk in provider.stream_responses(request)])
     finally:
         await provider.cleanup()
@@ -1216,18 +1215,16 @@ async def test_cold_route_specific_conversion_failure_precedes_generation() -> N
 
 
 @pytest.mark.asyncio
-async def test_warm_preflight_rejects_unknown_and_route_specific_fields() -> None:
+async def test_warm_startup_rejects_unknown_and_route_specific_fields() -> None:
     provider, generation_requests, _catalog_requests = _provider_with_wire_transports(
         _catalog_payload()
     )
     try:
         await provider.list_model_infos()
         with pytest.raises(InvalidRequestError, match="does not advertise"):
-            provider.preflight_messages(_request("missing"))
+            await _collect(provider, "missing")
         with pytest.raises(InvalidRequestError, match="stop_sequences"):
-            provider.preflight_messages(
-                _request("responses-selector", stop_sequences=["done"])
-            )
+            await _collect(provider, "responses-selector", stop_sequences=["done"])
     finally:
         await provider.cleanup()
 

--- a/tests/providers/test_stream_startup_contract.py
+++ b/tests/providers/test_stream_startup_contract.py
@@ -1,15 +1,10 @@
-"""The shared OpenAI-chat provider owns explicit request preflight."""
+"""The shared OpenAI-chat provider owns request conversion during stream construction."""
 
-from collections.abc import AsyncIterator, Mapping
 from unittest.mock import MagicMock
 
-import pytest
-
-from free_claude_code.application.model_metadata import ProviderModelInfo
 from free_claude_code.core.anthropic import ReasoningReplayMode
 from free_claude_code.core.anthropic.models import Message, MessagesRequest
 from free_claude_code.core.reasoning import DEFAULT_REASONING_POLICY, ReasoningPolicy
-from free_claude_code.providers.base import BaseProvider
 from free_claude_code.providers.openai_chat import (
     NO_REASONING,
     OpenAIChatBehavior,
@@ -40,40 +35,7 @@ class RecordingChatBehavior(OpenAIChatBehavior):
         return {}
 
 
-class ProviderWithoutPreflight(BaseProvider):
-    async def cleanup(self) -> None:
-        return None
-
-    async def list_model_infos(self) -> frozenset[ProviderModelInfo]:
-        return frozenset()
-
-    async def stream_messages(
-        self,
-        request: MessagesRequest,
-        input_tokens: int = 0,
-        *,
-        request_id: str | None = None,
-        response_model: str | None = None,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        request_headers: Mapping[str, str] | None = None,
-        model_info: ProviderModelInfo | None = None,
-    ) -> AsyncIterator[str]:
-        if False:
-            yield ""
-
-
-def test_provider_base_requires_an_explicit_preflight_implementation() -> None:
-    with pytest.raises(TypeError, match="preflight_messages"):
-        ProviderWithoutPreflight(
-            make_provider_config(api_key="test", base_url="https://test.invalid")
-        )
-
-
-def test_openai_provider_owns_preflight() -> None:
-    assert OpenAIChatProvider.preflight_messages is not BaseProvider.preflight_messages
-
-
-def test_provider_preflight_calls_builder_and_preserves_policy() -> None:
+def test_provider_stream_constructor_calls_builder_and_preserves_policy() -> None:
     behavior = RecordingChatBehavior()
     provider = OpenAIChatProvider(
         make_provider_config(api_key="test", base_url="https://test.invalid"),
@@ -86,6 +48,6 @@ def test_provider_preflight_calls_builder_and_preserves_policy() -> None:
         messages=[Message(role="user", content="hello")],
     )
 
-    provider.preflight_messages(request, reasoning=ReasoningPolicy.off())
+    provider.stream_messages(request, reasoning=ReasoningPolicy.off())
 
     assert behavior.build_calls == [(request, ReasoningPolicy.off())]

--- a/tests/runtime/test_application_runtime.py
+++ b/tests/runtime/test_application_runtime.py
@@ -65,23 +65,6 @@ class AdminModelProvider(BaseProvider):
         self._model_infos = model_infos
         self._error = error
 
-    def preflight_messages(
-        self,
-        request: MessagesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-        model_info: ProviderModelInfo | None = None,
-    ) -> None:
-        return None
-
-    def preflight_responses(
-        self,
-        request: OpenAIResponsesRequest,
-        *,
-        reasoning: ReasoningPolicy = DEFAULT_REASONING_POLICY,
-    ) -> None:
-        return None
-
     async def cleanup(self) -> None:
         return None
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.20"
+version = "6.2.21"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Provider preflight builds and validates a request, discards the converted body, then streaming builds it again. Warm OpenCode routes can perform three full conversions for one request.

## How

Remove the separate preflight contract and retain the conversion already performed during stream startup. OpenCode selects its execution route once, and Copilot converts within its current account lease. LM Studio keeps its context validation in the provider, after conversion and before generation.

As agreed, primary validation now runs during candidate startup after token counting. LM Studio's context lookup therefore counts toward the existing progress timeout, matching fallbacks. Its existing maximum loaded-context ceiling, 90% threshold, cache and failure-open lookup remain the context policy.

Bump the patch version to 6.2.21.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63549189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Safe to merge: the only remaining issue is redundant test code and does not affect product behavior.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fsingle-request-conversion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fsingle-request-conversion%22.%0A%0A%23%23%23%20Issue%201%0Atests%2Fapi%2Ftest_api_handlers.py%3A446-447%0AThe%20assertions%20on%20lines%20446%E2%80%93447%20and%20450%E2%80%93451%20each%20check%20the%20same%20value%20twice.%20Removing%20the%20second%20assertion%20from%20each%20pair%20is%20a%20non-blocking%20cleanup%20that%20makes%20the%20test%E2%80%99s%20distinct%20expectations%20clearer%20and%20less%20costly%20to%20maintain.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1783&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Remove duplicate assertions** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1783#discussion_r3998693385">▶</a>

<details open><summary><h3>Summary</h3></summary>

- This change centralizes provider request-startup conversion and fallback handling, with coverage for provider-specific conversion behavior. One non-blocking test cleanup remains in `tests/api/test_api_handlers.py`: two assertion pairs are duplicated consecutively.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Convert provider requests once at stream..."](https://github.com/alishahryar1/free-claude-code/commit/d107db3313f7e3882a82370bfe8d19a8e26245b3)</sub>

<!-- /greptile_comment -->