### PR TITLE
Show integration loading state in action buttons

### DIFF
--- a/e2e/test_admin_integrations.py
+++ b/e2e/test_admin_integrations.py
@@ -8,6 +8,45 @@ from playwright.sync_api import expect
 from free_claude_code.cli import vscode
 
 
+@pytest.mark.parametrize(
+    "integration,button_id",
+    [
+        ("claude-vscode", "openClaudeIntegration"),
+        ("codex", "openCodexIntegration"),
+    ],
+)
+@pytest.mark.parametrize("connected", [False, True])
+def test_connection_check_uses_disabled_loading_button(
+    page, admin_base_url, integration, button_id, connected
+):
+    pending = []
+    page.route(
+        f"**/admin/api/integrations/{integration}", lambda route: pending.append(route)
+    )
+    page.goto(f"{admin_base_url}/admin/integrations")
+    button = page.locator(f"#{button_id}")
+    for visit in range(2):
+        if visit:
+            page.get_by_role("button", name="Providers", exact=True).click()
+            page.get_by_role("button", name="Integrations", exact=True).click()
+        expect(button).to_be_disabled()
+        expect(button).to_have_text("Loading…")
+        expect(button).to_have_attribute("aria-busy", "true")
+        expect(button).to_have_css("background-color", "rgb(23, 27, 38)")
+        assert (
+            button.evaluate(
+                "element => getComputedStyle(element, '::before').animationName"
+            )
+            == "integration-spinner"
+        )
+        expect(page.locator("#view-integrations .status-pill")).to_have_count(0)
+        assert len(pending) == 1
+        pending.pop().fulfill(json={"connected": connected, "paths": None})
+        expect(button).to_be_enabled()
+        expect(button).to_have_text("Disconnect" if connected else "Connect")
+        expect(button).to_have_attribute("aria-busy", "false")
+
+
 @pytest.mark.parametrize("width", [1280, 1200, 390])
 def test_codex_connect_disconnect_and_modal_paths(
     page, admin_base_url, tmp_path, width
@@ -25,9 +64,9 @@ def test_codex_connect_disconnect_and_modal_paths(
             "Claude Code in JetBrains ACP",
         ]
     )
-    expect(page.locator("#claudeIntegrationStatus")).not_to_be_visible()
+    expect(page.locator("#claudeIntegrationStatus")).to_have_count(0)
     expect(page.locator("#openCodexIntegration")).to_be_enabled()
-    expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
+    expect(page.locator("#codexIntegrationStatus")).to_have_count(0)
     expect(cards.nth(1)).to_contain_text(
         "Use FCC's models in the Codex VS Code extension and desktop app."
     )
