### PR TITLE
Show context usage in native Code Sessions

### DIFF
--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -58,8 +58,8 @@ def test_context_usage_is_live_persistent_and_uses_only_raw_provider_capacity(
     expect(usage).to_have_attribute(
         "title", "Context used: 12,438 of 100,000 tokens (12%)"
     )
-    expect(usage).to_have_attribute(
-        "aria-label", "Context used: 12,438 of 100,000 tokens (12%)"
+    expect(usage).to_have_accessible_name(
+        "Context used: 12,438 of 100,000 tokens (12%)"
     )
     usage_box = usage.bounding_box()
     stop_box = page.locator("#codeStop").bounding_box()
@@ -74,13 +74,14 @@ def test_context_usage_is_live_persistent_and_uses_only_raw_provider_capacity(
 
     page.locator("#codeModel").fill("unknown")
     page.get_by_role("option", name="unknown", exact=True).click()
-    expect(usage).to_be_hidden()
+    expect(usage).to_have_text("104K")
+    expect(usage).to_have_accessible_name("Context used: 104,000 tokens")
     send(page, "Use the model without capacity metadata")
     code_control.run(code_control.harness.wait_inputs(2))
     code_control.run(connection.context_usage("turn-2", 12_438))
     expect(usage).to_have_text("12.4K")
     expect(usage).to_have_attribute("title", "Context used: 12,438 tokens")
-    expect(usage).to_have_attribute("aria-label", "Context used: 12,438 tokens")
+    expect(usage).to_have_accessible_name("Context used: 12,438 tokens")
     code_control.run(connection.finish("turn-2"))
 
 

--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -38,6 +38,52 @@ def test_five_header_controls_fit_without_hiding_composer(
     page.screenshot(path=str(tmp_path / f"code-modes-{width}.png"))
 
 
+@pytest.mark.parametrize("width", [1440, 390])
+def test_context_usage_is_live_persistent_and_uses_only_raw_provider_capacity(
+    page, admin_base_url, tmp_path, code_control, width
+):
+    code_control.harness.context_windows["provider/model"] = 100_000
+    code_control.harness.configurations["provider/unknown"] = "unknown"
+    page.set_viewport_size({"width": width, "height": 900})
+    create_session(page, admin_base_url, tmp_path)
+    usage = page.locator("#codeContextUsage")
+    expect(usage).to_be_hidden()
+
+    send(page, "Measure the active context")
+    connection = code_control.connection()
+    code_control.run(connection.context_usage("turn-1", 90_000))
+    expect(usage).to_have_text("90K / 100K (90%)")
+    code_control.run(connection.context_usage("turn-1", 12_438))
+    expect(usage).to_have_text("12.4K / 100K (12%)")
+    expect(usage).to_have_attribute(
+        "title", "Context used: 12,438 of 100,000 tokens (12%)"
+    )
+    expect(usage).to_have_attribute(
+        "aria-label", "Context used: 12,438 of 100,000 tokens (12%)"
+    )
+    usage_box = usage.bounding_box()
+    stop_box = page.locator("#codeStop").bounding_box()
+    assert usage_box["x"] + usage_box["width"] <= stop_box["x"]
+    assert stop_box["x"] + stop_box["width"] <= width
+
+    page.reload()
+    expect(usage).to_have_text("12.4K / 100K (12%)")
+    code_control.run(connection.context_usage("turn-1", 104_000))
+    expect(usage).to_have_text("104K / 100K (104%)")
+    code_control.run(connection.finish("turn-1"))
+
+    page.locator("#codeModel").fill("unknown")
+    page.get_by_role("option", name="unknown", exact=True).click()
+    expect(usage).to_be_hidden()
+    send(page, "Use the model without capacity metadata")
+    code_control.run(code_control.harness.wait_inputs(2))
+    code_control.run(connection.context_usage("turn-2", 12_438))
+    expect(usage).to_have_text("12.4K")
+    expect(usage).to_have_attribute("title", "Context used: 12,438 tokens")
+    expect(usage).to_have_attribute("aria-label", "Context used: 12,438 tokens")
+    code_control.run(connection.finish("turn-2"))
+
+
 def test_header_provider_draft_and_mode_sync(
     page, context, admin_base_url, tmp_path, code_control
 ):

--- a/e2e/test_code_sessions.py
+++ b/e2e/test_code_sessions.py
@@ -84,6 +84,45 @@ def test_context_usage_is_live_persistent_and_uses_only_raw_provider_capacity(
     code_control.run(connection.finish("turn-2"))
 
 
+def test_delayed_settings_response_cannot_replace_newer_context_usage(
+    page, admin_base_url, tmp_path, code_control
+):
+    code_control.harness.context_windows["provider/model"] = 100_000
+    create_session(page, admin_base_url, tmp_path)
+    send(page, "Start")
+    connection = code_control.connection()
+    code_control.run(connection.context_usage("turn-1", 10_000))
+    code_control.run(connection.finish("turn-1"))
+    usage = page.locator("#codeContextUsage")
+    expect(usage).to_have_text("10K / 100K (10%)")
+
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch;
+          window.fetch = async (...args) => {
+            const response = await originalFetch(...args);
+            const options = args[1] || {};
+            if (options.method === "PATCH" && String(args[0]).includes("/sessions/")) {
+              await new Promise((resolve) => { window.releaseCodeSettings = resolve; });
+            }
+            return response;
+          };
+        }
+        """
+    )
+    title = page.get_by_role("textbox", name="Code title", exact=True)
+    title.fill("Renamed while usage changes")
+    title.press("Tab")
+    page.wait_for_function("() => typeof window.releaseCodeSettings === 'function'")
+
+    code_control.run(connection.context_usage("turn-1", 20_000))
+    expect(usage).to_have_text("20K / 100K (20%)")
+    page.evaluate("window.releaseCodeSettings()")
+    expect(title).to_be_enabled()
+    expect(usage).to_have_text("20K / 100K (20%)")
+
+
 def test_header_provider_draft_and_mode_sync(
     page, context, admin_base_url, tmp_path, code_control
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "free-claude-code"
-version = "6.2.22"
+version = "6.2.23"
 description = "Local proxy connecting coding agents to OpenAI-compatible AI providers"
 readme = "README.md"
 requires-python = ">=3.14.0"

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -101,6 +101,49 @@
   function ready(record) {
     return synchronized && record?.loaded && record.session?.status === "ready";
   }
+  function compactTokens(tokens) {
+    let value = tokens;
+    let unit = 0;
+    const units = ["", "K", "M", "B"];
+    while (value >= 1000 && unit < units.length - 1) {
+      value /= 1000;
+      unit += 1;
+    }
+    let rounded = Math.round(value * 10) / 10;
+    if (rounded >= 1000 && unit < units.length - 1) {
+      rounded /= 1000;
+      unit += 1;
+    }
+    return `${rounded}${units[unit]}`;
+  }
+  function renderContextUsage(record) {
+    const node = root.querySelector("#codeContextUsage"),
+      used = record?.session?.context_used_tokens;
+    if (!node || !Number.isInteger(used) || used < 0) {
+      if (node) {
+        node.hidden = true;
+        node.textContent = "";
+        node.removeAttribute("title");
+        node.removeAttribute("aria-label");
+      }
+      return;
+    }
+    const maximum = catalog.find(
+        (model) => model.id === record.session.model,
+      )?.context_window_tokens,
+      knownMaximum = Number.isInteger(maximum) && maximum > 0,
+      percentage = knownMaximum ? Math.round((used / maximum) * 100) : null,
+      exactUsed = used.toLocaleString("en-US");
+    node.textContent = knownMaximum
+      ? `${compactTokens(used)} / ${compactTokens(maximum)} (${percentage}%)`
+      : compactTokens(used);
+    const description = knownMaximum
+      ? `Context used: ${exactUsed} of ${maximum.toLocaleString("en-US")} tokens (${percentage}%)`
+      : `Context used: ${exactUsed} tokens`;
+    node.title = description;
+    node.setAttribute("aria-label", description);
+    node.hidden = false;
+  }
   function mergeEntries(target, entries, version) {
     for (const value of entries || []) {
       if ((target.get(value.id)?.version ?? -1) <= version)
@@ -1001,6 +1044,10 @@
           void stop();
         },
       );
+      const contextUsage = element("span", "", "code-context-usage");
+      contextUsage.id = "codeContextUsage";
+      contextUsage.hidden = true;
+      composer.querySelector(".session-composer-actions").prepend(contextUsage);
       root.append(UI.shell(header, message, transcript, composer));
       UI.resizeComposer(composer.querySelector("textarea"));
     } else {
@@ -1153,6 +1200,7 @@
     const record = records.get(selected),
       isBusy = busy(record),
       input = root.querySelector("#codeComposer");
+    renderContextUsage(record);
     if (
       providerDraft &&
       (providerDraft.id !== selected ||

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -1046,6 +1046,7 @@
       );
       const contextUsage = element("span", "", "code-context-usage");
       contextUsage.id = "codeContextUsage";
+      contextUsage.setAttribute("role", "status");
       contextUsage.hidden = true;
       composer.querySelector(".session-composer-actions").prepend(contextUsage);
       root.append(UI.shell(header, message, transcript, composer));

--- a/src/free_claude_code/api/admin_static/code_sessions.js
+++ b/src/free_claude_code/api/admin_static/code_sessions.js
@@ -790,7 +790,7 @@
       });
       if (
         !deleted.has(id) &&
-        session.revision >= (records.get(id)?.session?.revision || 0)
+        session.revision > (records.get(id)?.session?.revision || 0)
       )
         get(id).session = session;
     } catch (error) {

--- a/src/free_claude_code/api/admin_static/session_layout.css
+++ b/src/free_claude_code/api/admin_static/session_layout.css
@@ -451,6 +451,13 @@
   margin-top: 4px;
 }
 
+.code-context-usage {
+  color: var(--muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .code-activity {
   color: var(--muted);
   font-size: 14px;

--- a/src/free_claude_code/application/code_sessions/models.py
+++ b/src/free_claude_code/application/code_sessions/models.py
@@ -35,6 +35,7 @@ class CodeSession(Record):
     native_thread_id: str | None = None
     native_permission_defaults: JsonObject | None = None
     native_may_have_input: bool = False
+    context_used_tokens: int | None = Field(default=None, ge=0)
     revision: int = 1
     status: Literal["ready", "deleting", "delete_uncertain"] = "ready"
     error: str | None = None
@@ -121,6 +122,7 @@ class CodeModel(Record):
     model_name: str
     reasoning_efforts: tuple[str, ...] = ()
     default_reasoning_effort: str | None = None
+    context_window_tokens: int | None = Field(default=None, gt=0)
 
 
 @dataclass(frozen=True, slots=True)
@@ -170,9 +172,11 @@ class HarnessEvent:
         "resolved",
         "error",
         "notice",
+        "context_usage",
         "closed",
     ]
     turn_id: str | None = None
+    context_used_tokens: int | None = None
     item: ItemUpdate | None = None
     prompt: PromptRequest | None = None
     request_id: str | int | None = None

--- a/src/free_claude_code/application/code_sessions/ports.py
+++ b/src/free_claude_code/application/code_sessions/ports.py
@@ -20,6 +20,7 @@ from .models import (
     NativeThread,
 )
 
+# Harness connections must await each call and preserve native wire order.
 type EventSink = Callable[[HarnessEvent], Awaitable[None]]
 
 

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -408,8 +408,6 @@ class CodeService:
                         "This effort is unavailable. Choose another effort."
                     )
                 updates.update(model=model, reasoning_effort=effort)
-                if model != owner.session.model:
-                    updates["context_used_tokens"] = None
             session = await self._store.update_settings(
                 _revision(owner.session, **updates), revision
             )
@@ -878,20 +876,8 @@ class CodeService:
                 if owner.session.status != "ready":
                     return
                 if event.kind == "context_usage":
-                    source = next(
-                        (
-                            candidate
-                            for candidate in owner.runs.values()
-                            if candidate.native_turn_id == event.turn_id
-                        ),
-                        None,
-                    )
                     if (
-                        source is None
-                        or owner.run is None
-                        or source.id != owner.run.id
-                        or source.model != owner.session.model
-                        or event.context_used_tokens is None
+                        event.context_used_tokens is None
                         or event.context_used_tokens
                         == owner.session.context_used_tokens
                     ):

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -408,6 +408,8 @@ class CodeService:
                         "This effort is unavailable. Choose another effort."
                     )
                 updates.update(model=model, reasoning_effort=effort)
+                if model != owner.session.model:
+                    updates["context_used_tokens"] = None
             session = await self._store.update_settings(
                 _revision(owner.session, **updates), revision
             )
@@ -874,6 +876,30 @@ class CodeService:
                 ):
                     return
                 if owner.session.status != "ready":
+                    return
+                if event.kind == "context_usage":
+                    source = next(
+                        (
+                            candidate
+                            for candidate in owner.runs.values()
+                            if candidate.native_turn_id == event.turn_id
+                        ),
+                        None,
+                    )
+                    if (
+                        source is None
+                        or source.model != owner.session.model
+                        or event.context_used_tokens is None
+                        or event.context_used_tokens
+                        == owner.session.context_used_tokens
+                    ):
+                        return
+                    session = owner.session.model_copy(
+                        update={"context_used_tokens": event.context_used_tokens}
+                    )
+                    await self._persist(owner, session)
+                    owner.session = session
+                    self._publish(owner, "session.updated")
                     return
                 run = owner.run
                 matches = (

--- a/src/free_claude_code/application/code_sessions/service.py
+++ b/src/free_claude_code/application/code_sessions/service.py
@@ -888,6 +888,8 @@ class CodeService:
                     )
                     if (
                         source is None
+                        or owner.run is None
+                        or source.id != owner.run.id
                         or source.model != owner.session.model
                         or event.context_used_tokens is None
                         or event.context_used_tokens

--- a/src/free_claude_code/runtime/code_sessions_sqlite.py
+++ b/src/free_claude_code/runtime/code_sessions_sqlite.py
@@ -146,6 +146,7 @@ def _write_session(
             "model",
             "reasoning_effort",
             "mode",
+            "context_used_tokens",
             "revision",
             "updated_at",
         }
@@ -154,6 +155,7 @@ def _write_session(
             "native_thread_id",
             "native_permission_defaults",
             "native_may_have_input",
+            "context_used_tokens",
             "revision",
             "updated_at",
             "status",
@@ -428,6 +430,12 @@ class SQLiteCodeStore:
                 "(json_valid(native_permission_defaults) AND json_type(native_permission_defaults) = 'object'))"
             )
             connection.execute("PRAGMA user_version = 2")
+        if connection.execute("PRAGMA user_version").fetchone()[0] == 2:
+            connection.execute(
+                "ALTER TABLE code_sessions ADD COLUMN context_used_tokens INTEGER "
+                "CHECK(context_used_tokens IS NULL OR context_used_tokens >= 0)"
+            )
+            connection.execute("PRAGMA user_version = 3")
         connection.execute(
             "UPDATE code_runs SET status = 'interrupted', finished_at = ?, error = ? "
             "WHERE status IN ('preparing','running','stopping')",

--- a/src/free_claude_code/runtime/codex_app_server.py
+++ b/src/free_claude_code/runtime/codex_app_server.py
@@ -641,7 +641,11 @@ class CodexHarnessFactory:
         return CodeCatalog(
             settings.model,
             tuple(
-                _model_option(model.provider_model_ref, object_value(entry))
+                _model_option(
+                    model.provider_model_ref,
+                    object_value(entry),
+                    context_window_tokens=model.context_window_tokens,
+                )
                 for model, entry in zip(models, entries, strict=True)
             ),
         )
@@ -672,7 +676,11 @@ class CodexHarnessFactory:
             for value in array_value(catalog.get("models"))
             if (entry := object_value(value))
         }
-        option = _model_option(model, entries[selected.wire_slug])
+        option = _model_option(
+            model,
+            entries[selected.wire_slug],
+            context_window_tokens=selected.context_window_tokens,
+        )
         if (
             reasoning_effort is not None
             and reasoning_effort not in option.reasoning_efforts
@@ -714,7 +722,9 @@ class CodexHarnessFactory:
         return connection
 
 
-def _model_option(model: str, entry: JsonObject) -> CodeModel:
+def _model_option(
+    model: str, entry: JsonObject, *, context_window_tokens: int | None
+) -> CodeModel:
     provider_id, model_name = split_provider_model_ref(model)
     efforts = tuple(
         string_value(object_value(level).get("effort"))
@@ -731,6 +741,7 @@ def _model_option(model: str, entry: JsonObject) -> CodeModel:
         or ("off",),
         default_reasoning_effort=string_value(entry.get("default_reasoning_level"))
         or "off",
+        context_window_tokens=context_window_tokens,
     )
 
 

--- a/src/free_claude_code/runtime/codex_protocol.py
+++ b/src/free_claude_code/runtime/codex_protocol.py
@@ -54,6 +54,25 @@ class CodexProtocol:
         turn_id = (
             string_value(params.get("turnId")) or string_value(turn.get("id")) or None
         )
+        if method == "thread/tokenUsage/updated":
+            used = object_value(object_value(params.get("tokenUsage")).get("last")).get(
+                "totalTokens"
+            )
+            if (
+                not thread_id
+                or not turn_id
+                or not isinstance(used, int)
+                or isinstance(used, bool)
+                or used < 0
+            ):
+                return None
+            return HarnessEvent(
+                self.generation,
+                thread_id,
+                "context_usage",
+                turn_id=turn_id,
+                context_used_tokens=used,
+            )
         if method in {"turn/started", "turn/completed"}:
             status: RunStatus = "completed"
             if turn.get("status") == "interrupted":

--- a/tests/api/test_code_sessions_routes.py
+++ b/tests/api/test_code_sessions_routes.py
@@ -130,6 +130,36 @@ async def test_code_library_has_one_harness_and_no_native_work_on_open(code_api)
 
 
 @pytest.mark.asyncio
+async def test_context_usage_and_raw_provider_capacity_are_public_session_state(
+    code_api,
+):
+    client, code, harness, _, _ = code_api
+    harness.context_windows[harness.model] = 100_000
+    harness.configurations["unknown/model"] = "unknown"
+    bootstrap = (await client.get("/admin/api/code/bootstrap")).json()
+    models = {model["id"]: model for model in bootstrap["models"]}
+    assert models[harness.model]["context_window_tokens"] == 100_000
+    assert models["unknown/model"]["context_window_tokens"] is None
+
+    session = await create_session(code_api)
+    assert session["context_used_tokens"] is None
+    await code.send(
+        session["id"],
+        str(uuid.uuid4()),
+        session["revision"],
+        "hello",
+        expected_epoch=code.epoch,
+    )
+    await harness.started.wait()
+    await harness.connections[0].context_usage("turn-1", 12_438)
+
+    detail = (await client.get(f"/admin/api/code/sessions/{session['id']}")).json()
+    assert detail["session"]["context_used_tokens"] == 12_438
+    library = (await client.get("/admin/api/code/sessions")).json()
+    assert library["sessions"][0]["context_used_tokens"] == 12_438
+
+
+@pytest.mark.asyncio
 async def test_http_send_competition_and_safe_item_projection(code_api):
     client, code, harness, _, _ = code_api
     session = await create_session(code_api)

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -1619,6 +1619,89 @@ async def test_streaming_does_not_invalidate_rename_revision(code):
 
 
 @pytest.mark.asyncio
+async def test_context_usage_is_an_absolute_deduplicated_session_snapshot(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "hello", expected_epoch=service.epoch
+    )
+    await harness.started.wait()
+    connection = harness.connections[0]
+    before = await service.get_detail(session.id)
+    subscription, _ = await service.subscribe()
+    events = subscription.__aiter__()
+    try:
+        await connection.context_usage("turn-1", 90_000)
+        async with asyncio.timeout(2):
+            event = await anext(events)
+        after = await service.get_detail(session.id)
+        assert event.event == "session.updated"
+        assert event.data["session"]["context_used_tokens"] == 90_000
+        assert after.session.context_used_tokens == 90_000
+        assert after.session.revision == before.session.revision
+        assert after.session.updated_at == before.session.updated_at
+        assert (
+            await service._store.get_session(session.id)
+        ).context_used_tokens == 90_000
+
+        await connection.context_usage("turn-1", 90_000)
+        duplicate = await service.get_detail(session.id)
+        assert duplicate.version == after.version
+
+        await connection.finish("turn-1")
+        finished = await service.get_detail(session.id)
+        await connection.context_usage("turn-1", 25_000)
+        compacted = await service.get_detail(session.id)
+        assert compacted.session.context_used_tokens == 25_000
+        assert compacted.session.revision == finished.session.revision
+        assert compacted.session.updated_at == finished.session.updated_at
+    finally:
+        await subscription.aclose()
+
+
+@pytest.mark.asyncio
+async def test_context_usage_follows_the_current_run_model_across_model_changes(code):
+    service, harness, _ = code
+    harness.configurations["provider/other"] = "other"
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "first", expected_epoch=service.epoch
+    )
+    await harness.started.wait()
+    connection = harness.connections[0]
+    await connection.context_usage("turn-1", 40_000)
+    await connection.finish("turn-1")
+
+    detail = await service.get_detail(session.id)
+    same_model = await service.update_settings(
+        session.id, detail.session.revision, {"model": "provider/model"}
+    )
+    assert same_model.context_used_tokens == 40_000
+    changed = await service.update_settings(
+        session.id, same_model.revision, {"model": "provider/other"}
+    )
+    assert changed.context_used_tokens is None
+    assert (await service._store.get_session(session.id)).context_used_tokens is None
+
+    await service.send(
+        session.id,
+        new_id(),
+        changed.revision,
+        "second",
+        expected_epoch=service.epoch,
+    )
+    await harness.wait_inputs(2)
+    await connection.context_usage("turn-1", 41_000)
+    await connection.context_usage("unknown-replay-turn", 42_000)
+    assert (await service.get_detail(session.id)).session.context_used_tokens is None
+
+    await connection.context_usage("turn-2", 7_500)
+    current = await service.get_detail(session.id)
+    assert current.session.context_used_tokens == 7_500
+    await connection.finish("turn-2")
+
+
+@pytest.mark.asyncio
 async def test_catalog_replacement_is_limited_to_selected_entry_and_session(code):
     service, harness, _ = code
     harness.configurations["provider/other"] = "other-1"

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -1702,6 +1702,32 @@ async def test_context_usage_follows_the_current_run_model_across_model_changes(
 
 
 @pytest.mark.asyncio
+async def test_late_context_usage_from_an_older_same_model_run_is_ignored(code):
+    service, harness, _ = code
+    session = await session_for(code)
+    await service.send(
+        session.id, new_id(), session.revision, "first", expected_epoch=service.epoch
+    )
+    await harness.started.wait()
+    connection = harness.connections[0]
+    await connection.context_usage("turn-1", 10_000)
+    await connection.finish("turn-1")
+
+    session = (await service.get_detail(session.id)).session
+    await service.send(
+        session.id, new_id(), session.revision, "second", expected_epoch=service.epoch
+    )
+    await harness.wait_inputs(2)
+    await connection.context_usage("turn-2", 20_000)
+    await connection.context_usage("turn-1", 11_000)
+
+    detail = await service.get_detail(session.id)
+    assert detail.session.context_used_tokens == 20_000
+    assert (await service._store.get_session(session.id)).context_used_tokens == 20_000
+    await connection.finish("turn-2")
+
+
+@pytest.mark.asyncio
 async def test_catalog_replacement_is_limited_to_selected_entry_and_session(code):
     service, harness, _ = code
     harness.configurations["provider/other"] = "other-1"

--- a/tests/application/test_code_sessions.py
+++ b/tests/application/test_code_sessions.py
@@ -1648,19 +1648,18 @@ async def test_context_usage_is_an_absolute_deduplicated_session_snapshot(code):
         duplicate = await service.get_detail(session.id)
         assert duplicate.version == after.version
 
-        await connection.finish("turn-1")
-        finished = await service.get_detail(session.id)
         await connection.context_usage("turn-1", 25_000)
         compacted = await service.get_detail(session.id)
         assert compacted.session.context_used_tokens == 25_000
-        assert compacted.session.revision == finished.session.revision
-        assert compacted.session.updated_at == finished.session.updated_at
+        assert compacted.session.revision == after.session.revision
+        assert compacted.session.updated_at == after.session.updated_at
+        await connection.finish("turn-1")
     finally:
         await subscription.aclose()
 
 
 @pytest.mark.asyncio
-async def test_context_usage_follows_the_current_run_model_across_model_changes(code):
+async def test_context_usage_is_retained_across_model_changes(code):
     service, harness, _ = code
     harness.configurations["provider/other"] = "other"
     session = await session_for(code)
@@ -1673,28 +1672,24 @@ async def test_context_usage_follows_the_current_run_model_across_model_changes(
     await connection.finish("turn-1")
 
     detail = await service.get_detail(session.id)
-    same_model = await service.update_settings(
-        session.id, detail.session.revision, {"model": "provider/model"}
-    )
-    assert same_model.context_used_tokens == 40_000
     changed = await service.update_settings(
-        session.id, same_model.revision, {"model": "provider/other"}
+        session.id, detail.session.revision, {"model": "provider/other"}
     )
-    assert changed.context_used_tokens is None
-    assert (await service._store.get_session(session.id)).context_used_tokens is None
+    assert changed.context_used_tokens == 40_000
+    restored = await service.update_settings(
+        session.id, changed.revision, {"model": "provider/model"}
+    )
+    assert restored.context_used_tokens == 40_000
+    assert (await service._store.get_session(session.id)).context_used_tokens == 40_000
 
     await service.send(
         session.id,
         new_id(),
-        changed.revision,
+        restored.revision,
         "second",
         expected_epoch=service.epoch,
     )
     await harness.wait_inputs(2)
-    await connection.context_usage("turn-1", 41_000)
-    await connection.context_usage("unknown-replay-turn", 42_000)
-    assert (await service.get_detail(session.id)).session.context_used_tokens is None
-
     await connection.context_usage("turn-2", 7_500)
     current = await service.get_detail(session.id)
     assert current.session.context_used_tokens == 7_500
@@ -1702,29 +1697,43 @@ async def test_context_usage_follows_the_current_run_model_across_model_changes(
 
 
 @pytest.mark.asyncio
-async def test_late_context_usage_from_an_older_same_model_run_is_ignored(code):
+async def test_resumed_context_usage_is_accepted_after_the_next_run_is_admitted(code):
     service, harness, _ = code
     session = await session_for(code)
     await service.send(
         session.id, new_id(), session.revision, "first", expected_epoch=service.epoch
     )
     await harness.started.wait()
-    connection = harness.connections[0]
-    await connection.context_usage("turn-1", 10_000)
-    await connection.finish("turn-1")
+    original = harness.connections[0]
+    await original.context_usage("turn-1", 10_000)
+    await original.finish("turn-1")
 
     session = (await service.get_detail(session.id)).session
+    harness.configurations[harness.model] = "replacement"
+    harness.start_gate.clear()
+    harness.started.clear()
+    harness.submitted.clear()
     await service.send(
         session.id, new_id(), session.revision, "second", expected_epoch=service.epoch
     )
-    await harness.wait_inputs(2)
-    await connection.context_usage("turn-2", 20_000)
-    await connection.context_usage("turn-1", 11_000)
+    await harness.submitted.wait()
+    resumed = harness.connections[1]
+    assert original.closed
+    assert resumed.resumed == [session.native_thread_id]
 
-    detail = await service.get_detail(session.id)
-    assert detail.session.context_used_tokens == 20_000
-    assert (await service._store.get_session(session.id)).context_used_tokens == 20_000
-    await connection.finish("turn-2")
+    await resumed.context_usage("turn-1", 11_000)
+    await resumed.context_usage("turn-1", 12_000, generation=original.generation)
+    await resumed.context_usage("turn-1", 13_000, thread_id="another-thread")
+    replayed = await service.get_detail(session.id)
+    assert replayed.session.context_used_tokens == 11_000
+    assert (await service._store.get_session(session.id)).context_used_tokens == 11_000
+
+    harness.start_gate.set()
+    await harness.started.wait()
+    await resumed.context_usage("turn-2", 20_000)
+    current = await service.get_detail(session.id)
+    assert current.session.context_used_tokens == 20_000
+    await resumed.finish("turn-2")
 
 
 @pytest.mark.asyncio

--- a/tests/code_sessions_support.py
+++ b/tests/code_sessions_support.py
@@ -126,6 +126,7 @@ class FakeHarness:
             "activePermissionProfile": {"id": ":workspace"},
         }
         self.configurations = {self.model: "capabilities-1"}
+        self.context_windows: dict[str, int | None] = {self.model: None}
         self.efforts = ("off", "low", "medium", "high", "xhigh", "max")
         self.default_effort = "medium"
         self.creation_gate = asyncio.Event()
@@ -165,6 +166,7 @@ class FakeHarness:
                     model_name=split_provider_model_ref(model)[1],
                     reasoning_efforts=self.efforts,
                     default_reasoning_effort=self.default_effort,
+                    context_window_tokens=self.context_windows.get(model),
                 )
                 for model in self.configurations
             ),
@@ -326,6 +328,24 @@ class FakeConnection:
         await self.sink(
             HarnessEvent(
                 self.generation, self.thread_id, "item", turn_id=turn_id, item=item
+            )
+        )
+
+    async def context_usage(
+        self,
+        turn_id: str,
+        used_tokens: int,
+        *,
+        thread_id: str | None = None,
+        generation: str | None = None,
+    ):
+        await self.sink(
+            HarnessEvent(
+                generation or self.generation,
+                self.thread_id if thread_id is None else thread_id,
+                "context_usage",
+                turn_id=turn_id,
+                context_used_tokens=used_tokens,
             )
         )
 

--- a/tests/runtime/codex_fake_process.py
+++ b/tests/runtime/codex_fake_process.py
@@ -63,7 +63,27 @@ for line in sys.stdin.buffer:
                 },
             }
         )
-        if mode in {"prompt", "child-prompt"}:
+        if mode == "ordered-usage":
+            emit(
+                {
+                    "method": "thread/tokenUsage/updated",
+                    "params": {
+                        "threadId": "native-1",
+                        "turnId": turn,
+                        "tokenUsage": {"last": {"totalTokens": 12_438}},
+                    },
+                }
+            )
+            emit(
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "native-1",
+                        "turn": {"id": turn, "status": "completed"},
+                    },
+                }
+            )
+        elif mode in {"prompt", "child-prompt"}:
             if mode == "child-prompt":
                 emit(
                     {

--- a/tests/runtime/test_code_sessions_sqlite.py
+++ b/tests/runtime/test_code_sessions_sqlite.py
@@ -171,6 +171,30 @@ async def test_mode_and_original_defaults_survive_restart_and_cannot_be_rewritte
 
 
 @pytest.mark.asyncio
+async def test_context_usage_progress_and_model_clear_use_existing_session_writes(
+    store,
+):
+    session = await _session(store)
+    snapshot = session.model_copy(update={"context_used_tokens": 12_438})
+    await store.save_progress(snapshot, session.revision)
+    saved = await store.get_session(session.id)
+    assert saved.context_used_tokens == 12_438
+    assert saved.revision == session.revision
+    assert saved.updated_at == session.updated_at
+
+    changed = snapshot.model_copy(
+        update={
+            "model": "provider/other",
+            "context_used_tokens": None,
+            "revision": snapshot.revision + 1,
+        }
+    )
+    changed = await store.update_settings(changed, snapshot.revision)
+    assert changed.model == "provider/other"
+    assert changed.context_used_tokens is None
+
+
+@pytest.mark.asyncio
 async def test_mode_is_guarded_by_sqlite_busy_and_run_immutability(store):
     session, run = await _admit(store, await _session(store))
     with pytest.raises(CodeConflictError):
@@ -198,6 +222,7 @@ async def test_version_one_database_gains_mode_without_losing_history(store, tmp
         connection.execute(
             "ALTER TABLE code_sessions DROP COLUMN native_permission_defaults"
         )
+        connection.execute("ALTER TABLE code_sessions DROP COLUMN context_used_tokens")
         connection.execute("ALTER TABLE code_runs DROP COLUMN mode")
         connection.execute("PRAGMA user_version = 1")
     for _ in range(2):
@@ -208,12 +233,38 @@ async def test_version_one_database_gains_mode_without_losing_history(store, tmp
         assert (await store.get_run(session.id, run.id)).mode == "config"
         assert await store.items(session.id, None, None) == items
         with closing(sqlite3.connect(tmp_path / "code.db")) as connection:
-            assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 3
             with pytest.raises(sqlite3.IntegrityError):
                 connection.execute("UPDATE code_sessions SET mode = 'unknown'")
             with pytest.raises(sqlite3.IntegrityError):
                 connection.execute(
                     "UPDATE code_sessions SET native_permission_defaults = '[]'"
+                )
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_version_two_database_gains_nullable_context_usage(store, tmp_path):
+    session = await _session(store)
+    await store.close()
+    with closing(sqlite3.connect(tmp_path / "code.db")) as connection, connection:
+        connection.execute("ALTER TABLE code_sessions DROP COLUMN context_used_tokens")
+        connection.execute("PRAGMA user_version = 2")
+    for _ in range(2):
+        await store.start()
+        assert (await store.get_session(session.id)).context_used_tokens is None
+        with closing(sqlite3.connect(tmp_path / "code.db")) as connection:
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 3
+            column = next(
+                row
+                for row in connection.execute("PRAGMA table_info(code_sessions)")
+                if row[1] == "context_used_tokens"
+            )
+            assert column[3] == 0
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    "UPDATE code_sessions SET context_used_tokens = -1 WHERE id = ?",
+                    (session.id,),
                 )
         await store.close()
 
@@ -504,6 +555,7 @@ async def _legacy_prompt_database(store, path):
         connection.execute(
             "ALTER TABLE code_sessions DROP COLUMN native_permission_defaults"
         )
+        connection.execute("ALTER TABLE code_sessions DROP COLUMN context_used_tokens")
         connection.execute("ALTER TABLE code_runs DROP COLUMN mode")
         connection.execute("PRAGMA user_version = 0")
         for prompt in prompts:
@@ -563,7 +615,7 @@ async def test_legacy_prompts_migrate_once_to_run_ends_without_resequencing(
             )
             assert saved[prompt.id] == expected
         with closing(sqlite3.connect(path)) as connection:
-            assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 3
             assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
             assert any(
                 row[2] == "code_items"

--- a/tests/runtime/test_code_sessions_sqlite.py
+++ b/tests/runtime/test_code_sessions_sqlite.py
@@ -171,7 +171,7 @@ async def test_mode_and_original_defaults_survive_restart_and_cannot_be_rewritte
 
 
 @pytest.mark.asyncio
-async def test_context_usage_progress_and_model_clear_use_existing_session_writes(
+async def test_context_usage_progress_and_settings_use_existing_session_writes(
     store,
 ):
     session = await _session(store)
@@ -185,13 +185,12 @@ async def test_context_usage_progress_and_model_clear_use_existing_session_write
     changed = snapshot.model_copy(
         update={
             "model": "provider/other",
-            "context_used_tokens": None,
             "revision": snapshot.revision + 1,
         }
     )
     changed = await store.update_settings(changed, snapshot.revision)
     assert changed.model == "provider/other"
-    assert changed.context_used_tokens is None
+    assert changed.context_used_tokens == 12_438
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_codex_app_server.py
+++ b/tests/runtime/test_codex_app_server.py
@@ -211,6 +211,55 @@ async def connect(tmp_path, mode):
 
 
 @pytest.mark.asyncio
+async def test_jsonl_sink_preserves_usage_before_turn_completion(tmp_path):
+    events = []
+    usage_received = asyncio.Event()
+    release_usage = asyncio.Event()
+    completed = asyncio.Event()
+
+    async def receive(event):
+        events.append(event.kind)
+        if event.kind == "context_usage":
+            usage_received.set()
+            await release_usage.wait()
+        elif event.kind == "turn_completed":
+            completed.set()
+
+    native = CodexAppServer(
+        [
+            sys.executable,
+            str(Path(__file__).with_name("codex_fake_process.py")),
+            "ordered-usage",
+        ],
+        dict(os.environ),
+        str(tmp_path),
+        receive,
+        model_slugs={"provider/model": "provider/model"},
+        fingerprints={"provider/model": "capabilities-1"},
+    )
+    try:
+        await native.start()
+        await native.create_thread()
+        turn_id = await native.start_turn(
+            "hello",
+            FakeHarness().prepare("provider/model", None, "config"),
+            "input-1",
+            FakeHarness().permission_defaults,
+        )
+        assert turn_id == "turn-1"
+        await asyncio.wait_for(usage_received.wait(), 3)
+        assert not completed.is_set()
+        release_usage.set()
+        await asyncio.wait_for(completed.wait(), 3)
+        assert [
+            kind for kind in events if kind in {"context_usage", "turn_completed"}
+        ] == ["context_usage", "turn_completed"]
+    finally:
+        release_usage.set()
+        await native.close()
+
+
+@pytest.mark.asyncio
 async def test_jsonl_large_unicode_events_can_precede_rpc_ack(tmp_path):
     native, events, completed, _ = await connect(tmp_path, "large")
     try:

--- a/tests/runtime/test_codex_catalog.py
+++ b/tests/runtime/test_codex_catalog.py
@@ -48,7 +48,9 @@ def _runtime() -> FakeRequestRuntime:
     settings = Settings().model_copy(update={"model": "nvidia_nim/configured"})
     return FakeRequestRuntime(
         settings=settings,
-        cached_infos=(ProviderModelInfo("open_router/discovered"),),
+        cached_infos=(
+            ProviderModelInfo("open_router/discovered", context_window_tokens=100_000),
+        ),
     )
 
 
@@ -111,6 +113,8 @@ def test_code_picker_and_native_selection_use_the_same_advertised_efforts():
     advertised = factory.catalog()
     assert advertised.default_model == "nvidia_nim/configured"
     model = advertised.models[1]
+    assert advertised.models[0].context_window_tokens is None
+    assert model.context_window_tokens == 100_000
     assert model.reasoning_efforts == ("off", "low", "medium", "high", "xhigh", "max")
     selected = factory.prepare(model.id, None, "config")
     assert selected.model == model.id

--- a/tests/runtime/test_codex_protocol.py
+++ b/tests/runtime/test_codex_protocol.py
@@ -77,6 +77,49 @@ def notification(protocol, method, **extra):
     )
 
 
+def test_context_usage_projects_the_latest_active_context_not_cumulative_usage():
+    event = notification(
+        CodexProtocol("generation"),
+        "thread/tokenUsage/updated",
+        tokenUsage={
+            "total": {"totalTokens": 98_765},
+            "last": {"totalTokens": 12_438},
+            "modelContextWindow": 95_000,
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "context_usage"
+    assert event.context_used_tokens == 12_438
+    assert event.turn_id == "turn"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, False, -1, 1.5, "12", [], {}],
+)
+def test_context_usage_ignores_invalid_active_context_totals(value):
+    assert (
+        notification(
+            CodexProtocol("generation"),
+            "thread/tokenUsage/updated",
+            tokenUsage={"total": {"totalTokens": 20}, "last": {"totalTokens": value}},
+        )
+        is None
+    )
+
+
+def test_context_usage_accepts_an_empty_active_context():
+    event = notification(
+        CodexProtocol("generation"),
+        "thread/tokenUsage/updated",
+        tokenUsage={"total": {"totalTokens": 0}, "last": {"totalTokens": 0}},
+    )
+
+    assert event is not None
+    assert event.context_used_tokens == 0
+
+
 def test_reasoning_keeps_summary_and_content_indices_and_original_completion():
     protocol = CodexProtocol("generation")
     notification(

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "free-claude-code"
-version = "6.2.22"
+version = "6.2.23"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Native Code Sessions receive Codex active-context snapshots, but FCC does not expose them. Users therefore cannot see how much context a session is using or compare it with a provider-advertised model limit.

Codex owns this usage as native-thread state and replays it when a thread resumes. Associating the snapshot with only the latest FCC run and selected model rejects valid resume state and clears useful context when the user changes models. The compact value also needs a real accessible status role so browsers expose its exact value.

## How

Project Codex `thread/tokenUsage/updated` `last.totalTokens` snapshots into typed session events and persist the active-context count without advancing editable session revisions or library timestamps. Accept ordered snapshots for the attached connection generation and owning native thread, deduplicate equal values, and let the last delivered snapshot win, including valid decreases after compaction.

Retain the thread snapshot across model selection changes and resume replays. The selected FCC model supplies only the optional raw `context_window_tokens` denominator, so the UI immediately reprojects retained usage for the selected model and shows only used tokens when its limit is unknown. The harness event-sink contract explicitly preserves native wire order, which is the ordering information Codex provides.

Render compact usage beside Send or Stop as `12.4K / 100K (12%)`, or `12.4K` when the provider limit is unknown, while retaining exact hover and accessible text. Mark the value as an ARIA status so Chromium exposes its accessible name. Persist the value through schema version 3, preserve it across refresh and restart, keep newer same-revision SSE telemetry over delayed settings responses, and bump FCC to 6.2.23.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63557891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not safe to merge until model changes clear or correctly scope the prior usage snapshot.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22alishahryar1%2Ffree-claude-code%22%20on%20the%20existing%20branch%20%22ali%2Fcode-context-usage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ali%2Fcode-context-usage%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ffree_claude_code%2Fapplication%2Fcode_sessions%2Fservice.py%3A410%0AAfter%20a%20completed%20session%20switches%20to%20a%20different%20model%2C%20this%20update%20keeps%20%60context_used_tokens%60%20from%20the%20prior%20model.%20The%20usage%20display%20then%20divides%20that%20old%20value%20by%20the%20newly%20selected%20model's%20context%20window%2C%20so%20it%20can%20present%20an%20incorrect%20percentage%20until%20another%20turn%20reports%20usage.%20Clear%20the%20usage%20snapshot%20when%20the%20model%20actually%20changes%2C%20while%20retaining%20it%20for%20same-model%20settings%20updates.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=alishahryar1%2Ffree-claude-code&pr=1785&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Clear stale model usage** <a href="https://github.com/Alishahryar1/free-claude-code/pull/1785/files#diff-67c22aaf24da468505650587f38aa99679489d1679dc580d83e79573fdae784aR410">▶</a>

<details open><summary><h3>Summary</h3></summary>

- Changing a completed Code Session to a different model preserves token usage measured for the previous model. The usage display then calculates a percentage using the newly selected model’s context window, which can show an incorrect remaining-context value until another turn reports usage.
</details>

<sub>Reviews (3) · Last reviewed commit: ["Align context usage with native thread s..."](https://github.com/alishahryar1/free-claude-code/commit/5a0a9a479a424ca7236548d06514b4c6c61a8039)</sub>

<!-- /greptile_comment -->