@@ -76,7 +115,7 @@ def test_codex_connect_disconnect_and_modal_paths(
     page.locator("#confirmCodexIntegration").click()
     expect(dialog).not_to_be_visible()
     expect(opener).to_have_text("Disconnect")
-    expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
+    expect(page.locator("#codexIntegrationStatus")).to_have_count(0)
     expect(opener).to_have_css("color", "rgb(239, 68, 68)")
     if width >= 1200:
         buttons = [
@@ -103,7 +142,7 @@ def test_codex_connect_disconnect_and_modal_paths(
     page.locator("#confirmCodexIntegration").click()
     expect(opener).to_have_text("Connect")
     expect(opener).to_have_css("color", "rgb(6, 16, 11)")
-    expect(page.locator("#codexIntegrationStatus")).not_to_be_visible()
+    expect(page.locator("#codexIntegrationStatus")).to_have_count(0)
     assert tomllib.loads(path.read_text()) == {"model": "my-choice"}
     assert not (tmp_path / "vscode" / "settings.json").exists()
     assert not (tmp_path / ".claude.json").exists()
@@ -229,7 +268,7 @@ def test_connect_disconnect_and_modal_dismissal(page, admin_base_url, tmp_path):
     action.click()
     expect(dialog).not_to_be_visible()
     expect(card_button).to_have_text("Disconnect")
-    expect(page.locator("#claudeIntegrationStatus")).not_to_be_visible()
+    expect(page.locator("#claudeIntegrationStatus")).to_have_count(0)
     expect(card_button).to_have_css("color", "rgb(239, 68, 68)")
     expect(page.locator("#claudeIntegrationMessage")).to_contain_text("Reload VS Code")
     assert json.loads(path.read_text())["claudeCode.disableLoginPrompt"] is True
@@ -247,7 +286,7 @@ def test_connect_disconnect_and_modal_dismissal(page, admin_base_url, tmp_path):
     action.click()
     expect(card_button).to_have_text("Connect")
     expect(card_button).to_have_css("color", "rgb(6, 16, 11)")
-    expect(page.locator("#claudeIntegrationStatus")).not_to_be_visible()
+    expect(page.locator("#claudeIntegrationStatus")).to_have_count(0)
     assert json.loads(path.read_text()) == {}
     assert json.loads(state_path.read_text())["hasCompletedOnboarding"] is True
 
@@ -285,9 +324,11 @@ def test_invalid_settings_error_can_be_retried_and_does_not_break_admin(
     path.write_text("{invalid}")
     page.goto(f"{admin_base_url}/admin/integrations")
     expect(page.locator("#claudeIntegrationMessage")).to_contain_text("Check the JSON")
-    expect(page.locator("#claudeIntegrationStatus")).to_have_text(
-        "Could not check settings"
+    expect(page.locator("#openClaudeIntegration")).to_have_text("Retry")
+    expect(page.locator("#openClaudeIntegration")).to_have_attribute(
+        "aria-busy", "false"
     )
+    expect(page.locator("#view-integrations .status-pill")).to_have_count(0)
     page.get_by_role("button", name="Providers", exact=True).click()
     expect(page.locator('[data-provider="nvidia_nim"]')).to_be_visible()
     page.get_by_role("button", name="Integrations", exact=True).click()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.21"
+version = "6.2.22"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/admin.css
+++ b/src/free_claude_code/api/admin_static/admin.css
@@ -267,10 +267,28 @@ textarea:focus-visible,
   margin-bottom: 0;
 }
 .integration-card > button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   margin-top: auto;
   min-height: 38px;
   padding: 6px 14px;
   font-size: 13px;
+}
+.integration-card > button[aria-busy="true"]::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: integration-spinner 0.8s linear infinite;
+}
+@keyframes integration-spinner {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .integration-card > button[aria-busy="true"]::before { animation: none; }
 }
 .integration-card h3 { min-height: 2lh; }
 .integration-dialog {

--- a/src/free_claude_code/api/admin_static/admin.js
+++ b/src/free_claude_code/api/admin_static/admin.js
@@ -1286,15 +1286,13 @@ function integrationMessage(id, message, error = false) {
 function renderClaudeIntegration() {
   const { connected, busy, paths } = claudeIntegration;
   const action = connected ? "Disconnect" : "Connect";
-  byId("openClaudeIntegration").textContent = connected === null && !busy ? "Retry" : action;
+  byId("openClaudeIntegration").textContent = busy ? "Loading…" : connected === null ? "Retry" : action;
   byId("openClaudeIntegration").disabled = busy;
+  byId("openClaudeIntegration").setAttribute("aria-busy", String(busy));
   byId("confirmClaudeIntegration").textContent = busy ? "Saving…" : action;
   byId("confirmClaudeIntegration").disabled = busy || connected === null;
-  byId("openClaudeIntegration").className = connected ? "danger-button" : "primary-button";
+  byId("openClaudeIntegration").className = connected && !busy ? "danger-button" : "primary-button";
   byId("confirmClaudeIntegration").className = connected ? "danger-button" : "primary-button";
-  const status = byId("claudeIntegrationStatus");
-  status.hidden = connected !== null;
-  status.textContent = busy ? "Checking settings…" : "Could not check settings";
   byId("claudeIntegrationDescription").textContent = connected
     ? "Remove FCC's VS Code settings. Claude onboarding stays completed."
     : "Will set FCC's URL and token, enable model discovery, skip VS Code login, and complete Claude onboarding.";
@@ -1376,15 +1374,13 @@ const codexIntegrationPath = "/admin/api/integrations/codex";
 function renderCodexIntegration() {
   const { connected, busy, paths } = codexIntegration;
   const action = connected ? "Disconnect" : "Connect";
-  byId("openCodexIntegration").textContent = connected === null && !busy ? "Retry" : action;
+  byId("openCodexIntegration").textContent = busy ? "Loading…" : connected === null ? "Retry" : action;
   byId("openCodexIntegration").disabled = busy;
+  byId("openCodexIntegration").setAttribute("aria-busy", String(busy));
   byId("confirmCodexIntegration").textContent = busy ? "Saving…" : action;
   byId("confirmCodexIntegration").disabled = busy || connected === null;
-  byId("openCodexIntegration").className = connected ? "danger-button" : "primary-button";
+  byId("openCodexIntegration").className = connected && !busy ? "danger-button" : "primary-button";
   byId("confirmCodexIntegration").className = connected ? "danger-button" : "primary-button";
-  const status = byId("codexIntegrationStatus");
-  status.hidden = connected !== null;
-  status.textContent = busy ? "Checking settings…" : "Could not check settings";
   byId("codexIntegrationDescription").textContent = connected
     ? "Remove FCC's Codex configuration. Other settings stay unchanged."
     : "Configure Codex to use FCC. Your selected model stays unchanged.";

--- a/src/free_claude_code/api/admin_static/index.html
+++ b/src/free_claude_code/api/admin_static/index.html
@@ -88,11 +88,10 @@
                 <div>
                   <h3>Claude Code in VS Code</h3>
                   <p>Use FCC's models in the Claude Code extension for VS Code.</p>
-                  <span id="claudeIntegrationStatus" class="status-pill neutral" role="status">Checking settings…</span>
                 </div>
               </div>
               <p id="claudeIntegrationMessage" class="message-area" role="status" hidden></p>
-              <button id="openClaudeIntegration" class="primary-button" type="button" disabled>Connect</button>
+              <button id="openClaudeIntegration" class="primary-button" type="button" aria-busy="true" disabled>Loading…</button>
             </article>
             <dialog id="claudeIntegrationDialog" class="integration-dialog" aria-labelledby="claudeIntegrationTitle" aria-describedby="claudeIntegrationDescription">
               <div class="section-heading">
@@ -112,11 +111,10 @@
                 <div>
                   <h3>Codex in VS Code and App</h3>
                   <p>Use FCC's models in the Codex VS Code extension and desktop app.</p>
-                  <span id="codexIntegrationStatus" class="status-pill neutral" role="status">Checking settings…</span>
                 </div>
               </div>
               <p id="codexIntegrationMessage" class="message-area" role="status" hidden></p>
-              <button id="openCodexIntegration" class="primary-button" type="button" disabled>Connect</button>
+              <button id="openCodexIntegration" class="primary-button" type="button" aria-busy="true" disabled>Loading…</button>
             </article>
             <dialog id="codexIntegrationDialog" class="integration-dialog" aria-labelledby="codexIntegrationTitle" aria-describedby="codexIntegrationDescription">
               <div class="section-heading">

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.21"
+version = "6.2.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

The Claude and Codex integration cards still show separate status tags while checking their settings. Loading feedback should appear in the action button.

## How

Replace the tags with gray, disabled Loading buttons containing a spinner. Each button becomes Connect or Disconnect when its check completes, or Retry if it fails, with the error shown below. Respect reduced-motion preferences and expose the busy state to assistive technology.

Bump the patch version to 6.2.22.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63550890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

What we checked:
- Ran a focused UI test on the Admin Integrations page with Claude and Codex checks pending, confirming the action buttons were disabled, displayed Loading…, and exposed aria-busy="true" while unresolved. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Independently resolved the checks and verified the buttons became enabled with Connect and Disconnect actions and aria-busy="false". <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Navigated back from Providers to Integrations, started a fresh check for each integration, observed it returned to pending, and settled to the updated action after the response. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details open><summary><h3>Summary</h3></summary>

- This update moves Claude and Codex integration-check feedback into their action buttons, adds accessible busy states and reduced-motion-safe loading indicators, retains retry behavior after check failures, updates end-to-end coverage, and synchronizes the release version to 6.2.22.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Show integration loading state in action..."](https://github.com/alishahryar1/free-claude-code/commit/303c1d26c4b14f6f484b92a24c5d20bd21cb09c1)</sub>

<!-- /greptile_comment -->